### PR TITLE
fix: DevBundle used after clean-frontend goal

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuild.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuild.java
@@ -316,8 +316,16 @@ public class TaskRunDevBundleBuild implements FallibleCommand {
 
         if (packageJsonFile.exists()) {
             try {
-                return Json.parse(FileUtils.readFileToString(packageJsonFile,
-                        StandardCharsets.UTF_8));
+                final JsonObject packageJson = Json
+                        .parse(FileUtils.readFileToString(packageJsonFile,
+                                StandardCharsets.UTF_8));
+                if (!packageJson.hasKey(NodeUpdater.VAADIN_DEP_KEY)
+                        || !packageJson.getObject(NodeUpdater.VAADIN_DEP_KEY)
+                                .hasKey(NodeUpdater.HASH_KEY)) {
+                    updatePackageJsonWithDefaultDependencies(options,
+                            frontendDependencies, finder, packageJson);
+                }
+                return packageJson;
             } catch (IOException e) {
                 getLogger().warn("Failed to read package.json", e);
             }
@@ -329,6 +337,33 @@ public class TaskRunDevBundleBuild implements FallibleCommand {
             }
         }
         return null;
+    }
+
+    private static void updatePackageJsonWithDefaultDependencies(
+            Options options, FrontendDependenciesScanner frontendDependencies,
+            ClassFinder finder, JsonObject packageJson) {
+        // If we have executed flow:clean-frontend we will have an empty
+        // package.json with no hash field.
+        JsonObject defaultPackageJson = getDefaultPackageJson(options,
+                frontendDependencies, finder);
+
+        // Add dependencies as it should be enough to have the expected
+        // dependencies in the package.json
+        final JsonObject defaultDependencies = defaultPackageJson
+                .getObject(NodeUpdater.DEPENDENCIES);
+        for (String key : defaultDependencies.keys()) {
+            packageJson.getObject(NodeUpdater.DEPENDENCIES).put(key,
+                    defaultDependencies.getString(key));
+        }
+
+        // Add hash to package.json so we don't fail just because it is missing
+        final String hash = TaskUpdatePackages
+                .generatePackageJsonHash(packageJson);
+        if (!packageJson.hasKey(NodeUpdater.VAADIN_DEP_KEY)) {
+            packageJson.put(NodeUpdater.VAADIN_DEP_KEY, Json.createObject());
+        }
+        packageJson.getObject(NodeUpdater.VAADIN_DEP_KEY)
+                .put(NodeUpdater.HASH_KEY, hash);
     }
 
     protected static JsonObject getDefaultPackageJson(Options options,

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuildTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuildTest.java
@@ -221,6 +221,95 @@ public class TaskRunDevBundleBuildTest {
     }
 
     @Test
+    public void noPackageJsonHashAfterCleanFrontend_statsHasDefaultJsonPackages_noCompilationRequired()
+            throws IOException {
+
+        File packageJson = new File(temporaryFolder.getRoot(), "package.json");
+        packageJson.createNewFile();
+
+        FileUtils.write(packageJson, "{\n" + "  \"name\": \"no-name\",\n"
+                + "  \"license\": \"UNLICENSED\",\n" + "  \"dependencies\": {\n"
+                + "    \"@vaadin/router\": \"1.7.4\"" + "  },\n"
+                + "  \"devDependencies\": {\n" + "  }\n" + "}",
+                StandardCharsets.UTF_8);
+
+        final FrontendDependenciesScanner depScanner = Mockito
+                .mock(FrontendDependenciesScanner.class);
+        Mockito.when(depScanner.getPackages())
+                .thenReturn(Collections.singletonMap("@vaadin/text", "1.0.0"));
+
+        try (MockedStatic<FrontendUtils> utils = Mockito
+                .mockStatic(FrontendUtils.class)) {
+            utils.when(() -> FrontendUtils.getDevBundleFolder(Mockito.any()))
+                    .thenReturn(temporaryFolder.getRoot());
+            utils.when(() -> FrontendUtils
+                    .findBundleStatsJson(temporaryFolder.getRoot()))
+                    .thenReturn("{\n" + " \"npmModules\": {\n"
+                            + "  \"@vaadin/router\": \"1.7.4\",\n"
+                            + "  \"@vaadin/text\": \"1.0.0\",\n"
+                            + "  \"@polymer/polymer\": \"3.5.1\",\n"
+                            + "  \"@vaadin/common-frontend\": \"0.0.17\",\n"
+                            + "  \"@vaadin/router\": \"1.7.4\",\n"
+                            + "  \"construct-style-sheets-polyfill\": \"3.1.0\",\n"
+                            + "  \"lit\": \"2.6.1\"" + " },\n"
+                            + " \"entryScripts\": [\n"
+                            + "  \"VAADIN/build/indexhtml-aa31f040.js\"\n"
+                            + " ],\n"
+                            + " \"packageJsonHash\": \"af45419b27dcb44b875197df4347b97316cc8fa6055458223a73aedddcfe7cc6\"\n"
+                            + "}");
+
+            final boolean needsBuild = TaskRunDevBundleBuild
+                    .needsBuildInternal(options, depScanner, finder);
+            Assert.assertFalse(
+                    "Not missing npmPackage in stats.json should not require compilation",
+                    needsBuild);
+        }
+    }
+
+    @Test
+    public void noPackageJsonHashAfterCleanFrontend_statsMissingDefaultJsonPackages_compilationRequired()
+            throws IOException {
+
+        File packageJson = new File(temporaryFolder.getRoot(), "package.json");
+        packageJson.createNewFile();
+
+        FileUtils.write(packageJson, "{\n" + "  \"name\": \"no-name\",\n"
+                + "  \"license\": \"UNLICENSED\",\n" + "  \"dependencies\": {\n"
+                + "    \"@vaadin/router\": \"1.7.4\"" + "  },\n"
+                + "  \"devDependencies\": {\n" + "  }\n" + "}",
+                StandardCharsets.UTF_8);
+
+        final FrontendDependenciesScanner depScanner = Mockito
+                .mock(FrontendDependenciesScanner.class);
+        Mockito.when(depScanner.getPackages())
+                .thenReturn(Collections.singletonMap("@vaadin/text", "1.0.0"));
+
+        try (MockedStatic<FrontendUtils> utils = Mockito
+                .mockStatic(FrontendUtils.class)) {
+            utils.when(() -> FrontendUtils.getDevBundleFolder(Mockito.any()))
+                    .thenReturn(temporaryFolder.getRoot());
+            utils.when(() -> FrontendUtils
+                    .findBundleStatsJson(temporaryFolder.getRoot()))
+                    .thenReturn("{\n" + " \"npmModules\": {\n"
+                            + "  \"@vaadin/router\": \"1.7.4\",\n"
+                            + "  \"@vaadin/text\": \"1.0.0\",\n"
+                            + "  \"@polymer/polymer\": \"3.5.1\",\n"
+                            + "  \"@vaadin/common-frontend\": \"0.0.17\",\n },\n"
+                            + " \"entryScripts\": [\n"
+                            + "  \"VAADIN/build/indexhtml-aa31f040.js\"\n"
+                            + " ],\n"
+                            + " \"packageJsonHash\": \"af45419b27dcb44b875197df4347b97316cc8fa6055458223a73aedddcfe7cc6\"\n"
+                            + "}");
+
+            final boolean needsBuild = TaskRunDevBundleBuild
+                    .needsBuildInternal(options, depScanner, finder);
+            Assert.assertTrue(
+                    "Missing npmPackage in stats.json should require compilation",
+                    needsBuild);
+        }
+    }
+
+    @Test
     public void hashesMatch_packageJsonHasRange_statsHasFixed_noCompilationRequired()
             throws IOException {
 


### PR DESCRIPTION
Dev bundle should be used if possible
even after `clean-frontend` goal has been
executed.

Fixes #15707
