### PR TITLE
chore: exclude frontend tests from dev tools package

### DIFF
--- a/vaadin-dev-server/pom.xml
+++ b/vaadin-dev-server/pom.xml
@@ -82,5 +82,16 @@
 
     </dependencies>
 
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <excludes>
+                    <!-- Exclude all frontend tests -->
+                    <exclude>META-INF/frontend/vaadin-dev-tools/**/*.test.ts</exclude>
+                </excludes>
+            </resource>
+        </resources>
+    </build>
 
 </project>


### PR DESCRIPTION
## Description

Excludes frontend test files from the vaadin-dev-tools JAR file.