### PR TITLE
chore: Upgrade to Spring Boot 2.7.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,14 +84,14 @@
 
         <!-- Dependencies -->
         <spring.version>5.3.25</spring.version>
-        <spring.boot.version>2.7.8</spring.boot.version>
-        <spring.security.version>5.7.6</spring.security.version>
+        <spring.boot.version>2.7.9</spring.boot.version>
+        <spring.security.version>5.7.7</spring.security.version>
         <gwt.version>2.9.0</gwt.version>
         <hibernate.validator.version>6.2.5.Final</hibernate.validator.version>
         <slf4j.version>1.7.36</slf4j.version>
         <polymer.version>2.6.1</polymer.version>
-        <jackson.version>2.14.1</jackson.version>
-        <jackson.databind.version>2.14.1</jackson.databind.version>
+        <jackson.version>2.14.2</jackson.version>
+        <jackson.databind.version>2.14.2</jackson.databind.version>
         <javax.validation.version>2.0.1.Final</javax.validation.version>
         <javax.annotation.api.version>1.3.2</javax.annotation.api.version>
         <jaxb.version>4.0.1</jaxb.version>
@@ -235,7 +235,7 @@
             <dependency>
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy</artifactId>
-                <version>1.12.20</version>
+                <version>1.12.23</version>
             </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>


### PR DESCRIPTION
Upgrades Spring Security to 5.7.7 and byte buddy to 1.12.23.

Also upgrades Jackson to 2.14.2 which is newer than what Spring Boot uses
