### PR TITLE
fix: pwa charset

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PwaHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PwaHandler.java
@@ -108,7 +108,8 @@ public class PwaHandler implements RequestHandler {
         requestHandlerMap.put(
                 pwaRegistry.getPwaConfiguration().relManifestPath(),
                 (session, request, response) -> {
-                    response.setContentType("application/manifest+json");
+                    response.setContentType(
+                            "application/manifest+json;charset=utf-8");
                     try (PrintWriter writer = response.getWriter()) {
                         writer.write(pwaRegistry.getManifestJson());
                     }


### PR DESCRIPTION
Set pwa character set to utf-8
instead of the default iso encoding

Fixes #15834
