### PR TITLE
refactor: replace invalid CSS template literals in dev tool

### DIFF
--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/vaadin-dev-tools.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/vaadin-dev-tools.ts
@@ -211,11 +211,6 @@ export const popupStyles = css`
   }
 `;
 export class VaadinDevTools extends LitElement {
-  static BLUE_HSL = css`206, 100%, 70%`;
-  static GREEN_HSL = css`145, 80%, 42%`;
-  static GREY_HSL = css`0, 0%, 50%`;
-  static YELLOW_HSL = css`38, 98%, 64%`;
-  static RED_HSL = css`355, 100%, 68%`;
   static MAX_LOG_ROWS = 1000;
 
   static get styles() {
@@ -242,15 +237,15 @@ export class VaadinDevTools extends LitElement {
           --dev-tools-border-radius: 0.5rem;
           --dev-tools-box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.05), 0 4px 12px -2px rgba(0, 0, 0, 0.4);
 
-          --dev-tools-blue-hsl: ${this.BLUE_HSL};
+          --dev-tools-blue-hsl: 206, 100%, 70%;
           --dev-tools-blue-color: hsl(var(--dev-tools-blue-hsl));
-          --dev-tools-green-hsl: ${this.GREEN_HSL};
+          --dev-tools-green-hsl: 145, 80%, 42%;
           --dev-tools-green-color: hsl(var(--dev-tools-green-hsl));
-          --dev-tools-grey-hsl: ${this.GREY_HSL};
+          --dev-tools-grey-hsl: 0, 0%, 50%;
           --dev-tools-grey-color: hsl(var(--dev-tools-grey-hsl));
-          --dev-tools-yellow-hsl: ${this.YELLOW_HSL};
+          --dev-tools-yellow-hsl: 38, 98%, 64%;
           --dev-tools-yellow-color: hsl(var(--dev-tools-yellow-hsl));
-          --dev-tools-red-hsl: ${this.RED_HSL};
+          --dev-tools-red-hsl: 355, 100%, 68%;
           --dev-tools-red-color: hsl(var(--dev-tools-red-hsl));
 
           /* Needs to be in ms, used in JavaScript as well */
@@ -1358,15 +1353,15 @@ export class VaadinDevTools extends LitElement {
 
   getStatusColor(status: ConnectionStatus | undefined) {
     if (status === ConnectionStatus.ACTIVE) {
-      return css`hsl(${VaadinDevTools.GREEN_HSL})`;
+      return 'var(--dev-tools-green-color)';
     } else if (status === ConnectionStatus.INACTIVE) {
-      return css`hsl(${VaadinDevTools.GREY_HSL})`;
+      return 'var(--dev-tools-grey-color)';
     } else if (status === ConnectionStatus.UNAVAILABLE) {
-      return css`hsl(${VaadinDevTools.YELLOW_HSL})`;
+      return 'var(--dev-tools-yellow-hsl)';
     } else if (status === ConnectionStatus.ERROR) {
-      return css`hsl(${VaadinDevTools.RED_HSL})`;
+      return 'var(--dev-tools-red-color)';
     } else {
-      return css`none`;
+      return 'none';
     }
   }
 


### PR DESCRIPTION
## Description

Some of the CSS template literals don't contain valid CSS, which at least IntelliJ complains about:

<img width="343" alt="Bildschirmfoto 2023-02-21 um 10 18 09" src="https://user-images.githubusercontent.com/357820/220303666-ac1191e9-5b6c-42c3-884f-33d2bbb07894.png">

Apart from that the construct of putting HSL color values in a template literal is kind of weird. Let's put them into the CSS right away, and use CSS custom properties to reference them instead.

## Type of change

- Refactoring