### PR TITLE
fix: Use correct SecurityContextRepository for stateless authentication

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -15,8 +15,8 @@
  */
 package com.vaadin.flow.spring.security;
 
-import javax.crypto.SecretKey;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.LinkedHashMap;
 import java.util.Objects;
 import java.util.Optional;
@@ -24,10 +24,8 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import jakarta.servlet.ServletContext;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import javax.crypto.SecretKey;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
@@ -41,6 +39,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer;
 import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
 import org.springframework.security.config.annotation.web.configurers.LogoutConfigurer;
+import org.springframework.security.config.annotation.web.configurers.SessionManagementConfigurer;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.context.SecurityContextHolderStrategy;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
@@ -54,6 +53,7 @@ import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.security.web.authentication.logout.SimpleUrlLogoutSuccessHandler;
+import org.springframework.security.web.context.SecurityContextRepository;
 import org.springframework.security.web.csrf.CsrfException;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 import org.springframework.security.web.savedrequest.RequestCache;
@@ -64,16 +64,17 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.web.context.WebApplicationContext;
 
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.UI;
-import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.internal.AnnotationReader;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.internal.RouteUtil;
 import com.vaadin.flow.server.HandlerHelper;
-import com.vaadin.flow.server.VaadinContext;
 import com.vaadin.flow.server.VaadinServletContext;
 import com.vaadin.flow.server.auth.ViewAccessChecker;
 import com.vaadin.flow.spring.security.stateless.VaadinStatelessSecurityConfigurer;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Provides basic Vaadin component-based security configuration for the project.
@@ -513,6 +514,17 @@ public abstract class VaadinWebSecurity {
         VaadinStatelessSecurityConfigurer<HttpSecurity> vaadinStatelessSecurityConfigurer = new VaadinStatelessSecurityConfigurer<>();
         vaadinStatelessSecurityConfigurer.setSharedObjects(http);
         http.apply(vaadinStatelessSecurityConfigurer);
+
+        // Workaround
+        // https://github.com/spring-projects/spring-security/issues/12579 until
+        // it is released
+        SessionManagementConfigurer sessionManagementConfigurer = http
+                .getConfigurer(SessionManagementConfigurer.class);
+        Field f = SessionManagementConfigurer.class
+                .getDeclaredField("sessionManagementSecurityContextRepository");
+        f.setAccessible(true);
+        f.set(sessionManagementConfigurer,
+                http.getSharedObject(SecurityContextRepository.class));
 
         vaadinStatelessSecurityConfigurer.withSecretKey().secretKey(secretKey)
                 .and().issuer(issuer).expiresIn(expiresIn);

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -511,6 +511,7 @@ public abstract class VaadinWebSecurity {
             SecretKey secretKey, String issuer, long expiresIn)
             throws Exception {
         VaadinStatelessSecurityConfigurer<HttpSecurity> vaadinStatelessSecurityConfigurer = new VaadinStatelessSecurityConfigurer<>();
+        vaadinStatelessSecurityConfigurer.setSharedObjects(http);
         http.apply(vaadinStatelessSecurityConfigurer);
 
         vaadinStatelessSecurityConfigurer.withSecretKey().secretKey(secretKey)

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/stateless/VaadinStatelessSecurityConfigurer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/stateless/VaadinStatelessSecurityConfigurer.java
@@ -26,9 +26,11 @@ import org.springframework.security.authentication.AuthenticationTrustResolver;
 import org.springframework.security.authentication.AuthenticationTrustResolverImpl;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.HttpSecurityBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.config.annotation.web.configurers.SecurityContextConfigurer;
+import org.springframework.security.config.annotation.web.configurers.SessionManagementConfigurer;
 import org.springframework.security.oauth2.jose.jws.JwsAlgorithm;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.web.context.SecurityContextRepository;
@@ -82,21 +84,16 @@ public final class VaadinStatelessSecurityConfigurer<H extends HttpSecurityBuild
 
     private SecretKeyConfigurer secretKeyConfigurer;
 
+    public void setSharedObjects(HttpSecurity http) {
+        JwtSecurityContextRepository jwtSecurityContextRepository = new JwtSecurityContextRepository(
+                new SerializedJwtSplitCookieRepository());
+        http.setSharedObject(SecurityContextRepository.class,
+                jwtSecurityContextRepository);
+    }
+
     @Override
     @SuppressWarnings("unchecked")
     public void init(H http) {
-        JwtSecurityContextRepository jwtSecurityContextRepository = new JwtSecurityContextRepository(
-                new SerializedJwtSplitCookieRepository());
-        SecurityContextConfigurer<H> securityContext = http
-                .getConfigurer(SecurityContextConfigurer.class);
-        if (securityContext != null) {
-            securityContext
-                    .securityContextRepository(jwtSecurityContextRepository);
-        } else {
-            http.setSharedObject(SecurityContextRepository.class,
-                    jwtSecurityContextRepository);
-        }
-
         CsrfConfigurer<H> csrf = http.getConfigurer(CsrfConfigurer.class);
         if (csrf != null) {
             // Use cookie for storing CSRF token, as it does not require a
@@ -112,7 +109,6 @@ public final class VaadinStatelessSecurityConfigurer<H extends HttpSecurityBuild
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public void configure(H http) {
         SecurityContextRepository securityContextRepository = http
                 .getSharedObject(SecurityContextRepository.class);


### PR DESCRIPTION
The shared objects need to be available when other configurers are run and because of https://github.com/spring-projects/spring-security/issues/12579 a workaround is needed to actually apply the correct SecurityContextRepository

Fixes https://github.com/vaadin/hilla/issues/681