### PR TITLE
refactor: basic editing of properties in theme editor

### DIFF
--- a/vaadin-dev-server/package.json
+++ b/vaadin-dev-server/package.json
@@ -19,6 +19,7 @@
     "sinon": "^15.0.1"
   },
   "dependencies": {
+    "@vaadin/button": "24.0.0-rc1",
     "lit": "^2.6.1"
   }
 }

--- a/vaadin-dev-server/package.json
+++ b/vaadin-dev-server/package.json
@@ -4,7 +4,7 @@
     "test": "web-test-runner --node-resolve",
     "test-watch": "web-test-runner --node-resolve --watch",
     "patch-app": "node patch-application.js",
-    "prettier": "prettier --write src/main/resources/META-INF/frontend/**/*.ts"
+    "prettier": "prettier --write src/main/resources/META-INF/frontend"
   },
   "devDependencies": {
     "@koa/cors": "^4.0.0",

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/detector.test.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/detector.test.ts
@@ -1,0 +1,64 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import '@vaadin/button';
+import buttonMetadata from './metadata/components/vaadin-button';
+import { detectTheme } from './detector';
+
+describe('theme-detector', () => {
+  it('should include all CSS property values from component metadata', () => {
+    const theme = detectTheme(buttonMetadata);
+    let propertyCount = 0;
+
+    buttonMetadata.parts.forEach((part) => {
+      part.properties.forEach((property) => {
+        propertyCount++;
+
+        const propertyValue = theme.getPropertyValue(part.partName, property.propertyName);
+        expect(propertyValue).to.exist;
+      });
+    });
+
+    expect(theme.properties.length).to.equal(propertyCount);
+  });
+
+  it('should detect default CSS property values', async () => {
+    const theme = detectTheme(buttonMetadata);
+
+    const button = await fixture(html` <vaadin-button></vaadin-button>`);
+    const labelColor = getComputedStyle(button.shadowRoot!.querySelector('[part="label"]')!).color;
+    const prefixColor = getComputedStyle(button.shadowRoot!.querySelector('[part="prefix"]')!).color;
+    const suffixColor = getComputedStyle(button.shadowRoot!.querySelector('[part="suffix"]')!).color;
+
+    expect(theme.getPropertyValue('label', 'color').value).to.equal(labelColor);
+    expect(theme.getPropertyValue('prefix', 'color').value).to.equal(prefixColor);
+    expect(theme.getPropertyValue('suffix', 'color').value).to.equal(suffixColor);
+  });
+
+  it('should detect themed CSS property values', async () => {
+    await fixture(html`
+      <style>
+        vaadin-button::part(label) {
+          color: red;
+        }
+
+        vaadin-button::part(prefix) {
+          color: rgb(0, 255, 0);
+        }
+
+        vaadin-button::part(suffix) {
+          color: blue;
+        }
+      </style>
+    `);
+    const theme = detectTheme(buttonMetadata);
+
+    expect(theme.getPropertyValue('label', 'color').value).to.equal('rgb(255, 0, 0)');
+    expect(theme.getPropertyValue('prefix', 'color').value).to.equal('rgb(0, 255, 0)');
+    expect(theme.getPropertyValue('suffix', 'color').value).to.equal('rgb(0, 0, 255)');
+  });
+
+  it('should remove test component from DOM', () => {
+    detectTheme(buttonMetadata);
+
+    expect(document.querySelector('vaadin-button')).to.not.exist;
+  });
+});

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/detector.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/detector.ts
@@ -4,7 +4,7 @@ import { ComponentMetadata } from './metadata/model';
 export function detectTheme(metadata: ComponentMetadata): ComponentTheme {
   const componentTheme = new ComponentTheme(metadata);
   const element = document.createElement(metadata.tagName);
-  element.style.display = 'hidden';
+  element.style.visibility = 'hidden';
   document.body.append(element);
 
   try {

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/detector.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/detector.ts
@@ -1,7 +1,7 @@
 import { ComponentTheme } from './model';
 import { ComponentMetadata } from './metadata/model';
 
-export function detectStyles(metadata: ComponentMetadata): ComponentTheme {
+export function detectTheme(metadata: ComponentMetadata): ComponentTheme {
   const componentTheme = new ComponentTheme(metadata);
   const element = document.createElement(metadata.tagName);
   element.style.display = 'hidden';

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.test.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.test.ts
@@ -176,7 +176,7 @@ describe('theme-editor', () => {
       });
     });
 
-    it('should initialize property editors with default theme values', async () => {
+    it('should initialize property editors with base theme values', async () => {
       await pickComponent();
 
       const propertyEditor = findPropertyEditor('label', 'color');

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.test.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.test.ts
@@ -7,6 +7,7 @@ import { PickerOptions, PickerProvider } from '../component-picker';
 import { metadataRegistry } from './metadata/registry';
 import buttonMetadata from './metadata/components/vaadin-button';
 import sinon from 'sinon';
+import {themePreview} from "./preview";
 
 describe('theme-editor', () => {
   let editor: ThemeEditor;
@@ -80,6 +81,7 @@ describe('theme-editor', () => {
   });
 
   beforeEach(async () => {
+    themePreview.reset();
     button = await fixture(html` <vaadin-button></vaadin-button>`);
     defaultButtonLabelStyles = getComputedStyle(button.shadowRoot!.querySelector('[part="label"]')!);
     const fixtureResult = await editorFixture();

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.test.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.test.ts
@@ -1,26 +1,241 @@
-import { fixture, html, expect } from '@open-wc/testing';
-import { ThemeEditorState } from './model';
+import { aTimeout, elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import '@vaadin/button';
+import { ThemeEditorRule, ThemeEditorState } from './model';
 import { ThemeEditor } from './editor';
 import './editor';
+import { PickerOptions, PickerProvider } from '../component-picker';
+import { metadataRegistry } from './metadata/registry';
+import buttonMetadata from './metadata/components/vaadin-button';
+import sinon from 'sinon';
 
 describe('theme-editor', () => {
+  let editor: ThemeEditor;
+  let button: HTMLElement;
+  let defaultButtonLabelStyles: CSSStyleDeclaration;
+  let connectionMock: {
+    sendThemeEditorRules: sinon.SinonSpy;
+  };
+
+  async function editorFixture() {
+    connectionMock = {
+      sendThemeEditorRules: sinon.spy(() => {})
+    };
+    const pickerMock = {
+      open: (options: PickerOptions) => {
+        options.pickCallback({ nodeId: 1, uiId: 1, element: button });
+      }
+    };
+    const pickerProvider: PickerProvider = () => pickerMock as any;
+    const editor = (await fixture(html` <vaadin-dev-tools-theme-editor
+      .pickerProvider=${pickerProvider}
+      .connection=${connectionMock}
+    ></vaadin-dev-tools-theme-editor>`)) as ThemeEditor;
+
+    return {
+      editor,
+      pickerProvider
+    };
+  }
+
+  async function pickComponent() {
+    const pickerButton = editor.shadowRoot!.querySelector('.picker button') as HTMLButtonElement;
+    pickerButton.click();
+    // Compensate for dynamic import of component picker
+    await aTimeout(50);
+  }
+
+  function findPropertyEditor(partName: string, propertyName: string) {
+    return editor
+      .shadowRoot!.querySelector('.property-list')
+      ?.shadowRoot!.querySelector(`.part[data-testid="${partName}"] .property-editor[data-testid="${propertyName}"]`)!;
+  }
+
+  async function editProperty(partName: string, propertyName: string, value: string) {
+    const propertyEditor = findPropertyEditor(partName, propertyName);
+
+    expect(propertyEditor).to.exist;
+
+    const input = propertyEditor.shadowRoot!.querySelector('input')!;
+    input.value = value;
+    input.dispatchEvent(new Event('change'));
+    await elementUpdated(editor);
+  }
+
+  function findPickerButton() {
+    return editor.shadowRoot!.querySelector('.picker button');
+  }
+
+  function findDiscardButton() {
+    return editor.shadowRoot!.querySelector('.modifications-actions button.discard') as HTMLElement;
+  }
+
+  function findApplyButton() {
+    return editor.shadowRoot!.querySelector('.modifications-actions button.apply') as HTMLElement;
+  }
+
+  before(async () => {
+    // Pre-cache button metadata
+    const button = document.createElement('vaadin-button');
+    await metadataRegistry.getMetadata({ nodeId: 1, uiId: 1, element: button });
+  });
+
+  beforeEach(async () => {
+    button = await fixture(html` <vaadin-button></vaadin-button>`);
+    defaultButtonLabelStyles = getComputedStyle(button.shadowRoot!.querySelector('[part="label"]')!);
+    const fixtureResult = await editorFixture();
+    editor = fixtureResult.editor;
+  });
+
   describe('theme editor states', () => {
     it('should show component picker in default state', async () => {
-      const editor: ThemeEditor = await fixture(html` <vaadin-dev-tools-theme-editor></vaadin-dev-tools-theme-editor>`);
-      const pickerButton = editor.shadowRoot!.querySelector('.picker button');
-
-      expect(pickerButton).to.exist;
+      expect(findPickerButton()).to.exist;
       expect(editor.shadowRoot!.innerHTML).to.not.contain('It looks like you have not set up a custom theme yet');
     });
 
     it('should show missing theme notice in theme missing state', async () => {
-      const editor: ThemeEditor = await fixture(html` <vaadin-dev-tools-theme-editor
-        .themeEditorState=${ThemeEditorState.missing_theme}
-      ></vaadin-dev-tools-theme-editor>`);
-      const pickerButton = editor.shadowRoot!.querySelector('.picker button');
+      editor.themeEditorState = ThemeEditorState.missing_theme;
+      await elementUpdated(editor);
 
-      expect(pickerButton).to.not.exist;
+      expect(findPickerButton()).to.not.exist;
       expect(editor.shadowRoot!.innerHTML).to.contain('It looks like you have not set up a custom theme yet');
+    });
+  });
+
+  describe('editing', () => {
+    it('should not be modified initially', async () => {
+      expect(findDiscardButton()).to.not.exist;
+      expect(findApplyButton()).to.not.exist;
+    });
+
+    it('should be modified after changing a property', async () => {
+      await pickComponent();
+      await editProperty('label', 'color', 'red');
+
+      expect(findDiscardButton()).to.exist;
+      expect(findApplyButton()).to.exist;
+    });
+
+    it('should not be modified after discarding changes', async () => {
+      await pickComponent();
+      await editProperty('label', 'color', 'red');
+
+      findDiscardButton().click();
+      await elementUpdated(editor);
+
+      expect(findDiscardButton()).to.not.exist;
+      expect(findApplyButton()).to.not.exist;
+    });
+
+    it('should not be modified after picking another component', async () => {
+      await pickComponent();
+      await editProperty('label', 'color', 'red');
+
+      await pickComponent();
+
+      expect(findDiscardButton()).to.not.exist;
+      expect(findApplyButton()).to.not.exist;
+    });
+
+    it('should update theme preview after changing a property', async () => {
+      await pickComponent();
+      await editProperty('label', 'color', 'red');
+
+      const labelStyle = getComputedStyle(button.shadowRoot!.querySelector('[part="label"]')!);
+      expect(labelStyle.color).to.equal('rgb(255, 0, 0)');
+    });
+
+    it('should reset theme preview after discarding changes', async () => {
+      await pickComponent();
+      await editProperty('label', 'color', 'red');
+
+      findDiscardButton().click();
+      await elementUpdated(editor);
+
+      const labelStyle = getComputedStyle(button.shadowRoot!.querySelector('[part="label"]')!);
+      expect(labelStyle.color).to.equal(defaultButtonLabelStyles.color);
+    });
+
+    it('should reset theme preview after picking another component', async () => {
+      await pickComponent();
+      await editProperty('label', 'color', 'red');
+
+      await pickComponent();
+
+      const labelStyle = getComputedStyle(button.shadowRoot!.querySelector('[part="label"]')!);
+      expect(labelStyle.color).to.equal(defaultButtonLabelStyles.color);
+    });
+
+    it('should show property editors for picked component', async () => {
+      await pickComponent();
+
+      buttonMetadata.parts.forEach((part) => {
+        part.properties.forEach((property) => {
+          const propertyEditor = findPropertyEditor(part.partName, property.propertyName);
+          expect(propertyEditor).to.exist;
+        });
+      });
+    });
+
+    it('should initialize property editors with default theme values', async () => {
+      await pickComponent();
+
+      const propertyEditor = findPropertyEditor('label', 'color');
+      const input = propertyEditor.shadowRoot!.querySelector('input')! as HTMLInputElement;
+
+      expect(input.value).to.equal(defaultButtonLabelStyles.color);
+    });
+
+    it('should update property editors with edited theme values', async () => {
+      await pickComponent();
+      await editProperty('label', 'color', 'red');
+
+      const propertyEditor = findPropertyEditor('label', 'color');
+      const input = propertyEditor.shadowRoot!.querySelector('input')! as HTMLInputElement;
+
+      expect(input.value).to.equal('red');
+    });
+
+    it('should reset property editors after discarding changes', async () => {
+      await pickComponent();
+      await editProperty('label', 'color', 'red');
+
+      findDiscardButton().click();
+      await elementUpdated(editor);
+
+      const propertyEditor = findPropertyEditor('label', 'color');
+      const input = propertyEditor.shadowRoot!.querySelector('input')! as HTMLInputElement;
+
+      expect(input.value).to.equal(defaultButtonLabelStyles.color);
+    });
+
+    it('should reset property editors after picking another component', async () => {
+      await pickComponent();
+      await editProperty('label', 'color', 'red');
+
+      await pickComponent();
+
+      const propertyEditor = findPropertyEditor('label', 'color');
+      const input = propertyEditor.shadowRoot!.querySelector('input')! as HTMLInputElement;
+
+      expect(input.value).to.equal(defaultButtonLabelStyles.color);
+    });
+
+    it('should send theme rules when applying changes', async () => {
+      await pickComponent();
+      await editProperty('label', 'color', 'red');
+
+      findApplyButton().click();
+
+      const expectedRules: ThemeEditorRule[] = [
+        {
+          selector: 'vaadin-button::part(label)',
+          property: 'color',
+          value: 'red'
+        }
+      ];
+
+      expect(connectionMock.sendThemeEditorRules.called);
+      expect(connectionMock.sendThemeEditorRules.args[0][0]).to.deep.equal(expectedRules);
     });
   });
 });

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.ts
@@ -5,7 +5,8 @@ import { ComponentMetadata } from './metadata/model';
 import { metadataRegistry } from './metadata/registry';
 import { icons } from './icons';
 import './property-list';
-import { ThemeEditorState } from './model';
+import { ComponentTheme, ThemeEditorState } from './model';
+import { detectStyles } from './style-detector';
 
 @customElement('vaadin-dev-tools-theme-editor')
 export class ThemeEditor extends LitElement {
@@ -16,6 +17,8 @@ export class ThemeEditor extends LitElement {
 
   @state()
   private selectedComponentMetadata: ComponentMetadata | null = null;
+  @state()
+  private componentTheme: ComponentTheme | null = null;
 
   static get styles() {
     return css`
@@ -73,6 +76,7 @@ export class ThemeEditor extends LitElement {
       ${this.selectedComponentMetadata
         ? html` <vaadin-dev-tools-theme-property-list
             .metadata=${this.selectedComponentMetadata}
+            .theme=${this.componentTheme}
           ></vaadin-dev-tools-theme-property-list>`
         : null}
     `;
@@ -106,6 +110,7 @@ export class ThemeEditor extends LitElement {
       `,
       pickCallback: async (component) => {
         this.selectedComponentMetadata = await metadataRegistry.getMetadata(component);
+        this.componentTheme = this.selectedComponentMetadata ? detectStyles(this.selectedComponentMetadata) : null;
       }
     });
   }

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.ts
@@ -6,7 +6,7 @@ import { metadataRegistry } from './metadata/registry';
 import { icons } from './icons';
 import './property-list';
 import { combineThemes, ComponentTheme, generateRules, ThemeEditorState } from './model';
-import { detectStyles } from './style-detector';
+import { detectStyles } from './detector';
 import { ThemePropertyValueChangeEvent } from './events';
 import { themePreview } from './preview';
 import { Connection } from '../vaadin-dev-tools';

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.ts
@@ -23,7 +23,7 @@ export class ThemeEditor extends LitElement {
   @state()
   private selectedComponentMetadata: ComponentMetadata | null = null;
   @state()
-  private defaultTheme: ComponentTheme | null = null;
+  private baseTheme: ComponentTheme | null = null;
   @state()
   private editedTheme: ComponentTheme | null = null;
   @state()
@@ -174,11 +174,11 @@ export class ThemeEditor extends LitElement {
         this.hasModifications = false;
         themePreview.reset();
         if (this.selectedComponentMetadata) {
-          this.defaultTheme = detectTheme(this.selectedComponentMetadata);
+          this.baseTheme = detectTheme(this.selectedComponentMetadata);
           this.editedTheme = new ComponentTheme(this.selectedComponentMetadata);
-          this.effectiveTheme = combineThemes(this.defaultTheme, this.editedTheme);
+          this.effectiveTheme = combineThemes(this.baseTheme, this.editedTheme);
         } else {
-          this.defaultTheme = null;
+          this.baseTheme = null;
           this.editedTheme = null;
           this.effectiveTheme = null;
         }
@@ -187,23 +187,23 @@ export class ThemeEditor extends LitElement {
   }
 
   private handlePropertyChange(e: ThemePropertyValueChangeEvent) {
-    if (!this.editedTheme || !this.defaultTheme) {
+    if (!this.editedTheme || !this.baseTheme) {
       return;
     }
     const { part, property, value } = e.detail;
     this.hasModifications = true;
     this.editedTheme.updatePropertyValue(part.partName, property.propertyName, value);
-    this.effectiveTheme = combineThemes(this.defaultTheme, this.editedTheme);
+    this.effectiveTheme = combineThemes(this.baseTheme, this.editedTheme);
     themePreview.update(this.editedTheme);
   }
 
   private discardChanges() {
-    if (!this.selectedComponentMetadata || !this.defaultTheme) {
+    if (!this.selectedComponentMetadata || !this.baseTheme) {
       return;
     }
     this.hasModifications = false;
     this.editedTheme = new ComponentTheme(this.selectedComponentMetadata);
-    this.effectiveTheme = combineThemes(this.defaultTheme, this.editedTheme);
+    this.effectiveTheme = combineThemes(this.baseTheme, this.editedTheme);
     themePreview.reset();
   }
 
@@ -215,6 +215,6 @@ export class ThemeEditor extends LitElement {
     const rules = generateRules(this.editedTheme);
     this.connection.sendThemeEditorRules(rules);
 
-    // Assume that page gets reloaded at this point, so no need to update theme states
+    // Assume that page gets reloaded at this point, so no need to update component state
   }
 }

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.ts
@@ -6,7 +6,7 @@ import { metadataRegistry } from './metadata/registry';
 import { icons } from './icons';
 import './property-list';
 import { combineThemes, ComponentTheme, generateRules, ThemeEditorState } from './model';
-import { detectStyles } from './detector';
+import { detectTheme } from './detector';
 import { ThemePropertyValueChangeEvent } from './events';
 import { themePreview } from './preview';
 import { Connection } from '../vaadin-dev-tools';
@@ -173,7 +173,7 @@ export class ThemeEditor extends LitElement {
         this.selectedComponentMetadata = await metadataRegistry.getMetadata(component);
         this.hasModifications = false;
         if (this.selectedComponentMetadata) {
-          this.defaultTheme = detectStyles(this.selectedComponentMetadata);
+          this.defaultTheme = detectTheme(this.selectedComponentMetadata);
           this.editedTheme = new ComponentTheme(this.selectedComponentMetadata);
           this.effectiveTheme = combineThemes(this.defaultTheme, this.editedTheme);
         } else {

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.ts
@@ -172,6 +172,7 @@ export class ThemeEditor extends LitElement {
       pickCallback: async (component) => {
         this.selectedComponentMetadata = await metadataRegistry.getMetadata(component);
         this.hasModifications = false;
+        themePreview.reset();
         if (this.selectedComponentMetadata) {
           this.defaultTheme = detectTheme(this.selectedComponentMetadata);
           this.editedTheme = new ComponentTheme(this.selectedComponentMetadata);
@@ -203,7 +204,7 @@ export class ThemeEditor extends LitElement {
     this.hasModifications = false;
     this.editedTheme = new ComponentTheme(this.selectedComponentMetadata);
     this.effectiveTheme = combineThemes(this.defaultTheme, this.editedTheme);
-    themePreview.update(this.editedTheme);
+    themePreview.reset();
   }
 
   private applyChanges() {

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/events.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/events.ts
@@ -1,0 +1,15 @@
+import { ComponentPartMetadata, CssPropertyMetadata } from './metadata/model';
+
+export class ThemePropertyValueChangeEvent extends CustomEvent<{
+  part: ComponentPartMetadata;
+  property: CssPropertyMetadata;
+  value: string;
+}> {
+  constructor(part: ComponentPartMetadata, property: CssPropertyMetadata, value: string) {
+    super('theme-property-value-change', {
+      bubbles: true,
+      composed: true,
+      detail: { part, property, value }
+    });
+  }
+}

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/components/vaadin-button.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/components/vaadin-button.ts
@@ -5,7 +5,7 @@ export default {
   displayName: 'Button',
   parts: [
     {
-      selector: '::part(label)',
+      partName: 'label',
       displayName: 'Label',
       properties: [
         {
@@ -23,7 +23,7 @@ export default {
       ]
     },
     {
-      selector: '::part(prefix)',
+      partName: 'prefix',
       displayName: 'Prefix',
       properties: [
         {
@@ -41,7 +41,7 @@ export default {
       ]
     },
     {
-      selector: '::part(suffix)',
+      partName: 'suffix',
       displayName: 'Suffix',
       properties: [
         {

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/components/vaadin-text-field.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/components/vaadin-text-field.ts
@@ -5,7 +5,7 @@ export default {
   displayName: 'TextField',
   parts: [
     {
-      selector: '::part(label)',
+      partName: 'label',
       displayName: 'Label',
       properties: [
         {
@@ -23,7 +23,7 @@ export default {
       ]
     },
     {
-      selector: '::part(input-field)',
+      partName: 'input-field',
       displayName: 'Input field',
       properties: [
         {
@@ -41,7 +41,7 @@ export default {
       ]
     },
     {
-      selector: '::part(helper-text)',
+      partName: 'helper-text',
       displayName: 'Helper text',
       properties: [
         {
@@ -59,7 +59,7 @@ export default {
       ]
     },
     {
-      selector: '::part(error-message)',
+      partName: 'error-message',
       displayName: 'Error message',
       properties: [
         {

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/model.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/model.ts
@@ -5,7 +5,7 @@ export interface CssPropertyMetadata {
 }
 
 export interface ComponentPartMetadata {
-  selector: string;
+  partName: string;
   displayName: string;
   description?: string;
   properties: CssPropertyMetadata[];

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/model.test.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/model.test.ts
@@ -1,0 +1,175 @@
+import { expect } from '@open-wc/testing';
+import { combineThemes, ComponentTheme, generateRules, ThemeEditorRule, ThemePropertyValue } from './model';
+import buttonMetadata from './metadata/components/vaadin-button';
+import { ComponentMetadata } from './metadata/model';
+
+describe('model', () => {
+  describe('ComponentTheme', () => {
+    let theme: ComponentTheme;
+
+    beforeEach(() => {
+      theme = new ComponentTheme(buttonMetadata);
+    });
+
+    it('should return null for unset properties', () => {
+      expect(theme.getPropertyValue(null, 'background')).to.be.null;
+      expect(theme.getPropertyValue('label', 'color')).to.be.null;
+    });
+
+    it('should add and return property values', () => {
+      theme.updatePropertyValue(null, 'background', 'cornflowerblue');
+      theme.updatePropertyValue('label', 'color', 'white');
+
+      const expectedHostBackgroundValue: ThemePropertyValue = {
+        partName: null,
+        propertyName: 'background',
+        value: 'cornflowerblue'
+      };
+      const expectedLabelColorValue: ThemePropertyValue = {
+        partName: 'label',
+        propertyName: 'color',
+        value: 'white'
+      };
+
+      expect(theme.properties).to.deep.equal([expectedHostBackgroundValue, expectedLabelColorValue]);
+
+      const hostBackgroundValue = theme.getPropertyValue(null, 'background');
+      expect(hostBackgroundValue).to.exist;
+      expect(hostBackgroundValue).to.deep.equal(expectedHostBackgroundValue);
+
+      const labelColorValue = theme.getPropertyValue('label', 'color');
+      expect(labelColorValue).to.exist;
+      expect(labelColorValue).to.deep.equal(expectedLabelColorValue);
+    });
+
+    it('should update property values', () => {
+      theme.updatePropertyValue('label', 'color', 'white');
+      theme.updatePropertyValue('label', 'color', 'green');
+      theme.updatePropertyValue('label', 'color', 'red');
+
+      expect(theme.properties.length).to.equal(1);
+
+      const labelColorValue = theme.getPropertyValue('label', 'color');
+      expect(labelColorValue.value).to.equal('red');
+    });
+
+    it('should merge a list of theme property values', () => {
+      theme.updatePropertyValue(null, 'background', 'cornflowerblue');
+      theme.updatePropertyValue('label', 'color', 'white');
+
+      theme.addPropertyValues([
+        // Add new host prop
+        { partName: null, propertyName: 'padding', value: '3px' },
+        // Update existing part prop
+        { partName: 'label', propertyName: 'color', value: 'red' },
+        // Add new part prop
+        { partName: 'label', propertyName: 'font-size', value: '20px' }
+      ]);
+
+      const expectedValues = [
+        { partName: null, propertyName: 'background', value: 'cornflowerblue' },
+        { partName: 'label', propertyName: 'color', value: 'red' },
+        { partName: null, propertyName: 'padding', value: '3px' },
+        { partName: 'label', propertyName: 'font-size', value: '20px' }
+      ];
+
+      expect(theme.properties).to.deep.equal(expectedValues);
+    });
+
+    it('should return a list of properties for a part', () => {
+      theme.updatePropertyValue(null, 'background', 'cornflowerblue');
+      theme.updatePropertyValue(null, 'padding', '3px');
+      theme.updatePropertyValue('label', 'color', 'white');
+      theme.updatePropertyValue('label', 'font-size', '20px');
+
+      const expectedHostProperties = [
+        { partName: null, propertyName: 'background', value: 'cornflowerblue' },
+        { partName: null, propertyName: 'padding', value: '3px' }
+      ];
+      const expectedLabelProperties = [
+        { partName: 'label', propertyName: 'color', value: 'white' },
+        { partName: 'label', propertyName: 'font-size', value: '20px' }
+      ];
+
+      expect(theme.getPropertyValuesForPart(null)).to.deep.equal(expectedHostProperties);
+      expect(theme.getPropertyValuesForPart('label')).to.deep.equal(expectedLabelProperties);
+      expect(theme.getPropertyValuesForPart('unknown-part')).to.deep.equal([]);
+    });
+  });
+
+  describe('combineThemes', () => {
+    it('should return new theme instance', () => {
+      const theme1 = new ComponentTheme(buttonMetadata);
+      const theme2 = new ComponentTheme(buttonMetadata);
+
+      const result = combineThemes(theme1, theme2);
+      expect(result).to.not.equal(theme1);
+      expect(result).to.not.equal(theme2);
+    });
+
+    it('should merge theme properties', () => {
+      const theme1 = new ComponentTheme(buttonMetadata);
+      theme1.updatePropertyValue(null, 'background', 'cornflowerblue');
+      theme1.updatePropertyValue('label', 'color', 'white');
+
+      const theme2 = new ComponentTheme(buttonMetadata);
+      theme2.updatePropertyValue(null, 'padding', '3px');
+      theme2.updatePropertyValue('label', 'color', 'red');
+      theme2.updatePropertyValue('label', 'font-size', '20px');
+
+      const result = combineThemes(theme1, theme2);
+      const expectedValues = [
+        { partName: null, propertyName: 'background', value: 'cornflowerblue' },
+        { partName: 'label', propertyName: 'color', value: 'red' },
+        { partName: null, propertyName: 'padding', value: '3px' },
+        { partName: 'label', propertyName: 'font-size', value: '20px' }
+      ];
+
+      expect(result.properties).to.deep.equal(expectedValues);
+    });
+
+    it('should throw when less than two themes are provided', () => {
+      expect(() => combineThemes()).to.throw;
+      expect(() => combineThemes(new ComponentTheme(buttonMetadata))).to.throw;
+    });
+
+    it('should adopt metadata from first theme', () => {
+      const fooMetadata: ComponentMetadata = {
+        tagName: 'foo-component',
+        displayName: 'Foo',
+        parts: []
+      };
+      const buttonTheme = new ComponentTheme(buttonMetadata);
+      const fooTheme = new ComponentTheme(fooMetadata);
+      const result = combineThemes(buttonTheme, fooTheme);
+
+      expect(result.metadata).to.equal(buttonMetadata);
+    });
+  });
+
+  describe('generateRules', () => {
+    it('should generate zero rules for empty theme', () => {
+      const theme = new ComponentTheme(buttonMetadata);
+      const rules = generateRules(theme);
+      expect(rules.length).to.equal(0);
+    });
+
+    it('should generate rules for theme', () => {
+      const theme = new ComponentTheme(buttonMetadata);
+      theme.updatePropertyValue(null, 'background', 'cornflowerblue');
+      theme.updatePropertyValue(null, 'padding', '3px');
+      theme.updatePropertyValue('label', 'color', 'white');
+      theme.updatePropertyValue('label', 'font-size', '20px');
+
+      const expectedRules: ThemeEditorRule[] = [
+        { selector: 'vaadin-button', property: 'background', value: 'cornflowerblue' },
+        { selector: 'vaadin-button', property: 'padding', value: '3px' },
+        { selector: 'vaadin-button::part(label)', property: 'color', value: 'white' },
+        { selector: 'vaadin-button::part(label)', property: 'font-size', value: '20px' }
+      ];
+
+      const rules = generateRules(theme);
+      expect(rules).to.deep.equal(expectedRules);
+    });
+  });
+});

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/model.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/model.ts
@@ -6,6 +6,12 @@ export enum ThemeEditorState {
   missing_theme = 'missing_theme'
 }
 
+export interface ThemeEditorRule {
+  selector: string;
+  property: string;
+  value: string;
+}
+
 export interface ThemePropertyValue {
   partName: string | null;
   propertyName: string;
@@ -72,4 +78,18 @@ export function combineThemes(...themes: ComponentTheme[]): ComponentTheme {
   themes.forEach((theme) => resultTheme.addPropertyValues(theme.properties));
 
   return resultTheme;
+}
+
+export function generateRules(theme: ComponentTheme): ThemeEditorRule[] {
+  return theme.properties.map((propertyValue) => {
+    const selector = propertyValue.partName
+      ? `${theme.metadata.tagName}::part(${propertyValue.partName})`
+      : theme.metadata.tagName;
+
+    return {
+      selector,
+      property: propertyValue.propertyName,
+      value: propertyValue.value
+    };
+  });
 }

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/model.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/model.ts
@@ -3,3 +3,52 @@ export enum ThemeEditorState {
   enabled = 'enabled',
   missing_theme = 'missing_theme'
 }
+
+export interface ThemePropertyValue {
+  partName: string | null;
+  propertyName: string;
+  value: string;
+}
+
+type PropertyValueMap = { [key: string]: ThemePropertyValue };
+
+function propertyKey(partName: string | null, propertyName: string) {
+  return `${partName}|${propertyName}`;
+}
+
+export class ComponentTheme {
+  private _tagName: string;
+  private properties: PropertyValueMap = {};
+
+  constructor(tagName: string) {
+    this._tagName = tagName;
+  }
+
+  get tagName(): string {
+    return this._tagName;
+  }
+
+  public getPropertyValue(partName: string | null, propertyName: string): ThemePropertyValue {
+    return this.properties[propertyKey(partName, propertyName)];
+  }
+
+  public updatePropertyValue(partName: string | null, propertyName: string, value: string) {
+    let propertyValue = this.getPropertyValue(partName, propertyName);
+    if (!propertyValue) {
+      propertyValue = {
+        partName,
+        propertyName,
+        value
+      };
+      this.properties[propertyKey(partName, propertyName)] = propertyValue;
+    } else {
+      propertyValue.value = value;
+    }
+  }
+
+  public addPropertyValues(values: ThemePropertyValue[]) {
+    values.forEach((value) => {
+      this.updatePropertyValue(value.partName, value.propertyName, value.value);
+    });
+  }
+}

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/model.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/model.ts
@@ -1,3 +1,5 @@
+import { ComponentMetadata } from './metadata/model';
+
 export enum ThemeEditorState {
   disabled = 'disabled',
   enabled = 'enabled',
@@ -17,19 +19,23 @@ function propertyKey(partName: string | null, propertyName: string) {
 }
 
 export class ComponentTheme {
-  private _tagName: string;
-  private properties: PropertyValueMap = {};
+  private _metadata: ComponentMetadata;
+  private _properties: PropertyValueMap = {};
 
-  constructor(tagName: string) {
-    this._tagName = tagName;
+  constructor(metadata: ComponentMetadata) {
+    this._metadata = metadata;
   }
 
-  get tagName(): string {
-    return this._tagName;
+  get metadata(): ComponentMetadata {
+    return this._metadata;
+  }
+
+  get properties(): ThemePropertyValue[] {
+    return Object.values(this._properties);
   }
 
   public getPropertyValue(partName: string | null, propertyName: string): ThemePropertyValue {
-    return this.properties[propertyKey(partName, propertyName)];
+    return this._properties[propertyKey(partName, propertyName)];
   }
 
   public updatePropertyValue(partName: string | null, propertyName: string, value: string) {
@@ -40,7 +46,7 @@ export class ComponentTheme {
         propertyName,
         value
       };
-      this.properties[propertyKey(partName, propertyName)] = propertyValue;
+      this._properties[propertyKey(partName, propertyName)] = propertyValue;
     } else {
       propertyValue.value = value;
     }
@@ -51,4 +57,19 @@ export class ComponentTheme {
       this.updatePropertyValue(value.partName, value.propertyName, value.value);
     });
   }
+
+  public getPropertyValuesForPart(partName: string | null) {
+    return this.properties.filter((property) => property.partName === partName);
+  }
+}
+
+export function combineThemes(...themes: ComponentTheme[]): ComponentTheme {
+  if (themes.length < 2) {
+    throw new Error('Must provide at least two themes');
+  }
+
+  const resultTheme = new ComponentTheme(themes[0].metadata);
+  themes.forEach((theme) => resultTheme.addPropertyValues(theme.properties));
+
+  return resultTheme;
 }

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/model.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/model.ts
@@ -41,7 +41,7 @@ export class ComponentTheme {
   }
 
   public getPropertyValue(partName: string | null, propertyName: string): ThemePropertyValue {
-    return this._properties[propertyKey(partName, propertyName)];
+    return this._properties[propertyKey(partName, propertyName)] || null;
   }
 
   public updatePropertyValue(partName: string | null, propertyName: string, value: string) {

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/preview.test.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/preview.test.ts
@@ -62,14 +62,14 @@ describe('theme-preview', () => {
     expect(buttonStyles.suffix.color).to.equal(colors.red);
   });
 
-  it('should clear theme preview', () => {
+  it('should reset theme preview', () => {
     const theme = new ComponentTheme(buttonMetadata);
     theme.updatePropertyValue('label', 'color', colors.red);
     theme.updatePropertyValue('prefix', 'color', colors.green);
     theme.updatePropertyValue('suffix', 'color', colors.blue);
     themePreview.update(theme);
 
-    themePreview.update(new ComponentTheme(buttonMetadata));
+    themePreview.reset();
 
     let buttonStyles = getButtonStyles();
     expect(buttonStyles.label.color).to.not.equal(colors.red);

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/preview.test.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/preview.test.ts
@@ -1,0 +1,79 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import '@vaadin/button';
+import buttonMetadata from './metadata/components/vaadin-button';
+import { themePreview } from './preview';
+import { ComponentTheme } from './model';
+
+describe('theme-preview', () => {
+  const colors = {
+    red: 'rgb(255, 0, 0)',
+    green: 'rgb(0, 255, 0)',
+    blue: 'rgb(0, 0, 255)'
+  };
+
+  let button: HTMLElement;
+
+  function getButtonStyles() {
+    return {
+      label: getComputedStyle(button.shadowRoot!.querySelector('[part="label"]')!),
+      prefix: getComputedStyle(button.shadowRoot!.querySelector('[part="prefix"]')!),
+      suffix: getComputedStyle(button.shadowRoot!.querySelector('[part="suffix"]')!)
+    };
+  }
+
+  beforeEach(async () => {
+    themePreview.stylesheet.replaceSync('');
+    button = await fixture(html` <vaadin-button></vaadin-button>`);
+  });
+
+  it('should apply theme preview', () => {
+    let buttonStyles = getButtonStyles();
+    expect(buttonStyles.label.color).to.not.equal(colors.red);
+    expect(buttonStyles.suffix.color).to.not.equal(colors.green);
+    expect(buttonStyles.prefix.color).to.not.equal(colors.blue);
+
+    const theme = new ComponentTheme(buttonMetadata);
+    theme.updatePropertyValue('label', 'color', colors.red);
+    theme.updatePropertyValue('prefix', 'color', colors.green);
+    theme.updatePropertyValue('suffix', 'color', colors.blue);
+    themePreview.update(theme);
+
+    buttonStyles = getButtonStyles();
+    expect(buttonStyles.label.color).to.equal(colors.red);
+    expect(buttonStyles.prefix.color).to.equal(colors.green);
+    expect(buttonStyles.suffix.color).to.equal(colors.blue);
+  });
+
+  it('should update theme preview', () => {
+    const theme = new ComponentTheme(buttonMetadata);
+    theme.updatePropertyValue('label', 'color', colors.red);
+    theme.updatePropertyValue('prefix', 'color', colors.green);
+    theme.updatePropertyValue('suffix', 'color', colors.blue);
+    themePreview.update(theme);
+
+    theme.updatePropertyValue('label', 'color', colors.red);
+    theme.updatePropertyValue('prefix', 'color', colors.red);
+    theme.updatePropertyValue('suffix', 'color', colors.red);
+    themePreview.update(theme);
+
+    let buttonStyles = getButtonStyles();
+    expect(buttonStyles.label.color).to.equal(colors.red);
+    expect(buttonStyles.prefix.color).to.equal(colors.red);
+    expect(buttonStyles.suffix.color).to.equal(colors.red);
+  });
+
+  it('should clear theme preview', () => {
+    const theme = new ComponentTheme(buttonMetadata);
+    theme.updatePropertyValue('label', 'color', colors.red);
+    theme.updatePropertyValue('prefix', 'color', colors.green);
+    theme.updatePropertyValue('suffix', 'color', colors.blue);
+    themePreview.update(theme);
+
+    themePreview.update(new ComponentTheme(buttonMetadata));
+
+    let buttonStyles = getButtonStyles();
+    expect(buttonStyles.label.color).to.not.equal(colors.red);
+    expect(buttonStyles.suffix.color).to.not.equal(colors.green);
+    expect(buttonStyles.prefix.color).to.not.equal(colors.blue);
+  });
+});

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/preview.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/preview.ts
@@ -1,12 +1,16 @@
 import { ComponentTheme } from './model';
 
 class ThemePreview {
-  private stylesheet: CSSStyleSheet;
+  private _stylesheet: CSSStyleSheet;
 
   constructor() {
-    this.stylesheet = new CSSStyleSheet();
-    this.stylesheet.replaceSync('');
-    document.adoptedStyleSheets = [...document.adoptedStyleSheets, this.stylesheet];
+    this._stylesheet = new CSSStyleSheet();
+    this._stylesheet.replaceSync('');
+    document.adoptedStyleSheets = [...document.adoptedStyleSheets, this._stylesheet];
+  }
+
+  get stylesheet(): CSSStyleSheet {
+    return this._stylesheet;
   }
 
   update(theme: ComponentTheme) {
@@ -22,7 +26,7 @@ class ThemePreview {
     });
 
     const themeCss = rules.join('\n');
-    this.stylesheet.replaceSync(themeCss);
+    this._stylesheet.replaceSync(themeCss);
   }
 }
 

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/preview.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/preview.ts
@@ -28,6 +28,10 @@ class ThemePreview {
     const themeCss = rules.join('\n');
     this._stylesheet.replaceSync(themeCss);
   }
+
+  reset() {
+    this._stylesheet.replaceSync('');
+  }
 }
 
 export const themePreview = new ThemePreview();

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/preview.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/preview.ts
@@ -1,0 +1,29 @@
+import { ComponentTheme } from './model';
+
+class ThemePreview {
+  private stylesheet: CSSStyleSheet;
+
+  constructor() {
+    this.stylesheet = new CSSStyleSheet();
+    this.stylesheet.replaceSync('');
+    document.adoptedStyleSheets = [...document.adoptedStyleSheets, this.stylesheet];
+  }
+
+  update(theme: ComponentTheme) {
+    const rules: string[] = [];
+    const uniquePartNames = theme.metadata.parts.map((part) => part.partName);
+
+    uniquePartNames.forEach((partName) => {
+      const selector = `${theme.metadata.tagName}::part(${partName})`;
+      const propertyValues = theme.getPropertyValuesForPart(partName);
+      const propertyDeclarations = propertyValues.map((value) => `${value.propertyName}: ${value.value}`).join(';');
+      const rule = `${selector} { ${propertyDeclarations} }`;
+      rules.push(rule);
+    });
+
+    const themeCss = rules.join('\n');
+    this.stylesheet.replaceSync(themeCss);
+  }
+}
+
+export const themePreview = new ThemePreview();

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/property-editor.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/property-editor.ts
@@ -2,6 +2,7 @@ import { css, html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { ComponentPartMetadata, CssPropertyMetadata } from './metadata/model';
 import { ComponentTheme } from './model';
+import { ThemePropertyValueChangeEvent } from './events';
 
 @customElement('vaadin-dev-tools-theme-property-editor')
 export class PropertyEditor extends LitElement {
@@ -48,6 +49,11 @@ export class PropertyEditor extends LitElement {
     `;
   }
 
+  handleInputChange(e: Event) {
+    const input = e.target as HTMLInputElement;
+    this.dispatchEvent(new ThemePropertyValueChangeEvent(this.partMetadata, this.propertyMetadata, input.value));
+  }
+
   render() {
     const propertyValue = this.theme.getPropertyValue(this.partMetadata.partName, this.propertyMetadata.propertyName);
 
@@ -55,7 +61,7 @@ export class PropertyEditor extends LitElement {
       <div class="property">
         <div class="property-name">${this.propertyMetadata.displayName}</div>
         <div class="property-editor">
-          <input class="input" .value=${propertyValue.value} />
+          <input class="input" .value=${propertyValue.value} @change=${this.handleInputChange} />
         </div>
       </div>
     `;

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/property-editor.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/property-editor.ts
@@ -1,11 +1,16 @@
 import { css, html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { CssPropertyMetadata } from './metadata/model';
+import { ComponentPartMetadata, CssPropertyMetadata } from './metadata/model';
+import { ComponentTheme } from './model';
 
 @customElement('vaadin-dev-tools-theme-property-editor')
 export class PropertyEditor extends LitElement {
   @property({})
+  public partMetadata!: ComponentPartMetadata;
+  @property({})
   public propertyMetadata!: CssPropertyMetadata;
+  @property({})
+  public theme!: ComponentTheme;
 
   static get styles() {
     return css`
@@ -44,11 +49,13 @@ export class PropertyEditor extends LitElement {
   }
 
   render() {
+    const propertyValue = this.theme.getPropertyValue(this.partMetadata.partName, this.propertyMetadata.propertyName);
+
     return html`
       <div class="property">
         <div class="property-name">${this.propertyMetadata.displayName}</div>
         <div class="property-editor">
-          <input class="input" />
+          <input class="input" .value=${propertyValue.value} />
         </div>
       </div>
     `;

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/property-list.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/property-list.ts
@@ -38,11 +38,12 @@ export class PropertyList extends LitElement {
         .partMetadata=${part}
         .propertyMetadata=${property}
         .theme=${this.theme}
+        data-testid=${property.propertyName}
       ></vaadin-dev-tools-theme-property-editor>`;
     });
 
     return html`
-      <div class="part">
+      <div class="part" data-testid=${part.partName}>
         <div class="header">${part.displayName}</div>
         <div class="property-list">${properties}</div>
       </div>

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/property-list.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/property-list.ts
@@ -2,6 +2,7 @@ import { css, html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { ComponentMetadata, ComponentPartMetadata } from './metadata/model';
 import './property-editor';
+import { ComponentTheme } from './model';
 
 @customElement('vaadin-dev-tools-theme-property-list')
 export class PropertyList extends LitElement {
@@ -26,6 +27,8 @@ export class PropertyList extends LitElement {
 
   @property({})
   public metadata!: ComponentMetadata;
+  @property({})
+  public theme!: ComponentTheme;
 
   render() {
     const partSections = this.metadata.parts.map((part) => this.renderPartSection(part));
@@ -37,7 +40,9 @@ export class PropertyList extends LitElement {
     const properties = part.properties.map((property) => {
       return html` <vaadin-dev-tools-theme-property-editor
         class="property-editor"
+        .partMetadata=${part}
         .propertyMetadata=${property}
+        .theme=${this.theme}
       ></vaadin-dev-tools-theme-property-editor>`;
     });
 

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/property-list.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/property-list.ts
@@ -8,11 +8,6 @@ import { ComponentTheme } from './model';
 export class PropertyList extends LitElement {
   static get styles() {
     return css`
-      .part-list {
-        max-height: 350px;
-        overflow-y: auto;
-      }
-
       .part .header {
         padding: 0.4rem var(--theme-editor-section-horizontal-padding);
         color: var(--dev-tools-text-color-emphasis);

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/style-detector.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/style-detector.ts
@@ -2,7 +2,7 @@ import { ComponentTheme } from './model';
 import { ComponentMetadata } from './metadata/model';
 
 export function detectStyles(metadata: ComponentMetadata): ComponentTheme {
-  const componentTheme = new ComponentTheme(metadata.tagName);
+  const componentTheme = new ComponentTheme(metadata);
   const element = document.createElement(metadata.tagName);
   element.style.display = 'hidden';
   document.body.append(element);

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/style-detector.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/style-detector.ts
@@ -1,0 +1,31 @@
+import { ComponentTheme } from './model';
+import { ComponentMetadata } from './metadata/model';
+
+export function detectStyles(metadata: ComponentMetadata): ComponentTheme {
+  const componentTheme = new ComponentTheme(metadata.tagName);
+  const element = document.createElement(metadata.tagName);
+  element.style.display = 'hidden';
+  document.body.append(element);
+
+  try {
+    metadata.parts.forEach((part) => {
+      const partElement = element.shadowRoot?.querySelector(`[part~="${part.partName}"]`);
+      if (!partElement) {
+        return;
+      }
+      const partStyles = getComputedStyle(partElement);
+
+      part.properties.forEach((property) => {
+        componentTheme.updatePropertyValue(
+          part.partName,
+          property.propertyName,
+          partStyles[property.propertyName as any]
+        );
+      });
+    });
+  } finally {
+    element.remove();
+  }
+
+  return componentTheme;
+}

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/vaadin-dev-tools.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/vaadin-dev-tools.ts
@@ -4,7 +4,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { ComponentPicker } from './component-picker';
 import { ComponentReference } from './component-util';
 import './theme-editor/editor';
-import { ThemeEditorState } from './theme-editor/model';
+import { ThemeEditorState, ThemeEditorRule } from './theme-editor/model';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { copy } from './copy-to-clipboard.js';
@@ -167,6 +167,10 @@ export class Connection extends Object {
   }
   sendShowComponentAttachLocation(component: ComponentReference) {
     this.send('showComponentAttachLocation', component);
+  }
+
+  sendThemeEditorRules(rules: ThemeEditorRule[]) {
+    this.send('themeEditorRules', { add: rules });
   }
 }
 
@@ -1636,6 +1640,7 @@ export class VaadinDevTools extends LitElement {
     return html` <vaadin-dev-tools-theme-editor
       .themeEditorState=${this.themeEditorState}
       .pickerProvider=${() => this.componentPicker}
+      .connection=${this.frontendConnection}
     ></vaadin-dev-tools-theme-editor>`;
   }
 

--- a/vaadin-dev-server/web-test-runner.config.mjs
+++ b/vaadin-dev-server/web-test-runner.config.mjs
@@ -1,6 +1,12 @@
 import { esbuildPlugin } from '@web/dev-server-esbuild';
+import { fileURLToPath } from "url";
 
 export default {
   files: ['src/main/resources/META-INF/frontend/vaadin-dev-tools/**/*.test.ts'],
-  plugins: [esbuildPlugin({ ts: true })],
+  plugins: [
+    esbuildPlugin({
+      ts: true,
+      tsconfig: fileURLToPath(new URL('./tsconfig.json', import.meta.url)),
+    }),
+  ],
 };


### PR DESCRIPTION
## Description

Added:
- base theme detection for the selected component and use it for filling property editors
- allow editing of properties and store them in an edited theme
- live preview of the edited theme
- save or discard the edited theme, where saving sends the pending changes to the dev server

For now the theme preview will always have higher priority over other stylesheets. When saving, it is expected that the page reloads, and there is no logic yet to either prevent the reload, or restore UI state after a reload.