### PR TITLE
feat: Allow every component to have styles

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/Component.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Component.java
@@ -52,7 +52,7 @@ import com.vaadin.flow.shared.Registration;
  * @since 1.0
  */
 public abstract class Component
-        implements HasElement, AttachNotifier, DetachNotifier {
+        implements HasStyle, AttachNotifier, DetachNotifier {
 
     /**
      * Encapsulates data required for mapping a new component instance to an


### PR DESCRIPTION
All components are capable of having class names yet you must remember to implement `HasStyle` every time you create a new component or the class API is missing. The only known exception is a text node which cannot have classes. It is fine if this edge case, which is almost never used, throws an exception from the API