### PR TITLE
fix: Add 'remote allow origins' option to chrome driver

### DIFF
--- a/flow-test-util/src/main/java/com/vaadin/flow/testutil/ChromeBrowserTest.java
+++ b/flow-test-util/src/main/java/com/vaadin/flow/testutil/ChromeBrowserTest.java
@@ -146,7 +146,8 @@ public class ChromeBrowserTest extends ViewOrUITest {
 
     static ChromeOptions createHeadlessChromeOptions() {
         final ChromeOptions options = new ChromeOptions();
-        options.addArguments("--headless", "--disable-gpu");
+        options.addArguments("--headless", "--disable-gpu",
+                "--remote-allow-origins=*");
         return options;
     }
 }

--- a/flow-test-util/src/main/java/com/vaadin/flow/testutil/ChromeDeviceTest.java
+++ b/flow-test-util/src/main/java/com/vaadin/flow/testutil/ChromeDeviceTest.java
@@ -121,6 +121,7 @@ public class ChromeDeviceTest extends ViewOrUITest {
             if (!isJavaInDebugMode()) {
                 chromeOptions.addArguments("--headless", "--disable-gpu");
             }
+            chromeOptions.addArguments("--remote-allow-origins=*");
         } else {
             // Enable service workers over http remote connection
             chromeOptions.addArguments(String.format(


### PR DESCRIPTION
Fixes status code=403 errors when running tests with chrome driver described here https://stackoverflow.com/questions/75678572/java-io-ioexception-invalid-status-code-403-text-forbidden
