### PR TITLE
refactor: lazily define theme editor global styles

### DIFF
--- a/vaadin-dev-server/frontend/theme-editor/components/scope-selector.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/scope-selector.ts
@@ -11,42 +11,6 @@ export class ScopeChangeEvent extends CustomEvent<{ value: ThemeScope }> {
   }
 }
 
-injectGlobalCss(css`
-  vaadin-select-overlay[theme~='vaadin-dev-tools-theme-scope-selector'] {
-    --lumo-primary-color-50pct: rgba(255, 255, 255, 0.5);
-    z-index: 100000;
-  }
-
-  vaadin-select-overlay[theme~='vaadin-dev-tools-theme-scope-selector']::part(overlay) {
-    background: #333;
-  }
-
-  vaadin-select-overlay[theme~='vaadin-dev-tools-theme-scope-selector'] vaadin-item {
-    color: rgba(255, 255, 255, 0.8);
-  }
-
-  vaadin-select-overlay[theme~='vaadin-dev-tools-theme-scope-selector'] vaadin-item::part(content) {
-    font-size: 13px;
-  }
-
-  vaadin-select-overlay[theme~='vaadin-dev-tools-theme-scope-selector'] vaadin-item .title {
-    color: rgba(255, 255, 255, 0.95);
-    font-weight: bold;
-  }
-
-  vaadin-select-overlay[theme~='vaadin-dev-tools-theme-scope-selector'] vaadin-item::part(checkmark) {
-    margin: 6px;
-  }
-
-  vaadin-select-overlay[theme~='vaadin-dev-tools-theme-scope-selector'] vaadin-item::part(checkmark)::before {
-    color: rgba(255, 255, 255, 0.95);
-  }
-
-  vaadin-select-overlay[theme~='vaadin-dev-tools-theme-scope-selector'] vaadin-item:hover {
-    background: rgba(255, 255, 255, 0.1);
-  }
-`);
-
 @customElement('vaadin-dev-tools-theme-scope-selector')
 export class ScopeSelector extends LitElement {
   static get styles() {
@@ -82,6 +46,52 @@ export class ScopeSelector extends LitElement {
   public metadata?: ComponentMetadata;
   @query('vaadin-select')
   private select?: Select;
+
+  connectedCallback() {
+    super.connectedCallback();
+    // Lazily init global styles
+    // Injecting global styles uses a constructed stylesheet, which requires a
+    // polyfill in Safari. The polyfill might not be loaded yet when this module
+    // loads, so we only run this when the component created.
+    injectGlobalCss(
+      'scope-selector',
+      css`
+        vaadin-select-overlay[theme~='vaadin-dev-tools-theme-scope-selector'] {
+          --lumo-primary-color-50pct: rgba(255, 255, 255, 0.5);
+          z-index: 100000;
+        }
+
+        vaadin-select-overlay[theme~='vaadin-dev-tools-theme-scope-selector']::part(overlay) {
+          background: #333;
+        }
+
+        vaadin-select-overlay[theme~='vaadin-dev-tools-theme-scope-selector'] vaadin-item {
+          color: rgba(255, 255, 255, 0.8);
+        }
+
+        vaadin-select-overlay[theme~='vaadin-dev-tools-theme-scope-selector'] vaadin-item::part(content) {
+          font-size: 13px;
+        }
+
+        vaadin-select-overlay[theme~='vaadin-dev-tools-theme-scope-selector'] vaadin-item .title {
+          color: rgba(255, 255, 255, 0.95);
+          font-weight: bold;
+        }
+
+        vaadin-select-overlay[theme~='vaadin-dev-tools-theme-scope-selector'] vaadin-item::part(checkmark) {
+          margin: 6px;
+        }
+
+        vaadin-select-overlay[theme~='vaadin-dev-tools-theme-scope-selector'] vaadin-item::part(checkmark)::before {
+          color: rgba(255, 255, 255, 0.95);
+        }
+
+        vaadin-select-overlay[theme~='vaadin-dev-tools-theme-scope-selector'] vaadin-item:hover {
+          background: rgba(255, 255, 255, 0.1);
+        }
+      `
+    );
+  }
 
   protected update(changedProperties: PropertyValues) {
     super.update(changedProperties);

--- a/vaadin-dev-server/frontend/theme-editor/detector.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/detector.test.ts
@@ -1,11 +1,15 @@
 import { expect, fixture, html } from '@open-wc/testing';
 import sinon from 'sinon';
-import { detectTheme } from './detector';
+import { detectTheme, setupThemeDetectorCss } from './detector';
 import { testElementMetadata } from './tests/utils';
 
 describe('theme-detector', () => {
   let setupElementStub: sinon.SinonStub;
   let cleanupElementStub: sinon.SinonStub;
+
+  before(() => {
+    setupThemeDetectorCss();
+  });
 
   beforeEach(() => {
     setupElementStub = sinon.stub(testElementMetadata, 'setupElement');
@@ -80,5 +84,5 @@ describe('theme-detector', () => {
 
     expect(setupElementStub.calledOnce).to.be.true;
     expect(cleanupElementStub.calledOnce).to.be.true;
-  })
+  });
 });

--- a/vaadin-dev-server/frontend/theme-editor/detector.ts
+++ b/vaadin-dev-server/frontend/theme-editor/detector.ts
@@ -8,14 +8,19 @@ const measureElementClassname = '__vaadin-theme-editor-measure-element';
 const pseudoRegex = /((::before)|(::after))$/;
 const partNameRegex = /::part\(([\w\d_-]+)\)$/;
 
-injectGlobalCss(css`
-  .__vaadin-theme-editor-measure-element {
-    position: absolute;
-    top: 0;
-    left: 0;
-    visibility: hidden;
-  }
-`);
+export function setupThemeDetectorCss() {
+  injectGlobalCss(
+    'theme-detector',
+    css`
+      .__vaadin-theme-editor-measure-element {
+        position: absolute;
+        top: 0;
+        left: 0;
+        visibility: hidden;
+      }
+    `
+  );
+}
 
 export async function detectTheme(metadata: ComponentMetadata): Promise<ComponentTheme> {
   const componentTheme = new ComponentTheme(metadata);

--- a/vaadin-dev-server/frontend/theme-editor/editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.ts
@@ -12,7 +12,7 @@ import {
   ThemeEditorState,
   ThemeScope
 } from './model';
-import { detectElementDisplayName, detectTheme } from './detector';
+import { detectElementDisplayName, detectTheme, setupThemeDetectorCss } from './detector';
 import { ThemePropertyValueChangeEvent } from './components/editors/base-property-editor';
 import { themePreview } from './preview';
 import { Connection } from '../connection';
@@ -24,13 +24,6 @@ import './components/property-list';
 import '../component-picker.js';
 import { ComponentReference } from '../component-util';
 import { injectGlobalCss } from './styles';
-
-injectGlobalCss(css`
-  .vaadin-theme-editor-highlight {
-    outline: solid 2px #9e2cc6;
-    outline-offset: 3px;
-  }
-`);
 
 @customElement('vaadin-dev-tools-theme-editor')
 export class ThemeEditor extends LitElement {
@@ -180,6 +173,24 @@ export class ThemeEditor extends LitElement {
         color: var(--dev-tools-text-color-emphasis);
       }
     `;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    // Lazily init global styles
+    // Injecting global styles uses a constructed stylesheet, which requires a
+    // polyfill in Safari. The polyfill might not be loaded yet when this module
+    // loads, so we only run this when the component created.
+    setupThemeDetectorCss();
+    injectGlobalCss(
+      'editor',
+      css`
+        .vaadin-theme-editor-highlight {
+          outline: solid 2px #9e2cc6;
+          outline-offset: 3px;
+        }
+      `
+    );
   }
 
   protected firstUpdated() {

--- a/vaadin-dev-server/frontend/theme-editor/styles.ts
+++ b/vaadin-dev-server/frontend/theme-editor/styles.ts
@@ -2,13 +2,18 @@ import { CSSResult } from 'lit';
 
 let globalStylesheet: CSSStyleSheet;
 let globalCss: string = '';
+const registeredModules: Set<string> = new Set();
 
-export function injectGlobalCss(css: CSSResult) {
-    if (!globalStylesheet) {
-        globalStylesheet = new CSSStyleSheet();
-        document.adoptedStyleSheets = [...document.adoptedStyleSheets, globalStylesheet];
-    }
+export function injectGlobalCss(moduleName: string, css: CSSResult) {
+  if (registeredModules.has(moduleName)) {
+    return;
+  }
+  if (!globalStylesheet) {
+    globalStylesheet = new CSSStyleSheet();
+    document.adoptedStyleSheets = [...document.adoptedStyleSheets, globalStylesheet];
+  }
 
-    globalCss += css.cssText;
-    globalStylesheet.replaceSync(globalCss);
+  globalCss += css.cssText;
+  globalStylesheet.replaceSync(globalCss);
+  registeredModules.add(moduleName);
 }


### PR DESCRIPTION
## Description

Inject theme editor global styles lazily to ensure the constructable stylesheets polyfill used in Safari has been loaded.
