### PR TITLE
refactor: editable host properties in theme editor

### DIFF
--- a/vaadin-dev-server/pom.xml
+++ b/vaadin-dev-server/pom.xml
@@ -93,8 +93,9 @@
             <resource>
                 <directory>src/main/resources</directory>
                 <excludes>
-                    <!-- Exclude all frontend tests -->
+                    <!-- Exclude all frontend tests and utils -->
                     <exclude>META-INF/frontend/vaadin-dev-tools/**/*.test.ts</exclude>
+                    <exclude>META-INF/frontend/vaadin-dev-tools/theme-editor/tests/*.*</exclude>
                 </excludes>
             </resource>
         </resources>

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/detector.test.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/detector.test.ts
@@ -1,17 +1,22 @@
 import { expect, fixture, html } from '@open-wc/testing';
-import '@vaadin/button';
-import buttonMetadata from './metadata/components/vaadin-button';
 import { detectTheme } from './detector';
+import { testElementMetadata } from './tests/utils';
 
 describe('theme-detector', () => {
   it('should include all CSS property values from component metadata', () => {
-    const theme = detectTheme(buttonMetadata);
+    const theme = detectTheme(testElementMetadata);
     let propertyCount = 0;
 
-    buttonMetadata.parts.forEach((part) => {
+    // Host properties
+    testElementMetadata.properties.forEach((property) => {
+      propertyCount++;
+      const propertyValue = theme.getPropertyValue(null, property.propertyName);
+      expect(propertyValue).to.exist;
+    });
+    // Part properties
+    testElementMetadata.parts.forEach((part) => {
       part.properties.forEach((property) => {
         propertyCount++;
-
         const propertyValue = theme.getPropertyValue(part.partName, property.propertyName);
         expect(propertyValue).to.exist;
       });
@@ -21,44 +26,33 @@ describe('theme-detector', () => {
   });
 
   it('should detect default CSS property values', async () => {
-    const theme = detectTheme(buttonMetadata);
+    const theme = detectTheme(testElementMetadata);
 
-    const button = await fixture(html` <vaadin-button></vaadin-button>`);
-    const labelColor = getComputedStyle(button.shadowRoot!.querySelector('[part="label"]')!).color;
-    const prefixColor = getComputedStyle(button.shadowRoot!.querySelector('[part="prefix"]')!).color;
-    const suffixColor = getComputedStyle(button.shadowRoot!.querySelector('[part="suffix"]')!).color;
-
-    expect(theme.getPropertyValue('label', 'color').value).to.equal(labelColor);
-    expect(theme.getPropertyValue('prefix', 'color').value).to.equal(prefixColor);
-    expect(theme.getPropertyValue('suffix', 'color').value).to.equal(suffixColor);
+    expect(theme.getPropertyValue(null, 'padding').value).to.equal('10px');
+    expect(theme.getPropertyValue('label', 'color').value).to.equal('rgb(0, 0, 0)');
   });
 
   it('should detect themed CSS property values', async () => {
     await fixture(html`
       <style>
-        vaadin-button::part(label) {
-          color: red;
+        test-element {
+          padding: 20px;
         }
 
-        vaadin-button::part(prefix) {
-          color: rgb(0, 255, 0);
-        }
-
-        vaadin-button::part(suffix) {
-          color: blue;
+        test-element::part(label) {
+          color: green;
         }
       </style>
     `);
-    const theme = detectTheme(buttonMetadata);
+    const theme = detectTheme(testElementMetadata);
 
-    expect(theme.getPropertyValue('label', 'color').value).to.equal('rgb(255, 0, 0)');
-    expect(theme.getPropertyValue('prefix', 'color').value).to.equal('rgb(0, 255, 0)');
-    expect(theme.getPropertyValue('suffix', 'color').value).to.equal('rgb(0, 0, 255)');
+    expect(theme.getPropertyValue(null, 'padding').value).to.equal('20px');
+    expect(theme.getPropertyValue('label', 'color').value).to.equal('rgb(0, 128, 0)');
   });
 
   it('should remove test component from DOM', () => {
-    detectTheme(buttonMetadata);
+    detectTheme(testElementMetadata);
 
-    expect(document.querySelector('vaadin-button')).to.not.exist;
+    expect(document.querySelector('test-element')).to.not.exist;
   });
 });

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/detector.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/detector.ts
@@ -8,6 +8,15 @@ export function detectTheme(metadata: ComponentMetadata): ComponentTheme {
   document.body.append(element);
 
   try {
+    // Host
+    const hostStyles = getComputedStyle(element);
+
+    metadata.properties.forEach((property) => {
+      const propertyValue = getPropertyValue(hostStyles, property.propertyName);
+      componentTheme.updatePropertyValue(null, property.propertyName, propertyValue);
+    });
+
+    // Parts
     metadata.parts.forEach((part) => {
       const partElement = element.shadowRoot?.querySelector(`[part~="${part.partName}"]`);
       if (!partElement) {
@@ -16,11 +25,8 @@ export function detectTheme(metadata: ComponentMetadata): ComponentTheme {
       const partStyles = getComputedStyle(partElement);
 
       part.properties.forEach((property) => {
-        componentTheme.updatePropertyValue(
-          part.partName,
-          property.propertyName,
-          partStyles[property.propertyName as any]
-        );
+        const propertyValue = getPropertyValue(partStyles, property.propertyName);
+        componentTheme.updatePropertyValue(part.partName, property.propertyName, propertyValue);
       });
     });
   } finally {
@@ -28,4 +34,8 @@ export function detectTheme(metadata: ComponentMetadata): ComponentTheme {
   }
 
   return componentTheme;
+}
+
+function getPropertyValue(styles: CSSStyleDeclaration, propertyName: string) {
+  return propertyName.indexOf('--') === 0 ? styles.getPropertyValue(propertyName) : styles[propertyName as any];
 }

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.test.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.test.ts
@@ -1,21 +1,20 @@
 import { aTimeout, elementUpdated, expect, fixture, html } from '@open-wc/testing';
-import '@vaadin/button';
 import { ThemeEditorRule, ThemeEditorState } from './model';
 import { ThemeEditor } from './editor';
 import './editor';
 import { PickerOptions, PickerProvider } from '../component-picker';
 import { metadataRegistry } from './metadata/registry';
-import buttonMetadata from './metadata/components/vaadin-button';
 import sinon from 'sinon';
 import { themePreview } from './preview';
+import { testElementMetadata } from './tests/utils';
 
 describe('theme-editor', () => {
   let editor: ThemeEditor;
-  let button: HTMLElement;
-  let defaultButtonLabelStyles: CSSStyleDeclaration;
+  let testElement: HTMLElement;
   let connectionMock: {
     sendThemeEditorRules: sinon.SinonSpy;
   };
+  let getMetadataStub: sinon.SinonStub;
 
   async function editorFixture() {
     connectionMock = {
@@ -23,7 +22,7 @@ describe('theme-editor', () => {
     };
     const pickerMock = {
       open: (options: PickerOptions) => {
-        options.pickCallback({ nodeId: 1, uiId: 1, element: button });
+        options.pickCallback({ nodeId: 1, uiId: 1, element: testElement });
       }
     };
     const pickerProvider: PickerProvider = () => pickerMock as any;
@@ -45,10 +44,11 @@ describe('theme-editor', () => {
     await aTimeout(50);
   }
 
-  function findPropertyEditor(partName: string, propertyName: string) {
+  function findPropertyEditor(partName: string | null, propertyName: string) {
+    const partTestId = partName || 'host';
     return editor
       .shadowRoot!.querySelector('.property-list')
-      ?.shadowRoot!.querySelector(`.part[data-testid="${partName}"] .property-editor[data-testid="${propertyName}"]`)!;
+      ?.shadowRoot!.querySelector(`.section[data-testid="${partTestId}"] .property-editor[data-testid="${propertyName}"]`)!;
   }
 
   async function editProperty(partName: string, propertyName: string, value: string) {
@@ -80,24 +80,24 @@ describe('theme-editor', () => {
     return editor.shadowRoot!.querySelector('.modifications-actions button.apply') as HTMLElement;
   }
 
-  function getButtonStyles() {
+  function getTestElementStyles() {
     return {
-      label: getComputedStyle(button.shadowRoot!.querySelector('[part="label"]')!),
-      prefix: getComputedStyle(button.shadowRoot!.querySelector('[part="prefix"]')!),
-      suffix: getComputedStyle(button.shadowRoot!.querySelector('[part="suffix"]')!)
+      host: getComputedStyle(testElement),
+      label: getComputedStyle(testElement.shadowRoot!.querySelector('[part="label"]')!)
     };
   }
 
   before(async () => {
-    // Pre-cache button metadata
-    const button = document.createElement('vaadin-button');
-    await metadataRegistry.getMetadata({ nodeId: 1, uiId: 1, element: button });
+    getMetadataStub = sinon.stub(metadataRegistry, 'getMetadata').returns(Promise.resolve(testElementMetadata));
+  });
+
+  after(() => {
+    getMetadataStub.restore();
   });
 
   beforeEach(async () => {
     themePreview.reset();
-    button = await fixture(html` <vaadin-button></vaadin-button>`);
-    defaultButtonLabelStyles = getComputedStyle(button.shadowRoot!.querySelector('[part="label"]')!);
+    testElement = await fixture(html` <test-element></test-element>`);
     const fixtureResult = await editorFixture();
     editor = fixtureResult.editor;
   });
@@ -125,6 +125,7 @@ describe('theme-editor', () => {
 
     it('should be modified after changing a property', async () => {
       await pickComponent();
+      debugger;
       await editProperty('label', 'color', 'red');
 
       expect(findDiscardButton()).to.exist;
@@ -166,7 +167,7 @@ describe('theme-editor', () => {
       await pickComponent();
       await editProperty('label', 'color', 'red');
 
-      expect(getButtonStyles().label.color).to.equal('rgb(255, 0, 0)');
+      expect(getTestElementStyles().label.color).to.equal('rgb(255, 0, 0)');
     });
 
     it('should reset theme preview after discarding changes', async () => {
@@ -176,7 +177,7 @@ describe('theme-editor', () => {
       findDiscardButton().click();
       await elementUpdated(editor);
 
-      expect(getButtonStyles().label.color).to.equal(defaultButtonLabelStyles.color);
+      expect(getTestElementStyles().label.color).to.equal('rgb(0, 0, 0)');
     });
 
     it('should reset theme preview after picking another component', async () => {
@@ -185,27 +186,33 @@ describe('theme-editor', () => {
 
       await pickComponent();
 
-      expect(getButtonStyles().label.color).to.equal(defaultButtonLabelStyles.color);
+      expect(getTestElementStyles().label.color).to.equal('rgb(0, 0, 0)');
     });
 
     it('should keep saved modifications in theme preview', async () => {
       await pickComponent();
       await editProperty('label', 'color', 'red');
       findApplyButton().click();
-      expect(getButtonStyles().label.color).to.equal('rgb(255, 0, 0)');
+      expect(getTestElementStyles().label.color).to.equal('rgb(255, 0, 0)');
 
       await pickComponent();
-      expect(getButtonStyles().label.color).to.equal('rgb(255, 0, 0)');
+      expect(getTestElementStyles().label.color).to.equal('rgb(255, 0, 0)');
 
       await editProperty('label', 'color', 'green');
       findDiscardButton().click();
-      expect(getButtonStyles().label.color).to.equal('rgb(255, 0, 0)');
+      expect(getTestElementStyles().label.color).to.equal('rgb(255, 0, 0)');
     });
 
     it('should show property editors for picked component', async () => {
       await pickComponent();
 
-      buttonMetadata.parts.forEach((part) => {
+      // Host properties
+      testElementMetadata.properties.forEach(property => {
+        const propertyEditor = findPropertyEditor(null, property.propertyName);
+        expect(propertyEditor).to.exist;
+      })
+      // Part properties
+      testElementMetadata.parts.forEach((part) => {
         part.properties.forEach((property) => {
           const propertyEditor = findPropertyEditor(part.partName, property.propertyName);
           expect(propertyEditor).to.exist;
@@ -216,20 +223,14 @@ describe('theme-editor', () => {
     it('should initialize property editors with base theme values', async () => {
       await pickComponent();
 
-      const propertyEditor = findPropertyEditor('label', 'color');
-      const input = propertyEditor.shadowRoot!.querySelector('input')! as HTMLInputElement;
-
-      expect(input.value).to.equal(defaultButtonLabelStyles.color);
+      expect(getPropertyValue('label', 'color')).to.equal('rgb(0, 0, 0)');
     });
 
     it('should update property editors with edited theme values', async () => {
       await pickComponent();
       await editProperty('label', 'color', 'red');
 
-      const propertyEditor = findPropertyEditor('label', 'color');
-      const input = propertyEditor.shadowRoot!.querySelector('input')! as HTMLInputElement;
-
-      expect(input.value).to.equal('red');
+      expect(getPropertyValue('label', 'color')).to.equal('red');
     });
 
     it('should reset property editors after discarding changes', async () => {
@@ -239,7 +240,7 @@ describe('theme-editor', () => {
       findDiscardButton().click();
       await elementUpdated(editor);
 
-      expect(getPropertyValue('label', 'color')).to.equal(defaultButtonLabelStyles.color);
+      expect(getPropertyValue('label', 'color')).to.equal('rgb(0, 0, 0)');
     });
 
     it('should reset property editors after picking another component', async () => {
@@ -248,7 +249,7 @@ describe('theme-editor', () => {
 
       await pickComponent();
 
-      expect(getPropertyValue('label', 'color')).to.equal(defaultButtonLabelStyles.color);
+      expect(getPropertyValue('label', 'color')).to.equal('rgb(0, 0, 0)');
     });
 
     it('should keep previously saved theme modifications', async () => {
@@ -275,7 +276,7 @@ describe('theme-editor', () => {
 
       const expectedRules: ThemeEditorRule[] = [
         {
-          selector: 'vaadin-button::part(label)',
+          selector: 'test-element::part(label)',
           property: 'color',
           value: 'red'
         }

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.test.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.test.ts
@@ -125,7 +125,6 @@ describe('theme-editor', () => {
 
     it('should be modified after changing a property', async () => {
       await pickComponent();
-      debugger;
       await editProperty('label', 'color', 'red');
 
       expect(findDiscardButton()).to.exist;

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.ts
@@ -218,8 +218,9 @@ export class ThemeEditor extends LitElement {
       return;
     }
     const { part, property, value } = e.detail;
+    const partName = part?.partName || null;
     this.hasModifications = true;
-    this.editedComponentTheme.updatePropertyValue(part.partName, property.propertyName, value);
+    this.editedComponentTheme.updatePropertyValue(partName, property.propertyName, value);
     this.effectiveComponentTheme = ComponentTheme.combine(
       this.baseComponentTheme,
       this.modifiedComponentTheme,

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/events.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/events.ts
@@ -1,11 +1,11 @@
 import { ComponentPartMetadata, CssPropertyMetadata } from './metadata/model';
 
 export class ThemePropertyValueChangeEvent extends CustomEvent<{
-  part: ComponentPartMetadata;
+  part: ComponentPartMetadata | null;
   property: CssPropertyMetadata;
   value: string;
 }> {
-  constructor(part: ComponentPartMetadata, property: CssPropertyMetadata, value: string) {
+  constructor(part: ComponentPartMetadata | null, property: CssPropertyMetadata, value: string) {
     super('theme-property-value-change', {
       bubbles: true,
       composed: true,

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/components/vaadin-button.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/components/vaadin-button.ts
@@ -1,62 +1,31 @@
-import { ComponentMetadata } from '../model';
+import { ComponentMetadata, CssPropertyEditorType } from '../model';
 
 export default {
   tagName: 'vaadin-button',
   displayName: 'Button',
-  parts: [
+  properties: [
     {
-      partName: 'label',
-      displayName: 'Label',
-      properties: [
-        {
-          propertyName: 'color',
-          displayName: 'Text color'
-        },
-        {
-          propertyName: 'font-size',
-          displayName: 'Font size'
-        },
-        {
-          propertyName: 'background',
-          displayName: 'Background'
-        }
-      ]
+      propertyName: 'background-color',
+      displayName: 'Background color',
+      editor: CssPropertyEditorType.colorPicker
     },
     {
-      partName: 'prefix',
-      displayName: 'Prefix',
-      properties: [
-        {
-          propertyName: 'color',
-          displayName: 'Text color'
-        },
-        {
-          propertyName: 'font-size',
-          displayName: 'Font size'
-        },
-        {
-          propertyName: 'background',
-          displayName: 'Background'
-        }
-      ]
+      propertyName: 'color',
+      displayName: 'Text color',
+      editor: CssPropertyEditorType.colorPicker
     },
     {
-      partName: 'suffix',
-      displayName: 'Suffix',
-      properties: [
-        {
-          propertyName: 'color',
-          displayName: 'Text color'
-        },
-        {
-          propertyName: 'font-size',
-          displayName: 'Font size'
-        },
-        {
-          propertyName: 'background',
-          displayName: 'Background'
-        }
-      ]
+      propertyName: '--lumo-button-size',
+      displayName: 'Size',
+      editor: CssPropertyEditorType.slider,
+      preferredValues: ['--lumo-size-xs', '--lumo-size-s', '--lumo-size-m', '--lumo-size-l', '--lumo-size-xl']
+    },
+    {
+      propertyName: 'padding-inline',
+      displayName: 'Padding',
+      editor: CssPropertyEditorType.slider,
+      preferredValues: ['--lumo-space-xs', '--lumo-space-s', '--lumo-space-m', '--lumo-space-l', '--lumo-space-xl']
     }
-  ]
+  ],
+  parts: []
 } as ComponentMetadata;

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/components/vaadin-button.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/components/vaadin-button.ts
@@ -1,4 +1,4 @@
-import { ComponentMetadata, CssPropertyEditorType } from '../model';
+import { ComponentMetadata } from '../model';
 
 export default {
   tagName: 'vaadin-button',
@@ -7,24 +7,18 @@ export default {
     {
       propertyName: 'background-color',
       displayName: 'Background color',
-      editor: CssPropertyEditorType.colorPicker
     },
     {
       propertyName: 'color',
       displayName: 'Text color',
-      editor: CssPropertyEditorType.colorPicker
     },
     {
       propertyName: '--lumo-button-size',
       displayName: 'Size',
-      editor: CssPropertyEditorType.slider,
-      preferredValues: ['--lumo-size-xs', '--lumo-size-s', '--lumo-size-m', '--lumo-size-l', '--lumo-size-xl']
     },
     {
       propertyName: 'padding-inline',
       displayName: 'Padding',
-      editor: CssPropertyEditorType.slider,
-      preferredValues: ['--lumo-space-xs', '--lumo-space-s', '--lumo-space-m', '--lumo-space-l', '--lumo-space-xl']
     }
   ],
   parts: []

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/components/vaadin-text-field.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/components/vaadin-text-field.ts
@@ -3,6 +3,7 @@ import { ComponentMetadata } from '../model';
 export default {
   tagName: 'vaadin-text-field',
   displayName: 'TextField',
+  properties: [],
   parts: [
     {
       partName: 'label',

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/model.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/model.ts
@@ -1,7 +1,15 @@
+export enum CssPropertyEditorType {
+  text,
+  colorPicker,
+  slider
+}
+
 export interface CssPropertyMetadata {
   propertyName: string;
   displayName: string;
   description?: string;
+  preferredValues?: string[]
+  editor?: CssPropertyEditorType
 }
 
 export interface ComponentPartMetadata {
@@ -16,4 +24,5 @@ export interface ComponentMetadata {
   displayName: string;
   description?: string;
   parts: ComponentPartMetadata[];
+  properties: CssPropertyMetadata[];
 }

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/model.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/model.ts
@@ -1,15 +1,7 @@
-export enum CssPropertyEditorType {
-  text,
-  colorPicker,
-  slider
-}
-
 export interface CssPropertyMetadata {
   propertyName: string;
   displayName: string;
   description?: string;
-  preferredValues?: string[]
-  editor?: CssPropertyEditorType
 }
 
 export interface ComponentPartMetadata {
@@ -23,6 +15,6 @@ export interface ComponentMetadata {
   tagName: string;
   displayName: string;
   description?: string;
-  parts: ComponentPartMetadata[];
   properties: CssPropertyMetadata[];
+  parts: ComponentPartMetadata[];
 }

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/model.test.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/model.test.ts
@@ -137,7 +137,8 @@ describe('model', () => {
       const fooMetadata: ComponentMetadata = {
         tagName: 'foo-component',
         displayName: 'Foo',
-        parts: []
+        properties: [],
+        parts: [],
       };
       const buttonTheme = new ComponentTheme(buttonMetadata);
       const fooTheme = new ComponentTheme(fooMetadata);

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/preview.test.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/preview.test.ts
@@ -1,86 +1,66 @@
 import { expect, fixture, html } from '@open-wc/testing';
-import '@vaadin/button';
-import buttonMetadata from './metadata/components/vaadin-button';
 import { themePreview } from './preview';
-import {ComponentTheme, Theme} from './model';
+import { ComponentTheme, Theme } from './model';
+import { testElementMetadata } from './tests/utils';
 
 describe('theme-preview', () => {
-  const colors = {
-    red: 'rgb(255, 0, 0)',
-    green: 'rgb(0, 255, 0)',
-    blue: 'rgb(0, 0, 255)'
-  };
+  let element: HTMLElement;
 
-  let button: HTMLElement;
-
-  function getButtonStyles() {
+  function getElementStyles() {
     return {
-      label: getComputedStyle(button.shadowRoot!.querySelector('[part="label"]')!),
-      prefix: getComputedStyle(button.shadowRoot!.querySelector('[part="prefix"]')!),
-      suffix: getComputedStyle(button.shadowRoot!.querySelector('[part="suffix"]')!)
+      host: getComputedStyle(element),
+      label: getComputedStyle(element.shadowRoot!.querySelector('[part="label"]')!)
     };
   }
 
   beforeEach(async () => {
     themePreview.stylesheet.replaceSync('');
-    button = await fixture(html` <vaadin-button></vaadin-button>`);
+    element = await fixture(html` <test-element></test-element>`);
   });
 
   it('should apply theme preview', () => {
-    let buttonStyles = getButtonStyles();
-    expect(buttonStyles.label.color).to.not.equal(colors.red);
-    expect(buttonStyles.suffix.color).to.not.equal(colors.green);
-    expect(buttonStyles.prefix.color).to.not.equal(colors.blue);
-
     const theme = new Theme();
-    const buttonTheme = new ComponentTheme(buttonMetadata);
-    buttonTheme.updatePropertyValue('label', 'color', colors.red);
-    buttonTheme.updatePropertyValue('prefix', 'color', colors.green);
-    buttonTheme.updatePropertyValue('suffix', 'color', colors.blue);
-    theme.updateComponentTheme(buttonTheme);
+    const componentTheme = new ComponentTheme(testElementMetadata);
+    componentTheme.updatePropertyValue(null, 'padding', '20px');
+    componentTheme.updatePropertyValue('label', 'color', 'red');
+    theme.updateComponentTheme(componentTheme);
     themePreview.update(theme);
 
-    buttonStyles = getButtonStyles();
-    expect(buttonStyles.label.color).to.equal(colors.red);
-    expect(buttonStyles.prefix.color).to.equal(colors.green);
-    expect(buttonStyles.suffix.color).to.equal(colors.blue);
+    const elementStyles = getElementStyles();
+    expect(elementStyles.host.padding).to.equal('20px');
+    expect(elementStyles.label.color).to.equal('rgb(255, 0, 0)');
   });
 
   it('should update theme preview', () => {
     const theme = new Theme();
-    const buttonTheme = new ComponentTheme(buttonMetadata);
-    buttonTheme.updatePropertyValue('label', 'color', colors.red);
-    buttonTheme.updatePropertyValue('prefix', 'color', colors.green);
-    buttonTheme.updatePropertyValue('suffix', 'color', colors.blue);
-    theme.updateComponentTheme(buttonTheme);
+    const componentTheme = new ComponentTheme(testElementMetadata);
+    componentTheme.updatePropertyValue(null, 'padding', '20px');
+    componentTheme.updatePropertyValue('label', 'color', 'red');
+    theme.updateComponentTheme(componentTheme);
     themePreview.update(theme);
 
-    buttonTheme.updatePropertyValue('label', 'color', colors.red);
-    buttonTheme.updatePropertyValue('prefix', 'color', colors.red);
-    buttonTheme.updatePropertyValue('suffix', 'color', colors.red);
-    theme.updateComponentTheme(buttonTheme);
+    componentTheme.updatePropertyValue(null, 'padding', '30px');
+    componentTheme.updatePropertyValue('label', 'color', 'green');
+    theme.updateComponentTheme(componentTheme);
     themePreview.update(theme);
 
-    let buttonStyles = getButtonStyles();
-    expect(buttonStyles.label.color).to.equal(colors.red);
-    expect(buttonStyles.prefix.color).to.equal(colors.red);
-    expect(buttonStyles.suffix.color).to.equal(colors.red);
+    const elementStyles = getElementStyles();
+    expect(elementStyles.host.padding).to.equal('30px');
+    expect(elementStyles.label.color).to.equal('rgb(0, 128, 0)');
   });
 
   it('should reset theme preview', () => {
     const theme = new Theme();
-    const buttonTheme = new ComponentTheme(buttonMetadata);
-    buttonTheme.updatePropertyValue('label', 'color', colors.red);
-    buttonTheme.updatePropertyValue('prefix', 'color', colors.green);
-    buttonTheme.updatePropertyValue('suffix', 'color', colors.blue);
-    theme.updateComponentTheme(buttonTheme)
+    const componentTheme = new ComponentTheme(testElementMetadata);
+    componentTheme.updatePropertyValue(null, 'padding', '20px');
+    componentTheme.updatePropertyValue('label', 'color', 'red');
+    theme.updateComponentTheme(componentTheme);
     themePreview.update(theme);
 
     themePreview.reset();
 
-    let buttonStyles = getButtonStyles();
-    expect(buttonStyles.label.color).to.not.equal(colors.red);
-    expect(buttonStyles.suffix.color).to.not.equal(colors.green);
-    expect(buttonStyles.prefix.color).to.not.equal(colors.blue);
+    const elementStyles = getElementStyles();
+    expect(elementStyles.host.padding).to.equal('10px');
+    expect(elementStyles.label.color).to.equal('rgb(0, 0, 0)');
   });
 });

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/preview.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/preview.ts
@@ -1,4 +1,4 @@
-import { Theme } from './model';
+import { ComponentTheme, Theme } from './model';
 
 class ThemePreview {
   private _stylesheet: CSSStyleSheet;
@@ -14,22 +14,28 @@ class ThemePreview {
   }
 
   update(theme: Theme) {
-    const rules: string[] = [];
+    let rules: string[] = [];
 
     theme.componentThemes.forEach((componentTheme) => {
-      componentTheme.metadata.parts
-        .map((part) => part.partName)
-        .forEach((partName) => {
-          const selector = `${componentTheme.metadata.tagName}::part(${partName})`;
-          const propertyValues = componentTheme.getPropertyValuesForPart(partName);
-          const propertyDeclarations = propertyValues.map((value) => `${value.propertyName}: ${value.value}`).join(';');
-          const rule = `${selector} { ${propertyDeclarations} }`;
-          rules.push(rule);
-        });
+      const hostRule = this.createRule(componentTheme, null);
+      const partRules = componentTheme.metadata.parts.map((part) => this.createRule(componentTheme, part.partName));
+
+      rules = [...rules, hostRule, ...partRules];
     });
 
     const themeCss = rules.join('\n');
     this._stylesheet.replaceSync(themeCss);
+  }
+
+  private createRule(componentTheme: ComponentTheme, partName: string | null) {
+    const selector = partName
+      ? // Part name selector
+        `${componentTheme.metadata.tagName}::part(${partName})`
+      : // Host selector
+        componentTheme.metadata.tagName;
+    const propertyValues = componentTheme.getPropertyValuesForPart(partName);
+    const propertyDeclarations = propertyValues.map((value) => `${value.propertyName}: ${value.value}`).join(';');
+    return `${selector} { ${propertyDeclarations} }`;
   }
 
   reset() {

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/property-editor.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/property-editor.ts
@@ -7,7 +7,7 @@ import { ThemePropertyValueChangeEvent } from './events';
 @customElement('vaadin-dev-tools-theme-property-editor')
 export class PropertyEditor extends LitElement {
   @property({})
-  public partMetadata!: ComponentPartMetadata;
+  public partMetadata?: ComponentPartMetadata;
   @property({})
   public propertyMetadata!: CssPropertyMetadata;
   @property({})
@@ -51,11 +51,12 @@ export class PropertyEditor extends LitElement {
 
   handleInputChange(e: Event) {
     const input = e.target as HTMLInputElement;
-    this.dispatchEvent(new ThemePropertyValueChangeEvent(this.partMetadata, this.propertyMetadata, input.value));
+    this.dispatchEvent(new ThemePropertyValueChangeEvent(this.partMetadata || null, this.propertyMetadata, input.value));
   }
 
   render() {
-    const propertyValue = this.theme.getPropertyValue(this.partMetadata.partName, this.propertyMetadata.propertyName);
+    const partName = this.partMetadata?.partName || null;
+    const propertyValue = this.theme.getPropertyValue(partName, this.propertyMetadata.propertyName);
 
     return html`
       <div class="property">

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/property-list.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/property-list.ts
@@ -1,6 +1,6 @@
 import { css, html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { ComponentMetadata, ComponentPartMetadata } from './metadata/model';
+import { ComponentMetadata, ComponentPartMetadata, CssPropertyMetadata } from './metadata/model';
 import './property-editor';
 import { ComponentTheme } from './model';
 
@@ -8,13 +8,13 @@ import { ComponentTheme } from './model';
 export class PropertyList extends LitElement {
   static get styles() {
     return css`
-      .part .header {
+      .section .header {
         padding: 0.4rem var(--theme-editor-section-horizontal-padding);
         color: var(--dev-tools-text-color-emphasis);
         background-color: rgba(0, 0, 0, 0.2);
       }
 
-      .part .property-list .property-editor:not(:last-child) {
+      .section .property-list .property-editor:not(:last-child) {
         border-bottom: solid 1px rgba(0, 0, 0, 0.2);
       }
     `;
@@ -26,13 +26,16 @@ export class PropertyList extends LitElement {
   public theme!: ComponentTheme;
 
   render() {
-    const partSections = this.metadata.parts.map((part) => this.renderPartSection(part));
+    const partSections = [
+      this.renderPartSection(null, this.metadata.properties),
+      ...this.metadata.parts.map((part) => this.renderPartSection(part, part.properties))
+    ];
 
     return html` <div class="part-list">${partSections}</div> `;
   }
 
-  private renderPartSection(part: ComponentPartMetadata) {
-    const properties = part.properties.map((property) => {
+  private renderPartSection(part: ComponentPartMetadata | null, properties: CssPropertyMetadata[]) {
+    const propertiesList = properties.map((property) => {
       return html` <vaadin-dev-tools-theme-property-editor
         class="property-editor"
         .partMetadata=${part}
@@ -43,9 +46,9 @@ export class PropertyList extends LitElement {
     });
 
     return html`
-      <div class="part" data-testid=${part.partName}>
-        <div class="header">${part.displayName}</div>
-        <div class="property-list">${properties}</div>
+      <div class="section" data-testid=${part?.partName || 'host'}>
+        ${part ? html` <div class="header">${part.displayName}</div>` : null}
+        <div class="property-list">${propertiesList}</div>
       </div>
     `;
   }

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/property-list.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/property-list.ts
@@ -26,15 +26,15 @@ export class PropertyList extends LitElement {
   public theme!: ComponentTheme;
 
   render() {
-    const partSections = [
-      this.renderPartSection(null, this.metadata.properties),
-      ...this.metadata.parts.map((part) => this.renderPartSection(part, part.properties))
+    const sections = [
+      this.renderSection(null, this.metadata.properties),
+      ...this.metadata.parts.map((part) => this.renderSection(part, part.properties))
     ];
 
-    return html` <div class="part-list">${partSections}</div> `;
+    return html` <div>${sections}</div> `;
   }
 
-  private renderPartSection(part: ComponentPartMetadata | null, properties: CssPropertyMetadata[]) {
+  private renderSection(part: ComponentPartMetadata | null, properties: CssPropertyMetadata[]) {
     const propertiesList = properties.map((property) => {
       return html` <vaadin-dev-tools-theme-property-editor
         class="property-editor"

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/tests/utils.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/tests/utils.ts
@@ -1,0 +1,48 @@
+import { ComponentMetadata } from '../metadata/model';
+
+export class TestElement extends HTMLElement {
+  constructor() {
+    super();
+
+    const shadow = this.attachShadow({ mode: 'open' });
+    const label = document.createElement('div');
+    label.setAttribute('part', 'label');
+    shadow.append(label);
+
+    const styles = new CSSStyleSheet();
+    styles.replaceSync(`
+      :host {
+        padding: 10px;
+      }
+
+      [part='label'] {
+        color: black;
+      }
+    `);
+    shadow.adoptedStyleSheets.push(styles);
+  }
+}
+customElements.define('test-element', TestElement);
+
+export const testElementMetadata: ComponentMetadata = {
+  tagName: 'test-element',
+  displayName: 'Test element',
+  properties: [
+    {
+      propertyName: 'padding',
+      displayName: 'Padding'
+    }
+  ],
+  parts: [
+    {
+      partName: 'label',
+      displayName: 'Label',
+      properties: [
+        {
+          propertyName: 'color',
+          displayName: 'Text color'
+        }
+      ]
+    }
+  ]
+};


### PR DESCRIPTION
## Description

- Extends component metadata to include host properties
- Show editors for host properties in theme editor
- Update button metadata to use host properties, as proposed by Jouni
- Update tests to use a test element / metadata in order to reduce changes when iterating on Vaadin component metadata in the future
