### PR TITLE
chore: update TB to 9.0.0.alpha7

### DIFF
--- a/flow-test-util/src/main/java/com/vaadin/flow/testutil/DevToolsWrapper.java
+++ b/flow-test-util/src/main/java/com/vaadin/flow/testutil/DevToolsWrapper.java
@@ -28,7 +28,7 @@ import org.openqa.selenium.devtools.SeleniumCdpConnection;
 import org.openqa.selenium.devtools.idealized.Domains;
 import org.openqa.selenium.devtools.idealized.target.model.SessionID;
 import org.openqa.selenium.devtools.idealized.target.model.TargetID;
-import org.openqa.selenium.devtools.v106.network.Network;
+import org.openqa.selenium.devtools.v109.network.Network;
 import org.openqa.selenium.remote.Augmenter;
 import org.openqa.selenium.remote.RemoteWebDriver;
 

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <maven.resources.plugin.version>3.0.2</maven.resources.plugin.version>
         <maven.clean.plugin.version>3.2.0</maven.clean.plugin.version>
         <maven.exec.plugin.version>1.6.0</maven.exec.plugin.version>
-        <testbench.version>9.0.0.alpha6</testbench.version>
+        <testbench.version>9.0.0.alpha7</testbench.version>
         <webdrivermanager.version>5.3.2</webdrivermanager.version>
         <jetty.version>11.0.13</jetty.version>
         <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>


### PR DESCRIPTION

in selenium 4.8.0. `Chrome DevTools support is now: v107, v108, and v109` 
[selenium 4.8.0 release blog](https://www.selenium.dev/blog/2023/selenium-4-8-0-released/)