### PR TITLE
refactor: add metadata for Checkbox, CheckboxGroup

### DIFF
--- a/vaadin-dev-server/frontend/theme-editor/detector.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/detector.test.ts
@@ -41,11 +41,18 @@ describe('theme-detector', () => {
     expect(theme.getPropertyValue('test-element::part(helper-text)', 'color').value).to.equal('rgb(200, 200, 200)');
   });
 
+  it('should use default value from metadata if property is not defined in computed styles', async () => {
+    const theme = await detectTheme(testElementMetadata);
+
+    expect(theme.getPropertyValue('test-element', '--custom-property').value).to.equal('foo');
+  });
+
   it('should detect themed CSS property values', async () => {
     await fixture(html`
       <style>
         test-element {
           padding: 20px;
+          --custom-property:bar;
         }
 
         test-element::part(label) {
@@ -64,6 +71,7 @@ describe('theme-detector', () => {
     const theme = await detectTheme(testElementMetadata);
 
     expect(theme.getPropertyValue('test-element', 'padding').value).to.equal('20px');
+    expect(theme.getPropertyValue('test-element', '--custom-property').value).to.equal('bar');
     expect(theme.getPropertyValue('test-element::part(label)', 'color').value).to.equal('rgb(0, 128, 0)');
     expect(theme.getPropertyValue('test-element input[slot="input"]', 'border-radius').value).to.equal('10px');
     expect(theme.getPropertyValue('test-element::part(helper-text)', 'color').value).to.equal('rgb(0, 0, 255)');

--- a/vaadin-dev-server/frontend/theme-editor/detector.ts
+++ b/vaadin-dev-server/frontend/theme-editor/detector.ts
@@ -68,7 +68,7 @@ export async function detectTheme(metadata: ComponentMetadata): Promise<Componen
       const elementStyles = getComputedStyle(subElement, pseudoName);
 
       elementMetadata.properties.forEach((property) => {
-        const propertyValue = elementStyles.getPropertyValue(property.propertyName);
+        const propertyValue = elementStyles.getPropertyValue(property.propertyName) || property.defaultValue || '';
         componentTheme.updatePropertyValue(elementMetadata.selector, property.propertyName, propertyValue);
       });
 

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-checkbox-group.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-checkbox-group.ts
@@ -1,7 +1,13 @@
 import { ComponentMetadata } from '../model';
 import { shapeProperties } from './defaults';
 import { errorMessageProperties, helperTextProperties, labelProperties } from './vaadin-text-field';
-import { checkboxElement, checkedCheckboxElement, checkmarkElement, labelElement } from './vaadin-checkbox';
+import {
+  checkboxElement,
+  checkedCheckboxElement,
+  checkmarkElement,
+  hostElement,
+  labelElement
+} from './vaadin-checkbox';
 
 export default {
   tagName: 'vaadin-checkbox-group',
@@ -34,14 +40,19 @@ export default {
       properties: errorMessageProperties
     },
     {
+      ...hostElement,
+      selector: `vaadin-checkbox-group ${hostElement.selector}`,
+      displayName: 'Checkboxes'
+    },
+    {
       ...checkboxElement,
       selector: `vaadin-checkbox-group ${checkboxElement.selector}`,
-      displayName: 'Checkboxes'
+      displayName: 'Checkmark boxes'
     },
     {
       ...checkedCheckboxElement,
       selector: `vaadin-checkbox-group ${checkedCheckboxElement.selector}`,
-      displayName: 'Checkboxes (when checked)',
+      displayName: 'Checkmark boxes (when checked)',
       // Checked state attribute needs to be applied on checkbox rather than group
       stateElementSelector: `vaadin-checkbox-group vaadin-checkbox`
     },

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-checkbox-group.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-checkbox-group.ts
@@ -19,11 +19,6 @@ export default {
       ]
     },
     {
-      selector: 'vaadin-checkbox-group::part(group-field)',
-      displayName: 'Checkbox container',
-      properties: [shapeProperties.gap]
-    },
-    {
       selector: 'vaadin-checkbox-group::part(label)',
       displayName: 'Label',
       properties: labelProperties

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-checkbox-group.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-checkbox-group.ts
@@ -1,0 +1,74 @@
+import { ComponentMetadata } from '../model';
+import { shapeProperties } from './defaults';
+import { errorMessageProperties, helperTextProperties, labelProperties } from './vaadin-text-field';
+import { checkboxElement, checkedCheckboxElement, checkmarkElement, labelElement } from './vaadin-checkbox';
+
+export default {
+  tagName: 'vaadin-checkbox-group',
+  displayName: 'CheckboxGroup',
+  elements: [
+    {
+      selector: 'vaadin-checkbox-group',
+      displayName: 'Group',
+      properties: [
+        shapeProperties.backgroundColor,
+        shapeProperties.borderColor,
+        shapeProperties.borderWidth,
+        shapeProperties.borderRadius,
+        shapeProperties.padding
+      ]
+    },
+    {
+      selector: 'vaadin-checkbox-group::part(group-field)',
+      displayName: 'Checkbox container',
+      properties: [shapeProperties.gap]
+    },
+    {
+      selector: 'vaadin-checkbox-group::part(label)',
+      displayName: 'Label',
+      properties: labelProperties
+    },
+    {
+      selector: 'vaadin-checkbox-group::part(helper-text)',
+      displayName: 'Helper text',
+      properties: helperTextProperties
+    },
+    {
+      selector: 'vaadin-checkbox-group::part(error-message)',
+      displayName: 'Error message',
+      properties: errorMessageProperties
+    },
+    {
+      ...checkboxElement,
+      selector: `vaadin-checkbox-group ${checkboxElement.selector}`,
+      displayName: 'Checkboxes'
+    },
+    {
+      ...checkedCheckboxElement,
+      selector: `vaadin-checkbox-group ${checkedCheckboxElement.selector}`,
+      displayName: 'Checkboxes (when checked)',
+      // Checked state attribute needs to be applied on checkbox rather than group
+      stateElementSelector: `vaadin-checkbox-group vaadin-checkbox`
+    },
+    {
+      ...checkmarkElement,
+      selector: `vaadin-checkbox-group ${checkmarkElement.selector}`,
+      displayName: 'Checkmarks'
+    },
+    {
+      ...labelElement,
+      selector: `vaadin-checkbox-group ${labelElement.selector}`,
+      displayName: 'Checkbox labels'
+    }
+  ],
+  setupElement(group: any) {
+    // Add a checkbox to the group
+    const checkbox = document.createElement('vaadin-checkbox') as any;
+    const label = document.createElement('label') as any;
+    label.textContent = 'Some label';
+    label.setAttribute('slot', 'label');
+    checkbox.append(label);
+
+    group.append(checkbox);
+  }
+} as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-checkbox.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-checkbox.ts
@@ -2,55 +2,53 @@ import { ComponentMetadata, EditorType } from '../model';
 import { presets } from './presets';
 import { iconProperties, shapeProperties, textProperties } from './defaults';
 
+export const checkboxElement = {
+  selector: 'vaadin-checkbox::part(checkbox)',
+  displayName: 'Checkbox',
+  properties: [
+    {
+      // Should probably use `--vaadin-checkbox-size`, however that can only
+      // be defined on the host rather than the checkbox part, and currently
+      // there is no default value for the property in the Lumo theme
+      propertyName: '--_checkbox-size',
+      displayName: 'Size',
+      editorType: EditorType.range,
+      presets: presets.lumoFontSize,
+      icon: 'square'
+    },
+    shapeProperties.backgroundColor,
+    shapeProperties.borderColor,
+    shapeProperties.borderWidth,
+    shapeProperties.borderRadius
+  ]
+};
+
+export const checkedCheckboxElement = {
+  selector: 'vaadin-checkbox[checked]::part(checkbox)',
+  stateAttribute: 'checked',
+  displayName: 'Checkbox (when checked)',
+  properties: [
+    shapeProperties.backgroundColor,
+    shapeProperties.borderColor,
+    shapeProperties.borderWidth,
+    shapeProperties.borderRadius
+  ]
+};
+
+export const checkmarkElement = {
+  selector: 'vaadin-checkbox::part(checkbox)::after',
+  displayName: 'Checkmark',
+  properties: [iconProperties.iconColor]
+};
+
+export const labelElement = {
+  selector: 'vaadin-checkbox label',
+  displayName: 'Label',
+  properties: [textProperties.textColor, textProperties.fontSize, textProperties.fontWeight, textProperties.fontStyle]
+};
+
 export default {
   tagName: 'vaadin-checkbox',
   displayName: 'Checkbox',
-  elements: [
-    {
-      selector: 'vaadin-checkbox::part(checkbox)',
-      displayName: 'Checkbox',
-      properties: [
-        {
-          // Should probably use `--vaadin-checkbox-size`, however that can only
-          // be defined on the host rather than the checkbox part, and currently
-          // there is no default value for the property in the Lumo theme
-          propertyName: '--_checkbox-size',
-          displayName: 'Size',
-          editorType: EditorType.range,
-          presets: presets.lumoFontSize,
-          icon: 'square'
-        },
-        shapeProperties.backgroundColor,
-        shapeProperties.borderColor,
-        shapeProperties.borderWidth,
-        shapeProperties.borderRadius
-      ]
-    },
-    {
-      selector: 'vaadin-checkbox[checked]::part(checkbox)',
-      stateAttribute: 'checked',
-      displayName: 'Checkbox (when checked)',
-      properties: [
-        shapeProperties.backgroundColor,
-        shapeProperties.borderColor,
-        shapeProperties.borderWidth,
-        shapeProperties.borderRadius
-      ]
-    },
-    {
-      selector: 'vaadin-checkbox::part(checkbox)::after',
-      displayName: 'Checkmark',
-      properties: [iconProperties.iconColor]
-    },
-    {
-      selector: 'vaadin-checkbox label',
-      displayName: 'Label',
-      properties: [
-        textProperties.textColor,
-        textProperties.fontSize,
-        textProperties.fontWeight,
-        textProperties.fontStyle
-      ]
-    }
-  ]
+  elements: [checkboxElement, checkedCheckboxElement, checkmarkElement, labelElement]
 } as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-checkbox.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-checkbox.ts
@@ -2,20 +2,25 @@ import { ComponentMetadata, EditorType } from '../model';
 import { presets } from './presets';
 import { iconProperties, shapeProperties, textProperties } from './defaults';
 
-export const checkboxElement = {
-  selector: 'vaadin-checkbox::part(checkbox)',
+export const hostElement = {
+  selector: 'vaadin-checkbox',
   displayName: 'Checkbox',
   properties: [
     {
-      // Should probably use `--vaadin-checkbox-size`, however that can only
-      // be defined on the host rather than the checkbox part, and currently
-      // there is no default value for the property in the Lumo theme
-      propertyName: '--_checkbox-size',
-      displayName: 'Size',
+      propertyName: '--vaadin-checkbox-size',
+      displayName: 'Checkbox size',
+      defaultValue: 'var(--lumo-font-size-l)',
       editorType: EditorType.range,
       presets: presets.lumoFontSize,
       icon: 'square'
-    },
+    }
+  ]
+};
+
+export const checkboxElement = {
+  selector: 'vaadin-checkbox::part(checkbox)',
+  displayName: 'Checkmark box',
+  properties: [
     shapeProperties.backgroundColor,
     shapeProperties.borderColor,
     shapeProperties.borderWidth,
@@ -26,7 +31,7 @@ export const checkboxElement = {
 export const checkedCheckboxElement = {
   selector: 'vaadin-checkbox[checked]::part(checkbox)',
   stateAttribute: 'checked',
-  displayName: 'Checkbox (when checked)',
+  displayName: 'Checkmark box (when checked)',
   properties: [
     shapeProperties.backgroundColor,
     shapeProperties.borderColor,
@@ -50,5 +55,5 @@ export const labelElement = {
 export default {
   tagName: 'vaadin-checkbox',
   displayName: 'Checkbox',
-  elements: [checkboxElement, checkedCheckboxElement, checkmarkElement, labelElement]
+  elements: [hostElement, checkboxElement, checkedCheckboxElement, checkmarkElement, labelElement]
 } as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-checkbox.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-checkbox.ts
@@ -1,39 +1,55 @@
 import { ComponentMetadata, EditorType } from '../model';
 import { presets } from './presets';
+import { iconProperties, shapeProperties, textProperties } from './defaults';
 
 export default {
   tagName: 'vaadin-checkbox',
   displayName: 'Checkbox',
   elements: [
     {
-      selector: 'vaadin-checkbox',
-      displayName: 'Host',
+      selector: 'vaadin-checkbox::part(checkbox)',
+      displayName: 'Checkbox',
       properties: [
         {
-          propertyName: '--lumo-primary-color',
-          displayName: 'Color',
-          editorType: EditorType.color
-        },
-        {
-          propertyName: '--vaadin-checkbox-size',
+          // Should probably use `--vaadin-checkbox-size`, however that can only
+          // be defined on the host rather than the checkbox part, and currently
+          // there is no default value for the property in the Lumo theme
+          propertyName: '--_checkbox-size',
           displayName: 'Size',
           editorType: EditorType.range,
-          presets: presets.lumoSize,
+          presets: presets.lumoFontSize,
           icon: 'square'
         },
-        {
-          propertyName: '--lumo-font-size-m',
-          displayName: 'Font Size',
-          editorType: EditorType.range,
-          presets: presets.lumoSize,
-          icon: 'square'
-        },
-        {
-          propertyName: '--lumo-body-text-color',
-          displayName: 'Text color',
-          editorType: EditorType.color,
-          presets: presets.lumoTextColor
-        }
+        shapeProperties.backgroundColor,
+        shapeProperties.borderColor,
+        shapeProperties.borderWidth,
+        shapeProperties.borderRadius
+      ]
+    },
+    {
+      selector: 'vaadin-checkbox[checked]::part(checkbox)',
+      stateAttribute: 'checked',
+      displayName: 'Checkbox (when checked)',
+      properties: [
+        shapeProperties.backgroundColor,
+        shapeProperties.borderColor,
+        shapeProperties.borderWidth,
+        shapeProperties.borderRadius
+      ]
+    },
+    {
+      selector: 'vaadin-checkbox::part(checkbox)::after',
+      displayName: 'Checkmark',
+      properties: [iconProperties.iconColor]
+    },
+    {
+      selector: 'vaadin-checkbox label',
+      displayName: 'Label',
+      properties: [
+        textProperties.textColor,
+        textProperties.fontSize,
+        textProperties.fontWeight,
+        textProperties.fontStyle
       ]
     }
   ]

--- a/vaadin-dev-server/frontend/theme-editor/metadata/model.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/model.ts
@@ -18,6 +18,7 @@ export interface CssPropertyMetadata {
 export interface ComponentElementMetadata {
   selector: string;
   stateAttribute?: string;
+  stateElementSelector?: string;
   displayName: string;
   description?: string;
   properties: CssPropertyMetadata[];

--- a/vaadin-dev-server/frontend/theme-editor/metadata/model.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/model.ts
@@ -8,6 +8,7 @@ export enum EditorType {
 export interface CssPropertyMetadata {
   propertyName: string;
   displayName: string;
+  defaultValue?: string;
   description?: string;
   editorType?: EditorType;
   presets?: string[];

--- a/vaadin-dev-server/frontend/theme-editor/metadata/model.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/model.ts
@@ -17,6 +17,7 @@ export interface CssPropertyMetadata {
 
 export interface ComponentElementMetadata {
   selector: string;
+  stateAttribute?: string;
   displayName: string;
   description?: string;
   properties: CssPropertyMetadata[];

--- a/vaadin-dev-server/frontend/theme-editor/tests/utils.ts
+++ b/vaadin-dev-server/frontend/theme-editor/tests/utils.ts
@@ -63,6 +63,11 @@ export const testElementMetadata: ComponentMetadata = {
         {
           propertyName: 'background',
           displayName: 'Background'
+        },
+        {
+          propertyName: '--custom-property',
+          displayName: 'Custom property',
+          defaultValue: 'foo'
         }
       ]
     },


### PR DESCRIPTION
## Description

Adds metadata for Checkbox and CheckboxGroup to the theme editor. Also added a basic solution for styling component states to the metadata model and theme detector (checked state in this case).

Compared to Daniel's suggestions:
- Checkbox
  - Left out `gap`, as that would need to be applied on an element that is not accessible with global CSS.
  - Added properties for checkbox size, checkmark color, label font style
  - For styling the label explicitly target the `label` child element
- Group
  - Left out `gap` and `direction`, which can require setting `display: flex` first. Instead of exposing `display` and `flex-direction` properties, which are likely to confuse users unfamiliar with CSS, long term the editor should provide some convenient UI that does this under the hood somehow.  