### PR TITLE
chore: cancel previous builds if there are new changes in the branch

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -7,6 +7,9 @@ on:
     types: [opened, synchronize, reopened, edited]
 permissions:
   contents: read
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true  
 jobs:
   build:
     timeout-minutes: 30


### PR DESCRIPTION
This avoids long queues in the project when pushing multiple changes to the same PR

