### PR TITLE
fix: Not throw for not yet copied CSS when checking for re-bundling (CP: 24.0)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -500,7 +500,19 @@ abstract class AbstractUpdateImports implements Runnable {
         return file.isFile() || file.isDirectory();
     }
 
-    private boolean addCssLines(Collection<String> lines, CssData cssData,
+    /**
+     * Adds CSS imports to the generated flow imports file based on the given
+     * CssImport data.
+     *
+     * @param lines
+     *            collection of generated file lines to add imports to
+     * @param cssData
+     *            CssImport data
+     * @param i
+     *            imported CSS counter
+     * @return true if the imported CSS files does exist, false otherwise
+     */
+    protected boolean addCssLines(Collection<String> lines, CssData cssData,
             int i) {
         String cssFile = resolveResource(cssData.getValue());
         boolean found = importedFileExists(cssFile);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/GenerateMainImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/GenerateMainImports.java
@@ -73,6 +73,16 @@ public class GenerateMainImports extends AbstractUpdateImports {
     }
 
     @Override
+    protected boolean addCssLines(Collection<String> lines, CssData cssData,
+            int i) {
+        super.addCssLines(lines, cssData, i);
+        // CSS files in 'generated/jar-resources' are not generated at this
+        // moment, so not let the application interrupt and continue with
+        // checking the dev-bundle
+        return true;
+    }
+
+    @Override
     protected void writeImportLines(List<String> lines) {
         // NO-OP. Only store the lines to write
         this.lines = lines;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/CssAnnotationVisitor.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/CssAnnotationVisitor.java
@@ -57,13 +57,13 @@ final class CssAnnotationVisitor extends RepeatedAnnotationVisitor {
             newData();
         }
         if (FrontendClassVisitor.VALUE.equals(name)) {
-            cssData.value = value;
+            cssData.setValue(value);
         } else if (FrontendClassVisitor.ID.equals(name)) {
-            cssData.id = value;
+            cssData.setId(value);
         } else if (FrontendClassVisitor.INCLUDE.equals(name)) {
-            cssData.include = value;
+            cssData.setInclude(value);
         } else if (FrontendClassVisitor.THEME_FOR.equals(name)) {
-            cssData.themefor = value;
+            cssData.setThemefor(value);
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/CssData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/CssData.java
@@ -28,10 +28,20 @@ import java.util.Objects;
  * @since 2.0
  */
 public final class CssData implements Serializable {
-    String value;
-    String id;
-    String include;
-    String themefor;
+    private String value;
+    private String id;
+    private String include;
+    private String themefor;
+
+    public CssData() {
+    }
+
+    public CssData(String value, String id, String include, String themefor) {
+        this.value = value;
+        this.id = id;
+        this.include = include;
+        this.themefor = themefor;
+    }
 
     /**
      * The value getter.
@@ -67,6 +77,22 @@ public final class CssData implements Serializable {
      */
     public String getThemefor() {
         return themefor;
+    }
+
+    void setValue(String value) {
+        this.value = value;
+    }
+
+    void setId(String id) {
+        this.id = id;
+    }
+
+    void setInclude(String include) {
+        this.include = include;
+    }
+
+    void setThemefor(String themefor) {
+        this.themefor = themefor;
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScanner.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScanner.java
@@ -207,12 +207,11 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
     }
 
     private CssData createCssData(Annotation cssImport) {
-        CssData data = new CssData();
-        data.id = adaptCssValue(cssImport, "id");
-        data.include = adaptCssValue(cssImport, "include");
-        data.themefor = adaptCssValue(cssImport, "themeFor");
-        data.value = adaptCssValue(cssImport, VALUE);
-        return data;
+        String id = adaptCssValue(cssImport, "id");
+        String include = adaptCssValue(cssImport, "include");
+        String themeFor = adaptCssValue(cssImport, "themeFor");
+        String value = adaptCssValue(cssImport, VALUE);
+        return new CssData(value, id, include, themeFor);
     }
 
     private String adaptCssValue(Annotation cssImport, String method) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuildTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuildTest.java
@@ -1710,9 +1710,11 @@ public class TaskRunDevBundleBuildTest {
         final FrontendDependenciesScanner depScanner = Mockito
                 .mock(FrontendDependenciesScanner.class);
 
-        CssData cssData = new CssData("./addons-styles/my-styles.css", null, null, null);
+        CssData cssData = new CssData("./addons-styles/my-styles.css", null,
+                null, null);
 
-        Mockito.when(depScanner.getCss()).thenReturn(Collections.singleton(cssData));
+        Mockito.when(depScanner.getCss())
+                .thenReturn(Collections.singleton(cssData));
 
         JsonObject stats = getBasicStats();
 
@@ -1721,7 +1723,7 @@ public class TaskRunDevBundleBuildTest {
             utils.when(() -> FrontendUtils.getDevBundleFolder(Mockito.any()))
                     .thenReturn(temporaryFolder.getRoot());
             utils.when(() -> FrontendUtils
-                            .findBundleStatsJson(temporaryFolder.getRoot()))
+                    .findBundleStatsJson(temporaryFolder.getRoot()))
                     .thenReturn(stats.toJson());
 
             // Should not throw an IllegalStateException:

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuildTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuildTest.java
@@ -19,6 +19,7 @@ import org.mockito.Mockito;
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
+import com.vaadin.flow.server.frontend.scanner.CssData;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 import com.vaadin.flow.testutil.TestUtils;
 import com.vaadin.flow.theme.ThemeDefinition;
@@ -1697,6 +1698,38 @@ public class TaskRunDevBundleBuildTest {
                     .needsBuildInternal(options, depScanner, finder);
             Assert.assertFalse(
                     "Should not require bundling if component JS is missing in jar-resources",
+                    needsBuild);
+        }
+    }
+
+    @Test
+    public void cssImport_cssInMetaInfResources_notThrow_bundleRequired()
+            throws IOException {
+        createPackageJsonStub(BLANK_PACKAGE_JSON_WITH_HASH);
+
+        final FrontendDependenciesScanner depScanner = Mockito
+                .mock(FrontendDependenciesScanner.class);
+
+        CssData cssData = new CssData("./addons-styles/my-styles.css", null, null, null);
+
+        Mockito.when(depScanner.getCss()).thenReturn(Collections.singleton(cssData));
+
+        JsonObject stats = getBasicStats();
+
+        try (MockedStatic<FrontendUtils> utils = Mockito
+                .mockStatic(FrontendUtils.class)) {
+            utils.when(() -> FrontendUtils.getDevBundleFolder(Mockito.any()))
+                    .thenReturn(temporaryFolder.getRoot());
+            utils.when(() -> FrontendUtils
+                            .findBundleStatsJson(temporaryFolder.getRoot()))
+                    .thenReturn(stats.toJson());
+
+            // Should not throw an IllegalStateException:
+            // "Failed to find the following css files in the...."
+            boolean needsBuild = TaskRunDevBundleBuild
+                    .needsBuildInternal(options, depScanner, finder);
+            Assert.assertTrue(
+                    "Should re-bundle if CSS is imported from META-INF/resources",
                     needsBuild);
         }
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScannerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScannerTest.java
@@ -342,12 +342,7 @@ public class FullDependenciesScannerTest {
 
     private CssData createCssData(String value, String id, String include,
             String themefor) {
-        CssData data = new CssData();
-        data.value = value;
-        data.id = id;
-        data.include = include;
-        data.themefor = themefor;
-        return data;
+        return new CssData(value, id, include, themefor);
     }
 
     private List<? extends Annotation> findAnnotations(Class<?> type,

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/ScannerDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/ScannerDependenciesTest.java
@@ -53,7 +53,7 @@ public class ScannerDependenciesTest {
         assertEquals("There should be 1 css import", 1, deps.getCss().size());
 
         assertEquals("Invalid css import", "frontend://styles/interface.css",
-                deps.getCss().iterator().next().value);
+                deps.getCss().iterator().next().getValue());
     }
 
     @Test

--- a/flow-tests/test-express-build/test-dev-bundle-frontend-add-on/src/main/java/com/vaadin/flow/frontend/DevBundleCssImportView.java
+++ b/flow-tests/test-express-build/test-dev-bundle-frontend-add-on/src/main/java/com/vaadin/flow/frontend/DevBundleCssImportView.java
@@ -20,8 +20,7 @@ import com.vaadin.flow.router.Route;
 
 @Route("com.vaadin.flow.frontend.DevBundleCssImportView")
 public class DevBundleCssImportView extends Div {
-    static final String MY_COMPONENT_ID =
-            "test-css-import-meta-inf-resources-span";
+    static final String MY_COMPONENT_ID = "test-css-import-meta-inf-resources-span";
 
     public DevBundleCssImportView() {
         MyComponent myComponent = new MyComponent();

--- a/flow-tests/test-express-build/test-dev-bundle-frontend-add-on/src/main/java/com/vaadin/flow/frontend/DevBundleCssImportView.java
+++ b/flow-tests/test-express-build/test-dev-bundle-frontend-add-on/src/main/java/com/vaadin/flow/frontend/DevBundleCssImportView.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.frontend;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route("com.vaadin.flow.frontend.DevBundleCssImportView")
+public class DevBundleCssImportView extends Div {
+    static final String MY_COMPONENT_ID =
+            "test-css-import-meta-inf-resources-span";
+
+    public DevBundleCssImportView() {
+        MyComponent myComponent = new MyComponent();
+        myComponent.setId(MY_COMPONENT_ID);
+        add(myComponent);
+    }
+}

--- a/flow-tests/test-express-build/test-dev-bundle-frontend-add-on/src/main/java/com/vaadin/flow/frontend/MyComponent.java
+++ b/flow-tests/test-express-build/test-dev-bundle-frontend-add-on/src/main/java/com/vaadin/flow/frontend/MyComponent.java
@@ -1,0 +1,13 @@
+package com.vaadin.flow.frontend;
+
+import com.vaadin.flow.component.dependency.CssImport;
+import com.vaadin.flow.component.html.Div;
+
+@CssImport("./addons-styles/add-on-styles.css")
+public class MyComponent extends Div {
+
+    public MyComponent() {
+        setText("Test CssImport from META-INF/resources with dev bundle");
+        addClassName("my-component");
+    }
+}

--- a/flow-tests/test-express-build/test-dev-bundle-frontend-add-on/src/main/resources/META-INF/resources/frontend/addons-styles/add-on-styles.css
+++ b/flow-tests/test-express-build/test-dev-bundle-frontend-add-on/src/main/resources/META-INF/resources/frontend/addons-styles/add-on-styles.css
@@ -1,0 +1,3 @@
+.my-component {
+    border: 1px solid green;
+}

--- a/flow-tests/test-express-build/test-dev-bundle-frontend-add-on/src/test/java/com/vaadin/flow/frontend/DevBundleCssImportIT.java
+++ b/flow-tests/test-express-build/test-dev-bundle-frontend-add-on/src/test/java/com/vaadin/flow/frontend/DevBundleCssImportIT.java
@@ -35,29 +35,33 @@ import elemental.json.JsonObject;
 public class DevBundleCssImportIT extends ChromeBrowserTest {
 
     @Test
-    public void cssImportedStyles_stylesInMetaInfResources_stylesApplied_hashCalculated() throws IOException {
+    public void cssImportedStyles_stylesInMetaInfResources_stylesApplied_hashCalculated()
+            throws IOException {
         open();
 
-        WebElement myComponent =
-                findElement(By.id(DevBundleCssImportView.MY_COMPONENT_ID));
+        WebElement myComponent = findElement(
+                By.id(DevBundleCssImportView.MY_COMPONENT_ID));
 
-        Assert.assertEquals("1px solid rgb(0, 128, 0)", myComponent.getCssValue(
-                "border"));
+        Assert.assertEquals("1px solid rgb(0, 128, 0)",
+                myComponent.getCssValue("border"));
 
         JsonObject frontendHashes = getFrontendHashes();
 
-        // TODO: remove '?inline' after https://github.com/vaadin/flow/pull/16125
+        // TODO: remove '?inline' after
+        // https://github.com/vaadin/flow/pull/16125
         Assert.assertTrue("Add-on styles content hash is expected",
-                frontendHashes.hasKey("addons-styles/add-on-styles.css?inline"));
+                frontendHashes
+                        .hasKey("addons-styles/add-on-styles.css?inline"));
         Assert.assertEquals("Unexpected addon styles content hash",
                 "5a7bc75b3b5edc5051ed36f75f625e204260459b4f1872dfc03a255b944fc89e",
-                frontendHashes.getString("addons-styles/add-on-styles.css?inline"));
+                frontendHashes
+                        .getString("addons-styles/add-on-styles.css?inline"));
 
         JsonArray bundleImports = getBundleImports();
         boolean found = false;
         for (int i = 0; i < bundleImports.length(); i++) {
-            if (bundleImports.get(i).asString()
-                    .equals("Frontend/generated/jar-resources/addons-styles/add-on-styles.css?inline")) {
+            if (bundleImports.get(i).asString().equals(
+                    "Frontend/generated/jar-resources/addons-styles/add-on-styles.css?inline")) {
                 found = true;
             }
         }

--- a/flow-tests/test-express-build/test-dev-bundle-frontend-add-on/src/test/java/com/vaadin/flow/frontend/DevBundleCssImportIT.java
+++ b/flow-tests/test-express-build/test-dev-bundle-frontend-add-on/src/test/java/com/vaadin/flow/frontend/DevBundleCssImportIT.java
@@ -53,7 +53,7 @@ public class DevBundleCssImportIT extends ChromeBrowserTest {
                 frontendHashes
                         .hasKey("addons-styles/add-on-styles.css?inline"));
         Assert.assertEquals("Unexpected addon styles content hash",
-                "5a7bc75b3b5edc5051ed36f75f625e204260459b4f1872dfc03a255b944fc89e",
+                "f6062ef78e2712e881faa15252bf001d737ab4f12b12e91f0d9f8030100643b6",
                 frontendHashes
                         .getString("addons-styles/add-on-styles.css?inline"));
 

--- a/flow-tests/test-express-build/test-dev-bundle-frontend-add-on/src/test/java/com/vaadin/flow/frontend/DevBundleCssImportIT.java
+++ b/flow-tests/test-express-build/test-dev-bundle-frontend-add-on/src/test/java/com/vaadin/flow/frontend/DevBundleCssImportIT.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.frontend;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+import elemental.json.Json;
+import elemental.json.JsonArray;
+import elemental.json.JsonObject;
+
+public class DevBundleCssImportIT extends ChromeBrowserTest {
+
+    @Test
+    public void cssImportedStyles_stylesInMetaInfResources_stylesApplied_hashCalculated() throws IOException {
+        open();
+
+        WebElement myComponent =
+                findElement(By.id(DevBundleCssImportView.MY_COMPONENT_ID));
+
+        Assert.assertEquals("1px solid rgb(0, 128, 0)", myComponent.getCssValue(
+                "border"));
+
+        JsonObject frontendHashes = getFrontendHashes();
+
+        // TODO: remove '?inline' after https://github.com/vaadin/flow/pull/16125
+        Assert.assertTrue("Add-on styles content hash is expected",
+                frontendHashes.hasKey("addons-styles/add-on-styles.css?inline"));
+        Assert.assertEquals("Unexpected addon styles content hash",
+                "5a7bc75b3b5edc5051ed36f75f625e204260459b4f1872dfc03a255b944fc89e",
+                frontendHashes.getString("addons-styles/add-on-styles.css?inline"));
+
+        JsonArray bundleImports = getBundleImports();
+        boolean found = false;
+        for (int i = 0; i < bundleImports.length(); i++) {
+            if (bundleImports.get(i).asString()
+                    .equals("Frontend/generated/jar-resources/addons-styles/add-on-styles.css?inline")) {
+                found = true;
+            }
+        }
+        Assert.assertTrue("Addon import is expected", found);
+    }
+
+    private static JsonObject getFrontendHashes() throws IOException {
+        JsonObject statsJson = getStatsJson();
+        JsonObject frontendHashes = statsJson.getObject("frontendHashes");
+        Assert.assertNotNull("Frontend hashes are expected in the stats.json",
+                frontendHashes);
+        return frontendHashes;
+    }
+
+    private static JsonArray getBundleImports() throws IOException {
+        JsonObject statsJson = getStatsJson();
+        JsonArray bundleImports = statsJson.getArray("bundleImports");
+        Assert.assertNotNull("Bundle imports are expected in the stats.json",
+                bundleImports);
+        return bundleImports;
+    }
+
+    private static JsonObject getStatsJson() throws IOException {
+        File baseDir = new File(System.getProperty("user.dir", "."));
+
+        // should create a dev-bundle
+        Assert.assertTrue("New devBundle should be generated",
+                new File(baseDir, Constants.DEV_BUNDLE_LOCATION).exists());
+
+        File statsJson = new File(baseDir,
+                Constants.DEV_BUNDLE_LOCATION + "/config/stats.json");
+        Assert.assertTrue("Stats.json should exist", statsJson.exists());
+
+        String content = FileUtils.readFileToString(statsJson,
+                StandardCharsets.UTF_8);
+        return Json.parse(content);
+    }
+}


### PR DESCRIPTION
When the stylesheet is imported by `AtCssImport` from `src/main/resources/META-INF/resources/frontend`, the Flow copies the stylesheets to `frontend/generated/jar-resources` in Vite dev server mode, and only then checks that the needed files are present.
For the dev bundle mode, these kind of files are checked even before any of the tasks run (when Flow check if re-bundling is needed), so before these files are copied. 
The fix is to make `GenerateMainImports` ignore missing files, because this class only runs for checking dev bundle and the absence of files is expected.

Related-to https://github.com/vaadin/flow/issues/16109