### PR TITLE
fix: Use correct scope for ee api's

### DIFF
--- a/flow-data/pom.xml
+++ b/flow-data/pom.xml
@@ -23,6 +23,7 @@
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
             <version>${jakarta.validation.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>

--- a/flow-data/pom.xml
+++ b/flow-data/pom.xml
@@ -61,6 +61,13 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- For DataSerializableTest -->
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>${jakarta.annotation.api.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>

--- a/flow-html-components/pom.xml
+++ b/flow-html-components/pom.xml
@@ -29,7 +29,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-web-api</artifactId>
-            <version>10.0.0</version>
             <scope>test</scope>
         </dependency>
         

--- a/flow-html-components/pom.xml
+++ b/flow-html-components/pom.xml
@@ -27,11 +27,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-web-api</artifactId>
+            <version>10.0.0</version>
+            <scope>test</scope>
         </dependency>
-
+        
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>flow-test-generic</artifactId>

--- a/flow-lit-template/pom.xml
+++ b/flow-lit-template/pom.xml
@@ -38,7 +38,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-web-api</artifactId>
-            <version>10.0.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/flow-lit-template/pom.xml
+++ b/flow-lit-template/pom.xml
@@ -36,9 +36,10 @@
         </dependency>
 
         <dependency>
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-web-api</artifactId>
+            <version>10.0.0</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/flow-polymer-template/pom.xml
+++ b/flow-polymer-template/pom.xml
@@ -48,10 +48,11 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
-            <scope>provided</scope>
+       <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-web-api</artifactId>
+            <version>10.0.0</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/flow-polymer-template/pom.xml
+++ b/flow-polymer-template/pom.xml
@@ -51,7 +51,6 @@
        <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-web-api</artifactId>
-            <version>10.0.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -61,6 +61,7 @@
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
             <version>${jakarta.annotation.api.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Library dependencies -->

--- a/flow-tests/test-frontend/vite-embedded-webcomponent-resync/pom.xml
+++ b/flow-tests/test-frontend/vite-embedded-webcomponent-resync/pom.xml
@@ -68,19 +68,19 @@
             <version>${jetty.version}</version>
         </dependency>
         <!-- This is probably needed here only because we run the tests with Jetty 11 (ee9) instead
-         of 12 (ee10) and the websocket API is from EE10 -->
-         <dependency>
-             <groupId>jakarta.websocket</groupId>
-             <artifactId>jakarta.websocket-api</artifactId>
-             <version>2.1.0</version>
-             <scope>provided</scope>
-         </dependency>
-         <dependency>
-             <groupId>jakarta.websocket</groupId>
-             <artifactId>jakarta.websocket-client-api</artifactId>
-             <version>2.1.0</version>
-             <scope>provided</scope>
-         </dependency>
+        of 12 (ee10) and the websocket API is from EE10 -->
+        <dependency>
+            <groupId>jakarta.websocket</groupId>
+            <artifactId>jakarta.websocket-api</artifactId>
+            <version>2.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.websocket</groupId>
+            <artifactId>jakarta.websocket-client-api</artifactId>
+            <version>2.1.0</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/flow-tests/test-frontend/vite-embedded-webcomponent-resync/pom.xml
+++ b/flow-tests/test-frontend/vite-embedded-webcomponent-resync/pom.xml
@@ -67,6 +67,20 @@
             <artifactId>jetty-servlet</artifactId>
             <version>${jetty.version}</version>
         </dependency>
+        <!-- This is probably needed here only because we run the tests with Jetty 11 (ee9) instead
+         of 12 (ee10) and the websocket API is from EE10 -->
+         <dependency>
+             <groupId>jakarta.websocket</groupId>
+             <artifactId>jakarta.websocket-api</artifactId>
+             <version>2.1.0</version>
+             <scope>provided</scope>
+         </dependency>
+         <dependency>
+             <groupId>jakarta.websocket</groupId>
+             <artifactId>jakarta.websocket-client-api</artifactId>
+             <version>2.1.0</version>
+             <scope>provided</scope>
+         </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -229,6 +229,12 @@
             </dependency>
 
             <dependency>
+                <groupId>jakarta.platform</groupId>
+                <artifactId>jakarta.jakartaee-web-api</artifactId>
+                <version>10.0.0</version>
+            </dependency>
+
+            <dependency>
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy</artifactId>
                 <version>1.14.0</version>

--- a/vaadin-dev-server/pom.xml
+++ b/vaadin-dev-server/pom.xml
@@ -66,7 +66,6 @@
         <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-web-api</artifactId>
-            <version>10.0.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/vaadin-dev-server/pom.xml
+++ b/vaadin-dev-server/pom.xml
@@ -52,16 +52,20 @@
             <groupId>jakarta.websocket</groupId>
             <artifactId>jakarta.websocket-api</artifactId>
             <version>2.1.0</version>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.websocket</groupId>
-            <artifactId>jakarta.websocket-api</artifactId>
-            <version>2.1.0</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.websocket</groupId>
             <artifactId>jakarta.websocket-client-api</artifactId>
             <version>2.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+        
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-web-api</artifactId>
+            <version>10.0.0</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- Test dependencies -->


### PR DESCRIPTION
## Description

Jakarta EE APIs should be in provided scope.

Related to https://github.com/vaadin/platform/issues/3898

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
