### PR TITLE
fix: use setAttribute in setAriaLabel method

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/HasAriaLabel.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasAriaLabel.java
@@ -51,8 +51,13 @@ public interface HasAriaLabel extends HasElement {
      *            the aria-label text to set or {@code null} to clear
      */
     default void setAriaLabel(String ariaLabel) {
-        getElement().setAttribute(ElementConstants.ARIA_LABEL_PROPERTY_NAME,
-                ariaLabel);
+        if (ariaLabel != null) {
+            getElement().setAttribute(ElementConstants.ARIA_LABEL_PROPERTY_NAME,
+                    ariaLabel);
+        } else {
+            getElement()
+                    .removeAttribute(ElementConstants.ARIA_LABEL_PROPERTY_NAME);
+        }
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasAriaLabel.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasAriaLabel.java
@@ -51,7 +51,7 @@ public interface HasAriaLabel extends HasElement {
      *            the aria-label text to set or {@code null} to clear
      */
     default void setAriaLabel(String ariaLabel) {
-        getElement().setProperty(ElementConstants.ARIA_LABEL_PROPERTY_NAME,
+        getElement().setAttribute(ElementConstants.ARIA_LABEL_PROPERTY_NAME,
                 ariaLabel);
     }
 
@@ -63,6 +63,6 @@ public interface HasAriaLabel extends HasElement {
      */
     default Optional<String> getAriaLabel() {
         return Optional.ofNullable(getElement()
-                .getProperty(ElementConstants.ARIA_LABEL_PROPERTY_NAME, null));
+                .getAttribute(ElementConstants.ARIA_LABEL_PROPERTY_NAME));
     }
 }


### PR DESCRIPTION
## Description

This is a follow-up of https://github.com/vaadin/flow/pull/16081, where a bug on `HasAriaLabel#setAriaLabel` was found. It turns out that the current implementation uses `getElement().setProperty()` to set the aria-label to the component, but since the value of `ElementConstants.ARIA_LABEL_PROPERTY_NAME` is in the Kebab Case format (`aria-label`) instead of the Camel Case one (`ariaLabel`), it doesn't correctly set the property.


## Type of change

- [X] Bugfix
- [ ] Feature