### PR TITLE
refactor: show notice for missing theme in theme editor

### DIFF
--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.test.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.test.ts
@@ -1,0 +1,26 @@
+import { fixture, html, expect } from '@open-wc/testing';
+import { ThemeEditorState } from './model';
+import { ThemeEditor } from './editor';
+import './editor';
+
+describe('theme-editor', () => {
+  describe('theme editor states', () => {
+    it('should show component picker in default state', async () => {
+      const editor: ThemeEditor = await fixture(html` <vaadin-dev-tools-theme-editor></vaadin-dev-tools-theme-editor>`);
+      const pickerButton = editor.shadowRoot!.querySelector('.picker button');
+
+      expect(pickerButton).to.exist;
+      expect(editor.shadowRoot!.innerHTML).to.not.contain('It looks like you have not set up a custom theme yet');
+    });
+
+    it('should show missing theme notice in theme missing state', async () => {
+      const editor: ThemeEditor = await fixture(html` <vaadin-dev-tools-theme-editor
+        .themeEditorState=${ThemeEditorState.missing_theme}
+      ></vaadin-dev-tools-theme-editor>`);
+      const pickerButton = editor.shadowRoot!.querySelector('.picker button');
+
+      expect(pickerButton).to.not.exist;
+      expect(editor.shadowRoot!.innerHTML).to.contain('It looks like you have not set up a custom theme yet');
+    });
+  });
+});

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.ts
@@ -5,9 +5,12 @@ import { ComponentMetadata } from './metadata/model';
 import { metadataRegistry } from './metadata/registry';
 import { icons } from './icons';
 import './property-list';
+import { ThemeEditorState } from './model';
 
 @customElement('vaadin-dev-tools-theme-editor')
 export class ThemeEditor extends LitElement {
+  @property({})
+  public themeEditorState: ThemeEditorState = ThemeEditorState.enabled;
   @property({})
   public pickerProvider!: PickerProvider;
 
@@ -19,6 +22,14 @@ export class ThemeEditor extends LitElement {
       :host {
         animation: fade-in var(--dev-tools-transition-duration) ease-in;
         --theme-editor-section-horizontal-padding: 0.75rem;
+      }
+
+      .missing-theme {
+        padding: var(--theme-editor-section-horizontal-padding);
+      }
+
+      .missing-theme a {
+        color: var(--dev-tools-text-color-emphasis);
       }
 
       .picker {
@@ -48,6 +59,10 @@ export class ThemeEditor extends LitElement {
   }
 
   render() {
+    if (this.themeEditorState === ThemeEditorState.missing_theme) {
+      return this.renderMissingThemeNotice();
+    }
+
     return html`
       <div class="picker">
         <button class="button" @click=${this.pickComponent}>${icons.crosshair}</button>
@@ -60,6 +75,19 @@ export class ThemeEditor extends LitElement {
             .metadata=${this.selectedComponentMetadata}
           ></vaadin-dev-tools-theme-property-list>`
         : null}
+    `;
+  }
+
+  renderMissingThemeNotice() {
+    return html`
+      <div class="missing-theme">
+        It looks like you have not set up a custom theme yet. Theme editor requires an existing theme to work with.
+        Please check our
+        <a href="https://vaadin.com/docs/latest/styling/custom-theme/creating-custom-theme" target="_blank"
+          >documentation</a
+        >
+        on how to set up a custom theme.
+      </div>
     `;
   }
 

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/vaadin-dev-tools.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/vaadin-dev-tools.ts
@@ -1637,6 +1637,7 @@ export class VaadinDevTools extends LitElement {
 
   renderThemeEditor() {
     return html` <vaadin-dev-tools-theme-editor
+      .themeEditorState=${this.themeEditorState}
       .pickerProvider=${() => this.componentPicker}
     ></vaadin-dev-tools-theme-editor>`;
   }


### PR DESCRIPTION
## Description

Show a notice in the theme editor in case a theme has not been set up yet. The notice includes a link to the documentation that explains how to set up a theme.

![Bildschirmfoto 2023-02-23 um 20 28 55](https://user-images.githubusercontent.com/357820/221010752-7bddf986-9c13-4192-b961-2ef12e672842.png)
