### PR TITLE
chore: optimize (and fix) generateEventModifierFilter() method, to handle more implementations of Key interface: (#16276)(#16086)(CP: 2.9) 

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/Shortcuts.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Shortcuts.java
@@ -24,7 +24,7 @@ import com.vaadin.flow.shared.Registration;
  * <p>
  * Unlike the shortcut methods offered by {@link Focusable} and {@link
  * ClickNotifier}, these methods allow for configuring the {@code
- * lifecycleOwner} directly, making it possible to added the shortcut onto any
+ * lifecycleOwner} directly, making it possible to add the shortcut onto any
  * component. The {@code lifecycleOwner} denotes the component to which the
  * shortcut is bound to. If the lifecycle owner is not attached, visible, or
  * enabled, the shortcut won't work, and vice-versa.
@@ -160,7 +160,7 @@ public final class Shortcuts {
      */
     public static Registration setShortcutListenOnElement(
             String elementLocatorJs, Component listenOnComponent) {
-        // a bit wasteful to store this for each component instance but it
+        // a bit wasteful to store this for each component instance, but it
         // stays in memory only as long as the component itself does
         ComponentUtil.setData(listenOnComponent, ELEMENT_LOCATOR_JS_KEY,
                 elementLocatorJs);

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortCutRegistrationFilterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortCutRegistrationFilterTest.java
@@ -1,0 +1,149 @@
+package com.vaadin.flow.component;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ShortCutRegistrationFilterTest {
+
+    /**
+     * This method is used to test the generateEventModifierFilter method in the
+     * ShortcutRegistration class. This method is private, so we need to use
+     * reflection to invoke it.
+     *
+     * @param list
+     * @return
+     * @throws NoSuchMethodException
+     * @throws InvocationTargetException
+     * @throws IllegalAccessException
+     */
+    private static String invokeGenerateEventModifierFilter(List<Key> list)
+            throws NoSuchMethodException, InvocationTargetException,
+            IllegalAccessException {
+        Method privateMethod = ShortcutRegistration.class.getDeclaredMethod(
+                "generateEventModifierFilter", Collection.class);
+        privateMethod.setAccessible(true);
+        // invoke the private method for testing
+        String result = (String) privateMethod.invoke(null, list);
+        return result;
+    }
+
+    /**
+     * This method is used to get the HashableKey object from the
+     * ShortcutRegistration class. This is needed because the HashableKey class
+     * is private, and we need to create an instance of it to test the
+     * generateEventModifierFilter method.
+     *
+     * @param keyModifier
+     * @return
+     * @throws ClassNotFoundException
+     * @throws InvocationTargetException
+     * @throws InstantiationException
+     * @throws IllegalAccessException
+     */
+    private static Object getHashableKey(KeyModifier keyModifier)
+            throws ClassNotFoundException, InvocationTargetException,
+            InstantiationException, IllegalAccessException {
+        final Class<?> nestedClass = Class.forName(
+                "com.vaadin.flow.component.ShortcutRegistration$HashableKey");
+        final Constructor<?> ctor = nestedClass.getDeclaredConstructors()[0];
+        ctor.setAccessible(true);
+        return ctor.newInstance(keyModifier);
+    }
+
+    private static ArrayList<String> getModifierFilterConditions(
+            String eventModifierFilter, int expectedFilterCount) {
+        ArrayList<String> filterConditions = new ArrayList<>(Arrays
+                .asList(eventModifierFilter.split(" && ", Integer.MAX_VALUE)));
+        assertTrue(
+                "Split filter conditions should not contain '&' character or blank strings.",
+                filterConditions.stream()
+                        .filter(c -> c.contains("&") || StringUtils.isBlank(c))
+                        .collect(Collectors.toList()).isEmpty());
+        assertEquals(expectedFilterCount, filterConditions.size());
+        return filterConditions;
+    }
+
+    @Test
+    public void testGenerateEventModifierFilterWithModifierKeyAlt()
+            throws InvocationTargetException, NoSuchMethodException,
+            IllegalAccessException, ClassNotFoundException,
+            InstantiationException {
+        String result = invokeGenerateEventModifierFilter(Collections
+                .singletonList(((Key) getHashableKey(KeyModifier.ALT))));
+        ArrayList<String> conditions = getModifierFilterConditions(result, 4);
+        assertTrue(conditions.contains("event.getModifierState('Alt')"));
+        assertTrue(conditions.contains("!event.getModifierState('Control')"));
+        assertFalse(conditions.contains("event.getModifierState('AltGraph')"));
+        assertFalse(conditions.contains("!event.getModifierState('AltGraph')"));
+    }
+
+    @Test
+    public void testGenerateEventModifierFilterWithModifierKeyAltGr()
+            throws InvocationTargetException, NoSuchMethodException,
+            IllegalAccessException, ClassNotFoundException,
+            InstantiationException {
+        String result = invokeGenerateEventModifierFilter(Collections
+                .singletonList(((Key) getHashableKey(KeyModifier.ALT_GRAPH))));
+        ArrayList<String> conditions = getModifierFilterConditions(result, 5);
+        assertTrue(conditions.contains("event.getModifierState('AltGraph')"));
+        assertTrue(conditions.contains("!event.getModifierState('Alt')"));
+        assertTrue(conditions.contains("!event.getModifierState('Control')"));
+    }
+
+    @Test
+    public void testGenerateEventModifierFilterWithModifierKeyAltAndAltGr()
+            throws InvocationTargetException, NoSuchMethodException,
+            IllegalAccessException, ClassNotFoundException,
+            InstantiationException {
+        String result = invokeGenerateEventModifierFilter(
+                Arrays.asList((Key) getHashableKey(KeyModifier.ALT),
+                        (Key) getHashableKey(KeyModifier.ALT_GRAPH)));
+        ArrayList<String> conditions = getModifierFilterConditions(result, 5);
+        assertTrue(conditions.contains("event.getModifierState('Alt')"));
+        assertTrue(conditions.contains("event.getModifierState('AltGraph')"));
+        assertTrue(conditions.contains("!event.getModifierState('Control')"));
+    }
+
+    @Test
+    public void testGenerateEventModifierFilterWithModifierKeyAltGrAndCtrl()
+            throws InvocationTargetException, NoSuchMethodException,
+            IllegalAccessException, ClassNotFoundException,
+            InstantiationException {
+        String result = invokeGenerateEventModifierFilter(
+                Arrays.asList((Key) getHashableKey(KeyModifier.ALT_GRAPH),
+                        (Key) getHashableKey(KeyModifier.CONTROL)));
+        ArrayList<String> conditions = getModifierFilterConditions(result, 5);
+        assertTrue(conditions.contains("event.getModifierState('AltGraph')"));
+        assertTrue(conditions.contains("event.getModifierState('Control')"));
+        assertTrue(conditions.contains("!event.getModifierState('Alt')"));
+    }
+
+    @Test
+    public void testGenerateEventModifierFilterWithModifierKeyAltAndCtrl()
+            throws InvocationTargetException, NoSuchMethodException,
+            IllegalAccessException, ClassNotFoundException,
+            InstantiationException {
+        String result = invokeGenerateEventModifierFilter(
+                Arrays.asList((Key) getHashableKey(KeyModifier.ALT),
+                        (Key) getHashableKey(KeyModifier.CONTROL)));
+        ArrayList<String> conditions = getModifierFilterConditions(result, 4);
+        assertTrue(conditions.contains("event.getModifierState('Alt')"));
+        assertTrue(conditions.contains("event.getModifierState('Control')"));
+        assertFalse(conditions.contains("event.getModifierState('AltGraph')"));
+        assertFalse(conditions.contains("!event.getModifierState('AltGraph')"));
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutEventTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutEventTest.java
@@ -15,6 +15,9 @@ public class ShortcutEventTest {
     private ShortcutEvent eventTwoModifiers = event(Key.KEY_F, KeyModifier.ALT,
             KeyModifier.CONTROL);
 
+    private ShortcutEvent eventWithAltAndAltGr = event(Key.KEY_F,
+            KeyModifier.ALT, KeyModifier.ALT_GRAPH);
+
     @Test
     public void matches() {
         assertFalse("Null key should return false",
@@ -23,6 +26,11 @@ public class ShortcutEventTest {
                 eventNoModifiers.matches(Key.KEY_F, KeyModifier.ALT));
         assertFalse("Missing modifier should return false",
                 eventOneModifier.matches(Key.KEY_F));
+        assertFalse(
+                "Matching key and two modifiers (Alt, Alt_Gr) plus an extra one (Control), "
+                        + "should return false",
+                eventWithAltAndAltGr.matches(Key.KEY_F, KeyModifier.ALT,
+                        KeyModifier.ALT_GRAPH, KeyModifier.CONTROL));
 
         assertTrue("Matching key should return true",
                 eventNoModifiers.matches(Key.KEY_F));
@@ -31,6 +39,10 @@ public class ShortcutEventTest {
         assertTrue("Matching key and two modifiers should return true",
                 eventTwoModifiers.matches(Key.KEY_F, KeyModifier.ALT,
                         KeyModifier.CONTROL));
+        assertTrue(
+                "Matching key and two modifiers (Alt_Gr, Alt) should return true",
+                eventWithAltAndAltGr.matches(Key.KEY_F, KeyModifier.ALT_GRAPH,
+                        KeyModifier.ALT));
     }
 
     private static ShortcutEvent event(Key key, KeyModifier... modifiers) {


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description
This will handle the browser implementation differences in Flow 2.8 as well.
From original [PR](https://github.com/vaadin/flow/pull/16282):
```
Context:
In Firefox, the option key is not working. The reason behind this as the browser implementing differently the KeyboardEvent when the option key is pushed, and when getModifierState() is called it will give back different true or false events based on whether you are using Chrome or Firefox.

The difference comes down to this:

Mozzila:

event.getModifierState('Alt') -> true
event.getModifierState('AltGraph') -> true
Chrome:

event.getModifierState('Alt') -> true
event.getModifierState('AltGraph') -> false
For more information:
Check to please the table for When getModifierState() returns true on Gecko? here:

https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/getModifierState
Fixes # (issue)
https://github.com/vaadin/flow/issues/7798
```

There were some problems in testbench, and to prevent any further problems in any other service, I am just making this part more general, to accept every Key implementation not just HashableKey (although right now it is only called in the real-life apps with HashableKeys).

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
