### PR TITLE
refactor: keep modified component themes in theme editor

### DIFF
--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/model.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/model.ts
@@ -67,17 +67,17 @@ export class ComponentTheme {
   public getPropertyValuesForPart(partName: string | null) {
     return this.properties.filter((property) => property.partName === partName);
   }
-}
 
-export function combineThemes(...themes: ComponentTheme[]): ComponentTheme {
-  if (themes.length < 2) {
-    throw new Error('Must provide at least two themes');
+  static combine(...themes: ComponentTheme[]) {
+    if (themes.length < 2) {
+      throw new Error('Must provide at least two themes');
+    }
+
+    const resultTheme = new ComponentTheme(themes[0].metadata);
+    themes.forEach((theme) => resultTheme.addPropertyValues(theme.properties));
+
+    return resultTheme;
   }
-
-  const resultTheme = new ComponentTheme(themes[0].metadata);
-  themes.forEach((theme) => resultTheme.addPropertyValues(theme.properties));
-
-  return resultTheme;
 }
 
 export function generateRules(theme: ComponentTheme): ThemeEditorRule[] {
@@ -92,4 +92,33 @@ export function generateRules(theme: ComponentTheme): ThemeEditorRule[] {
       value: propertyValue.value
     };
   });
+}
+
+type ComponentThemeMap = { [key: string]: ComponentTheme };
+
+export class Theme {
+  private _componentThemes: ComponentThemeMap = {};
+
+  get componentThemes(): ComponentTheme[] {
+    return Object.values(this._componentThemes);
+  }
+
+  getComponentTheme(tagName: string) {
+    return this._componentThemes[tagName] || null;
+  }
+
+  updateComponentTheme(updatedTheme: ComponentTheme) {
+    let existingTheme = this.getComponentTheme(updatedTheme.metadata.tagName);
+    if (!existingTheme) {
+      existingTheme = new ComponentTheme(updatedTheme.metadata);
+      this._componentThemes[existingTheme.metadata.tagName] = existingTheme;
+    }
+    existingTheme.addPropertyValues(updatedTheme.properties);
+  }
+
+  clone() {
+    const resultTheme = new Theme();
+    this.componentThemes.forEach((componentTheme) => resultTheme.updateComponentTheme(componentTheme));
+    return resultTheme;
+  }
 }

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/preview.test.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/preview.test.ts
@@ -2,7 +2,7 @@ import { expect, fixture, html } from '@open-wc/testing';
 import '@vaadin/button';
 import buttonMetadata from './metadata/components/vaadin-button';
 import { themePreview } from './preview';
-import { ComponentTheme } from './model';
+import {ComponentTheme, Theme} from './model';
 
 describe('theme-preview', () => {
   const colors = {
@@ -32,10 +32,12 @@ describe('theme-preview', () => {
     expect(buttonStyles.suffix.color).to.not.equal(colors.green);
     expect(buttonStyles.prefix.color).to.not.equal(colors.blue);
 
-    const theme = new ComponentTheme(buttonMetadata);
-    theme.updatePropertyValue('label', 'color', colors.red);
-    theme.updatePropertyValue('prefix', 'color', colors.green);
-    theme.updatePropertyValue('suffix', 'color', colors.blue);
+    const theme = new Theme();
+    const buttonTheme = new ComponentTheme(buttonMetadata);
+    buttonTheme.updatePropertyValue('label', 'color', colors.red);
+    buttonTheme.updatePropertyValue('prefix', 'color', colors.green);
+    buttonTheme.updatePropertyValue('suffix', 'color', colors.blue);
+    theme.updateComponentTheme(buttonTheme);
     themePreview.update(theme);
 
     buttonStyles = getButtonStyles();
@@ -45,15 +47,18 @@ describe('theme-preview', () => {
   });
 
   it('should update theme preview', () => {
-    const theme = new ComponentTheme(buttonMetadata);
-    theme.updatePropertyValue('label', 'color', colors.red);
-    theme.updatePropertyValue('prefix', 'color', colors.green);
-    theme.updatePropertyValue('suffix', 'color', colors.blue);
+    const theme = new Theme();
+    const buttonTheme = new ComponentTheme(buttonMetadata);
+    buttonTheme.updatePropertyValue('label', 'color', colors.red);
+    buttonTheme.updatePropertyValue('prefix', 'color', colors.green);
+    buttonTheme.updatePropertyValue('suffix', 'color', colors.blue);
+    theme.updateComponentTheme(buttonTheme);
     themePreview.update(theme);
 
-    theme.updatePropertyValue('label', 'color', colors.red);
-    theme.updatePropertyValue('prefix', 'color', colors.red);
-    theme.updatePropertyValue('suffix', 'color', colors.red);
+    buttonTheme.updatePropertyValue('label', 'color', colors.red);
+    buttonTheme.updatePropertyValue('prefix', 'color', colors.red);
+    buttonTheme.updatePropertyValue('suffix', 'color', colors.red);
+    theme.updateComponentTheme(buttonTheme);
     themePreview.update(theme);
 
     let buttonStyles = getButtonStyles();
@@ -63,10 +68,12 @@ describe('theme-preview', () => {
   });
 
   it('should reset theme preview', () => {
-    const theme = new ComponentTheme(buttonMetadata);
-    theme.updatePropertyValue('label', 'color', colors.red);
-    theme.updatePropertyValue('prefix', 'color', colors.green);
-    theme.updatePropertyValue('suffix', 'color', colors.blue);
+    const theme = new Theme();
+    const buttonTheme = new ComponentTheme(buttonMetadata);
+    buttonTheme.updatePropertyValue('label', 'color', colors.red);
+    buttonTheme.updatePropertyValue('prefix', 'color', colors.green);
+    buttonTheme.updatePropertyValue('suffix', 'color', colors.blue);
+    theme.updateComponentTheme(buttonTheme)
     themePreview.update(theme);
 
     themePreview.reset();

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/preview.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/preview.ts
@@ -1,4 +1,4 @@
-import { ComponentTheme } from './model';
+import { Theme } from './model';
 
 class ThemePreview {
   private _stylesheet: CSSStyleSheet;
@@ -13,16 +13,19 @@ class ThemePreview {
     return this._stylesheet;
   }
 
-  update(theme: ComponentTheme) {
+  update(theme: Theme) {
     const rules: string[] = [];
-    const uniquePartNames = theme.metadata.parts.map((part) => part.partName);
 
-    uniquePartNames.forEach((partName) => {
-      const selector = `${theme.metadata.tagName}::part(${partName})`;
-      const propertyValues = theme.getPropertyValuesForPart(partName);
-      const propertyDeclarations = propertyValues.map((value) => `${value.propertyName}: ${value.value}`).join(';');
-      const rule = `${selector} { ${propertyDeclarations} }`;
-      rules.push(rule);
+    theme.componentThemes.forEach((componentTheme) => {
+      componentTheme.metadata.parts
+        .map((part) => part.partName)
+        .forEach((partName) => {
+          const selector = `${componentTheme.metadata.tagName}::part(${partName})`;
+          const propertyValues = componentTheme.getPropertyValuesForPart(partName);
+          const propertyDeclarations = propertyValues.map((value) => `${value.propertyName}: ${value.value}`).join(';');
+          const rule = `${selector} { ${propertyDeclarations} }`;
+          rules.push(rule);
+        });
     });
 
     const themeCss = rules.join('\n');


### PR DESCRIPTION
## Description

Adds a `Theme` data structure and state for keeping all previously saved component theme modifictions in the theme editor. The theme instance contains all modifications to all components since the last reload. This allows to keep the modifications in the theme preview when picking a different component, and also to restore the modified values in the property editors when picking the same component again.
