### PR TITLE
refactor: initialize component theme in theme editor

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/ThemeEditorMessageHandler.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/ThemeEditorMessageHandler.java
@@ -7,6 +7,7 @@ import elemental.json.JsonObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -29,7 +30,11 @@ public class ThemeEditorMessageHandler {
                 this::handleThemeEditorRules, ClassNamesRequest.COMMAND_NAME,
                 this::handleThemeEditorClassNames,
                 ComponentMetadataRequest.COMMAND_NAME,
-                this::handleComponentMetadata);
+                this::handleComponentMetadata,
+                LoadPreviewRequest.COMMAND_NAME,
+                this::handleLoadPreview,
+                LoadRulesRequest.COMMAND_NAME,
+                this::handleLoadRules);
     }
 
     public boolean isEnabled() {
@@ -59,7 +64,7 @@ public class ThemeEditorMessageHandler {
      */
     public boolean canHandle(String command, JsonObject data) {
         return command != null && data != null && data.hasKey("requestId")
-                && handlers.containsKey(command);
+               && handlers.containsKey(command);
     }
 
     /**
@@ -116,6 +121,18 @@ public class ThemeEditorMessageHandler {
                 .getMetadata(request.getUiId(), request.getNodeId());
         return new ComponentMetadataResponse(request.getRequestId(),
                 metadata.isAccessible());
+    }
+
+    protected BaseResponse handleLoadPreview(JsonObject data) {
+        LoadPreviewRequest request = JsonUtils.readToObject(data, LoadPreviewRequest.class);
+        String css = getThemeModifier().getCss();
+        return new LoadPreviewResponse(request.getRequestId(), css);
+    }
+
+    protected BaseResponse handleLoadRules(JsonObject data) {
+        LoadRulesRequest request = JsonUtils.readToObject(data, LoadRulesRequest.class);
+        List<LoadRulesResponse.CssRule> rules = getThemeModifier().getCssRules(request.getSelectorFilter());
+        return new LoadRulesResponse(request.getRequestId(), rules);
     }
 
     private static Logger getLogger() {

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/ThemeEditorMessageHandler.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/ThemeEditorMessageHandler.java
@@ -30,10 +30,8 @@ public class ThemeEditorMessageHandler {
                 this::handleThemeEditorRules, ClassNamesRequest.COMMAND_NAME,
                 this::handleThemeEditorClassNames,
                 ComponentMetadataRequest.COMMAND_NAME,
-                this::handleComponentMetadata,
-                LoadPreviewRequest.COMMAND_NAME,
-                this::handleLoadPreview,
-                LoadRulesRequest.COMMAND_NAME,
+                this::handleComponentMetadata, LoadPreviewRequest.COMMAND_NAME,
+                this::handleLoadPreview, LoadRulesRequest.COMMAND_NAME,
                 this::handleLoadRules);
     }
 
@@ -64,7 +62,7 @@ public class ThemeEditorMessageHandler {
      */
     public boolean canHandle(String command, JsonObject data) {
         return command != null && data != null && data.hasKey("requestId")
-               && handlers.containsKey(command);
+                && handlers.containsKey(command);
     }
 
     /**
@@ -124,14 +122,17 @@ public class ThemeEditorMessageHandler {
     }
 
     protected BaseResponse handleLoadPreview(JsonObject data) {
-        LoadPreviewRequest request = JsonUtils.readToObject(data, LoadPreviewRequest.class);
+        LoadPreviewRequest request = JsonUtils.readToObject(data,
+                LoadPreviewRequest.class);
         String css = getThemeModifier().getCss();
         return new LoadPreviewResponse(request.getRequestId(), css);
     }
 
     protected BaseResponse handleLoadRules(JsonObject data) {
-        LoadRulesRequest request = JsonUtils.readToObject(data, LoadRulesRequest.class);
-        List<LoadRulesResponse.CssRule> rules = getThemeModifier().getCssRules(request.getSelectorFilter());
+        LoadRulesRequest request = JsonUtils.readToObject(data,
+                LoadRulesRequest.class);
+        List<LoadRulesResponse.CssRule> rules = getThemeModifier()
+                .getCssRules(request.getSelectorFilter());
         return new LoadRulesResponse(request.getRequestId(), rules);
     }
 

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/ThemeModifier.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/ThemeModifier.java
@@ -97,6 +97,7 @@ public class ThemeModifier {
 
     /**
      * Returns the full content of the theme editor CSS file.
+     *
      * @return CSS string
      */
     public String getCss() {
@@ -104,7 +105,8 @@ public class ThemeModifier {
         try {
             return Files.readString(Path.of(styles.getAbsolutePath()));
         } catch (IOException e) {
-            throw new ThemeEditorException("Could not read stylesheet from " + styles.getAbsolutePath());
+            throw new ThemeEditorException("Could not read stylesheet from "
+                    + styles.getAbsolutePath());
         }
     }
 
@@ -113,13 +115,18 @@ public class ThemeModifier {
         CSSWriterSettings cssWriterSettings = new CSSWriterSettings();
 
         return styleSheet.getAllStyleRules().stream().filter(rule -> {
-            String cssSelector = rule.getSelectorCount() > 0 ? rule.getSelectorAtIndex(0).getAsCSSString() : null;
-            return cssSelector != null && cssSelector.startsWith(selectorFilter);
+            String cssSelector = rule.getSelectorCount() > 0
+                    ? rule.getSelectorAtIndex(0).getAsCSSString()
+                    : null;
+            return cssSelector != null
+                    && cssSelector.startsWith(selectorFilter);
         }).map(rule -> {
-            String selector = rule.getSelectorsAsCSSString(cssWriterSettings, 0);
+            String selector = rule.getSelectorsAsCSSString(cssWriterSettings,
+                    0);
             Map<String, String> properties = new HashMap<>();
             rule.getAllDeclarations().forEach(cssDeclaration -> {
-                properties.put(cssDeclaration.getProperty(), cssDeclaration.getExpressionAsCSSString());
+                properties.put(cssDeclaration.getProperty(),
+                        cssDeclaration.getExpressionAsCSSString());
             });
             return new LoadRulesResponse.CssRule(selector, properties);
         }).toList();

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/messages/LoadPreviewRequest.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/messages/LoadPreviewRequest.java
@@ -1,0 +1,5 @@
+package com.vaadin.base.devserver.themeeditor.messages;
+
+public class LoadPreviewRequest extends BaseRequest {
+    public static final String COMMAND_NAME = "themeEditorLoadPreview";
+}

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/messages/LoadPreviewResponse.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/messages/LoadPreviewResponse.java
@@ -1,0 +1,18 @@
+package com.vaadin.base.devserver.themeeditor.messages;
+
+public class LoadPreviewResponse extends BaseResponse {
+    private String css;
+
+    public LoadPreviewResponse(String requestId, String css) {
+        super(requestId, CODE_OK);
+        this.css = css;
+    }
+
+    public String getCss() {
+        return css;
+    }
+
+    public void setCss(String css) {
+        this.css = css;
+    }
+}

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/messages/LoadRulesRequest.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/messages/LoadRulesRequest.java
@@ -1,0 +1,15 @@
+package com.vaadin.base.devserver.themeeditor.messages;
+
+public class LoadRulesRequest extends BaseRequest {
+    public static final String COMMAND_NAME = "themeEditorLoadRules";
+
+    private String selectorFilter;
+
+    public String getSelectorFilter() {
+        return selectorFilter;
+    }
+
+    public void setSelectorFilter(String selectorFilter) {
+        this.selectorFilter = selectorFilter;
+    }
+}

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/messages/LoadRulesResponse.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/messages/LoadRulesResponse.java
@@ -1,0 +1,24 @@
+package com.vaadin.base.devserver.themeeditor.messages;
+
+import java.util.List;
+import java.util.Map;
+
+public class LoadRulesResponse extends BaseResponse{
+    public record CssRule(String selector, Map<String, String> properties) {
+    }
+
+    private List<CssRule> rules;
+
+    public LoadRulesResponse(String requestId, List<CssRule> rules) {
+        super(requestId, CODE_OK);
+        this.rules = rules;
+    }
+
+    public List<CssRule> getRules() {
+        return rules;
+    }
+
+    public void setRules(List<CssRule> rules) {
+        this.rules = rules;
+    }
+}

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/messages/LoadRulesResponse.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/messages/LoadRulesResponse.java
@@ -3,7 +3,7 @@ package com.vaadin.base.devserver.themeeditor.messages;
 import java.util.List;
 import java.util.Map;
 
-public class LoadRulesResponse extends BaseResponse{
+public class LoadRulesResponse extends BaseResponse {
     public record CssRule(String selector, Map<String, String> properties) {
     }
 

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/api.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/api.ts
@@ -3,7 +3,9 @@ import { ThemeEditorRule } from './model';
 
 export enum Commands {
   response = 'themeEditorResponse',
-  updateCssRules = 'themeEditorRules'
+  updateCssRules = 'themeEditorRules',
+  loadPreview = 'themeEditorLoadPreview',
+  loadRules = 'themeEditorLoadRules'
 }
 
 export enum ResponseCode {
@@ -14,6 +16,19 @@ export enum ResponseCode {
 export interface BaseResponse {
   requestId: string;
   code: ResponseCode;
+}
+
+export interface LoadPreviewResponse extends BaseResponse {
+  css: string;
+}
+
+export interface ServerCssRule {
+  selector: string;
+  properties: { [key: string]: string };
+}
+
+export interface LoadRulesResponse {
+  rules: ServerCssRule[];
 }
 
 interface RequestHandle {
@@ -74,5 +89,13 @@ export class ThemeEditorApi {
       add,
       remove
     });
+  }
+
+  public loadPreview(): Promise<LoadPreviewResponse> {
+    return this.sendRequest(Commands.loadPreview, {});
+  }
+
+  public loadRules(selectorFilter: string): Promise<LoadRulesResponse> {
+    return this.sendRequest(Commands.loadRules, { selectorFilter });
   }
 }

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.test.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.test.ts
@@ -7,19 +7,26 @@ import { metadataRegistry } from './metadata/registry';
 import sinon from 'sinon';
 import { themePreview } from './preview';
 import { testElementMetadata } from './tests/utils';
-import { Commands } from './api';
+import { ThemeEditorApi } from './api';
 
 describe('theme-editor', () => {
   let editor: ThemeEditor;
   let testElement: HTMLElement;
   let connectionMock: {
+    onMessage: sinon.SinonSpy;
     send: sinon.SinonSpy;
+  };
+  let apiMock: {
+    updateCssRules: sinon.SinonStub;
+    loadPreview: sinon.SinonStub;
+    loadRules: sinon.SinonStub;
   };
   let getMetadataStub: sinon.SinonStub;
 
   async function editorFixture() {
     connectionMock = {
-      send: sinon.spy(() => {})
+      onMessage: sinon.spy(),
+      send: sinon.spy()
     };
     const pickerMock = {
       open: (options: PickerOptions) => {
@@ -31,6 +38,15 @@ describe('theme-editor', () => {
       .pickerProvider=${pickerProvider}
       .connection=${connectionMock}
     ></vaadin-dev-tools-theme-editor>`)) as ThemeEditor;
+
+    apiMock = {
+      updateCssRules: sinon.stub((editor as any).api as ThemeEditorApi, 'updateCssRules'),
+      loadPreview: sinon.stub((editor as any).api as ThemeEditorApi, 'loadPreview'),
+      loadRules: sinon.stub((editor as any).api as ThemeEditorApi, 'loadRules')
+    };
+    apiMock.updateCssRules.returns(Promise.resolve({}));
+    apiMock.loadPreview.returns(Promise.resolve({ css: '' }));
+    apiMock.loadRules.returns(Promise.resolve({ rules: [] }));
 
     return {
       editor,
@@ -91,7 +107,7 @@ describe('theme-editor', () => {
   });
 
   beforeEach(async () => {
-    themePreview.reset();
+    themePreview.update('');
     testElement = await fixture(html` <test-element></test-element>`);
     const fixtureResult = await editorFixture();
     editor = fixtureResult.editor;
@@ -114,18 +130,15 @@ describe('theme-editor', () => {
 
   describe('editing', () => {
     it('should update theme preview after changing a property', async () => {
+      apiMock.loadPreview.returns(
+        Promise.resolve({
+          css: 'test-element::part(label) { color: red }'
+        })
+      );
       await pickComponent();
       await editProperty('label', 'color', 'red');
 
-      expect(getTestElementStyles().label.color).to.equal('rgb(255, 0, 0)');
-    });
-
-    it('should keep saved modifications in theme preview', async () => {
-      await pickComponent();
-      await editProperty('label', 'color', 'red');
-      expect(getTestElementStyles().label.color).to.equal('rgb(255, 0, 0)');
-
-      await pickComponent();
+      expect(apiMock.loadPreview.calledOnce).to.be.true;
       expect(getTestElementStyles().label.color).to.equal('rgb(255, 0, 0)');
     });
 
@@ -146,10 +159,28 @@ describe('theme-editor', () => {
       });
     });
 
-    it('should initialize property editors with base theme values', async () => {
+    it('should initialize property editors with base theme values when there are no custom rules', async () => {
       await pickComponent();
 
       expect(getPropertyValue('label', 'color')).to.equal('rgb(0, 0, 0)');
+    });
+
+    it('should initialize property editors with values from custom rules', async () => {
+      apiMock.loadRules.returns(
+        Promise.resolve({
+          rules: [
+            {
+              selector: 'test-element::part(label)',
+              properties: {
+                color: 'red'
+              }
+            }
+          ]
+        })
+      );
+      await pickComponent();
+
+      expect(getPropertyValue('label', 'color')).to.equal('red');
     });
 
     it('should update property editors with edited theme values', async () => {
@@ -159,49 +190,31 @@ describe('theme-editor', () => {
       expect(getPropertyValue('label', 'color')).to.equal('red');
     });
 
-    it('should keep previously saved theme modifications', async () => {
-      await pickComponent();
-      await editProperty('label', 'color', 'red');
-      await elementUpdated(editor);
-      expect(getPropertyValue('label', 'color')).to.equal('red');
-
-      await pickComponent();
-      expect(getPropertyValue('label', 'color')).to.equal('red');
-    });
-
     it('should send theme rules when changing properties', async () => {
       await pickComponent();
-      await editProperty('label', 'color', 'red');
 
-      expect(connectionMock.send.calledOnce);
-      expect(connectionMock.send.args[0][0]).to.equal(Commands.updateCssRules);
-      expect(connectionMock.send.args[0][1]).to.deep.equal({
-        requestId: '0',
-        add: [
-          {
-            selector: 'test-element::part(label)',
-            property: 'color',
-            value: 'red'
-          }
-        ],
-        remove: []
-      });
-      connectionMock.send.resetHistory();
+      await editProperty('label', 'color', 'red');
+      expect(apiMock.updateCssRules.calledOnce).to.be.true;
+      expect(apiMock.updateCssRules.args[0][0]).to.deep.equal([
+        {
+          selector: 'test-element::part(label)',
+          property: 'color',
+          value: 'red'
+        }
+      ]);
+      expect(apiMock.updateCssRules.args[0][1]).to.deep.equal([]);
+      apiMock.updateCssRules.resetHistory();
 
       await editProperty('label', 'color', 'green');
-      expect(connectionMock.send.calledOnce);
-      expect(connectionMock.send.args[0][0]).to.equal(Commands.updateCssRules);
-      expect(connectionMock.send.args[0][1]).to.deep.equal({
-        requestId: '1',
-        add: [
-          {
-            selector: 'test-element::part(label)',
-            property: 'color',
-            value: 'green'
-          }
-        ],
-        remove: []
-      });
+      expect(apiMock.updateCssRules.calledOnce).to.be.true;
+      expect(apiMock.updateCssRules.args[0][0]).to.deep.equal([
+        {
+          selector: 'test-element::part(label)',
+          property: 'color',
+          value: 'green'
+        }
+      ]);
+      expect(apiMock.updateCssRules.args[0][1]).to.deep.equal([]);
     });
 
     it('should dispatch event before saving changes', async () => {

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editor.ts
@@ -5,7 +5,7 @@ import { ComponentMetadata } from './metadata/model';
 import { metadataRegistry } from './metadata/registry';
 import { icons } from './icons';
 import './property-list';
-import { ComponentTheme, generateThemeRule, Theme, ThemeEditorState } from './model';
+import { ComponentTheme, generateThemeRule, ThemeEditorState } from './model';
 import { detectTheme } from './detector';
 import { ThemePropertyValueChangeEvent } from './events';
 import { themePreview } from './preview';
@@ -28,25 +28,20 @@ export class ThemeEditor extends LitElement {
   @state()
   private selectedComponentMetadata: ComponentMetadata | null = null;
   /**
-   * Theme modifications for all components, containing all changes since the
-   * last reload
-   */
-  private theme: Theme = new Theme();
-  /**
    * Base theme detected from existing CSS files for the selected component
    */
-  private baseComponentTheme: ComponentTheme | null = null;
+  private baseTheme: ComponentTheme | null = null;
   /**
-   * Previously saved theme modifications for the selected component since the
+   * Currently edited theme modifications for the selected component since the
    * last reload
    */
-  private modifiedComponentTheme: ComponentTheme | null = null;
+  private editedTheme: ComponentTheme | null = null;
   /**
    * The effective theme for the selected component, including base theme and
    * previously saved modifications
    */
   @state()
-  private effectiveComponentTheme: ComponentTheme | null = null;
+  private effectiveTheme: ComponentTheme | null = null;
 
   static get styles() {
     return css`
@@ -118,7 +113,7 @@ export class ThemeEditor extends LitElement {
         ? html` <vaadin-dev-tools-theme-property-list
             class="property-list"
             .metadata=${this.selectedComponentMetadata}
-            .theme=${this.effectiveComponentTheme}
+            .theme=${this.effectiveTheme}
             @theme-property-value-change=${this.handlePropertyChange}
           ></vaadin-dev-tools-theme-property-list>`
         : null}
@@ -152,33 +147,35 @@ export class ThemeEditor extends LitElement {
         </div>
       `,
       pickCallback: async (component) => {
-        this.selectedComponentMetadata = await metadataRegistry.getMetadata(component);
-        if (this.selectedComponentMetadata) {
-          themePreview.reset();
-          this.baseComponentTheme = detectTheme(this.selectedComponentMetadata);
-          this.modifiedComponentTheme = this.theme.getOrCreateComponentTheme(this.selectedComponentMetadata);
-          this.effectiveComponentTheme = ComponentTheme.combine(this.baseComponentTheme, this.modifiedComponentTheme);
-        } else {
-          this.baseComponentTheme = null;
-          this.modifiedComponentTheme = null;
-          this.effectiveComponentTheme = null;
+        const metadata = await metadataRegistry.getMetadata(component);
+        if (!metadata) {
+          this.baseTheme = null;
+          this.editedTheme = null;
+          this.effectiveTheme = null;
+          return;
         }
-        this.updateThemePreview();
+
+        const scopeSelector = metadata.tagName;
+        const serverRules = await this.api.loadRules(scopeSelector);
+
+        this.selectedComponentMetadata = metadata;
+        this.baseTheme = detectTheme(metadata);
+        this.editedTheme = ComponentTheme.fromServerRules(metadata, serverRules.rules);
+        this.effectiveTheme = ComponentTheme.combine(this.baseTheme, this.editedTheme);
       }
     });
   }
 
-  private handlePropertyChange(e: ThemePropertyValueChangeEvent) {
-    if (!this.selectedComponentMetadata || !this.baseComponentTheme || !this.modifiedComponentTheme) {
+  private async handlePropertyChange(e: ThemePropertyValueChangeEvent) {
+    if (!this.selectedComponentMetadata || !this.baseTheme || !this.editedTheme) {
       return;
     }
 
     // Update local theme state
     const { part, property, value } = e.detail;
     const partName = part?.partName || null;
-    this.modifiedComponentTheme.updatePropertyValue(partName, property.propertyName, value);
-    this.effectiveComponentTheme = ComponentTheme.combine(this.baseComponentTheme, this.modifiedComponentTheme);
-    this.updateThemePreview();
+    this.editedTheme.updatePropertyValue(partName, property.propertyName, value);
+    this.effectiveTheme = ComponentTheme.combine(this.baseTheme, this.editedTheme);
 
     // Update theme editor CSS
     // Notify dev tools that we are about to save CSS, so that it can disable
@@ -190,10 +187,12 @@ export class ThemeEditor extends LitElement {
       property.propertyName,
       value
     );
-    this.api.updateCssRules([updateRule], []);
+    await this.api.updateCssRules([updateRule], []);
+    await this.updateThemePreview();
   }
 
-  private updateThemePreview() {
-    themePreview.update(this.theme);
+  private async updateThemePreview() {
+    const preview = await this.api.loadPreview();
+    themePreview.update(preview.css);
   }
 }

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/model.test.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/model.test.ts
@@ -2,6 +2,8 @@ import { expect } from '@open-wc/testing';
 import { ComponentTheme, generateThemeRule, ThemeEditorRule, ThemePropertyValue } from './model';
 import buttonMetadata from './metadata/components/vaadin-button';
 import { ComponentMetadata } from './metadata/model';
+import { ServerCssRule } from './api';
+import { testElementMetadata } from './tests/utils';
 
 describe('model', () => {
   describe('ComponentTheme', () => {
@@ -145,6 +147,70 @@ describe('model', () => {
       const result = ComponentTheme.combine(buttonTheme, fooTheme);
 
       expect(result.metadata).to.equal(buttonMetadata);
+    });
+  });
+
+  describe('fromServerRules', () => {
+    it('should create empty theme from empty rules', () => {
+      const theme = ComponentTheme.fromServerRules(buttonMetadata, []);
+
+      expect(theme.properties.length).to.equal(0);
+    });
+
+    it('should create theme from rules', () => {
+      const serverRules: ServerCssRule[] = [
+        {
+          selector: 'test-element',
+          properties: {
+            background: 'cornflowerblue',
+            padding: '3px'
+          }
+        },
+        {
+          selector: 'test-element::part(label)',
+          properties: {
+            color: 'red',
+            'font-size': '20px'
+          }
+        }
+      ];
+      const expectedProperties = [
+        { partName: null, propertyName: 'padding', value: '3px' },
+        { partName: null, propertyName: 'background', value: 'cornflowerblue' },
+        { partName: 'label', propertyName: 'color', value: 'red' },
+        { partName: 'label', propertyName: 'font-size', value: '20px' }
+      ];
+
+      const theme = ComponentTheme.fromServerRules(testElementMetadata, serverRules);
+      expect(theme.metadata).to.equal(testElementMetadata);
+      expect(theme.properties).to.deep.equal(expectedProperties);
+    });
+
+    it('should ignore unknown selectors and properties', () => {
+      const serverRules: ServerCssRule[] = [
+        {
+          selector: 'test-element',
+          properties: {
+            foo: 'cornflowerblue'
+          }
+        },
+        {
+          selector: 'test-element::part(label)',
+          properties: {
+            bar: '20px'
+          }
+        },
+        {
+          selector: 'test-element::part(foo)',
+          properties: {
+            color: 'cornflowerblue',
+            background: 'cornflowerblue'
+          }
+        }
+      ];
+
+      const theme = ComponentTheme.fromServerRules(testElementMetadata, serverRules);
+      expect(theme.properties.length).to.equal(0);
     });
   });
 

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/model.test.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/model.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@open-wc/testing';
-import {ComponentTheme, generateThemeRule, Theme, ThemeEditorRule, ThemePropertyValue} from './model';
+import { ComponentTheme, generateThemeRule, ThemeEditorRule, ThemePropertyValue } from './model';
 import buttonMetadata from './metadata/components/vaadin-button';
 import { ComponentMetadata } from './metadata/model';
 
@@ -138,7 +138,7 @@ describe('model', () => {
         tagName: 'foo-component',
         displayName: 'Foo',
         properties: [],
-        parts: [],
+        parts: []
       };
       const buttonTheme = new ComponentTheme(buttonMetadata);
       const fooTheme = new ComponentTheme(fooMetadata);
@@ -151,11 +151,11 @@ describe('model', () => {
   describe('generateRule', () => {
     it('should generate rules for property changes', () => {
       const rules = [
-          generateThemeRule('vaadin-button', null, 'background', 'cornflowerblue'),
-          generateThemeRule('vaadin-button', null, 'padding', '3px'),
-          generateThemeRule('vaadin-button', 'label', 'color', 'white'),
-          generateThemeRule('vaadin-button', 'label', 'font-size', '20px'),
-      ]
+        generateThemeRule('vaadin-button', null, 'background', 'cornflowerblue'),
+        generateThemeRule('vaadin-button', null, 'padding', '3px'),
+        generateThemeRule('vaadin-button', 'label', 'color', 'white'),
+        generateThemeRule('vaadin-button', 'label', 'font-size', '20px')
+      ];
 
       const expectedRules: ThemeEditorRule[] = [
         { selector: 'vaadin-button', property: 'background', value: 'cornflowerblue' },
@@ -166,76 +166,5 @@ describe('model', () => {
 
       expect(rules).to.deep.equal(expectedRules);
     });
-  });
-
-  describe('Theme', () => {
-    let theme: Theme;
-
-    beforeEach(() => {
-      theme = new Theme();
-    });
-
-    it('should return null for non-existing component themes', () => {
-      expect(theme.getComponentTheme('vaadin-button')).to.be.null;
-    });
-
-    it('should get or create theme component themes', () => {
-      const buttonTheme = theme.getOrCreateComponentTheme(buttonMetadata);
-      expect(buttonTheme).to.not.be.null;
-      expect(theme.getOrCreateComponentTheme(buttonMetadata)).to.equal(buttonTheme);
-    });
-
-    it('should add and return component themes', () => {
-      const buttonTheme = new ComponentTheme(buttonMetadata);
-      buttonTheme.updatePropertyValue(null, 'background', 'cornflowerblue');
-      buttonTheme.updatePropertyValue('label', 'color', 'white');
-
-      theme.updateComponentTheme(buttonTheme);
-
-      const storedTheme = theme.getComponentTheme('vaadin-button');
-      expect(storedTheme).to.deep.equal(buttonTheme);
-      expect(theme.componentThemes).to.deep.equal([buttonTheme]);
-    });
-
-    it('should update component themes', () => {
-      const buttonTheme = new ComponentTheme(buttonMetadata);
-      buttonTheme.updatePropertyValue(null, 'background', 'cornflowerblue');
-      buttonTheme.updatePropertyValue('label', 'color', 'white');
-      theme.updateComponentTheme(buttonTheme);
-
-      const updatedTheme = new ComponentTheme(buttonMetadata);
-      updatedTheme.updatePropertyValue(null, 'padding', '3px');
-      updatedTheme.updatePropertyValue('label', 'color', 'red');
-      updatedTheme.updatePropertyValue('label', 'font-size', '20px');
-      theme.updateComponentTheme(updatedTheme);
-
-      const expectedTheme = new ComponentTheme(buttonMetadata);
-      expectedTheme.updatePropertyValue(null, 'background', 'cornflowerblue');
-      expectedTheme.updatePropertyValue(null, 'padding', '3px');
-      expectedTheme.updatePropertyValue('label', 'color', 'red');
-      expectedTheme.updatePropertyValue('label', 'font-size', '20px');
-
-      const storedTheme = theme.getComponentTheme('vaadin-button');
-      expect(storedTheme).to.deep.equal(expectedTheme);
-    });
-
-    it('should not store references to passed component themes', () => {
-      const buttonTheme = new ComponentTheme(buttonMetadata);
-      theme.updateComponentTheme(buttonTheme);
-
-      const storedTheme = theme.getComponentTheme('vaadin-button');
-      expect(storedTheme).to.not.equal(buttonTheme);
-    });
-
-    it('should clone theme', () => {
-      const buttonTheme = new ComponentTheme(buttonMetadata);
-      buttonTheme.updatePropertyValue(null, 'background', 'cornflowerblue');
-      buttonTheme.updatePropertyValue('label', 'color', 'white');
-      theme.updateComponentTheme(buttonTheme);
-
-      const clonedTheme = theme.clone();
-      expect(clonedTheme).to.not.equal(theme);
-      expect(clonedTheme).to.deep.equal(theme);
-    })
   });
 });

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/preview.test.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/preview.test.ts
@@ -1,7 +1,6 @@
 import { expect, fixture, html } from '@open-wc/testing';
 import { themePreview } from './preview';
-import { ComponentTheme, Theme } from './model';
-import { testElementMetadata } from './tests/utils';
+import './tests/utils';
 
 describe('theme-preview', () => {
   let element: HTMLElement;
@@ -19,12 +18,16 @@ describe('theme-preview', () => {
   });
 
   it('should apply theme preview', () => {
-    const theme = new Theme();
-    const componentTheme = new ComponentTheme(testElementMetadata);
-    componentTheme.updatePropertyValue(null, 'padding', '20px');
-    componentTheme.updatePropertyValue('label', 'color', 'red');
-    theme.updateComponentTheme(componentTheme);
-    themePreview.update(theme);
+    const css = `
+      test-element {
+        padding: 20px;
+      }
+      
+      test-element::part(label) {
+        color: red;
+      }
+    `;
+    themePreview.update(css);
 
     const elementStyles = getElementStyles();
     expect(elementStyles.host.padding).to.equal('20px');
@@ -32,17 +35,27 @@ describe('theme-preview', () => {
   });
 
   it('should update theme preview', () => {
-    const theme = new Theme();
-    const componentTheme = new ComponentTheme(testElementMetadata);
-    componentTheme.updatePropertyValue(null, 'padding', '20px');
-    componentTheme.updatePropertyValue('label', 'color', 'red');
-    theme.updateComponentTheme(componentTheme);
-    themePreview.update(theme);
+    const css = `
+      test-element {
+        padding: 20px;
+      }
+      
+      test-element::part(label) {
+        color: red;
+      }
+    `;
+    themePreview.update(css);
 
-    componentTheme.updatePropertyValue(null, 'padding', '30px');
-    componentTheme.updatePropertyValue('label', 'color', 'green');
-    theme.updateComponentTheme(componentTheme);
-    themePreview.update(theme);
+    const updatedCss = `
+      test-element {
+        padding: 30px;
+      }
+      
+      test-element::part(label) {
+        color: green;
+      }
+    `;
+    themePreview.update(updatedCss);
 
     const elementStyles = getElementStyles();
     expect(elementStyles.host.padding).to.equal('30px');
@@ -50,14 +63,17 @@ describe('theme-preview', () => {
   });
 
   it('should reset theme preview', () => {
-    const theme = new Theme();
-    const componentTheme = new ComponentTheme(testElementMetadata);
-    componentTheme.updatePropertyValue(null, 'padding', '20px');
-    componentTheme.updatePropertyValue('label', 'color', 'red');
-    theme.updateComponentTheme(componentTheme);
-    themePreview.update(theme);
-
-    themePreview.reset();
+    const css = `
+      test-element {
+        padding: 20px;
+      }
+      
+      test-element::part(label) {
+        color: red;
+      }
+    `;
+    themePreview.update(css);
+    themePreview.update('');
 
     const elementStyles = getElementStyles();
     expect(elementStyles.host.padding).to.equal('10px');

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/preview.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/preview.ts
@@ -1,5 +1,3 @@
-import { ComponentTheme, Theme } from './model';
-
 class ThemePreview {
   private _stylesheet: CSSStyleSheet;
 
@@ -13,33 +11,8 @@ class ThemePreview {
     return this._stylesheet;
   }
 
-  update(theme: Theme) {
-    let rules: string[] = [];
-
-    theme.componentThemes.forEach((componentTheme) => {
-      const hostRule = this.createRule(componentTheme, null);
-      const partRules = componentTheme.metadata.parts.map((part) => this.createRule(componentTheme, part.partName));
-
-      rules = [...rules, hostRule, ...partRules];
-    });
-
-    const themeCss = rules.join('\n');
-    this._stylesheet.replaceSync(themeCss);
-  }
-
-  private createRule(componentTheme: ComponentTheme, partName: string | null) {
-    const selector = partName
-      ? // Part name selector
-        `${componentTheme.metadata.tagName}::part(${partName})`
-      : // Host selector
-        componentTheme.metadata.tagName;
-    const propertyValues = componentTheme.getPropertyValuesForPart(partName);
-    const propertyDeclarations = propertyValues.map((value) => `${value.propertyName}: ${value.value}`).join(';');
-    return `${selector} { ${propertyDeclarations} }`;
-  }
-
-  reset() {
-    this._stylesheet.replaceSync('');
+  update(css: string) {
+    this._stylesheet.replaceSync(css);
   }
 }
 

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/tests/utils.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/tests/utils.ts
@@ -22,6 +22,7 @@ export class TestElement extends HTMLElement {
     shadow.adoptedStyleSheets.push(styles);
   }
 }
+
 customElements.define('test-element', TestElement);
 
 export const testElementMetadata: ComponentMetadata = {
@@ -31,6 +32,10 @@ export const testElementMetadata: ComponentMetadata = {
     {
       propertyName: 'padding',
       displayName: 'Padding'
+    },
+    {
+      propertyName: 'background',
+      displayName: 'Background'
     }
   ],
   parts: [
@@ -41,6 +46,10 @@ export const testElementMetadata: ComponentMetadata = {
         {
           propertyName: 'color',
           displayName: 'Text color'
+        },
+        {
+          propertyName: 'font-size',
+          displayName: 'Font size'
         }
       ]
     }

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/themeeditor/ThemeEditorMessageHandlerTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/themeeditor/ThemeEditorMessageHandlerTest.java
@@ -111,8 +111,8 @@ public class ThemeEditorMessageHandlerTest extends AbstractThemeEditorTest {
         String requestId = UUID.randomUUID().toString();
         data.put("requestId", requestId);
 
-        BaseResponse response = handler.handleDebugMessageData(
-                LoadPreviewRequest.COMMAND_NAME, data);
+        BaseResponse response = handler
+                .handleDebugMessageData(LoadPreviewRequest.COMMAND_NAME, data);
         assertResponseOk(response, requestId);
     }
 
@@ -124,8 +124,8 @@ public class ThemeEditorMessageHandlerTest extends AbstractThemeEditorTest {
         data.put("requestId", requestId);
         data.put("selectorFilter", "vaadin-button");
 
-        BaseResponse response = handler.handleDebugMessageData(
-                LoadRulesRequest.COMMAND_NAME, data);
+        BaseResponse response = handler
+                .handleDebugMessageData(LoadRulesRequest.COMMAND_NAME, data);
         assertResponseOk(response, requestId);
     }
 

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/themeeditor/ThemeEditorMessageHandlerTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/themeeditor/ThemeEditorMessageHandlerTest.java
@@ -105,6 +105,31 @@ public class ThemeEditorMessageHandlerTest extends AbstractThemeEditorTest {
     }
 
     @Test
+    public void testHandleLoadPreview() {
+        ThemeEditorMessageHandler handler = new TestThemeEditorMessageHandler();
+        JsonObject data = Json.createObject();
+        String requestId = UUID.randomUUID().toString();
+        data.put("requestId", requestId);
+
+        BaseResponse response = handler.handleDebugMessageData(
+                LoadPreviewRequest.COMMAND_NAME, data);
+        assertResponseOk(response, requestId);
+    }
+
+    @Test
+    public void testHandleLoadRules() {
+        ThemeEditorMessageHandler handler = new TestThemeEditorMessageHandler();
+        JsonObject data = Json.createObject();
+        String requestId = UUID.randomUUID().toString();
+        data.put("requestId", requestId);
+        data.put("selectorFilter", "vaadin-button");
+
+        BaseResponse response = handler.handleDebugMessageData(
+                LoadRulesRequest.COMMAND_NAME, data);
+        assertResponseOk(response, requestId);
+    }
+
+    @Test
     public void testError() {
         prepareComponentTracker(42);
         ThemeEditorMessageHandler handler = new TestThemeEditorMessageHandler();

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/themeeditor/ThemeModifierTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/themeeditor/ThemeModifierTest.java
@@ -300,7 +300,8 @@ public class ThemeModifierTest extends AbstractThemeEditorTest {
         String css = modifier.getCss();
         System.out.println(css);
 
-        String fileContent = Files.readString(getThemeFile("theme-editor.css").toPath());
+        String fileContent = Files
+                .readString(getThemeFile("theme-editor.css").toPath());
 
         assertEquals(fileContent, css);
     }
@@ -309,19 +310,19 @@ public class ThemeModifierTest extends AbstractThemeEditorTest {
     public void getCssRules() {
         ThemeModifier modifier = new TestThemeModifier();
         List<RulesRequest.CssRuleProperty> toBeAdded = new ArrayList<>();
-        toBeAdded.add(new RulesRequest.CssRuleProperty("vaadin-button",
-                "color", "red"));
+        toBeAdded.add(new RulesRequest.CssRuleProperty("vaadin-button", "color",
+                "red"));
         toBeAdded.add(new RulesRequest.CssRuleProperty("vaadin-button",
                 "background", "black"));
-        toBeAdded.add(new RulesRequest.CssRuleProperty("vaadin-button::part(label)",
-                "font-family", "serif"));
+        toBeAdded.add(new RulesRequest.CssRuleProperty(
+                "vaadin-button::part(label)", "font-family", "serif"));
         toBeAdded.add(new RulesRequest.CssRuleProperty("vaadin-text-field",
                 "color", "red"));
-        toBeAdded.add(new RulesRequest.CssRuleProperty("span",
-                "color", "red"));
+        toBeAdded.add(new RulesRequest.CssRuleProperty("span", "color", "red"));
         modifier.setThemeProperties(toBeAdded);
 
-        List<LoadRulesResponse.CssRule> cssRules = modifier.getCssRules("vaadin-button");
+        List<LoadRulesResponse.CssRule> cssRules = modifier
+                .getCssRules("vaadin-button");
         assertEquals(2, cssRules.size());
 
         assertEquals("vaadin-button", cssRules.get(0).selector());


### PR DESCRIPTION
## Description

Adds an API for loading existing rules for a component. After picking a component in the editor, loads all rules for the picked component, so that property edtiors initialize with the previously modified value. For the future this API could also be used to load rules for different component scopes (global or instances with a specific CSS class name).

Also adds an API for loading the current content of the theme editor CSS file in order to update the theme preview. This allows to remove the double-bookkeeping of modifications since the last reload on the client. Whenever a property is modified we just save the change on the server, and then retrieve the current CSS again. This creates more traffic than the previous approach, but it is how the Flow live reload is going to work as well when it eventually gets implemented. Besides all traffic happens on localhost, so it should be fast enough. I tested with a CSS file with 3000 lines (~50kb), which worked fine.
