### PR TITLE
fix: use .ts instead of .js

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrap.java
@@ -41,7 +41,7 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.INDEX_TSX;
 public class TaskGenerateBootstrap extends AbstractTaskClientGenerator {
 
     static final String DEV_TOOLS_IMPORT = String.format(
-            "import '%svaadin-dev-tools.js';%n",
+            "import '%svaadin-dev-tools.ts';%n",
             FrontendUtils.JAR_RESOURCES_IMPORT + "vaadin-dev-tools/");
     private final FrontendDependenciesScanner frontDeps;
     private final Options options;

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrapTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrapTest.java
@@ -49,7 +49,7 @@ public class TaskGenerateBootstrapTest {
 
     private static final String DEV_TOOLS_IMPORT = "import '"
             + FrontendUtils.JAR_RESOURCES_IMPORT
-            + "vaadin-dev-tools/vaadin-dev-tools.js';";
+            + "vaadin-dev-tools/vaadin-dev-tools.ts';";
 
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();


### PR DESCRIPTION
vaadin-dev-tools is now a ts file
and not a js file.
reflect this in the generated bootstrap.
