### PR TITLE
chore: added more covering tests to ComponentTest.java for covering getLocale() method

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
@@ -30,6 +30,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.i18n.I18NProvider;
+import net.bytebuddy.asm.Advice;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.After;
@@ -322,6 +324,60 @@ public class ComponentTest {
         Assert.assertEquals("System default locale should be returned",
                 Locale.getDefault(), locale);
     }
+
+    @Test
+    public void getComponentLocale_hasCurrentUI_returnsUILocale() {
+        UI ui = new UI();
+        ui.setLocale(Locale.CANADA_FRENCH);
+        UI.setCurrent(ui);
+        Component test = new TestButton();
+        final Locale locale = test.getLocale();
+        Assert.assertEquals("Component getLocale returns the UI locale",
+                Locale.CANADA_FRENCH, locale);
+    }
+
+    @Test
+    public void getComponentLocale_noCurrentUI_returnsFirstLocaleFromProvidedLocales() {
+        UI.setCurrent(null);
+        Instantiator instantiator = mocks.getService().getInstantiator();
+        Mockito.when(instantiator.getI18NProvider()).thenReturn(new I18NProvider() {
+            @Override
+            public List<Locale> getProvidedLocales() {
+                return List.of(Locale.US, Locale.CANADA_FRENCH);
+            }
+
+            @Override
+            public String getTranslation(String key, Locale locale, Object... params) {
+                return null;
+            }
+        });
+        Component test = new TestButton();
+        final Locale locale = test.getLocale();
+        Assert.assertEquals("First provided locale should be returned",
+                Locale.getDefault(), locale);
+    }
+
+    @Test
+    public void getComponentLocale_noCurrentUI_returnsDefaultLocale_ifNoProvidedLocale() {
+        UI.setCurrent(null);
+        Instantiator instantiator = mocks.getService().getInstantiator();
+        Mockito.when(instantiator.getI18NProvider()).thenReturn(new I18NProvider() {
+            @Override
+            public List<Locale> getProvidedLocales() {
+                return List.of();
+            }
+
+            @Override
+            public String getTranslation(String key, Locale locale, Object... params) {
+                return null;
+            }
+        });
+        Component test = new TestButton();
+        final Locale locale = test.getLocale();
+        Assert.assertEquals("System default locale should be returned",
+                Locale.getDefault(), locale);
+    }
+
 
     @Test
     public void getElement() {

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
@@ -354,7 +354,7 @@ public class ComponentTest {
         Component test = new TestButton();
         final Locale locale = test.getLocale();
         Assert.assertEquals("First provided locale should be returned",
-                Locale.getDefault(), locale);
+                Locale.CANADA_FRENCH, locale);
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
@@ -340,17 +340,19 @@ public class ComponentTest {
     public void getComponentLocale_noCurrentUI_returnsFirstLocaleFromProvidedLocales() {
         UI.setCurrent(null);
         Instantiator instantiator = mocks.getService().getInstantiator();
-        Mockito.when(instantiator.getI18NProvider()).thenReturn(new I18NProvider() {
-            @Override
-            public List<Locale> getProvidedLocales() {
-                return List.of(Locale.US, Locale.CANADA_FRENCH);
-            }
+        Mockito.when(instantiator.getI18NProvider())
+                .thenReturn(new I18NProvider() {
+                    @Override
+                    public List<Locale> getProvidedLocales() {
+                        return List.of(Locale.US, Locale.CANADA_FRENCH);
+                    }
 
-            @Override
-            public String getTranslation(String key, Locale locale, Object... params) {
-                return null;
-            }
-        });
+                    @Override
+                    public String getTranslation(String key, Locale locale,
+                            Object... params) {
+                        return null;
+                    }
+                });
         Component test = new TestButton();
         final Locale locale = test.getLocale();
         Assert.assertEquals("First provided locale should be returned",
@@ -361,23 +363,24 @@ public class ComponentTest {
     public void getComponentLocale_noCurrentUI_returnsDefaultLocale_ifNoProvidedLocale() {
         UI.setCurrent(null);
         Instantiator instantiator = mocks.getService().getInstantiator();
-        Mockito.when(instantiator.getI18NProvider()).thenReturn(new I18NProvider() {
-            @Override
-            public List<Locale> getProvidedLocales() {
-                return List.of();
-            }
+        Mockito.when(instantiator.getI18NProvider())
+                .thenReturn(new I18NProvider() {
+                    @Override
+                    public List<Locale> getProvidedLocales() {
+                        return List.of();
+                    }
 
-            @Override
-            public String getTranslation(String key, Locale locale, Object... params) {
-                return null;
-            }
-        });
+                    @Override
+                    public String getTranslation(String key, Locale locale,
+                            Object... params) {
+                        return null;
+                    }
+                });
         Component test = new TestButton();
         final Locale locale = test.getLocale();
         Assert.assertEquals("System default locale should be returned",
                 Locale.getDefault(), locale);
     }
-
 
     @Test
     public void getElement() {

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
@@ -356,7 +356,7 @@ public class ComponentTest {
         Component test = new TestButton();
         final Locale locale = test.getLocale();
         Assert.assertEquals("First provided locale should be returned",
-                Locale.CANADA_FRENCH, locale);
+                Locale.US, locale);
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
@@ -31,7 +31,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.i18n.I18NProvider;
-import net.bytebuddy.asm.Advice;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.After;
@@ -340,11 +339,15 @@ public class ComponentTest {
     public void getComponentLocale_noCurrentUI_returnsFirstLocaleFromProvidedLocales() {
         UI.setCurrent(null);
         Instantiator instantiator = mocks.getService().getInstantiator();
+        List<Locale> providedLocales = new ArrayList<>(
+                List.of(Locale.US, Locale.CANADA_FRENCH, Locale.FRANCE));
+        providedLocales.remove(Locale.getDefault());
+
         Mockito.when(instantiator.getI18NProvider())
                 .thenReturn(new I18NProvider() {
                     @Override
                     public List<Locale> getProvidedLocales() {
-                        return List.of(Locale.US, Locale.CANADA_FRENCH);
+                        return providedLocales;
                     }
 
                     @Override
@@ -356,7 +359,7 @@ public class ComponentTest {
         Component test = new TestButton();
         final Locale locale = test.getLocale();
         Assert.assertEquals("First provided locale should be returned",
-                Locale.US, locale);
+                providedLocales.get(0), locale);
     }
 
     @Test


### PR DESCRIPTION
## Description

Added more covering tests to ComponentTest.java for covering the getLocale() method. 
It was needed because another external contributor PR is tackling a refactor/optimization of this method (as well), and this change, it will ensure the functionality, and execution branches are the same:

Fixes # (issue):
- https://github.com/vaadin/flow/pull/16160

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed a self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria was created.
