### PR TITLE
refactor: add support for themeEditorOpenCss command

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/OpenInCurrentIde.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/OpenInCurrentIde.java
@@ -74,6 +74,7 @@ public final class OpenInCurrentIde {
             try {
                 run(getBinary(processInfo), "--line", lineNumber + "",
                         absolutePath);
+                return true;
             } catch (Exception e) {
                 getLogger().error("Unable to launch IntelliJ IDEA", e);
             }
@@ -82,6 +83,7 @@ public final class OpenInCurrentIde {
             if (OSUtils.isMac()) {
                 try {
                     run("open", "-a", getBinary(processInfo), absolutePath);
+                    return true;
                 } catch (Exception e) {
                     getLogger().error("Unable to launch Eclipse", e);
                 }
@@ -89,11 +91,11 @@ public final class OpenInCurrentIde {
                 try {
                     run(getBinary(processInfo),
                             absolutePath + ":" + lineNumber);
+                    return true;
                 } catch (Exception e) {
                     getLogger().error("Unable to launch Eclipse", e);
                 }
             }
-            return true;
         }
 
         return false;

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/ThemeEditorCommand.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/ThemeEditorCommand.java
@@ -22,4 +22,6 @@ public interface ThemeEditorCommand {
 
     String LOAD_PREVIEW = "themeEditorLoadPreview";
 
+    String OPEN_CSS = "themeEditorOpenCss";
+
 }

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/ThemeEditorMessageHandler.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/ThemeEditorMessageHandler.java
@@ -5,6 +5,7 @@ import com.vaadin.base.devserver.themeeditor.handlers.HistoryHandler;
 import com.vaadin.base.devserver.themeeditor.handlers.LoadPreviewHandler;
 import com.vaadin.base.devserver.themeeditor.handlers.LoadRulesHandler;
 import com.vaadin.base.devserver.themeeditor.handlers.LocalClassNameHandler;
+import com.vaadin.base.devserver.themeeditor.handlers.OpenCssHandler;
 import com.vaadin.base.devserver.themeeditor.handlers.RulesHandler;
 import com.vaadin.base.devserver.themeeditor.messages.BaseResponse;
 import com.vaadin.base.devserver.themeeditor.messages.ErrorResponse;
@@ -44,6 +45,7 @@ public class ThemeEditorMessageHandler
         this.handlers.add(new HistoryHandler());
         this.handlers.add(new LoadRulesHandler(this));
         this.handlers.add(new LoadPreviewHandler(this));
+        this.handlers.add((new OpenCssHandler(this)));
     }
 
     public boolean isEnabled() {

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/ThemeModifier.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/ThemeModifier.java
@@ -87,7 +87,7 @@ public class ThemeModifier {
             }
         }
         sortStylesheet(styleSheet);
-        writeStylesheet(styleSheet, true);
+        writeStylesheet(styleSheet);
     }
 
     /**
@@ -137,7 +137,7 @@ public class ThemeModifier {
             String newClassName) {
         CascadingStyleSheet styleSheet = getCascadingStyleSheet();
         replaceClassName(styleSheet, tagName, oldClassName, newClassName);
-        writeStylesheet(styleSheet, true);
+        writeStylesheet(styleSheet);
     }
 
     /**
@@ -167,7 +167,7 @@ public class ThemeModifier {
         CSSStyleRule rule = new CSSStyleRule().addSelector(newSelector);
         styleSheet.addRule(rule);
         sortStylesheet(styleSheet);
-        writeStylesheet(styleSheet, false);
+        writeStylesheet(styleSheet);
     }
 
     protected String getCssFileName() {
@@ -269,14 +269,12 @@ public class ThemeModifier {
         }
     }
 
-    protected void writeStylesheet(CascadingStyleSheet styleSheet,
-            boolean removeUnnecessaryCode) {
+    protected void writeStylesheet(CascadingStyleSheet styleSheet) {
         File styles = getStyleSheetFile();
         try {
             CSSWriter writer = new CSSWriter().setWriteHeaderText(true)
                     .setHeaderText(getHeaderText());
-            writer.getSettings().setOptimizedOutput(false)
-                    .setRemoveUnnecessaryCode(removeUnnecessaryCode);
+            writer.getSettings().setOptimizedOutput(false);
             writer.writeCSS(styleSheet, new FileWriter(styles));
         } catch (IOException e) {
             throw new ThemeEditorException("Cannot write " + styles.getPath(),

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/ThemeModifier.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/ThemeModifier.java
@@ -162,10 +162,10 @@ public class ThemeModifier {
      */
     public void createEmptyStyleRule(String selector) {
         CascadingStyleSheet styleSheet = getCascadingStyleSheet();
-        CSSSelector newSelector = new CSSSelector()
+        CSSSelector cssSelector = new CSSSelector()
                 .addMember(new CSSSelectorSimpleMember(selector));
-        CSSStyleRule rule = new CSSStyleRule().addSelector(newSelector);
-        styleSheet.addRule(rule);
+        CSSStyleRule cssStyleRule = new CSSStyleRule().addSelector(cssSelector);
+        styleSheet.addRule(cssStyleRule);
         sortStylesheet(styleSheet);
         writeStylesheet(styleSheet);
     }

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/ThemeModifier.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/ThemeModifier.java
@@ -87,7 +87,7 @@ public class ThemeModifier {
             }
         }
         sortStylesheet(styleSheet);
-        writeStylesheet(styleSheet);
+        writeStylesheet(styleSheet, true);
     }
 
     /**
@@ -137,14 +137,13 @@ public class ThemeModifier {
             String newClassName) {
         CascadingStyleSheet styleSheet = getCascadingStyleSheet();
         replaceClassName(styleSheet, tagName, oldClassName, newClassName);
-        writeStylesheet(styleSheet);
+        writeStylesheet(styleSheet, true);
     }
 
     /**
      * Gets location line of rule with given selector
      *
      * @param selector
-     *            selector to be located
      * @return line number when located, -1 otherwise
      */
     public int getRuleLocationLine(String selector) {
@@ -154,6 +153,21 @@ public class ThemeModifier {
             return -1;
         }
         return rule.getSourceLocation().getFirstTokenBeginLineNumber();
+    }
+
+    /**
+     * Creates empty rule with given selector
+     *
+     * @param selector
+     */
+    public void createEmptyStyleRule(String selector) {
+        CascadingStyleSheet styleSheet = getCascadingStyleSheet();
+        CSSSelector newSelector = new CSSSelector()
+                .addMember(new CSSSelectorSimpleMember(selector));
+        CSSStyleRule rule = new CSSStyleRule().addSelector(newSelector);
+        styleSheet.addRule(rule);
+        sortStylesheet(styleSheet);
+        writeStylesheet(styleSheet, false);
     }
 
     protected String getCssFileName() {
@@ -255,12 +269,14 @@ public class ThemeModifier {
         }
     }
 
-    protected void writeStylesheet(CascadingStyleSheet styleSheet) {
+    protected void writeStylesheet(CascadingStyleSheet styleSheet,
+            boolean removeUnnecessaryCode) {
         File styles = getStyleSheetFile();
         try {
             CSSWriter writer = new CSSWriter().setWriteHeaderText(true)
                     .setHeaderText(getHeaderText());
-            writer.getSettings().setOptimizedOutput(false);
+            writer.getSettings().setOptimizedOutput(false)
+                    .setRemoveUnnecessaryCode(removeUnnecessaryCode);
             writer.writeCSS(styleSheet, new FileWriter(styles));
         } catch (IOException e) {
             throw new ThemeEditorException("Cannot write " + styles.getPath(),

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/ThemeModifier.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/ThemeModifier.java
@@ -29,6 +29,8 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public class ThemeModifier {
@@ -138,6 +140,22 @@ public class ThemeModifier {
         writeStylesheet(styleSheet);
     }
 
+    /**
+     * Gets location line of rule with given selector
+     *
+     * @param selector
+     *            selector to be located
+     * @return line number when located, -1 otherwise
+     */
+    public int getRuleLocationLine(String selector) {
+        CascadingStyleSheet styleSheet = getCascadingStyleSheet();
+        CSSStyleRule rule = findRuleBySelector(styleSheet, selector);
+        if (rule == null) {
+            return -1;
+        }
+        return rule.getSourceLocation().getFirstTokenBeginLineNumber();
+    }
+
     protected String getCssFileName() {
         return THEME_EDITOR_CSS;
     }
@@ -164,7 +182,7 @@ public class ThemeModifier {
                 FrontendUtils.PROJECT_BASEDIR, null), "frontend");
     }
 
-    protected File getStyleSheetFile() {
+    public File getStyleSheetFile() {
         File themes = new File(getFrontendFolder(), "themes");
         String themeName = getThemeName(themes);
         File theme = new File(themes, themeName);
@@ -291,6 +309,15 @@ public class ThemeModifier {
             CSSStyleRule rule) {
         return styleSheet.getAllStyleRules().stream().filter(
                 r -> r.getAllSelectors().containsAll(rule.getAllSelectors()))
+                .findFirst().orElse(null);
+    }
+
+    protected CSSStyleRule findRuleBySelector(CascadingStyleSheet styleSheet,
+            String selector) {
+        Predicate<CSSSelector> selectorPredicate = s -> Objects.equals(selector,
+                s.getAsCSSString());
+        return styleSheet.getAllStyleRules().stream()
+                .filter(r -> r.getAllSelectors().containsAny(selectorPredicate))
                 .findFirst().orElse(null);
     }
 

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/handlers/OpenCssHandler.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/handlers/OpenCssHandler.java
@@ -1,0 +1,45 @@
+package com.vaadin.base.devserver.themeeditor.handlers;
+
+import com.vaadin.base.devserver.OpenInCurrentIde;
+import com.vaadin.base.devserver.themeeditor.ThemeEditorCommand;
+import com.vaadin.base.devserver.themeeditor.messages.BaseResponse;
+import com.vaadin.base.devserver.themeeditor.messages.OpenCssRequest;
+import com.vaadin.base.devserver.themeeditor.utils.HasThemeModifier;
+import com.vaadin.base.devserver.themeeditor.utils.MessageHandler;
+import com.vaadin.base.devserver.themeeditor.utils.ThemeEditorException;
+import com.vaadin.flow.internal.JsonUtils;
+import elemental.json.JsonObject;
+
+import java.io.File;
+import java.util.Optional;
+
+public class OpenCssHandler implements MessageHandler {
+
+    private HasThemeModifier hasThemeModifier;
+
+    public OpenCssHandler(HasThemeModifier hasThemeModifier) {
+        this.hasThemeModifier = hasThemeModifier;
+    }
+
+    @Override
+    public ExecuteAndUndo handle(JsonObject data) {
+        OpenCssRequest request = JsonUtils.readToObject(data,
+                OpenCssRequest.class);
+        return new ExecuteAndUndo(() -> {
+            File stylesheet = hasThemeModifier.getThemeModifier()
+                    .getStyleSheetFile();
+            int line = hasThemeModifier.getThemeModifier()
+                    .getRuleLocationLine(request.getSelector());
+            if (line == -1 || !OpenInCurrentIde.openFile(stylesheet, line)) {
+                throw new ThemeEditorException("Cannot open "
+                        + stylesheet.getAbsolutePath() + ":" + line);
+            }
+            return BaseResponse.ok();
+        }, Optional.empty());
+    }
+
+    @Override
+    public String getCommandName() {
+        return ThemeEditorCommand.OPEN_CSS;
+    }
+}

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/messages/OpenCssRequest.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/messages/OpenCssRequest.java
@@ -1,0 +1,14 @@
+package com.vaadin.base.devserver.themeeditor.messages;
+
+public class OpenCssRequest extends BaseRequest {
+
+    private String selector;
+
+    public String getSelector() {
+        return selector;
+    }
+
+    public void setSelector(String selector) {
+        this.selector = selector;
+    }
+}

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/themeeditor/ThemeEditorMessageHandlerTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/themeeditor/ThemeEditorMessageHandlerTest.java
@@ -281,23 +281,55 @@ public class ThemeEditorMessageHandlerTest extends AbstractThemeEditorTest {
         BaseResponse response = setRule(0, "id1", handler, "vaadin-button",
                 "color", "red");
         assertResponseOk(response, "id1");
-        response = setRule(0, "id2", handler, "vaadin-button::part(label)",
-                "font-size", "12px");
-        assertResponseOk(response, "id2");
 
+        // request existing selector
+        // expected: 4 lines of comment + 1 = 5
         JsonObject data = Json.createObject();
-        data.put("requestId", "id3");
+        data.put("requestId", "id2");
         data.put("uiId", 0);
         data.put("selector", "vaadin-button");
-
         try (MockedStatic<OpenInCurrentIde> openInIde = Mockito
                 .mockStatic(OpenInCurrentIde.class)) {
-            openInIde.when(() -> OpenInCurrentIde.openFile(Mockito.any(),
-                    Mockito.anyInt())).thenReturn(true);
+            MockedStatic.Verification verification = () -> OpenInCurrentIde
+                    .openFile(Mockito.any(), Mockito.eq(5));
+            openInIde.when(verification).thenReturn(true);
             response = handler
                     .handleDebugMessageData(ThemeEditorCommand.OPEN_CSS, data);
+            openInIde.verify(verification);
+            assertResponseOk(response, "id2");
+        }
+
+        // request non-existing selector
+        // expected: 4 lines of comment + 2 lines of vaadin-button with empty
+        // line + 1 = 7
+        data.put("requestId", "id3");
+        data.put("selector", "vaadin-text-field");
+        try (MockedStatic<OpenInCurrentIde> openInIde = Mockito
+                .mockStatic(OpenInCurrentIde.class)) {
+            MockedStatic.Verification verification = () -> OpenInCurrentIde
+                    .openFile(Mockito.any(), Mockito.eq(7));
+            openInIde.when(verification).thenReturn(true);
+            response = handler
+                    .handleDebugMessageData(ThemeEditorCommand.OPEN_CSS, data);
+            openInIde.verify(verification);
             assertResponseOk(response, "id3");
         }
+
+        // request non-existing selector, CSS is sorted - should be on top
+        // expected: 4 lines of comment + 1 = 5
+        data.put("requestId", "id4");
+        data.put("selector", "vaadin-app-layout");
+        try (MockedStatic<OpenInCurrentIde> openInIde = Mockito
+                .mockStatic(OpenInCurrentIde.class)) {
+            MockedStatic.Verification verification = () -> OpenInCurrentIde
+                    .openFile(Mockito.any(), Mockito.eq(5));
+            openInIde.when(verification).thenReturn(true);
+            response = handler
+                    .handleDebugMessageData(ThemeEditorCommand.OPEN_CSS, data);
+            openInIde.verify(verification);
+            assertResponseOk(response, "id4");
+        }
+
     }
 
     @Test

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/themeeditor/ThemeModifierTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/themeeditor/ThemeModifierTest.java
@@ -149,6 +149,15 @@ public class ThemeModifierTest extends AbstractThemeEditorTest {
     }
 
     @Test
+    public void emptyRuleAdded_ruleIsPresent() {
+        ThemeModifier modifier = new TestThemeModifier();
+        modifier.createEmptyStyleRule("vaadin-button");
+        List<CssRule> rules = modifier.getCssRules(List.of("vaadin-button"));
+        assertEquals(1, rules.size());
+        assertTrue(rules.get(0).getProperties().isEmpty());
+    }
+
+    @Test
     public void ruleExists_ruleIsUpdated() {
         ThemeModifier modifier = new TestThemeModifier();
         List<CssRule> toBeAdded = new ArrayList<>();

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/themeeditor/ThemeModifierTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/themeeditor/ThemeModifierTest.java
@@ -129,6 +129,26 @@ public class ThemeModifierTest extends AbstractThemeEditorTest {
     }
 
     @Test
+    public void locateLines() {
+        ThemeModifier modifier = new TestThemeModifier();
+        modifier.setThemeProperties(Collections.singletonList(
+                new CssRule(SELECTOR_WITH_PART, "color", "red")));
+
+        CascadingStyleSheet styleSheet = getStylesheet("theme-editor.css");
+        assertEquals(1, styleSheet.getStyleRuleCount());
+
+        CSSStyleRule expected = modifier.createStyleRule(SELECTOR_WITH_PART,
+                "color", "red");
+        assertTrue(styleSheet.getAllStyleRules().contains(expected));
+
+        int line = modifier.getRuleLocationLine(SELECTOR_WITH_PART);
+        assertEquals(5, line); // 4-line comment before
+
+        line = modifier.getRuleLocationLine("vaadin-app-layout");
+        assertEquals(-1, line); // not found
+    }
+
+    @Test
     public void ruleExists_ruleIsUpdated() {
         ThemeModifier modifier = new TestThemeModifier();
         List<CssRule> toBeAdded = new ArrayList<>();


### PR DESCRIPTION
## Description

Adds support for opening theme-editor.css on line where rule with given selector is defined. If there is no such rule creates new empty rule and opens line where it has been defined.

disclaimer: not to add & clear empty rules each time files is opened and saved,  empty rules are preserved. To be discussed later.

### themeEditorOpenCss

`{ uid: int, requestId: string, selector: string }`
