### PR TITLE
fix: forward messages asynchronously in Vite websocket proxy

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketProxy.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketProxy.java
@@ -52,15 +52,15 @@ public class ViteWebsocketProxy implements MessageHandler.Whole<String> {
     public ViteWebsocketProxy(Session browserSession, Integer vitePort)
             throws InterruptedException, ExecutionException {
         viteConnection = new ViteWebsocketConnection(vitePort,
-                browserSession.getNegotiatedSubprotocol(), msg -> {
-                    try {
-                        browserSession.getBasicRemote().sendText(msg);
-                        getLogger().debug("Message sent to browser: " + msg);
-                    } catch (Exception e) {
+                browserSession.getNegotiatedSubprotocol(),
+                msg -> browserSession.getAsyncRemote().sendText(msg, result -> {
+                    if (result.isOK()) {
+                        getLogger().debug("Message sent to browser: {}", msg);
+                    } else {
                         getLogger().debug("Error sending message to browser",
-                                e);
+                                result.getException());
                     }
-                }, () -> {
+                }), () -> {
                     try {
                         browserSession.close();
                     } catch (IOException e) {


### PR DESCRIPTION
## Description

Prevents deadlocks in Quarkus environments.

Fixes #15744

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
