### PR TITLE
fix: rename stats dependencies

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuild.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuild.java
@@ -357,7 +357,8 @@ public class TaskRunDevBundleBuild implements FallibleCommand {
             return false;
         }
 
-        JsonObject bundleModules = statsJson.getObject("npmModules");
+        JsonObject bundleModules = statsJson
+                .getObject("packageJsonDependencies");
 
         // Check that bundle modules contains all package dependencies
         if (packageJsonHash.equals(bundlePackageJsonHash)) {

--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -247,8 +247,8 @@ function statsExtracterPlugin(): PluginOption {
       }
 
       const stats = {
-        npmModules: projectPackageJson.dependencies,
-        handledModules: npmModuleAndVersion,
+        packageJsonDependencies: projectPackageJson.dependencies,
+        npmModules: npmModuleAndVersion,
         bundleImports: generatedImports,
         frontendHashes: frontendFiles,
         themeJsonHashes: themeJsonHashes,

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuildTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuildTest.java
@@ -31,7 +31,7 @@ public class TaskRunDevBundleBuildTest {
     public static final String BLANK_PACKAGE_JSON_WITH_HASH = "{\n \"dependencies\": {},"
             + "\"vaadin\": { \"hash\": \"a5\"} \n}";
 
-    public static final String NPM_MODULES = "npmModules";
+    public static final String PACKAGE_JSON_DEPENDENCIES = "packageJsonDependencies";
     public static final String ENTRY_SCRIPTS = "entryScripts";
     public static final String BUNDLE_IMPORTS = "bundleImports";
     public static final String FRONTEND_HASHES = "frontendHashes";
@@ -55,24 +55,25 @@ public class TaskRunDevBundleBuildTest {
     private JsonObject getBasicStats() {
         JsonObject stats = Json.createObject();
 
-        JsonObject npmModules = Json.createObject();
+        JsonObject packageJsonDependencies = Json.createObject();
         JsonObject frontendHashes = Json.createObject();
         JsonObject themeJsonHashes = Json.createObject();
 
         JsonArray entryScripts = Json.createArray();
         JsonArray bundleImports = Json.createArray();
 
-        stats.put(NPM_MODULES, npmModules);
+        stats.put(PACKAGE_JSON_DEPENDENCIES, packageJsonDependencies);
         stats.put(ENTRY_SCRIPTS, entryScripts);
         stats.put(BUNDLE_IMPORTS, bundleImports);
         stats.put(FRONTEND_HASHES, frontendHashes);
         stats.put(THEME_JSON_HASHES, themeJsonHashes);
         stats.put(PACKAGE_JSON_HASH, "aHash");
 
-        // Add default npmModules
+        // Add default packageJson dependencies
         for (Map.Entry<String, String> dependency : NodeUpdater
                 .getDefaultDependencies().entrySet()) {
-            npmModules.put(dependency.getKey(), dependency.getValue());
+            packageJsonDependencies.put(dependency.getKey(),
+                    dependency.getValue());
         }
 
         return stats;
@@ -124,7 +125,8 @@ public class TaskRunDevBundleBuildTest {
                 .thenReturn(Collections.emptyMap());
 
         JsonObject stats = getBasicStats();
-        stats.getObject(NPM_MODULES).put("@vaadin/router", "1.7.4");
+        stats.getObject(PACKAGE_JSON_DEPENDENCIES).put("@vaadin/router",
+                "1.7.4");
 
         try (MockedStatic<FrontendUtils> utils = Mockito
                 .mockStatic(FrontendUtils.class)) {
@@ -161,7 +163,8 @@ public class TaskRunDevBundleBuildTest {
         Mockito.when(depScanner.getPackages()).thenReturn(packages);
 
         JsonObject stats = getBasicStats();
-        stats.getObject(NPM_MODULES).put("@vaadin/router", "1.7.4");
+        stats.getObject(PACKAGE_JSON_DEPENDENCIES).put("@vaadin/router",
+                "1.7.4");
 
         try (MockedStatic<FrontendUtils> utils = Mockito
                 .mockStatic(FrontendUtils.class)) {
@@ -196,7 +199,8 @@ public class TaskRunDevBundleBuildTest {
                 .thenReturn(Collections.emptyMap());
 
         JsonObject stats = getBasicStats();
-        stats.getObject(NPM_MODULES).put("@vaadin/router", "1.7.4");
+        stats.getObject(PACKAGE_JSON_DEPENDENCIES).put("@vaadin/router",
+                "1.7.4");
 
         try (MockedStatic<FrontendUtils> utils = Mockito
                 .mockStatic(FrontendUtils.class)) {
@@ -231,8 +235,9 @@ public class TaskRunDevBundleBuildTest {
                 .thenReturn(Collections.singletonMap("@vaadin/text", "1.0.0"));
 
         JsonObject stats = getBasicStats();
-        stats.getObject(NPM_MODULES).put("@vaadin/router", "1.7.4");
-        stats.getObject(NPM_MODULES).put("@vaadin/text", "1.0.0");
+        stats.getObject(PACKAGE_JSON_DEPENDENCIES).put("@vaadin/router",
+                "1.7.4");
+        stats.getObject(PACKAGE_JSON_DEPENDENCIES).put("@vaadin/text", "1.0.0");
 
         try (MockedStatic<FrontendUtils> utils = Mockito
                 .mockStatic(FrontendUtils.class)) {
@@ -271,8 +276,9 @@ public class TaskRunDevBundleBuildTest {
         Mockito.when(depScanner.getPackages()).thenReturn(packages);
 
         JsonObject stats = getBasicStats();
-        stats.getObject(NPM_MODULES).put("@vaadin/router", "1.9.2");
-        stats.getObject(NPM_MODULES).put("@vaadin/text", "2.1.0");
+        stats.getObject(PACKAGE_JSON_DEPENDENCIES).put("@vaadin/router",
+                "1.9.2");
+        stats.getObject(PACKAGE_JSON_DEPENDENCIES).put("@vaadin/text", "2.1.0");
 
         try (MockedStatic<FrontendUtils> utils = Mockito
                 .mockStatic(FrontendUtils.class)) {
@@ -309,8 +315,9 @@ public class TaskRunDevBundleBuildTest {
                 .thenReturn(Collections.singletonMap("@vaadin/text", "1.0.0"));
 
         JsonObject stats = getBasicStats();
-        stats.getObject(NPM_MODULES).put("@vaadin/router", "1.7.4");
-        stats.getObject(NPM_MODULES).put("@vaadin/text", "1.0.0");
+        stats.getObject(PACKAGE_JSON_DEPENDENCIES).put("@vaadin/router",
+                "1.7.4");
+        stats.getObject(PACKAGE_JSON_DEPENDENCIES).put("@vaadin/text", "1.0.0");
         stats.put(PACKAGE_JSON_HASH,
                 "af45419b27dcb44b875197df4347b97316cc8fa6055458223a73aedddcfe7cc6");
         stats.getArray(ENTRY_SCRIPTS).set(0,
@@ -351,7 +358,8 @@ public class TaskRunDevBundleBuildTest {
                 .thenReturn(Collections.singletonMap("@vaadin/text", "1.0.0"));
 
         JsonObject stats = getBasicStats();
-        stats.getObject(NPM_MODULES).put("@vaadin/router", "1.7.4");
+        stats.getObject(PACKAGE_JSON_DEPENDENCIES).put("@vaadin/router",
+                "1.7.4");
 
         try (MockedStatic<FrontendUtils> utils = Mockito
                 .mockStatic(FrontendUtils.class)) {
@@ -387,7 +395,8 @@ public class TaskRunDevBundleBuildTest {
                 .thenReturn(Collections.emptyMap());
 
         JsonObject stats = getBasicStats();
-        stats.getObject(NPM_MODULES).put("@vaadin/router", "1.7.4");
+        stats.getObject(PACKAGE_JSON_DEPENDENCIES).put("@vaadin/router",
+                "1.7.4");
 
         try (MockedStatic<FrontendUtils> utils = Mockito
                 .mockStatic(FrontendUtils.class)) {
@@ -423,7 +432,8 @@ public class TaskRunDevBundleBuildTest {
                 .thenReturn(Collections.emptyMap());
 
         JsonObject stats = getBasicStats();
-        stats.getObject(NPM_MODULES).put("@vaadin/router", "1.7.6");
+        stats.getObject(PACKAGE_JSON_DEPENDENCIES).put("@vaadin/router",
+                "1.7.6");
 
         try (MockedStatic<FrontendUtils> utils = Mockito
                 .mockStatic(FrontendUtils.class)) {
@@ -439,7 +449,8 @@ public class TaskRunDevBundleBuildTest {
                     "No compilation if tilde range only patch update",
                     needsBuild);
 
-            stats.getObject(NPM_MODULES).put("@vaadin/router", "1.8.1");
+            stats.getObject(PACKAGE_JSON_DEPENDENCIES).put("@vaadin/router",
+                    "1.8.1");
             utils.when(() -> FrontendUtils
                     .findBundleStatsJson(temporaryFolder.getRoot()))
                     .thenReturn(stats.toJson());
@@ -470,7 +481,8 @@ public class TaskRunDevBundleBuildTest {
                 .thenReturn(Collections.emptyMap());
 
         JsonObject stats = getBasicStats();
-        stats.getObject(NPM_MODULES).put("@vaadin/router", "1.8.6");
+        stats.getObject(PACKAGE_JSON_DEPENDENCIES).put("@vaadin/router",
+                "1.8.6");
 
         try (MockedStatic<FrontendUtils> utils = Mockito
                 .mockStatic(FrontendUtils.class)) {
@@ -486,7 +498,8 @@ public class TaskRunDevBundleBuildTest {
                     "No compilation if caret range only minor version update",
                     needsBuild);
 
-            stats.getObject(NPM_MODULES).put("@vaadin/router", "2.0.0");
+            stats.getObject(PACKAGE_JSON_DEPENDENCIES).put("@vaadin/router",
+                    "2.0.0");
             utils.when(() -> FrontendUtils
                     .findBundleStatsJson(temporaryFolder.getRoot()))
                     .thenReturn(stats.toJson());
@@ -513,8 +526,9 @@ public class TaskRunDevBundleBuildTest {
                 .getString(NodeUpdater.HASH_KEY);
 
         JsonObject stats = getBasicStats();
-        stats.getObject(NPM_MODULES).put("@vaadin/router", "1.7.4");
-        stats.getObject(NPM_MODULES).put("@vaadin/text", "1.0.0");
+        stats.getObject(PACKAGE_JSON_DEPENDENCIES).put("@vaadin/router",
+                "1.7.4");
+        stats.getObject(PACKAGE_JSON_DEPENDENCIES).put("@vaadin/text", "1.0.0");
         stats.put(PACKAGE_JSON_HASH, defaultHash);
 
         try (MockedStatic<FrontendUtils> utils = Mockito
@@ -547,7 +561,8 @@ public class TaskRunDevBundleBuildTest {
                 .getString(NodeUpdater.HASH_KEY);
 
         JsonObject stats = getBasicStats();
-        stats.getObject(NPM_MODULES).put("@vaadin/router", "1.7.4");
+        stats.getObject(PACKAGE_JSON_DEPENDENCIES).put("@vaadin/router",
+                "1.7.4");
         stats.put(PACKAGE_JSON_HASH, defaultHash);
 
         try (MockedStatic<FrontendUtils> utils = Mockito
@@ -580,7 +595,8 @@ public class TaskRunDevBundleBuildTest {
                 .getString(NodeUpdater.HASH_KEY);
 
         JsonObject stats = getBasicStats();
-        stats.getObject(NPM_MODULES).put("@vaadin/router", "1.7.4");
+        stats.getObject(PACKAGE_JSON_DEPENDENCIES).put("@vaadin/router",
+                "1.7.4");
         stats.put(PACKAGE_JSON_HASH, defaultHash);
 
         try (MockedStatic<FrontendUtils> utils = Mockito
@@ -619,7 +635,8 @@ public class TaskRunDevBundleBuildTest {
                 .singletonList("@polymer/paper-checkbox/paper-checkbox.js"));
 
         JsonObject stats = getBasicStats();
-        stats.getObject(NPM_MODULES).put("@vaadin/router", "1.8.6");
+        stats.getObject(PACKAGE_JSON_DEPENDENCIES).put("@vaadin/router",
+                "1.8.6");
         JsonArray bundleImports = stats.getArray(BUNDLE_IMPORTS);
         bundleImports.set(0,
                 "@Frontend/generated/jar-resources/dndConnector-es6.js");
@@ -663,7 +680,8 @@ public class TaskRunDevBundleBuildTest {
                 .singletonList("@polymer/paper-checkbox/paper-checkbox.js"));
 
         JsonObject stats = getBasicStats();
-        stats.getObject(NPM_MODULES).put("@vaadin/router", "1.8.6");
+        stats.getObject(PACKAGE_JSON_DEPENDENCIES).put("@vaadin/router",
+                "1.8.6");
         JsonArray bundleImports = stats.getArray(BUNDLE_IMPORTS);
         bundleImports.set(0, "@polymer/paper-checkbox/paper-checkbox.js");
         bundleImports.set(1, "@polymer/paper-input/paper-input.js");
@@ -709,7 +727,8 @@ public class TaskRunDevBundleBuildTest {
                 .thenReturn(new NodeTestComponents.LumoTest());
 
         JsonObject stats = getBasicStats();
-        stats.getObject(NPM_MODULES).put("@vaadin/router", "1.8.6");
+        stats.getObject(PACKAGE_JSON_DEPENDENCIES).put("@vaadin/router",
+                "1.8.6");
         JsonArray bundleImports = stats.getArray(BUNDLE_IMPORTS);
         bundleImports.set(0, "@polymer/paper-checkbox/paper-checkbox.js");
         bundleImports.set(1, "@polymer/paper-input/paper-input.js");
@@ -753,7 +772,8 @@ public class TaskRunDevBundleBuildTest {
                         "Frontend/generated/jar-resources/TodoTemplate.js"));
 
         JsonObject stats = getBasicStats();
-        stats.getObject(NPM_MODULES).put("@vaadin/router", "1.8.6");
+        stats.getObject(PACKAGE_JSON_DEPENDENCIES).put("@vaadin/router",
+                "1.8.6");
         stats.getArray(BUNDLE_IMPORTS).set(0,
                 "Frontend/generated/jar-resources/TodoTemplate.js");
         stats.getObject(FRONTEND_HASHES).put("TodoTemplate.js",
@@ -797,7 +817,8 @@ public class TaskRunDevBundleBuildTest {
                         "Frontend/generated/jar-resources/TodoTemplate.js"));
 
         JsonObject stats = getBasicStats();
-        stats.getObject(NPM_MODULES).put("@vaadin/router", "1.8.6");
+        stats.getObject(PACKAGE_JSON_DEPENDENCIES).put("@vaadin/router",
+                "1.8.6");
         stats.getArray(BUNDLE_IMPORTS).set(0,
                 "Frontend/generated/jar-resources/TodoTemplate.js");
 
@@ -838,7 +859,8 @@ public class TaskRunDevBundleBuildTest {
                         "Frontend/generated/jar-resources/TodoTemplate.js"));
 
         JsonObject stats = getBasicStats();
-        stats.getObject(NPM_MODULES).put("@vaadin/router", "1.8.6");
+        stats.getObject(PACKAGE_JSON_DEPENDENCIES).put("@vaadin/router",
+                "1.8.6");
         stats.getArray(BUNDLE_IMPORTS).set(0,
                 "Frontend/generated/jar-resources/TodoTemplate.js");
         stats.getObject(FRONTEND_HASHES).put("TodoTemplate.js",


### PR DESCRIPTION
package dependencies have
new name and vite handled
dependencies go to npmModules

Closes #15871
