### PR TITLE
fix: Do not bring junit4 into all TestBench projects

### DIFF
--- a/flow-html-components-testbench/pom.xml
+++ b/flow-html-components-testbench/pom.xml
@@ -17,8 +17,9 @@
     <dependencies>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-testbench-core</artifactId>
+            <artifactId>vaadin-testbench-shared</artifactId>
             <version>${testbench.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>


### PR DESCRIPTION
Use the same dependency as flow-components
