### PR TITLE
refactor: save theme editor changes immediately

### DIFF
--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/model.test.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/model.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@open-wc/testing';
-import { ComponentTheme, generateRules, Theme, ThemeEditorRule, ThemePropertyValue } from './model';
+import {ComponentTheme, generateThemeRule, Theme, ThemeEditorRule, ThemePropertyValue} from './model';
 import buttonMetadata from './metadata/components/vaadin-button';
 import { ComponentMetadata } from './metadata/model';
 
@@ -148,19 +148,14 @@ describe('model', () => {
     });
   });
 
-  describe('generateRules', () => {
-    it('should generate zero rules for empty theme', () => {
-      const theme = new ComponentTheme(buttonMetadata);
-      const rules = generateRules(theme);
-      expect(rules.length).to.equal(0);
-    });
-
-    it('should generate rules for theme', () => {
-      const theme = new ComponentTheme(buttonMetadata);
-      theme.updatePropertyValue(null, 'background', 'cornflowerblue');
-      theme.updatePropertyValue(null, 'padding', '3px');
-      theme.updatePropertyValue('label', 'color', 'white');
-      theme.updatePropertyValue('label', 'font-size', '20px');
+  describe('generateRule', () => {
+    it('should generate rules for property changes', () => {
+      const rules = [
+          generateThemeRule('vaadin-button', null, 'background', 'cornflowerblue'),
+          generateThemeRule('vaadin-button', null, 'padding', '3px'),
+          generateThemeRule('vaadin-button', 'label', 'color', 'white'),
+          generateThemeRule('vaadin-button', 'label', 'font-size', '20px'),
+      ]
 
       const expectedRules: ThemeEditorRule[] = [
         { selector: 'vaadin-button', property: 'background', value: 'cornflowerblue' },
@@ -169,7 +164,6 @@ describe('model', () => {
         { selector: 'vaadin-button::part(label)', property: 'font-size', value: '20px' }
       ];
 
-      const rules = generateRules(theme);
       expect(rules).to.deep.equal(expectedRules);
     });
   });
@@ -183,6 +177,12 @@ describe('model', () => {
 
     it('should return null for non-existing component themes', () => {
       expect(theme.getComponentTheme('vaadin-button')).to.be.null;
+    });
+
+    it('should get or create theme component themes', () => {
+      const buttonTheme = theme.getOrCreateComponentTheme(buttonMetadata);
+      expect(buttonTheme).to.not.be.null;
+      expect(theme.getOrCreateComponentTheme(buttonMetadata)).to.equal(buttonTheme);
     });
 
     it('should add and return component themes', () => {

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/model.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/model.ts
@@ -80,18 +80,17 @@ export class ComponentTheme {
   }
 }
 
-export function generateRules(theme: ComponentTheme): ThemeEditorRule[] {
-  return theme.properties.map((propertyValue) => {
-    const selector = propertyValue.partName
-      ? `${theme.metadata.tagName}::part(${propertyValue.partName})`
-      : theme.metadata.tagName;
+function generateSelector(tagName: string, partName: string | null) {
+  return partName ? `${tagName}::part(${partName})` : tagName;
+}
 
-    return {
-      selector,
-      property: propertyValue.propertyName,
-      value: propertyValue.value
-    };
-  });
+export function generateThemeRule(tagName: string, partName: string | null, propertyName: string, value: string) {
+  const selector = generateSelector(tagName, partName);
+  return {
+    selector,
+    property: propertyName,
+    value: value
+  };
 }
 
 type ComponentThemeMap = { [key: string]: ComponentTheme };
@@ -107,13 +106,18 @@ export class Theme {
     return this._componentThemes[tagName] || null;
   }
 
-  updateComponentTheme(updatedTheme: ComponentTheme) {
-    let existingTheme = this.getComponentTheme(updatedTheme.metadata.tagName);
-    if (!existingTheme) {
-      existingTheme = new ComponentTheme(updatedTheme.metadata);
-      this._componentThemes[existingTheme.metadata.tagName] = existingTheme;
+  getOrCreateComponentTheme(metadata: ComponentMetadata) {
+    let componentTheme = this.getComponentTheme(metadata.tagName);
+    if (!componentTheme) {
+      componentTheme = new ComponentTheme(metadata);
+      this._componentThemes[metadata.tagName] = componentTheme;
     }
-    existingTheme.addPropertyValues(updatedTheme.properties);
+    return componentTheme;
+  }
+
+  updateComponentTheme(updatedTheme: ComponentTheme) {
+    const componentTheme = this.getOrCreateComponentTheme(updatedTheme.metadata);
+    componentTheme.addPropertyValues(updatedTheme.properties);
   }
 
   clone() {

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/vaadin-dev-tools.test.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/vaadin-dev-tools.test.ts
@@ -80,8 +80,7 @@ describe('vaadin-dev-tools', function () {
       });
 
       it('should temporarily disable live reload on theme editor before save event', async () => {
-        expect(VaadinDevTools.isActive).to.be.true;
-
+        // enable and open theme editor tab
         sendThemeEditorStateMessage(ThemeEditorState.enabled);
         await elementUpdated(devTools);
 
@@ -92,11 +91,40 @@ describe('vaadin-dev-tools', function () {
         const editor = devTools.shadowRoot!.querySelector('vaadin-dev-tools-theme-editor')!;
         expect(editor).to.exist;
 
+        // simulate saving
+        expect(VaadinDevTools.isActive).to.be.true;
         editor.dispatchEvent(new CustomEvent('before-save'));
         expect(VaadinDevTools.isActive).to.be.false;
 
-        clock.tick(5000);
+        clock.tick(2500);
+        expect(VaadinDevTools.isActive).to.be.true;
+      });
 
+      it('should extend disabling live reload when theme editor saves again', async () => {
+        // enable and open theme editor tab
+        sendThemeEditorStateMessage(ThemeEditorState.enabled);
+        await elementUpdated(devTools);
+
+        const themeEditorTab = getTab('theme-editor');
+        themeEditorTab.click();
+        await elementUpdated(devTools);
+
+        const editor = devTools.shadowRoot!.querySelector('vaadin-dev-tools-theme-editor')!;
+        expect(editor).to.exist;
+
+        // simulate saving
+        expect(VaadinDevTools.isActive).to.be.true;
+        editor.dispatchEvent(new CustomEvent('before-save'));
+        expect(VaadinDevTools.isActive).to.be.false;
+
+        clock.tick(2000);
+        editor.dispatchEvent(new CustomEvent('before-save'));
+        expect(VaadinDevTools.isActive).to.be.false;
+
+        clock.tick(1000);
+        expect(VaadinDevTools.isActive).to.be.false;
+
+        clock.tick(1500);
         expect(VaadinDevTools.isActive).to.be.true;
       });
     });

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/vaadin-dev-tools.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/vaadin-dev-tools.ts
@@ -1009,6 +1009,8 @@ export class VaadinDevTools extends LitElement {
 
   private transitionDuration: number = 0;
 
+  disableLiveReloadTimeout: number | null = null;
+
   elementTelemetry() {
     let data = {};
     try {
@@ -1376,11 +1378,14 @@ export class VaadinDevTools extends LitElement {
   }
 
   disableLiveReloadTemporarily() {
-    if (!VaadinDevTools.isActive) {
-      return;
+    if (VaadinDevTools.isActive || this.disableLiveReloadTimeout != null) {
+      this.setActive(false);
+      clearTimeout(this.disableLiveReloadTimeout!);
+      this.disableLiveReloadTimeout = window.setTimeout(() => {
+        this.setActive(true);
+        this.disableLiveReloadTimeout = null;
+      }, 2500);
     }
-    this.setActive(false);
-    setTimeout(() => this.setActive(true), 5000);
   }
 
   getStatusColor(status: ConnectionStatus | undefined) {


### PR DESCRIPTION
## Description

Changes the theme editor to push individual property changes immediately to the dev server to store them in the theme editor CSS file.

Does not yet include undo history, or parsing the initial theme editor stylesheet.