### PR TITLE
refactor: implement theme editor API client

### DIFF
--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/api.test.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/api.test.ts
@@ -1,0 +1,110 @@
+import { aTimeout, expect } from '@open-wc/testing';
+import sinon from 'sinon';
+import { Commands, ResponseCode, ThemeEditorApi } from './api';
+import { ThemeEditorRule } from './model';
+
+describe('theme editor API', () => {
+  let api: ThemeEditorApi;
+  let onMessageSpy: sinon.SinonSpy;
+  let connectionMock: {
+    onMessage: sinon.SinonSpy;
+    send: sinon.SinonSpy;
+  };
+
+  beforeEach(() => {
+    onMessageSpy = sinon.spy(() => {});
+    connectionMock = {
+      onMessage: onMessageSpy,
+      send: sinon.spy(() => {})
+    };
+    api = new ThemeEditorApi(connectionMock as any);
+  });
+
+  function message(command: string, data: any) {
+    return {
+      command,
+      data
+    };
+  }
+
+  it('should pass through unhandled messages', () => {
+    const unknownMessage = message('unknown1', {});
+    connectionMock.onMessage(unknownMessage);
+
+    expect(onMessageSpy.called).to.be.true;
+    expect(onMessageSpy.args[0][0]).to.equal(unknownMessage);
+  });
+
+  it('should not pass through handled messages', () => {
+    connectionMock.onMessage(message(Commands.response, { requestId: '0' }));
+
+    expect(onMessageSpy.called).to.be.false;
+  });
+
+  it('should send messages', () => {
+    const addRules: ThemeEditorRule[] = [{ selector: 'vaadin-button', property: 'background', value: 'red' }];
+    const removeRules: ThemeEditorRule[] = [{ selector: 'vaadin-text-field', property: 'color', value: 'inherit' }];
+
+    api.updateCssRules(addRules, removeRules);
+
+    expect(connectionMock.send.calledOnce).to.be.true;
+    expect(connectionMock.send.args[0][0]).to.equal(Commands.updateCssRules);
+    expect(connectionMock.send.args[0][1]).to.deep.equal({
+      requestId: '0',
+      add: addRules,
+      remove: removeRules
+    });
+  });
+
+  it('should resolve request when receiving ok response', async () => {
+    const resolveSpy = sinon.spy();
+    const rejectSpy = sinon.spy();
+    api.updateCssRules([], []).then(resolveSpy).catch(rejectSpy);
+
+    const responseData = { requestId: '0', code: ResponseCode.ok };
+    connectionMock.onMessage(message(Commands.response, responseData));
+    await aTimeout(0);
+
+    expect(resolveSpy.called).to.be.true;
+    expect(resolveSpy.calledWith(responseData)).to.be.true;
+    expect(rejectSpy.called).to.be.false;
+  });
+
+  it('should reject request when receiving error response', async () => {
+    const resolveSpy = sinon.spy();
+    const rejectSpy = sinon.spy();
+    api.updateCssRules([], []).then(resolveSpy).catch(rejectSpy);
+
+    const responseData = { requestId: '0', code: ResponseCode.error };
+    connectionMock.onMessage(message(Commands.response, responseData));
+    await aTimeout(0);
+
+    expect(resolveSpy.called).to.be.false;
+    expect(rejectSpy.called).to.be.true;
+    expect(rejectSpy.calledWith(responseData)).to.be.true;
+  });
+
+  it('should not resolve or reject request when receiving unknown request ID', async () => {
+    const resolveSpy = sinon.spy();
+    const rejectSpy = sinon.spy();
+    api.updateCssRules([], []).then(resolveSpy).catch(rejectSpy);
+
+    const responseData = { requestId: 'unknown', code: ResponseCode.error };
+    connectionMock.onMessage(message(Commands.response, responseData));
+    await aTimeout(0);
+
+    expect(resolveSpy.called).to.be.false;
+    expect(rejectSpy.called).to.be.false;
+  });
+
+  it('should increase request ID', () => {
+    api.updateCssRules([], []);
+    api.updateCssRules([], []);
+    api.updateCssRules([], []);
+
+    expect(connectionMock.send.calledThrice).to.be.true;
+    expect(connectionMock.send.args[0][1].requestId).to.equal('0');
+    expect(connectionMock.send.args[1][1].requestId).to.equal('1');
+    expect(connectionMock.send.args[2][1].requestId).to.equal('2');
+  });
+});

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/api.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/api.ts
@@ -1,0 +1,78 @@
+import { Connection } from '../vaadin-dev-tools';
+import { ThemeEditorRule } from './model';
+
+export enum Commands {
+  response = 'themeEditorResponse',
+  updateCssRules = 'themeEditorRules'
+}
+
+export enum ResponseCode {
+  ok = 'ok',
+  error = 'error'
+}
+
+export interface BaseResponse {
+  requestId: string;
+  code: ResponseCode;
+}
+
+interface RequestHandle {
+  resolve: (response: unknown) => void;
+  reject: (response: unknown) => void;
+}
+
+export class ThemeEditorApi {
+  private wrappedConnection: Connection;
+  private pendingRequests: { [key: string]: RequestHandle } = {};
+  private requestCounter: number = 0;
+
+  constructor(wrappedConnection: Connection) {
+    this.wrappedConnection = wrappedConnection;
+    const prevOnMessage = this.wrappedConnection.onMessage;
+    this.wrappedConnection.onMessage = (message: any) => {
+      if (message.command === Commands.response) {
+        this.handleResponse(message.data);
+      } else {
+        prevOnMessage.call(this.wrappedConnection, message);
+      }
+    };
+  }
+
+  private sendRequest(command: string, data: any) {
+    const requestId = (this.requestCounter++).toString();
+
+    return new Promise<any>((resolve, reject) => {
+      this.wrappedConnection.send(command, {
+        ...data,
+        requestId
+      });
+      this.pendingRequests[requestId] = {
+        resolve,
+        reject
+      };
+    });
+  }
+
+  private handleResponse(data: BaseResponse) {
+    const requestHandle = this.pendingRequests[data.requestId];
+    if (!requestHandle) {
+      console.warn('Received response for unknown request');
+      return;
+    }
+
+    delete this.pendingRequests[data.requestId];
+
+    if (data.code === ResponseCode.ok) {
+      requestHandle.resolve(data);
+    } else {
+      requestHandle.reject(data);
+    }
+  }
+
+  public updateCssRules(add: ThemeEditorRule[], remove: ThemeEditorRule[]): Promise<BaseResponse> {
+    return this.sendRequest(Commands.updateCssRules, {
+      add,
+      remove
+    });
+  }
+}

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.test.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.test.ts
@@ -7,18 +7,19 @@ import { metadataRegistry } from './metadata/registry';
 import sinon from 'sinon';
 import { themePreview } from './preview';
 import { testElementMetadata } from './tests/utils';
+import { Commands } from './api';
 
 describe('theme-editor', () => {
   let editor: ThemeEditor;
   let testElement: HTMLElement;
   let connectionMock: {
-    sendThemeEditorRules: sinon.SinonSpy;
+    send: sinon.SinonSpy;
   };
   let getMetadataStub: sinon.SinonStub;
 
   async function editorFixture() {
     connectionMock = {
-      sendThemeEditorRules: sinon.spy(() => {})
+      send: sinon.spy(() => {})
     };
     const pickerMock = {
       open: (options: PickerOptions) => {
@@ -172,25 +173,35 @@ describe('theme-editor', () => {
       await pickComponent();
       await editProperty('label', 'color', 'red');
 
-      expect(connectionMock.sendThemeEditorRules.calledOnce);
-      expect(connectionMock.sendThemeEditorRules.args[0][0]).to.deep.equal([
-        {
-          selector: 'test-element::part(label)',
-          property: 'color',
-          value: 'red'
-        }
-      ]);
-      connectionMock.sendThemeEditorRules.resetHistory();
+      expect(connectionMock.send.calledOnce);
+      expect(connectionMock.send.args[0][0]).to.equal(Commands.updateCssRules);
+      expect(connectionMock.send.args[0][1]).to.deep.equal({
+        requestId: '0',
+        add: [
+          {
+            selector: 'test-element::part(label)',
+            property: 'color',
+            value: 'red'
+          }
+        ],
+        remove: []
+      });
+      connectionMock.send.resetHistory();
 
       await editProperty('label', 'color', 'green');
-      expect(connectionMock.sendThemeEditorRules.calledOnce);
-      expect(connectionMock.sendThemeEditorRules.args[0][0]).to.deep.equal([
-        {
-          selector: 'test-element::part(label)',
-          property: 'color',
-          value: 'green'
-        }
-      ]);
+      expect(connectionMock.send.calledOnce);
+      expect(connectionMock.send.args[0][0]).to.equal(Commands.updateCssRules);
+      expect(connectionMock.send.args[0][1]).to.deep.equal({
+        requestId: '1',
+        add: [
+          {
+            selector: 'test-element::part(label)',
+            property: 'color',
+            value: 'green'
+          }
+        ],
+        remove: []
+      });
     });
 
     it('should dispatch event before saving changes', async () => {

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.ts
@@ -10,6 +10,7 @@ import { detectTheme } from './detector';
 import { ThemePropertyValueChangeEvent } from './events';
 import { themePreview } from './preview';
 import { Connection } from '../vaadin-dev-tools';
+import { ThemeEditorApi } from './api';
 
 @customElement('vaadin-dev-tools-theme-editor')
 export class ThemeEditor extends LitElement {
@@ -19,6 +20,7 @@ export class ThemeEditor extends LitElement {
   public pickerProvider!: PickerProvider;
   @property({})
   public connection!: Connection;
+  private api!: ThemeEditorApi;
 
   /**
    * Metadata for the selected / picked component
@@ -94,6 +96,10 @@ export class ThemeEditor extends LitElement {
         overflow-y: auto;
       }
     `;
+  }
+
+  protected firstUpdated() {
+    this.api = new ThemeEditorApi(this.connection);
   }
 
   render() {
@@ -184,7 +190,7 @@ export class ThemeEditor extends LitElement {
       property.propertyName,
       value
     );
-    this.connection.sendThemeEditorRules([updateRule]);
+    this.api.updateCssRules([updateRule], []);
   }
 
   private updateThemePreview() {

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/vaadin-dev-tools.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/vaadin-dev-tools.ts
@@ -4,7 +4,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { ComponentPicker } from './component-picker';
 import { ComponentReference } from './component-util';
 import './theme-editor/editor';
-import { ThemeEditorState, ThemeEditorRule } from './theme-editor/model';
+import { ThemeEditorState } from './theme-editor/model';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { copy } from './copy-to-clipboard.js';
@@ -141,7 +141,7 @@ export class Connection extends Object {
     }
   }
 
-  private send(command: string, data: any) {
+  public send(command: string, data: any) {
     const message = JSON.stringify({ command, data });
     if (!this.webSocket) {
       // eslint-disable-next-line no-console
@@ -167,10 +167,6 @@ export class Connection extends Object {
   }
   sendShowComponentAttachLocation(component: ComponentReference) {
     this.send('showComponentAttachLocation', component);
-  }
-
-  sendThemeEditorRules(rules: ThemeEditorRule[]) {
-    this.send('themeEditorRules', { requestId: 'abc-123-def-456', add: rules });
   }
 }
 


### PR DESCRIPTION
## Description

Add an API client to the theme editor that wraps the websocket connection, can send messages and correlate responses to the original request. Each request returns a `Promise` that resolves when a successful response is received, and rejects when an error response is received.

Only covers sending rule updates, we can cover component metadata when adding a related feature.