### PR TITLE
fix: Add reserved /VAADIN segment to the theme pattern

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -1661,7 +1661,9 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
         Element element = new Element("link");
         element.attr("rel", "stylesheet");
         element.attr("type", "text/css");
-        element.attr("href", "themes/" + themeName + "/" + fileName);
+        element.attr("href",
+                Constants.VAADIN_MAPPING + Constants.APPLICATION_THEME_ROOT
+                        + "/" + themeName + "/" + fileName);
         return element;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
@@ -65,9 +65,6 @@ import static com.vaadin.flow.server.Constants.VAADIN_WEBAPP_RESOURCES;
  */
 public class StaticFileServer implements StaticFileHandler {
     private static final String EXPRESS_MODE_BUNDLE_PATH_PREFIX = "/VAADIN/dev-bundle/";
-
-    private static final String APP_THEME_PATTERN = "/"
-            + Constants.VAADIN_MAPPING + Constants.APPLICATION_THEME_ROOT;
     static final String PROPERTY_FIX_INCORRECT_WEBJAR_PATHS = Constants.VAADIN_PREFIX
             + "fixIncorrectWebjarPaths";
     private static final Pattern INCORRECT_WEBJAR_PATH_REGEX = Pattern
@@ -78,7 +75,13 @@ public class StaticFileServer implements StaticFileHandler {
     private DeploymentConfiguration deploymentConfiguration;
     private DevModeHandler devModeHandler;
 
-    // Matcher to match string starting with '/themes/[theme-name]/'
+    // Matches paths to theme files referenced from link tags (e.g. styles
+    // .css or document.css)
+    private static final Pattern APP_THEME_PATTERN = Pattern
+            .compile("^\\/VAADIN\\/themes\\/([\\s\\S]+?)\\/");
+
+    // Matches paths to theme asset files referenced from CSS as an url() or
+    // from Java (e.g. new Image("themes/my-theme/...")
     public static final Pattern APP_THEME_ASSETS_PATTERN = Pattern
             .compile("^\\/themes\\/([\\s\\S]+?)\\/");
 
@@ -265,7 +268,9 @@ public class StaticFileServer implements StaticFileHandler {
                 resourceUrl = FrontendUtils.findBundleFile(
                         deploymentConfiguration.getProjectFolder(),
                         "webapp/" + filenameInsideBundle);
-            } else if (filenameWithPath.startsWith(APP_THEME_PATTERN)) {
+            } else if (APP_THEME_PATTERN.matcher(filenameWithPath).find()
+                    || APP_THEME_ASSETS_PATTERN.matcher(filenameWithPath)
+                            .find()) {
                 // Express mode theme file request
                 resourceUrl = findAssetInFrontendThemesOrDevBundle(
                         vaadinService,

--- a/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
@@ -79,7 +79,7 @@ public class StaticFileServer implements StaticFileHandler {
 
     // Matcher to match string starting with '/themes/[theme-name]/'
     public static final Pattern APP_THEME_PATTERN = Pattern
-            .compile("^\\/themes\\/([\\s\\S]+?)\\/");
+            .compile("^(?:\\/VAADIN)?\\/themes\\/([\\s\\S]+?)\\/");
 
     // Mapped uri is for the jar file
     static final Map<URI, Integer> openFileSystems = new HashMap<>();
@@ -323,11 +323,17 @@ public class StaticFileServer implements StaticFileHandler {
     }
 
     private static URL findAssetInFrontendThemesOrDevBundle(
-            VaadinService vaadinService, File projectFolder, String assetPath)
-            throws IOException {
+            VaadinService vaadinService, File projectFolder,
+            String fileNameWithPath) throws IOException {
         // First, look for the theme assets in the {project.root}/frontend/
         // themes/my-theme folder
         File frontendFolder = new File(projectFolder, FrontendUtils.FRONTEND);
+        String assetPath = fileNameWithPath;
+        if (fileNameWithPath.startsWith("/" + VAADIN_MAPPING)) {
+            int themesPathIndex = fileNameWithPath
+                    .indexOf("/" + Constants.APPLICATION_THEME_ROOT);
+            assetPath = fileNameWithPath.substring(themesPathIndex);
+        }
         File assetInFrontendThemes = new File(frontendFolder, assetPath);
         if (assetInFrontendThemes.exists()) {
             return assetInFrontendThemes.toURI().toURL();

--- a/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
@@ -1180,7 +1180,7 @@ public class StaticFileServerTest implements Serializable {
         Mockito.when(configuration.getProjectFolder())
                 .thenReturn(projectRootFolder);
 
-        setupRequestURI("", "", "/themes/my-theme/styles.css");
+        setupRequestURI("", "", "/VAADIN/themes/my-theme/styles.css");
         Assert.assertTrue(fileServer.serveStaticResource(request, response));
         Assert.assertEquals(styles, out.getOutputString());
     }
@@ -1198,7 +1198,7 @@ public class StaticFileServerTest implements Serializable {
         Mockito.when(configuration.getProjectFolder())
                 .thenReturn(projectRootFolder);
 
-        setupRequestURI("", "", "/themes/my-theme/styles.css");
+        setupRequestURI("", "", "/VAADIN/themes/my-theme/styles.css");
         Assert.assertTrue(fileServer.serveStaticResource(request, response));
         Assert.assertEquals(styles, out.getOutputString());
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
@@ -875,7 +875,7 @@ public class IndexHtmlRequestHandlerTest {
         Elements linkElements = document.head().getElementsByTag("link");
         assertEquals(1, linkElements.size());
         assertEquals("stylesheet", linkElements.get(0).attr("rel"));
-        assertEquals("themes/my-theme/styles.css",
+        assertEquals("VAADIN/themes/my-theme/styles.css",
                 linkElements.get(0).attr("href"));
     }
 

--- a/flow-tests/test-express-build/test-embedding-express-build/src/test/java/com/vaadin/flow/webcomponent/ApplicationThemeComponentIT.java
+++ b/flow-tests/test-express-build/test-embedding-express-build/src/test/java/com/vaadin/flow/webcomponent/ApplicationThemeComponentIT.java
@@ -107,16 +107,18 @@ public class ApplicationThemeComponentIT extends ChromeBrowserTest {
                 "Embedded style should not match external component",
                 "rgba(0, 0, 255, 1)",
                 $(SpanElement.class).id("overflow").getCssValue("color"));
-        getDriver().get(getRootURL() + "/themes/embedded-theme/img/bg.jpg");
+        getDriver()
+                .get(getRootURL() + "/VAADIN/themes/embedded-theme/img/bg.jpg");
         Assert.assertFalse("app-theme background file should be served",
-                driver.getPageSource().contains("Could not navigate"));
+                driver.getPageSource().contains("Could not navigate") || driver
+                        .getPageSource().contains("Error 404 Not Found"));
     }
 
     private void validateEmbeddedComponent(TestBenchElement themedComponent,
             String target) {
         String imageUrl = themedComponent.getCssValue("background-image");
         Assert.assertTrue(target + " didn't contain the background image",
-                imageUrl.contains("/themes/embedded-theme/img/bg.jpg"));
+                imageUrl.contains("VAADIN/themes/embedded-theme/img/bg.jpg"));
 
         final TestBenchElement embeddedComponent = themedComponent
                 .$(DivElement.class).id(EMBEDDED_ID);
@@ -136,7 +138,7 @@ public class ApplicationThemeComponentIT extends ChromeBrowserTest {
         List<TestBenchElement> links = themedComponent.$("link").all();
         Assert.assertEquals(1, links.size());
         Assert.assertTrue(links.get(0).getAttribute("href")
-                .contains("/themes/embedded-theme/styles.css"));
+                .contains("VAADIN/themes/embedded-theme/styles.css"));
     }
 
     @Test
@@ -213,7 +215,7 @@ public class ApplicationThemeComponentIT extends ChromeBrowserTest {
                 .findElements(By.tagName("link"));
         Assert.assertEquals(1, links.size());
         Assert.assertTrue(links.get(0).getAttribute("href")
-                .contains("/themes/embedded-theme/document.css"));
+                .contains("VAADIN/themes/embedded-theme/document.css"));
     }
 
 }

--- a/flow-tests/test-express-build/test-theme-dev-bundle/src/test/java/com/vaadin/flow/devbuild/DevBundleThemeIT.java
+++ b/flow-tests/test-express-build/test-theme-dev-bundle/src/test/java/com/vaadin/flow/devbuild/DevBundleThemeIT.java
@@ -19,6 +19,7 @@ package com.vaadin.flow.devbuild;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import net.jcip.annotations.NotThreadSafe;
 import org.apache.commons.io.FileUtils;
@@ -58,8 +59,10 @@ public class DevBundleThemeIT extends ChromeBrowserTest {
 
     @After
     public void cleanUp() {
-        doActionAndWaitUntilLiveReloadComplete(
-                () -> changeBackgroundColor(GREEN_COLOR, RED_COLOR));
+        if (isCustomBackGroundColor()) {
+            doActionAndWaitUntilLiveReloadComplete(
+                    () -> changeBackgroundColor(GREEN_COLOR, RED_COLOR));
+        }
     }
 
     @Test
@@ -88,6 +91,26 @@ public class DevBundleThemeIT extends ChromeBrowserTest {
         waitUntilImportedFrontendStyles();
 
         checkLogsForErrors();
+    }
+
+    @Test
+    public void noVaadinSegmentInTheURL_notFound() {
+        getDriver().get(getRootURL() + "/themes/my-theme/styles.css");
+        Assert.assertTrue("Theme requests without /VAADIN should not be served",
+                driver.getPageSource().contains("Error 404 Not Found"));
+    }
+
+    @Test
+    public void stylesCssLinkAddedToHead() {
+        open();
+
+        final WebElement documentHead = getDriver()
+                .findElement(By.xpath("/html/head"));
+        final List<WebElement> links = documentHead
+                .findElements(By.tagName("link"));
+        Assert.assertEquals(1, links.size());
+        Assert.assertTrue(links.get(0).getAttribute("href")
+                .contains("VAADIN/themes/my-theme/styles.css"));
     }
 
     private void waitUntilImportedFrontendStyles() {


### PR DESCRIPTION
Theme files in Express Build mode should be served with a pattern /VAADIN/themes/ like for the hot deploy mode with Vite.

Fixes https://github.com/vaadin/flow/issues/15915
