### PR TITLE
fix: Don't generate frontend files with devBundle

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -153,7 +153,11 @@ public class NodeTasks implements FallibleCommand {
         if (frontendDependencies != null) {
             addGenerateServiceWorkerTask(options,
                     frontendDependencies.getPwaConfiguration());
-            addGenerateTsConfigTask(options);
+
+            if (options.productionMode || options.isEnableDevServer()
+                    || options.isDevBundleBuild()) {
+                addGenerateTsConfigTask(options);
+            }
         }
 
         addBootstrapTasks(options);
@@ -199,7 +203,10 @@ public class NodeTasks implements FallibleCommand {
             pwa = new PwaConfiguration();
         }
         commands.add(new TaskUpdateSettingsFile(options, themeName, pwa));
-        commands.add(new TaskUpdateVite(options));
+        if (options.productionMode || options.isEnableDevServer()
+                || options.isDevBundleBuild()) {
+            commands.add(new TaskUpdateVite(options));
+        }
 
         if (options.enableImportsUpdate) {
             commands.add(new TaskUpdateImports(classFinder,
@@ -218,14 +225,13 @@ public class NodeTasks implements FallibleCommand {
     }
 
     private void addBootstrapTasks(Options options) {
-        TaskGenerateIndexHtml taskGenerateIndexHtml = new TaskGenerateIndexHtml(
-                options);
-        commands.add(taskGenerateIndexHtml);
-        TaskGenerateIndexTs taskGenerateIndexTs = new TaskGenerateIndexTs(
-                options);
-        commands.add(taskGenerateIndexTs);
-        if (!options.productionMode) {
-            commands.add(new TaskGenerateViteDevMode(options));
+        commands.add(new TaskGenerateIndexHtml(options));
+        if (options.productionMode || options.isEnableDevServer()
+                || options.isDevBundleBuild()) {
+            commands.add(new TaskGenerateIndexTs(options));
+            if (!options.productionMode) {
+                commands.add(new TaskGenerateViteDevMode(options));
+            }
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -488,7 +488,10 @@ public abstract class NodeUpdater implements FallibleCommand {
         log().debug("writing file {}.", packageFile.getAbsolutePath());
         FileUtils.forceMkdirParent(packageFile);
         String content = stringify(json, 2) + "\n";
-        FileUtils.writeStringToFile(packageFile, content, UTF_8.name());
+        if (options.productionMode || options.isEnableDevServer()
+                || options.isDevBundleBuild()) {
+            FileUtils.writeStringToFile(packageFile, content, UTF_8.name());
+        }
         return content;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateViteDevMode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateViteDevMode.java
@@ -55,7 +55,8 @@ public class TaskGenerateViteDevMode extends AbstractTaskClientGenerator {
 
     @Override
     protected boolean shouldGenerate() {
-        return true;
+        return options.productionMode || options.isEnableDevServer()
+                || options.isDevBundleBuild();
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -66,20 +66,8 @@ public class TaskUpdatePackages extends NodeUpdater {
      *            a reusable class finder
      * @param frontendDependencies
      *            a reusable frontend dependencies
-     * @param npmFolder
-     *            folder with the `package.json` file
-     * @param generatedPath
-     *            folder where flow generated files will be placed.
-     * @param jarResourcesFolder
-     *            folder where frontend resources from jar files will be placed.
-     * @param forceCleanUp
-     *            forces the clean up process to be run. If {@code false}, clean
-     *            up will be performed when platform version update is detected.
-     * @param enablePnpm
-     *            if {@code true} then pnpm is used instead of npm, otherwise
-     *            npm is used
-     * @param buildDir
-     *            the used build directory
+     * @param options
+     *            the task options
      */
     TaskUpdatePackages(ClassFinder finder,
             FrontendDependenciesScanner frontendDependencies, Options options) {

--- a/flow-tests/test-express-build/test-dev-bundle-no-plugin/src/test/java/com/vaadin/flow/testnpmonlyfeatures/nobuildmojo/NoAppBundleIT.java
+++ b/flow-tests/test-express-build/test-dev-bundle-no-plugin/src/test/java/com/vaadin/flow/testnpmonlyfeatures/nobuildmojo/NoAppBundleIT.java
@@ -31,15 +31,15 @@ public class NoAppBundleIT extends ChromeBrowserTest {
                 new File(baseDir, "node_modules").exists());
 
         // These should not be generated either, but at the moment they are
-        // Assert.assertFalse("No package.json should be created", new
-        // File(baseDir, "package.json").exists());
-        // Assert.assertFalse("No vite generated should be created", new
-        // File(baseDir, "vite.generated.ts").exists());
-        // Assert.assertFalse("No vite config should be created", new
-        // File(baseDir, "vite.config.ts").exists());
-        // Assert.assertFalse("No types should be created", new File(baseDir,
-        // "types.d.ts").exists());
-        // Assert.assertFalse("No tsconfig should be created", new File(baseDir,
-        // "tsconfig.json").exists());
+        Assert.assertFalse("No package.json should be created",
+                new File(baseDir, "package.json").exists());
+        Assert.assertFalse("No vite generated should be created",
+                new File(baseDir, "vite.generated.ts").exists());
+        Assert.assertFalse("No vite config should be created",
+                new File(baseDir, "vite.config.ts").exists());
+        Assert.assertFalse("No types should be created",
+                new File(baseDir, "types.d.ts").exists());
+        Assert.assertFalse("No tsconfig should be created",
+                new File(baseDir, "tsconfig.json").exists());
     }
 }


### PR DESCRIPTION
If running application using devBundle
do not generate frontend files like,
package.json, vite.*.ts etc.

Closes #15640
