### PR TITLE
fix: Allow access to /favicon even when the vaadin mapping is /something

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/HandlerHelper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/HandlerHelper.java
@@ -108,10 +108,10 @@ public class HandlerHelper implements Serializable {
         }
     }
 
+    private static final String[] publicResourcesRoot;
     private static final String[] publicResources;
     static {
         List<String> resources = new ArrayList<>();
-        resources.add("/favicon.ico");
         resources.add("/" + PwaConfiguration.DEFAULT_PATH);
         resources.add("/" + FrontendUtils.SERVICE_WORKER_SRC_JS);
         resources.add(PwaHandler.SW_RUNTIME_PRECACHE_PATH);
@@ -122,6 +122,11 @@ public class HandlerHelper implements Serializable {
         resources.addAll(getIconVariants(PwaConfiguration.DEFAULT_ICON));
         publicResources = resources.toArray(new String[resources.size()]);
 
+        // These are always in the root of the app, not inside any url mapping
+        List<String> rootResources = new ArrayList<>();
+        rootResources.add("/favicon.ico");
+        publicResourcesRoot = rootResources
+                .toArray(new String[rootResources.size()]);
     }
 
     private HandlerHelper() {
@@ -451,9 +456,23 @@ public class HandlerHelper implements Serializable {
      * URLs matching these patterns should be publicly available for
      * applications to work. Can be used for defining a bypass for rules in e.g.
      * Spring Security.
+     * <p>
+     * These paths are relative to a potential Vaadin mapping
      */
     public static String[] getPublicResources() {
         return publicResources;
+    }
+
+    /**
+     * URLs matching these patterns should be publicly available for
+     * applications to work. Can be used for defining a bypass for rules in e.g.
+     * Spring Security.
+     * <p>
+     * These URLs are always relative to the root path and independent of any
+     * Vaadin mapping
+     */
+    public static String[] getPublicResourcesRoot() {
+        return publicResourcesRoot;
     }
 
     private static List<String> getIconVariants(String iconPath) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/HandlerHelperTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/HandlerHelperTest.java
@@ -331,7 +331,6 @@ public class HandlerHelperTest {
     @Test
     public void publicResources() {
         Set<String> expected = new HashSet<>();
-        expected.add("/favicon.ico");
         expected.add("/manifest.webmanifest");
         expected.add("/sw.js");
         expected.add("/sw-runtime-resources-precache.js");
@@ -376,5 +375,11 @@ public class HandlerHelperTest {
         Set<String> actual = new HashSet<>();
         Collections.addAll(actual, HandlerHelper.getPublicResources());
         Assert.assertEquals(expected, actual);
+
+        Set<String> expectedRoot = Set.of("/favicon.ico");
+
+        Set<String> actualRoot = new HashSet<>();
+        Collections.addAll(actualRoot, HandlerHelper.getPublicResourcesRoot());
+        Assert.assertEquals(expectedRoot, actualRoot);
     }
 }

--- a/flow-test-util/src/main/java/com/vaadin/flow/testutil/TestBenchHelpers.java
+++ b/flow-test-util/src/main/java/com/vaadin/flow/testutil/TestBenchHelpers.java
@@ -342,9 +342,8 @@ public class TestBenchHelpers extends ParallelTest {
                             .contains(WEB_SOCKET_CONNECTION_ERROR_PREFIX)
                     && !acceptableMessagePredicate
                             .test(logEntry.getMessage())) {
-                throw new AssertionError(String.format(
-                        "Error message in browser log: %s",
-                        logEntry));
+                throw new AssertionError(String
+                        .format("Error message in browser log: %s", logEntry));
             } else {
                 LoggerFactory.getLogger(TestBenchHelpers.class.getName()).warn(
                         "This message in browser log console may be a potential error: '{}'",

--- a/flow-test-util/src/main/java/com/vaadin/flow/testutil/TestBenchHelpers.java
+++ b/flow-test-util/src/main/java/com/vaadin/flow/testutil/TestBenchHelpers.java
@@ -343,7 +343,7 @@ public class TestBenchHelpers extends ParallelTest {
                     && !acceptableMessagePredicate
                             .test(logEntry.getMessage())) {
                 throw new AssertionError(String.format(
-                        "Received error message in browser log console right after opening the page, message: %s",
+                        "Error message in browser log: %s",
                         logEntry));
             } else {
                 LoggerFactory.getLogger(TestBenchHelpers.class.getName()).warn(

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/SecurityConfig.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/SecurityConfig.java
@@ -63,6 +63,10 @@ public class SecurityConfig extends VaadinWebSecurity {
         http.authorizeHttpRequests()
                 .requestMatchers(new AntPathRequestMatcher("/public/**"))
                 .permitAll();
+        http.authorizeHttpRequests()
+                .requestMatchers(new AntPathRequestMatcher("/error"))
+                .permitAll();
+
         super.configure(http);
         if (getLogoutSuccessUrl().equals("/")) {
             // Test the default url with empty context path

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AbstractIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AbstractIT.java
@@ -46,7 +46,9 @@ public abstract class AbstractIT extends AbstractSpringTest {
         checkLogsForErrors(msg -> msg.contains(
                 "admin-only/secret.txt - Failed to load resource: the server responded with a status of 403")
                 || msg.contains(
-                        "admin-only/secret.txt?continue - Failed to load resource: the server responded with a status of 403"));
+                        "admin-only/secret.txt?continue - Failed to load resource: the server responded with a status of 403")
+                || msg.matches(
+                        ".*VAADIN/push?v-r=push&.*X-Atmosphere-Transport=close.* - Failed to load resource: the server responded with a status of 403"));
     }
 
     /**

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AbstractIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AbstractIT.java
@@ -48,7 +48,7 @@ public abstract class AbstractIT extends AbstractSpringTest {
                 || msg.contains(
                         "admin-only/secret.txt?continue - Failed to load resource: the server responded with a status of 403")
                 || msg.matches(
-                        ".*VAADIN/push?v-r=push&.*X-Atmosphere-Transport=close.* - Failed to load resource: the server responded with a status of 403"));
+                        ".*VAADIN/push\\?v-r=push&.*X-Atmosphere-Transport=close.* - Failed to load resource: the server responded with a status of 403"));
     }
 
     /**

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AbstractIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AbstractIT.java
@@ -48,7 +48,8 @@ public abstract class AbstractIT extends AbstractSpringTest {
                 || msg.contains(
                         "admin-only/secret.txt?continue - Failed to load resource: the server responded with a status of 403")
                 || (msg.contains("X-Atmosphere-Transport=close")
-                        && msg.contains("Failed to load resource: the server responded with a status of 403")));
+                        && msg.contains(
+                                "Failed to load resource: the server responded with a status of 403")));
     }
 
     /**

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AbstractIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AbstractIT.java
@@ -47,8 +47,8 @@ public abstract class AbstractIT extends AbstractSpringTest {
                 "admin-only/secret.txt - Failed to load resource: the server responded with a status of 403")
                 || msg.contains(
                         "admin-only/secret.txt?continue - Failed to load resource: the server responded with a status of 403")
-                || msg.matches(
-                        ".*VAADIN/push\\?v-r=push&.*X-Atmosphere-Transport=close.* - Failed to load resource: the server responded with a status of 403"));
+                || (msg.contains("X-Atmosphere-Transport=close")
+                        && msg.contains("Failed to load resource: the server responded with a status of 403")));
     }
 
     /**

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -311,7 +311,8 @@ public abstract class VaadinWebSecurity {
                 .map(path -> RequestUtil.applyUrlMapping(urlMapping, path));
         Stream<String> rootPaths = Stream
                 .of(HandlerHelper.getPublicResourcesRoot());
-        return new OrRequestMatcher(Stream.concat(mappingRelativePaths, rootPaths)
+        return new OrRequestMatcher(Stream
+                .concat(mappingRelativePaths, rootPaths)
                 .map(AntPathRequestMatcher::new).collect(Collectors.toList()));
     }
 

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -17,7 +17,9 @@ package com.vaadin.flow.spring.security;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -304,9 +306,12 @@ public abstract class VaadinWebSecurity {
             String urlMapping) {
         Objects.requireNonNull(urlMapping,
                 "Vaadin servlet url mapping is required");
-        return new OrRequestMatcher(Stream
+        Stream<String> mappingRelativePaths = Stream
                 .of(HandlerHelper.getPublicResources())
-                .map(path -> RequestUtil.applyUrlMapping(urlMapping, path))
+                .map(path -> RequestUtil.applyUrlMapping(urlMapping, path));
+        Stream<String> rootPaths = Stream
+                .of(HandlerHelper.getPublicResourcesRoot());
+        return new OrRequestMatcher(Stream.concat(mappingRelativePaths, rootPaths)
                 .map(AntPathRequestMatcher::new).collect(Collectors.toList()));
     }
 


### PR DESCRIPTION
Allow accessing the error page in security tests so that the 404 is sent to the browser

Fixes #16371
