### PR TITLE
fix: apply variant when using default theme (#15641) (CP: 2.8)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
@@ -278,6 +278,7 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
                 .filter(data -> data.getTheme().getThemeClass() != null
                         || (data.getTheme().getThemeName() != null
                                 && !data.getTheme().getThemeName().isEmpty())
+                        || !data.getTheme().getVariant().isEmpty()
                         || data.getTheme().isNotheme())
                 .map(EndPointData::getTheme)
                 // Remove duplicates by returning a set

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
@@ -267,6 +267,21 @@ public class FrontendDependenciesTest {
 
     }
 
+    @Test
+    public void onlyThemeVariantDefined_getsLumoAsTheme_preserveVariant() {
+        Mockito.when(classFinder.getAnnotatedClasses(Route.class))
+                .thenReturn(Collections.singleton(ThemeVariantOnly.class));
+
+        FrontendDependencies dependencies = new FrontendDependencies(
+                classFinder, false);
+
+        Assert.assertEquals("Faulty default theme received", FakeLumo.class,
+                dependencies.getThemeDefinition().getTheme());
+        Assert.assertEquals("Faulty variant received", "dark",
+                dependencies.getThemeDefinition().getVariant());
+
+    }
+
     @Theme(FakeLumo.class)
     public static class MyApp extends Component {
     }
@@ -281,6 +296,10 @@ public class FrontendDependenciesTest {
 
     @Theme(themeFolder = "my-theme", value = MyLumoTheme.class)
     public static class OkClassExtension extends Component {
+    }
+
+    @Theme(variant = "dark")
+    public static class ThemeVariantOnly extends Component {
     }
 
     public static class MyComponent extends Component {


### PR DESCRIPTION
If Theme annotation specifies a variant but not theme name or class, the production build applies the default Lumo theme but without the variant. This change makes the variant work even when theme name or class are not specified.

Fixes #15638