### PR TITLE
refactor: indicate that theme editor is going to be a commercial feature on stable release

### DIFF
--- a/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
+++ b/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
@@ -58,8 +58,8 @@ public class FeatureFlags implements Serializable {
             "Collaboration Engine backend for clustering support",
             "collaborationEngineBackend",
             "https://github.com/vaadin/platform/issues/1988", true, null);
-    public static final Feature THEME_EDITOR = new Feature("Theme Editor",
-            "themeEditor", null, true, null);
+    public static final Feature THEME_EDITOR = new Feature(
+            "Theme Editor (Free Preview)", "themeEditor", null, true, null);
     private List<Feature> features = new ArrayList<>();
 
     File propertiesFolder = null;

--- a/vaadin-dev-server/frontend/vaadin-dev-tools.ts
+++ b/vaadin-dev-server/frontend/vaadin-dev-tools.ts
@@ -950,7 +950,7 @@ export class VaadinDevTools extends LitElement {
       const isFlowApp = !!(window as any).Vaadin.Flow;
       this.themeEditorState = message.data;
       if (isFlowApp && this.themeEditorState !== ThemeEditorState.disabled) {
-        this.tabs.push({ id: 'theme-editor', title: 'Theme Editor', render: () => this.renderThemeEditor() });
+        this.tabs.push({ id: 'theme-editor', title: 'Theme Editor (Free Preview)', render: () => this.renderThemeEditor() });
         this.requestUpdate();
       }
     } else {


### PR DESCRIPTION
## Description

Theme editor is going to be a commercial feature. While it is going to stay behind a feature flag for now and will be freely accessible, it has been decided that it should already indicate that it is not going to be accessible without a subscription in a future stable release. Added a "Free Preview" to the feature flag name, and the dev tools tab title.

<img width="473" alt="Bildschirmfoto 2023-03-28 um 12 08 26" src="https://user-images.githubusercontent.com/357820/228204406-99dda487-2b68-4dc6-9234-4a77de22cd2a.png">
