### PR TITLE
refactor: fix range editor sizing issues

### DIFF
--- a/vaadin-dev-server/frontend/theme-editor/components/editors/range-property-editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/editors/range-property-editor.ts
@@ -28,7 +28,7 @@ export class RangePropertyEditor extends BasePropertyEditor {
 
         .input {
           flex: 0 0 auto;
-          width: 60px;
+          width: 80px;
         }
 
         .slider-wrapper {
@@ -49,12 +49,12 @@ export class RangePropertyEditor extends BasePropertyEditor {
         }
 
         .slider {
+          flex: 1 1 0;
           -webkit-appearance: none;
           background: linear-gradient(to right, #666, #666 2px, transparent 2px);
           background-size: calc((100% - 13px) / (var(--preset-count) - 1)) 8px;
           background-position: 5px 50%;
           background-repeat: repeat-x;
-          width: 15em;
         }
 
         .slider::-webkit-slider-runnable-track {


### PR DESCRIPTION
## Description

Remove fixed width from range slider and make it use the remaining space instead. Also restores the initial custom value input width.