### PR TITLE
fix: Reload theme in dev bundle mode when running on Jetty

### DIFF
--- a/vaadin-dev-server/frontend/vaadin-dev-tools.ts
+++ b/vaadin-dev-server/frontend/vaadin-dev-tools.ts
@@ -873,9 +873,6 @@ export class VaadinDevTools extends LitElement {
 
     const onConnectionError = (msg: string) => this.log(MessageType.ERROR, msg);
     const onReload = () => {
-      if (this.liveReloadDisabled) {
-        return;
-      }
       this.showSplashMessage('Reloading…');
       const lastReload = window.sessionStorage.getItem(VaadinDevTools.TRIGGERED_COUNT_KEY_IN_SESSION_STORAGE);
       const nextReload = lastReload ? parseInt(lastReload, 10) + 1 : 1;


### PR DESCRIPTION
Jetty does not send live reload events automatically but this should not prevent handling reload events from the server. They need to be handled if you modify the theme in dev bundle mode
