### PR TITLE
refactor: add open css button to theme editor

### DIFF
--- a/vaadin-dev-server/frontend/theme-editor/api.ts
+++ b/vaadin-dev-server/frontend/theme-editor/api.ts
@@ -8,7 +8,8 @@ export enum Commands {
   setCssRules = 'themeEditorRules',
   loadPreview = 'themeEditorLoadPreview',
   loadRules = 'themeEditorLoadRules',
-  history = 'themeEditorHistory'
+  history = 'themeEditorHistory',
+  openCss = 'themeEditorOpenCss'
 }
 
 export enum ResponseCode {
@@ -122,6 +123,10 @@ export class ThemeEditorApi {
 
   public redo(requestId: string): Promise<BaseResponse> {
     return this.sendRequest(Commands.history, { redo: requestId });
+  }
+
+  public openCss(selector: string): Promise<BaseResponse> {
+    return this.sendRequest(Commands.openCss, { selector });
   }
 
   private getGlobalUiId(): number {

--- a/vaadin-dev-server/frontend/theme-editor/components/property-list.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/property-list.ts
@@ -1,18 +1,27 @@
 import { css, html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { html as staticHtml, literal, StaticValue } from 'lit/static-html.js';
-import { ComponentMetadata, ComponentElementMetadata, CssPropertyMetadata, EditorType } from '../metadata/model';
+import { ComponentElementMetadata, ComponentMetadata, CssPropertyMetadata, EditorType } from '../metadata/model';
 import { ComponentTheme } from '../model';
 import './editors/checkbox-property-editor';
 import './editors/text-property-editor';
 import './editors/range-property-editor';
 import './editors/color-property-editor';
 
+export class OpenCssEvent extends CustomEvent<{ element: ComponentElementMetadata }> {
+  constructor(element: ComponentElementMetadata) {
+    super('open-css', { detail: { element } });
+  }
+}
+
 @customElement('vaadin-dev-tools-theme-property-list')
 export class PropertyList extends LitElement {
   static get styles() {
     return css`
       .section .header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
         padding: 0.4rem var(--theme-editor-section-horizontal-padding);
         color: var(--dev-tools-text-color-emphasis);
         background-color: rgba(0, 0, 0, 0.2);
@@ -20,6 +29,23 @@ export class PropertyList extends LitElement {
 
       .section .property-list .property-editor:not(:last-child) {
         border-bottom: solid 1px rgba(0, 0, 0, 0.2);
+      }
+
+      .section .header .open-css {
+        all: initial;
+        font-family: inherit;
+        font-size: var(--dev-tools-font-size-small);
+        line-height: 1;
+        white-space: nowrap;
+        background-color: rgba(255, 255, 255, 0.12);
+        color: var(--dev-tools-text-color);
+        font-weight: 600;
+        padding: 0.25rem 0.375rem;
+        border-radius: 0.25rem;
+      }
+
+      .section .header .open-css:hover {
+        color: var(--dev-tools-text-color-emphasis);
       }
     `;
   }
@@ -40,10 +66,17 @@ export class PropertyList extends LitElement {
 
     return html`
       <div class="section" data-testid=${element?.displayName}>
-        ${element ? html` <div class="header">${element.displayName}</div>` : null}
+        <div class="header">
+          <span> ${element.displayName} </span>
+          <button class="open-css" @click=${() => this.handleOpenCss(element)}>Edit CSS</button>
+        </div>
         <div class="property-list">${propertiesList}</div>
       </div>
     `;
+  }
+
+  private handleOpenCss(element: ComponentElementMetadata) {
+    this.dispatchEvent(new OpenCssEvent(element));
   }
 
   private renderPropertyEditor(element: ComponentElementMetadata, property: CssPropertyMetadata) {

--- a/vaadin-dev-server/frontend/vaadin-dev-tools.test.ts
+++ b/vaadin-dev-server/frontend/vaadin-dev-tools.test.ts
@@ -12,6 +12,10 @@ describe('vaadin-dev-tools', function () {
     // @ts-ignore
     window.Vaadin = {};
     // @ts-ignore
+    window.Vaadin.Flow = {};
+    // @ts-ignore
+    window.Vaadin.Flow.clients = {};
+    // @ts-ignore
     window.Vaadin.ConsoleErrors = [];
     // @ts-ignore
     window.Vaadin.devTools = {};

--- a/vaadin-dev-server/package.json
+++ b/vaadin-dev-server/package.json
@@ -24,6 +24,7 @@
     "@vaadin/button": "24.0.0",
     "@vaadin/overlay": "24.0.0",
     "@vaadin/select": "24.0.0",
+    "construct-style-sheets-polyfill": "^3.1.0",
     "lit": "^2.6.1",
     "vanilla-colorful": "^0.7.2"
   }


### PR DESCRIPTION
## Description

Adds a button for opening / editing each element's respective CSS rule in the IDE. Kept the "open CSS" terminology in the code, but thought that "Edit CSS" would be a better label for the button itself. When using local theming, the action also adds a local class name to the component if it doesn't have one yet, so that a proper selector / CSS rule can be generated.

![Bildschirmfoto 2023-03-29 um 11 21 42](https://user-images.githubusercontent.com/357820/228488688-b788167e-3996-4622-9d09-e8e5f471c76e.png)
