### PR TITLE
refactor: Keep local reference of I18NProvider in Component.getTranslation

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/Component.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Component.java
@@ -678,10 +678,11 @@ public abstract class Component
      */
     @Deprecated
     public String getTranslation(String key, Locale locale, Object... params) {
-        if (getI18NProvider() == null) {
+        final I18NProvider i18NProvider = getI18NProvider();
+        if (i18nProvider == null) {
             return "!{" + key + "}!";
         }
-        return getI18NProvider().getTranslation(key, locale, params);
+        return i18nProvider.getTranslation(key, locale, params);
     }
 
     /**


### PR DESCRIPTION
## Description

The I18NProvider should be stored in a local reference, because it will always be present for projects were it is set. This results in doubled access to the backing TheadLocal, which can reduce performance when translation is heavily used.

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
