### PR TITLE
test: Avoid using Jetty API that is going away

### DIFF
--- a/flow-tests/test-frontend/vite-embedded-webcomponent-resync/src/test/java/com/vaadin/viteapp/BasicComponentIT.java
+++ b/flow-tests/test-frontend/vite-embedded-webcomponent-resync/src/test/java/com/vaadin/viteapp/BasicComponentIT.java
@@ -17,8 +17,6 @@ package com.vaadin.viteapp;
 
 import java.io.File;
 
-import jakarta.servlet.http.HttpSessionEvent;
-import jakarta.servlet.http.HttpSessionListener;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.webapp.WebAppContext;
@@ -29,17 +27,25 @@ import org.junit.Test;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.StaleElementReferenceException;
 
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.testutil.ChromeDeviceTest;
 
+import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpSessionEvent;
+import jakarta.servlet.http.HttpSessionListener;
+
 public class BasicComponentIT extends ChromeDeviceTest {
+
+    private static final String HOTDEPLOY_PROPERTY = "vaadin."
+            + InitParameters.FRONTEND_HOTDEPLOY;
 
     private Server server;
 
     private WebAppContext context;
 
-    private String sessionId;
-
     private String hotdeploy;
+
+    protected HttpSession session;
 
     @Before
     public void init() throws Exception {
@@ -58,7 +64,7 @@ public class BasicComponentIT extends ChromeDeviceTest {
                 getAuthenticationResult());
 
         // simulate expired session by invalidating current session
-        context.getSessionHandler().getSession(sessionId).invalidate();
+        session.invalidate();
 
         // init request to resynchronize expired session and recreate components
         clickButton();
@@ -100,8 +106,8 @@ public class BasicComponentIT extends ChromeDeviceTest {
     }
 
     public void setup(int port) throws Exception {
-        hotdeploy = System.getProperty("vaadin.frontend.hotdeploy");
-        System.setProperty("vaadin.frontend.hotdeploy", "true");
+        hotdeploy = System.getProperty(HOTDEPLOY_PROPERTY);
+        System.setProperty(HOTDEPLOY_PROPERTY, "true");
         server = new Server();
         try (ServerConnector connector = new ServerConnector(server)) {
             connector.setPort(port);
@@ -119,7 +125,7 @@ public class BasicComponentIT extends ChromeDeviceTest {
         context.getSessionHandler().addEventListener(new HttpSessionListener() {
             @Override
             public void sessionCreated(HttpSessionEvent httpSessionEvent) {
-                sessionId = httpSessionEvent.getSession().getId();
+                session = httpSessionEvent.getSession();
             }
         });
 
@@ -135,7 +141,11 @@ public class BasicComponentIT extends ChromeDeviceTest {
             context = null;
         } finally {
             server.stop();
-            System.setProperty("vaadin.frontend.hotdeploy", hotdeploy);
+            if (hotdeploy == null) {
+                System.clearProperty(HOTDEPLOY_PROPERTY);
+            } else {
+                System.setProperty(HOTDEPLOY_PROPERTY, hotdeploy);
+            }
         }
     }
 }


### PR DESCRIPTION
context.getSessionHandler().getSession is no more in Jetty 12
