### PR TITLE
refactor: implement color property editor in theme editor

### DIFF
--- a/vaadin-dev-server/package.json
+++ b/vaadin-dev-server/package.json
@@ -19,7 +19,8 @@
     "sinon": "^15.0.1"
   },
   "dependencies": {
-    "@vaadin/button": "24.0.0-rc1",
+    "@vaadin/button": "24.0.0",
+    "@vaadin/overlay": "24.0.0",
     "lit": "^2.6.1"
   }
 }

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editors/color-picker.test.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editors/color-picker.test.ts
@@ -1,0 +1,175 @@
+import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import sinon from 'sinon';
+import { Overlay } from '@vaadin/overlay';
+import '@vaadin/overlay';
+import { RgbaStringColorPicker } from '../../vendor/vanilla-colorful/rgba-string-color-picker';
+import { ColorPicker, ColorPickerOverlayContent } from './color-picker';
+import './color-picker';
+
+describe('color-picker', () => {
+  let colorPicker: ColorPicker;
+  let colorChangeSpy: sinon.SinonSpy;
+  let commitSpy: sinon.SinonSpy;
+  let cancelSpy: sinon.SinonSpy;
+
+  beforeEach(async () => {
+    colorPicker = await fixture(html` <vaadin-dev-tools-color-picker></vaadin-dev-tools-color-picker>`);
+    colorChangeSpy = sinon.spy();
+    commitSpy = sinon.spy();
+    cancelSpy = sinon.spy();
+    colorPicker.addEventListener('color-picker-change', colorChangeSpy);
+    colorPicker.addEventListener('color-picker-commit', commitSpy);
+    colorPicker.addEventListener('color-picker-cancel', cancelSpy);
+  });
+
+  function getToggleButton() {
+    return colorPicker.shadowRoot!.querySelector('#toggle') as HTMLElement;
+  }
+
+  function getOverlay() {
+    return document.body.querySelector('vaadin-dev-tools-color-picker-overlay') as Overlay;
+  }
+
+  function getOverlayContent() {
+    return getOverlay().querySelector('vaadin-dev-tools-color-picker-overlay-content') as ColorPickerOverlayContent;
+  }
+
+  async function openOverlay() {
+    getToggleButton().click();
+    await elementUpdated(getOverlayContent());
+  }
+
+  function getInternalPicker() {
+    return getOverlayContent().shadowRoot!.querySelector('rgba-string-color-picker') as RgbaStringColorPicker;
+  }
+
+  function changeInternalPickerColor(color: string) {
+    getInternalPicker().dispatchEvent(new CustomEvent('color-changed', { detail: { value: color } }));
+  }
+
+  function getSwatchesContainer() {
+    return getOverlayContent().shadowRoot!.querySelector('.swatches') as HTMLElement;
+  }
+
+  function getSwatches() {
+    return Array.from(getSwatchesContainer().querySelectorAll('.preview')) as HTMLElement[];
+  }
+
+  it('should show color preview', async () => {
+    colorPicker.value = '#ff0000';
+    await elementUpdated(colorPicker);
+
+    const previewStyles = getComputedStyle(getToggleButton(), '::after');
+    expect(previewStyles.backgroundColor).to.equal('rgb(255, 0, 0)');
+  });
+
+  it('should open overlay when clicking toggle button', () => {
+    getToggleButton().click();
+
+    const overlay = getOverlay();
+    expect(overlay).to.exist;
+    expect(overlay.opened).to.be.true;
+  });
+
+  it('should pass RGB color to internal color picker', async () => {
+    colorPicker.value = '#ff0000';
+    await elementUpdated(colorPicker);
+    await openOverlay();
+
+    const picker = getInternalPicker();
+    expect(picker.color).to.equal('rgb(255, 0, 0)');
+  });
+
+  it('should update internal color picker when value changes', async () => {
+    colorPicker.value = '#ff0000';
+    await elementUpdated(colorPicker);
+    await openOverlay();
+
+    const picker = getInternalPicker();
+    expect(picker.color).to.equal('rgb(255, 0, 0)');
+
+    colorPicker.value = '#0000ff';
+    await elementUpdated(colorPicker);
+    expect(picker.color).to.equal('rgb(0, 0, 255)');
+  });
+
+  it('should dispatch change event when internal picker changes', async () => {
+    colorPicker.value = '#ff0000';
+    await elementUpdated(colorPicker);
+    await openOverlay();
+
+    changeInternalPickerColor('rgba(0, 255, 0, 1)');
+
+    expect(colorChangeSpy.calledOnce).to.be.true;
+    expect(colorChangeSpy.args[0][0].detail.value).to.be.equal('rgba(0, 255, 0, 1)');
+  });
+
+  it('should dispatch cancel event when closing overlay without modifying value', async () => {
+    await openOverlay();
+
+    getOverlay().dispatchEvent(new CustomEvent('vaadin-overlay-close'));
+
+    expect(commitSpy.called).to.be.false;
+    expect(cancelSpy.calledOnce).to.be.true;
+  });
+
+  it('should dispatch cancel event when closing overlay with escape', async () => {
+    await openOverlay();
+
+    changeInternalPickerColor('rgba(0, 255, 0, 1)');
+
+    getOverlay().dispatchEvent(new CustomEvent('vaadin-overlay-escape-press'));
+    getOverlay().dispatchEvent(new CustomEvent('vaadin-overlay-close'));
+
+    expect(commitSpy.called).to.be.false;
+    expect(cancelSpy.calledOnce).to.be.true;
+  });
+
+  it('should dispatch commit event when closing overlay after modifying value', async () => {
+    await openOverlay();
+
+    changeInternalPickerColor('rgba(0, 255, 0, 1)');
+
+    getOverlay().dispatchEvent(new CustomEvent('vaadin-overlay-close'));
+
+    expect(commitSpy.calledOnce).to.be.true;
+    expect(cancelSpy.called).to.be.false;
+  });
+
+  it('should not render swatches if there are no presets', async () => {
+    await openOverlay();
+
+    expect(getSwatchesContainer()).to.not.exist;
+  });
+
+  it('should render swatches if there are presets', async () => {
+    function assertSwatchColor(swatch: HTMLElement, color: string) {
+      const style = getComputedStyle(swatch, '::after');
+      expect(style.backgroundColor).to.equal(color);
+    }
+
+    colorPicker.presets = ['#f00', '#0f0', '#00f'];
+    await elementUpdated(colorPicker);
+    await openOverlay();
+
+    expect(getSwatchesContainer()).to.exist;
+
+    const swatches = getSwatches();
+    expect(swatches.length).to.equal(3);
+    assertSwatchColor(swatches[0], 'rgb(255, 0, 0)');
+    assertSwatchColor(swatches[1], 'rgb(0, 255, 0)');
+    assertSwatchColor(swatches[2], 'rgb(0, 0, 255)');
+  });
+
+  it('should dispatch change event when selecting swatch', async () => {
+    colorPicker.presets = ['#f00', '#0f0', '#00f'];
+    await elementUpdated(colorPicker);
+    await openOverlay();
+
+    const swatches = getSwatches();
+    swatches[1].click();
+
+    expect(colorChangeSpy.calledOnce).to.be.true;
+    expect(colorChangeSpy.args[0][0].detail.value).to.be.equal('#0f0');
+  });
+});

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editors/color-picker.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editors/color-picker.ts
@@ -1,7 +1,8 @@
 import { css, html, LitElement, PropertyValues, render } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import { Overlay } from '@vaadin/overlay';
-import { PositionMixin } from '@vaadin/overlay/src/vaadin-overlay-position-mixin';
+// @ts-ignore
+import { PositionMixin } from '../../vendor/@vaadin/overlay/src/vaadin-overlay-position-mixin.js';
 import '../../vendor/vanilla-colorful/rgba-string-color-picker.js';
 
 export class ColorPickerChangeEvent extends CustomEvent<{ value: string }> {

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editors/color-picker.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editors/color-picker.ts
@@ -1,6 +1,5 @@
 import { css, html, LitElement, PropertyValues, render } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
-import { Overlay } from '@vaadin/overlay';
 // @ts-ignore
 import { PositionMixin } from '../../vendor/@vaadin/overlay/src/vaadin-overlay-position-mixin.js';
 import '../../vendor/vanilla-colorful/rgba-string-color-picker.js';
@@ -78,7 +77,7 @@ export class ColorPicker extends LitElement {
 
   @query('#toggle')
   private toggle!: HTMLElement;
-  private overlay!: Overlay;
+  private overlay!: VaadinOverlay;
   private commitValue: boolean = false;
 
   protected update(changedProperties: PropertyValues) {
@@ -93,10 +92,10 @@ export class ColorPicker extends LitElement {
     // Create custom Vaadin overlay and wire up renderer and event listeners
     // Not creating this in the render function as Lit gets confused after
     // the overlay teleports itself to the document body
-    this.overlay = document.createElement('vaadin-dev-tools-color-picker-overlay') as Overlay;
+    this.overlay = document.createElement('vaadin-dev-tools-color-picker-overlay') as VaadinOverlay;
     this.overlay.renderer = this.renderOverlayContent.bind(this);
-    (this.overlay as any).positionTarget = this.toggle;
-    (this.overlay as any).noVerticalOverlap = true;
+    this.overlay.positionTarget = this.toggle;
+    this.overlay.noVerticalOverlap = true;
     this.overlay.addEventListener('vaadin-overlay-escape-press', this.handleOverlayEscape.bind(this));
     this.overlay.addEventListener('vaadin-overlay-close', this.handleOverlayClose.bind(this));
     this.append(this.overlay);
@@ -246,11 +245,20 @@ export class ColorPickerOverlayContent extends LitElement {
   }
 }
 
+// Define basic interface for Vaadin Overlay
+// Importing the interface is not possible as it breaks the Flow build
+interface VaadinOverlay extends HTMLElement {
+  opened: boolean;
+  positionTarget: HTMLElement;
+  noVerticalOverlap: boolean;
+
+  renderer(root: HTMLElement): void;
+
+  requestContentUpdate(): void;
+}
+
 // Define a custom overlay Polymer element that includes the position mixin.
-// Not using a direct import for the Overlay class here as that could lead to
-// loading different versions of the component on the same page when using the
-// development setup (one from the app, the other from the dev tools frontend
-// dev server), which is not supported by Vaadin components.
+// Importing the Overlay class is not possible as it breaks the Flow build
 customElements.whenDefined('vaadin-overlay').then(() => {
   const OverlayClass = customElements.get('vaadin-overlay');
 

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editors/color-picker.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editors/color-picker.ts
@@ -1,0 +1,259 @@
+import { css, html, LitElement, PropertyValues, render } from 'lit';
+import { customElement, property, query } from 'lit/decorators.js';
+import { Overlay } from '@vaadin/overlay';
+import { PositionMixin } from '@vaadin/overlay/src/vaadin-overlay-position-mixin';
+import '../../vendor/vanilla-colorful/rgba-string-color-picker.js';
+
+export class ColorPickerChangeEvent extends CustomEvent<{ value: string }> {
+  constructor(value: string) {
+    super('color-picker-change', { detail: { value } });
+  }
+}
+
+const previewStyles = css`
+  :host {
+    --preview-size: 24px;
+    --preview-color: rgba(0, 0, 0, 0);
+  }
+
+  .preview {
+    --preview-bg-size: calc(var(--preview-size) / 2);
+    --preview-bg-pos: calc(var(--preview-size) / 4);
+
+    width: var(--preview-size);
+    height: var(--preview-size);
+    padding: 0;
+    position: relative;
+    overflow: hidden;
+    background: none;
+    border: solid 2px #888;
+    border-radius: 4px;
+    box-sizing: content-box;
+  }
+
+  .preview::before,
+  .preview::after {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+
+  .preview::before {
+    content: '';
+    background: white;
+    background-image: linear-gradient(45deg, #666 25%, transparent 25%),
+      linear-gradient(45deg, transparent 75%, #666 75%), linear-gradient(45deg, transparent 75%, #666 75%),
+      linear-gradient(45deg, #666 25%, transparent 25%);
+    background-size: var(--preview-bg-size) var(--preview-bg-size);
+    background-position: 0 0, 0 0, calc(var(--preview-bg-pos) * -1) calc(var(--preview-bg-pos) * -1),
+      var(--preview-bg-pos) var(--preview-bg-pos);
+  }
+
+  .preview::after {
+    content: '';
+    background-color: var(--preview-color);
+  }
+`;
+
+@customElement('vaadin-dev-tools-color-picker')
+export class ColorPicker extends LitElement {
+  static get styles() {
+    return [
+      previewStyles,
+      css`
+        #toggle {
+          display: block;
+        }
+      `
+    ];
+  }
+
+  @property({})
+  public value!: string;
+  @property({})
+  public presets?: string[];
+
+  @query('#toggle')
+  private toggle!: HTMLElement;
+  private overlay!: Overlay;
+  private commitValue: boolean = false;
+
+  protected update(changedProperties: PropertyValues) {
+    super.update(changedProperties);
+
+    if (changedProperties.has('value') && this.overlay) {
+      this.overlay.requestContentUpdate();
+    }
+  }
+
+  protected firstUpdated() {
+    // Create custom Vaadin overlay and wire up renderer and event listeners
+    // Not creating this in the render function as Lit gets confused after
+    // the overlay teleports itself to the document body
+    this.overlay = document.createElement('vaadin-dev-tools-color-picker-overlay') as Overlay;
+    this.overlay.renderer = this.renderOverlayContent.bind(this);
+    (this.overlay as any).positionTarget = this.toggle;
+    (this.overlay as any).noVerticalOverlap = true;
+    this.overlay.addEventListener('vaadin-overlay-escape-press', this.handleOverlayEscape.bind(this));
+    this.overlay.addEventListener('vaadin-overlay-close', this.handleOverlayClose.bind(this));
+    this.append(this.overlay);
+  }
+
+  render() {
+    const previewColor = this.value || 'rgba(0, 0, 0, 0)';
+
+    return html` <button
+      id="toggle"
+      class="preview"
+      style="--preview-color: ${previewColor}"
+      @click=${this.open}
+    ></button>`;
+  }
+
+  private open() {
+    this.commitValue = false;
+    this.overlay.opened = true;
+    // Seems zIndex is cleared on opening overlay, so set it after opening
+    this.overlay.style.zIndex = '1000000';
+    // Need to find better way of styling overlay parts...
+    const overlayPart = this.overlay.shadowRoot!.querySelector('[part="overlay"]') as HTMLElement;
+    overlayPart.style.background = '#333';
+  }
+
+  private renderOverlayContent(root: HTMLElement) {
+    // vanilla-colorful requires an RGBA value, which we can get from computed
+    // styles of the preview element
+    const previewStyles = getComputedStyle(this.toggle, '::after');
+    const color = previewStyles.getPropertyValue('background-color');
+
+    render(
+      html` <div>
+        <vaadin-dev-tools-color-picker-overlay-content
+          .value=${color}
+          .presets=${this.presets}
+          @color-changed=${this.handleColorChange.bind(this)}
+        ></vaadin-dev-tools-color-picker-overlay-content>
+      </div>`,
+      root
+    );
+  }
+
+  private handleColorChange(event: CustomEvent<{ value: string; close?: boolean }>) {
+    this.commitValue = true;
+    this.dispatchEvent(new ColorPickerChangeEvent(event.detail.value));
+    if (event.detail.close) {
+      this.overlay.opened = false;
+      this.handleOverlayClose();
+    }
+  }
+
+  private handleOverlayEscape() {
+    this.commitValue = false;
+  }
+
+  private handleOverlayClose() {
+    const eventType = this.commitValue ? 'color-picker-commit' : 'color-picker-cancel';
+    this.dispatchEvent(new CustomEvent(eventType));
+  }
+}
+
+@customElement('vaadin-dev-tools-color-picker-overlay-content')
+export class ColorPickerOverlayContent extends LitElement {
+  @property({})
+  public value!: string;
+  @property({})
+  public presets?: string[];
+
+  static get styles() {
+    return [
+      previewStyles,
+      css`
+        :host {
+          display: block;
+          padding: 12px;
+        }
+
+        .picker::part(saturation),
+        .picker::part(hue) {
+          margin-bottom: 10px;
+        }
+
+        .picker::part(hue),
+        .picker::part(alpha) {
+          flex: 0 0 20px;
+        }
+
+        .picker::part(saturation),
+        .picker::part(hue),
+        .picker::part(alpha) {
+          border-radius: 3px;
+        }
+
+        .picker::part(saturation-pointer),
+        .picker::part(hue-pointer),
+        .picker::part(alpha-pointer) {
+          width: 20px;
+          height: 20px;
+        }
+
+        .swatches {
+          display: grid;
+          grid-template-columns: repeat(6, var(--preview-size));
+          grid-column-gap: 10px;
+          grid-row-gap: 6px;
+          margin-top: 16px;
+        }
+      `
+    ];
+  }
+
+  render() {
+    return html` <div>
+      <rgba-string-color-picker
+        class="picker"
+        .color=${this.value}
+        @color-changed=${this.handlePickerChange}
+      ></rgba-string-color-picker>
+      ${this.renderSwatches()}
+    </div>`;
+  }
+
+  renderSwatches() {
+    if (!this.presets || this.presets.length === 0) {
+      return;
+    }
+
+    const swatches = this.presets.map((preset) => {
+      return html` <button
+        class="preview"
+        style="--preview-color: ${preset}"
+        @click=${() => this.selectPreset(preset)}
+      ></button>`;
+    });
+
+    return html` <div class="swatches">${swatches}</div>`;
+  }
+
+  private handlePickerChange(e: CustomEvent<{ value: string }>) {
+    this.dispatchEvent(new CustomEvent('color-changed', { detail: { value: e.detail.value } }));
+  }
+
+  private selectPreset(preset: string) {
+    this.dispatchEvent(new CustomEvent('color-changed', { detail: { value: preset, close: true } }));
+  }
+}
+
+// Define a custom overlay Polymer element that includes the position mixin.
+// Not using a direct import for the Overlay class here as that could lead to
+// loading different versions of the component on the same page when using the
+// development setup (one from the app, the other from the dev tools frontend
+// dev server), which is not supported by Vaadin components.
+customElements.whenDefined('vaadin-overlay').then(() => {
+  const OverlayClass = customElements.get('vaadin-overlay');
+
+  class ColorPickerOverlay extends PositionMixin<any>(OverlayClass) {}
+
+  customElements.define('vaadin-dev-tools-color-picker-overlay', ColorPickerOverlay as any);
+});

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editors/color-property-editor.test.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editors/color-property-editor.test.ts
@@ -1,0 +1,181 @@
+import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import sinon from 'sinon';
+import '@vaadin/overlay';
+import { CssPropertyMetadata } from '../metadata/model';
+import { ComponentTheme } from '../model';
+import { testElementMetadata } from '../tests/utils';
+import { ColorPropertyEditor } from './color-property-editor';
+import './color-property-editor';
+import { ColorPicker, ColorPickerChangeEvent } from './color-picker';
+
+const colorMetadata: CssPropertyMetadata = {
+  propertyName: 'color',
+  displayName: 'Color',
+  presets: ['--test-primary-color', '--test-success-color', '--test-error-color']
+};
+
+const backgroundColorMetadata: CssPropertyMetadata = {
+  propertyName: 'background-color',
+  displayName: 'Background color',
+  presets: ['yellow', 'orange', 'brown']
+};
+
+describe('color property editor', () => {
+  let theme: ComponentTheme;
+  let editor: ColorPropertyEditor;
+  let valueChangeSpy: sinon.SinonSpy;
+
+  beforeEach(async () => {
+    // Define custom CSS properties
+    await fixture(html` <style>
+      html {
+        --test-primary-color: #00f;
+        --test-success-color: #0f0;
+        --test-error-color: #f00;
+      }
+    </style>`);
+
+    theme = new ComponentTheme(testElementMetadata);
+    theme.updatePropertyValue(null, 'color', 'black');
+    theme.updatePropertyValue(null, 'background-color', 'white');
+    valueChangeSpy = sinon.spy();
+
+    editor = await fixture(html` <vaadin-dev-tools-theme-color-property-editor
+      .theme=${theme}
+      .propertyMetadata=${colorMetadata}
+      @theme-property-value-change=${valueChangeSpy}
+    >
+    </vaadin-dev-tools-theme-color-property-editor>`);
+  });
+
+  function getInput() {
+    return editor.shadowRoot!.querySelector('input') as HTMLInputElement;
+  }
+
+  function getColorPicker() {
+    return editor.shadowRoot!.querySelector('vaadin-dev-tools-color-picker') as ColorPicker;
+  }
+
+  function cloneTheme() {
+    const result = new ComponentTheme(testElementMetadata);
+    result.addPropertyValues(theme.properties);
+    return result;
+  }
+
+  it('should display property value from theme', () => {
+    expect(getInput().value).to.equal('black');
+    expect(getColorPicker().value).to.equal('black');
+  });
+
+  it('should update value when theme changes', async () => {
+    const updatedTheme = cloneTheme();
+    updatedTheme.updatePropertyValue(null, 'color', 'red');
+    editor.theme = updatedTheme;
+    await elementUpdated(editor);
+
+    expect(getInput().value).to.equal('red');
+    expect(getColorPicker().value).to.equal('red');
+  });
+
+  it('should display raw preset value if theme value is a preset value', async () => {
+    const updatedTheme = cloneTheme();
+    updatedTheme.updatePropertyValue(null, 'color', 'var(--test-primary-color)');
+    editor.theme = updatedTheme;
+    await elementUpdated(editor);
+
+    expect(getInput().value).to.equal('rgb(0, 0, 255)');
+    expect(getColorPicker().value).to.equal('rgb(0, 0, 255)');
+  });
+
+  it('should update value when metadata changes', async () => {
+    editor.propertyMetadata = backgroundColorMetadata;
+    await elementUpdated(editor);
+
+    expect(getInput().value).to.equal('white');
+    expect(getColorPicker().value).to.equal('white');
+  });
+
+  it('should pass presets to color picker', () => {
+    expect(getColorPicker().presets).to.deep.equal([
+      'var(--test-primary-color)',
+      'var(--test-success-color)',
+      'var(--test-error-color)'
+    ]);
+  });
+
+  it('should update presets when metadata changes', async () => {
+    editor.propertyMetadata = backgroundColorMetadata;
+    await elementUpdated(editor);
+
+    expect(getColorPicker().presets).to.deep.equal(['yellow', 'orange', 'brown']);
+  });
+
+  it('should update value when color picker changes', async () => {
+    getColorPicker().dispatchEvent(new ColorPickerChangeEvent('red'));
+    await elementUpdated(editor);
+
+    expect(getInput().value).to.equal('red');
+    expect(getColorPicker().value).to.equal('red');
+  });
+
+  it('should revert value when color picker changes and cancels', async () => {
+    getColorPicker().dispatchEvent(new ColorPickerChangeEvent('red'));
+    await elementUpdated(editor);
+
+    expect(getInput().value).to.equal('red');
+    expect(getColorPicker().value).to.equal('red');
+
+    getColorPicker().dispatchEvent(new CustomEvent('color-picker-cancel'));
+    await elementUpdated(editor);
+
+    expect(getInput().value).to.equal('black');
+    expect(getColorPicker().value).to.equal('black');
+  });
+
+  it('should not dispatch change event when color picker changes', () => {
+    getColorPicker().dispatchEvent(new ColorPickerChangeEvent('yellow'));
+
+    expect(valueChangeSpy.called).to.be.false;
+  });
+
+  it('should not dispatch change event when color picker changes and cancels', () => {
+    getColorPicker().dispatchEvent(new ColorPickerChangeEvent('yellow'));
+    getColorPicker().dispatchEvent(new CustomEvent('color-picker-cancel'));
+
+    expect(valueChangeSpy.called).to.be.false;
+  });
+
+  it('should dispatch change event when color picker changes and commits', () => {
+    getColorPicker().dispatchEvent(new ColorPickerChangeEvent('yellow'));
+    getColorPicker().dispatchEvent(new CustomEvent('color-picker-commit'));
+
+    expect(valueChangeSpy.called).to.be.true;
+    expect(valueChangeSpy.args[0][0].detail.value).to.be.equal('yellow');
+  });
+
+  it('should dispatch change event with preset value when color picker commits a preset', () => {
+    getColorPicker().dispatchEvent(new ColorPickerChangeEvent('var(--test-error-color)'));
+    getColorPicker().dispatchEvent(new CustomEvent('color-picker-commit'));
+
+    expect(valueChangeSpy.called).to.be.true;
+    expect(valueChangeSpy.args[0][0].detail.value).to.be.equal('var(--test-error-color)');
+  });
+
+  it('should dispatch change event when entering a value', () => {
+    const input = getInput();
+    input.value = 'yellow';
+    input.dispatchEvent(new CustomEvent('change'));
+
+    expect(valueChangeSpy.called).to.be.true;
+    expect(valueChangeSpy.args[0][0].detail.value).to.be.equal('yellow');
+  });
+
+  it('should dispatch change event with preset value when entering a value that matches a preset', () => {
+    const input = getInput();
+    input.value = 'rgb(255, 0, 0)';
+    input.dispatchEvent(new CustomEvent('change'));
+
+    expect(valueChangeSpy.called).to.be.true;
+    expect(valueChangeSpy.args[0][0].detail.value).to.be.equal('var(--test-error-color)');
+  });
+});

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editors/color-property-editor.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/editors/color-property-editor.ts
@@ -1,0 +1,80 @@
+import { css, html, PropertyValues, TemplateResult } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import './color-picker';
+import { ColorPickerChangeEvent } from './color-picker';
+import { BasePropertyEditor, PropertyPresets } from './base-property-editor';
+
+@customElement('vaadin-dev-tools-theme-color-property-editor')
+export class ColorPropertyEditor extends BasePropertyEditor {
+  static get styles() {
+    return [
+      BasePropertyEditor.styles,
+      css`
+        .property {
+          align-items: center;
+        }
+
+        .property .property-editor {
+          display: flex;
+          align-items: center;
+          gap: 0.5rem;
+        }
+      `
+    ];
+  }
+
+  private presets: PropertyPresets = new PropertyPresets();
+
+  protected update(changedProperties: PropertyValues) {
+    if (changedProperties.has('propertyMetadata')) {
+      this.presets = new PropertyPresets(this.propertyMetadata);
+    }
+
+    super.update(changedProperties);
+  }
+
+  protected renderEditor(): TemplateResult {
+    return html`
+      <vaadin-dev-tools-color-picker
+        .value=${this.value}
+        .presets=${this.presets.values}
+        @color-picker-change=${this.handleColorPickerChange}
+        @color-picker-commit=${this.handleColorPickerCommit}
+        @color-picker-cancel=${this.handleColorPickerCancel}
+      ></vaadin-dev-tools-color-picker>
+      <input class="input" .value=${this.value} @change=${this.handleInputChange} />
+    `;
+  }
+
+  private handleInputChange(e: Event) {
+    const input = e.target as HTMLInputElement;
+    this.value = input.value;
+    this.dispatchChange(this.value);
+  }
+
+  private handleColorPickerChange(e: ColorPickerChangeEvent) {
+    this.value = e.detail.value;
+  }
+
+  private handleColorPickerCommit() {
+    this.dispatchChange(this.value);
+  }
+
+  private handleColorPickerCancel() {
+    this.updateValueFromTheme();
+  }
+
+  protected dispatchChange(value: string) {
+    // If value matches a raw preset value, send preset instead
+    const effectiveValue = this.presets.tryMapToPreset(value);
+
+    super.dispatchChange(effectiveValue);
+  }
+
+  protected updateValueFromTheme() {
+    super.updateValueFromTheme();
+
+    // If value matches a preset, then display raw preset value
+    this.value = this.presets.tryMapToRawValue(this.propertyValue?.value || '');
+  }
+}

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/components/presets.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/components/presets.ts
@@ -10,5 +10,15 @@ export const presets = {
     '--lumo-font-size-xl',
     '--lumo-font-size-xxl',
     '--lumo-font-size-xxxl'
+  ],
+  lumoTextColor: [
+    '--lumo-header-text-color',
+    '--lumo-body-text-color',
+    '--lumo-secondary-text-color',
+    '--lumo-tertiary-text-color',
+    '--lumo-disabled-text-color',
+    '--lumo-primary-text-color',
+    '--lumo-error-text-color',
+    '--lumo-success-text-color'
   ]
 };

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/components/vaadin-button.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/components/vaadin-button.ts
@@ -7,11 +7,14 @@ export default {
   properties: [
     {
       propertyName: 'background-color',
-      displayName: 'Background color'
+      displayName: 'Background color',
+      editorType: EditorType.color
     },
     {
       propertyName: 'color',
-      displayName: 'Text color'
+      displayName: 'Text color',
+      editorType: EditorType.color,
+      presets: presets.lumoTextColor
     },
     {
       propertyName: '--lumo-button-size',

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/model.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/metadata/model.ts
@@ -1,6 +1,7 @@
 export enum EditorType {
-  text,
-  range
+  text = 'text',
+  range = 'range',
+  color = 'color'
 }
 
 export interface CssPropertyMetadata {

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/property-list.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/theme-editor/property-list.ts
@@ -5,6 +5,7 @@ import { ComponentMetadata, ComponentPartMetadata, CssPropertyMetadata, EditorTy
 import { ComponentTheme } from './model';
 import './editors/text-property-editor';
 import './editors/range-property-editor';
+import './editors/color-property-editor';
 
 @customElement('vaadin-dev-tools-theme-property-list')
 export class PropertyList extends LitElement {
@@ -52,6 +53,9 @@ export class PropertyList extends LitElement {
     switch (property.editorType) {
       case EditorType.range:
         editorTagName = literal`vaadin-dev-tools-theme-range-property-editor`;
+        break;
+      case EditorType.color:
+        editorTagName = literal`vaadin-dev-tools-theme-color-property-editor`;
         break;
       default:
         editorTagName = literal`vaadin-dev-tools-theme-text-property-editor`;

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/vendor/@vaadin/overlay/src/vaadin-overlay-position-mixin.js
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/vendor/@vaadin/overlay/src/vaadin-overlay-position-mixin.js
@@ -1,0 +1,412 @@
+/**
+ * @license
+ * Copyright (c) 2017 - 2023 Vaadin Ltd.
+ * This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
+ */
+
+// Copy of @vaadin/overlay/src/vaadin-overlay-position-mixin
+// Can not be imported directly as that breaks the Flow build
+
+/**
+ * Returns an array of ancestor root nodes for the given node.
+ *
+ * A root node is either a document node or a document fragment node (Shadow Root).
+ * The array is collected by a bottom-up DOM traversing that starts with the given node
+ * and involves both the light DOM and ancestor shadow DOM trees.
+ *
+ * @param {Node} node
+ * @return {Node[]}
+ */
+export function getAncestorRootNodes(node) {
+  const result = [];
+
+  while (node) {
+    if (node.nodeType === Node.DOCUMENT_NODE) {
+      result.push(node);
+      break;
+    }
+
+    if (node.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
+      result.push(node);
+      node = node.host;
+      continue;
+    }
+
+    if (node.assignedSlot) {
+      node = node.assignedSlot;
+      continue;
+    }
+
+    node = node.parentNode;
+  }
+
+  return result;
+}
+
+const PROP_NAMES_VERTICAL = {
+  start: 'top',
+  end: 'bottom',
+};
+
+const PROP_NAMES_HORIZONTAL = {
+  start: 'left',
+  end: 'right',
+};
+
+const targetResizeObserver = new ResizeObserver((entries) => {
+  setTimeout(() => {
+    entries.forEach((entry) => {
+      if (entry.target.__overlay) {
+        entry.target.__overlay._updatePosition();
+      }
+    });
+  });
+});
+
+/**
+ * @polymerMixin
+ */
+export const PositionMixin = (superClass) =>
+  class PositionMixin extends superClass {
+    static get properties() {
+      return {
+        /**
+         * The element next to which this overlay should be aligned.
+         * The position of the overlay relative to the positionTarget can be adjusted
+         * with properties `horizontalAlign`, `verticalAlign`, `noHorizontalOverlap`
+         * and `noVerticalOverlap`.
+         */
+        positionTarget: {
+          type: Object,
+          value: null,
+        },
+
+        /**
+         * When `positionTarget` is set, this property defines whether to align the overlay's
+         * left or right side to the target element by default.
+         * Possible values are `start` and `end`.
+         * RTL is taken into account when interpreting the value.
+         * The overlay is automatically flipped to the opposite side when it doesn't fit into
+         * the default side defined by this property.
+         *
+         * @attr {start|end} horizontal-align
+         */
+        horizontalAlign: {
+          type: String,
+          value: 'start',
+        },
+
+        /**
+         * When `positionTarget` is set, this property defines whether to align the overlay's
+         * top or bottom side to the target element by default.
+         * Possible values are `top` and `bottom`.
+         * The overlay is automatically flipped to the opposite side when it doesn't fit into
+         * the default side defined by this property.
+         *
+         * @attr {top|bottom} vertical-align
+         */
+        verticalAlign: {
+          type: String,
+          value: 'top',
+        },
+
+        /**
+         * When `positionTarget` is set, this property defines whether the overlay should overlap
+         * the target element in the x-axis, or be positioned right next to it.
+         *
+         * @attr {boolean} no-horizontal-overlap
+         */
+        noHorizontalOverlap: {
+          type: Boolean,
+          value: false,
+        },
+
+        /**
+         * When `positionTarget` is set, this property defines whether the overlay should overlap
+         * the target element in the y-axis, or be positioned right above/below it.
+         *
+         * @attr {boolean} no-vertical-overlap
+         */
+        noVerticalOverlap: {
+          type: Boolean,
+          value: false,
+        },
+
+        /**
+         * If the overlay content has no intrinsic height, this property can be used to set
+         * the minimum vertical space (in pixels) required by the overlay. Setting a value to
+         * the property effectively disables the content measurement in favor of using this
+         * fixed value for determining the open direction.
+         *
+         * @attr {number} required-vertical-space
+         */
+        requiredVerticalSpace: {
+          type: Number,
+          value: 0,
+        },
+      };
+    }
+
+    static get observers() {
+      return [
+        '__positionSettingsChanged(horizontalAlign, verticalAlign, noHorizontalOverlap, noVerticalOverlap, requiredVerticalSpace)',
+        '__overlayOpenedChanged(opened, positionTarget)',
+      ];
+    }
+
+    constructor() {
+      super();
+
+      this.__onScroll = this.__onScroll.bind(this);
+      this._updatePosition = this._updatePosition.bind(this);
+    }
+
+    /** @protected */
+    connectedCallback() {
+      super.connectedCallback();
+
+      if (this.opened) {
+        this.__addUpdatePositionEventListeners();
+      }
+    }
+
+    /** @protected */
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      this.__removeUpdatePositionEventListeners();
+    }
+
+    /** @private */
+    __addUpdatePositionEventListeners() {
+      window.addEventListener('resize', this._updatePosition);
+
+      this.__positionTargetAncestorRootNodes = getAncestorRootNodes(this.positionTarget);
+      this.__positionTargetAncestorRootNodes.forEach((node) => {
+        node.addEventListener('scroll', this.__onScroll, true);
+      });
+    }
+
+    /** @private */
+    __removeUpdatePositionEventListeners() {
+      window.removeEventListener('resize', this._updatePosition);
+
+      if (this.__positionTargetAncestorRootNodes) {
+        this.__positionTargetAncestorRootNodes.forEach((node) => {
+          node.removeEventListener('scroll', this.__onScroll, true);
+        });
+        this.__positionTargetAncestorRootNodes = null;
+      }
+    }
+
+    /** @private */
+    __overlayOpenedChanged(opened, positionTarget) {
+      this.__removeUpdatePositionEventListeners();
+
+      if (positionTarget) {
+        positionTarget.__overlay = null;
+        targetResizeObserver.unobserve(positionTarget);
+
+        if (opened) {
+          this.__addUpdatePositionEventListeners();
+          positionTarget.__overlay = this;
+          targetResizeObserver.observe(positionTarget);
+        }
+      }
+
+      if (opened) {
+        const computedStyle = getComputedStyle(this);
+        if (!this.__margins) {
+          this.__margins = {};
+          ['top', 'bottom', 'left', 'right'].forEach((propName) => {
+            this.__margins[propName] = parseInt(computedStyle[propName], 10);
+          });
+        }
+        this.setAttribute('dir', computedStyle.direction);
+
+        this._updatePosition();
+        // Schedule another position update (to cover virtual keyboard opening for example)
+        requestAnimationFrame(() => this._updatePosition());
+      }
+    }
+
+    __positionSettingsChanged() {
+      this._updatePosition();
+    }
+
+    /** @private */
+    __onScroll(e) {
+      // If the scroll event occurred inside the overlay, ignore it.
+      if (!this.contains(e.target)) {
+        this._updatePosition();
+      }
+    }
+
+    _updatePosition() {
+      if (!this.positionTarget || !this.opened) {
+        return;
+      }
+
+      const targetRect = this.positionTarget.getBoundingClientRect();
+
+      // Detect the desired alignment and update the layout accordingly
+      const shouldAlignStartVertically = this.__shouldAlignStartVertically(targetRect);
+      this.style.justifyContent = shouldAlignStartVertically ? 'flex-start' : 'flex-end';
+
+      const isRTL = this.__isRTL;
+      const shouldAlignStartHorizontally = this.__shouldAlignStartHorizontally(targetRect, isRTL);
+      const flexStart = (!isRTL && shouldAlignStartHorizontally) || (isRTL && !shouldAlignStartHorizontally);
+      this.style.alignItems = flexStart ? 'flex-start' : 'flex-end';
+
+      // Get the overlay rect after possible overlay alignment changes
+      const overlayRect = this.getBoundingClientRect();
+
+      // Obtain vertical positioning properties
+      const verticalProps = this.__calculatePositionInOneDimension(
+        targetRect,
+        overlayRect,
+        this.noVerticalOverlap,
+        PROP_NAMES_VERTICAL,
+        this,
+        shouldAlignStartVertically,
+      );
+
+      // Obtain horizontal positioning properties
+      const horizontalProps = this.__calculatePositionInOneDimension(
+        targetRect,
+        overlayRect,
+        this.noHorizontalOverlap,
+        PROP_NAMES_HORIZONTAL,
+        this,
+        shouldAlignStartHorizontally,
+      );
+
+      // Apply the positioning properties to the overlay
+      Object.assign(this.style, verticalProps, horizontalProps);
+
+      this.toggleAttribute('bottom-aligned', !shouldAlignStartVertically);
+      this.toggleAttribute('top-aligned', shouldAlignStartVertically);
+
+      this.toggleAttribute('end-aligned', !flexStart);
+      this.toggleAttribute('start-aligned', flexStart);
+    }
+
+    __shouldAlignStartHorizontally(targetRect, rtl) {
+      // Using previous size to fix a case where window resize may cause the overlay to be squeezed
+      // smaller than its current space before the fit-calculations.
+      const contentWidth = Math.max(this.__oldContentWidth || 0, this.$.overlay.offsetWidth);
+      this.__oldContentWidth = this.$.overlay.offsetWidth;
+
+      const viewportWidth = Math.min(window.innerWidth, document.documentElement.clientWidth);
+      const defaultAlignLeft = (!rtl && this.horizontalAlign === 'start') || (rtl && this.horizontalAlign === 'end');
+
+      return this.__shouldAlignStart(
+        targetRect,
+        contentWidth,
+        viewportWidth,
+        this.__margins,
+        defaultAlignLeft,
+        this.noHorizontalOverlap,
+        PROP_NAMES_HORIZONTAL,
+      );
+    }
+
+    __shouldAlignStartVertically(targetRect) {
+      // Using previous size to fix a case where window resize may cause the overlay to be squeezed
+      // smaller than its current space before the fit-calculations.
+      const contentHeight =
+        this.requiredVerticalSpace || Math.max(this.__oldContentHeight || 0, this.$.overlay.offsetHeight);
+      this.__oldContentHeight = this.$.overlay.offsetHeight;
+
+      const viewportHeight = Math.min(window.innerHeight, document.documentElement.clientHeight);
+      const defaultAlignTop = this.verticalAlign === 'top';
+
+      return this.__shouldAlignStart(
+        targetRect,
+        contentHeight,
+        viewportHeight,
+        this.__margins,
+        defaultAlignTop,
+        this.noVerticalOverlap,
+        PROP_NAMES_VERTICAL,
+      );
+    }
+
+    // eslint-disable-next-line max-params
+    __shouldAlignStart(targetRect, contentSize, viewportSize, margins, defaultAlignStart, noOverlap, propNames) {
+      const spaceForStartAlignment =
+        viewportSize - targetRect[noOverlap ? propNames.end : propNames.start] - margins[propNames.end];
+      const spaceForEndAlignment = targetRect[noOverlap ? propNames.start : propNames.end] - margins[propNames.start];
+
+      const spaceForDefaultAlignment = defaultAlignStart ? spaceForStartAlignment : spaceForEndAlignment;
+      const spaceForOtherAlignment = defaultAlignStart ? spaceForEndAlignment : spaceForStartAlignment;
+
+      const shouldGoToDefaultSide =
+        spaceForDefaultAlignment > spaceForOtherAlignment || spaceForDefaultAlignment > contentSize;
+
+      return defaultAlignStart === shouldGoToDefaultSide;
+    }
+
+    /**
+     * Returns an adjusted value after resizing the browser window,
+     * to avoid wrong calculations when e.g. previously set `bottom`
+     * CSS property value is larger than the updated viewport height.
+     * See https://github.com/vaadin/web-components/issues/4604
+     */
+    __adjustBottomProperty(cssPropNameToSet, propNames, currentValue) {
+      let adjustedProp;
+
+      if (cssPropNameToSet === propNames.end) {
+        // Adjust horizontally
+        if (propNames.end === PROP_NAMES_VERTICAL.end) {
+          const viewportHeight = Math.min(window.innerHeight, document.documentElement.clientHeight);
+
+          if (currentValue > viewportHeight && this.__oldViewportHeight) {
+            const heightDiff = this.__oldViewportHeight - viewportHeight;
+            adjustedProp = currentValue - heightDiff;
+          }
+
+          this.__oldViewportHeight = viewportHeight;
+        }
+
+        // Adjust vertically
+        if (propNames.end === PROP_NAMES_HORIZONTAL.end) {
+          const viewportWidth = Math.min(window.innerWidth, document.documentElement.clientWidth);
+
+          if (currentValue > viewportWidth && this.__oldViewportWidth) {
+            const widthDiff = this.__oldViewportWidth - viewportWidth;
+            adjustedProp = currentValue - widthDiff;
+          }
+
+          this.__oldViewportWidth = viewportWidth;
+        }
+      }
+
+      return adjustedProp;
+    }
+
+    /**
+     * Returns an object with CSS position properties to set,
+     * e.g. { top: "100px" }
+     */
+    // eslint-disable-next-line max-params
+    __calculatePositionInOneDimension(targetRect, overlayRect, noOverlap, propNames, overlay, shouldAlignStart) {
+      const cssPropNameToSet = shouldAlignStart ? propNames.start : propNames.end;
+      const cssPropNameToClear = shouldAlignStart ? propNames.end : propNames.start;
+
+      const currentValue = parseFloat(overlay.style[cssPropNameToSet] || getComputedStyle(overlay)[cssPropNameToSet]);
+      const adjustedValue = this.__adjustBottomProperty(cssPropNameToSet, propNames, currentValue);
+
+      const diff =
+        overlayRect[shouldAlignStart ? propNames.start : propNames.end] -
+        targetRect[noOverlap === shouldAlignStart ? propNames.end : propNames.start];
+
+      const valueToSet = adjustedValue
+        ? `${adjustedValue}px`
+        : `${currentValue + diff * (shouldAlignStart ? -1 : 1)}px`;
+
+      return {
+        [cssPropNameToSet]: valueToSet,
+        [cssPropNameToClear]: '',
+      };
+    }
+  };


### PR DESCRIPTION
## Description

Adds a custom editor for CSS properties that represent colors. The component is structured into two parts:
- A more general color picker component, which is mostly a wrapper for putting a vanilla-colorful picker into an overlay. 
- The actual color property editor that uses the same layout as the other property editors and contains a color-picker as well as an input for displaying and entering color values.