### PR TITLE
chore: Throw an exception when a download fails

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/DefaultFileDownloader.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/DefaultFileDownloader.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.channels.Channels;
-import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 
 import org.apache.commons.io.FileUtils;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/DefaultFileDownloader.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/DefaultFileDownloader.java
@@ -21,10 +21,12 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
@@ -108,11 +110,22 @@ public final class DefaultFileDownloader implements FileDownloader {
                 FilenameUtils.getFullPathNoEndSeparator(destination.toString()))
                 .mkdirs();
 
+        HttpEntity responseEntity = response.getEntity();
+        long expected = responseEntity.getContentLength();
         try (ReadableByteChannel rbc = Channels
-                .newChannel(response.getEntity().getContent());
+                .newChannel(responseEntity.getContent());
                 FileOutputStream fos = new FileOutputStream(destination)) {
-            fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
+            long transferred = fos.getChannel().transferFrom(rbc, 0,
+                    Long.MAX_VALUE);
+            if (expected > 0 && transferred != expected) {
+                // Download failed and channel.transferFrom does not rethrow the
+                // exception
+                throw new DownloadException(
+                        "Error downloading from " + downloadUri + ". Expected "
+                                + expected + " bytes but got " + transferred);
+            }
         }
+
     }
 
     private CloseableHttpResponse execute(URI requestUri) throws IOException {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
@@ -20,12 +20,10 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;


### PR DESCRIPTION
Makes it easier to understand that download of Node failed instead of that the archive was corrupt
