### PR TITLE
fix: align javaparser version with the one used by Spreadsheet

### DIFF
--- a/vaadin-dev-server/pom.xml
+++ b/vaadin-dev-server/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.github.javaparser</groupId>
             <artifactId>javaparser-symbol-solver-core</artifactId>
-            <version>3.25.1</version>
+            <version>3.24.2</version>
         </dependency>
 
         <!-- API dependencies -->

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/editor/Editor.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/editor/Editor.java
@@ -1120,8 +1120,7 @@ public class Editor {
         // Configure JavaParser to use type resolution
         JavaSymbolSolver symbolSolver = new JavaSymbolSolver(
                 combinedTypeSolver);
-        StaticJavaParser.getParserConfiguration()
-                .setSymbolResolver(symbolSolver);
+        StaticJavaParser.getConfiguration().setSymbolResolver(symbolSolver);
 
         return LexicalPreservingPrinter.setup(StaticJavaParser.parse(source));
     }


### PR DESCRIPTION
## Description

Align `javaparser` version with the one transitively used by Spreadsheet.