### PR TITLE
dep: bump webdrivermanager from 5.3.1 to 5.3.2 (CP 23.2)

### DIFF
--- a/flow-tests/vaadin-spring-tests/pom.xml
+++ b/flow-tests/vaadin-spring-tests/pom.xml
@@ -130,6 +130,12 @@
             <artifactId>jaxb-runtime</artifactId>
             <version>2.3.7</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.2.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <maven.clean.plugin.version>3.2.0</maven.clean.plugin.version>
         <maven.exec.plugin.version>1.6.0</maven.exec.plugin.version>
         <testbench.version>8.1.4</testbench.version>
-        <webdrivermanager.version>5.3.0</webdrivermanager.version>
+        <webdrivermanager.version>5.3.2</webdrivermanager.version>
         <jetty.version>10.0.13</jetty.version>
         <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>
 


### PR DESCRIPTION
Manual CP of https://github.com/vaadin/flow/pull/15734