### PR TITLE
chore: remove the enforceFieldValidation feature flag

### DIFF
--- a/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
+++ b/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
@@ -58,10 +58,6 @@ public class FeatureFlags implements Serializable {
             "Collaboration Engine backend for clustering support",
             "collaborationEngineBackend",
             "https://github.com/vaadin/platform/issues/1988", true, null);
-    public static final Feature ENFORCE_FIELD_VALIDATION = new Feature(
-            "Enforce client / constraint / binder validation",
-            "enforceFieldValidation",
-            "https://github.com/vaadin/platform/issues/3066", false, null);
     public static final Feature THEME_EDITOR = new Feature("Theme Editor",
             "themeEditor", null, true, null);
     private List<Feature> features = new ArrayList<>();
@@ -82,7 +78,6 @@ public class FeatureFlags implements Serializable {
         this.lookup = lookup;
         features.add(new Feature(EXAMPLE));
         features.add(new Feature(COLLABORATION_ENGINE_BACKEND));
-        features.add(new Feature(ENFORCE_FIELD_VALIDATION));
         features.add(new Feature(THEME_EDITOR));
         loadProperties();
     }


### PR DESCRIPTION
## Description

Removed the `enforcedFieldValidation` feature flag because the new validation mechanism has been made the default one since v24.

Part of https://github.com/vaadin/platform/issues/3066
