### PR TITLE
fix: Enable style injection again in express build mode

### DIFF
--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
@@ -108,7 +108,6 @@ export const injectGlobalCss = (css, target, first) => {
  */
 function generateThemeFile(themeFolder, themeName, themeProperties, options) {
   const productionMode = !options.devMode;
-  const useDevServer = !options.useDevBundle;
   const styles = resolve(themeFolder, stylesCssFile);
   const document = resolve(themeFolder, documentCssFile);
   const autoInjectComponents = themeProperties.autoInjectComponents ?? true;
@@ -159,9 +158,9 @@ function generateThemeFile(themeFolder, themeName, themeProperties, options) {
   // styles.css will always be available as we write one if it doesn't exist.
   let filename = basename(styles);
   let variable = camelCase(filename);
-  if (useDevServer) {
-    imports.push(`import ${variable} from 'themes/${themeName}/${filename}?inline';\n`);
-  }
+
+  imports.push(`import ${variable} from 'themes/${themeName}/${filename}?inline';\n`);
+
   /* Lumo must be first so that custom styles override Lumo styles */
   const lumoImports = themeProperties.lumoImports || ['color', 'typography'];
   if (lumoImports && lumoImports.length > 0) {
@@ -174,9 +173,8 @@ function generateThemeFile(themeFolder, themeName, themeProperties, options) {
     });
   }
 
-  if (useDevServer) {
-    globalCssCode.push(`injectGlobalCss(${variable}.toString(), target);\n    `);
-  }
+  globalCssCode.push(`injectGlobalCss(${variable}.toString(), target);\n    `);
+
   if (existsSync(document)) {
     filename = basename(document);
     variable = camelCase(filename);

--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -50,7 +50,6 @@ const themeProjectFolders = projectStaticAssetsFolders.map((folder) => path.reso
 
 const themeOptions = {
   devMode: false,
-  useDevBundle: devBundle,
   // The following matches folder 'frontend/generated/themes/'
   // (not 'frontend/themes') for theme in JAR that is copied there
   themeResourceFolder: path.resolve(themeResourceFolder, settings.themeFolder),


### PR DESCRIPTION
## Description

It doesn't make sense to disable styles injection for theme generator in express build mode. There is no harm if the dev bundle contains all needed injections, this is a feature instead. This makes embedded components styling work with express build, but still the theme should be handled separately from bundle to have a hot deploy for embedded apps.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
