### PR TITLE
refactor: highlight selected component in theme editor

### DIFF
--- a/vaadin-dev-server/frontend/component-picker.ts
+++ b/vaadin-dev-server/frontend/component-picker.ts
@@ -56,7 +56,8 @@ export class ComponentPicker extends LitElement {
     const globalStyles = new CSSStyleSheet();
     globalStyles.replaceSync(`
     .vaadin-dev-tools-highlight {
-      outline: 1px solid red
+      outline: solid 2px #9e2cc6;
+      outline-offset: 3px;
     }`);
 
     document.adoptedStyleSheets = [...document.adoptedStyleSheets, globalStyles];

--- a/vaadin-dev-server/frontend/theme-editor/editor.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.test.ts
@@ -588,4 +588,23 @@ describe('theme-editor', () => {
       expect(getPropertyValue('label', 'color')).to.equal('rgb(255, 0, 0)');
     });
   });
+
+  describe('highlighting', () => {
+    it('should highlight selected component', async () => {
+      await pickComponent();
+      expect(testElement.classList.contains('vaadin-theme-editor-highlight')).to.be.true;
+    });
+
+    it('should update highlight when selecting a different component', async () => {
+      await pickComponent();
+      expect(testElement.classList.contains('vaadin-theme-editor-highlight')).to.be.true;
+
+      const anotherElement = (await fixture(html` <test-element></test-element>`)) as HTMLElement;
+      testComponentRef = { nodeId: 123, uiId: 456, element: anotherElement };
+      await pickComponent();
+
+      expect(testElement.classList.contains('vaadin-theme-editor-highlight')).to.be.false;
+      expect(anotherElement.classList.contains('vaadin-theme-editor-highlight')).to.be.true;
+    });
+  });
 });

--- a/vaadin-dev-server/frontend/theme-editor/editor.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.test.ts
@@ -606,5 +606,13 @@ describe('theme-editor', () => {
       expect(testElement.classList.contains('vaadin-theme-editor-highlight')).to.be.false;
       expect(anotherElement.classList.contains('vaadin-theme-editor-highlight')).to.be.true;
     });
+
+    it('should remove highlight when removing editor from DOM', async () => {
+      await pickComponent();
+      expect(testElement.classList.contains('vaadin-theme-editor-highlight')).to.be.true;
+
+      editor.remove();
+      expect(testElement.classList.contains('vaadin-theme-editor-highlight')).to.be.false;
+    });
   });
 });

--- a/vaadin-dev-server/frontend/theme-editor/editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.ts
@@ -15,6 +15,14 @@ import './components/scope-selector';
 import './components/property-list';
 import '../component-picker.js';
 import { ComponentReference } from '../component-util';
+import { injectGlobalCss } from './styles';
+
+injectGlobalCss(css`
+  .vaadin-theme-editor-highlight {
+    outline: solid 3px #9e2cc6;
+    outline-offset: 3px;
+  }
+`);
 
 @customElement('vaadin-dev-tools-theme-editor')
 export class ThemeEditor extends LitElement {
@@ -141,6 +149,12 @@ export class ThemeEditor extends LitElement {
     this.historyActions = this.history.allowedActions;
   }
 
+  disconnectedCallback() {
+    super.disconnectedCallback();
+
+    this.removeElementHighlight(this.context?.component.element);
+  }
+
   render() {
     if (this.themeEditorState === ThemeEditorState.missing_theme) {
       return this.renderMissingThemeNotice();
@@ -257,6 +271,8 @@ export class ThemeEditor extends LitElement {
   }
 
   private async pickComponent() {
+    this.removeElementHighlight(this.context?.component.element);
+
     this.pickerProvider().open({
       infoTemplate: html`
         <div>
@@ -275,6 +291,8 @@ export class ThemeEditor extends LitElement {
           this.effectiveTheme = null;
           return;
         }
+
+        this.highlightElement(component.element);
 
         this.refreshTheme({
           scope: this.context?.scope || ThemeScope.local,
@@ -367,5 +385,17 @@ export class ThemeEditor extends LitElement {
     // Notify dev tools that we are about to save CSS, so that it can disable
     // live reload temporarily
     this.dispatchEvent(new CustomEvent('before-save'));
+  }
+
+  private highlightElement(element?: HTMLElement) {
+    if (element) {
+      element.classList.add('vaadin-theme-editor-highlight');
+    }
+  }
+
+  private removeElementHighlight(element?: HTMLElement) {
+    if (element) {
+      element.classList.remove('vaadin-theme-editor-highlight');
+    }
   }
 }

--- a/vaadin-dev-server/frontend/theme-editor/editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.ts
@@ -19,7 +19,7 @@ import { injectGlobalCss } from './styles';
 
 injectGlobalCss(css`
   .vaadin-theme-editor-highlight {
-    outline: solid 3px #9e2cc6;
+    outline: solid 2px #9e2cc6;
     outline-offset: 3px;
   }
 `);


### PR DESCRIPTION
## Description

Adds an outline to the selected component in the theme editor. The outline gets removed when the component picker is opened again, or when the editor is removed from the DOM.

![Bildschirmfoto 2023-03-15 um 21 27 39](https://user-images.githubusercontent.com/357820/225434370-5d6c06a9-32d7-4e8a-8ae1-d9fbdb3655eb.png)
![Bildschirmfoto 2023-03-15 um 21 27 29](https://user-images.githubusercontent.com/357820/225434373-e8469966-9933-43c1-af1c-afe3e0d71613.png)
