### PR TITLE
fix: Ignore ?inline suffix for imported stylesheets

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuild.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuild.java
@@ -296,6 +296,10 @@ public class TaskRunDevBundleBuild implements FallibleCommand {
                 .filter(line -> line.startsWith("import"))
                 .map(line -> line.substring(line.indexOf('\'') + 1,
                         line.lastIndexOf('\'')))
+                .map(importString -> importString.contains("?")
+                        ? importString.substring(0,
+                                importString.lastIndexOf("?"))
+                        : importString)
                 .collect(Collectors.toList());
         JsonArray statsBundle = statsJson.hasKey("bundleImports")
                 ? statsJson.getArray("bundleImports")


### PR DESCRIPTION
Frontend resources checking ignores ?inline suffixes in the stylesheet path when comparing file names.