### PR TITLE
fix: Use uiId instead of appId to find an element

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
@@ -175,13 +175,17 @@ public class ApplicationConnection {
         var ap = this;
         var client = {};
         client.isActive = $entry(function() {
-            return ap.@com.vaadin.client.ApplicationConnection::isActive()();
+            return ap.@ApplicationConnection::isActive()();
         });
         client.getByNodeId = $entry(function(nodeId) {
             return ap.@ApplicationConnection::getDomElementByNodeId(*)(nodeId);
         });
         client.getNodeId = $entry(function(element) {
             return ap.@ApplicationConnection::getNodeId(*)(element);
+        });
+        client.getUIId = $entry(function() {
+            var appConfiguration = ap.@ApplicationConnection::registry.@com.vaadin.client.Registry::getApplicationConfiguration()();
+            return appConfiguration.@ApplicationConfiguration::getUIId(*)();
         });
         client.addDomBindingListener = $entry(function(nodeId, callback) {
             ap.@ApplicationConnection::addDomSetListener(*)(nodeId, callback);

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
@@ -1169,37 +1169,32 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
     /**
      * Finds the given element in the session.
      * <p>
-     * The ids are typically acquired in the browser: {@literal appId} (client
-     * side the key in {@code window.Vaadin.Flow.clients}) refers to the UI
-     * instance and {@literal nodeId} (client side fetched using
-     * {@code getNodeId} in the {@code window.Vaadin.Flow.clients} value) refers
-     * to the element inside that UI instance.
+     * The ids are typically acquired in the browser using {@code getUiId()} and
+     * {@code getNodeId(element)} available in the
+     * {@code window.Vaadin.Flow.clients} value.
      *
-     * @param appId
-     *            the application id
+     * @param uiId
+     *            The UI id
      * @param nodeId
      *            the node id
-     * @return the component instance
+     * @return the element instance
      * @throws IllegalArgumentException
-     *             if the component was not found
+     *             if the element was not found
      */
-    public Element findElement(String appId, int nodeId)
+    public Element findElement(int uiId, int nodeId)
             throws IllegalArgumentException {
         checkHasLock();
 
-        Optional<UI> ui = getUIs().stream().filter(u -> {
-            return u.getInternals().getAppId().equals(appId);
-        }).findFirst();
-        if (!ui.isPresent()) {
+        UI ui = getUIById(uiId);
+        if (ui == null) {
             throw new IllegalArgumentException(
-                    "Unable to find the UI for app id " + appId);
+                    "Unable to find the UI for UI id " + uiId);
         }
-        StateNode node = ui.get().getInternals().getStateTree()
-                .getNodeById(nodeId);
+        StateNode node = ui.getInternals().getStateTree().getNodeById(nodeId);
         if (node == null) {
             throw new IllegalArgumentException(
                     "Unable to find the component for node " + nodeId
-                            + " in app " + appId);
+                            + " in the UI " + uiId);
         }
 
         return Element.get(node);

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinSessionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinSessionTest.java
@@ -482,19 +482,19 @@ public class VaadinSessionTest {
     public void findComponent_existingComponentFound() {
         TestComponent testComponent = createTestComponentInSession();
         int nodeId = testComponent.getElement().getNode().getId();
-        String appId = testComponent.getUI().get().getInternals().getAppId();
+        int uiId = testComponent.getUI().get().getUIId();
         VaadinSession session = testComponent.getUI().get().getSession();
         Assert.assertSame(testComponent,
-                session.findElement(appId, nodeId).getComponent().get());
+                session.findElement(uiId, nodeId).getComponent().get());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void findComponent_nonExistingNodeIdThrows() {
         TestComponent testComponent = createTestComponentInSession();
         int nodeId = testComponent.getElement().getNode().getId();
-        String appId = testComponent.getUI().get().getInternals().getAppId();
+        int uiId = testComponent.getUI().get().getUIId();
         VaadinSession session = testComponent.getUI().get().getSession();
-        session.findElement(appId, nodeId * 10);
+        session.findElement(uiId, nodeId * 10);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -502,7 +502,7 @@ public class VaadinSessionTest {
         TestComponent testComponent = createTestComponentInSession();
         int nodeId = testComponent.getElement().getNode().getId();
         VaadinSession session = testComponent.getUI().get().getSession();
-        session.findElement("foo", nodeId);
+        session.findElement(123, nodeId);
     }
 
     private TestComponent createTestComponentInSession() {

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/FindComponentView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/FindComponentView.java
@@ -34,10 +34,10 @@ public class FindComponentView extends Div {
         result.setId("result");
 
         NativeButton button = new NativeButton("Check", e -> {
-            String appId = "view";
+            int uiId = getUI().get().getUIId();
             int nodeId = Integer.parseInt(nodeIdInput.getValue());
             VaadinSession session = VaadinSession.getCurrent();
-            Element element = session.findElement(appId, nodeId);
+            Element element = session.findElement(uiId, nodeId);
             result.setText("Found component with id "
                     + element.getComponent().get().getId().get());
         });

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/FindComponentIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/FindComponentIT.java
@@ -7,7 +7,6 @@ import org.openqa.selenium.Keys;
 import com.vaadin.flow.component.html.testbench.DivElement;
 import com.vaadin.flow.component.html.testbench.InputTextElement;
 import com.vaadin.flow.component.html.testbench.NativeButtonElement;
-import com.vaadin.flow.server.frontend.installer.NodeInstaller;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 


### PR DESCRIPTION
An appId only identifies a servlet and does not identify which UI instance connected to that servlet to use. A UI id uniquely identifies the UI and app id is not needed at all
