### PR TITLE
chore: Correct spelling mistake in `ApplicationConfiguration` exception message

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ApplicationConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ApplicationConfiguration.java
@@ -52,7 +52,7 @@ public interface ApplicationConfiguration extends AbstractConfiguration {
                         + Lookup.class.getSimpleName()
                         + " instance is not found in "
                         + VaadinContext.class.getSimpleName()
-                        + ". The instance is suppoed to be created by a ServletContainerInitializer. Issues known to cause this problem are:\n"
+                        + ". The instance is supposed to be created by a ServletContainerInitializer. Issues known to cause this problem are:\n"
                         + "- A Spring Boot application deployed as a war-file but the main application class does not extend SpringBootServletInitializer\n"
                         + "- An embedded server that is not set up to execute ServletContainerInitializers\n"
                         + "- Unit tests which do not properly set up the context for the test\n");


### PR DESCRIPTION
## Description

Corrects a small spelling mistake in the message for an exception in `ApplicationConfiguration::get`.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.