### PR TITLE
refactor: remove circular dependencies in dev tools

### DIFF
--- a/vaadin-dev-server/frontend/component-picker.ts
+++ b/vaadin-dev-server/frontend/component-picker.ts
@@ -3,7 +3,7 @@ import { customElement, query, state } from 'lit/decorators.js';
 import { ComponentReference, getComponents } from './component-util.js';
 import './shim.js';
 import { Shim } from './shim.js';
-import { popupStyles } from './vaadin-dev-tools.js';
+import { popupStyles } from './styles';
 
 export interface PickerOptions {
   infoTemplate: TemplateResult;

--- a/vaadin-dev-server/frontend/connection.ts
+++ b/vaadin-dev-server/frontend/connection.ts
@@ -1,0 +1,143 @@
+import { licenseCheckFailed, licenseCheckNoKey, licenseCheckOk, Product } from './License';
+import { ComponentReference } from './component-util';
+
+export enum ConnectionStatus {
+  ACTIVE = 'active',
+  INACTIVE = 'inactive',
+  UNAVAILABLE = 'unavailable',
+  ERROR = 'error'
+}
+
+export class Connection extends Object {
+  static HEARTBEAT_INTERVAL = 180000;
+
+  status: ConnectionStatus = ConnectionStatus.UNAVAILABLE;
+  webSocket?: WebSocket;
+
+  constructor(url?: string) {
+    super();
+
+    if (url) {
+      this.webSocket = new WebSocket(url);
+      this.webSocket.onmessage = (msg) => this.handleMessage(msg);
+      this.webSocket.onerror = (err) => this.handleError(err);
+      this.webSocket.onclose = (_) => {
+        if (this.status !== ConnectionStatus.ERROR) {
+          this.setStatus(ConnectionStatus.UNAVAILABLE);
+        }
+        this.webSocket = undefined;
+      };
+    }
+
+    setInterval(() => {
+      if (this.webSocket && self.status !== ConnectionStatus.ERROR && this.status !== ConnectionStatus.UNAVAILABLE) {
+        this.webSocket.send('');
+      }
+    }, Connection.HEARTBEAT_INTERVAL);
+  }
+
+  onHandshake() {
+    // Intentionally empty
+  }
+
+  onReload() {
+    // Intentionally empty
+  }
+
+  onConnectionError(_: string) {
+    // Intentionally empty
+  }
+
+  onStatusChange(_: ConnectionStatus) {
+    // Intentionally empty
+  }
+
+  onMessage(message: any) {
+    // eslint-disable-next-line no-console
+    console.error('Unknown message received from the live reload server:', message);
+  }
+
+  handleMessage(msg: any) {
+    let json;
+    try {
+      json = JSON.parse(msg.data);
+    } catch (e: any) {
+      this.handleError(`[${e.name}: ${e.message}`);
+      return;
+    }
+    if (json.command === 'hello') {
+      this.setStatus(ConnectionStatus.ACTIVE);
+      this.onHandshake();
+    } else if (json.command === 'reload') {
+      if (this.status === ConnectionStatus.ACTIVE) {
+        this.onReload();
+      }
+    } else if (json.command === 'license-check-ok') {
+      licenseCheckOk(json.data);
+    } else if (json.command === 'license-check-failed') {
+      licenseCheckFailed(json.data);
+    } else if (json.command === 'license-check-nokey') {
+      licenseCheckNoKey(json.data);
+    } else {
+      this.onMessage(json);
+    }
+  }
+
+  handleError(msg: any) {
+    // eslint-disable-next-line no-console
+    console.error(msg);
+    this.setStatus(ConnectionStatus.ERROR);
+    if (msg instanceof Event && this.webSocket) {
+      this.onConnectionError(`Error in WebSocket connection to ${this.webSocket.url}`);
+    } else {
+      this.onConnectionError(msg);
+    }
+  }
+
+  setActive(yes: boolean) {
+    if (!yes && this.status === ConnectionStatus.ACTIVE) {
+      this.setStatus(ConnectionStatus.INACTIVE);
+    } else if (yes && this.status === ConnectionStatus.INACTIVE) {
+      this.setStatus(ConnectionStatus.ACTIVE);
+    }
+  }
+
+  setStatus(status: ConnectionStatus) {
+    if (this.status !== status) {
+      this.status = status;
+      this.onStatusChange(status);
+    }
+  }
+
+  public send(command: string, data: any) {
+    const message = JSON.stringify({ command, data });
+    if (!this.webSocket) {
+      // eslint-disable-next-line no-console
+      console.error(`Unable to send message ${command}. No websocket is available`);
+    } else if (this.webSocket.readyState !== WebSocket.OPEN) {
+      this.webSocket.addEventListener('open', () => this.webSocket!.send(message));
+    } else {
+      this.webSocket.send(message);
+    }
+  }
+
+  setFeature(featureId: string, enabled: boolean) {
+    this.send('setFeature', { featureId, enabled });
+  }
+
+  sendTelemetry(browserData: any) {
+    this.send('reportTelemetry', { browserData });
+  }
+
+  sendLicenseCheck(product: Product) {
+    this.send('checkLicense', product);
+  }
+
+  sendShowComponentCreateLocation(component: ComponentReference) {
+    this.send('showComponentCreateLocation', component);
+  }
+
+  sendShowComponentAttachLocation(component: ComponentReference) {
+    this.send('showComponentAttachLocation', component);
+  }
+}

--- a/vaadin-dev-server/frontend/styles.ts
+++ b/vaadin-dev-server/frontend/styles.ts
@@ -1,0 +1,27 @@
+import { css } from 'lit';
+
+export const popupStyles = css`
+  .popup {
+    width: auto;
+    position: fixed;
+    background-color: var(--dev-tools-background-color-active-blurred);
+    color: var(--dev-tools-text-color-primary);
+    padding: 0.1875rem 0.75rem 0.1875rem 1rem;
+    background-clip: padding-box;
+    border-radius: var(--dev-tools-border-radius);
+    overflow: hidden;
+    margin: 0.5rem;
+    width: 30rem;
+    max-width: calc(100% - 1rem);
+    max-height: calc(100vh - 1rem);
+    flex-shrink: 1;
+    background-color: var(--dev-tools-background-color-active);
+    color: var(--dev-tools-text-color);
+    transition: var(--dev-tools-transition-duration);
+    transform-origin: bottom right;
+    display: flex;
+    flex-direction: column;
+    box-shadow: var(--dev-tools-box-shadow);
+    outline: none;
+  }
+`;

--- a/vaadin-dev-server/frontend/theme-editor/api.ts
+++ b/vaadin-dev-server/frontend/theme-editor/api.ts
@@ -1,4 +1,4 @@
-import { Connection } from '../vaadin-dev-tools';
+import { Connection } from '../connection';
 
 export enum Commands {
   response = 'themeEditorResponse',

--- a/vaadin-dev-server/frontend/theme-editor/editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.ts
@@ -9,7 +9,7 @@ import { ComponentTheme, generateThemeRule, ThemeEditorState } from './model';
 import { detectTheme } from './detector';
 import { ThemePropertyValueChangeEvent } from './editors/base-property-editor';
 import { themePreview } from './preview';
-import { Connection } from '../vaadin-dev-tools';
+import { Connection } from '../connection';
 import { ThemeEditorApi } from './api';
 import { ThemeEditorHistory, ThemeEditorHistoryActions } from './history';
 

--- a/vaadin-dev-server/frontend/vaadin-dev-tools.ts
+++ b/vaadin-dev-server/frontend/vaadin-dev-tools.ts
@@ -8,7 +8,9 @@ import { ThemeEditorState } from './theme-editor/model';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { copy } from './copy-to-clipboard.js';
-import { licenseCheckFailed, licenseCheckNoKey, licenseCheckOk, licenseInit, Product } from './License';
+import { licenseCheckFailed, licenseInit, Product } from './License';
+import { Connection, ConnectionStatus } from './connection';
+import { popupStyles } from './styles';
 
 interface ServerInfo {
   vaadinVersion: string;
@@ -33,143 +35,6 @@ interface Tab {
   activate?: () => void;
 }
 
-enum ConnectionStatus {
-  ACTIVE = 'active',
-  INACTIVE = 'inactive',
-  UNAVAILABLE = 'unavailable',
-  ERROR = 'error'
-}
-
-export class Connection extends Object {
-  static HEARTBEAT_INTERVAL = 180000;
-
-  status: ConnectionStatus = ConnectionStatus.UNAVAILABLE;
-  webSocket?: WebSocket;
-
-  constructor(url?: string) {
-    super();
-
-    if (url) {
-      this.webSocket = new WebSocket(url);
-      this.webSocket.onmessage = (msg) => this.handleMessage(msg);
-      this.webSocket.onerror = (err) => this.handleError(err);
-      this.webSocket.onclose = (_) => {
-        if (this.status !== ConnectionStatus.ERROR) {
-          this.setStatus(ConnectionStatus.UNAVAILABLE);
-        }
-        this.webSocket = undefined;
-      };
-    }
-
-    setInterval(() => {
-      if (this.webSocket && self.status !== ConnectionStatus.ERROR && this.status !== ConnectionStatus.UNAVAILABLE) {
-        this.webSocket.send('');
-      }
-    }, Connection.HEARTBEAT_INTERVAL);
-  }
-
-  onHandshake() {
-    // Intentionally empty
-  }
-
-  onReload() {
-    // Intentionally empty
-  }
-
-  onConnectionError(_: string) {
-    // Intentionally empty
-  }
-
-  onStatusChange(_: ConnectionStatus) {
-    // Intentionally empty
-  }
-
-  onMessage(message: any) {
-    // eslint-disable-next-line no-console
-    console.error('Unknown message received from the live reload server:', message);
-  }
-
-  handleMessage(msg: any) {
-    let json;
-    try {
-      json = JSON.parse(msg.data);
-    } catch (e: any) {
-      this.handleError(`[${e.name}: ${e.message}`);
-      return;
-    }
-    if (json.command === 'hello') {
-      this.setStatus(ConnectionStatus.ACTIVE);
-      this.onHandshake();
-    } else if (json.command === 'reload') {
-      if (this.status === ConnectionStatus.ACTIVE) {
-        this.onReload();
-      }
-    } else if (json.command === 'license-check-ok') {
-      licenseCheckOk(json.data);
-    } else if (json.command === 'license-check-failed') {
-      licenseCheckFailed(json.data);
-    } else if (json.command === 'license-check-nokey') {
-      licenseCheckNoKey(json.data);
-    } else {
-      this.onMessage(json);
-    }
-  }
-
-  handleError(msg: any) {
-    // eslint-disable-next-line no-console
-    console.error(msg);
-    this.setStatus(ConnectionStatus.ERROR);
-    if (msg instanceof Event && this.webSocket) {
-      this.onConnectionError(`Error in WebSocket connection to ${this.webSocket.url}`);
-    } else {
-      this.onConnectionError(msg);
-    }
-  }
-
-  setActive(yes: boolean) {
-    if (!yes && this.status === ConnectionStatus.ACTIVE) {
-      this.setStatus(ConnectionStatus.INACTIVE);
-    } else if (yes && this.status === ConnectionStatus.INACTIVE) {
-      this.setStatus(ConnectionStatus.ACTIVE);
-    }
-  }
-
-  setStatus(status: ConnectionStatus) {
-    if (this.status !== status) {
-      this.status = status;
-      this.onStatusChange(status);
-    }
-  }
-
-  public send(command: string, data: any) {
-    const message = JSON.stringify({ command, data });
-    if (!this.webSocket) {
-      // eslint-disable-next-line no-console
-      console.error(`Unable to send message ${command}. No websocket is available`);
-    } else if (this.webSocket.readyState !== WebSocket.OPEN) {
-      this.webSocket.addEventListener('open', () => this.webSocket!.send(message));
-    } else {
-      this.webSocket.send(message);
-    }
-  }
-
-  setFeature(featureId: string, enabled: boolean) {
-    this.send('setFeature', { featureId, enabled });
-  }
-  sendTelemetry(browserData: any) {
-    this.send('reportTelemetry', { browserData });
-  }
-  sendLicenseCheck(product: Product) {
-    this.send('checkLicense', product);
-  }
-  sendShowComponentCreateLocation(component: ComponentReference) {
-    this.send('showComponentCreateLocation', component);
-  }
-  sendShowComponentAttachLocation(component: ComponentReference) {
-    this.send('showComponentAttachLocation', component);
-  }
-}
-
 enum MessageType {
   LOG = 'log',
   INFORMATION = 'information',
@@ -188,31 +53,6 @@ interface Message {
   deleted: boolean;
 }
 
-export const popupStyles = css`
-  .popup {
-    width: auto;
-    position: fixed;
-    background-color: var(--dev-tools-background-color-active-blurred);
-    color: var(--dev-tools-text-color-primary);
-    padding: 0.1875rem 0.75rem 0.1875rem 1rem;
-    background-clip: padding-box;
-    border-radius: var(--dev-tools-border-radius);
-    overflow: hidden;
-    margin: 0.5rem;
-    width: 30rem;
-    max-width: calc(100% - 1rem);
-    max-height: calc(100vh - 1rem);
-    flex-shrink: 1;
-    background-color: var(--dev-tools-background-color-active);
-    color: var(--dev-tools-text-color);
-    transition: var(--dev-tools-transition-duration);
-    transform-origin: bottom right;
-    display: flex;
-    flex-direction: column;
-    box-shadow: var(--dev-tools-box-shadow);
-    outline: none;
-  }
-`;
 export class VaadinDevTools extends LitElement {
   static MAX_LOG_ROWS = 1000;
 


### PR DESCRIPTION
## Description

There are currently circular dependencies between TS modules in the dev tools:
- `vaadin-dev-tools.ts` -> `await import('./component-picker.js');`
  - `component-picker.ts` -> `import { popupStyles } from './vaadin-dev-tools.js';`
- `vaadin-dev-tools.ts` -> `import './theme-editor/editor';`
  - `editor.ts` -> `import { Connection } from '../vaadin-dev-tools.ts';`
  - `editor.ts` -> `await import('./component-picker.js');`
    - `component-picker.ts` -> `import { popupStyles } from './vaadin-dev-tools.js';`

In general these should be avoided, as they can work, but also can result in random errors which are hard to debug. I just ran into one where the lazy import of the component picker from the dev tools module loaded the dev tools module again (with several other side effects), due to some seemingly unrelated change in the theme editor. Removing the circular dependencies seems to fix that.