### PR TITLE
fix: Allow Gradle builds to use custom sourcesets (#15739) (CP: 9.0)

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/AbstractGradleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/AbstractGradleTest.kt
@@ -27,7 +27,7 @@ import java.io.File
  */
 abstract class AbstractGradleTest {
 
-    val flowVersion = System.getenv("vaadin.version").takeUnless { it.isNullOrEmpty() } ?: "10.0-SNAPSHOT"
+    val flowVersion = System.getenv("vaadin.version").takeUnless { it.isNullOrEmpty() } ?: "9.0-SNAPSHOT"
 
     /**
      * The testing Gradle project. Automatically deleted after every test.

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
@@ -65,7 +65,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
             """
             plugins {
                 id 'war'
-                id 'org.gretty' version '3.0.1'
+                id 'org.gretty' version '3.0.5'
                 id("com.vaadin")
             }
             repositories {
@@ -99,7 +99,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
             """
             plugins {
                 id 'war'
-                id 'org.gretty' version '3.0.1'
+                id 'org.gretty' version '3.0.5'
                 id("com.vaadin")
             }
             repositories {
@@ -314,7 +314,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
             """
             plugins {
                 id 'war'
-                id 'org.gretty' version '3.0.1'
+                id 'org.gretty' version '3.0.5'
                 id("com.vaadin")
             }
             repositories {
@@ -562,7 +562,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
         """.trimIndent()
         )
 
-        val build: BuildResult = testProject.build("-Pvaadin.productionMode", "build")
+        val build: BuildResult = testProject.build("build")
         build.expectTaskSucceded("vaadinPrepareFrontend")
         build.expectTaskSucceded("vaadinBuildFrontend")
 

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
@@ -489,7 +489,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
             """
             plugins {
                 id 'java'
-                id 'org.springframework.boot' version '2.7.6'
+                id 'org.springframework.boot' version '2.2.4.RELEASE'
                 id 'io.spring.dependency-management' version '1.0.11.RELEASE'
                 id("com.vaadin")
             }

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
@@ -564,6 +564,6 @@ class MiscSingleModuleTest : AbstractGradleTest() {
         build.expectTaskSucceded("vaadinBuildFrontend")
 
         val jar: File = testProject.builtJar
-        expectArchiveContainsVaadinBundle(jar, true)
+        expectArchiveContainsVaadinWebpackBundle(jar, true)
     }
 }

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
@@ -473,4 +473,97 @@ class MiscSingleModuleTest : AbstractGradleTest() {
             classpath.map { it.removeSuffix("-SNAPSHOT.jar").dropLastWhile { it != '-' } }
         }
     }
+
+    @Test
+    fun testUsingNonMainSourceSet() {
+        testProject.settingsFile.writeText(
+            """
+            pluginManagement {
+                repositories {
+                  gradlePluginPortal()
+                }
+              }
+            """
+        )
+        testProject.buildFile.writeText(
+            """
+            plugins {
+                id 'java'
+                id 'org.springframework.boot' version '2.7.6'
+                id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+                id("com.vaadin")
+            }
+            
+            repositories {
+                mavenLocal()
+                mavenCentral()
+                maven { url 'https://maven.vaadin.com/vaadin-prereleases' }
+            }
+            
+            sourceSets {
+                ui {
+                    java
+                }
+                main {
+                    java {
+                        compileClasspath += ui.output
+                        runtimeClasspath += ui.output + ui.runtimeClasspath
+                    }
+                }
+            }
+            
+            vaadin {
+                productionMode = true
+                sourceSetName = 'ui'
+            }
+            
+            dependencies {
+                uiImplementation('com.vaadin:flow:$flowVersion')
+                implementation('org.springframework.boot:spring-boot-starter-web')
+            }
+            
+            jar {
+                enabled = false
+            }
+            """
+        )
+
+        testProject.newFile(
+            "src/main/java/com/example/demo/DemoApplication.java", """
+            package com.example.demo;
+            
+            import org.springframework.boot.SpringApplication;
+            import org.springframework.boot.autoconfigure.SpringBootApplication;
+            
+            @SpringBootApplication
+            public class DemoApplication {
+            
+                public static void main(String[] args) {
+                    SpringApplication.run(DemoApplication.class, args);
+                }
+            
+            }
+        """.trimIndent()
+        )
+
+        testProject.newFile(
+            "src/ui/java/com/example/demo/AppShell.java", """
+            package com.example.demo;
+            
+            import com.vaadin.flow.component.page.AppShellConfigurator;
+            import com.vaadin.flow.server.PWA;
+
+            @PWA(name = "Demo application", shortName = "Demo")
+            public class AppShell implements AppShellConfigurator {
+            }
+        """.trimIndent()
+        )
+
+        val build: BuildResult = testProject.build("build")
+        build.expectTaskSucceded("vaadinPrepareFrontend")
+        build.expectTaskSucceded("vaadinBuildFrontend")
+
+        val jar: File = testProject.builtJar
+        expectArchiveContainsVaadinBundle(jar, true)
+    }
 }

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
@@ -221,7 +221,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
     fun testSpringProjectProductionMode() {
 
         val springBootVersion = "2.2.4.RELEASE"
-        val springVersion = "17.0-SNAPSHOT"
+        val springVersion = "19.0-SNAPSHOT"
 
         testProject.buildFile.writeText(
             """
@@ -490,7 +490,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
             plugins {
                 id 'java'
                 id 'org.springframework.boot' version '2.2.4.RELEASE'
-                id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+                id 'io.spring.dependency-management' version '1.0.9.RELEASE'
                 id("com.vaadin")
             }
             
@@ -524,6 +524,9 @@ class MiscSingleModuleTest : AbstractGradleTest() {
             
             jar {
                 enabled = false
+            }
+            bootJar {
+                duplicatesStrategy = DuplicatesStrategy.EXCLUDE
             }
             """
         )
@@ -559,7 +562,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
         """.trimIndent()
         )
 
-        val build: BuildResult = testProject.build("build")
+        val build: BuildResult = testProject.build("-Pvaadin.productionMode", "build")
         build.expectTaskSucceded("vaadinPrepareFrontend")
         build.expectTaskSucceded("vaadinBuildFrontend")
 

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/TestUtils.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/TestUtils.kt
@@ -235,7 +235,7 @@ class TestProject {
         .withPluginClasspath()
         .withDebug(true) // use --debug to catch ReflectionsException: https://github.com/vaadin/vaadin-gradle-plugin/issues/99
         .forwardOutput()   // a must, otherwise ./gradlew check freezes on windows!
-        .withGradleVersion("5.0")
+        .withGradleVersion("5.1")
 
     override fun toString(): String = "TestProject(dir=$dir)"
 

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
@@ -321,7 +321,7 @@ public open class VaadinFlowPluginExtension(project: Project) {
             "nodeVersion=$nodeVersion, " +
             "nodeDownloadRoot=$nodeDownloadRoot, " +
             "nodeAutoUpdate=$nodeAutoUpdate" +
-            "resourceOutputDirectory=$resourceOutputDirectory" +
+            "resourceOutputDirectory=$resourceOutputDirectory, " +
             "sourceSetName=$sourceSetName, " +
             "dependencyScope=$dependencyScope, " +
             "processResourcesTaskName=$processResourcesTaskName" +

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
@@ -281,7 +281,7 @@ public open class VaadinFlowPluginExtension(project: Project) {
             processResourcesTaskName = if (sourceSetName == "main") {
                 "processResources"
             } else {
-                "process${sourceSetName.replaceFirstChar(Char::titlecase)}Resources"
+                "process${sourceSetName.capitalize()}Resources"
             }
         }
 

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinPlugin.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinPlugin.kt
@@ -48,10 +48,10 @@ public class VaadinPlugin : Plugin<Project> {
 
             // add a new source-set folder for generated stuff, by default `vaadin-generated`
             val sourceSets: SourceSetContainer = it.properties["sourceSets"] as SourceSetContainer
-            sourceSets.getByName("main").resources.srcDirs(extension.resourceOutputDirectory)
+            sourceSets.getByName(extension.sourceSetName).resources.srcDirs(extension.resourceOutputDirectory)
 
             // auto-activate tasks: https://github.com/vaadin/vaadin-gradle-plugin/issues/48
-            project.tasks.getByPath("processResources").dependsOn("vaadinPrepareFrontend")
+            project.tasks.getByPath(extension.processResourcesTaskName!!).dependsOn("vaadinPrepareFrontend")
             if (extension.productionMode) {
                 // this will also catch the War task since it extends from Jar
                 project.tasks.withType(Jar::class.java) { task: Jar ->

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinPrepareFrontendTask.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinPrepareFrontendTask.kt
@@ -33,17 +33,18 @@ public open class VaadinPrepareFrontendTask : DefaultTask() {
         group = "Vaadin"
         description = "checks that node and npm tools are installed, copies frontend resources available inside `.jar` dependencies to `node_modules`, and creates or updates `package.json` and `webpack.config.json` files."
 
+        val extension: VaadinFlowPluginExtension = VaadinFlowPluginExtension.get(project)
         // Maven's task run in the LifecyclePhase.PROCESS_RESOURCES phase
 
         // the processResources copies stuff from build/vaadin-generated
         // (which is populated by this task) and therefore must run after this task.
-        project.tasks.getByName("processResources").mustRunAfter("vaadinPrepareFrontend")
+        project.tasks.getByName(extension.processResourcesTaskName!!).mustRunAfter("vaadinPrepareFrontend")
 
         // make sure all dependent projects have finished building their jars, otherwise
         // the Vaadin classpath scanning will not work properly. See
         // https://github.com/vaadin/vaadin-gradle-plugin/issues/38
         // for more details.
-        dependsOn(project.configurations.runtimeClasspath.jars)
+        dependsOn(project.configurations.getByName(extension.dependencyScope!!).jars)
     }
 
     @TaskAction

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinUtils.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinUtils.kt
@@ -75,12 +75,6 @@ internal fun VaadinFlowPluginExtension.createFrontendTools(): FrontendTools {
 }
 
 /**
- * Returns the "runtimeClasspath" file collection.
- */
-internal val ConfigurationContainer.runtimeClasspath: Configuration
-    get() = getByName("runtimeClasspath")
-
-/**
  * Returns only jar files from given file collection.
  */
 internal val Configuration.jars: FileCollection


### PR DESCRIPTION
When a sourceset other than `main` is used for holding classes using Vaadin components, or for providing a resolution scope for Vaadin dependencies, the `prepareVaadinFrontend` task does not correctly extract the correct Node libraries required by those classes, and the `buildVaadinFrontend` task subsequently fails to complete due to Vite requiring those Node dependencies to have been extracted into the project so failing to find all of its front-end dependencies.

The `VaadinFlowPluginExtension` is being altered to include a `sourceSetName` field, that defaults to `main` for backwards compatibility but allows users to specify a custom sourceset to use for the prepare and build tasks. As the use of a custom sourceset generally implies that different Gradle tasks will be executed for operating on those sourcesets, and a different dependency scope generated for the custom sourceset, fields have also been added to the extension that allow users to override the values the plugin uses, whilst the default values follow the Gradle conventions for both `main` and non-`main` sourcesets.

Fixes #15738