### PR TITLE
test: Increase build timeout to 30min

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 jobs:
   build:
-    timeout-minutes: 20
+    timeout-minutes: 30
     runs-on: ubuntu-22.04
     outputs:
       matrix-unit: ${{ steps.set-matrix.outputs.matrix-unit }}
@@ -68,7 +68,7 @@ jobs:
           path: workspace.tar
   unit-tests:
     needs: build
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.build.outputs.matrix-unit)}}
@@ -130,7 +130,7 @@ jobs:
           path: tests-report-*.tgz
   it-tests:
     needs: build
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.build.outputs.matrix-it)}}


### PR DESCRIPTION
Should make it easier to see what goes wrong in the builds that cause them to take longer

