### PR TITLE
fix: make application-theme-plugin type module

### DIFF
--- a/flow-server/src/main/resources/plugins/application-theme-plugin/application-theme-plugin.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/application-theme-plugin.js
@@ -14,7 +14,7 @@
  * the License.
  */
 
-import { processThemeResources, extractThemeName, findParentThemes } from './theme-handle';
+import { processThemeResources, extractThemeName, findParentThemes } from './theme-handle.js';
 
 /**
  * The application theme plugin is for generating, collecting and copying of theme files for the application theme.

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/package.json
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/package.json
@@ -13,6 +13,7 @@
   "bugs": {
     "url": "https://github.com/vaadin/flow/issues"
   },
+  "type": "module",
   "dependencies": {
     "mkdirp": "0.5.6",
     "glob": "7.2.3"

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-copy.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-copy.js
@@ -20,8 +20,11 @@
 
 import { readdirSync, statSync, mkdirSync, existsSync, copyFileSync } from 'fs';
 import { resolve, basename, relative, extname } from 'path';
-import { sync } from 'glob';
-import { sync as mkdirpSync } from 'mkdirp';
+import glob from 'glob';
+import mkdirp from 'mkdirp';
+
+const { sync } = glob;
+const { sync: mkdirpSync } = mkdirp;
 
 const ignoredFileExtensions = ['.css', '.js', '.json'];
 

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
@@ -18,10 +18,12 @@
  * This file handles the generation of the '[theme-name].js' to
  * the themes/[theme-name] folder according to properties from 'theme.json'.
  */
-import { sync } from 'glob';
+import glob from 'glob';
 import { resolve, basename } from 'path';
 import { existsSync, writeFileSync } from 'fs';
-import { checkModules } from './theme-copy';
+import { checkModules } from './theme-copy.js';
+
+const { sync } = glob;
 
 // Special folder inside a theme for component themes that go inside the component shadow root
 const themeComponentsFolder = 'components';

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-handle.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-handle.js
@@ -20,8 +20,8 @@
  */
 import { existsSync, writeFileSync, readFileSync } from 'fs';
 import { resolve } from 'path';
-import { generateThemeFile } from './theme-generator';
-import { copyStaticAssets, copyThemeResources } from './theme-copy';
+import { generateThemeFile } from './theme-generator.js';
+import { copyStaticAssets, copyThemeResources } from './theme-copy.js';
 
 // matches theme name in './theme-my-theme.generated.js'
 const nameRegex = /theme-(.*)\.generated\.js/;


### PR DESCRIPTION
## Description

Since https://github.com/vaadin/flow/pull/15535 the `application-theme-plugin` package should be marked to include ES modules

## Type of change

Bugfix