### PR TITLE
refactor: add theme metadata to dev tools

### DIFF
--- a/vaadin-dev-server/package.json
+++ b/vaadin-dev-server/package.json
@@ -1,15 +1,21 @@
 {
   "scripts": {
     "start": "web-dev-server --node-resolve",
+    "test": "web-test-runner --node-resolve",
     "patch-app": "node patch-application.js",
     "prettier": "prettier --write src/main/resources/META-INF/frontend/**/*.ts"
   },
   "devDependencies": {
+    "@esm-bundle/chai": "^4.3.4-fix.0",
     "@koa/cors": "^4.0.0",
     "@open-wc/dev-server-hmr": "^0.1.2-next.0",
+    "@types/chai": "^4.3.4",
+    "@types/sinon": "^10.0.13",
     "@web/dev-server": "^0.1.35",
     "@web/dev-server-esbuild": "^0.3.3",
-    "prettier": "^2.8.4"
+    "@web/test-runner": "^0.15.0",
+    "prettier": "^2.8.4",
+    "sinon": "^15.0.1"
   },
   "dependencies": {
     "lit": "^2.6.1"

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/components/vaadin-button.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/components/vaadin-button.ts
@@ -1,0 +1,62 @@
+import { ComponentMetadata } from '../model';
+
+export default {
+  tagName: 'vaadin-button',
+  displayName: 'Button',
+  parts: [
+    {
+      selector: '::part(label)',
+      displayName: 'Label',
+      properties: [
+        {
+          propertyName: 'color',
+          displayName: 'Text color'
+        },
+        {
+          propertyName: 'font-size',
+          displayName: 'Font size'
+        },
+        {
+          propertyName: 'background',
+          displayName: 'Background'
+        }
+      ]
+    },
+    {
+      selector: '::part(prefix)',
+      displayName: 'Prefix',
+      properties: [
+        {
+          propertyName: 'color',
+          displayName: 'Text color'
+        },
+        {
+          propertyName: 'font-size',
+          displayName: 'Font size'
+        },
+        {
+          propertyName: 'background',
+          displayName: 'Background'
+        }
+      ]
+    },
+    {
+      selector: '::part(suffix)',
+      displayName: 'Suffix',
+      properties: [
+        {
+          propertyName: 'color',
+          displayName: 'Text color'
+        },
+        {
+          propertyName: 'font-size',
+          displayName: 'Font size'
+        },
+        {
+          propertyName: 'background',
+          displayName: 'Background'
+        }
+      ]
+    }
+  ]
+} as ComponentMetadata;

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/components/vaadin-text-field.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/components/vaadin-text-field.ts
@@ -1,0 +1,80 @@
+import { ComponentMetadata } from '../model';
+
+export default {
+  tagName: 'vaadin-text-field',
+  displayName: 'TextField',
+  parts: [
+    {
+      selector: '::part(label)',
+      displayName: 'Label',
+      properties: [
+        {
+          propertyName: 'color',
+          displayName: 'Text color'
+        },
+        {
+          propertyName: 'font-size',
+          displayName: 'Font size'
+        },
+        {
+          propertyName: 'background',
+          displayName: 'Background'
+        }
+      ]
+    },
+    {
+      selector: '::part(input-field)',
+      displayName: 'Input field',
+      properties: [
+        {
+          propertyName: 'color',
+          displayName: 'Text color'
+        },
+        {
+          propertyName: 'font-size',
+          displayName: 'Font size'
+        },
+        {
+          propertyName: 'background',
+          displayName: 'Background'
+        }
+      ]
+    },
+    {
+      selector: '::part(helper-text)',
+      displayName: 'Helper text',
+      properties: [
+        {
+          propertyName: 'color',
+          displayName: 'Text color'
+        },
+        {
+          propertyName: 'font-size',
+          displayName: 'Font size'
+        },
+        {
+          propertyName: 'background',
+          displayName: 'Background'
+        }
+      ]
+    },
+    {
+      selector: '::part(error-message)',
+      displayName: 'Error message',
+      properties: [
+        {
+          propertyName: 'color',
+          displayName: 'Text color'
+        },
+        {
+          propertyName: 'font-size',
+          displayName: 'Font size'
+        },
+        {
+          propertyName: 'background',
+          displayName: 'Background'
+        }
+      ]
+    }
+  ]
+} as ComponentMetadata;

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/model.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/model.ts
@@ -1,0 +1,19 @@
+export interface CssPropertyMetadata {
+  propertyName: string;
+  displayName: string;
+  description?: string;
+}
+
+export interface ComponentPartMetadata {
+  selector: string;
+  displayName: string;
+  description?: string;
+  properties: CssPropertyMetadata[];
+}
+
+export interface ComponentMetadata {
+  tagName: string;
+  displayName: string;
+  description?: string;
+  parts: ComponentPartMetadata[];
+}

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/registry.test.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/registry.test.ts
@@ -1,0 +1,74 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { MetadataRegistry } from './registry';
+import { ComponentReference } from '../../component-util';
+
+describe('metadata-registry', () => {
+  let moduleLoaderSpy: sinon.SinonSpy;
+  let registry: MetadataRegistry;
+
+  function mockComponentReference(tagName?: string): ComponentReference {
+    return {
+      nodeId: 1,
+      uiId: 1,
+      element: tagName ? ({ localName: tagName } as any) : null
+    };
+  }
+
+  beforeEach(() => {
+    // Setup default registry with mock loader that returns a mock module
+    moduleLoaderSpy = sinon.spy(() => Promise.resolve({ default: {} }));
+    registry = new MetadataRegistry(moduleLoaderSpy);
+  });
+
+  it('should not load metadata for unknown elements', async () => {
+    // No element
+    let componentRef = mockComponentReference();
+    let metadata = await registry.getMetadata(componentRef);
+
+    expect(metadata).to.be.null;
+    expect(moduleLoaderSpy.called).to.be.false;
+
+    // Unknown element
+    componentRef = mockComponentReference('unknown-element');
+    metadata = await registry.getMetadata(componentRef);
+
+    expect(metadata).to.be.null;
+    expect(moduleLoaderSpy.called).to.be.false;
+  });
+
+  it('should return null for unknown Vaadin component', async () => {
+    // Setup registry with mock loader that fails to load module
+    moduleLoaderSpy = sinon.spy(() => Promise.reject('could not find module'));
+    registry = new MetadataRegistry(moduleLoaderSpy);
+
+    const componentRef = mockComponentReference('vaadin-unknown-element');
+    const metadata = await registry.getMetadata(componentRef);
+
+    expect(metadata).to.be.null;
+    expect(moduleLoaderSpy.calledWith('vaadin-unknown-element')).to.be.true;
+  });
+
+  it('should dynamically load metadata for known Vaadin component', async () => {
+    // Setup registry with default metadata loader using dynamic imports
+    registry = new MetadataRegistry();
+
+    const componentRef = mockComponentReference('vaadin-button');
+    const metadata = await registry.getMetadata(componentRef);
+
+    expect(metadata).to.not.be.null;
+    expect(metadata!.tagName).to.equal('vaadin-button');
+    expect(metadata!.displayName).to.equal('Button');
+    expect(metadata!.parts).to.be.instanceof(Array);
+  });
+
+  it('should cache metadata', async () => {
+    const componentRef = mockComponentReference('vaadin-button');
+
+    await registry.getMetadata(componentRef);
+    await registry.getMetadata(componentRef);
+    await registry.getMetadata(componentRef);
+
+    expect(moduleLoaderSpy.calledOnce).to.be.true;
+  });
+});

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/registry.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/registry.ts
@@ -1,0 +1,44 @@
+import { ComponentReference } from '../../component-util';
+import { ComponentMetadata } from './model';
+
+type MetadataMap = { [key: string]: ComponentMetadata };
+
+type ModuleLoader = (modulePath: string) => Promise<any>;
+
+const defaultModuleLoader: ModuleLoader = (tagName: string) => {
+  // Module path needs to be part of the import statement for Vite bundling to work
+  return import(`./components/${tagName}.ts`);
+};
+
+export class MetadataRegistry {
+  private metadata: MetadataMap = {};
+
+  constructor(private loader: ModuleLoader = defaultModuleLoader) {}
+
+  async getMetadata(component: ComponentReference): Promise<ComponentMetadata | null> {
+    // Ignore if there is no element, or it's not a Vaadin component
+    const tagName = component.element?.localName;
+    if (!tagName || !tagName.startsWith('vaadin-')) {
+      return null;
+    }
+
+    // Check for existing metadata
+    let metadata = this.metadata[tagName];
+    if (metadata) {
+      return metadata;
+    }
+
+    // Try load metadata for component
+    try {
+      const module = await this.loader(tagName);
+      metadata = module.default;
+      this.metadata[tagName] = metadata;
+    } catch (error) {
+      console.warn(`Failed to load metadata for component: ${tagName}`);
+    }
+
+    return metadata || null;
+  }
+}
+
+export const metadataRegistry = new MetadataRegistry();

--- a/vaadin-dev-server/tsconfig.json
+++ b/vaadin-dev-server/tsconfig.json
@@ -17,6 +17,7 @@
     "experimentalDecorators": true,
     "useDefineForClassFields": false,
     "skipLibCheck": true,
-    "baseUrl": "."
+    "baseUrl": ".",
+    "esModuleInterop": true,
   }
 }

--- a/vaadin-dev-server/web-test-runner.config.mjs
+++ b/vaadin-dev-server/web-test-runner.config.mjs
@@ -1,0 +1,6 @@
+import { esbuildPlugin } from '@web/dev-server-esbuild';
+
+export default {
+  files: ['src/main/resources/META-INF/frontend/vaadin-dev-tools/**/*.test.ts'],
+  plugins: [esbuildPlugin({ ts: true })],
+};


### PR DESCRIPTION
## Description

- Add initial theme metadata model for the theme editor
- Add example metadata for button and text-field
- Add a registry / loader for lazily loading theme metadata for individual components. The loading mechanism uses dynamic `import` statements, which seems to work fine with Vite. Once loaded, the metadata is cached.
- Add a frontend test setup in order to be able to write tests for individual parts of the dev tools frontend.

