### PR TITLE
chore: Upgrade to vite plugin checker 0.5.4 (#15730) (CP: 23.3)

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
@@ -13,7 +13,7 @@
     "vite": "3.2.5",
     "@rollup/plugin-replace": "3.1.0",
     "rollup-plugin-brotli": "3.1.0",
-    "vite-plugin-checker": "0.5.1",
+    "vite-plugin-checker": "0.5.4",
     "mkdirp": "1.0.4",
     "workbox-build": "6.5.4",
     "@rollup/pluginutils": "4.1.0",


### PR DESCRIPTION
Now has only one websocket connection to Vite instead of two
