### PR TITLE
fix: Interpret a directory import as an import for index.js in the directory (#15005) (CP: 2.8)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -446,19 +446,32 @@ abstract class AbstractUpdateImports implements Runnable {
      */
     private File getImportedFrontendFile(String jsImport) {
         // file is in /frontend
-        File file = getFile(frontendDir, jsImport);
+        File file = getJsImportFile(frontendDir, jsImport);
         if (file.exists()) {
             return file;
         }
         // file is a flow resource e.g.
         // /node_modules/@vaadin/flow-frontend/gridConnector.js
-        file = getFile(new File(getNodeModulesDir(), NODE_MODULES),
-                FLOW_NPM_PACKAGE_NAME, jsImport);
+        file = getJsImportFile(
+                getFile(new File(getNodeModulesDir(), NODE_MODULES),
+                        FLOW_NPM_PACKAGE_NAME),
+                jsImport);
         return file.exists() ? file : null;
     }
 
     private File getNodeModulesDir() {
         return new File(npmDir, NODE_MODULES);
+    }
+
+    private File getJsImportFile(File base, String path) {
+        File file = getFile(base, path);
+
+        if (file.isDirectory()) {
+            // import './foo' seems to be valid according to tools when 'foo' is
+            // a directory. What is imported is 'foo/index.js'.
+            file = new File(file, "index.js");
+        }
+        return file;
     }
 
     private File getFile(File base, String... path) {

--- a/flow-tests/test-frontend/vite-basics/frontend/a-directory/index.js
+++ b/flow-tests/test-frontend/vite-basics/frontend/a-directory/index.js
@@ -1,0 +1,1 @@
+document.getElementById('directoryImportResult').innerText = 'Directory import ok';

--- a/flow-tests/test-frontend/vite-basics/frontend/importdir.js
+++ b/flow-tests/test-frontend/vite-basics/frontend/importdir.js
@@ -1,0 +1,1 @@
+import './a-directory'

--- a/flow-tests/test-root-context/frontend/a-directory/index.js
+++ b/flow-tests/test-root-context/frontend/a-directory/index.js
@@ -1,0 +1,8 @@
+import { LitElement, html } from 'lit';
+
+export class ADirectoryComponent extends LitElement {
+  render() {
+    return html`Directory import ok`;
+  }
+}
+customElements.define('a-directory-component', ADirectoryComponent);

--- a/flow-tests/test-root-context/frontend/importdir.js
+++ b/flow-tests/test-root-context/frontend/importdir.js
@@ -1,0 +1,1 @@
+import './a-directory'

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/frontend/DirectoryImportView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/frontend/DirectoryImportView.java
@@ -1,0 +1,22 @@
+package com.vaadin.flow.uitest.ui.frontend;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+@JsModule("./importdir.js")
+@Route(value = "com.vaadin.flow.uitest.ui.frontend.DirectoryImportView", layout = ViewTestLayout.class)
+public class DirectoryImportView extends Div {
+
+    @Tag("a-directory-component")
+    public static class DirectoryComponent extends Component {
+
+    }
+
+    public DirectoryImportView() {
+        add(new DirectoryComponent());
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/frontend/DirectoryImportIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/frontend/DirectoryImportIT.java
@@ -1,0 +1,19 @@
+package com.vaadin.flow.uitest.ui.frontend;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+import com.vaadin.testbench.TestBenchElement;
+
+public class DirectoryImportIT extends ChromeBrowserTest {
+
+    @Test
+    public void directoryImportWorks() {
+        open();
+
+        TestBenchElement component = $("a-directory-component").first();
+        Assert.assertEquals("Directory import ok", component.getText());
+    }
+
+}


### PR DESCRIPTION
This is only used by the theme import rewriter which traverses all imports. It does not actually affect which files are imported

Fixes #13347