### PR TITLE
fix: Parent theme should not trigger a re-bundle

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuild.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuild.java
@@ -310,11 +310,6 @@ public class TaskRunDevBundleBuild implements FallibleCommand {
         } else if (bundleJsonType == JsonType.NUMBER) {
             return JsonUtils.numbersEqual(jsonFromBundle, projectJson);
         } else if (bundleJsonType == JsonType.STRING) {
-            // ignore parent theme, because having a parent theme doesn't
-            // need a new bundle per se
-            if (projectJson.toJson().equals("parent")) {
-                return true;
-            }
             return JsonUtils.stringEqual(jsonFromBundle, projectJson);
         } else if (bundleJsonType == JsonType.ARRAY) {
             JsonArray jsonArrayFromBundle = (JsonArray) jsonFromBundle;
@@ -984,6 +979,12 @@ public class TaskRunDevBundleBuild implements FallibleCommand {
 
         for (String projectEntryKey : projectJsonObject.keys()) {
             JsonValue projectEntry = projectJsonObject.get(projectEntryKey);
+            // ignore parent theme, because having a parent theme doesn't
+            // need a new bundle per se
+            if (projectEntry.getType() == JsonType.STRING
+                    && "parent".equals(projectEntryKey)) {
+                continue;
+            }
             boolean entryFound = false;
             for (String bundleEntryKey : jsonObjectFromBundle.keys()) {
                 JsonValue bundleEntry = jsonObjectFromBundle

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuildTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuildTest.java
@@ -1345,6 +1345,40 @@ public class TaskRunDevBundleBuildTest {
     }
 
     @Test
+    public void themeJsonUpdates_containsParentTheme_noBundleRebuild()
+            throws IOException {
+        createPackageJsonStub(BLANK_PACKAGE_JSON_WITH_HASH);
+        createProjectThemeJsonStub("{\"parent\": \"my-parent-theme\"}");
+
+        final FrontendDependenciesScanner depScanner = Mockito
+                .mock(FrontendDependenciesScanner.class);
+        final ThemeDefinition themeDefinition = Mockito
+                .mock(ThemeDefinition.class);
+        Mockito.when(themeDefinition.getName()).thenReturn("my-theme");
+        Mockito.when(depScanner.getThemeDefinition())
+                .thenReturn(themeDefinition);
+
+        try (MockedStatic<FrontendUtils> utils = Mockito
+                .mockStatic(FrontendUtils.class)) {
+            JsonObject stats = getBasicStats();
+            stats.getObject(THEME_JSON_CONTENTS).put("vaadin-dev-bundle",
+                    "{\"lumoImports\": [\"typography\"]}");
+
+            utils.when(() -> FrontendUtils.getDevBundleFolder(Mockito.any()))
+                    .thenReturn(temporaryFolder.getRoot());
+            utils.when(() -> FrontendUtils
+                    .findBundleStatsJson(temporaryFolder.getRoot()))
+                    .thenReturn(stats.toJson());
+
+            boolean needsBuild = TaskRunDevBundleBuild
+                    .needsBuildInternal(options, depScanner, finder);
+            Assert.assertFalse(
+                    "Should not trigger a bundle rebuild when parent theme is used",
+                    needsBuild);
+        }
+    }
+
+    @Test
     public void themeJsonUpdates_statsHasThemeJson_projectHasNoThemeJson_noBundleRebuild()
             throws IOException {
         createPackageJsonStub(BLANK_PACKAGE_JSON_WITH_HASH);


### PR DESCRIPTION
Parent theme key in theme.json is skipped when theme.json content is analysed, because having a parent theme shouldn't trigger a re-bundle per se.

Follow-up for https://github.com/vaadin/flow/issues/16004