### PR TITLE
 chore: added more covering tests to ComponentTest.java for covering getLocale() method (#16367) (CP: 23.3)

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2022 Vaadin Ltd.
+ * Copyright 2000-2023 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -36,6 +36,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import com.vaadin.flow.i18n.I18NProvider;
 import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.dependency.Uses;
@@ -311,6 +312,67 @@ public class ComponentTest {
         UI.setCurrent(null);
         Instantiator instantiator = mocks.getService().getInstantiator();
         Mockito.when(instantiator.getI18NProvider()).thenReturn(null);
+        Component test = new TestButton();
+        final Locale locale = test.getLocale();
+        Assert.assertEquals("System default locale should be returned",
+                Locale.getDefault(), locale);
+    }
+
+    @Test
+    public void getComponentLocale_hasCurrentUI_returnsUILocale() {
+        UI ui = new UI();
+        ui.setLocale(Locale.CANADA_FRENCH);
+        UI.setCurrent(ui);
+        Component test = new TestButton();
+        final Locale locale = test.getLocale();
+        Assert.assertEquals("Component getLocale returns the UI locale",
+                Locale.CANADA_FRENCH, locale);
+    }
+
+    @Test
+    public void getComponentLocale_noCurrentUI_returnsFirstLocaleFromProvidedLocales() {
+        UI.setCurrent(null);
+        Instantiator instantiator = mocks.getService().getInstantiator();
+        List<Locale> providedLocales = new ArrayList<>(
+                List.of(Locale.US, Locale.CANADA_FRENCH, Locale.FRANCE));
+        providedLocales.remove(Locale.getDefault());
+
+        Mockito.when(instantiator.getI18NProvider())
+                .thenReturn(new I18NProvider() {
+                    @Override
+                    public List<Locale> getProvidedLocales() {
+                        return providedLocales;
+                    }
+
+                    @Override
+                    public String getTranslation(String key, Locale locale,
+                            Object... params) {
+                        return null;
+                    }
+                });
+        Component test = new TestButton();
+        final Locale locale = test.getLocale();
+        Assert.assertEquals("First provided locale should be returned",
+                providedLocales.get(0), locale);
+    }
+
+    @Test
+    public void getComponentLocale_noCurrentUI_returnsDefaultLocale_ifNoProvidedLocale() {
+        UI.setCurrent(null);
+        Instantiator instantiator = mocks.getService().getInstantiator();
+        Mockito.when(instantiator.getI18NProvider())
+                .thenReturn(new I18NProvider() {
+                    @Override
+                    public List<Locale> getProvidedLocales() {
+                        return List.of();
+                    }
+
+                    @Override
+                    public String getTranslation(String key, Locale locale,
+                            Object... params) {
+                        return null;
+                    }
+                });
         Component test = new TestButton();
         final Locale locale = test.getLocale();
         Assert.assertEquals("System default locale should be returned",


### PR DESCRIPTION
CP from https://github.com/vaadin/flow/pull/16367 to 23.3 branch.

Added more covering tests to ComponentTest.java for covering the getLocale() method.
It was needed because another external contributor PR is tackling a refactor/optimization of this method (as well), and this change, it will ensure the functionality, and execution branches are the same:

Fixes # (issue):

https://github.com/vaadin/flow/pull/16160