### PR TITLE
refactor: allow editing local class name in theme editor

### DIFF
--- a/vaadin-dev-server/frontend/theme-editor/components/class-name-editor.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/class-name-editor.test.ts
@@ -1,0 +1,99 @@
+import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import sinon from 'sinon';
+import './class-name-editor';
+
+describe('class name editor', () => {
+  let editor: HTMLElement;
+  let classNameChangeEventSpy: sinon.SinonSpy;
+
+  function getInput() {
+    return editor.shadowRoot!.querySelector('input') as HTMLInputElement;
+  }
+
+  function getErrorMessage() {
+    return editor.shadowRoot!.querySelector('.error') as HTMLElement | null;
+  }
+
+  async function editClassName(className: string) {
+    const input = getInput();
+    input.value = className;
+    input.dispatchEvent(new Event('change'));
+    await elementUpdated(editor);
+  }
+
+  beforeEach(async () => {
+    classNameChangeEventSpy = sinon.spy();
+    editor = await fixture(html` <vaadin-dev-tools-theme-class-name-editor
+      .className=${'test-class'}
+      @class-name-change=${classNameChangeEventSpy}
+    ></vaadin-dev-tools-theme-class-name-editor>`);
+  });
+
+  it('should show class name', () => {
+    expect(getInput().value).to.equal('test-class');
+  });
+
+  it('should update class name', async () => {
+    editor.className = 'custom-class';
+    await elementUpdated(editor);
+
+    expect(getInput().value).to.equal('custom-class');
+  });
+
+  it('should dispatch class name change event', async () => {
+    await editClassName('custom-class');
+
+    expect(classNameChangeEventSpy.calledOnce).to.be.true;
+    expect(classNameChangeEventSpy.args[0][0].detail.value).to.equal('custom-class');
+  });
+
+  it('should not dispatch class name change event if class name did not change', async () => {
+    await editClassName('test-class');
+
+    expect(classNameChangeEventSpy.called).to.be.false;
+  });
+
+  it('should show error message if class name is invalid', async () => {
+    await editClassName('custom class');
+
+    expect(getErrorMessage()).to.exist;
+
+    await editClassName('custom-class');
+
+    expect(getErrorMessage()).to.not.exist;
+  });
+
+  it('should validate class name', async () => {
+    const invalidClassNames = [
+      'custom class',
+      ' custom-class',
+      'custom-class ',
+      '1custom-class',
+      '--custom-class',
+      '.custom-class',
+      '#custom-class',
+      '+custom-class'
+    ];
+
+    for (let i = 0; i < invalidClassNames.length; i++) {
+      const className = invalidClassNames[i];
+      await editClassName(className);
+      expect(getErrorMessage()).to.exist;
+    }
+  });
+
+  it('should not dispatch class name change event for invalid class name', async () => {
+    await editClassName('custom class');
+
+    expect(classNameChangeEventSpy.called).to.be.false;
+  });
+
+  it('should reset invalid state when setting className property', async () => {
+    await editClassName('custom class');
+    expect(getErrorMessage()).to.exist;
+
+    editor.className = 'custom-class';
+    await elementUpdated(editor);
+    expect(getErrorMessage()).to.not.exist;
+  });
+});

--- a/vaadin-dev-server/frontend/theme-editor/components/class-name-editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/class-name-editor.ts
@@ -1,0 +1,68 @@
+import { css, html, LitElement, PropertyValues } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { editorRowStyles } from '../styles';
+
+export class ClassNameChangeEvent extends CustomEvent<{ value: string }> {
+  constructor(value: string) {
+    super('class-name-change', { detail: { value } });
+  }
+}
+
+@customElement('vaadin-dev-tools-theme-class-name-editor')
+export class ClassNameEditor extends LitElement {
+  static get styles() {
+    return [
+      editorRowStyles,
+      css`
+        .editor-row {
+          padding-top: 0;
+        }
+
+        .editor-row .editor .error {
+          display: inline-block;
+          color: var(--dev-tools-red-color);
+          margin-top: 4px;
+        }
+      `
+    ];
+  }
+
+  @property({})
+  public className!: string;
+
+  @state()
+  private editedClassName: string = '';
+  @state()
+  private invalid: boolean = false;
+
+  protected update(changedProperties: PropertyValues) {
+    super.update(changedProperties);
+
+    if (changedProperties.has('className')) {
+      this.editedClassName = this.className;
+      this.invalid = false;
+    }
+  }
+
+  render() {
+    return html` <div class="editor-row local-class-name">
+      <div class="label">CSS class name</div>
+      <div class="editor">
+        <input class="input" type="text" .value=${this.editedClassName} @change=${this.handleInputChange} />
+        ${this.invalid ? html`<br /><span class="error">Please enter a valid CSS class name</span>` : null}
+      </div>
+    </div>`;
+  }
+
+  private handleInputChange(e: Event) {
+    const input = e.target as HTMLInputElement;
+    this.editedClassName = input.value;
+
+    const classNameRegex = /^-?[_a-zA-Z]+[_a-zA-Z0-9-]*$/;
+    this.invalid = !this.editedClassName.match(classNameRegex);
+
+    if (!this.invalid && this.editedClassName !== this.className) {
+      this.dispatchEvent(new ClassNameChangeEvent(this.editedClassName));
+    }
+  }
+}

--- a/vaadin-dev-server/frontend/theme-editor/components/editors/base-property-editor.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/editors/base-property-editor.test.ts
@@ -64,7 +64,7 @@ describe('base property editor', () => {
   });
 
   it('should not show modified indicator if property value is not modified', () => {
-    const modifiedIndicator = editor.shadowRoot!.querySelector('.property-name .modified');
+    const modifiedIndicator = editor.shadowRoot!.querySelector('.label .modified');
 
     expect(modifiedIndicator).to.not.exist;
   });
@@ -75,7 +75,7 @@ describe('base property editor', () => {
     editor.theme = updatedTheme;
     await elementUpdated(editor);
 
-    const modifiedIndicator = editor.shadowRoot!.querySelector('.property-name .modified');
+    const modifiedIndicator = editor.shadowRoot!.querySelector('.label .modified');
 
     expect(modifiedIndicator).to.exist;
   });

--- a/vaadin-dev-server/frontend/theme-editor/components/editors/base-property-editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/editors/base-property-editor.ts
@@ -2,6 +2,7 @@ import { css, CSSResultGroup, html, LitElement, PropertyValues, TemplateResult }
 import { property, state } from 'lit/decorators.js';
 import { ComponentElementMetadata, CssPropertyMetadata } from '../../metadata/model';
 import { ComponentTheme, ThemePropertyValue } from '../../model';
+import { editorRowStyles } from '../../styles';
 
 export class ThemePropertyValueChangeEvent extends CustomEvent<{
   element: ComponentElementMetadata;
@@ -19,45 +20,23 @@ export class ThemePropertyValueChangeEvent extends CustomEvent<{
 
 export abstract class BasePropertyEditor extends LitElement {
   static get styles(): CSSResultGroup {
-    return css`
-      :host {
-        display: block;
-      }
+    return [
+      editorRowStyles,
+      css`
+        :host {
+          display: block;
+        }
 
-      .property {
-        display: flex;
-        align-items: baseline;
-        padding: var(--theme-editor-section-horizontal-padding);
-      }
-
-      .property .property-name {
-        flex: 0 0 auto;
-        width: 100px;
-      }
-
-      .property .property-name .modified {
-        display: inline-block;
-        width: 6px;
-        height: 6px;
-        background: orange;
-        border-radius: 3px;
-        margin-left: 3px;
-      }
-
-      .property .property-editor {
-        flex: 1 1 0;
-      }
-
-      .input {
-        width: 100%;
-        box-sizing: border-box;
-        padding: 0.25rem 0.375rem;
-        color: inherit;
-        background: rgba(0, 0, 0, 0.2);
-        border-radius: 0.25rem;
-        border: none;
-      }
-    `;
+        .editor-row .label .modified {
+          display: inline-block;
+          width: 6px;
+          height: 6px;
+          background: orange;
+          border-radius: 3px;
+          margin-left: 3px;
+        }
+      `
+    ];
   }
 
   @property({})
@@ -82,12 +61,12 @@ export abstract class BasePropertyEditor extends LitElement {
 
   render() {
     return html`
-      <div class="property">
-        <div class="property-name">
+      <div class="editor-row">
+        <div class="label">
           ${this.propertyMetadata.displayName}
           ${this.propertyValue?.modified ? html`<span class="modified"></span>` : null}
         </div>
-        <div class="property-editor">${this.renderEditor()}</div>
+        <div class="editor">${this.renderEditor()}</div>
       </div>
     `;
   }

--- a/vaadin-dev-server/frontend/theme-editor/components/editors/checkbox-property-editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/editors/checkbox-property-editor.ts
@@ -8,7 +8,7 @@ export class CheckboxPropertyEditor extends BasePropertyEditor {
     return [
       BasePropertyEditor.styles,
       css`
-        .property {
+        .editor-row {
           align-items: center;
         }
       `

--- a/vaadin-dev-server/frontend/theme-editor/components/editors/color-property-editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/editors/color-property-editor.ts
@@ -10,11 +10,11 @@ export class ColorPropertyEditor extends BasePropertyEditor {
     return [
       BasePropertyEditor.styles,
       css`
-        .property {
+        .editor-row {
           align-items: center;
         }
 
-        .property .property-editor {
+        .editor-row > .editor {
           display: flex;
           align-items: center;
           gap: 0.5rem;

--- a/vaadin-dev-server/frontend/theme-editor/components/editors/range-property-editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/editors/range-property-editor.ts
@@ -16,17 +16,17 @@ export class RangePropertyEditor extends BasePropertyEditor {
           --slider-border: #333;
         }
 
-        .property {
+        .editor-row {
           align-items: center;
         }
 
-        .property .property-editor {
+        .editor-row > .editor {
           display: flex;
           align-items: center;
           gap: 1rem;
         }
 
-        .input {
+        .editor-row .input {
           flex: 0 0 auto;
           width: 80px;
         }

--- a/vaadin-dev-server/frontend/theme-editor/editor.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.test.ts
@@ -152,11 +152,10 @@ describe('theme-editor', () => {
   }
 
   async function editLocalClassName(className: string) {
-    const classNameInput = editor.shadowRoot!.querySelector(
-      '.header .editor-row.local-class-name input'
-    ) as HTMLInputElement;
-
-    expect(classNameInput).to.exist;
+    const classNameEditor = editor.shadowRoot!.querySelector(
+      '.header vaadin-dev-tools-theme-class-name-editor'
+    ) as HTMLElement;
+    const classNameInput = classNameEditor.shadowRoot!.querySelector('input') as HTMLInputElement;
 
     classNameInput.value = className;
     classNameInput.dispatchEvent(new Event('change'));
@@ -369,7 +368,7 @@ describe('theme-editor', () => {
     it('should show local class name editor if instance is accessible', async () => {
       await pickComponent();
 
-      const localClassNameEditor = editor.shadowRoot!.querySelector('.header .editor-row.local-class-name');
+      const localClassNameEditor = editor.shadowRoot!.querySelector('.header vaadin-dev-tools-theme-class-name-editor');
       expect(localClassNameEditor).to.exist;
     });
 
@@ -377,7 +376,7 @@ describe('theme-editor', () => {
       apiMock.loadComponentMetadata.returns(Promise.resolve({ accessible: false }));
       await pickComponent();
 
-      const localClassNameEditor = editor.shadowRoot!.querySelector('.header .editor-row.local-class-name');
+      const localClassNameEditor = editor.shadowRoot!.querySelector('.header vaadin-dev-tools-theme-class-name-editor');
       expect(localClassNameEditor).to.not.exist;
     });
 
@@ -446,7 +445,7 @@ describe('theme-editor', () => {
       await pickComponent();
       await changeThemeScope(ThemeScope.global);
 
-      const localClassNameEditor = editor.shadowRoot!.querySelector('.header .editor-row.local-class-name');
+      const localClassNameEditor = editor.shadowRoot!.querySelector('.header vaadin-dev-tools-theme-class-name-editor');
       expect(localClassNameEditor).to.not.exist;
     });
   });
@@ -845,16 +844,9 @@ describe('theme-editor', () => {
       expect(testElement.classList.contains('test-class')).to.be.false;
     });
 
-    it('should not allow submitting invalid class names', async () => {
+    it('should not submit invalid class name', async () => {
       await pickComponent();
       await editLocalClassName('custom class');
-      await editLocalClassName(' custom-class');
-      await editLocalClassName('custom-class ');
-      await editLocalClassName('1custom-class');
-      await editLocalClassName('.custom-class');
-      await editLocalClassName('custom/class');
-      await editLocalClassName('custom:class');
-      await editLocalClassName('custom+class');
 
       expect(apiMock.setLocalClassName.called).to.be.false;
     });

--- a/vaadin-dev-server/frontend/theme-editor/editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.ts
@@ -19,12 +19,14 @@ import { Connection } from '../connection';
 import { ThemeEditorApi } from './api';
 import { ThemeEditorHistory, ThemeEditorHistoryActions } from './history';
 import { ScopeChangeEvent } from './components/scope-selector';
+import './components/class-name-editor';
 import './components/scope-selector';
 import './components/property-list';
 import '../component-picker.js';
 import { ComponentReference } from '../component-util';
-import { editorRowStyles, injectGlobalCss } from './styles';
+import { injectGlobalCss } from './styles';
 import { ComponentMetadata } from './metadata/model';
+import { ClassNameChangeEvent } from './components/class-name-editor';
 
 injectGlobalCss(css`
   .vaadin-theme-editor-highlight {
@@ -68,129 +70,122 @@ export class ThemeEditor extends LitElement {
   private effectiveTheme: ComponentTheme | null = null;
 
   static get styles() {
-    return [
-      editorRowStyles,
-      css`
-        :host {
-          animation: fade-in var(--dev-tools-transition-duration) ease-in;
-          --theme-editor-section-horizontal-padding: 0.75rem;
-          display: flex;
-          flex-direction: column;
-          max-height: 400px;
-        }
+    return css`
+      :host {
+        animation: fade-in var(--dev-tools-transition-duration) ease-in;
+        --theme-editor-section-horizontal-padding: 0.75rem;
+        display: flex;
+        flex-direction: column;
+        max-height: 400px;
+      }
 
-        .notice {
-          padding: var(--theme-editor-section-horizontal-padding);
-        }
+      .notice {
+        padding: var(--theme-editor-section-horizontal-padding);
+      }
 
-        .notice a {
-          color: var(--dev-tools-text-color-emphasis);
-        }
+      .notice a {
+        color: var(--dev-tools-text-color-emphasis);
+      }
 
-        .header {
-          flex: 0 0 auto;
-          border-bottom: solid 1px rgba(0, 0, 0, 0.2);
-        }
+      .header {
+        flex: 0 0 auto;
+        border-bottom: solid 1px rgba(0, 0, 0, 0.2);
+      }
 
-        .header .picker-row {
-          padding: var(--theme-editor-section-horizontal-padding);
-          display: flex;
-          gap: 20px;
-          align-items: center;
-          justify-content: space-between;
-        }
+      .header .picker-row {
+        padding: var(--theme-editor-section-horizontal-padding);
+        display: flex;
+        gap: 20px;
+        align-items: center;
+        justify-content: space-between;
+      }
 
-        .header .editor-row.local-class-name {
-          padding-top: 0;
-        }
+      .picker {
+        flex: 1 1 0;
+        min-width: 0;
+        display: flex;
+        align-items: center;
+      }
 
-        .picker {
-          flex: 1 1 0;
-          min-width: 0;
-          display: flex;
-          align-items: center;
-        }
+      .picker button {
+        min-width: 0;
+        display: inline-flex;
+        align-items: center;
+        padding: 0;
+        line-height: 20px;
+        border: none;
+        background: none;
+        color: var(--dev-tools-text-color);
+      }
 
-        .picker button {
-          min-width: 0;
-          display: inline-flex;
-          align-items: center;
-          padding: 0;
-          line-height: 20px;
-          border: none;
-          background: none;
-          color: var(--dev-tools-text-color);
-        }
+      .picker button:not(:disabled):hover {
+        color: var(--dev-tools-text-color-emphasis);
+      }
 
-        .picker button:not(:disabled):hover {
-          color: var(--dev-tools-text-color-emphasis);
-        }
+      .picker svg,
+      .picker .component-type {
+        flex: 0 0 auto;
+        margin-right: 4px;
+      }
 
-        .picker svg,
-        .picker .component-type {
-          flex: 0 0 auto;
-          margin-right: 4px;
-        }
+      .picker .instance-name {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        color: #e5a2fce5;
+      }
 
-        .picker .instance-name {
-          overflow: hidden;
-          text-overflow: ellipsis;
-          white-space: nowrap;
-          color: #e5a2fce5;
-        }
+      .picker .instance-name-quote {
+        color: #e5a2fce5;
+      }
 
-        .picker .instance-name-quote {
-          color: #e5a2fce5;
-        }
+      .picker .no-selection {
+        font-style: italic;
+      }
 
-        .picker .no-selection {
-          font-style: italic;
-        }
+      .actions {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
 
-        .actions {
-          display: flex;
-          align-items: center;
-          gap: 8px;
-        }
+      .property-list {
+        flex: 1 1 auto;
+        overflow-y: auto;
+      }
 
-        .property-list {
-          flex: 1 1 auto;
-          overflow-y: auto;
-        }
+      .link-button {
+        all: initial;
+        font-family: inherit;
+        font-size: var(--dev-tools-font-size-small);
+        line-height: 1;
+        white-space: nowrap;
+        color: inherit;
+        font-weight: 600;
+        text-decoration: underline;
+      }
 
-        .link-button {
-          all: initial;
-          font-family: inherit;
-          font-size: var(--dev-tools-font-size-small);
-          line-height: 1;
-          white-space: nowrap;
-          color: inherit;
-          font-weight: 600;
-          text-decoration: underline;
-        }
+      .link-button:focus,
+      .link-button:hover {
+        color: var(--dev-tools-text-color-emphasis);
+      }
 
-        .link-button:focus,
-        .link-button:hover {
-          color: var(--dev-tools-text-color-emphasis);
-        }
+      .icon-button {
+        padding: 0;
+        line-height: 0;
+        border: none;
+        background: none;
+        color: var(--dev-tools-text-color);
+      }
 
-        .icon-button {
-          padding: 0;
-          line-height: 0;
-          border: none;
-          background: none;
-          color: var(--dev-tools-text-color);
-        }
+      .icon-button:disabled {
+        opacity: 0.5;
+      }
 
-        .icon-button:disabled {
-          opacity: 0.5;
-        }
-
-        .icon-button:not(:disabled):hover {
-          color: var(--dev-tools-text-color-emphasis);
-        }
-      `
-    ];
+      .icon-button:not(:disabled):hover {
+        color: var(--dev-tools-text-color-emphasis);
+      }
+    `;
   }
 
   protected firstUpdated() {
@@ -344,34 +339,24 @@ export class ThemeEditor extends LitElement {
 
     const instanceClassName = this.context.localClassName || this.context.suggestedClassName;
 
-    return html` <div class="editor-row local-class-name">
-      <div class="label">Class name</div>
-      <div class="editor">
-        <input class="input" type="text" .value=${instanceClassName} @change=${this.handleClassNameChange} />
-      </div>
-    </div>`;
+    return html` <vaadin-dev-tools-theme-class-name-editor
+      .className=${instanceClassName}
+      @class-name-change=${this.handleClassNameChange}
+    >
+    </vaadin-dev-tools-theme-class-name-editor>`;
   }
 
-  private async handleClassNameChange(e: Event) {
+  private async handleClassNameChange(e: ClassNameChangeEvent) {
     if (!this.context) {
       return;
     }
 
-    const input = e.target as HTMLInputElement;
-    const newClassName = input.value;
-
-    // Validate class name, just roll back value if it is invalid
-    const classNameRegex = /^-?[_a-zA-Z]+[_a-zA-Z0-9-]*$/;
-    if (!newClassName.match(classNameRegex)) {
-      input.value = (this.context.localClassName || this.context.suggestedClassName)!;
-      return;
-    }
-
-    if (this.context.localClassName) {
+    const previousClassName = this.context.localClassName;
+    const newClassName = e.detail.value;
+    if (previousClassName) {
       // Update local class name if there is an existing one
       this.preventLiveReload();
       const element = this.context.component.element;
-      const previousClassName = this.context.localClassName;
       this.context.localClassName = newClassName;
       const classNameResponse = await this.api.setLocalClassName(this.context.component, newClassName);
       this.historyActions = this.history.push(

--- a/vaadin-dev-server/frontend/theme-editor/editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.ts
@@ -23,7 +23,8 @@ import './components/scope-selector';
 import './components/property-list';
 import '../component-picker.js';
 import { ComponentReference } from '../component-util';
-import { injectGlobalCss } from './styles';
+import { editorRowStyles, injectGlobalCss } from './styles';
+import { ComponentMetadata } from './metadata/model';
 
 injectGlobalCss(css`
   .vaadin-theme-editor-highlight {
@@ -67,119 +68,129 @@ export class ThemeEditor extends LitElement {
   private effectiveTheme: ComponentTheme | null = null;
 
   static get styles() {
-    return css`
-      :host {
-        animation: fade-in var(--dev-tools-transition-duration) ease-in;
-        --theme-editor-section-horizontal-padding: 0.75rem;
-        display: flex;
-        flex-direction: column;
-        max-height: 400px;
-      }
+    return [
+      editorRowStyles,
+      css`
+        :host {
+          animation: fade-in var(--dev-tools-transition-duration) ease-in;
+          --theme-editor-section-horizontal-padding: 0.75rem;
+          display: flex;
+          flex-direction: column;
+          max-height: 400px;
+        }
 
-      .notice {
-        padding: var(--theme-editor-section-horizontal-padding);
-      }
+        .notice {
+          padding: var(--theme-editor-section-horizontal-padding);
+        }
 
-      .notice a {
-        color: var(--dev-tools-text-color-emphasis);
-      }
+        .notice a {
+          color: var(--dev-tools-text-color-emphasis);
+        }
 
-      .header {
-        flex: 0 0 auto;
-        gap: 20px;
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        border-bottom: solid 1px rgba(0, 0, 0, 0.2);
-        padding: var(--theme-editor-section-horizontal-padding);
-      }
+        .header {
+          flex: 0 0 auto;
+          border-bottom: solid 1px rgba(0, 0, 0, 0.2);
+        }
 
-      .picker {
-        flex: 1 1 0;
-        min-width: 0;
-        display: flex;
-        align-items: center;
-      }
+        .header .picker-row {
+          padding: var(--theme-editor-section-horizontal-padding);
+          display: flex;
+          gap: 20px;
+          align-items: center;
+          justify-content: space-between;
+        }
 
-      .picker button {
-        min-width: 0;
-        display: inline-flex;
-        align-items: center;
-        padding: 0;
-        line-height: 20px;
-        border: none;
-        background: none;
-        color: var(--dev-tools-text-color);
-      }
+        .header .editor-row.local-class-name {
+          padding-top: 0;
+        }
 
-      .picker button:not(:disabled):hover {
-        color: var(--dev-tools-text-color-emphasis);
-      }
+        .picker {
+          flex: 1 1 0;
+          min-width: 0;
+          display: flex;
+          align-items: center;
+        }
 
-      .picker svg,
-      .picker .component-type {
-        flex: 0 0 auto;
-        margin-right: 4px;
-      }
+        .picker button {
+          min-width: 0;
+          display: inline-flex;
+          align-items: center;
+          padding: 0;
+          line-height: 20px;
+          border: none;
+          background: none;
+          color: var(--dev-tools-text-color);
+        }
 
-      .picker .instance-name {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        color: #e5a2fce5;
-      }
+        .picker button:not(:disabled):hover {
+          color: var(--dev-tools-text-color-emphasis);
+        }
 
-      .picker .instance-name-quote {
-        color: #e5a2fce5;
-      }
+        .picker svg,
+        .picker .component-type {
+          flex: 0 0 auto;
+          margin-right: 4px;
+        }
 
-      .picker .no-selection {
-        font-style: italic;
-      }
+        .picker .instance-name {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          color: #e5a2fce5;
+        }
 
-      .actions {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-      }
+        .picker .instance-name-quote {
+          color: #e5a2fce5;
+        }
 
-      .property-list {
-        flex: 1 1 auto;
-        overflow-y: auto;
-      }
+        .picker .no-selection {
+          font-style: italic;
+        }
 
-      .link-button {
-        all: initial;
-        font-family: inherit;
-        font-size: var(--dev-tools-font-size-small);
-        line-height: 1;
-        white-space: nowrap;
-        color: inherit;
-        font-weight: 600;
-        text-decoration: underline;
-      }
+        .actions {
+          display: flex;
+          align-items: center;
+          gap: 8px;
+        }
 
-      .link-button:focus,
-      .link-button:hover {
-        color: var(--dev-tools-text-color-emphasis);
-      }
+        .property-list {
+          flex: 1 1 auto;
+          overflow-y: auto;
+        }
 
-      .icon-button {
-        padding: 0;
-        line-height: 0;
-        border: none;
-        background: none;
-        color: var(--dev-tools-text-color);
-      }
+        .link-button {
+          all: initial;
+          font-family: inherit;
+          font-size: var(--dev-tools-font-size-small);
+          line-height: 1;
+          white-space: nowrap;
+          color: inherit;
+          font-weight: 600;
+          text-decoration: underline;
+        }
 
-      .icon-button:disabled {
-        opacity: 0.5;
-      }
+        .link-button:focus,
+        .link-button:hover {
+          color: var(--dev-tools-text-color-emphasis);
+        }
 
-      .icon-button:not(:disabled):hover {
-        color: var(--dev-tools-text-color-emphasis);
-      }
-    `;
+        .icon-button {
+          padding: 0;
+          line-height: 0;
+          border: none;
+          background: none;
+          color: var(--dev-tools-text-color);
+        }
+
+        .icon-button:disabled {
+          opacity: 0.5;
+        }
+
+        .icon-button:not(:disabled):hover {
+          color: var(--dev-tools-text-color-emphasis);
+        }
+      `
+    ];
   }
 
   protected firstUpdated() {
@@ -214,32 +225,35 @@ export class ThemeEditor extends LitElement {
 
     return html`
       <div class="header">
-        ${this.renderPicker()}
-        <div class="actions">
-          ${this.context
-            ? html` <vaadin-dev-tools-theme-scope-selector
-                .value=${this.context.scope}
-                .metadata=${this.context.metadata}
-                @scope-change=${this.handleScopeChange}
-              ></vaadin-dev-tools-theme-scope-selector>`
-            : null}
-          <button
-            class="icon-button"
-            data-testid="undo"
-            ?disabled=${!this.historyActions?.allowUndo}
-            @click=${this.handleUndo}
-          >
-            ${icons.undo}
-          </button>
-          <button
-            class="icon-button"
-            data-testid="redo"
-            ?disabled=${!this.historyActions?.allowRedo}
-            @click=${this.handleRedo}
-          >
-            ${icons.redo}
-          </button>
+        <div class="picker-row">
+          ${this.renderPicker()}
+          <div class="actions">
+            ${this.context
+              ? html` <vaadin-dev-tools-theme-scope-selector
+                  .value=${this.context.scope}
+                  .metadata=${this.context.metadata}
+                  @scope-change=${this.handleScopeChange}
+                ></vaadin-dev-tools-theme-scope-selector>`
+              : null}
+            <button
+              class="icon-button"
+              data-testid="undo"
+              ?disabled=${!this.historyActions?.allowUndo}
+              @click=${this.handleUndo}
+            >
+              ${icons.undo}
+            </button>
+            <button
+              class="icon-button"
+              data-testid="redo"
+              ?disabled=${!this.historyActions?.allowRedo}
+              @click=${this.handleRedo}
+            >
+              ${icons.redo}
+            </button>
+          </div>
         </div>
+        ${this.renderLocalClassNameEditor()}
       </div>
       ${this.renderPropertyList()}
     `;
@@ -322,6 +336,61 @@ export class ThemeEditor extends LitElement {
     `;
   }
 
+  renderLocalClassNameEditor() {
+    const allowEditing = this.context?.scope === ThemeScope.local && this.context.accessible;
+    if (!this.context || !allowEditing) {
+      return null;
+    }
+
+    const instanceClassName = this.context.localClassName || this.context.suggestedClassName;
+
+    return html` <div class="editor-row local-class-name">
+      <div class="label">Class name</div>
+      <div class="editor">
+        <input class="input" type="text" .value=${instanceClassName} @change=${this.handleClassNameChange} />
+      </div>
+    </div>`;
+  }
+
+  private async handleClassNameChange(e: Event) {
+    if (!this.context) {
+      return;
+    }
+
+    const input = e.target as HTMLInputElement;
+    const newClassName = input.value;
+
+    // Validate class name, just roll back value if it is invalid
+    const classNameRegex = /^-?[_a-zA-Z]+[_a-zA-Z0-9-]*$/;
+    if (!newClassName.match(classNameRegex)) {
+      input.value = (this.context.localClassName || this.context.suggestedClassName)!;
+      return;
+    }
+
+    if (this.context.localClassName) {
+      // Update local class name if there is an existing one
+      this.preventLiveReload();
+      const element = this.context.component.element;
+      const previousClassName = this.context.localClassName;
+      this.context.localClassName = newClassName;
+      const classNameResponse = await this.api.setLocalClassName(this.context.component, newClassName);
+      this.historyActions = this.history.push(
+        classNameResponse.requestId,
+        () => themePreview.previewLocalClassName(element, newClassName),
+        () => themePreview.previewLocalClassName(element, previousClassName)
+      );
+      // Update preview, as class names in CSS have changed
+      await this.updateThemePreview();
+    } else {
+      // Update suggested class name for now, will effectively be applied when
+      // changing a property
+      this.context = {
+        ...this.context,
+        suggestedClassName: newClassName
+      };
+    }
+  }
+
   private async pickComponent() {
     this.removeElementHighlight(this.context?.component.element);
 
@@ -345,17 +414,7 @@ export class ThemeEditor extends LitElement {
         }
 
         this.highlightElement(component.element);
-        const componentResponse = await this.api.loadComponentMetadata(component);
-        this.previewGeneratedClassName(component.element, componentResponse.className);
-
-        this.refreshTheme({
-          scope: this.context?.scope || ThemeScope.local,
-          metadata,
-          component,
-          localClassName: componentResponse.className,
-          suggestedClassName: componentResponse.suggestedClassName,
-          accessible: componentResponse.accessible
-        });
+        this.refreshComponentAndTheme(component, metadata);
       }
     });
   }
@@ -384,11 +443,15 @@ export class ThemeEditor extends LitElement {
     // If we are theming locally, and the component does not have a local class
     // name yet, then apply suggested class name from server first
     if (this.context.scope === ThemeScope.local && !this.context.localClassName && this.context.suggestedClassName) {
+      const element = this.context.component.element;
       const newClassName = this.context.suggestedClassName;
       this.context.localClassName = newClassName;
       const classNameResponse = await this.api.setLocalClassName(this.context.component, newClassName);
-      this.historyActions = this.history.push(classNameResponse.requestId);
-      this.previewGeneratedClassName(this.context.component.element, newClassName);
+      this.historyActions = this.history.push(
+        classNameResponse.requestId,
+        () => themePreview.previewLocalClassName(element, newClassName),
+        () => themePreview.previewLocalClassName(element)
+      );
     }
 
     // Can't generate a local scoped selector without a local classname
@@ -416,13 +479,33 @@ export class ThemeEditor extends LitElement {
   private async handleUndo() {
     this.preventLiveReload();
     this.historyActions = await this.history.undo();
-    await this.refreshTheme();
+    await this.refreshComponentAndTheme();
   }
 
   private async handleRedo() {
     this.preventLiveReload();
     this.historyActions = await this.history.redo();
-    await this.refreshTheme();
+    await this.refreshComponentAndTheme();
+  }
+
+  private async refreshComponentAndTheme(component?: ComponentReference, metadata?: ComponentMetadata) {
+    component = component || this.context?.component;
+    metadata = metadata || this.context?.metadata;
+    if (!component || !metadata) {
+      return;
+    }
+
+    const componentResponse = await this.api.loadComponentMetadata(component);
+    themePreview.previewLocalClassName(component.element, componentResponse.className);
+
+    await this.refreshTheme({
+      scope: this.context?.scope || ThemeScope.local,
+      metadata,
+      component,
+      localClassName: componentResponse.className,
+      suggestedClassName: componentResponse.suggestedClassName,
+      accessible: componentResponse.accessible
+    });
   }
 
   private async refreshTheme(newContext?: ThemeContext) {
@@ -493,20 +576,5 @@ export class ThemeEditor extends LitElement {
     if (element) {
       element.classList.remove('vaadin-theme-editor-highlight');
     }
-  }
-
-  /**
-   * Adds instance class name generated by the server to the specified element,
-   * so that instance-specific styles can be previewed.
-   * @param element
-   * @param className
-   * @private
-   */
-  private previewGeneratedClassName(element?: HTMLElement, className?: string) {
-    if (!className || !element) {
-      return;
-    }
-
-    element.classList.add(className);
   }
 }

--- a/vaadin-dev-server/frontend/theme-editor/preview.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/preview.test.ts
@@ -79,4 +79,42 @@ describe('theme-preview', () => {
     expect(elementStyles.host.padding).to.equal('10px');
     expect(elementStyles.label.color).to.equal('rgb(0, 0, 0)');
   });
+
+  describe('preview local class name', () => {
+    let element: HTMLElement;
+
+    beforeEach(async () => {
+      element = await fixture(html` <test-element></test-element>`);
+      // Reset applied class names
+      (themePreview as any)._localClassNameMap = new Map();
+    });
+
+    it('should apply class name to element', () => {
+      themePreview.previewLocalClassName(element, 'test-class');
+
+      expect(element.classList.contains('test-class')).to.be.true;
+    });
+
+    it('should update class name on element', () => {
+      themePreview.previewLocalClassName(element, 'test-class');
+      themePreview.previewLocalClassName(element, 'other-class');
+
+      expect(element.classList.contains('test-class')).to.be.false;
+      expect(element.classList.contains('other-class')).to.be.true;
+    });
+
+    it('should remove class name from element', () => {
+      themePreview.previewLocalClassName(element, 'test-class');
+      themePreview.previewLocalClassName(element);
+
+      expect(element.classList.contains('test-class')).to.be.false;
+      expect(element.classList.length).to.equal(0);
+    });
+
+    it('should not add undefined class name', () => {
+      themePreview.previewLocalClassName(element);
+
+      expect(element.classList.length).to.equal(0);
+    });
+  });
 });

--- a/vaadin-dev-server/frontend/theme-editor/preview.ts
+++ b/vaadin-dev-server/frontend/theme-editor/preview.ts
@@ -1,5 +1,6 @@
 class ThemePreview {
   private _stylesheet?: CSSStyleSheet;
+  private _localClassNameMap: Map<HTMLElement, string> = new Map();
 
   get stylesheet(): CSSStyleSheet {
     this.ensureStylesheet();
@@ -9,6 +10,24 @@ class ThemePreview {
   update(css: string) {
     this.ensureStylesheet();
     this._stylesheet!.replaceSync(css);
+  }
+
+  previewLocalClassName(element?: HTMLElement, className?: string) {
+    if (!element) {
+      return;
+    }
+    // Remove previously assigned class name if exists
+    const previousClassName = this._localClassNameMap.get(element);
+    if (previousClassName) {
+      element.classList.remove(previousClassName);
+    }
+    // Update class name
+    if (className) {
+      element.classList.add(className);
+      this._localClassNameMap.set(element, className);
+    } else {
+      this._localClassNameMap.delete(element);
+    }
   }
 
   private ensureStylesheet() {

--- a/vaadin-dev-server/frontend/theme-editor/styles.ts
+++ b/vaadin-dev-server/frontend/theme-editor/styles.ts
@@ -18,11 +18,12 @@ export const editorRowStyles = css`
     display: flex;
     align-items: baseline;
     padding: var(--theme-editor-section-horizontal-padding);
+    gap: 10px;
   }
 
   .editor-row > .label {
     flex: 0 0 auto;
-    width: 100px;
+    width: 120px;
   }
 
   .editor-row > .editor {

--- a/vaadin-dev-server/frontend/theme-editor/styles.ts
+++ b/vaadin-dev-server/frontend/theme-editor/styles.ts
@@ -1,14 +1,41 @@
-import { CSSResult } from 'lit';
+import { css, CSSResult } from 'lit';
 
 let globalStylesheet: CSSStyleSheet;
 let globalCss: string = '';
 
 export function injectGlobalCss(css: CSSResult) {
-    if (!globalStylesheet) {
-        globalStylesheet = new CSSStyleSheet();
-        document.adoptedStyleSheets = [...document.adoptedStyleSheets, globalStylesheet];
-    }
+  if (!globalStylesheet) {
+    globalStylesheet = new CSSStyleSheet();
+    document.adoptedStyleSheets = [...document.adoptedStyleSheets, globalStylesheet];
+  }
 
-    globalCss += css.cssText;
-    globalStylesheet.replaceSync(globalCss);
+  globalCss += css.cssText;
+  globalStylesheet.replaceSync(globalCss);
 }
+
+export const editorRowStyles = css`
+  .editor-row {
+    display: flex;
+    align-items: baseline;
+    padding: var(--theme-editor-section-horizontal-padding);
+  }
+
+  .editor-row > .label {
+    flex: 0 0 auto;
+    width: 100px;
+  }
+
+  .editor-row > .editor {
+    flex: 1 1 0;
+  }
+
+  .editor-row .input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 0.25rem 0.375rem;
+    color: inherit;
+    background: rgba(0, 0, 0, 0.2);
+    border-radius: 0.25rem;
+    border: none;
+  }
+`;


### PR DESCRIPTION
## Description

Allows editing a component's local class name in the theme editor:
- If component does not have a class name yet, the custom class name is only applied when actually changing a property
- If a component already has a class name, it is changed immediately
- Only valid class names are accepted, otherwise an error message is shown
- Enhanced undo / redo to update the local class name for elements that are not selected anymore
- Extracted styles from property editor rows to be reused for class name editor row

![Bildschirmfoto 2023-03-27 um 16 49 34](https://user-images.githubusercontent.com/357820/227978522-2ce1e6d3-2fcc-4a52-9ffa-aad0326c9ec6.png)
