### PR TITLE
refactor: fix base theme detection in theme editor

### DIFF
--- a/vaadin-dev-server/frontend/theme-editor/editor.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.test.ts
@@ -517,4 +517,75 @@ describe('theme-editor', () => {
       expect(beforeSaveSpy.calledOnce).to.be.true;
     });
   });
+
+  describe('theme detection', () => {
+    it('should detect base theme when changing scope', async () => {
+      await pickComponent();
+      await changeThemeScope(ThemeScope.global);
+      await editProperty('label', 'color', 'red');
+      apiMock.loadPreview.returns(
+        Promise.resolve({
+          css: 'test-element::part(label) { color: red }'
+        })
+      );
+      await changeThemeScope(ThemeScope.local);
+
+      expect(getPropertyValue('label', 'color')).to.equal('rgb(255, 0, 0)');
+    });
+
+    it('should detect base theme on undo', async () => {
+      await pickComponent();
+      await changeThemeScope(ThemeScope.global);
+      await editProperty('label', 'color', 'red');
+      apiMock.loadPreview.returns(
+          Promise.resolve({
+            css: 'test-element::part(label) { color: red }'
+          })
+      );
+      await changeThemeScope(ThemeScope.local);
+
+      expect(getPropertyValue('label', 'color')).to.equal('rgb(255, 0, 0)');
+
+      apiMock.loadPreview.returns(
+        Promise.resolve({
+          css: ''
+        })
+      );
+      await undo();
+
+      expect(getPropertyValue('label', 'color')).to.equal('rgb(0, 0, 0)');
+    });
+
+    it('should detect base theme on redo', async () => {
+      await pickComponent();
+      await changeThemeScope(ThemeScope.global);
+      await editProperty('label', 'color', 'red');
+      apiMock.loadPreview.returns(
+          Promise.resolve({
+            css: 'test-element::part(label) { color: red }'
+          })
+      );
+      await changeThemeScope(ThemeScope.local);
+
+      expect(getPropertyValue('label', 'color')).to.equal('rgb(255, 0, 0)');
+
+      apiMock.loadPreview.returns(
+        Promise.resolve({
+          css: ''
+        })
+      );
+      await undo();
+
+      expect(getPropertyValue('label', 'color')).to.equal('rgb(0, 0, 0)');
+
+      apiMock.loadPreview.returns(
+        Promise.resolve({
+          css: 'test-element::part(label) { color: red }'
+        })
+      );
+      await redo();
+
+      expect(getPropertyValue('label', 'color')).to.equal('rgb(255, 0, 0)');
+    });
+  });
 });

--- a/vaadin-dev-server/frontend/theme-editor/editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.ts
@@ -276,9 +276,6 @@ export class ThemeEditor extends LitElement {
           return;
         }
 
-        // Detect base theme whenever a new component is picked
-        this.baseTheme = detectTheme(metadata);
-
         this.refreshTheme({
           scope: this.context?.scope || ThemeScope.local,
           metadata,
@@ -346,6 +343,10 @@ export class ThemeEditor extends LitElement {
     const component = context.scope === ThemeScope.local ? context.component : null;
     const serverRules = await this.api.loadRules(scopeSelector, component);
 
+    // Update preview, which can result in changes to the base theme
+    await this.updateThemePreview();
+    this.baseTheme = detectTheme(context.metadata);
+
     // Update state properties after data has loaded, so that everything
     // consistently updates at once - this avoids re-rendering the editor with
     // new metadata but without matching theme data
@@ -355,7 +356,6 @@ export class ThemeEditor extends LitElement {
     };
     this.editedTheme = ComponentTheme.fromServerRules(context.metadata, serverRules.rules);
     this.effectiveTheme = ComponentTheme.combine(this.baseTheme!, this.editedTheme);
-    await this.updateThemePreview();
   }
 
   private async updateThemePreview() {


### PR DESCRIPTION
## Description

After merging the scope changing, the base theme detection used for showing default values in the property editor does not work correctly anymore. For example in the following case:
- Change background color globally
- Switch to local scope
- Property editor shows initial background color, because the base theme has not been updated with the modified global background color

A similar problem exists with undo/redo, which can also affect properties outside of the current scope.

This fix updates the base theme whenever the scope is changed, or undo / redo is performed.