### PR TITLE
test: added suffix for test reports

### DIFF
--- a/flow-tests/test-ccdm-flow-navigation/pom-production.xml
+++ b/flow-tests/test-ccdm-flow-navigation/pom-production.xml
@@ -13,6 +13,7 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <surefire.reportNameSuffix>production</surefire.reportNameSuffix>
     </properties>
 
     <dependencies>

--- a/flow-tests/test-ccdm/pom-production.xml
+++ b/flow-tests/test-ccdm/pom-production.xml
@@ -13,6 +13,7 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <surefire.reportNameSuffix>production</surefire.reportNameSuffix>
     </properties>
 
     <dependencies>

--- a/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/pom-generatedTsDir.xml
+++ b/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/pom-generatedTsDir.xml
@@ -12,6 +12,7 @@
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
         <vaadin.devmode.liveReload.enabled>true</vaadin.devmode.liveReload.enabled>
+        <surefire.reportNameSuffix>generatedTsDir</surefire.reportNameSuffix>
     </properties>
 
     <dependencies>

--- a/flow-tests/test-frontend/test-npm/pom-production.xml
+++ b/flow-tests/test-frontend/test-npm/pom-production.xml
@@ -12,6 +12,7 @@
     <packaging>war</packaging>
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <surefire.reportNameSuffix>production</surefire.reportNameSuffix>
     </properties>
 
     <dependencies>

--- a/flow-tests/test-frontend/test-pnpm/pom-production.xml
+++ b/flow-tests/test-frontend/test-pnpm/pom-production.xml
@@ -12,6 +12,7 @@
     <packaging>war</packaging>
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <surefire.reportNameSuffix>production</surefire.reportNameSuffix>
     </properties>
 
     <dependencies>

--- a/flow-tests/test-frontend/vite-context-path/pom-production.xml
+++ b/flow-tests/test-frontend/vite-context-path/pom-production.xml
@@ -12,6 +12,10 @@
     <name>Vite with a context path (production mode)</name>
     <packaging>war</packaging>
 
+    <properties>
+        <surefire.reportNameSuffix>production</surefire.reportNameSuffix>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/flow-tests/test-frontend/vite-embedded/pom-production.xml
+++ b/flow-tests/test-frontend/vite-embedded/pom-production.xml
@@ -12,6 +12,10 @@
     <name>Vite embedded app (production mode)</name>
     <packaging>war</packaging>
 
+    <properties>
+        <surefire.reportNameSuffix>production</surefire.reportNameSuffix>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/flow-tests/test-frontend/vite-pwa-custom-offline-path/pom-production.xml
+++ b/flow-tests/test-frontend/vite-pwa-custom-offline-path/pom-production.xml
@@ -12,6 +12,10 @@
     <name>Vite PWA app with a custom offline path (production mode)</name>
     <packaging>war</packaging>
 
+    <properties>
+        <surefire.reportNameSuffix>production</surefire.reportNameSuffix>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/flow-tests/test-frontend/vite-pwa-disabled-offline/pom-production.xml
+++ b/flow-tests/test-frontend/vite-pwa-disabled-offline/pom-production.xml
@@ -12,6 +12,7 @@
     <packaging>war</packaging>
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <surefire.reportNameSuffix>production</surefire.reportNameSuffix>
     </properties>
 
     <dependencies>

--- a/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-devmode.xml
+++ b/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-devmode.xml
@@ -30,6 +30,7 @@
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
         <exclude.it.tests>ByteCodeScanningIT,FallbackByteCodeScanningIT</exclude.it.tests>
+        <surefire.reportNameSuffix>devmode</surefire.reportNameSuffix>
     </properties>
 
     <dependencies>

--- a/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-prod-fallback.xml
+++ b/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-prod-fallback.xml
@@ -31,6 +31,7 @@
         <maven.deploy.skip>true</maven.deploy.skip>
         <vaadin.productionMode>true</vaadin.productionMode>
         <exclude.it.tests>FullCPScanningIT,ByteCodeScanningIT</exclude.it.tests>
+        <surefire.reportNameSuffix>prodfallback</surefire.reportNameSuffix>
     </properties>
 
     <dependencies>

--- a/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-production.xml
+++ b/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-production.xml
@@ -31,6 +31,7 @@
         <maven.deploy.skip>true</maven.deploy.skip>
         <vaadin.productionMode>true</vaadin.productionMode>
         <exclude.it.tests>FullCPScanningIT,FallbackByteCodeScanningIT</exclude.it.tests>
+        <surefire.reportNameSuffix>production</surefire.reportNameSuffix>
     </properties>
 
     <dependencies>

--- a/flow-tests/test-pwa-disabled-offline/pom-production.xml
+++ b/flow-tests/test-pwa-disabled-offline/pom-production.xml
@@ -12,6 +12,7 @@
     <packaging>war</packaging>
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <surefire.reportNameSuffix>production</surefire.reportNameSuffix>
     </properties>
 
     <dependencies>

--- a/flow-tests/test-pwa/pom-production.xml
+++ b/flow-tests/test-pwa/pom-production.xml
@@ -12,6 +12,7 @@
     <packaging>war</packaging>
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <surefire.reportNameSuffix>production</surefire.reportNameSuffix>
     </properties>
 
     <dependencies>

--- a/flow-tests/test-themes/pom-devbundle.xml
+++ b/flow-tests/test-themes/pom-devbundle.xml
@@ -14,6 +14,7 @@
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
         <vaadin.frontend.hotdeploy>false</vaadin.frontend.hotdeploy>
+        <surefire.reportNameSuffix>devbundle</surefire.reportNameSuffix>
     </properties>
 
     <dependencies>

--- a/flow-tests/test-themes/pom-production.xml
+++ b/flow-tests/test-themes/pom-production.xml
@@ -13,6 +13,7 @@
     <packaging>war</packaging>
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <surefire.reportNameSuffix>production</surefire.reportNameSuffix>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Configured maven to add a suffix for test reports in modules that have multiple pom files, to prevent results to be overwritten during test-results validation job.