### PR TITLE
chore: Remove dev mode detector version force

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/default/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/default/package.json
@@ -21,7 +21,6 @@
     "typescript": "4.9.3",
     "workbox-core": "6.5.4",
     "workbox-precaching": "6.5.4",
-    "strip-css-comments": "5.0.0",
-    "@vaadin/vaadin-development-mode-detector": "2.0.6"
+    "strip-css-comments": "5.0.0"
   }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -136,7 +136,6 @@ public class NodeUpdaterTest {
         expectedDependencies.add("workbox-build");
         expectedDependencies.add("transform-ast");
         expectedDependencies.add("strip-css-comments");
-        expectedDependencies.add("@vaadin/vaadin-development-mode-detector");
 
         Set<String> actualDependendencies = defaultDeps.keySet();
 


### PR DESCRIPTION
This should no longer be needed
