### PR TITLE
feat: ThemeModifier support for DebugWindowConnection command

### DIFF
--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
@@ -82,6 +82,7 @@ public abstract class ClassesSerializableTest extends ClassFinder {
                 "com\\.vaadin\\.base\\.devserver\\.DevServerWatchDog\\$WatchDogServer",
                 "com\\.vaadin\\.base\\.devserver\\.IdeIntegration",
                 "com\\.vaadin\\.base\\.devserver\\.OpenInCurrentIde",
+                "com\\.vaadin\\.base\\.devserver\\.ThemeModifier",
                 "com\\.vaadin\\.base\\.devserver\\.util\\.BrowserLauncher",
                 "com\\.vaadin\\.base\\.devserver\\.util\\.net\\.PortProber",
                 "com\\.vaadin\\.base\\.devserver\\.util\\.net\\.FixedIANAPortRange",

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DebugWindowConnection.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DebugWindowConnection.java
@@ -70,6 +70,8 @@ public class DebugWindowConnection implements BrowserLiveReload {
 
     private IdeIntegration ideIntegration;
 
+    private ThemeModifier themeModifier;
+
     static {
         IDENTIFIER_CLASSES.put(Backend.JREBEL, Collections.singletonList(
                 "org.zeroturnaround.jrebel.vaadin.JRebelClassEventListener"));
@@ -89,6 +91,7 @@ public class DebugWindowConnection implements BrowserLiveReload {
         this.context = context;
         this.ideIntegration = new IdeIntegration(
                 ApplicationConfiguration.get(context));
+        this.themeModifier = new ThemeModifier(context);
     }
 
     @Override
@@ -239,6 +242,8 @@ public class DebugWindowConnection implements BrowserLiveReload {
                             "Only component locations are tracked. The given node id refers to an element and not a component");
                 }
             });
+        } else if ("themeEditorSetRule".equals(command)) {
+            themeModifier.handleDebugMessageData(data);
         } else {
             getLogger().info("Unknown command from the browser: " + command);
         }

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/ThemeModifier.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/ThemeModifier.java
@@ -1,0 +1,124 @@
+package com.vaadin.base.devserver;
+
+import com.helger.css.ECSSVersion;
+import com.helger.css.decl.*;
+import com.helger.css.reader.CSSReader;
+import com.helger.css.writer.CSSWriter;
+import com.vaadin.flow.server.VaadinContext;
+import com.vaadin.flow.server.frontend.FrontendUtils;
+import com.vaadin.flow.server.startup.ApplicationConfiguration;
+import elemental.json.JsonArray;
+import elemental.json.JsonObject;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class ThemeModifier {
+
+    private static final String THEME_EDITOR_CSS = "theme-editor.css";
+
+    private final String HEADER_TEXT = "This file has been created by Vaadin, please be concerned that\n"
+            + "manual changes may be overwritten while using ThemeEditor";
+
+    private VaadinContext context;
+
+    public ThemeModifier(VaadinContext context) {
+        this.context = context;
+    }
+
+    protected File getFrontendFolder() {
+        return new File(ApplicationConfiguration.get(context).getStringProperty(
+                FrontendUtils.PROJECT_BASEDIR, null), "frontend");
+    }
+
+    protected File getThemeEditorStyleSheet() {
+        File themes = new File(getFrontendFolder(), "themes");
+        String themeName = getThemeName(themes);
+        File theme = new File(themes, themeName);
+        File themeEditorStyles = new File(theme, THEME_EDITOR_CSS);
+
+        if (!themeEditorStyles.exists()) {
+            try {
+                if (!themeEditorStyles.createNewFile()) {
+                    throw new IllegalStateException(
+                            "Cannot create " + themeEditorStyles.getPath());
+                }
+            } catch (IOException e) {
+                throw new IllegalStateException(
+                        "Cannot create " + themeEditorStyles.getPath(), e);
+            }
+        }
+
+        return themeEditorStyles;
+    }
+
+    /**
+     * Sets CSS rule in theme-editor.css. If rule is already present -
+     * overwrites it.
+     */
+    public void setCssRule(String selector, String property, String value) {
+        File styles = getThemeEditorStyleSheet();
+        CascadingStyleSheet styleSheet = CSSReader.readFromFile(styles,
+                StandardCharsets.UTF_8, ECSSVersion.LATEST);
+
+        CSSStyleRule rule = parseStyleRule(selector, property, value);
+        removeRuleIfExists(styleSheet, rule);
+
+        styleSheet.addRule(rule);
+
+        try {
+            new CSSWriter().setWriteHeaderText(true).setHeaderText(HEADER_TEXT)
+                    .writeCSS(styleSheet, new FileWriter(styles));
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot write " + styles.getPath(),
+                    e);
+        }
+    }
+
+    private CSSStyleRule parseStyleRule(String selector, String property,
+            String value) {
+        return CSSReader
+                .readFromString(selector + "{" + property + ": " + value + "}",
+                        StandardCharsets.UTF_8, ECSSVersion.LATEST)
+                .getStyleRuleAtIndex(0);
+    }
+
+    protected void removeRuleIfExists(CascadingStyleSheet styleSheet,
+            CSSStyleRule rule) {
+        String propertyName = rule.getDeclarationAtIndex(0).getProperty();
+        styleSheet.getAllStyleRules().stream()
+                .filter(r -> r.getAllSelectors()
+                        .containsAll(rule.getAllSelectors()))
+                .filter(r -> r
+                        .getDeclarationOfPropertyName(propertyName) != null)
+                .findFirst().ifPresent(styleSheet::removeRule);
+    }
+
+    private String getThemeName(File themes) {
+        String[] themeFolders = themes.list();
+        if (themeFolders == null || themeFolders.length == 0) {
+            throw new IllegalStateException(
+                    "No theme folder found in " + themes.getAbsolutePath());
+        } else if (themeFolders.length > 1) {
+            throw new IllegalStateException("Multiple theme folders found in "
+                    + themes.getAbsolutePath()
+                    + ". I don't know which to update");
+        }
+
+        return themeFolders[0];
+    }
+
+    public void handleDebugMessageData(JsonObject data) {
+        // int uiId = (int) data.getNumber("uiId");
+        // int nodeId = (int) data.getNumber("nodeId");
+        JsonArray rules = data.getArray("rules");
+        for (int i = 0; i < rules.length(); ++i) {
+            JsonObject rule = rules.getObject(i);
+            setCssRule(rule.getString("selector"), rule.getString("property"),
+                    rule.getString("value"));
+        }
+    }
+
+}

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/ThemeModifierTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/ThemeModifierTest.java
@@ -1,0 +1,91 @@
+package com.vaadin.base.devserver;
+
+import com.vaadin.flow.testutil.TestUtils;
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.List;
+
+public class ThemeModifierTest {
+
+    private String FRONTEND_FOLDER = "themeeditor/META-INF/frontend";
+
+    private String SELECTOR_WITH_PART = "vaadin-text-field::part(label)";
+
+    private class TestThemeModifier extends ThemeModifier {
+
+        public TestThemeModifier() {
+            super(new MockVaadinContext());
+        }
+
+        @Override
+        protected File getFrontendFolder() {
+            return TestUtils.getTestFolder(FRONTEND_FOLDER);
+        }
+    }
+
+    @Before
+    public void removeThemeEditorCss() {
+        File themeFolder = TestUtils
+                .getTestFolder(FRONTEND_FOLDER + "/themes/my-theme");
+        File themeEditorCss = new File(themeFolder, "theme-editor.css");
+        if (themeEditorCss.exists()) {
+            themeEditorCss.delete();
+        }
+    }
+
+    @Test
+    public void ruleAdded_ruleIsPresent() {
+        ThemeModifier modifier = new TestThemeModifier();
+        modifier.setCssRule(SELECTOR_WITH_PART, "color", "red");
+        assertThemeEditorCssContains(SELECTOR_WITH_PART + " { color:red; }");
+    }
+
+    @Test
+    public void ruleExists_ruleIsUpdated() {
+        ThemeModifier modifier = new TestThemeModifier();
+        modifier.setCssRule(SELECTOR_WITH_PART, "color", "red");
+        modifier.setCssRule(SELECTOR_WITH_PART, "color", "blue");
+        assertThemeEditorCssNotContains(SELECTOR_WITH_PART + " { color:red; }");
+        assertThemeEditorCssContains(SELECTOR_WITH_PART + " { color:blue; }");
+    }
+
+    @Test
+    public void rulesWithSameSelectorExists_ruleIsUpdated() {
+        ThemeModifier modifier = new TestThemeModifier();
+        modifier.setCssRule(SELECTOR_WITH_PART, "color", "red");
+        modifier.setCssRule(SELECTOR_WITH_PART, "font-family", "serif");
+        modifier.setCssRule(SELECTOR_WITH_PART, "color", "blue");
+        assertThemeEditorCssNotContains(SELECTOR_WITH_PART + " { color:red; }");
+        assertThemeEditorCssContains(SELECTOR_WITH_PART + " { color:blue; }");
+        assertThemeEditorCssContains(
+                SELECTOR_WITH_PART + " { font-family:serif; }");
+    }
+
+    private void assertThemeEditorCssNotContains(String string) {
+        Assert.assertTrue(
+                getThemeEditorCssLines().stream().noneMatch(string::equals));
+    }
+
+    private void assertThemeEditorCssContains(String string) {
+        Assert.assertTrue(
+                getThemeEditorCssLines().stream().anyMatch(string::equals));
+    }
+
+    private List<String> getThemeEditorCssLines() {
+        File themeFolder = TestUtils
+                .getTestFolder(FRONTEND_FOLDER + "/themes/my-theme");
+        File themeEditorCss = new File(themeFolder, "theme-editor.css");
+        try {
+            return IOUtils.readLines(new FileReader(themeEditorCss));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/ThemeModifierTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/ThemeModifierTest.java
@@ -30,13 +30,45 @@ public class ThemeModifierTest {
     }
 
     @Before
-    public void removeThemeEditorCss() {
+    public void prepareFiles() throws IOException {
         File themeFolder = TestUtils
                 .getTestFolder(FRONTEND_FOLDER + "/themes/my-theme");
+        File stylesCss = new File(themeFolder, "styles.css");
+        if (stylesCss.exists()) {
+            stylesCss.delete();
+        }
+        stylesCss.createNewFile();
         File themeEditorCss = new File(themeFolder, "theme-editor.css");
         if (themeEditorCss.exists()) {
             themeEditorCss.delete();
         }
+    }
+
+    @Test
+    public void noImport_importPresent() {
+        String string = "@import \"theme-editor.css\";";
+        Assert.assertTrue(
+                getFileLines("styles.css").stream().noneMatch(string::equals));
+
+        ThemeModifier modifier = new TestThemeModifier();
+        modifier.setCssRule(SELECTOR_WITH_PART, "color", "red");
+
+        Assert.assertTrue(
+                getFileLines("styles.css").stream().anyMatch(string::equals));
+    }
+
+    @Test
+    public void multipleRulesAdded_singleImportPresent() {
+        String string = "@import \"theme-editor.css\";";
+        Assert.assertTrue(
+                getFileLines("styles.css").stream().noneMatch(string::equals));
+
+        ThemeModifier modifier = new TestThemeModifier();
+        modifier.setCssRule(SELECTOR_WITH_PART, "color", "red");
+        modifier.setCssRule(SELECTOR_WITH_PART, "font-family", "serif");
+
+        Assert.assertTrue(getFileLines("styles.css").stream()
+                .filter(string::equals).count() == 1);
     }
 
     @Test
@@ -68,19 +100,19 @@ public class ThemeModifierTest {
     }
 
     private void assertThemeEditorCssNotContains(String string) {
-        Assert.assertTrue(
-                getThemeEditorCssLines().stream().noneMatch(string::equals));
+        Assert.assertTrue(getFileLines("theme-editor.css").stream()
+                .noneMatch(string::equals));
     }
 
     private void assertThemeEditorCssContains(String string) {
-        Assert.assertTrue(
-                getThemeEditorCssLines().stream().anyMatch(string::equals));
+        Assert.assertTrue(getFileLines("theme-editor.css").stream()
+                .anyMatch(string::equals));
     }
 
-    private List<String> getThemeEditorCssLines() {
+    private List<String> getFileLines(String file) {
         File themeFolder = TestUtils
                 .getTestFolder(FRONTEND_FOLDER + "/themes/my-theme");
-        File themeEditorCss = new File(themeFolder, "theme-editor.css");
+        File themeEditorCss = new File(themeFolder, file);
         try {
             return IOUtils.readLines(new FileReader(themeEditorCss));
         } catch (IOException e) {


### PR DESCRIPTION
## Description
Added `ThemeModifier` that inserts or updates CSS rules in `theme-editor.css` of given theme. `@import "theme-editor.css";` is added automatically to `styles.css`.

Added support for `themeEditorSetRule` command of json object data structure:
```
var data = {
  rules: [
    {
      selector: 'vaadin-button::part(label)',
      property: 'color',
      value: 'red'
    },
    {
      selector: 'vaadin-text-field::part(label)',
      property: 'color',
      value: 'green'
    }
  ]
};
```

To send command use `Connection.send('themeEditorSetRule', data);`.

In general due to selectors complexity (normal part _vaadin-button_ and function part _::part(label)_) rule is parsed again by ph-css library using `selector {property: value}` string.