### PR TITLE
chore: add frontend dev setup to vaadin-dev-tools

### DIFF
--- a/vaadin-dev-server/README.md
+++ b/vaadin-dev-server/README.md
@@ -1,0 +1,20 @@
+# vaadin-dev-server
+
+## Using the local dev tool files in a Flow application
+
+In order to work iteratively on the dev tool UI, this project contains a frontend dev server setup that allows to use the local version of the dev tool files within an actual Flow app.
+The dev server supports hot module reload (HMR), which allows making changes to the dev tool without requiring to rebuild / restart the Flow app, or having to reload the page in the browser.
+
+First, start the Flow app that you want to develop the dev tool in, then patch the app to use the local files using:
+```shell
+npm run patch-app /path/to/flow-app
+```
+
+Then start the frontend dev server:
+```shell
+npm start
+```
+
+Open the Flow app in the browser and open the dev tool.
+Then start making changes to the local dev tools files (e.g. change a CSS style).
+Verify the changes are immediately reflected in the dev tool opened in the browser.

--- a/vaadin-dev-server/README.md
+++ b/vaadin-dev-server/README.md
@@ -1,17 +1,21 @@
 # vaadin-dev-server
 
-## Using the local dev tool files in a Flow application
+## Development
+
+### Using the local dev tool files in a Flow application
 
 In order to work iteratively on the dev tool UI, this project contains a frontend dev server setup that allows to use the local version of the dev tool files within an actual Flow app.
 The dev server supports hot module reload (HMR), which allows making changes to the dev tool without requiring to rebuild / restart the Flow app, or having to reload the page in the browser.
 
-First, start the Flow app that you want to develop the dev tool in, then patch the app to use the local files using:
+First, start the Flow app that you want to develop the dev tool in.
+Then patch the app to use the local files using:
 ```shell
 npm run patch-app /path/to/flow-app
 ```
 
 Then start the frontend dev server:
 ```shell
+npm install
 npm start
 ```
 

--- a/vaadin-dev-server/package.json
+++ b/vaadin-dev-server/package.json
@@ -1,0 +1,15 @@
+{
+  "scripts": {
+    "start": "web-dev-server --node-resolve",
+    "patch-app": "node patch-application.js"
+  },
+  "devDependencies": {
+    "@koa/cors": "^4.0.0",
+    "@open-wc/dev-server-hmr": "^0.1.2-next.0",
+    "@web/dev-server": "^0.1.35",
+    "@web/dev-server-esbuild": "^0.3.3"
+  },
+  "dependencies": {
+    "lit": "^2.6.1"
+  }
+}

--- a/vaadin-dev-server/patch-application.js
+++ b/vaadin-dev-server/patch-application.js
@@ -6,16 +6,17 @@ const path = require('path');
 
 // Verify that the script was passed a path to a Flow application
 const appPath = process.argv[2];
-
 if (!appPath) {
-  throw new Error("Missing application path argument. " +
-    "The patch-app script should be run as: npm run patch-app /path/to/flow-app");
+  throw new Error(
+    'Missing application path argument. The patch-app script should be run as: npm run patch-app /path/to/flow-app'
+  );
 }
 
-const generatedFrontendPath = path.join(appPath, 'frontend', 'generated');
-
-if (!fs.existsSync(generatedFrontendPath)) {
-  throw new Error(`Application path does not contain a ./frontend/generated directory: ${generatedFrontendPath}. Make sure to start the app first.`);
+const vaadinFilePath = path.join(appPath, 'frontend', 'generated', 'vaadin.ts');
+if (!fs.existsSync(vaadinFilePath)) {
+  throw new Error(
+    `Application path does not contain a ./frontend/generated directory: ${vaadinFilePath}. Make sure to start the app first.`
+  );
 }
 
 // Patch content of vaadin.ts to:
@@ -23,14 +24,16 @@ if (!fs.existsSync(generatedFrontendPath)) {
 // - add HMR script from @web/dev-server
 // - add the vaadin-dev-tools hosted by web-dev-server with HMR support
 const webDevServerUrl = 'http://localhost:8000';
-const vaadinFilePath = path.join(generatedFrontendPath, 'vaadin.ts');
-const vaadinFileContent = `
-import './vaadin-featureflags.ts';
-import './index';
-import { applyTheme } from './theme.js';
+const devToolsImport = "import 'Frontend/generated/jar-resources/vaadin-dev-tools.js';";
+const vaadinFileContent = fs.readFileSync(vaadinFilePath, 'utf8');
 
-applyTheme(document);
+const isPatched = vaadinFileContent.includes('__web-dev-server__web-socket.js');
+const hasDevToolsImport = vaadinFileContent.includes(devToolsImport);
 
+if (isPatched) {
+  console.log(`✅ ${vaadinFilePath} is already patched`);
+} else if (hasDevToolsImport) {
+  const patchContent = `
 const hmrScript = document.createElement("script");
 hmrScript.setAttribute("type", "module");
 hmrScript.setAttribute("src", "${webDevServerUrl}/__web-dev-server__web-socket.js");
@@ -42,6 +45,9 @@ devToolsScript.setAttribute("src", "${webDevServerUrl}/src/main/resources/META-I
 document.body.append(devToolsScript);
 `;
 
-fs.writeFileSync(vaadinFilePath, vaadinFileContent, 'utf8');
-
-console.log(`✅ Patched ${vaadinFilePath}`);
+  const patchedVaadinFileContent = vaadinFileContent.replace(devToolsImport, patchContent);
+  fs.writeFileSync(vaadinFilePath, patchedVaadinFileContent, 'utf8');
+  console.log(`✅ Patched ${vaadinFilePath}`);
+} else {
+  console.log(`❌ Failed to patch ${vaadinFilePath}. The file does not seem to contain an import for the dev tools.`);
+}

--- a/vaadin-dev-server/patch-application.js
+++ b/vaadin-dev-server/patch-application.js
@@ -1,0 +1,47 @@
+// Patches a Flow application's frontend to use the local vaadin-dev-tools, in
+// order to be able to work on the dev tools UI within an actual application
+// Usage: npm run patch-app /path/to/flow-app
+const fs = require('fs');
+const path = require('path');
+
+// Verify that the script was passed a path to a Flow application
+const appPath = process.argv[2];
+
+if (!appPath) {
+  throw new Error("Missing application path argument. " +
+    "The patch-app script should be run as: npm run patch-app /path/to/flow-app");
+}
+
+const generatedFrontendPath = path.join(appPath, 'frontend', 'generated');
+
+if (!fs.existsSync(generatedFrontendPath)) {
+  throw new Error(`Application path does not contain a ./frontend/generated directory: ${generatedFrontendPath}. Make sure to start the app first.`);
+}
+
+// Patch content of vaadin.ts to:
+// - exclude vaadin-dev-tools from classpath
+// - add HMR script from @web/dev-server
+// - add the vaadin-dev-tools hosted by web-dev-server with HMR support
+const webDevServerUrl = 'http://localhost:8000';
+const vaadinFilePath = path.join(generatedFrontendPath, 'vaadin.ts');
+const vaadinFileContent = `
+import './vaadin-featureflags.ts';
+import './index';
+import { applyTheme } from './theme.js';
+
+applyTheme(document);
+
+const hmrScript = document.createElement("script");
+hmrScript.setAttribute("type", "module");
+hmrScript.setAttribute("src", "${webDevServerUrl}/__web-dev-server__web-socket.js");
+document.body.append(hmrScript);
+
+const devToolsScript = document.createElement("script");
+devToolsScript.setAttribute("type", "module");
+devToolsScript.setAttribute("src", "${webDevServerUrl}/src/main/resources/META-INF/frontend/vaadin-dev-tools/vaadin-dev-tools.ts");
+document.body.append(devToolsScript);
+`;
+
+fs.writeFileSync(vaadinFilePath, vaadinFileContent, 'utf8');
+
+console.log(`✅ Patched ${vaadinFilePath}`);

--- a/vaadin-dev-server/web-dev-server.config.mjs
+++ b/vaadin-dev-server/web-dev-server.config.mjs
@@ -1,0 +1,26 @@
+import {fileURLToPath} from 'url';
+import {hmrPlugin, presets} from '@open-wc/dev-server-hmr';
+import {esbuildPlugin} from '@web/dev-server-esbuild';
+import cors from '@koa/cors';
+
+export default {
+  plugins: [
+    // Transpile TS to JS, using existing TS config
+    esbuildPlugin({
+      ts: true,
+      tsconfig: fileURLToPath(new URL('./tsconfig.json', import.meta.url)),
+    }),
+    // Enable hot module reload for dev tools components
+    hmrPlugin({
+      include: ['src/main/resources/META-INF/frontend/vaadin-dev-tools/**/*'],
+      presets: [presets.lit]
+    }),
+  ],
+  middleware: [
+    // Configure CORS so that local dev tools can be loaded from a Flow
+    // application, the app needs to run on port 8080
+    cors({
+      origin: 'http://localhost:8080'
+    })
+  ]
+};


### PR DESCRIPTION
## Description

Adds a frontend dev setup to the `vaadin-dev-tools` module in order to be able to work iteratively on the dev tools UI.

The setup includes a dev server that hosts the Typescript files for the dev tool UI, and provides hot module replacement functionality so that changes to the dev tool don't require a page reload. In order to use the local dev tool files in a Flow app, the setup includes a script that patches a Flow app to load the dev tool from the dev server instead of from the classpath.

Due to how the dev tool Lit component is constructed, changes to tab contents currently don't work correctly, but changes to the outer HTML or CSS should be visible. If this is merged I'll open a separate PR to refactor the component to make this work as well.