### PR TITLE
Added a missing navigate method

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -1064,6 +1064,52 @@ public class UI extends Component
 
     /**
      * Updates this UI to show the view corresponding to the given navigation
+     * target with the specified parameters. The route parameters needs to
+     * comply with the ones defined in one of the
+     * {@link com.vaadin.flow.router.Route} or
+     * {@link com.vaadin.flow.router.RouteAlias} annotating the navigationTarget
+     * and with any {@link com.vaadin.flow.router.RoutePrefix} annotating the
+     * parent layouts of the navigationTarget.
+     * <p>
+     * Besides the navigation to the {@code location} this method also updates
+     * the browser location (and page history).
+     * <p>
+     * If the view change actually happens (e.g. the view itself doesn't cancel
+     * the navigation), all navigation listeners are notified and a reference of
+     * the new view is returned for additional configuration.
+     *
+     * @param navigationTarget
+     *            navigation target to navigate to
+     * @param routeParameter
+     *            route parameters to pass to view
+     * @param queryParameters
+     *            additional query parameters to pass to view
+     * @param <C>
+     *            navigation target type
+     * @return the view instance, if navigation actually happened
+     * @throws IllegalArgumentException
+     *             if a {@code null} parameter is given while navigationTarget's
+     *             parameter is not annotated with @OptionalParameter
+     *             or @WildcardParameter.
+     * @throws NotFoundException
+     *             in case there is no route defined for the given
+     *             navigationTarget matching the parameters.
+     */
+    @SuppressWarnings("unchecked")
+    public <C extends Component> Optional<C> navigate(
+            Class<? extends C> navigationTarget, RouteParameters routeParameter,
+            QueryParameters queryParameters) {
+        RouteConfiguration configuration = RouteConfiguration
+                .forRegistry(getInternals().getRouter().getRegistry());
+        String url = configuration.getUrl(navigationTarget, routeParameter);
+        getInternals().getRouter().navigate(this,
+                new Location(url, queryParameters),
+                NavigationTrigger.UI_NAVIGATE);
+        return (Optional<C>) findCurrentNavigationTarget(navigationTarget);
+    }
+
+    /**
+     * Updates this UI to show the view corresponding to the given navigation
      * target and query parameters.
      * <p>
      * Besides the navigation to the {@code location} this method also updates

--- a/flow-server/src/test/java/com/vaadin/flow/component/UITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/UITest.java
@@ -353,6 +353,32 @@ public class UITest {
         MatcherAssert.assertThat(chain.get(1), CoreMatchers
                 .instanceOf(FooBarParamParentNavigationTarget.class));
     }
+    
+    @Test
+    public void navigateWithQueryAndRouteParameters_afterServerNavigation()
+            throws InvalidRouteConfigurationException {
+        UI ui = new UI();
+        initUI(ui, "", null);
+        
+        Optional<FooBarParamNavigationTarget> newView = ui.navigate(
+                FooBarParamNavigationTarget.class,
+                new RouteParameters(new RouteParam("fooParam", "flu"),
+                        new RouteParam("barParam", "beer")),
+                QueryParameters.of("bigBeer", "forMePlease"));
+
+        assertEquals(FooBarParamNavigationTarget.class,
+                newView.get().getClass());
+
+        assertEquals("foo/flu/beer/bar?bigBeer=forMePlease",
+                ui.getInternals().getActiveViewLocation().getPathWithQueryParameters());
+        List<HasElement> chain = ui.getInternals()
+                .getActiveRouterTargetsChain();
+        Assert.assertEquals(2, chain.size());
+        MatcherAssert.assertThat(chain.get(0),
+                CoreMatchers.instanceOf(FooBarParamNavigationTarget.class));
+        MatcherAssert.assertThat(chain.get(1), CoreMatchers
+                .instanceOf(FooBarParamParentNavigationTarget.class));
+    }
 
     @Test
     public void localeSet_directionUpdated() {

--- a/flow-server/src/test/java/com/vaadin/flow/component/UITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/UITest.java
@@ -353,13 +353,13 @@ public class UITest {
         MatcherAssert.assertThat(chain.get(1), CoreMatchers
                 .instanceOf(FooBarParamParentNavigationTarget.class));
     }
-    
+
     @Test
     public void navigateWithQueryAndRouteParameters_afterServerNavigation()
             throws InvalidRouteConfigurationException {
         UI ui = new UI();
         initUI(ui, "", null);
-        
+
         Optional<FooBarParamNavigationTarget> newView = ui.navigate(
                 FooBarParamNavigationTarget.class,
                 new RouteParameters(new RouteParam("fooParam", "flu"),
@@ -369,8 +369,8 @@ public class UITest {
         assertEquals(FooBarParamNavigationTarget.class,
                 newView.get().getClass());
 
-        assertEquals("foo/flu/beer/bar?bigBeer=forMePlease",
-                ui.getInternals().getActiveViewLocation().getPathWithQueryParameters());
+        assertEquals("foo/flu/beer/bar?bigBeer=forMePlease", ui.getInternals()
+                .getActiveViewLocation().getPathWithQueryParameters());
         List<HasElement> chain = ui.getInternals()
                 .getActiveRouterTargetsChain();
         Assert.assertEquals(2, chain.size());


### PR DESCRIPTION
A variant that support both RouteParameters and QueryParameters that was missing for some reason. Requested by community members in Discord.

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
