### PR TITLE
fix: Try determining the project folder from the classpath (#16266) (CP: 23.3)

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
@@ -394,6 +394,15 @@ public class DevModeInitializer implements Serializable {
      * (see tickets #8249, #8403).
      */
     private static String getBaseDirectoryFallback() {
+        /* Try determining the project folder from the classpath. */
+        URL url = DevModeInitializer.class.getClassLoader().getResource(".");
+        if (url != null && url.getProtocol().equals("file")) {
+            String path = url.getPath();
+            if (path.endsWith("/target/classes/")) {
+                return path.replaceFirst("/target/classes/$", "");
+            }
+        }
+
         String baseDirCandidate = System.getProperty("user.dir", ".");
         Path path = Paths.get(baseDirCandidate);
         if (path.toFile().isDirectory()


### PR DESCRIPTION
Resolves the correct project folder when running a Vaadin project inside a multi module project

Fixes #16265
