### PR TITLE
chore: Upgrade to vite plugin checker 0.5.4

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
@@ -14,7 +14,7 @@
     "@rollup/plugin-replace": "5.0.2",
     "@rollup/pluginutils": "5.0.2",
     "rollup-plugin-brotli": "3.1.0",
-    "vite-plugin-checker": "0.5.3",
+    "vite-plugin-checker": "0.5.4",
     "mkdirp": "1.0.4",
     "workbox-build": "6.5.4",
     "transform-ast": "2.4.4"


### PR DESCRIPTION
Now has only one websocket connection to Vite instead of two
