### PR TITLE
fix: add .js to imports used by Hilla 2.0 (target: 24.0)

### DIFF
--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/vaadin-dev-tools.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/vaadin-dev-tools.ts
@@ -1,11 +1,11 @@
 import { css, html, LitElement, nothing } from 'lit';
 import { property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
-import { ComponentReference } from './component-util';
+import { ComponentReference } from './component-util.js';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { copy } from './copy-to-clipboard.js';
-import { licenseCheckFailed, licenseCheckNoKey, licenseCheckOk, Product, licenseInit } from './License';
+import { licenseCheckFailed, licenseCheckNoKey, licenseCheckOk, Product, licenseInit } from './License.js';
 
 interface ServerInfo {
   vaadinVersion: string;


### PR DESCRIPTION
Those imports are marked as errors since Hilla projects are supposed to use ES modules.