### PR TITLE
feat: offline mode

### DIFF
--- a/flow-client/src/main/frontend/Flow.ts
+++ b/flow-client/src/main/frontend/Flow.ts
@@ -7,6 +7,7 @@ import {
 
 export interface FlowConfig {
   imports?: () => void;
+  offlineMode?: boolean;
 }
 
 class FlowUiInitializationError extends Error {}
@@ -146,7 +147,7 @@ export class Flow {
       // Store last action pathname so as we can check it in events
       this.pathname = params.pathname;
 
-      if ($wnd.Vaadin.connectionState.online) {
+      if (this.config.offlineMode || $wnd.Vaadin.connectionState.online) {
         try {
           await this.flowInit();
         } catch (error) {


### PR DESCRIPTION
## Description

This PR allows Vaadin apps to work offline; without checking the connection state.

Offline flag cannot be implemented as other servlet init parameters because that information is required **before** doing first servlet init request.

ConnectionIndicator is still visible and reacts for connection state changes which can be confusing for users.

Fixes #13616

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
