### PR TITLE
refactor: use selectors in theme editor component metadata

### DIFF
--- a/vaadin-dev-server/frontend/theme-editor/api.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/api.test.ts
@@ -42,8 +42,8 @@ describe('theme editor API', () => {
 
   it('should send messages', () => {
     const rules: ServerCssRule[] = [
-      { tagName: 'vaadin-button', partName: null, properties: { background: 'red' } },
-      { tagName: 'vaadin-text-field', partName: null, properties: { color: '' } }
+      { selector: 'vaadin-button', properties: { background: 'red' } },
+      { selector: 'vaadin-text-field', properties: { color: '' } }
     ];
 
     api.setCssRules(rules);

--- a/vaadin-dev-server/frontend/theme-editor/api.ts
+++ b/vaadin-dev-server/frontend/theme-editor/api.ts
@@ -4,7 +4,7 @@ import { ComponentReference } from '../component-util';
 export enum Commands {
   response = 'themeEditorResponse',
   loadComponentMetadata = 'themeEditorComponentMetadata',
-  setComponentClassName = 'themeEditorSetComponentClassName',
+  setLocalClassName = 'themeEditorLocalClassName',
   setCssRules = 'themeEditorRules',
   loadPreview = 'themeEditorLoadPreview',
   loadRules = 'themeEditorLoadRules',
@@ -100,8 +100,8 @@ export class ThemeEditorApi {
     return this.sendRequest(Commands.loadComponentMetadata, { nodeId: componentRef.nodeId });
   }
 
-  public setComponentClassName(componentRef: ComponentReference, className: string): Promise<BaseResponse> {
-    return this.sendRequest(Commands.setComponentClassName, { nodeId: componentRef.nodeId, className });
+  public setLocalClassName(componentRef: ComponentReference, className: string): Promise<BaseResponse> {
+    return this.sendRequest(Commands.setLocalClassName, { nodeId: componentRef.nodeId, className });
   }
 
   public setCssRules(rules: ServerCssRule[]): Promise<BaseResponse> {

--- a/vaadin-dev-server/frontend/theme-editor/api.ts
+++ b/vaadin-dev-server/frontend/theme-editor/api.ts
@@ -3,6 +3,8 @@ import { ComponentReference } from '../component-util';
 
 export enum Commands {
   response = 'themeEditorResponse',
+  loadComponentMetadata = 'themeEditorComponentMetadata',
+  setComponentClassName = 'themeEditorSetComponentClassName',
   setCssRules = 'themeEditorRules',
   loadPreview = 'themeEditorLoadPreview',
   loadRules = 'themeEditorLoadRules',
@@ -19,24 +21,23 @@ export interface BaseResponse {
   code: ResponseCode;
 }
 
+export interface LoadComponentMetadataResponse extends BaseResponse {
+  accessible?: boolean;
+  className?: string;
+  suggestedClassName?: string;
+}
+
 export interface LoadPreviewResponse extends BaseResponse {
   css: string;
 }
 
 export interface ServerCssRule {
-  tagName: string;
-  partName: string | null;
+  selector: string;
   properties: { [key: string]: string };
 }
 
 export interface LoadRulesResponse extends BaseResponse {
-  accessible?: boolean;
-  className?: string;
   rules: ServerCssRule[];
-}
-
-export interface SetRulesResponse extends BaseResponse {
-  className?: string;
 }
 
 interface RequestHandle {
@@ -95,31 +96,31 @@ export class ThemeEditorApi {
     }
   }
 
-  public setCssRules(rules: ServerCssRule[], componentRef?: ComponentReference | null): Promise<SetRulesResponse> {
-    const payload: any = { rules };
-    if (componentRef?.nodeId) {
-      payload.nodeId = componentRef?.nodeId;
-    }
-    return this.sendRequest(Commands.setCssRules, payload);
+  public loadComponentMetadata(componentRef: ComponentReference): Promise<LoadComponentMetadataResponse> {
+    return this.sendRequest(Commands.loadComponentMetadata, { nodeId: componentRef.nodeId });
+  }
+
+  public setComponentClassName(componentRef: ComponentReference, className: string): Promise<BaseResponse> {
+    return this.sendRequest(Commands.setComponentClassName, { nodeId: componentRef.nodeId, className });
+  }
+
+  public setCssRules(rules: ServerCssRule[]): Promise<BaseResponse> {
+    return this.sendRequest(Commands.setCssRules, { rules });
   }
 
   public loadPreview(): Promise<LoadPreviewResponse> {
     return this.sendRequest(Commands.loadPreview, {});
   }
 
-  public loadRules(selectorFilter: string, componentRef?: ComponentReference | null): Promise<LoadRulesResponse> {
-    const payload: any = { selectorFilter };
-    if (componentRef?.nodeId) {
-      payload.nodeId = componentRef?.nodeId;
-    }
-    return this.sendRequest(Commands.loadRules, payload);
+  public loadRules(selectors: string[]): Promise<LoadRulesResponse> {
+    return this.sendRequest(Commands.loadRules, { selectors });
   }
 
-  public undo(requestId: string) {
+  public undo(requestId: string): Promise<BaseResponse> {
     return this.sendRequest(Commands.history, { undo: requestId });
   }
 
-  public redo(requestId: string) {
+  public redo(requestId: string): Promise<BaseResponse> {
     return this.sendRequest(Commands.history, { redo: requestId });
   }
 

--- a/vaadin-dev-server/frontend/theme-editor/components/editors/base-property-editor.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/editors/base-property-editor.test.ts
@@ -2,7 +2,7 @@ import { TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import { ComponentTheme } from '../../model';
-import { CssPropertyMetadata } from '../../metadata/model';
+import { ComponentElementMetadata, CssPropertyMetadata } from '../../metadata/model';
 import { testElementMetadata } from '../../tests/utils';
 import { BasePropertyEditor } from './base-property-editor';
 
@@ -16,6 +16,12 @@ class TestPropertyEditor extends BasePropertyEditor {
 const colorMetadata: CssPropertyMetadata = {
   propertyName: 'color',
   displayName: 'Color'
+};
+
+const labelMetadata: ComponentElementMetadata = {
+  selector: 'test-element::part(label)',
+  displayName: 'Label',
+  properties: [colorMetadata]
 };
 
 describe('base property editor', () => {
@@ -34,9 +40,13 @@ describe('base property editor', () => {
 
   beforeEach(async () => {
     theme = new ComponentTheme(testElementMetadata);
-    theme.updatePropertyValue(null, 'color', 'black');
+    theme.updatePropertyValue(labelMetadata.selector, 'color', 'black');
 
-    editor = await fixture(html` <test-property-editor .theme=${theme} .propertyMetadata=${colorMetadata}>
+    editor = await fixture(html` <test-property-editor
+      .theme=${theme}
+      .elementMetadata=${labelMetadata}
+      .propertyMetadata=${colorMetadata}
+    >
     </test-property-editor>`);
   });
 
@@ -46,7 +56,7 @@ describe('base property editor', () => {
     expect(input.value).to.equal('black');
 
     const updatedTheme = cloneTheme();
-    updatedTheme.updatePropertyValue(null, 'color', 'red', true);
+    updatedTheme.updatePropertyValue(labelMetadata.selector, 'color', 'red', true);
     editor.theme = updatedTheme;
     await elementUpdated(editor);
 
@@ -61,7 +71,7 @@ describe('base property editor', () => {
 
   it('should show modified indicator if property value is modified', async () => {
     const updatedTheme = cloneTheme();
-    updatedTheme.updatePropertyValue(null, 'color', 'red', true);
+    updatedTheme.updatePropertyValue(labelMetadata.selector, 'color', 'red', true);
     editor.theme = updatedTheme;
     await elementUpdated(editor);
 

--- a/vaadin-dev-server/frontend/theme-editor/components/editors/base-property-editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/editors/base-property-editor.ts
@@ -1,18 +1,18 @@
 import { css, CSSResultGroup, html, LitElement, PropertyValues, TemplateResult } from 'lit';
 import { property, state } from 'lit/decorators.js';
-import { ComponentPartMetadata, CssPropertyMetadata } from '../../metadata/model';
+import { ComponentElementMetadata, CssPropertyMetadata } from '../../metadata/model';
 import { ComponentTheme, ThemePropertyValue } from '../../model';
 
 export class ThemePropertyValueChangeEvent extends CustomEvent<{
-  part: ComponentPartMetadata | null;
+  element: ComponentElementMetadata;
   property: CssPropertyMetadata;
   value: string;
 }> {
-  constructor(part: ComponentPartMetadata | null, property: CssPropertyMetadata, value: string) {
+  constructor(element: ComponentElementMetadata, property: CssPropertyMetadata, value: string) {
     super('theme-property-value-change', {
       bubbles: true,
       composed: true,
-      detail: { part, property, value }
+      detail: { element, property, value }
     });
   }
 }
@@ -61,7 +61,7 @@ export abstract class BasePropertyEditor extends LitElement {
   }
 
   @property({})
-  public partMetadata?: ComponentPartMetadata;
+  public elementMetadata!: ComponentElementMetadata;
   @property({})
   public propertyMetadata!: CssPropertyMetadata;
   @property({})
@@ -95,13 +95,12 @@ export abstract class BasePropertyEditor extends LitElement {
   protected abstract renderEditor(): TemplateResult;
 
   protected updateValueFromTheme() {
-    const partName = this.partMetadata?.partName || null;
-    this.propertyValue = this.theme.getPropertyValue(partName, this.propertyMetadata.propertyName);
+    this.propertyValue = this.theme.getPropertyValue(this.elementMetadata.selector, this.propertyMetadata.propertyName);
     this.value = this.propertyValue?.value || '';
   }
 
   protected dispatchChange(value: string) {
-    this.dispatchEvent(new ThemePropertyValueChangeEvent(this.partMetadata || null, this.propertyMetadata, value));
+    this.dispatchEvent(new ThemePropertyValueChangeEvent(this.elementMetadata, this.propertyMetadata, value));
   }
 }
 

--- a/vaadin-dev-server/frontend/theme-editor/components/editors/color-property-editor.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/editors/color-property-editor.test.ts
@@ -1,7 +1,7 @@
 import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import sinon from 'sinon';
 import '@vaadin/overlay';
-import { CssPropertyMetadata } from '../../metadata/model';
+import { ComponentElementMetadata, CssPropertyMetadata } from '../../metadata/model';
 import { ComponentTheme } from '../../model';
 import { testElementMetadata } from '../../tests/utils';
 import { ColorPropertyEditor } from './color-property-editor';
@@ -20,6 +20,12 @@ const backgroundColorMetadata: CssPropertyMetadata = {
   presets: ['yellow', 'orange', 'brown']
 };
 
+const inputMetadata: ComponentElementMetadata = {
+  selector: 'test-element > input',
+  displayName: 'Input',
+  properties: [colorMetadata, backgroundColorMetadata]
+};
+
 describe('color property editor', () => {
   let theme: ComponentTheme;
   let editor: ColorPropertyEditor;
@@ -36,12 +42,13 @@ describe('color property editor', () => {
     </style>`);
 
     theme = new ComponentTheme(testElementMetadata);
-    theme.updatePropertyValue(null, 'color', 'black');
-    theme.updatePropertyValue(null, 'background-color', 'white');
+    theme.updatePropertyValue(inputMetadata.selector, 'color', 'black');
+    theme.updatePropertyValue(inputMetadata.selector, 'background-color', 'white');
     valueChangeSpy = sinon.spy();
 
     editor = await fixture(html` <vaadin-dev-tools-theme-color-property-editor
       .theme=${theme}
+      .elementMetadata=${inputMetadata}
       .propertyMetadata=${colorMetadata}
       @theme-property-value-change=${valueChangeSpy}
     >
@@ -69,7 +76,7 @@ describe('color property editor', () => {
 
   it('should update value when theme changes', async () => {
     const updatedTheme = cloneTheme();
-    updatedTheme.updatePropertyValue(null, 'color', 'red');
+    updatedTheme.updatePropertyValue(inputMetadata.selector, 'color', 'red');
     editor.theme = updatedTheme;
     await elementUpdated(editor);
 
@@ -79,7 +86,7 @@ describe('color property editor', () => {
 
   it('should display raw preset value if theme value is a preset value', async () => {
     const updatedTheme = cloneTheme();
-    updatedTheme.updatePropertyValue(null, 'color', 'var(--test-primary-color)');
+    updatedTheme.updatePropertyValue(inputMetadata.selector, 'color', 'var(--test-primary-color)');
     editor.theme = updatedTheme;
     await elementUpdated(editor);
 

--- a/vaadin-dev-server/frontend/theme-editor/components/editors/range-property-editor.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/editors/range-property-editor.test.ts
@@ -1,6 +1,6 @@
 import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import sinon from 'sinon';
-import { CssPropertyMetadata } from '../../metadata/model';
+import { ComponentElementMetadata, CssPropertyMetadata } from '../../metadata/model';
 import { ComponentTheme } from '../../model';
 import { testElementMetadata } from '../../tests/utils';
 import { RangePropertyEditor } from './range-property-editor';
@@ -15,6 +15,11 @@ const paddingMetadata: CssPropertyMetadata = {
   propertyName: 'padding',
   displayName: 'Padding',
   presets: ['--test-space-s', '--test-space-m', '--test-space-l']
+};
+const hostMetadata: ComponentElementMetadata = {
+  selector: 'test-element',
+  displayName: 'Host',
+  properties: [heightMetadata, paddingMetadata]
 };
 
 describe('range property editor', () => {
@@ -39,12 +44,13 @@ describe('range property editor', () => {
     </style>`);
 
     theme = new ComponentTheme(testElementMetadata);
-    theme.updatePropertyValue(null, 'height', '40px');
-    theme.updatePropertyValue(null, 'padding', '15px');
+    theme.updatePropertyValue(hostMetadata.selector, 'height', '40px');
+    theme.updatePropertyValue(hostMetadata.selector, 'padding', '15px');
     valueChangeSpy = sinon.spy();
 
     editor = await fixture(html` <vaadin-dev-tools-theme-range-property-editor
       .theme=${theme}
+      .elementMetadata=${hostMetadata}
       .propertyMetadata=${heightMetadata}
       @theme-property-value-change=${valueChangeSpy}
     >
@@ -99,7 +105,7 @@ describe('range property editor', () => {
 
   it('should should mark slider as having custom value if theme value does not match a preset value', async () => {
     const updatedTheme = cloneTheme();
-    updatedTheme.updatePropertyValue(null, 'height', '25px');
+    updatedTheme.updatePropertyValue(hostMetadata.selector, 'height', '25px');
     editor.theme = updatedTheme;
     await elementUpdated(editor);
 
@@ -135,7 +141,7 @@ describe('range property editor', () => {
 
   it('should display raw preset value in input field if theme value is a preset value', async () => {
     const updatedTheme = cloneTheme();
-    updatedTheme.updatePropertyValue(null, 'height', 'var(--test-size-xl)');
+    updatedTheme.updatePropertyValue(hostMetadata.selector, 'height', 'var(--test-size-xl)');
     editor.theme = updatedTheme;
     await elementUpdated(editor);
 

--- a/vaadin-dev-server/frontend/theme-editor/components/editors/text-property-editor.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/editors/text-property-editor.test.ts
@@ -1,6 +1,6 @@
 import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import { ComponentTheme } from '../../model';
-import { CssPropertyMetadata } from '../../metadata/model';
+import { ComponentElementMetadata, CssPropertyMetadata } from '../../metadata/model';
 import { testElementMetadata } from '../../tests/utils';
 import { TextPropertyEditor } from './text-property-editor';
 import './text-property-editor';
@@ -9,6 +9,11 @@ import sinon from 'sinon';
 const colorMetadata: CssPropertyMetadata = {
   propertyName: 'color',
   displayName: 'Color'
+};
+const labelMetadata: ComponentElementMetadata = {
+  selector: 'test-element::part(label)',
+  displayName: 'Label',
+  properties: [colorMetadata]
 };
 
 describe('text property editor', () => {
@@ -28,11 +33,12 @@ describe('text property editor', () => {
 
   beforeEach(async () => {
     theme = new ComponentTheme(testElementMetadata);
-    theme.updatePropertyValue(null, 'color', 'black');
+    theme.updatePropertyValue(labelMetadata.selector, 'color', 'black');
     valueChangeSpy = sinon.spy();
 
     editor = await fixture(html` <vaadin-dev-tools-theme-text-property-editor
       .theme=${theme}
+      .elementMetadata=${labelMetadata}
       .propertyMetadata=${colorMetadata}
       @theme-property-value-change=${valueChangeSpy}
     >
@@ -45,7 +51,7 @@ describe('text property editor', () => {
     expect(input.value).to.equal('black');
 
     const updatedTheme = cloneTheme();
-    updatedTheme.updatePropertyValue(null, 'color', 'red', true);
+    updatedTheme.updatePropertyValue(labelMetadata.selector, 'color', 'red', true);
     editor.theme = updatedTheme;
     await elementUpdated(editor);
 

--- a/vaadin-dev-server/frontend/theme-editor/components/property-list.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/property-list.ts
@@ -1,7 +1,7 @@
 import { css, html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { html as staticHtml, literal, StaticValue } from 'lit/static-html.js';
-import { ComponentMetadata, ComponentPartMetadata, CssPropertyMetadata, EditorType } from '../metadata/model';
+import { ComponentMetadata, ComponentElementMetadata, CssPropertyMetadata, EditorType } from '../metadata/model';
 import { ComponentTheme } from '../model';
 import './editors/text-property-editor';
 import './editors/range-property-editor';
@@ -29,26 +29,23 @@ export class PropertyList extends LitElement {
   public theme!: ComponentTheme;
 
   render() {
-    const sections = [
-      this.renderSection(null, this.metadata.properties),
-      ...this.metadata.parts.map((part) => this.renderSection(part, part.properties))
-    ];
+    const sections = this.metadata.elements.map((element) => this.renderSection(element));
 
     return html` <div>${sections}</div> `;
   }
 
-  private renderSection(part: ComponentPartMetadata | null, properties: CssPropertyMetadata[]) {
-    const propertiesList = properties.map((property) => this.renderPropertyEditor(part, property));
+  private renderSection(element: ComponentElementMetadata) {
+    const propertiesList = element.properties.map((property) => this.renderPropertyEditor(element, property));
 
     return html`
-      <div class="section" data-testid=${part?.partName || 'host'}>
-        ${part ? html` <div class="header">${part.displayName}</div>` : null}
+      <div class="section" data-testid=${element?.displayName}>
+        ${element ? html` <div class="header">${element.displayName}</div>` : null}
         <div class="property-list">${propertiesList}</div>
       </div>
     `;
   }
 
-  private renderPropertyEditor(part: ComponentPartMetadata | null, property: CssPropertyMetadata) {
+  private renderPropertyEditor(part: ComponentElementMetadata | null, property: CssPropertyMetadata) {
     let editorTagName: StaticValue;
     switch (property.editorType) {
       case EditorType.range:

--- a/vaadin-dev-server/frontend/theme-editor/components/property-list.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/property-list.ts
@@ -45,7 +45,7 @@ export class PropertyList extends LitElement {
     `;
   }
 
-  private renderPropertyEditor(part: ComponentElementMetadata | null, property: CssPropertyMetadata) {
+  private renderPropertyEditor(element: ComponentElementMetadata, property: CssPropertyMetadata) {
     let editorTagName: StaticValue;
     switch (property.editorType) {
       case EditorType.range:
@@ -60,7 +60,7 @@ export class PropertyList extends LitElement {
 
     return staticHtml` <${editorTagName}
           class="property-editor"
-          .partMetadata=${part}
+          .elementMetadata=${element}
           .propertyMetadata=${property}
           .theme=${this.theme}
           data-testid=${property.propertyName}

--- a/vaadin-dev-server/frontend/theme-editor/detector.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/detector.test.ts
@@ -7,17 +7,10 @@ describe('theme-detector', () => {
     const theme = detectTheme(testElementMetadata);
     let propertyCount = 0;
 
-    // Host properties
-    testElementMetadata.properties.forEach((property) => {
-      propertyCount++;
-      const propertyValue = theme.getPropertyValue(null, property.propertyName);
-      expect(propertyValue).to.exist;
-    });
-    // Part properties
-    testElementMetadata.parts.forEach((part) => {
-      part.properties.forEach((property) => {
+    testElementMetadata.elements.forEach((element) => {
+      element.properties.forEach((property) => {
         propertyCount++;
-        const propertyValue = theme.getPropertyValue(part.partName, property.propertyName);
+        const propertyValue = theme.getPropertyValue(element.selector, property.propertyName);
         expect(propertyValue).to.exist;
       });
     });
@@ -28,8 +21,10 @@ describe('theme-detector', () => {
   it('should detect default CSS property values', async () => {
     const theme = detectTheme(testElementMetadata);
 
-    expect(theme.getPropertyValue(null, 'padding').value).to.equal('10px');
-    expect(theme.getPropertyValue('label', 'color').value).to.equal('rgb(0, 0, 0)');
+    expect(theme.getPropertyValue('test-element', 'padding').value).to.equal('10px');
+    expect(theme.getPropertyValue('test-element::part(label)', 'color').value).to.equal('rgb(0, 0, 0)');
+    expect(theme.getPropertyValue('test-element input[slot="input"]', 'border-radius').value).to.equal('5px');
+    expect(theme.getPropertyValue('test-element::part(helper-text)', 'color').value).to.equal('rgb(200, 200, 200)');
   });
 
   it('should detect themed CSS property values', async () => {
@@ -42,12 +37,22 @@ describe('theme-detector', () => {
         test-element::part(label) {
           color: green;
         }
+
+        test-element input[slot='input'] {
+          border-radius: 10px;
+        }
+
+        test-element::part(helper-text) {
+          color: blue;
+        }
       </style>
     `);
     const theme = detectTheme(testElementMetadata);
 
-    expect(theme.getPropertyValue(null, 'padding').value).to.equal('20px');
-    expect(theme.getPropertyValue('label', 'color').value).to.equal('rgb(0, 128, 0)');
+    expect(theme.getPropertyValue('test-element', 'padding').value).to.equal('20px');
+    expect(theme.getPropertyValue('test-element::part(label)', 'color').value).to.equal('rgb(0, 128, 0)');
+    expect(theme.getPropertyValue('test-element input[slot="input"]', 'border-radius').value).to.equal('10px');
+    expect(theme.getPropertyValue('test-element::part(helper-text)', 'color').value).to.equal('rgb(0, 0, 255)');
   });
 
   it('should remove test component from DOM', () => {

--- a/vaadin-dev-server/frontend/theme-editor/editor.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.test.ts
@@ -452,6 +452,25 @@ describe('theme-editor', () => {
       expect(historySpy.push.args).to.deep.equal([['request1']]);
     });
 
+    it('should add history entry for setting class name when editing property', async () => {
+      // Simulate selected component not having a class name yet
+      apiMock.loadComponentMetadata.returns(
+        Promise.resolve({
+          accessible: true,
+          suggestedClassName: 'suggested-class'
+        })
+      );
+      apiMock.setLocalClassName.returns(Promise.resolve({ requestId: 'request1' }));
+      apiMock.setCssRules.returns(Promise.resolve({ requestId: 'request2' }));
+
+      // edit something
+      await pickComponent();
+      await editProperty('Label', 'color', 'red');
+
+      expect(historySpy.push.calledTwice).to.be.true;
+      expect(historySpy.push.args).to.deep.equal([['request1'], ['request2']]);
+    });
+
     it('should call undo when clicking undo button', async () => {
       apiMock.setCssRules.returns(Promise.resolve({ requestId: 'request1' }));
 

--- a/vaadin-dev-server/frontend/theme-editor/editor.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.test.ts
@@ -23,7 +23,7 @@ describe('theme-editor', () => {
   };
   let apiMock: {
     loadComponentMetadata: sinon.SinonStub;
-    setComponentClassName: sinon.SinonStub;
+    setLocalClassName: sinon.SinonStub;
     setCssRules: sinon.SinonStub;
     loadPreview: sinon.SinonStub;
     loadRules: sinon.SinonStub;
@@ -56,7 +56,7 @@ describe('theme-editor', () => {
 
     apiMock = {
       loadComponentMetadata: sinon.stub((editor as any).api as ThemeEditorApi, 'loadComponentMetadata'),
-      setComponentClassName: sinon.stub((editor as any).api as ThemeEditorApi, 'setComponentClassName'),
+      setLocalClassName: sinon.stub((editor as any).api as ThemeEditorApi, 'setLocalClassName'),
       setCssRules: sinon.stub((editor as any).api as ThemeEditorApi, 'setCssRules'),
       loadPreview: sinon.stub((editor as any).api as ThemeEditorApi, 'loadPreview'),
       loadRules: sinon.stub((editor as any).api as ThemeEditorApi, 'loadRules'),
@@ -64,7 +64,7 @@ describe('theme-editor', () => {
       redo: sinon.stub((editor as any).api as ThemeEditorApi, 'redo')
     };
     apiMock.loadComponentMetadata.returns(Promise.resolve({ accessible: true, className: 'test-class' }));
-    apiMock.setComponentClassName.returns(Promise.resolve({}));
+    apiMock.setLocalClassName.returns(Promise.resolve({}));
     apiMock.setCssRules.returns(Promise.resolve({}));
     apiMock.loadPreview.returns(Promise.resolve({ css: '' }));
     apiMock.loadRules.returns(Promise.resolve({ rules: [], accessible: true }));
@@ -683,8 +683,8 @@ describe('theme-editor', () => {
       await editProperty('Label', 'color', 'red');
 
       // should make API call to apply class name
-      expect(apiMock.setComponentClassName.calledOnce).to.be.true;
-      expect(apiMock.setComponentClassName.args[0]).to.deep.equal([testComponentRef, 'suggested-class']);
+      expect(apiMock.setLocalClassName.calledOnce).to.be.true;
+      expect(apiMock.setLocalClassName.args[0]).to.deep.equal([testComponentRef, 'suggested-class']);
       // should add class name to selected component
       expect(testElement.classList.contains('suggested-class')).to.be.true;
     });

--- a/vaadin-dev-server/frontend/theme-editor/editor.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.test.ts
@@ -22,6 +22,8 @@ describe('theme-editor', () => {
     send: sinon.SinonSpy;
   };
   let apiMock: {
+    loadComponentMetadata: sinon.SinonStub;
+    setComponentClassName: sinon.SinonStub;
     setCssRules: sinon.SinonStub;
     loadPreview: sinon.SinonStub;
     loadRules: sinon.SinonStub;
@@ -53,12 +55,16 @@ describe('theme-editor', () => {
     ></vaadin-dev-tools-theme-editor>`)) as ThemeEditor;
 
     apiMock = {
+      loadComponentMetadata: sinon.stub((editor as any).api as ThemeEditorApi, 'loadComponentMetadata'),
+      setComponentClassName: sinon.stub((editor as any).api as ThemeEditorApi, 'setComponentClassName'),
       setCssRules: sinon.stub((editor as any).api as ThemeEditorApi, 'setCssRules'),
       loadPreview: sinon.stub((editor as any).api as ThemeEditorApi, 'loadPreview'),
       loadRules: sinon.stub((editor as any).api as ThemeEditorApi, 'loadRules'),
       undo: sinon.stub((editor as any).api as ThemeEditorApi, 'undo'),
       redo: sinon.stub((editor as any).api as ThemeEditorApi, 'redo')
     };
+    apiMock.loadComponentMetadata.returns(Promise.resolve({ accessible: true, className: 'test-class' }));
+    apiMock.setComponentClassName.returns(Promise.resolve({}));
     apiMock.setCssRules.returns(Promise.resolve({}));
     apiMock.loadPreview.returns(Promise.resolve({ css: '' }));
     apiMock.loadRules.returns(Promise.resolve({ rules: [], accessible: true }));
@@ -85,17 +91,16 @@ describe('theme-editor', () => {
     await aTimeout(50);
   }
 
-  function findPropertyEditor(partName: string | null, propertyName: string) {
-    const partTestId = partName || 'host';
+  function findPropertyEditor(elementName: string, propertyName: string) {
     return editor
       .shadowRoot!.querySelector('.property-list')
       ?.shadowRoot!.querySelector(
-        `.section[data-testid="${partTestId}"] .property-editor[data-testid="${propertyName}"]`
+        `.section[data-testid="${elementName}"] .property-editor[data-testid="${propertyName}"]`
       )!;
   }
 
-  async function editProperty(partName: string, propertyName: string, value: string) {
-    const propertyEditor = findPropertyEditor(partName, propertyName);
+  async function editProperty(elementName: string, propertyName: string, value: string) {
+    const propertyEditor = findPropertyEditor(elementName, propertyName);
 
     expect(propertyEditor).to.exist;
 
@@ -105,8 +110,8 @@ describe('theme-editor', () => {
     await elementUpdated(editor);
   }
 
-  function getPropertyValue(partName: string, propertyName: string) {
-    const propertyEditor = findPropertyEditor(partName, propertyName);
+  function getPropertyValue(elementName: string, propertyName: string) {
+    const propertyEditor = findPropertyEditor(elementName, propertyName);
     const input = propertyEditor.shadowRoot!.querySelector('input')! as HTMLInputElement;
     return input.value;
   }
@@ -153,13 +158,11 @@ describe('theme-editor', () => {
     };
   }
 
-  function mockRulesResponse(partName: string, propertyName: string, value: string) {
+  function mockRulesResponse(selector: string, propertyName: string, value: string) {
     return Promise.resolve({
-      accessible: true,
       rules: [
         {
-          tagName: 'test-element',
-          partName,
+          selector,
           properties: {
             [propertyName]: value
           }
@@ -219,7 +222,7 @@ describe('theme-editor', () => {
       await pickComponent();
       apiMock.loadPreview.resetHistory();
 
-      await editProperty('label', 'color', 'red');
+      await editProperty('Label', 'color', 'red');
 
       expect(apiMock.loadPreview.calledOnce).to.be.true;
       expect(getTestElementStyles().label.color).to.equal('rgb(255, 0, 0)');
@@ -228,15 +231,9 @@ describe('theme-editor', () => {
     it('should show property editors for picked component', async () => {
       await pickComponent();
 
-      // Host properties
-      testElementMetadata.properties.forEach((property) => {
-        const propertyEditor = findPropertyEditor(null, property.propertyName);
-        expect(propertyEditor).to.exist;
-      });
-      // Part properties
-      testElementMetadata.parts.forEach((part) => {
-        part.properties.forEach((property) => {
-          const propertyEditor = findPropertyEditor(part.partName, property.propertyName);
+      testElementMetadata.elements.forEach((element) => {
+        element.properties.forEach((property) => {
+          const propertyEditor = findPropertyEditor(element.displayName, property.propertyName);
           expect(propertyEditor).to.exist;
         });
       });
@@ -245,17 +242,15 @@ describe('theme-editor', () => {
     it('should initialize property editors with base theme values when there are no custom rules', async () => {
       await pickComponent();
 
-      expect(getPropertyValue('label', 'color')).to.equal('rgb(0, 0, 0)');
+      expect(getPropertyValue('Label', 'color')).to.equal('rgb(0, 0, 0)');
     });
 
     it('should initialize property editors with values from custom rules', async () => {
       apiMock.loadRules.returns(
         Promise.resolve({
-          accessible: true,
           rules: [
             {
-              tagName: 'test-element',
-              partName: 'label',
+              selector: 'test-element.test-class::part(label)',
               properties: {
                 color: 'red'
               }
@@ -265,21 +260,21 @@ describe('theme-editor', () => {
       );
       await pickComponent();
 
-      expect(getPropertyValue('label', 'color')).to.equal('red');
+      expect(getPropertyValue('Label', 'color')).to.equal('red');
     });
 
     it('should update property editors with edited theme values', async () => {
       await pickComponent();
-      await editProperty('label', 'color', 'red');
+      await editProperty('Label', 'color', 'red');
 
-      expect(getPropertyValue('label', 'color')).to.equal('red');
+      expect(getPropertyValue('Label', 'color')).to.equal('red');
     });
 
     it('should mark property as modified', async () => {
       await pickComponent();
-      await editProperty('label', 'color', 'red');
+      await editProperty('Label', 'color', 'red');
 
-      const modifiedIndicator = findPropertyEditor('label', 'color').shadowRoot!.querySelector(
+      const modifiedIndicator = findPropertyEditor('Label', 'color').shadowRoot!.querySelector(
         '.property-name .modified'
       );
       expect(modifiedIndicator).to.exist;
@@ -288,23 +283,21 @@ describe('theme-editor', () => {
     it('should send theme rules when changing properties', async () => {
       await pickComponent();
 
-      await editProperty('label', 'color', 'red');
+      await editProperty('Label', 'color', 'red');
       expect(apiMock.setCssRules.calledOnce).to.be.true;
       expect(apiMock.setCssRules.args[0][0]).to.deep.equal([
         {
-          tagName: 'test-element',
-          partName: 'label',
+          selector: 'test-element.test-class::part(label)',
           properties: { color: 'red' }
         }
       ]);
       apiMock.setCssRules.resetHistory();
 
-      await editProperty('label', 'color', 'green');
+      await editProperty('Label', 'color', 'green');
       expect(apiMock.setCssRules.calledOnce).to.be.true;
       expect(apiMock.setCssRules.args[0][0]).to.deep.equal([
         {
-          tagName: 'test-element',
-          partName: 'label',
+          selector: 'test-element.test-class::part(label)',
           properties: { color: 'green' }
         }
       ]);
@@ -312,7 +305,7 @@ describe('theme-editor', () => {
 
     it('should dispatch event before saving changes', async () => {
       await pickComponent();
-      await editProperty('label', 'color', 'red');
+      await editProperty('Label', 'color', 'red');
 
       expect(beforeSaveSpy.calledOnce).to.be.true;
     });
@@ -322,35 +315,65 @@ describe('theme-editor', () => {
     it('should load rules for instance', async () => {
       await pickComponent();
 
-      expect(apiMock.loadRules.calledOnce);
-      expect(apiMock.loadRules.args).to.deep.equal([['test-element', testComponentRef]]);
+      expect(apiMock.loadRules.calledOnce).to.be.true;
+      expect(apiMock.loadRules.args).to.deep.equal([
+        [
+          [
+            'test-element.test-class',
+            'test-element.test-class::part(label)',
+            'test-element.test-class input[slot="input"]',
+            'test-element.test-class::part(helper-text)'
+          ]
+        ]
+      ]);
     });
 
     it('should update rules for instance', async () => {
       await pickComponent();
-      await editProperty('label', 'color', 'red');
+      await editProperty('Label', 'color', 'red');
 
       const expectedRules = [
         {
-          tagName: 'test-element',
-          partName: 'label',
+          selector: 'test-element.test-class::part(label)',
           properties: {
             color: 'red'
           }
         }
       ];
 
-      expect(apiMock.setCssRules.calledOnce);
-      expect(apiMock.setCssRules.args).to.deep.equal([[expectedRules, testComponentRef]]);
+      expect(apiMock.setCssRules.calledOnce).to.be.true;
+      expect(apiMock.setCssRules.args).to.deep.equal([[expectedRules]]);
     });
 
     it('should show notice if instance is inaccessible', async () => {
-      apiMock.loadRules.returns(Promise.resolve({ rules: [], accessible: false }));
+      apiMock.loadComponentMetadata.returns(Promise.resolve({ accessible: false }));
       await pickComponent();
 
       const propertyList = editor.shadowRoot!.querySelector('.property-list');
       expect(propertyList).to.not.exist;
       expect(editor.shadowRoot!.textContent).to.contain('The selected Test element can not be styled locally');
+    });
+
+    it('should not load rules if instance is inaccessible', async () => {
+      apiMock.loadComponentMetadata.returns(Promise.resolve({ accessible: false }));
+      await pickComponent();
+
+      expect(apiMock.loadRules.calledOnce).to.be.false;
+    });
+
+    it('should not load rules if instance does not have local class name', async () => {
+      apiMock.loadComponentMetadata.returns(Promise.resolve({ accessible: true }));
+      await pickComponent();
+
+      expect(apiMock.loadRules.calledOnce).to.be.false;
+    });
+
+    it('should render property list if instance does not have local class name', async () => {
+      apiMock.loadComponentMetadata.returns(Promise.resolve({ accessible: true }));
+      await pickComponent();
+
+      findPropertyEditor('Label', 'color');
+      findPropertyEditor('Input', 'color');
     });
   });
 
@@ -360,28 +383,36 @@ describe('theme-editor', () => {
       apiMock.loadRules.resetHistory();
       await changeThemeScope(ThemeScope.global);
 
-      expect(apiMock.loadRules.calledOnce);
-      expect(apiMock.loadRules.args).to.deep.equal([['test-element', null]]);
+      expect(apiMock.loadRules.calledOnce).to.be.true;
+      expect(apiMock.loadRules.args).to.deep.equal([
+        [
+          [
+            'test-element',
+            'test-element::part(label)',
+            'test-element input[slot="input"]',
+            'test-element::part(helper-text)'
+          ]
+        ]
+      ]);
     });
 
-    it('should update rules for instance', async () => {
+    it('should update global rules', async () => {
       await pickComponent();
       apiMock.loadRules.resetHistory();
       await changeThemeScope(ThemeScope.global);
-      await editProperty('label', 'color', 'red');
+      await editProperty('Label', 'color', 'red');
 
       const expectedRules = [
         {
-          tagName: 'test-element',
-          partName: 'label',
+          selector: 'test-element::part(label)',
           properties: {
             color: 'red'
           }
         }
       ];
 
-      expect(apiMock.setCssRules.calledOnce);
-      expect(apiMock.setCssRules.args).to.deep.equal([[expectedRules, null]]);
+      expect(apiMock.setCssRules.calledOnce).to.be.true;
+      expect(apiMock.setCssRules.args).to.deep.equal([[expectedRules]]);
     });
   });
 
@@ -396,7 +427,7 @@ describe('theme-editor', () => {
 
       // edit something
       await pickComponent();
-      await editProperty('label', 'color', 'red');
+      await editProperty('Label', 'color', 'red');
 
       // undo allowed
       expect(undoButton.getAttribute('disabled')).to.be.null;
@@ -415,7 +446,7 @@ describe('theme-editor', () => {
 
       // edit something
       await pickComponent();
-      await editProperty('label', 'color', 'red');
+      await editProperty('Label', 'color', 'red');
 
       expect(historySpy.push.calledOnce).to.be.true;
       expect(historySpy.push.args).to.deep.equal([['request1']]);
@@ -426,7 +457,7 @@ describe('theme-editor', () => {
 
       // edit something
       await pickComponent();
-      await editProperty('label', 'color', 'red');
+      await editProperty('Label', 'color', 'red');
 
       // undo
       await undo();
@@ -438,10 +469,10 @@ describe('theme-editor', () => {
     it('should refresh theme on undo', async () => {
       // edit something
       await pickComponent();
-      await editProperty('label', 'color', 'red');
+      await editProperty('Label', 'color', 'red');
 
       // mock theme responses
-      const rulesResponse = mockRulesResponse('label', 'color', 'green');
+      const rulesResponse = mockRulesResponse('test-element.test-class::part(label)', 'color', 'green');
       apiMock.loadRules.returns(rulesResponse);
       const previewResponse = mockPreviewResponse('test-element::part(label) { color: green }');
       apiMock.loadPreview.returns(previewResponse);
@@ -449,14 +480,14 @@ describe('theme-editor', () => {
       // undo
       await undo();
 
-      expect(getPropertyValue('label', 'color')).to.equal('green');
+      expect(getPropertyValue('Label', 'color')).to.equal('green');
       expect(getTestElementStyles().label.color).to.equal('rgb(0, 128, 0)');
     });
 
     it('should prevent live reload on undo', async () => {
       // edit something
       await pickComponent();
-      await editProperty('label', 'color', 'red');
+      await editProperty('Label', 'color', 'red');
 
       // undo
       beforeSaveSpy.resetHistory();
@@ -470,7 +501,7 @@ describe('theme-editor', () => {
 
       // edit something
       await pickComponent();
-      await editProperty('label', 'color', 'red');
+      await editProperty('Label', 'color', 'red');
 
       // undo
       await undo();
@@ -485,13 +516,13 @@ describe('theme-editor', () => {
     it('should refresh theme on redo', async () => {
       // edit something
       await pickComponent();
-      await editProperty('label', 'color', 'red');
+      await editProperty('Label', 'color', 'red');
 
       // undo
       await undo();
 
       // mock theme responses
-      const rulesResponse = mockRulesResponse('label', 'color', 'green');
+      const rulesResponse = mockRulesResponse('test-element.test-class::part(label)', 'color', 'green');
       apiMock.loadRules.returns(rulesResponse);
       const previewResponse = mockPreviewResponse('test-element::part(label) { color: green }');
       apiMock.loadPreview.returns(previewResponse);
@@ -499,14 +530,14 @@ describe('theme-editor', () => {
       // redo
       await redo();
 
-      expect(getPropertyValue('label', 'color')).to.equal('green');
+      expect(getPropertyValue('Label', 'color')).to.equal('green');
       expect(getTestElementStyles().label.color).to.equal('rgb(0, 128, 0)');
     });
 
     it('should prevent live reload on redo', async () => {
       // edit something
       await pickComponent();
-      await editProperty('label', 'color', 'red');
+      await editProperty('Label', 'color', 'red');
 
       // undo
       await undo();
@@ -523,7 +554,7 @@ describe('theme-editor', () => {
     it('should detect base theme when changing scope', async () => {
       await pickComponent();
       await changeThemeScope(ThemeScope.global);
-      await editProperty('label', 'color', 'red');
+      await editProperty('Label', 'color', 'red');
       apiMock.loadPreview.returns(
         Promise.resolve({
           css: 'test-element::part(label) { color: red }'
@@ -531,13 +562,13 @@ describe('theme-editor', () => {
       );
       await changeThemeScope(ThemeScope.local);
 
-      expect(getPropertyValue('label', 'color')).to.equal('rgb(255, 0, 0)');
+      expect(getPropertyValue('Label', 'color')).to.equal('rgb(255, 0, 0)');
     });
 
     it('should detect base theme on undo', async () => {
       await pickComponent();
       await changeThemeScope(ThemeScope.global);
-      await editProperty('label', 'color', 'red');
+      await editProperty('Label', 'color', 'red');
       apiMock.loadPreview.returns(
         Promise.resolve({
           css: 'test-element::part(label) { color: red }'
@@ -545,7 +576,7 @@ describe('theme-editor', () => {
       );
       await changeThemeScope(ThemeScope.local);
 
-      expect(getPropertyValue('label', 'color')).to.equal('rgb(255, 0, 0)');
+      expect(getPropertyValue('Label', 'color')).to.equal('rgb(255, 0, 0)');
 
       apiMock.loadPreview.returns(
         Promise.resolve({
@@ -554,13 +585,13 @@ describe('theme-editor', () => {
       );
       await undo();
 
-      expect(getPropertyValue('label', 'color')).to.equal('rgb(0, 0, 0)');
+      expect(getPropertyValue('Label', 'color')).to.equal('rgb(0, 0, 0)');
     });
 
     it('should detect base theme on redo', async () => {
       await pickComponent();
       await changeThemeScope(ThemeScope.global);
-      await editProperty('label', 'color', 'red');
+      await editProperty('Label', 'color', 'red');
       apiMock.loadPreview.returns(
         Promise.resolve({
           css: 'test-element::part(label) { color: red }'
@@ -568,7 +599,7 @@ describe('theme-editor', () => {
       );
       await changeThemeScope(ThemeScope.local);
 
-      expect(getPropertyValue('label', 'color')).to.equal('rgb(255, 0, 0)');
+      expect(getPropertyValue('Label', 'color')).to.equal('rgb(255, 0, 0)');
 
       apiMock.loadPreview.returns(
         Promise.resolve({
@@ -577,7 +608,7 @@ describe('theme-editor', () => {
       );
       await undo();
 
-      expect(getPropertyValue('label', 'color')).to.equal('rgb(0, 0, 0)');
+      expect(getPropertyValue('Label', 'color')).to.equal('rgb(0, 0, 0)');
 
       apiMock.loadPreview.returns(
         Promise.resolve({
@@ -586,7 +617,7 @@ describe('theme-editor', () => {
       );
       await redo();
 
-      expect(getPropertyValue('label', 'color')).to.equal('rgb(255, 0, 0)');
+      expect(getPropertyValue('Label', 'color')).to.equal('rgb(255, 0, 0)');
     });
   });
 
@@ -635,42 +666,52 @@ describe('theme-editor', () => {
     });
   });
 
-  describe('optimistic class name update', () => {
-    it('should add generated className from set rules response to selected component', async () => {
-      apiMock.setCssRules.returns({
-        className: 'tb-1234567890'
-      });
-      await pickComponent();
-      await editProperty('label', 'color', 'red');
-
-      expect(testElement.classList.contains('tb-1234567890')).to.be.true;
+  describe('applying class name', () => {
+    beforeEach(() => {
+      // Simulate selected component not having a class name yet
+      apiMock.loadComponentMetadata.returns(
+        Promise.resolve({
+          accessible: true,
+          suggestedClassName: 'suggested-class'
+        })
+      );
     });
 
-    it('should add generated className from load rules response to selected component', async () => {
-      apiMock.loadRules.returns({
+    it('should apply suggested class name before setting rules', async () => {
+      await pickComponent();
+      debugger;
+      await editProperty('Label', 'color', 'red');
+
+      // should make API call to apply class name
+      expect(apiMock.setComponentClassName.calledOnce).to.be.true;
+      expect(apiMock.setComponentClassName.args[0]).to.deep.equal([testComponentRef, 'suggested-class']);
+      // should add class name to selected component
+      expect(testElement.classList.contains('suggested-class')).to.be.true;
+    });
+
+    it('should add existing className from component metadata response to selected component', async () => {
+      apiMock.loadComponentMetadata.returns({
         accessible: true,
-        className: 'tb-1234567890',
-        rules: []
+        className: 'existing-class'
       });
       await pickComponent();
 
-      expect(testElement.classList.contains('tb-1234567890')).to.be.true;
+      expect(testElement.classList.contains('existing-class')).to.be.true;
     });
 
-    it('should not add generated className from load rules response to previously selected component', async () => {
+    it('should not add existing className from component metadata response to previously selected component', async () => {
       await pickComponent();
 
       const anotherElement = (await fixture(html` <test-element></test-element>`)) as HTMLElement;
       testComponentRef = { nodeId: 123, uiId: 456, element: anotherElement };
-      apiMock.loadRules.returns({
+      apiMock.loadComponentMetadata.returns({
         accessible: true,
-        className: 'tb-1234567890',
-        rules: []
+        className: 'existing-class'
       });
       await pickComponent();
 
-      expect(testElement.classList.contains('tb-1234567890')).to.be.false;
-      expect(anotherElement.classList.contains('tb-1234567890')).to.be.true;
+      expect(testElement.classList.contains('existing-class')).to.be.false;
+      expect(anotherElement.classList.contains('existing-class')).to.be.true;
     });
   });
 });

--- a/vaadin-dev-server/frontend/theme-editor/editor.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.test.ts
@@ -698,7 +698,6 @@ describe('theme-editor', () => {
 
     it('should apply suggested class name before setting rules', async () => {
       await pickComponent();
-      debugger;
       await editProperty('Label', 'color', 'red');
 
       // should make API call to apply class name

--- a/vaadin-dev-server/frontend/theme-editor/editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.ts
@@ -368,7 +368,8 @@ export class ThemeEditor extends LitElement {
     if (this.context.scope === ThemeScope.local && !this.context.localClassName && this.context.suggestedClassName) {
       const newClassName = this.context.suggestedClassName;
       this.context.localClassName = newClassName;
-      await this.api.setLocalClassName(this.context.component, newClassName);
+      const classNameResponse = await this.api.setLocalClassName(this.context.component, newClassName);
+      this.historyActions = this.history.push(classNameResponse.requestId);
       this.previewGeneratedClassName(this.context.component.element, newClassName);
     }
 

--- a/vaadin-dev-server/frontend/theme-editor/editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.ts
@@ -368,12 +368,12 @@ export class ThemeEditor extends LitElement {
     if (this.context.scope === ThemeScope.local && !this.context.localClassName && this.context.suggestedClassName) {
       const newClassName = this.context.suggestedClassName;
       this.context.localClassName = newClassName;
-      await this.api.setComponentClassName(this.context.component, newClassName);
+      await this.api.setLocalClassName(this.context.component, newClassName);
       this.previewGeneratedClassName(this.context.component.element, newClassName);
     }
 
     // Can't generate a local scoped selector without a local classname
-    if (this.context.scope === ThemeScope.global && !this.context.localClassName) {
+    if (this.context.scope === ThemeScope.local && !this.context.localClassName) {
       console.error('Failed to update property value because selected component does not have a local class name');
       return;
     }

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-avatar.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-avatar.ts
@@ -1,15 +1,22 @@
-import {ComponentMetadata, EditorType} from '../model';
-import {presets} from "./presets";
+import { ComponentMetadata, EditorType } from '../model';
+import { presets } from './presets';
 
 export default {
-    tagName: 'vaadin-avatar',
-    displayName: 'Avatar',
-    properties: [{
-        propertyName: '--vaadin-avatar-size',
-        displayName: 'Size',
-        editorType: EditorType.range,
-        presets: presets.lumoSize,
-        icon: 'square'
-    }],
-    parts: []
+  tagName: 'vaadin-avatar',
+  displayName: 'Avatar',
+  elements: [
+    {
+      selector: 'vaadin-avatar',
+      displayName: 'Host',
+      properties: [
+        {
+          propertyName: '--vaadin-avatar-size',
+          displayName: 'Size',
+          editorType: EditorType.range,
+          presets: presets.lumoSize,
+          icon: 'square'
+        }
+      ]
+    }
+  ]
 } as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-button.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-button.ts
@@ -4,36 +4,40 @@ import { presets } from './presets';
 export default {
   tagName: 'vaadin-button',
   displayName: 'Button',
-  properties: [
+  elements: [
     {
-      propertyName: 'background-color',
-      displayName: 'Background color',
-      editorType: EditorType.color
+      selector: 'vaadin-button',
+      displayName: 'Host',
+      properties: [
+        {
+          propertyName: 'background-color',
+          displayName: 'Background color',
+          editorType: EditorType.color
+        },
+        {
+          propertyName: 'color',
+          displayName: 'Text color',
+          editorType: EditorType.color,
+          presets: presets.lumoTextColor
+        },
+        {
+          propertyName: '--lumo-button-size',
+          displayName: 'Size',
+          editorType: EditorType.range,
+          presets: presets.lumoSize,
+          icon: 'square'
+        },
+        {
+          propertyName: 'padding-inline',
+          displayName: 'Padding',
+          editorType: EditorType.range,
+          presets: presets.lumoSpace,
+          icon: 'square'
+        }
+      ]
     },
     {
-      propertyName: 'color',
-      displayName: 'Text color',
-      editorType: EditorType.color,
-      presets: presets.lumoTextColor
-    },
-    {
-      propertyName: '--lumo-button-size',
-      displayName: 'Size',
-      editorType: EditorType.range,
-      presets: presets.lumoSize,
-      icon: 'square'
-    },
-    {
-      propertyName: 'padding-inline',
-      displayName: 'Padding',
-      editorType: EditorType.range,
-      presets: presets.lumoSpace,
-      icon: 'square'
-    }
-  ],
-  parts: [
-    {
-      partName: 'label',
+      selector: 'vaadin-button::part(label)',
       displayName: 'Label',
       properties: [
         {

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-checkbox.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-checkbox.ts
@@ -1,34 +1,40 @@
-import {ComponentMetadata, EditorType} from '../model';
-import {presets} from "./presets";
+import { ComponentMetadata, EditorType } from '../model';
+import { presets } from './presets';
 
 export default {
-    tagName: 'vaadin-checkbox',
-    displayName: 'Checkbox',
-    properties: [
+  tagName: 'vaadin-checkbox',
+  displayName: 'Checkbox',
+  elements: [
+    {
+      selector: 'vaadin-checkbox',
+      displayName: 'Host',
+      properties: [
         {
-            propertyName: '--lumo-primary-color',
-            displayName: 'Color',
-            editorType: EditorType.color
+          propertyName: '--lumo-primary-color',
+          displayName: 'Color',
+          editorType: EditorType.color
         },
         {
-            propertyName: '--vaadin-checkbox-size',
-            displayName: 'Size',
-            editorType: EditorType.range,
-            presets: presets.lumoSize,
-            icon: 'square'
+          propertyName: '--vaadin-checkbox-size',
+          displayName: 'Size',
+          editorType: EditorType.range,
+          presets: presets.lumoSize,
+          icon: 'square'
         },
         {
-            propertyName: '--lumo-font-size-m',
-            displayName: 'Font Size',
-            editorType: EditorType.range,
-            presets: presets.lumoSize,
-            icon: 'square'
+          propertyName: '--lumo-font-size-m',
+          displayName: 'Font Size',
+          editorType: EditorType.range,
+          presets: presets.lumoSize,
+          icon: 'square'
         },
         {
-            propertyName: '--lumo-body-text-color',
-            displayName: 'Text color',
-            editorType: EditorType.color,
-            presets: presets.lumoTextColor
-        }],
-    parts: []
+          propertyName: '--lumo-body-text-color',
+          displayName: 'Text color',
+          editorType: EditorType.color,
+          presets: presets.lumoTextColor
+        }
+      ]
+    }
+  ]
 } as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-number-field.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-number-field.ts
@@ -1,8 +1,34 @@
 import { ComponentMetadata } from '../model';
-import vaadinTextField from './vaadin-text-field';
+import {
+  errorMessageProperties,
+  helperTextProperties,
+  inputFieldProperties,
+  labelProperties
+} from './vaadin-text-field';
 
 export default {
-    ...vaadinTextField,
-    tagName: 'vaadin-number-field',
-    displayName: 'NumberField'
+  tagName: 'vaadin-number-field',
+  displayName: 'NumberField',
+  elements: [
+    {
+      selector: 'vaadin-number-field::part(label)',
+      displayName: 'Label',
+      properties: labelProperties
+    },
+    {
+      selector: 'vaadin-number-field::part(input-field)',
+      displayName: 'Input field',
+      properties: inputFieldProperties
+    },
+    {
+      selector: 'vaadin-number-field::part(helper-text)',
+      displayName: 'Helper text',
+      properties: helperTextProperties
+    },
+    {
+      selector: 'vaadin-number-field::part(error-message)',
+      displayName: 'Error message',
+      properties: errorMessageProperties
+    }
+  ]
 } as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-progress-bar.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-progress-bar.ts
@@ -1,31 +1,32 @@
-import {ComponentMetadata, EditorType} from '../model';
-import {presets} from "./presets";
+import { ComponentMetadata, EditorType } from '../model';
+import { presets } from './presets';
 
 export default {
-    tagName: 'vaadin-progress-bar',
-    displayName: 'ProgressBar',
-    properties: [],
-    parts: [{
-        partName: 'bar',
-        displayName: 'Bar',
-        properties: [
-            {
-                propertyName: 'background-color',
-                displayName: 'Color',
-                editorType: EditorType.color
-            }
-        ]
+  tagName: 'vaadin-progress-bar',
+  displayName: 'ProgressBar',
+  elements: [
+    {
+      selector: 'vaadin-progress-bar::part(bar)',
+      displayName: 'Bar',
+      properties: [
+        {
+          propertyName: 'background-color',
+          displayName: 'Color',
+          editorType: EditorType.color
+        }
+      ]
     },
     {
-        partName: 'value',
-        displayName: 'Value',
-        properties: [
-            {
-                propertyName: 'background-color',
-                displayName: 'Color',
-                editorType: EditorType.color,
-                presets: presets.lumoTextColor
-            }
-        ]
-    }]
+      selector: 'vaadin-progress-bar::part(value)',
+      displayName: 'Value',
+      properties: [
+        {
+          propertyName: 'background-color',
+          displayName: 'Color',
+          editorType: EditorType.color,
+          presets: presets.lumoTextColor
+        }
+      ]
+    }
+  ]
 } as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-text-area.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-text-area.ts
@@ -1,106 +1,34 @@
-import {ComponentMetadata, EditorType} from '../model';
-import {presets} from "./presets";
+import { ComponentMetadata } from '../model';
+import {
+  errorMessageProperties,
+  helperTextProperties,
+  inputFieldProperties,
+  labelProperties
+} from './vaadin-text-field';
 
 export default {
-    tagName: 'vaadin-text-area',
-    displayName: 'TextArea',
-    properties: [],
-    parts: [
-        {
-            partName: 'label',
-            displayName: 'Label',
-            properties: [
-                {
-                    propertyName: 'color',
-                    displayName: 'Text color',
-                    editorType: EditorType.color,
-                    presets: presets.lumoTextColor
-                },
-                {
-                    propertyName: 'font-size',
-                    displayName: 'Font size',
-                    editorType: EditorType.range,
-                    presets: presets.lumoFontSize,
-                    icon: 'font'
-                },
-                {
-                    propertyName: 'background-color',
-                    displayName: 'Background color',
-                    editorType: EditorType.color
-                }
-            ]
-        },
-        {
-            partName: 'input-field',
-            displayName: 'Input field',
-            properties: [
-                {
-                    propertyName: 'color',
-                    displayName: 'Text color',
-                    editorType: EditorType.color,
-                    presets: presets.lumoTextColor
-                },
-                {
-                    propertyName: 'font-size',
-                    displayName: 'Font size',
-                    editorType: EditorType.range,
-                    presets: presets.lumoFontSize,
-                    icon: 'font'
-                },
-                {
-                    propertyName: 'background-color',
-                    displayName: 'Background color',
-                    editorType: EditorType.color
-                }
-            ]
-        },
-        {
-            partName: 'helper-text',
-            displayName: 'Helper text',
-            properties: [
-                {
-                    propertyName: 'color',
-                    displayName: 'Text color',
-                    editorType: EditorType.color,
-                    presets: presets.lumoTextColor
-                },
-                {
-                    propertyName: 'font-size',
-                    displayName: 'Font size',
-                    editorType: EditorType.range,
-                    presets: presets.lumoFontSize,
-                    icon: 'font'
-                },
-                {
-                    propertyName: 'background-color',
-                    displayName: 'Background color',
-                    editorType: EditorType.color
-                }
-            ]
-        },
-        {
-            partName: 'error-message',
-            displayName: 'Error message',
-            properties: [
-                {
-                    propertyName: 'color',
-                    displayName: 'Text color',
-                    editorType: EditorType.color,
-                    presets: presets.lumoTextColor
-                },
-                {
-                    propertyName: 'font-size',
-                    displayName: 'Font size',
-                    editorType: EditorType.range,
-                    presets: presets.lumoFontSize,
-                    icon: 'font'
-                },
-                {
-                    propertyName: 'background-color',
-                    displayName: 'Background color',
-                    editorType: EditorType.color
-                }
-            ]
-        }
-    ]
+  tagName: 'vaadin-text-area',
+  displayName: 'TextArea',
+  elements: [
+    {
+      selector: 'vaadin-text-area::part(label)',
+      displayName: 'Label',
+      properties: labelProperties
+    },
+    {
+      selector: 'vaadin-text-area::part(input-field)',
+      displayName: 'Input field',
+      properties: inputFieldProperties
+    },
+    {
+      selector: 'vaadin-text-area::part(helper-text)',
+      displayName: 'Helper text',
+      properties: helperTextProperties
+    },
+    {
+      selector: 'vaadin-text-area::part(error-message)',
+      displayName: 'Error message',
+      properties: errorMessageProperties
+    }
+  ]
 } as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-text-field.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-text-field.ts
@@ -1,106 +1,113 @@
-import {ComponentMetadata, EditorType} from '../model';
-import {presets} from "./presets";
+import { ComponentMetadata, CssPropertyMetadata, EditorType } from '../model';
+import { presets } from './presets';
+
+export const labelProperties: CssPropertyMetadata[] = [
+  {
+    propertyName: 'color',
+    displayName: 'Text color',
+    editorType: EditorType.color,
+    presets: presets.lumoTextColor
+  },
+  {
+    propertyName: 'font-size',
+    displayName: 'Font size',
+    editorType: EditorType.range,
+    presets: presets.lumoFontSize,
+    icon: 'font'
+  },
+  {
+    propertyName: 'background-color',
+    displayName: 'Background color',
+    editorType: EditorType.color
+  }
+];
+
+export const inputFieldProperties: CssPropertyMetadata[] = [
+  {
+    propertyName: 'color',
+    displayName: 'Text color',
+    editorType: EditorType.color,
+    presets: presets.lumoTextColor
+  },
+  {
+    propertyName: 'font-size',
+    displayName: 'Font size',
+    editorType: EditorType.range,
+    presets: presets.lumoFontSize,
+    icon: 'font'
+  },
+  {
+    propertyName: 'background-color',
+    displayName: 'Background color',
+    editorType: EditorType.color
+  }
+];
+
+export const helperTextProperties: CssPropertyMetadata[] = [
+  {
+    propertyName: 'color',
+    displayName: 'Text color',
+    editorType: EditorType.color,
+    presets: presets.lumoTextColor
+  },
+  {
+    propertyName: 'font-size',
+    displayName: 'Font size',
+    editorType: EditorType.range,
+    presets: presets.lumoFontSize,
+    icon: 'font'
+  },
+  {
+    propertyName: 'background-color',
+    displayName: 'Background color',
+    editorType: EditorType.color
+  }
+];
+
+export const errorMessageProperties: CssPropertyMetadata[] = [
+  {
+    propertyName: 'color',
+    displayName: 'Text color',
+    editorType: EditorType.color,
+    presets: presets.lumoTextColor
+  },
+  {
+    propertyName: 'font-size',
+    displayName: 'Font size',
+    editorType: EditorType.range,
+    presets: presets.lumoFontSize,
+    icon: 'font'
+  },
+  {
+    propertyName: 'background-color',
+    displayName: 'Background color',
+    editorType: EditorType.color
+  }
+];
 
 export default {
   tagName: 'vaadin-text-field',
   displayName: 'TextField',
-  properties: [],
-  parts: [
+  elements: [
     {
-      partName: 'label',
+      selector: 'vaadin-text-field::part(label)',
       displayName: 'Label',
-      properties: [
-        {
-          propertyName: 'color',
-          displayName: 'Text color',
-          editorType: EditorType.color,
-          presets: presets.lumoTextColor
-        },
-        {
-          propertyName: 'font-size',
-          displayName: 'Font size',
-          editorType: EditorType.range,
-          presets: presets.lumoFontSize,
-          icon: 'font'
-        },
-        {
-          propertyName: 'background-color',
-          displayName: 'Background color',
-          editorType: EditorType.color
-        }
-      ]
+      properties: labelProperties
     },
     {
-      partName: 'input-field',
+      selector: 'vaadin-text-field::part(input-field)',
       displayName: 'Input field',
-      properties: [
-        {
-          propertyName: 'color',
-          displayName: 'Text color',
-          editorType: EditorType.color,
-          presets: presets.lumoTextColor
-        },
-        {
-          propertyName: 'font-size',
-          displayName: 'Font size',
-          editorType: EditorType.range,
-          presets: presets.lumoFontSize,
-          icon: 'font'
-        },
-        {
-          propertyName: 'background-color',
-          displayName: 'Background color',
-          editorType: EditorType.color
-        }
-      ]
+      properties: inputFieldProperties
     },
     {
-      partName: 'helper-text',
+      selector: 'vaadin-text-field::part(helper-text)',
       displayName: 'Helper text',
-      properties: [
-        {
-          propertyName: 'color',
-          displayName: 'Text color',
-          editorType: EditorType.color,
-          presets: presets.lumoTextColor
-        },
-        {
-          propertyName: 'font-size',
-          displayName: 'Font size',
-          editorType: EditorType.range,
-          presets: presets.lumoFontSize,
-          icon: 'font'
-        },
-        {
-          propertyName: 'background-color',
-          displayName: 'Background color',
-          editorType: EditorType.color
-        }
-      ]
+      properties: helperTextProperties
     },
     {
-      partName: 'error-message',
+      selector: 'vaadin-text-field::part(error-message)',
       displayName: 'Error message',
-      properties: [
-        {
-          propertyName: 'color',
-          displayName: 'Text color',
-          editorType: EditorType.color,
-          presets: presets.lumoTextColor
-        },
-        {
-          propertyName: 'font-size',
-          displayName: 'Font size',
-          editorType: EditorType.range,
-          presets: presets.lumoFontSize,
-          icon: 'font'
-        },
-        {
-          propertyName: 'background-color',
-          displayName: 'Background color',
-          editorType: EditorType.color
-        }
-      ]
+      properties: errorMessageProperties
     }
   ]
 } as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/model.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/model.ts
@@ -13,8 +13,8 @@ export interface CssPropertyMetadata {
   icon?: string;
 }
 
-export interface ComponentPartMetadata {
-  partName: string;
+export interface ComponentElementMetadata {
+  selector: string;
   displayName: string;
   description?: string;
   properties: CssPropertyMetadata[];
@@ -24,6 +24,5 @@ export interface ComponentMetadata {
   tagName: string;
   displayName: string;
   description?: string;
-  properties: CssPropertyMetadata[];
-  parts: ComponentPartMetadata[];
+  elements: ComponentElementMetadata[];
 }

--- a/vaadin-dev-server/frontend/theme-editor/metadata/registry.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/registry.test.ts
@@ -59,7 +59,7 @@ describe('metadata-registry', () => {
     expect(metadata).to.not.be.null;
     expect(metadata!.tagName).to.equal('vaadin-button');
     expect(metadata!.displayName).to.equal('Button');
-    expect(metadata!.parts).to.be.instanceof(Array);
+    expect(metadata!.elements).to.be.instanceof(Array);
   });
 
   it('should cache metadata', async () => {

--- a/vaadin-dev-server/frontend/theme-editor/model.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/model.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@open-wc/testing';
-import { ComponentTheme, generateThemeRule, ThemePropertyValue } from './model';
+import { ComponentTheme, generateThemeRule, SelectorScope, ThemePropertyValue, ThemeScope } from './model';
 import buttonMetadata from './metadata/components/vaadin-button';
 import { ComponentMetadata } from './metadata/model';
 import { ServerCssRule } from './api';
@@ -14,22 +14,22 @@ describe('model', () => {
     });
 
     it('should return null for unset properties', () => {
-      expect(theme.getPropertyValue(null, 'background')).to.be.null;
-      expect(theme.getPropertyValue('label', 'color')).to.be.null;
+      expect(theme.getPropertyValue('vaadin-button', 'background')).to.be.null;
+      expect(theme.getPropertyValue('vaadin-button::part(label)', 'color')).to.be.null;
     });
 
     it('should add and return property values', () => {
-      theme.updatePropertyValue(null, 'background', 'cornflowerblue');
-      theme.updatePropertyValue('label', 'color', 'white');
+      theme.updatePropertyValue('vaadin-button', 'background', 'cornflowerblue');
+      theme.updatePropertyValue('vaadin-button::part(label)', 'color', 'white');
 
       const expectedHostBackgroundValue: ThemePropertyValue = {
-        partName: null,
+        elementSelector: 'vaadin-button',
         propertyName: 'background',
         value: 'cornflowerblue',
         modified: false
       };
       const expectedLabelColorValue: ThemePropertyValue = {
-        partName: 'label',
+        elementSelector: 'vaadin-button::part(label)',
         propertyName: 'color',
         value: 'white',
         modified: false
@@ -37,83 +37,108 @@ describe('model', () => {
 
       expect(theme.properties).to.deep.equal([expectedHostBackgroundValue, expectedLabelColorValue]);
 
-      const hostBackgroundValue = theme.getPropertyValue(null, 'background');
+      const hostBackgroundValue = theme.getPropertyValue('vaadin-button', 'background');
       expect(hostBackgroundValue).to.exist;
       expect(hostBackgroundValue).to.deep.equal(expectedHostBackgroundValue);
 
-      const labelColorValue = theme.getPropertyValue('label', 'color');
+      const labelColorValue = theme.getPropertyValue('vaadin-button::part(label)', 'color');
       expect(labelColorValue).to.exist;
       expect(labelColorValue).to.deep.equal(expectedLabelColorValue);
     });
 
     it('should update property values', () => {
-      theme.updatePropertyValue('label', 'color', 'white');
-      theme.updatePropertyValue('label', 'color', 'green');
-      theme.updatePropertyValue('label', 'color', 'red');
+      theme.updatePropertyValue('vaadin-button::part(label)', 'color', 'white');
+      theme.updatePropertyValue('vaadin-button::part(label)', 'color', 'green');
+      theme.updatePropertyValue('vaadin-button::part(label)', 'color', 'red');
 
       expect(theme.properties.length).to.equal(1);
 
-      const labelColorValue = theme.getPropertyValue('label', 'color');
+      const labelColorValue = theme.getPropertyValue('vaadin-button::part(label)', 'color');
       expect(labelColorValue.value).to.equal('red');
     });
 
     it('should merge a list of theme property values', () => {
-      theme.updatePropertyValue(null, 'background', 'cornflowerblue');
-      theme.updatePropertyValue('label', 'color', 'white');
+      theme.updatePropertyValue('vaadin-button', 'background', 'cornflowerblue');
+      theme.updatePropertyValue('vaadin-button::part(label)', 'color', 'white');
 
       theme.addPropertyValues([
         // Add new host prop
-        { partName: null, propertyName: 'padding', value: '3px', modified: false },
+        { elementSelector: 'vaadin-button', propertyName: 'padding', value: '3px', modified: false },
         // Update existing part prop
-        { partName: 'label', propertyName: 'color', value: 'red', modified: false },
+        { elementSelector: 'vaadin-button::part(label)', propertyName: 'color', value: 'red', modified: false },
         // Add new part prop
-        { partName: 'label', propertyName: 'font-size', value: '20px', modified: false }
+        {
+          elementSelector: 'vaadin-button::part(label)',
+          propertyName: 'font-size',
+          value: '20px',
+          modified: false
+        }
       ]);
 
-      const expectedValues = [
-        { partName: null, propertyName: 'background', value: 'cornflowerblue', modified: false },
-        { partName: 'label', propertyName: 'color', value: 'red', modified: false },
-        { partName: null, propertyName: 'padding', value: '3px', modified: false },
-        { partName: 'label', propertyName: 'font-size', value: '20px', modified: false }
+      const expectedValues: ThemePropertyValue[] = [
+        {
+          elementSelector: 'vaadin-button',
+          propertyName: 'background',
+          value: 'cornflowerblue',
+          modified: false
+        },
+        { elementSelector: 'vaadin-button::part(label)', propertyName: 'color', value: 'red', modified: false },
+        { elementSelector: 'vaadin-button', propertyName: 'padding', value: '3px', modified: false },
+        {
+          elementSelector: 'vaadin-button::part(label)',
+          propertyName: 'font-size',
+          value: '20px',
+          modified: false
+        }
       ];
 
       expect(theme.properties).to.deep.equal(expectedValues);
     });
 
     it('should update modified state when merging properties', () => {
-      theme.updatePropertyValue(null, 'background', 'cornflowerblue');
+      theme.updatePropertyValue('vaadin-button', 'background', 'cornflowerblue');
 
       theme.addPropertyValues([
-        { partName: null, propertyName: 'background', value: 'red', modified: true },
-        { partName: null, propertyName: 'padding', value: '3px', modified: true }
+        { elementSelector: 'vaadin-button', propertyName: 'background', value: 'red', modified: true },
+        { elementSelector: 'vaadin-button', propertyName: 'padding', value: '3px', modified: true }
       ]);
 
-      const expectedValues = [
-        { partName: null, propertyName: 'background', value: 'red', modified: true },
-        { partName: null, propertyName: 'padding', value: '3px', modified: true }
+      const expectedValues: ThemePropertyValue[] = [
+        { elementSelector: 'vaadin-button', propertyName: 'background', value: 'red', modified: true },
+        { elementSelector: 'vaadin-button', propertyName: 'padding', value: '3px', modified: true }
       ];
 
       expect(theme.properties).to.deep.equal(expectedValues);
     });
 
     it('should return a list of properties for a part', () => {
-      theme.updatePropertyValue(null, 'background', 'cornflowerblue');
-      theme.updatePropertyValue(null, 'padding', '3px');
-      theme.updatePropertyValue('label', 'color', 'white');
-      theme.updatePropertyValue('label', 'font-size', '20px');
+      theme.updatePropertyValue('vaadin-button', 'background', 'cornflowerblue');
+      theme.updatePropertyValue('vaadin-button', 'padding', '3px');
+      theme.updatePropertyValue('vaadin-button::part(label)', 'color', 'white');
+      theme.updatePropertyValue('vaadin-button::part(label)', 'font-size', '20px');
 
-      const expectedHostProperties = [
-        { partName: null, propertyName: 'background', value: 'cornflowerblue', modified: false },
-        { partName: null, propertyName: 'padding', value: '3px', modified: false }
+      const expectedHostProperties: ThemePropertyValue[] = [
+        {
+          elementSelector: 'vaadin-button',
+          propertyName: 'background',
+          value: 'cornflowerblue',
+          modified: false
+        },
+        { elementSelector: 'vaadin-button', propertyName: 'padding', value: '3px', modified: false }
       ];
-      const expectedLabelProperties = [
-        { partName: 'label', propertyName: 'color', value: 'white', modified: false },
-        { partName: 'label', propertyName: 'font-size', value: '20px', modified: false }
+      const expectedLabelProperties: ThemePropertyValue[] = [
+        { elementSelector: 'vaadin-button::part(label)', propertyName: 'color', value: 'white', modified: false },
+        {
+          elementSelector: 'vaadin-button::part(label)',
+          propertyName: 'font-size',
+          value: '20px',
+          modified: false
+        }
       ];
 
-      expect(theme.getPropertyValuesForPart(null)).to.deep.equal(expectedHostProperties);
-      expect(theme.getPropertyValuesForPart('label')).to.deep.equal(expectedLabelProperties);
-      expect(theme.getPropertyValuesForPart('unknown-part')).to.deep.equal([]);
+      expect(theme.getPropertyValuesForElement('vaadin-button')).to.deep.equal(expectedHostProperties);
+      expect(theme.getPropertyValuesForElement('vaadin-button::part(label)')).to.deep.equal(expectedLabelProperties);
+      expect(theme.getPropertyValuesForElement('vaadin-button::part(unknown-part)')).to.deep.equal([]);
     });
   });
 
@@ -129,20 +154,30 @@ describe('model', () => {
 
     it('should merge theme properties', () => {
       const theme1 = new ComponentTheme(buttonMetadata);
-      theme1.updatePropertyValue(null, 'background', 'cornflowerblue');
-      theme1.updatePropertyValue('label', 'color', 'white');
+      theme1.updatePropertyValue('vaadin-button', 'background', 'cornflowerblue');
+      theme1.updatePropertyValue('vaadin-button::part(label)', 'color', 'white');
 
       const theme2 = new ComponentTheme(buttonMetadata);
-      theme2.updatePropertyValue(null, 'padding', '3px');
-      theme2.updatePropertyValue('label', 'color', 'red');
-      theme2.updatePropertyValue('label', 'font-size', '20px');
+      theme2.updatePropertyValue('vaadin-button', 'padding', '3px');
+      theme2.updatePropertyValue('vaadin-button::part(label)', 'color', 'red');
+      theme2.updatePropertyValue('vaadin-button::part(label)', 'font-size', '20px');
 
       const result = ComponentTheme.combine(theme1, theme2);
-      const expectedValues = [
-        { partName: null, propertyName: 'background', value: 'cornflowerblue', modified: false },
-        { partName: 'label', propertyName: 'color', value: 'red', modified: false },
-        { partName: null, propertyName: 'padding', value: '3px', modified: false },
-        { partName: 'label', propertyName: 'font-size', value: '20px', modified: false }
+      const expectedValues: ThemePropertyValue[] = [
+        {
+          elementSelector: 'vaadin-button',
+          propertyName: 'background',
+          value: 'cornflowerblue',
+          modified: false
+        },
+        { elementSelector: 'vaadin-button::part(label)', propertyName: 'color', value: 'red', modified: false },
+        { elementSelector: 'vaadin-button', propertyName: 'padding', value: '3px', modified: false },
+        {
+          elementSelector: 'vaadin-button::part(label)',
+          propertyName: 'font-size',
+          value: '20px',
+          modified: false
+        }
       ];
 
       expect(result.properties).to.deep.equal(expectedValues);
@@ -157,8 +192,7 @@ describe('model', () => {
       const fooMetadata: ComponentMetadata = {
         tagName: 'foo-component',
         displayName: 'Foo',
-        properties: [],
-        parts: []
+        elements: []
       };
       const buttonTheme = new ComponentTheme(buttonMetadata);
       const fooTheme = new ComponentTheme(fooMetadata);
@@ -169,39 +203,109 @@ describe('model', () => {
   });
 
   describe('fromServerRules', () => {
+    const globalScope: SelectorScope = {
+      themeScope: ThemeScope.global
+    };
+
+    const localScope: SelectorScope = {
+      themeScope: ThemeScope.local,
+      localClassName: 'foo'
+    };
+
     it('should create empty theme from empty rules', () => {
-      const theme = ComponentTheme.fromServerRules(buttonMetadata, []);
+      const theme = ComponentTheme.fromServerRules(testElementMetadata, globalScope, []);
 
       expect(theme.properties.length).to.equal(0);
     });
 
-    it('should create theme from rules', () => {
+    it('should create theme from global scoped rules', () => {
       const serverRules: ServerCssRule[] = [
         {
-          tagName: 'test-element',
-          partName: null,
+          selector: 'test-element',
           properties: {
             background: 'cornflowerblue',
             padding: '3px'
           }
         },
         {
-          tagName: 'test-element',
-          partName: 'label',
+          selector: 'test-element::part(label)',
           properties: {
             color: 'red',
             'font-size': '20px'
           }
+        },
+        {
+          selector: 'test-element input[slot="input"]',
+          properties: {
+            'border-radius': '10px'
+          }
         }
       ];
-      const expectedProperties = [
-        { partName: null, propertyName: 'padding', value: '3px', modified: true },
-        { partName: null, propertyName: 'background', value: 'cornflowerblue', modified: true },
-        { partName: 'label', propertyName: 'color', value: 'red', modified: true },
-        { partName: 'label', propertyName: 'font-size', value: '20px', modified: true }
+      const expectedProperties: ThemePropertyValue[] = [
+        { elementSelector: 'test-element', propertyName: 'padding', value: '3px', modified: true },
+        { elementSelector: 'test-element', propertyName: 'background', value: 'cornflowerblue', modified: true },
+        { elementSelector: 'test-element::part(label)', propertyName: 'color', value: 'red', modified: true },
+        {
+          elementSelector: 'test-element::part(label)',
+          propertyName: 'font-size',
+          value: '20px',
+          modified: true
+        },
+        {
+          elementSelector: 'test-element input[slot="input"]',
+          propertyName: 'border-radius',
+          value: '10px',
+          modified: true
+        }
       ];
 
-      const theme = ComponentTheme.fromServerRules(testElementMetadata, serverRules);
+      const theme = ComponentTheme.fromServerRules(testElementMetadata, globalScope, serverRules);
+      expect(theme.metadata).to.equal(testElementMetadata);
+      expect(theme.properties).to.deep.equal(expectedProperties);
+    });
+
+    it('should create theme from local scoped rules', () => {
+      const serverRules: ServerCssRule[] = [
+        {
+          selector: 'test-element.foo',
+          properties: {
+            background: 'cornflowerblue',
+            padding: '3px'
+          }
+        },
+        {
+          selector: 'test-element.foo::part(label)',
+          properties: {
+            color: 'red',
+            'font-size': '20px'
+          }
+        },
+        {
+          selector: 'test-element.foo input[slot="input"]',
+          properties: {
+            'border-radius': '10px'
+          }
+        }
+      ];
+      const expectedProperties: ThemePropertyValue[] = [
+        { elementSelector: 'test-element', propertyName: 'padding', value: '3px', modified: true },
+        { elementSelector: 'test-element', propertyName: 'background', value: 'cornflowerblue', modified: true },
+        { elementSelector: 'test-element::part(label)', propertyName: 'color', value: 'red', modified: true },
+        {
+          elementSelector: 'test-element::part(label)',
+          propertyName: 'font-size',
+          value: '20px',
+          modified: true
+        },
+        {
+          elementSelector: 'test-element input[slot="input"]',
+          propertyName: 'border-radius',
+          value: '10px',
+          modified: true
+        }
+      ];
+
+      const theme = ComponentTheme.fromServerRules(testElementMetadata, localScope, serverRules);
       expect(theme.metadata).to.equal(testElementMetadata);
       expect(theme.properties).to.deep.equal(expectedProperties);
     });
@@ -209,22 +313,19 @@ describe('model', () => {
     it('should ignore unknown selectors and properties', () => {
       const serverRules: ServerCssRule[] = [
         {
-          tagName: 'test-element',
-          partName: null,
+          selector: 'test-element.foo',
           properties: {
             foo: 'cornflowerblue'
           }
         },
         {
-          tagName: 'test-element',
-          partName: 'label',
+          selector: 'test-element.foo::part(label)',
           properties: {
             bar: '20px'
           }
         },
         {
-          tagName: 'test-element',
-          partName: 'foo',
+          selector: 'test-element.foo::part(foo)',
           properties: {
             color: 'cornflowerblue',
             background: 'cornflowerblue'
@@ -232,25 +333,62 @@ describe('model', () => {
         }
       ];
 
-      const theme = ComponentTheme.fromServerRules(testElementMetadata, serverRules);
+      const theme = ComponentTheme.fromServerRules(testElementMetadata, localScope, serverRules);
       expect(theme.properties.length).to.equal(0);
     });
   });
 
   describe('generateRule', () => {
-    it('should generate rules for property changes', () => {
+    const globalScope: SelectorScope = {
+      themeScope: ThemeScope.global
+    };
+    const localScope: SelectorScope = {
+      themeScope: ThemeScope.local,
+      localClassName: 'foo'
+    };
+    const hostElement = testElementMetadata.elements.find((element) => element.selector === 'test-element')!;
+    const labelElement = testElementMetadata.elements.find(
+      (element) => element.selector === 'test-element::part(label)'
+    )!;
+    const inputElement = testElementMetadata.elements.find(
+      (element) => element.selector === 'test-element input[slot="input"]'
+    )!;
+
+    it('should generate rules for global scope', () => {
       const rules = [
-        generateThemeRule('vaadin-button', null, 'background', 'cornflowerblue'),
-        generateThemeRule('vaadin-button', null, 'padding', '3px'),
-        generateThemeRule('vaadin-button', 'label', 'color', 'white'),
-        generateThemeRule('vaadin-button', 'label', 'font-size', '20px')
+        generateThemeRule(hostElement, globalScope, 'background', 'cornflowerblue'),
+        generateThemeRule(hostElement, globalScope, 'padding', '3px'),
+        generateThemeRule(labelElement, globalScope, 'color', 'white'),
+        generateThemeRule(labelElement, globalScope, 'font-size', '20px'),
+        generateThemeRule(inputElement, globalScope, 'border-radius', '10px')
       ];
 
       const expectedRules: ServerCssRule[] = [
-        { tagName: 'vaadin-button', partName: null, properties: { background: 'cornflowerblue' } },
-        { tagName: 'vaadin-button', partName: null, properties: { padding: '3px' } },
-        { tagName: 'vaadin-button', partName: 'label', properties: { color: 'white' } },
-        { tagName: 'vaadin-button', partName: 'label', properties: { 'font-size': '20px' } }
+        { selector: 'test-element', properties: { background: 'cornflowerblue' } },
+        { selector: 'test-element', properties: { padding: '3px' } },
+        { selector: 'test-element::part(label)', properties: { color: 'white' } },
+        { selector: 'test-element::part(label)', properties: { 'font-size': '20px' } },
+        { selector: 'test-element input[slot="input"]', properties: { 'border-radius': '10px' } }
+      ];
+
+      expect(rules).to.deep.equal(expectedRules);
+    });
+
+    it('should generate rules for local scope', () => {
+      const rules = [
+        generateThemeRule(hostElement, localScope, 'background', 'cornflowerblue'),
+        generateThemeRule(hostElement, localScope, 'padding', '3px'),
+        generateThemeRule(labelElement, localScope, 'color', 'white'),
+        generateThemeRule(labelElement, localScope, 'font-size', '20px'),
+        generateThemeRule(inputElement, localScope, 'border-radius', '10px')
+      ];
+
+      const expectedRules: ServerCssRule[] = [
+        { selector: 'test-element.foo', properties: { background: 'cornflowerblue' } },
+        { selector: 'test-element.foo', properties: { padding: '3px' } },
+        { selector: 'test-element.foo::part(label)', properties: { color: 'white' } },
+        { selector: 'test-element.foo::part(label)', properties: { 'font-size': '20px' } },
+        { selector: 'test-element.foo input[slot="input"]', properties: { 'border-radius': '10px' } }
       ];
 
       expect(rules).to.deep.equal(expectedRules);

--- a/vaadin-dev-server/frontend/theme-editor/model.ts
+++ b/vaadin-dev-server/frontend/theme-editor/model.ts
@@ -1,4 +1,4 @@
-import { ComponentMetadata } from './metadata/model';
+import { ComponentElementMetadata, ComponentMetadata } from './metadata/model';
 import { ServerCssRule } from './api';
 import { ComponentReference } from '../component-util';
 
@@ -13,15 +13,22 @@ export enum ThemeScope {
   global = 'global'
 }
 
+export interface SelectorScope {
+  themeScope: ThemeScope;
+  localClassName?: string;
+}
+
 export interface ThemeContext {
   scope: ThemeScope;
   metadata: ComponentMetadata;
   component: ComponentReference;
   accessible?: boolean;
+  localClassName?: string;
+  suggestedClassName?: string;
 }
 
 export interface ThemePropertyValue {
-  partName: string | null;
+  elementSelector: string;
   propertyName: string;
   value: string;
   modified: boolean;
@@ -29,8 +36,8 @@ export interface ThemePropertyValue {
 
 type PropertyValueMap = { [key: string]: ThemePropertyValue };
 
-function propertyKey(partName: string | null, propertyName: string) {
-  return `${partName}|${propertyName}`;
+function propertyKey(elementSelector: string, propertyName: string) {
+  return `${elementSelector}|${propertyName}`;
 }
 
 export class ComponentTheme {
@@ -49,20 +56,20 @@ export class ComponentTheme {
     return Object.values(this._properties);
   }
 
-  public getPropertyValue(partName: string | null, propertyName: string): ThemePropertyValue {
-    return this._properties[propertyKey(partName, propertyName)] || null;
+  public getPropertyValue(elementSelector: string, propertyName: string): ThemePropertyValue {
+    return this._properties[propertyKey(elementSelector, propertyName)] || null;
   }
 
-  public updatePropertyValue(partName: string | null, propertyName: string, value: string, modified?: boolean) {
-    let propertyValue = this.getPropertyValue(partName, propertyName);
+  public updatePropertyValue(elementSelector: string, propertyName: string, value: string, modified?: boolean) {
+    let propertyValue = this.getPropertyValue(elementSelector, propertyName);
     if (!propertyValue) {
       propertyValue = {
-        partName,
+        elementSelector,
         propertyName,
         value,
         modified: modified || false
       };
-      this._properties[propertyKey(partName, propertyName)] = propertyValue;
+      this._properties[propertyKey(elementSelector, propertyName)] = propertyValue;
     } else {
       propertyValue.value = value;
       propertyValue.modified = modified || false;
@@ -71,12 +78,12 @@ export class ComponentTheme {
 
   public addPropertyValues(values: ThemePropertyValue[]) {
     values.forEach((value) => {
-      this.updatePropertyValue(value.partName, value.propertyName, value.value, value.modified);
+      this.updatePropertyValue(value.elementSelector, value.propertyName, value.value, value.modified);
     });
   }
 
-  public getPropertyValuesForPart(partName: string | null) {
-    return this.properties.filter((property) => property.partName === partName);
+  public getPropertyValuesForElement(elementSelector: string) {
+    return this.properties.filter((property) => property.elementSelector === elementSelector);
   }
 
   static combine(...themes: ComponentTheme[]) {
@@ -90,27 +97,18 @@ export class ComponentTheme {
     return resultTheme;
   }
 
-  static fromServerRules(metadata: ComponentMetadata, rules: ServerCssRule[]) {
+  static fromServerRules(metadata: ComponentMetadata, scope: SelectorScope, rules: ServerCssRule[]) {
     const theme = new ComponentTheme(metadata);
 
-    const hostRule = rules.find((rule) => !rule.partName);
-    if (hostRule) {
-      metadata.properties.forEach((property) => {
-        const value = hostRule.properties[property.propertyName];
-        if (value) {
-          theme.updatePropertyValue(null, property.propertyName, value, true);
-        }
-      });
-    }
+    metadata.elements.forEach((element) => {
+      const scopedSelector = createScopedSelector(element, scope);
+      const elementRule = rules.find((rule) => rule.selector === scopedSelector);
 
-    metadata.parts.forEach((part) => {
-      const partRule = rules.find((rule) => rule.partName === part.partName);
-
-      if (partRule) {
-        part.properties.forEach((property) => {
-          const value = partRule.properties[property.propertyName];
+      if (elementRule) {
+        element.properties.forEach((property) => {
+          const value = elementRule.properties[property.propertyName];
           if (value) {
-            theme.updatePropertyValue(part.partName, property.propertyName, value, true);
+            theme.updatePropertyValue(element.selector, property.propertyName, value, true);
           }
         });
       }
@@ -120,16 +118,40 @@ export class ComponentTheme {
   }
 }
 
+export function createScopedSelector(element: ComponentElementMetadata, scope: SelectorScope) {
+  const baseSelector = element.selector;
+
+  // Use base selector for global scope
+  if (scope.themeScope === ThemeScope.global) {
+    return baseSelector;
+  }
+
+  // Local scope needs a classname
+  if (!scope.localClassName) {
+    throw new Error('Can not build local scoped selector without instance class name');
+  }
+
+  // Insert classname into selector
+  const tagNameMatch = baseSelector.match(/^[\w\d-_]+/);
+  const tagName = tagNameMatch && tagNameMatch[0];
+
+  if (!tagName) {
+    throw new Error(`Selector does not start with a tag name: ${baseSelector}`);
+  }
+
+  return `${tagName}.${scope.localClassName}${baseSelector.substring(tagName.length, baseSelector.length)}`;
+}
+
 export function generateThemeRule(
-  tagName: string,
-  partName: string | null,
+  element: ComponentElementMetadata,
+  scope: SelectorScope,
   propertyName: string,
   value: string
 ): ServerCssRule {
+  const scopedSelector = createScopedSelector(element, scope);
   const properties = { [propertyName]: value };
   return {
-    tagName,
-    partName,
+    selector: scopedSelector,
     properties
   };
 }

--- a/vaadin-dev-server/frontend/theme-editor/tests/utils.ts
+++ b/vaadin-dev-server/frontend/theme-editor/tests/utils.ts
@@ -9,6 +9,14 @@ export class TestElement extends HTMLElement {
     label.setAttribute('part', 'label');
     shadow.append(label);
 
+    const inputSlot = document.createElement('slot');
+    inputSlot.setAttribute('name', 'input');
+    shadow.append(inputSlot);
+
+    const helperText = document.createElement('div');
+    helperText.setAttribute('part', 'helper-text');
+    shadow.append(helperText);
+
     const styles = new CSSStyleSheet();
     styles.replaceSync(`
       :host {
@@ -18,8 +26,23 @@ export class TestElement extends HTMLElement {
       [part='label'] {
         color: black;
       }
+      
+      ::slotted(input) {
+        border: solid 1px black;
+        border-radius: 5px;
+      }
+
+      [part='helper-text'] {
+        color: rgb(200, 200, 200);
+      }
     `);
     shadow.adoptedStyleSheets.push(styles);
+  }
+
+  connectedCallback() {
+    const input = document.createElement('input');
+    input.setAttribute('slot', 'input');
+    this.append(input);
   }
 }
 
@@ -28,20 +51,48 @@ customElements.define('test-element', TestElement);
 export const testElementMetadata: ComponentMetadata = {
   tagName: 'test-element',
   displayName: 'Test element',
-  properties: [
+  elements: [
     {
-      propertyName: 'padding',
-      displayName: 'Padding'
+      selector: 'test-element',
+      displayName: 'Host',
+      properties: [
+        {
+          propertyName: 'padding',
+          displayName: 'Padding'
+        },
+        {
+          propertyName: 'background',
+          displayName: 'Background'
+        }
+      ]
     },
     {
-      propertyName: 'background',
-      displayName: 'Background'
-    }
-  ],
-  parts: [
-    {
-      partName: 'label',
+      selector: 'test-element::part(label)',
       displayName: 'Label',
+      properties: [
+        {
+          propertyName: 'color',
+          displayName: 'Text color'
+        },
+        {
+          propertyName: 'font-size',
+          displayName: 'Font size'
+        }
+      ]
+    },
+    {
+      selector: 'test-element input[slot="input"]',
+      displayName: 'Input',
+      properties: [
+        {
+          propertyName: 'border-radius',
+          displayName: 'Border radius'
+        }
+      ]
+    },
+    {
+      selector: 'test-element::part(helper-text)',
+      displayName: 'Helper text',
       properties: [
         {
           propertyName: 'color',


### PR DESCRIPTION
## Description

- Updates component metadata model to contain a list of elements, each element having a selector and a list of properties. The host itself is now also just an element.
- Update API calls to pass/receive selectors when loading / setting rules
- Update theme model to work with selectors, add logic for generating local and global scoped selectors
- Update theme detector to work with selectors
- Set local class name before sending rules
