### PR TITLE
refactor: add menubar metadata to theme editor

### DIFF
--- a/vaadin-dev-server/frontend/theme-editor/components/editors/base-property-editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/editors/base-property-editor.ts
@@ -130,6 +130,8 @@ export class PropertyPresets {
       // and in reverse allows to select a preset in the slider from a computed
       // style value such as `2.25rem`.
       const measureElement = document.createElement('div');
+      // Enable borders so that measuring border styles works properly
+      measureElement.style.borderStyle = 'solid';
       measureElement.style.visibility = 'hidden';
       document.body.append(measureElement);
 

--- a/vaadin-dev-server/frontend/theme-editor/components/editors/checkbox-property-editor.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/editors/checkbox-property-editor.test.ts
@@ -1,0 +1,75 @@
+import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { ComponentTheme } from '../../model';
+import { ComponentElementMetadata, CssPropertyMetadata } from '../../metadata/model';
+import { testElementMetadata } from '../../tests/utils';
+import { TextPropertyEditor } from './text-property-editor';
+import './checkbox-property-editor';
+import sinon from 'sinon';
+
+const fontWeightMetadata: CssPropertyMetadata = {
+  propertyName: 'font-weight',
+  displayName: 'Bold',
+  checkedValue: 'bold'
+};
+const labelMetadata: ComponentElementMetadata = {
+  selector: 'test-element::part(label)',
+  displayName: 'Label',
+  properties: [fontWeightMetadata]
+};
+
+describe('checkbox property editor', () => {
+  let theme: ComponentTheme;
+  let editor: TextPropertyEditor;
+  let valueChangeSpy: sinon.SinonSpy;
+
+  function getCheckbox() {
+    return editor.shadowRoot!.querySelector('input') as HTMLInputElement;
+  }
+
+  function cloneTheme() {
+    const result = new ComponentTheme(testElementMetadata);
+    result.addPropertyValues(theme.properties);
+    return result;
+  }
+
+  beforeEach(async () => {
+    theme = new ComponentTheme(testElementMetadata);
+    theme.updatePropertyValue(labelMetadata.selector, 'font-weight', 'bold');
+    valueChangeSpy = sinon.spy();
+
+    editor = await fixture(html` <vaadin-dev-tools-theme-checkbox-property-editor
+      .theme=${theme}
+      .elementMetadata=${labelMetadata}
+      .propertyMetadata=${fontWeightMetadata}
+      @theme-property-value-change=${valueChangeSpy}
+    >
+    </vaadin-dev-tools-theme-checkbox-property-editor>`);
+  });
+
+  it('should update checkbox from theme', async () => {
+    const input = getCheckbox();
+
+    expect(input.checked).to.be.true;
+
+    const updatedTheme = cloneTheme();
+    updatedTheme.updatePropertyValue(labelMetadata.selector, 'font-weight', '', true);
+    editor.theme = updatedTheme;
+    await elementUpdated(editor);
+
+    expect(input.checked).to.be.false;
+  });
+
+  it('should dispatch event when changing checkbox value', () => {
+    const checkbox = getCheckbox();
+    checkbox.click();
+
+    expect(valueChangeSpy.calledOnce).to.be.true;
+    expect(valueChangeSpy.args[0][0].detail.value).to.equal('');
+
+    valueChangeSpy.resetHistory();
+    checkbox.click();
+
+    expect(valueChangeSpy.calledOnce).to.be.true;
+    expect(valueChangeSpy.args[0][0].detail.value).to.equal('bold');
+  });
+});

--- a/vaadin-dev-server/frontend/theme-editor/components/editors/checkbox-property-editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/editors/checkbox-property-editor.ts
@@ -1,0 +1,28 @@
+import { html, css, TemplateResult } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { BasePropertyEditor } from './base-property-editor';
+
+@customElement('vaadin-dev-tools-theme-checkbox-property-editor')
+export class CheckboxPropertyEditor extends BasePropertyEditor {
+  static get styles() {
+    return [
+      BasePropertyEditor.styles,
+      css`
+        .property {
+          align-items: center;
+        }
+      `
+    ];
+  }
+
+  handleInputChange(e: Event) {
+    const input = e.target as HTMLInputElement;
+    const value = input.checked ? this.propertyMetadata.checkedValue : '';
+    this.dispatchChange(value || '');
+  }
+
+  protected renderEditor(): TemplateResult {
+    const checked = this.value === this.propertyMetadata.checkedValue;
+    return html` <input type="checkbox" .checked=${checked} @change=${this.handleInputChange} /> `;
+  }
+}

--- a/vaadin-dev-server/frontend/theme-editor/components/property-list.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/property-list.ts
@@ -3,6 +3,7 @@ import { customElement, property } from 'lit/decorators.js';
 import { html as staticHtml, literal, StaticValue } from 'lit/static-html.js';
 import { ComponentMetadata, ComponentElementMetadata, CssPropertyMetadata, EditorType } from '../metadata/model';
 import { ComponentTheme } from '../model';
+import './editors/checkbox-property-editor';
 import './editors/text-property-editor';
 import './editors/range-property-editor';
 import './editors/color-property-editor';
@@ -48,6 +49,9 @@ export class PropertyList extends LitElement {
   private renderPropertyEditor(element: ComponentElementMetadata, property: CssPropertyMetadata) {
     let editorTagName: StaticValue;
     switch (property.editorType) {
+      case EditorType.checkbox:
+        editorTagName = literal`vaadin-dev-tools-theme-checkbox-property-editor`;
+        break;
       case EditorType.range:
         editorTagName = literal`vaadin-dev-tools-theme-range-property-editor`;
         break;

--- a/vaadin-dev-server/frontend/theme-editor/detector.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/detector.test.ts
@@ -1,10 +1,24 @@
 import { expect, fixture, html } from '@open-wc/testing';
+import sinon from 'sinon';
 import { detectTheme } from './detector';
 import { testElementMetadata } from './tests/utils';
 
 describe('theme-detector', () => {
-  it('should include all CSS property values from component metadata', () => {
-    const theme = detectTheme(testElementMetadata);
+  let setupElementStub: sinon.SinonStub;
+  let cleanupElementStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    setupElementStub = sinon.stub(testElementMetadata, 'setupElement');
+    cleanupElementStub = sinon.stub(testElementMetadata, 'cleanupElement');
+  });
+
+  afterEach(() => {
+    setupElementStub.restore();
+    cleanupElementStub.restore();
+  });
+
+  it('should include all CSS property values from component metadata', async () => {
+    const theme = await detectTheme(testElementMetadata);
     let propertyCount = 0;
 
     testElementMetadata.elements.forEach((element) => {
@@ -19,7 +33,7 @@ describe('theme-detector', () => {
   });
 
   it('should detect default CSS property values', async () => {
-    const theme = detectTheme(testElementMetadata);
+    const theme = await detectTheme(testElementMetadata);
 
     expect(theme.getPropertyValue('test-element', 'padding').value).to.equal('10px');
     expect(theme.getPropertyValue('test-element::part(label)', 'color').value).to.equal('rgb(0, 0, 0)');
@@ -47,7 +61,7 @@ describe('theme-detector', () => {
         }
       </style>
     `);
-    const theme = detectTheme(testElementMetadata);
+    const theme = await detectTheme(testElementMetadata);
 
     expect(theme.getPropertyValue('test-element', 'padding').value).to.equal('20px');
     expect(theme.getPropertyValue('test-element::part(label)', 'color').value).to.equal('rgb(0, 128, 0)');
@@ -55,9 +69,16 @@ describe('theme-detector', () => {
     expect(theme.getPropertyValue('test-element::part(helper-text)', 'color').value).to.equal('rgb(0, 0, 255)');
   });
 
-  it('should remove test component from DOM', () => {
-    detectTheme(testElementMetadata);
+  it('should remove test component from DOM', async () => {
+    await detectTheme(testElementMetadata);
 
     expect(document.querySelector('test-element')).to.not.exist;
   });
+
+  it('should call custom setup and cleanup functions', async () => {
+    await detectTheme(testElementMetadata);
+
+    expect(setupElementStub.calledOnce).to.be.true;
+    expect(cleanupElementStub.calledOnce).to.be.true;
+  })
 });

--- a/vaadin-dev-server/frontend/theme-editor/editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.ts
@@ -447,10 +447,11 @@ export class ThemeEditor extends LitElement {
     // Update theme state after data has loaded, so that everything consistently
     // updates at once - this avoids re-rendering the editor with new metadata
     // but without matching theme state
+    const baseTheme = await detectTheme(context.metadata);
     this.context = context;
-    this.baseTheme = detectTheme(context.metadata);
+    this.baseTheme = baseTheme;
     this.editedTheme = editedTheme;
-    this.effectiveTheme = ComponentTheme.combine(this.baseTheme!, this.editedTheme);
+    this.effectiveTheme = ComponentTheme.combine(baseTheme, this.editedTheme);
   }
 
   private async updateThemePreview() {

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/presets.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/presets.ts
@@ -1,6 +1,7 @@
 export const presets = {
   lumoSize: ['--lumo-size-xs', '--lumo-size-s', '--lumo-size-m', '--lumo-size-l', '--lumo-size-xl'],
   lumoSpace: ['--lumo-space-xs', '--lumo-space-s', '--lumo-space-m', '--lumo-space-l', '--lumo-space-xl'],
+  lumoBorderRadius: ['0', '--lumo-border-radius-m', '--lumo-border-radius-l'],
   lumoFontSize: [
     '--lumo-font-size-xxs',
     '--lumo-font-size-xs',
@@ -20,5 +21,6 @@ export const presets = {
     '--lumo-primary-text-color',
     '--lumo-error-text-color',
     '--lumo-success-text-color'
-  ]
+  ],
+  basicBorderSize: ['0px', '1px', '2px', '3px']
 };

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-menu-bar.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-menu-bar.ts
@@ -21,7 +21,17 @@ export default {
         },
         {
           propertyName: 'border-width',
-          displayName: 'Border width'
+          displayName: 'Border width',
+          editorType: EditorType.range,
+          presets: presets.basicBorderSize,
+          icon: 'square'
+        },
+        {
+          propertyName: 'border-radius',
+          displayName: 'Border radius',
+          editorType: EditorType.range,
+          presets: presets.lumoBorderRadius,
+          icon: 'square'
         },
         {
           propertyName: '--lumo-button-size',
@@ -33,13 +43,6 @@ export default {
         {
           propertyName: 'padding-inline',
           displayName: 'Padding',
-          editorType: EditorType.range,
-          presets: presets.lumoSpace,
-          icon: 'square'
-        },
-        {
-          propertyName: 'margin',
-          displayName: 'Margin',
           editorType: EditorType.range,
           presets: presets.lumoSpace,
           icon: 'square'
@@ -68,12 +71,6 @@ export default {
           displayName: 'Bold',
           editorType: EditorType.checkbox,
           checkedValue: 'bold'
-        },
-        {
-          propertyName: 'font-style',
-          displayName: 'Italic',
-          editorType: EditorType.checkbox,
-          checkedValue: 'italic'
         }
       ]
     },
@@ -93,7 +90,17 @@ export default {
         },
         {
           propertyName: 'border-width',
-          displayName: 'Border width'
+          displayName: 'Border width',
+          editorType: EditorType.range,
+          presets: presets.basicBorderSize,
+          icon: 'square'
+        },
+        {
+          propertyName: 'border-radius',
+          displayName: 'Border radius',
+          editorType: EditorType.range,
+          presets: presets.lumoBorderRadius,
+          icon: 'square'
         },
         {
           propertyName: 'padding',
@@ -126,12 +133,6 @@ export default {
           displayName: 'Bold',
           editorType: EditorType.checkbox,
           checkedValue: 'bold'
-        },
-        {
-          propertyName: 'font-style',
-          displayName: 'Italic',
-          editorType: EditorType.checkbox,
-          checkedValue: 'italic'
         }
       ]
     }

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-menu-bar.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-menu-bar.ts
@@ -1,0 +1,166 @@
+import { ComponentMetadata, EditorType } from '../model';
+import { presets } from './presets';
+
+export default {
+  tagName: 'vaadin-menu-bar',
+  displayName: 'MenuBar',
+  elements: [
+    {
+      selector: 'vaadin-menu-bar vaadin-menu-bar-button',
+      displayName: 'Buttons',
+      properties: [
+        {
+          propertyName: 'background-color',
+          displayName: 'Background color',
+          editorType: EditorType.color
+        },
+        {
+          propertyName: 'border-color',
+          displayName: 'Border color',
+          editorType: EditorType.color
+        },
+        {
+          propertyName: 'border-width',
+          displayName: 'Border width'
+        },
+        {
+          propertyName: '--lumo-button-size',
+          displayName: 'Size',
+          editorType: EditorType.range,
+          presets: presets.lumoSize,
+          icon: 'square'
+        },
+        {
+          propertyName: 'padding-inline',
+          displayName: 'Padding',
+          editorType: EditorType.range,
+          presets: presets.lumoSpace,
+          icon: 'square'
+        },
+        {
+          propertyName: 'margin',
+          displayName: 'Margin',
+          editorType: EditorType.range,
+          presets: presets.lumoSpace,
+          icon: 'square'
+        }
+      ]
+    },
+    {
+      selector: 'vaadin-menu-bar vaadin-menu-bar-button vaadin-menu-bar-item',
+      displayName: 'Button labels',
+      properties: [
+        {
+          propertyName: 'color',
+          displayName: 'Text color',
+          editorType: EditorType.color,
+          presets: presets.lumoTextColor
+        },
+        {
+          propertyName: 'font-size',
+          displayName: 'Font size',
+          editorType: EditorType.range,
+          presets: presets.lumoFontSize,
+          icon: 'font'
+        },
+        {
+          propertyName: 'font-weight',
+          displayName: 'Bold',
+          editorType: EditorType.checkbox,
+          checkedValue: 'bold'
+        },
+        {
+          propertyName: 'font-style',
+          displayName: 'Italic',
+          editorType: EditorType.checkbox,
+          checkedValue: 'italic'
+        }
+      ]
+    },
+    {
+      selector: 'vaadin-menu-bar-overlay::part(overlay)',
+      displayName: 'Menus',
+      properties: [
+        {
+          propertyName: 'background-color',
+          displayName: 'Background color',
+          editorType: EditorType.color
+        },
+        {
+          propertyName: 'border-color',
+          displayName: 'Border color',
+          editorType: EditorType.color
+        },
+        {
+          propertyName: 'border-width',
+          displayName: 'Border width'
+        },
+        {
+          propertyName: 'padding',
+          displayName: 'Padding',
+          editorType: EditorType.range,
+          presets: presets.lumoSpace,
+          icon: 'square'
+        }
+      ]
+    },
+    {
+      selector: 'vaadin-menu-bar-overlay vaadin-menu-bar-item',
+      displayName: 'Menu items',
+      properties: [
+        {
+          propertyName: 'color',
+          displayName: 'Text color',
+          editorType: EditorType.color,
+          presets: presets.lumoTextColor
+        },
+        {
+          propertyName: 'font-size',
+          displayName: 'Font size',
+          editorType: EditorType.range,
+          presets: presets.lumoFontSize,
+          icon: 'font'
+        },
+        {
+          propertyName: 'font-weight',
+          displayName: 'Bold',
+          editorType: EditorType.checkbox,
+          checkedValue: 'bold'
+        },
+        {
+          propertyName: 'font-style',
+          displayName: 'Italic',
+          editorType: EditorType.checkbox,
+          checkedValue: 'italic'
+        }
+      ]
+    }
+  ],
+  async setupElement(menuBar: any) {
+    // Apply overlay class name
+    menuBar.overlayClass = menuBar.getAttribute('class');
+    // Setup items
+    // Flow component wraps all button contents into a vaadin-menu-bar-item, so
+    // we need to reproduce that
+    const rootItem = document.createElement('vaadin-menu-bar-item');
+    menuBar.items = [
+      {
+        component: rootItem,
+        children: [
+          {
+            text: 'Sub item'
+          }
+        ]
+      }
+    ];
+    // Open overlay
+    menuBar.querySelector('vaadin-menu-bar-button').click();
+    // Wait for overlay to open
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  },
+  async cleanupElement(menuBar: any) {
+    // Menu bar does not close / remove its overlay when it is removed from DOM,
+    // so we need to do it manually
+    menuBar._close();
+  }
+} as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/model.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/model.ts
@@ -1,5 +1,6 @@
 export enum EditorType {
   text = 'text',
+  checkbox = 'checkbox',
   range = 'range',
   color = 'color'
 }
@@ -11,6 +12,7 @@ export interface CssPropertyMetadata {
   editorType?: EditorType;
   presets?: string[];
   icon?: string;
+  checkedValue?: string;
 }
 
 export interface ComponentElementMetadata {
@@ -25,4 +27,6 @@ export interface ComponentMetadata {
   displayName: string;
   description?: string;
   elements: ComponentElementMetadata[];
+  setupElement?: (element: any) => Promise<void>;
+  cleanupElement?: (element: any) => Promise<void>;
 }

--- a/vaadin-dev-server/frontend/theme-editor/model.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/model.test.ts
@@ -393,5 +393,27 @@ describe('model', () => {
 
       expect(rules).to.deep.equal(expectedRules);
     });
+
+    describe('individual property handling', () => {
+      it('should add border-style when setting border-width to larger than zero', () => {
+        const rules = [
+          generateThemeRule(hostElement, globalScope, 'border-width', '0'),
+          generateThemeRule(hostElement, globalScope, 'border-width', '0px'),
+          generateThemeRule(hostElement, globalScope, 'border-width', '0rem'),
+          generateThemeRule(hostElement, globalScope, 'border-width', '1px'),
+          generateThemeRule(hostElement, globalScope, 'border-width', '1rem')
+        ];
+
+        const expectedRules: ServerCssRule[] = [
+          { selector: 'test-element', properties: { 'border-width': '0' } },
+          { selector: 'test-element', properties: { 'border-width': '0px' } },
+          { selector: 'test-element', properties: { 'border-width': '0rem' } },
+          { selector: 'test-element', properties: { 'border-width': '1px', 'border-style': 'solid' } },
+          { selector: 'test-element', properties: { 'border-width': '1rem', 'border-style': 'solid' } }
+        ];
+
+        expect(rules).to.deep.equal(expectedRules);
+      });
+    });
   });
 });

--- a/vaadin-dev-server/frontend/theme-editor/model.ts
+++ b/vaadin-dev-server/frontend/theme-editor/model.ts
@@ -150,6 +150,14 @@ export function generateThemeRule(
 ): ServerCssRule {
   const scopedSelector = createScopedSelector(element, scope);
   const properties = { [propertyName]: value };
+
+  // Individual property handling
+
+  // Enable border style when setting a border width
+  if (propertyName === 'border-width' && parseInt(value) > 0) {
+    properties['border-style'] = 'solid';
+  }
+
   return {
     selector: scopedSelector,
     properties

--- a/vaadin-dev-server/frontend/theme-editor/tests/utils.ts
+++ b/vaadin-dev-server/frontend/theme-editor/tests/utils.ts
@@ -104,5 +104,11 @@ export const testElementMetadata: ComponentMetadata = {
         }
       ]
     }
-  ]
+  ],
+  setupElement() {
+    return Promise.resolve();
+  },
+  cleanupElement() {
+    return Promise.resolve();
+  }
 };


### PR DESCRIPTION
## Description

Adds metadata for the MenuBar component. 

Also:
- Improves theme detection to work with more complex components. To detect styles for components that have children or overlays we need an instance that has all of these set up. Relying on the selected element seems brittle, as that might not have all of the elements we want to measure, and its custom styles would lead to incorrect results for detecting styles for the global scope. It gets even more difficult for data-driven components like ComboBox. Having a generic setup for all types of components seems impossible, so for now, for each complex component the metadata defines functions on how to properly set up or clean up an instance from which styles can be detected.
- Adds a property editor with a checkbox to allow toggling bold / italic text styles. Could be improved in the future to use a single editor for multiple properties. Checkbox is not styled at the moment.
- Adds a customization to the server rule generation, so that when setting a `border-width` larger than zero, it also sets the `border-style` property to solid. This avoids the user having to set the border style separately for a border to show up.

The generated style rules for the menu bar overlay depend on the overlay class name being set on the menu bar, which means the backend also needs to be changed so that it applies the local class name as overlay class name. In the meanwhile for testing this, the overlay class name can be applied manually:
```java
menuBar.setOverlayClassName("local-class-name");
```

~~PR depends on the changes from https://github.com/vaadin/flow/pull/16372, and is currently set to merge against it.~~

