### PR TITLE
refactor: use overlay for component picker hover styles

### DIFF
--- a/vaadin-dev-server/frontend/component-picker.ts
+++ b/vaadin-dev-server/frontend/component-picker.ts
@@ -28,6 +28,7 @@ export class ComponentPicker extends LitElement {
   selected: number = 0;
 
   highlighted?: HTMLElement;
+  overlayElement!: HTMLElement;
 
   @query('vaadin-dev-tools-shim')
   shim!: Shim;
@@ -55,12 +56,16 @@ export class ComponentPicker extends LitElement {
     super.connectedCallback();
     const globalStyles = new CSSStyleSheet();
     globalStyles.replaceSync(`
-    .vaadin-dev-tools-highlight {
-      outline: solid 2px #9e2cc6;
-      outline-offset: 3px;
+    .vaadin-dev-tools-highlight-overlay {
+      pointer-events: none;
+      position: absolute;
+      z-index: 10000;
+      background: rgba(158,44,198,0.25);
     }`);
-
     document.adoptedStyleSheets = [...document.adoptedStyleSheets, globalStyles];
+
+    this.overlayElement = document.createElement('div');
+    this.overlayElement.classList.add('vaadin-dev-tools-highlight-overlay');
   }
   render() {
     if (!this.active) {
@@ -161,12 +166,21 @@ export class ComponentPicker extends LitElement {
   }
 
   highlight(element: HTMLElement | undefined) {
-    if (this.highlighted) {
-      this.highlighted.classList.remove('vaadin-dev-tools-highlight');
+    if (this.highlighted !== element) {
+      if (element) {
+        const clientRect = element.getBoundingClientRect();
+        const computedStyles = getComputedStyle(element);
+
+        this.overlayElement.style.top = `${clientRect.top}px`;
+        this.overlayElement.style.left = `${clientRect.left}px`;
+        this.overlayElement.style.width = `${clientRect.width}px`;
+        this.overlayElement.style.height = `${clientRect.height}px`;
+        this.overlayElement.style.borderRadius = computedStyles.borderRadius;
+        document.body.append(this.overlayElement);
+      } else {
+        this.overlayElement.remove();
+      }
     }
     this.highlighted = element;
-    if (this.highlighted) {
-      this.highlighted.classList.add('vaadin-dev-tools-highlight');
-    }
   }
 }


### PR DESCRIPTION
## Description

Follow up from: https://github.com/vaadin/flow/pull/16270

Make the component picker use an overlay when hovering over elements, which makes it more obvious that something is happening, and also avoids the outline being cut off if the element is at the bounds of the client area.

https://user-images.githubusercontent.com/357820/225763596-3b9e2f4c-ea37-425a-8d1f-c38182877c21.mp4


