### PR TITLE
refactor: add clear property button

### DIFF
--- a/vaadin-dev-server/frontend/theme-editor/components/class-name-editor.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/class-name-editor.test.ts
@@ -7,7 +7,9 @@ describe('class name editor', () => {
   let classNameChangeEventSpy: sinon.SinonSpy;
 
   function getInput() {
-    return editor.shadowRoot!.querySelector('input') as HTMLInputElement;
+    return editor
+      .shadowRoot!.querySelector('vaadin-dev-tools-theme-text-input')!
+      .shadowRoot!.querySelector('input') as HTMLInputElement;
   }
 
   function getErrorMessage() {
@@ -35,7 +37,7 @@ describe('class name editor', () => {
 
   it('should update class name', async () => {
     editor.className = 'custom-class';
-    await elementUpdated(editor);
+    await elementUpdated(getInput());
 
     expect(getInput().value).to.equal('custom-class');
   });

--- a/vaadin-dev-server/frontend/theme-editor/components/class-name-editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/class-name-editor.ts
@@ -1,6 +1,8 @@
 import { css, html, LitElement, PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { editorRowStyles } from '../styles';
+import { TextInputChangeEvent } from './editors/base-property-editor';
+import './editors/base-property-editor';
 
 export class ClassNameChangeEvent extends CustomEvent<{ value: string }> {
   constructor(value: string) {
@@ -48,15 +50,18 @@ export class ClassNameEditor extends LitElement {
     return html` <div class="editor-row local-class-name">
       <div class="label">CSS class name</div>
       <div class="editor">
-        <input class="input" type="text" .value=${this.editedClassName} @change=${this.handleInputChange} />
+        <vaadin-dev-tools-theme-text-input
+          type="text"
+          .value=${this.editedClassName}
+          @change=${this.handleInputChange}
+        ></vaadin-dev-tools-theme-text-input>
         ${this.invalid ? html`<br /><span class="error">Please enter a valid CSS class name</span>` : null}
       </div>
     </div>`;
   }
 
-  private handleInputChange(e: Event) {
-    const input = e.target as HTMLInputElement;
-    this.editedClassName = input.value;
+  private handleInputChange(e: TextInputChangeEvent) {
+    this.editedClassName = e.detail.value;
 
     const classNameRegex = /^-?[_a-zA-Z]+[_a-zA-Z0-9-]*$/;
     this.invalid = !this.editedClassName.match(classNameRegex);

--- a/vaadin-dev-server/frontend/theme-editor/components/editors/base-property-editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/editors/base-property-editor.ts
@@ -1,8 +1,9 @@
 import { css, CSSResultGroup, html, LitElement, PropertyValues, TemplateResult } from 'lit';
-import { property, state } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { ComponentElementMetadata, CssPropertyMetadata } from '../../metadata/model';
 import { ComponentTheme, ThemePropertyValue } from '../../model';
 import { editorRowStyles } from '../../styles';
+import { icons } from '../../icons';
 
 export class ThemePropertyValueChangeEvent extends CustomEvent<{
   element: ComponentElementMetadata;
@@ -137,5 +138,97 @@ export class PropertyPresets {
   findPreset(rawValue: string) {
     const sanitizedValue = rawValue ? rawValue.trim() : rawValue;
     return this.values.find((preset) => this._rawValues[preset] === sanitizedValue);
+  }
+}
+
+export class TextInputChangeEvent extends CustomEvent<{ value: string }> {
+  constructor(value: string) {
+    super('change', { detail: { value } });
+  }
+}
+
+@customElement('vaadin-dev-tools-theme-text-input')
+export class TextInput extends LitElement {
+  static get styles() {
+    return css`
+      :host {
+        display: inline-block;
+        width: 100%;
+        position: relative;
+      }
+
+      input {
+        width: 100%;
+        box-sizing: border-box;
+        padding: 0.25rem 0.375rem;
+        color: inherit;
+        background: rgba(0, 0, 0, 0.2);
+        border-radius: 0.25rem;
+        border: none;
+      }
+
+      button {
+        display: none;
+        position: absolute;
+        right: 4px;
+        top: 4px;
+        padding: 0;
+        line-height: 0;
+        border: none;
+        background: none;
+        color: var(--dev-tools-text-color);
+      }
+
+      button svg {
+        width: 16px;
+        height: 16px;
+      }
+
+      button:not(:disabled):hover {
+        color: var(--dev-tools-text-color-emphasis);
+      }
+
+      :host(.show-clear-button) input {
+        padding-right: 20px;
+      }
+
+      :host(.show-clear-button) button {
+        display: block;
+      }
+    `;
+  }
+
+  @property({})
+  public value: string = '';
+  @property({})
+  public showClearButton: boolean = false;
+
+  protected update(changedProperties: PropertyValues) {
+    super.update(changedProperties);
+
+    if (changedProperties.has('showClearButton')) {
+      if (this.showClearButton) {
+        this.classList.add('show-clear-button');
+      } else {
+        this.classList.remove('show-clear-button');
+      }
+    }
+  }
+
+  render() {
+    return html`
+      <input class="input" .value=${this.value} @change=${this.handleInputChange} />
+      <button @click=${this.handleClearClick}>${icons.cross}</button>
+    `;
+  }
+
+  private handleInputChange(e: Event) {
+    const input = e.target as HTMLInputElement;
+
+    this.dispatchEvent(new TextInputChangeEvent(input.value));
+  }
+
+  private handleClearClick() {
+    this.dispatchEvent(new TextInputChangeEvent(''));
   }
 }

--- a/vaadin-dev-server/frontend/theme-editor/components/editors/color-property-editor.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/editors/color-property-editor.test.ts
@@ -55,8 +55,24 @@ describe('color property editor', () => {
     </vaadin-dev-tools-theme-color-property-editor>`);
   });
 
+  function getTextInput() {
+    return editor.shadowRoot!.querySelector('vaadin-dev-tools-theme-text-input') as HTMLElement;
+  }
+
   function getInput() {
-    return editor.shadowRoot!.querySelector('input') as HTMLInputElement;
+    return getTextInput().shadowRoot!.querySelector('input') as HTMLInputElement;
+  }
+
+  function getClearButton() {
+    return editor
+      .shadowRoot!.querySelector('vaadin-dev-tools-theme-text-input')!
+      .shadowRoot!.querySelector('button') as HTMLButtonElement;
+  }
+
+  function isClearButtonVisible() {
+    const button = getClearButton();
+
+    return getComputedStyle(button).display === 'block';
   }
 
   function getColorPicker() {
@@ -78,7 +94,7 @@ describe('color property editor', () => {
     const updatedTheme = cloneTheme();
     updatedTheme.updatePropertyValue(inputMetadata.selector, 'color', 'red');
     editor.theme = updatedTheme;
-    await elementUpdated(editor);
+    await elementUpdated(getInput());
 
     expect(getInput().value).to.equal('red');
     expect(getColorPicker().value).to.equal('red');
@@ -88,7 +104,7 @@ describe('color property editor', () => {
     const updatedTheme = cloneTheme();
     updatedTheme.updatePropertyValue(inputMetadata.selector, 'color', 'var(--test-primary-color)');
     editor.theme = updatedTheme;
-    await elementUpdated(editor);
+    await elementUpdated(getInput());
 
     expect(getInput().value).to.equal('rgb(0, 0, 255)');
     expect(getColorPicker().value).to.equal('rgb(0, 0, 255)');
@@ -96,7 +112,7 @@ describe('color property editor', () => {
 
   it('should update value when metadata changes', async () => {
     editor.propertyMetadata = backgroundColorMetadata;
-    await elementUpdated(editor);
+    await elementUpdated(getInput());
 
     expect(getInput().value).to.equal('white');
     expect(getColorPicker().value).to.equal('white');
@@ -184,5 +200,23 @@ describe('color property editor', () => {
 
     expect(valueChangeSpy.called).to.be.true;
     expect(valueChangeSpy.args[0][0].detail.value).to.be.equal('var(--test-error-color)');
+  });
+
+  it('should display clear button when property is modified', async () => {
+    expect(isClearButtonVisible()).to.be.false;
+
+    const updatedTheme = cloneTheme();
+    updatedTheme.updatePropertyValue(inputMetadata.selector, 'color', 'red', true);
+    editor.theme = updatedTheme;
+    await elementUpdated(getInput());
+
+    expect(isClearButtonVisible()).to.be.true;
+  });
+
+  it('should dispatch event with empty value when clearing value', () => {
+    getClearButton().click();
+
+    expect(valueChangeSpy.calledOnce).to.be.true;
+    expect(valueChangeSpy.args[0][0].detail.value).to.equal('');
   });
 });

--- a/vaadin-dev-server/frontend/theme-editor/components/editors/color-property-editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/editors/color-property-editor.ts
@@ -2,7 +2,7 @@ import { css, html, PropertyValues, TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import './color-picker';
 import { ColorPickerChangeEvent } from './color-picker';
-import { BasePropertyEditor, PropertyPresets } from './base-property-editor';
+import { BasePropertyEditor, PropertyPresets, TextInputChangeEvent } from './base-property-editor';
 
 @customElement('vaadin-dev-tools-theme-color-property-editor')
 export class ColorPropertyEditor extends BasePropertyEditor {
@@ -42,13 +42,16 @@ export class ColorPropertyEditor extends BasePropertyEditor {
         @color-picker-commit=${this.handleColorPickerCommit}
         @color-picker-cancel=${this.handleColorPickerCancel}
       ></vaadin-dev-tools-color-picker>
-      <input class="input" .value=${this.value} @change=${this.handleInputChange} />
+      <vaadin-dev-tools-theme-text-input
+        .value=${this.value}
+        .showClearButton=${this.propertyValue?.modified || false}
+        @change=${this.handleInputChange}
+      ></vaadin-dev-tools-theme-text-input>
     `;
   }
 
-  private handleInputChange(e: Event) {
-    const input = e.target as HTMLInputElement;
-    this.value = input.value;
+  private handleInputChange(e: TextInputChangeEvent) {
+    this.value = e.detail.value;
     this.dispatchChange(this.value);
   }
 

--- a/vaadin-dev-server/frontend/theme-editor/components/editors/range-property-editor.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/editors/range-property-editor.test.ts
@@ -66,7 +66,21 @@ describe('range property editor', () => {
   }
 
   function getInput() {
-    return editor.shadowRoot!.querySelector('input[type="text"]') as HTMLInputElement;
+    return editor
+      .shadowRoot!.querySelector('vaadin-dev-tools-theme-text-input')!
+      .shadowRoot!.querySelector('input') as HTMLInputElement;
+  }
+
+  function getClearButton() {
+    return editor
+      .shadowRoot!.querySelector('vaadin-dev-tools-theme-text-input')!
+      .shadowRoot!.querySelector('button') as HTMLButtonElement;
+  }
+
+  function isClearButtonVisible() {
+    const button = getClearButton();
+
+    return getComputedStyle(button).display === 'block';
   }
 
   function cloneTheme() {
@@ -143,7 +157,7 @@ describe('range property editor', () => {
     const updatedTheme = cloneTheme();
     updatedTheme.updatePropertyValue(hostMetadata.selector, 'height', 'var(--test-size-xl)');
     editor.theme = updatedTheme;
-    await elementUpdated(editor);
+    await elementUpdated(getInput());
 
     expect(getInput().value).to.equal('60px');
   });
@@ -187,5 +201,24 @@ describe('range property editor', () => {
 
     expect(valueChangeSpy.calledOnce).to.be.true;
     expect(valueChangeSpy.args[0][0].detail.value).to.equal('25px');
+  });
+
+  it('should display clear button when property is modified', async () => {
+    expect(isClearButtonVisible()).to.be.false;
+
+    const updatedTheme = cloneTheme();
+    updatedTheme.updatePropertyValue(hostMetadata.selector, 'height', '35px', true);
+    editor.theme = updatedTheme;
+    await elementUpdated(editor);
+    await elementUpdated(getInput());
+
+    expect(isClearButtonVisible()).to.be.true;
+  });
+
+  it('should dispatch event with empty value when clearing value', () => {
+    getClearButton().click();
+
+    expect(valueChangeSpy.calledOnce).to.be.true;
+    expect(valueChangeSpy.args[0][0].detail.value).to.equal('');
   });
 });

--- a/vaadin-dev-server/frontend/theme-editor/components/editors/range-property-editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/editors/range-property-editor.ts
@@ -2,7 +2,7 @@ import { css, html, PropertyValues, TemplateResult } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { icons } from '../../icons';
-import { BasePropertyEditor, PropertyPresets } from './base-property-editor';
+import { BasePropertyEditor, PropertyPresets, TextInputChangeEvent } from './base-property-editor';
 
 @customElement('vaadin-dev-tools-theme-range-property-editor')
 export class RangePropertyEditor extends BasePropertyEditor {
@@ -151,7 +151,12 @@ export class RangePropertyEditor extends BasePropertyEditor {
         />
         ${icon ? html` <div class="icon suffix">${icon}</div>` : null}
       </div>
-      <input type="text" class="input" .value=${this.value} @change=${this.handleValueChange} />
+      <vaadin-dev-tools-theme-text-input
+        class="input"
+        .value=${this.value}
+        .showClearButton=${this.propertyValue?.modified || false}
+        @change=${this.handleValueChange}
+      ></vaadin-dev-tools-theme-text-input>
     `;
   }
 
@@ -168,9 +173,8 @@ export class RangePropertyEditor extends BasePropertyEditor {
     this.dispatchChange(this.value);
   }
 
-  private handleValueChange(e: Event) {
-    const input = e.target as HTMLInputElement;
-    this.value = input.value;
+  private handleValueChange(e: TextInputChangeEvent) {
+    this.value = e.detail.value;
 
     this.updateSliderValue();
     this.dispatchChange(this.value);

--- a/vaadin-dev-server/frontend/theme-editor/components/editors/text-property-editor.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/editors/text-property-editor.test.ts
@@ -22,7 +22,21 @@ describe('text property editor', () => {
   let valueChangeSpy: sinon.SinonSpy;
 
   function getInput() {
-    return editor.shadowRoot!.querySelector('input') as HTMLInputElement;
+    return editor
+      .shadowRoot!.querySelector('vaadin-dev-tools-theme-text-input')!
+      .shadowRoot!.querySelector('input') as HTMLInputElement;
+  }
+
+  function getClearButton() {
+    return editor
+      .shadowRoot!.querySelector('vaadin-dev-tools-theme-text-input')!
+      .shadowRoot!.querySelector('button') as HTMLButtonElement;
+  }
+
+  function isClearButtonVisible() {
+    const button = getClearButton();
+
+    return getComputedStyle(button).display === 'block';
   }
 
   function cloneTheme() {
@@ -53,7 +67,7 @@ describe('text property editor', () => {
     const updatedTheme = cloneTheme();
     updatedTheme.updatePropertyValue(labelMetadata.selector, 'color', 'red', true);
     editor.theme = updatedTheme;
-    await elementUpdated(editor);
+    await elementUpdated(getInput());
 
     expect(input.value).to.equal('red');
   });
@@ -65,5 +79,23 @@ describe('text property editor', () => {
 
     expect(valueChangeSpy.calledOnce).to.be.true;
     expect(valueChangeSpy.args[0][0].detail.value).to.equal('red');
+  });
+
+  it('should display clear button when property is modified', async () => {
+    expect(isClearButtonVisible()).to.be.false;
+
+    const updatedTheme = cloneTheme();
+    updatedTheme.updatePropertyValue(labelMetadata.selector, 'color', 'red', true);
+    editor.theme = updatedTheme;
+    await elementUpdated(getInput());
+
+    expect(isClearButtonVisible()).to.be.true;
+  });
+
+  it('should dispatch event with empty value when clearing value', () => {
+    getClearButton().click();
+
+    expect(valueChangeSpy.calledOnce).to.be.true;
+    expect(valueChangeSpy.args[0][0].detail.value).to.equal('');
   });
 });

--- a/vaadin-dev-server/frontend/theme-editor/components/editors/text-property-editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/editors/text-property-editor.ts
@@ -1,15 +1,20 @@
 import { html, TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { BasePropertyEditor } from './base-property-editor';
+import { BasePropertyEditor, TextInputChangeEvent } from './base-property-editor';
 
 @customElement('vaadin-dev-tools-theme-text-property-editor')
 export class TextPropertyEditor extends BasePropertyEditor {
-  handleInputChange(e: Event) {
-    const input = e.target as HTMLInputElement;
-    this.dispatchChange(input.value);
+  handleInputChange(e: TextInputChangeEvent) {
+    this.dispatchChange(e.detail.value);
   }
 
   protected renderEditor(): TemplateResult {
-    return html` <input class="input" .value=${this.value} @change=${this.handleInputChange} /> `;
+    return html`
+      <vaadin-dev-tools-theme-text-input
+        .value=${this.value}
+        .showClearButton=${this.propertyValue?.modified || false}
+        @change=${this.handleInputChange}
+      ></vaadin-dev-tools-theme-text-input>
+    `;
   }
 }

--- a/vaadin-dev-server/frontend/theme-editor/editor.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.test.ts
@@ -107,7 +107,9 @@ describe('theme-editor', () => {
 
     expect(propertyEditor).to.exist;
 
-    const input = propertyEditor.shadowRoot!.querySelector('input')!;
+    const input = propertyEditor
+      .shadowRoot!.querySelector('vaadin-dev-tools-theme-text-input')!
+      .shadowRoot!.querySelector('input') as HTMLInputElement;
     input.value = value;
     input.dispatchEvent(new Event('change'));
     await elementUpdated(editor);
@@ -124,7 +126,9 @@ describe('theme-editor', () => {
 
   function getPropertyValue(elementName: string, propertyName: string) {
     const propertyEditor = findPropertyEditor(elementName, propertyName);
-    const input = propertyEditor.shadowRoot!.querySelector('input')! as HTMLInputElement;
+    const input = propertyEditor
+      .shadowRoot!.querySelector('vaadin-dev-tools-theme-text-input')!
+      .shadowRoot!.querySelector('input') as HTMLInputElement;
     return input.value;
   }
 
@@ -167,7 +171,9 @@ describe('theme-editor', () => {
     const classNameEditor = editor.shadowRoot!.querySelector(
       '.header vaadin-dev-tools-theme-class-name-editor'
     ) as HTMLElement;
-    const classNameInput = classNameEditor.shadowRoot!.querySelector('input') as HTMLInputElement;
+    const classNameInput = classNameEditor
+      .shadowRoot!.querySelector('vaadin-dev-tools-theme-text-input')!
+      .shadowRoot!.querySelector('input') as HTMLInputElement;
 
     classNameInput.value = className;
     classNameInput.dispatchEvent(new Event('change'));

--- a/vaadin-dev-server/frontend/theme-editor/icons.ts
+++ b/vaadin-dev-server/frontend/theme-editor/icons.ts
@@ -29,5 +29,10 @@ export const icons = {
   redo: svg`<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
    <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
    <path d="M15 13l4 -4l-4 -4m4 4h-11a4 4 0 0 0 0 8h1"></path>
+</svg>`,
+  cross: svg`<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" stroke-width="3" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+   <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+   <path d="M18 6l-12 12"></path>
+   <path d="M6 6l12 12"></path>
 </svg>`
 };

--- a/vaadin-dev-server/frontend/theme-editor/model.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/model.test.ts
@@ -57,6 +57,19 @@ describe('model', () => {
       expect(labelColorValue.value).to.equal('red');
     });
 
+    it('should remove property values if value is an empty string', () => {
+      theme.updatePropertyValue('vaadin-button::part(label)', 'color', 'white');
+      theme.updatePropertyValue('vaadin-button::part(label)', 'color', '');
+
+      expect(theme.properties.length).to.equal(0);
+    });
+
+    it('should not add property value if value is an empty string', () => {
+      theme.updatePropertyValue('vaadin-button::part(label)', 'color', '');
+
+      expect(theme.properties.length).to.equal(0);
+    });
+
     it('should merge a list of theme property values', () => {
       theme.updatePropertyValue('vaadin-button', 'background', 'cornflowerblue');
       theme.updatePropertyValue('vaadin-button::part(label)', 'color', 'white');
@@ -395,7 +408,7 @@ describe('model', () => {
     });
 
     describe('individual property handling', () => {
-      it('should add border-style when setting border-width to larger than zero', () => {
+      it('should update border-style when setting border-width', () => {
         const rules = [
           generateThemeRule(hostElement, globalScope, 'border-width', '0'),
           generateThemeRule(hostElement, globalScope, 'border-width', '0px'),
@@ -405,9 +418,9 @@ describe('model', () => {
         ];
 
         const expectedRules: ServerCssRule[] = [
-          { selector: 'test-element', properties: { 'border-width': '0' } },
-          { selector: 'test-element', properties: { 'border-width': '0px' } },
-          { selector: 'test-element', properties: { 'border-width': '0rem' } },
+          { selector: 'test-element', properties: { 'border-width': '0', 'border-style': '' } },
+          { selector: 'test-element', properties: { 'border-width': '0px', 'border-style': '' } },
+          { selector: 'test-element', properties: { 'border-width': '0rem', 'border-style': '' } },
           { selector: 'test-element', properties: { 'border-width': '1px', 'border-style': 'solid' } },
           { selector: 'test-element', properties: { 'border-width': '1rem', 'border-style': 'solid' } }
         ];

--- a/vaadin-dev-server/frontend/theme-editor/model.ts
+++ b/vaadin-dev-server/frontend/theme-editor/model.ts
@@ -61,6 +61,12 @@ export class ComponentTheme {
   }
 
   public updatePropertyValue(elementSelector: string, propertyName: string, value: string, modified?: boolean) {
+    // Remove property when value is an empty string
+    if (!value) {
+      delete this._properties[propertyKey(elementSelector, propertyName)];
+      return;
+    }
+
     let propertyValue = this.getPropertyValue(elementSelector, propertyName);
     if (!propertyValue) {
       propertyValue = {
@@ -154,8 +160,12 @@ export function generateThemeRule(
   // Individual property handling
 
   // Enable border style when setting a border width
-  if (propertyName === 'border-width' && parseInt(value) > 0) {
-    properties['border-style'] = 'solid';
+  if (propertyName === 'border-width') {
+    if (parseInt(value) > 0) {
+      properties['border-style'] = 'solid';
+    } else {
+      properties['border-style'] = '';
+    }
   }
 
   return {

--- a/vaadin-dev-server/frontend/theme-editor/styles.ts
+++ b/vaadin-dev-server/frontend/theme-editor/styles.ts
@@ -29,14 +29,4 @@ export const editorRowStyles = css`
   .editor-row > .editor {
     flex: 1 1 0;
   }
-
-  .editor-row .input {
-    width: 100%;
-    box-sizing: border-box;
-    padding: 0.25rem 0.375rem;
-    color: inherit;
-    background: rgba(0, 0, 0, 0.2);
-    border-radius: 0.25rem;
-    border: none;
-  }
 `;


### PR DESCRIPTION
## Description

Adds a button to property editors that allows clearing customized property values. The button will only be shown if the property has been previously customized by the theme editor.

![Bildschirmfoto 2023-03-30 um 16 20 55](https://user-images.githubusercontent.com/357820/228867843-fa6329c0-7d61-4e31-8cbe-afeaa71a4ec3.png)


Note that until HMR for CSS is implemented, the component will still be styled with the modified value if it was present in the CSS file when the page was loaded.
