### PR TITLE
fix: added the same license-checker versions for plugins, sub-modules, what we have now in the ./pom.xml

### DIFF
--- a/flow-plugins/flow-plugin-base/pom.xml
+++ b/flow-plugins/flow-plugin-base/pom.xml
@@ -20,6 +20,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>license-checker</artifactId>
+            <version>1.12.3</version>
         </dependency>
         <dependency>
             <groupId>org.reflections</groupId>

--- a/flow-polymer-template/pom.xml
+++ b/flow-polymer-template/pom.xml
@@ -36,6 +36,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>license-checker</artifactId>
+            <version>1.12.3</version>
         </dependency>
 
 

--- a/flow-server/README.md
+++ b/flow-server/README.md
@@ -121,3 +121,7 @@ For debug level logs one should have the settings as:
     }
   }
 ```
+
+## Java version
+Java 17 version is needed for compiling the project:
+`mvn clean install -DskipTests`

--- a/vaadin-dev-server/pom.xml
+++ b/vaadin-dev-server/pom.xml
@@ -28,6 +28,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>license-checker</artifactId>
+            <version>1.12.3</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>


### PR DESCRIPTION
## Description
Even tho, the license checker shall be `[12.2.2](https://github.com/vaadin/license-checker-vaadin10/releases/tag/1.12.2)` in the kara project:
- https://github.com/vaadin/vaadin-flow-karaf-example/pull/145

As the following is true:
- [OSHI 6.4.1 release contains the fix](https://github.com/oshi/oshi/releases/tag/oshi-parent-6.4.1)
- [licence checker 12.2.2 contains OSHI 6.4.1](https://github.com/vaadin/license-checker-vaadin10/releases/tag/1.12.2)
- [Vaadin flow 23.3.5 shall contain proper licence checker version](https://github.com/vaadin/flow/releases/tag/23.3.5)
([23.3.4 ... 23.3.5 commits](https://github.com/vaadin/flow/compare/23.3.4...23.3.5))
- [Vaadin Platform 23.3.8 contains Vaadin Flow 23.3.5](https://github.com/vaadin/platform/releases/tag/23.3.8)

So This the new kara PR should fix the OSHI SLF4J-related problems:
- https://github.com/vaadin/vaadin-flow-karaf-example/pull/145

But it is having this transitive dependency:
![image](https://user-images.githubusercontent.com/61667986/227998489-7a523890-1abc-4264-bf34-7f887c5b2868.png)

Giving properly the versions for licence checker dependencies shall solve the problem.

(alternatively, we could do it maybe with version params just like for testbench or jetty in pom.xml e.g.:
  <jetty.version>11.0.14</jetty.version>)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
