### PR TITLE
fix: ignore missing files in theme processing (#15896) (CP: 2.8)

### DIFF
--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-copy.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-copy.js
@@ -72,18 +72,22 @@ function collectFolders(folderToCopy, logger) {
   logger.trace("files in directory", fs.readdirSync(folderToCopy));
   fs.readdirSync(folderToCopy).forEach(file => {
     const fileToCopy = path.resolve(folderToCopy, file);
-    if (fs.statSync(fileToCopy).isDirectory()) {
-      logger.debug("Going through directory", fileToCopy);
-      const result = collectFolders(fileToCopy, logger);
-      if (result.files.length > 0) {
-        collection.directories.push(fileToCopy);
-        logger.debug("Adding directory", fileToCopy);
-        collection.directories.push.apply(collection.directories, result.directories);
-        collection.files.push.apply(collection.files, result.files);
+    try {
+      if (fs.statSync(fileToCopy).isDirectory()) {
+        logger.debug("Going through directory", fileToCopy);
+        const result = collectFolders(fileToCopy, logger);
+        if (result.files.length > 0) {
+          collection.directories.push(fileToCopy);
+          logger.debug("Adding directory", fileToCopy);
+          collection.directories.push.apply(collection.directories, result.directories);
+          collection.files.push.apply(collection.files, result.files);
+        }
+      } else if (!ignoredFileExtensions.includes(path.extname(fileToCopy))) {
+        logger.debug("Adding file", fileToCopy);
+        collection.files.push(fileToCopy);
       }
-    } else if (!ignoredFileExtensions.includes(path.extname(fileToCopy))) {
-      logger.debug("Adding file", fileToCopy);
-      collection.files.push(fileToCopy);
+    } catch (error) {
+      handleNoSuchFileError(fileToCopy, error, logger);
     }
   });
   return collection;
@@ -173,10 +177,26 @@ function checkModules(modules) {
  * @param {object} logger plugin logger
  */
 function copyFileIfAbsentOrNewer(fileToCopy, copyTarget, logger) {
-  if (!fs.existsSync(copyTarget) || fs.statSync(copyTarget).mtime < fs.statSync(fileToCopy).mtime) {
-    logger.trace("Copying: ", fileToCopy, '=>', copyTarget);
-    fs.copyFileSync(fileToCopy, copyTarget);
+  try {
+    if (!fs.existsSync(copyTarget) || fs.statSync(copyTarget).mtime < fs.statSync(fileToCopy).mtime) {
+      logger.trace("Copying: ", fileToCopy, '=>', copyTarget);
+      fs.copyFileSync(fileToCopy, copyTarget);
+    }
+  } catch (error) {
+    handleNoSuchFileError(fileToCopy, error, logger);
   }
+}
+
+// Ignores errors due to file missing during theme processing
+// This may happen for example when an IDE creates a temporary file
+// and then immediately deletes it
+function handleNoSuchFileError(file, error, logger) {
+    if (error.code === 'ENOENT') {
+        logger.warn('Ignoring not existing file ' + file +
+            '. File may have been deleted during theme processing.');
+    } else {
+        throw error;
+    }
 }
 
 module.exports = {checkModules, copyStaticAssets, copyThemeResources};


### PR DESCRIPTION
During theme processing, a file detected as existing may be delete before it gets copied, causing a ENOENT (No such file or directory) error. After such failure, dev server live reload stops working. This change catches errors in file copy operations, ignoring ENOENT and propagating other failures.

Fixes #13885