### PR TITLE
refactor: allow theming non-Vaadin components

### DIFF
--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/defaults.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/defaults.ts
@@ -20,6 +20,12 @@ export const textProperties = {
     displayName: 'Bold',
     editorType: EditorType.checkbox,
     checkedValue: 'bold'
+  },
+  fontStyle: {
+    propertyName: 'font-style',
+    displayName: 'Italic',
+    editorType: EditorType.checkbox,
+    checkedValue: 'italic'
   }
 };
 
@@ -48,6 +54,13 @@ export const shapeProperties = {
     presets: presets.lumoBorderRadius,
     icon: 'square'
   },
+  padding: {
+    propertyName: 'padding',
+    displayName: 'Padding',
+    editorType: EditorType.range,
+    presets: presets.lumoSpace,
+    icon: 'square'
+  }
 };
 
 export const fieldProperties = {

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/generic.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/generic.ts
@@ -1,0 +1,28 @@
+import { ComponentMetadata } from '../model';
+import { shapeProperties, textProperties } from './defaults';
+
+export function createGenericMetadata(tagName: string): ComponentMetadata {
+  const displayName = tagName.charAt(0).toUpperCase() + tagName.slice(1);
+
+  return {
+    tagName,
+    displayName,
+    elements: [
+      {
+        selector: tagName,
+        displayName: 'Element',
+        properties: [
+          shapeProperties.backgroundColor,
+          shapeProperties.borderColor,
+          shapeProperties.borderWidth,
+          shapeProperties.borderRadius,
+          shapeProperties.padding,
+          textProperties.textColor,
+          textProperties.fontSize,
+          textProperties.fontWeight,
+          textProperties.fontStyle
+        ]
+      }
+    ]
+  };
+}

--- a/vaadin-dev-server/frontend/theme-editor/metadata/registry.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/registry.test.ts
@@ -2,6 +2,7 @@ import { expect } from '@open-wc/testing';
 import sinon from 'sinon';
 import { MetadataRegistry } from './registry';
 import { ComponentReference } from '../../component-util';
+import { createGenericMetadata } from './components/generic';
 
 describe('metadata-registry', () => {
   let moduleLoaderSpy: sinon.SinonSpy;
@@ -21,19 +22,21 @@ describe('metadata-registry', () => {
     registry = new MetadataRegistry(moduleLoaderSpy);
   });
 
-  it('should not load metadata for unknown elements', async () => {
-    // No element
-    let componentRef = mockComponentReference();
-    let metadata = await registry.getMetadata(componentRef);
+  it('should not load metadata for null element', async () => {
+    const componentRef = mockComponentReference();
+    const metadata = await registry.getMetadata(componentRef);
 
     expect(metadata).to.be.null;
     expect(moduleLoaderSpy.called).to.be.false;
+  });
 
-    // Unknown element
-    componentRef = mockComponentReference('unknown-element');
-    metadata = await registry.getMetadata(componentRef);
+  it('should return generic metadata for non-Vaadin element', async () => {
+    const componentRef = mockComponentReference('h2');
+    const metadata = await registry.getMetadata(componentRef);
+    const expectedMetadata = createGenericMetadata('h2');
 
-    expect(metadata).to.be.null;
+    expect(metadata).to.deep.equal(expectedMetadata);
+    expect(metadata?.displayName).to.equal('H2');
     expect(moduleLoaderSpy.called).to.be.false;
   });
 

--- a/vaadin-dev-server/frontend/theme-editor/metadata/registry.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/registry.ts
@@ -1,5 +1,6 @@
 import { ComponentReference } from '../../component-util';
 import { ComponentMetadata } from './model';
+import { createGenericMetadata } from './components/generic';
 
 type MetadataMap = { [key: string]: ComponentMetadata };
 
@@ -16,10 +17,15 @@ export class MetadataRegistry {
   constructor(private loader: ModuleLoader = defaultModuleLoader) {}
 
   async getMetadata(component: ComponentReference): Promise<ComponentMetadata | null> {
-    // Ignore if there is no element, or it's not a Vaadin component
+    // Ignore if there is no element
     const tagName = component.element?.localName;
-    if (!tagName || !tagName.startsWith('vaadin-')) {
+    if (!tagName) {
       return null;
+    }
+
+    // For non-Vaadin elements, return generic metadata
+    if (!tagName.startsWith('vaadin-')) {
+      return createGenericMetadata(tagName);
     }
 
     // Check for existing metadata


### PR DESCRIPTION
## Description

Allows styling non-Vaadin components, such as `H1`, `Div`, `Span`, etc., using a generic set of metadata. The generic metadata is used whenever a component's tag name does not start with `vaadin-`. For Vaadin components we should attempt to cover them with specific metadata, so the generic metadata is not used as fallback for Vaadin components that don't have their own metadata yet.

~~Based on the changes from https://github.com/vaadin/flow/pull/16413 and is currently set to merge against it.~~

