### PR TITLE
TEST: Revert "chore(deps): bump maven.version from 3.8.7 to 3.9.0 (#15838)"

### DIFF
--- a/flow-plugins/flow-dev-bundle-plugin/pom.xml
+++ b/flow-plugins/flow-dev-bundle-plugin/pom.xml
@@ -12,7 +12,7 @@
     <name>Flow devBundle Maven plugin</name>
 
     <properties>
-        <maven.version>3.9.0</maven.version>
+        <maven.version>3.8.7</maven.version>
     </properties>
 
     <dependencies>

--- a/flow-plugins/flow-maven-plugin/pom.xml
+++ b/flow-plugins/flow-maven-plugin/pom.xml
@@ -12,7 +12,7 @@
     <name>Flow Maven plugin</name>
 
     <properties>
-        <maven.version>3.9.0</maven.version>
+        <maven.version>3.8.7</maven.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This reverts commit f59e5a1557e9833a7036bb39ba58ce3da20b61fc.

Test if maven upgrade has an impact on GHA build time.