### PR TITLE
fix: consume parallel streams when fetching paginated data

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -33,6 +33,9 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.UI;
@@ -51,9 +54,6 @@ import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.internal.StateTree;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.shared.communication.PushMode;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import elemental.json.Json;
 import elemental.json.JsonArray;
@@ -996,8 +996,19 @@ public class DataCommunicator<T> implements Serializable {
                 int page = 0;
                 do {
                     final int newOffset = offset + page * pageSize;
-                    doFetchFromDataProvider(newOffset, pageSize)
-                            .forEach(addItemAndCheckConsumer);
+                    Stream<T> dataProviderStream = doFetchFromDataProvider(
+                            newOffset, pageSize);
+                    // Stream.Builder is not thread safe, so for parallel stream
+                    // we need to first collect items before adding them
+                    if (dataProviderStream.isParallel()) {
+                        getLogger().debug(
+                                "Data provider {} has returned parallel stream on 'fetch' call",
+                                getDataProvider().getClass());
+                        dataProviderStream.collect(Collectors.toList())
+                                .forEach(addItemAndCheckConsumer);
+                    } else {
+                        dataProviderStream.forEach(addItemAndCheckConsumer);
+                    }
                     page++;
                 } while (page < pages
                         && fetchedPerPage.getAndSet(0) == pageSize);


### PR DESCRIPTION
## Description

DataCommunicator internally uses a Stream.Builder to collect paginated data. but it fails it the DataProvider returns a parallel stream. This change consumes parallel streams before adding items to the builder.

Fixes #15881

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
