### PR TITLE
fix: Make routes work with native Spring

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -69,6 +69,12 @@
             <artifactId>license-checker</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>${spring.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>com.vaadin.external.gwt</groupId>

--- a/flow-server/src/main/java/com/vaadin/flow/router/Route.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/Route.java
@@ -22,6 +22,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 import com.vaadin.flow.component.UI;
@@ -53,6 +54,7 @@ import com.vaadin.flow.server.VaadinContext;
 @Inherited
 @Documented
 @Component
+@Scope("prototype")
 public @interface Route {
 
     String NAMING_CONVENTION = "___NAMING_CONVENTION___";

--- a/flow-server/src/main/java/com/vaadin/flow/router/Route.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/Route.java
@@ -22,6 +22,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.stereotype.Component;
+
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.router.internal.RouteUtil;
 import com.vaadin.flow.server.VaadinContext;
@@ -37,6 +39,8 @@ import com.vaadin.flow.server.VaadinContext;
  * <p>
  * There is also {@link RouteAlias} annotation which may be declared in addition
  * to this annotation and may be used multiple times.
+ * <p>
+ * The annotated class is a Spring component, when used together with Spring.
  *
  * @see RouteAlias
  * @see RoutePrefix
@@ -48,6 +52,7 @@ import com.vaadin.flow.server.VaadinContext;
 @Target(ElementType.TYPE)
 @Inherited
 @Documented
+@Component
 public @interface Route {
 
     String NAMING_CONVENTION = "___NAMING_CONVENTION___";


### PR DESCRIPTION
Marks routes as Spring components. The annotation is ignored when Spring is not available on the classpath
