### PR TITLE
chore: optimize getModifierKey method, to handle more implementations of Key interface:

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -765,7 +765,7 @@ public class ShortcutRegistration implements Registration, Serializable {
          */
 
         final boolean altAdded = modifiers.stream()
-                .anyMatch(key -> key.matches(Key.ALT.toString()));
+                .anyMatch(key -> key.matches(Key.ALT.getKeys().get(0)));
 
         return Arrays.stream(KeyModifier.values()).map(modifier -> {
             String modKey = modifier.getKeys().get(0);

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -765,7 +765,7 @@ public class ShortcutRegistration implements Registration, Serializable {
          */
 
         final boolean altAdded = modifiers
-                .contains(new HashableKey(KeyModifier.ALT));
+                .stream().anyMatch(key -> key.matches(Key.ALT.toString()));
 
         return Arrays.stream(KeyModifier.values()).map(modifier -> {
             String modKey = modifier.getKeys().get(0);

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -764,8 +764,8 @@ public class ShortcutRegistration implements Registration, Serializable {
          * can be based on browser implementations.
          */
 
-        final boolean altAdded = modifiers
-                .stream().anyMatch(key -> key.matches(Key.ALT.toString()));
+        final boolean altAdded = modifiers.stream()
+                .anyMatch(key -> key.matches(Key.ALT.toString()));
 
         return Arrays.stream(KeyModifier.values()).map(modifier -> {
             String modKey = modifier.getKeys().get(0);
@@ -778,7 +778,7 @@ public class ShortcutRegistration implements Registration, Serializable {
                 return (modifierRequired ? "" : "!")
                         + "event.getModifierState('" + modKey + "')";
             }
-        }).filter(Objects::nonNull).filter(s -> !s.isBlank())
+        }).filter(Objects::nonNull).filter(s -> !s.trim().isEmpty())
                 .collect(Collectors.joining(" && "));
 
     }


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description
There were some problems in testbench, and to prevent any further problems in any other service, I am just making this part more general, to accept every Key implementation not just HashableKey (although right now it is only called in real-life app with HashableKeys).

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
