### PR TITLE
refactor: import constructable stylesheets polyfill from dev tools

### DIFF
--- a/vaadin-dev-server/frontend/vaadin-dev-tools.ts
+++ b/vaadin-dev-server/frontend/vaadin-dev-tools.ts
@@ -1,3 +1,4 @@
+import 'construct-style-sheets-polyfill';
 import { css, html, LitElement, nothing, TemplateResult } from 'lit';
 import { property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';

--- a/vaadin-dev-server/vite.config.js
+++ b/vaadin-dev-server/vite.config.js
@@ -15,9 +15,10 @@ export default defineConfig({
         // Ensure consistent file name for dev tools bundle
         entryFileNames: 'vaadin-dev-tools.js'
       },
-      // Do not resolve imports for Lit and Vaadin components, these modules
+      // Do not resolve the following imports, these modules
       // will be provided by the application that hosts the dev tools.
       external: [
+        /^construct-style-sheets-polyfill.*/,
         /^lit.*/,
         /^@vaadin.*/,
       ]


### PR DESCRIPTION
## Description

The theme editor injects global styles using constructable stylesheets right when its JS modules are loaded. While we use a polyfill for constructable stylesheets for Safari, the current loading order does not guarantee that the polyfill is loaded before the theme editor modules. Adding an explicit import to the polyfill in the dev tools should fix that.