### PR TITLE
chore: clarify inactive session closing log messages

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -1269,7 +1269,8 @@ public abstract class VaadinService implements Serializable {
             if (session.getState() == VaadinSessionState.OPEN) {
                 closeSession(session);
                 if (session.getSession() != null) {
-                    getLogger().debug("Closing inactive session {}",
+                    getLogger().debug(
+                            "Closing inactive Vaadin session bound to HTTP session {}",
                             session.getSession().getId());
                 }
             }


### PR DESCRIPTION
When closing inactive VaadinSession the framework prints a log message stating that it is 'Closing inactive session  <SID>', but this message can be misunderstood, as it seems that the HTTP session will be closed. This change updates the log message to make it explicit that the framework is closing the Vaadin session.

Related to #15476