### PR TITLE
refactor: hide selection highlight when closing theme editor

### DIFF
--- a/vaadin-dev-server/frontend/theme-editor/editor.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.test.ts
@@ -47,6 +47,7 @@ describe('theme-editor', () => {
     };
     const pickerProvider: PickerProvider = () => pickerMock as any;
     const editor = (await fixture(html` <vaadin-dev-tools-theme-editor
+      .expanded=${true}
       .pickerProvider=${pickerProvider}
       .connection=${connectionMock}
     ></vaadin-dev-tools-theme-editor>`)) as ThemeEditor;
@@ -613,6 +614,24 @@ describe('theme-editor', () => {
 
       editor.remove();
       expect(testElement.classList.contains('vaadin-theme-editor-highlight')).to.be.false;
+    });
+
+    it('should remove highlight when editor is closed', async () => {
+      await pickComponent();
+
+      editor.expanded = false;
+      await elementUpdated(editor);
+      expect(testElement.classList.contains('vaadin-theme-editor-highlight')).to.be.false;
+    });
+
+    it('should restore highlight when editor is opened again', async () => {
+      await pickComponent();
+
+      editor.expanded = false;
+      await elementUpdated(editor);
+      editor.expanded = true;
+      await elementUpdated(editor);
+      expect(testElement.classList.contains('vaadin-theme-editor-highlight')).to.be.true;
     });
   });
 

--- a/vaadin-dev-server/frontend/theme-editor/editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.ts
@@ -1,4 +1,4 @@
-import { css, html, LitElement, TemplateResult } from 'lit';
+import { css, html, LitElement, PropertyValues, TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { PickerProvider } from '../component-picker';
 import { metadataRegistry } from './metadata/registry';
@@ -26,6 +26,8 @@ injectGlobalCss(css`
 
 @customElement('vaadin-dev-tools-theme-editor')
 export class ThemeEditor extends LitElement {
+  @property({})
+  public expanded: boolean = false;
   @property({})
   public themeEditorState: ThemeEditorState = ThemeEditorState.enabled;
   @property({})
@@ -147,6 +149,19 @@ export class ThemeEditor extends LitElement {
     this.api = new ThemeEditorApi(this.connection);
     this.history = new ThemeEditorHistory(this.api);
     this.historyActions = this.history.allowedActions;
+  }
+
+  protected update(changedProperties: PropertyValues) {
+    super.update(changedProperties);
+
+    // Remove or restore selected element highlight when expanded state changes
+    if (changedProperties.has('expanded')) {
+      if (this.expanded) {
+        this.highlightElement(this.context?.component.element);
+      } else {
+        this.removeElementHighlight(this.context?.component.element);
+      }
+    }
   }
 
   disconnectedCallback() {

--- a/vaadin-dev-server/frontend/vaadin-dev-tools.ts
+++ b/vaadin-dev-server/frontend/vaadin-dev-tools.ts
@@ -1493,6 +1493,7 @@ export class VaadinDevTools extends LitElement {
 
   renderThemeEditor() {
     return html` <vaadin-dev-tools-theme-editor
+      .expanded=${this.expanded}  
       .themeEditorState=${this.themeEditorState}
       .pickerProvider=${() => this.componentPicker}
       .connection=${this.frontendConnection}


### PR DESCRIPTION
## Description

Removes / restores the selected element highlight when closing / opening the dev tools.

Addresses feedback from DX tests that highlight is still visible after closing dev tools.


https://user-images.githubusercontent.com/357820/226929991-68a54d70-f252-4872-8bea-c2782448963f.mp4


