### PR TITLE
fix: Skip checking @vaadin/flow-frontend package (CP: 24.0)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuild.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuild.java
@@ -642,7 +642,13 @@ public class TaskRunDevBundleBuild implements FallibleCommand {
 
         JsonObject dependencies = packageJson.getObject("dependencies");
 
-        List<String> missingFromBundle = Arrays.stream(dependencies.keys())
+        List<String> dependenciesList = Arrays.stream(dependencies.keys())
+                // skip checking flow-frontend as it was used in previous
+                // versions as an alias for ./target/flow-frontend
+                .filter(pkg -> !"@vaadin/flow-frontend".equals(pkg))
+                .collect(Collectors.toList());
+
+        List<String> missingFromBundle = dependenciesList.stream()
                 .filter(pkg -> !bundleModules.hasKey(pkg))
                 .collect(Collectors.toList());
 
@@ -655,7 +661,7 @@ public class TaskRunDevBundleBuild implements FallibleCommand {
         }
 
         // We know here that all dependencies exist
-        missingFromBundle = Arrays.stream(dependencies.keys())
+        missingFromBundle = dependenciesList.stream()
                 .filter(pkg -> !versionAccepted(dependencies.getString(pkg),
                         bundleModules.getString(pkg)))
                 .collect(Collectors.toList());

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuildTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuildTest.java
@@ -1701,6 +1701,33 @@ public class TaskRunDevBundleBuildTest {
         }
     }
 
+    @Test
+    public void flowFrontendPackageInPackageJson_noBundleRebuild()
+            throws IOException {
+        createPackageJsonStub(
+                "{\"dependencies\": {\"@vaadin/flow-frontend\": \"./target/flow-frontend\"}, \"vaadin\": { \"hash\": \"aHash\"} }");
+
+        final FrontendDependenciesScanner depScanner = Mockito
+                .mock(FrontendDependenciesScanner.class);
+
+        try (MockedStatic<FrontendUtils> utils = Mockito
+                .mockStatic(FrontendUtils.class)) {
+            JsonObject stats = getBasicStats();
+
+            utils.when(() -> FrontendUtils.getDevBundleFolder(Mockito.any()))
+                    .thenReturn(temporaryFolder.getRoot());
+            utils.when(() -> FrontendUtils
+                    .findBundleStatsJson(temporaryFolder.getRoot()))
+                    .thenReturn(stats.toJson());
+
+            boolean needsBuild = TaskRunDevBundleBuild
+                    .needsBuildInternal(options, depScanner, finder);
+            Assert.assertFalse(
+                    "Shouldn't re-bundle when old @vaadin/flow-frontend package is in package.json",
+                    needsBuild);
+        }
+    }
+
     private void createPackageJsonStub(String content) throws IOException {
         File packageJson = new File(temporaryFolder.getRoot(),
                 Constants.PACKAGE_JSON);


### PR DESCRIPTION
@vaadin/flow-frontend package was used in previous Vaadin versions to alias .target/flow-frontend folder. Since it is present only under "dependencies" object, Flow cannot decide was it added by user or not. Now Flow ignores this legacy package to not re-bundle erroneously.