### PR TITLE
fix: Initialize the route only once when using eager server load

### DIFF
--- a/flow-client/src/main/frontend/Flow.ts
+++ b/flow-client/src/main/frontend/Flow.ts
@@ -244,8 +244,6 @@ export class Flow {
 
         // Call server side to navigate to the given route
         flowRoot.$server.connectClient(
-          this.container.localName,
-          this.container.id,
           this.getFlowRoutePath(ctx),
           this.getFlowRouteQuery(ctx),
           this.appShellTitle,
@@ -296,15 +294,20 @@ export class Flow {
         await this.config.imports();
       }
 
+      // we use a custom tag for the flow app container
+      const tag = `flow-container-${appId.toLowerCase()}`;
+      const serverCreatedContainer = document.querySelector(tag);
+      if (serverCreatedContainer) {
+        this.container = serverCreatedContainer as HTMLElement;
+      } else {
+        this.container = document.createElement(tag);
+        this.container.id = appId;
+      }
+      flowRoot.$[appId] = this.container;
+
       // Load flow-client module
       const clientMod = await import('./FlowClient');
       await this.flowInitClient(clientMod);
-
-      // we use a custom tag for the flow app container
-      const tag = `flow-container-${appId.toLowerCase()}`;
-      this.container = document.createElement(tag);
-      flowRoot.$[appId] = this.container;
-      this.container.id = appId;
 
       // hide flow progress indicator
       this.loadingFinished();

--- a/flow-client/src/test/frontend/FlowTests.ts
+++ b/flow-client/src/test/frontend/FlowTests.ts
@@ -114,6 +114,9 @@ describe('Flow', () => {
     if (indicator) {
       indicator.remove();
     }
+    Array.from(document.body.children)
+      .filter((e) => e.tagName.toLowerCase().startsWith('flow-container'))
+      .forEach((e) => e.remove());
 
     $wnd.addEventListener = (type, listener) => {
       listeners.push({ type: type, listener: listener });
@@ -704,18 +707,13 @@ function stubServerRemoteFunction(
   flowRoot.$server = {
     timers: [],
 
-    connectClient: (localName: string, elemId: string, route: string) => {
-      expect(localName).not.to.be.undefined;
-      expect(elemId).not.to.be.undefined;
+    connectClient: (route: string) => {
       expect(route).not.to.be.undefined;
       if (routeRegex) {
         expect(route).to.match(routeRegex);
       }
 
-      expect(elemId).to.equal(id);
-      expect(localName).to.equal(`flow-container-${elemId.toLowerCase()}`);
-
-      container = flowRoot.$[elemId];
+      container = flowRoot.$[id];
 
       expect(container).not.to.be.undefined;
       expect(container.serverConnected).not.to.be.undefined;

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -1699,9 +1699,8 @@ public class UI extends Component
                     event -> renderViewForRoute(event.getLocation(),
                             event.getTrigger()));
 
-            if (!getInternals().getActiveRouterTargetsChain().isEmpty()) {
-                // The view has already been rendered eagerly
-            } else {
+            if (getInternals().getActiveRouterTargetsChain().isEmpty()) {
+                // Render the route unless it was rendered eagerly
                 renderViewForRoute(location, navigationTrigger);
             }
         } else {

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -24,12 +24,17 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
@@ -75,9 +80,6 @@ import com.vaadin.flow.server.frontend.FallbackChunk.CssImportData;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.shared.communication.PushMode;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Holds UI-specific methods and data which are intended for internal use by the
  * framework.
@@ -89,6 +91,9 @@ import org.slf4j.LoggerFactory;
  * @since 1.0
  */
 public class UIInternals implements Serializable {
+
+    private static final Pattern APP_ID_REPLACE_PATTERN = Pattern
+            .compile("-\\d+$");
 
     /**
      * A {@link Page#executeJs(String, Serializable...)} invocation that has not
@@ -199,6 +204,8 @@ public class UIInternals implements Serializable {
     private String contextRootRelativePath;
 
     private String appId;
+
+    private String fullAppId;
 
     private Component activeDragSourceComponent;
 
@@ -983,11 +990,13 @@ public class UIInternals implements Serializable {
      * Sets the application id tied with this UI. Different applications in the
      * same page have different unique ids.
      *
-     * @param appId
-     *            the id of the application tied with this UI
+     * @param fullAppId
+     *            the (full, not stripped) id of the application tied with this
+     *            UI
      */
-    public void setAppId(String appId) {
-        this.appId = appId;
+    public void setFullAppId(String fullAppId) {
+        this.fullAppId = fullAppId;
+        this.appId = APP_ID_REPLACE_PATTERN.matcher(fullAppId).replaceAll("");
     }
 
     /**
@@ -998,6 +1007,17 @@ public class UIInternals implements Serializable {
      */
     public String getAppId() {
         return appId;
+    }
+
+    /**
+     * Gets the full app id, which funnily enough is not the same as appId. This
+     * really should be removed but not right now. Don't use this method, it
+     * will be gone.
+     *
+     * @return the full app id
+     */
+    public String getFullAppId() {
+        return fullAppId;
     }
 
     /**
@@ -1214,5 +1234,10 @@ public class UIInternals implements Serializable {
             }
             oldContent = oldChildren.get(oldContent);
         }
+    }
+
+    public String getContainerTag() {
+        return "flow-container-" + getFullAppId().toLowerCase(Locale.ENGLISH);
+
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
@@ -99,9 +99,18 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
         if (service.getBootstrapInitialPredicate()
                 .includeInitialUidl(request)) {
             includeInitialUidl(initialJson, session, request, response);
-
+            UI ui = UI.getCurrent();
+            var flowContainerElement = new Element(
+                    ui.getInternals().getContainerTag());
+            flowContainerElement.attr("id", ui.getInternals().getAppId());
+            Elements outlet = indexDocument.body().select("#outlet");
+            if (!outlet.isEmpty()) {
+                outlet.first().appendChild(flowContainerElement);
+            } else {
+                indexDocument.body().appendChild(flowContainerElement);
+            }
             indexHtmlResponse = new IndexHtmlResponse(request, response,
-                    indexDocument, UI.getCurrent());
+                    indexDocument, ui);
         } else {
             indexHtmlResponse = new IndexHtmlResponse(request, response,
                     indexDocument);

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandlerTest.java
@@ -139,7 +139,7 @@ public class JavaScriptBootstrapHandlerTest {
         jsInitHandler.handleRequest(session, request, response);
 
         UI ui = UI.getCurrent();
-        ui.connectClient("a-tag", "an-id", "a-route", "", "", null, "");
+        ui.connectClient("a-route", "", "", null, "");
 
         TestNodeVisitor visitor = new TestNodeVisitor(true);
         BasicElementStateProvider.get().visit(ui.getElement().getNode(),
@@ -147,7 +147,7 @@ public class JavaScriptBootstrapHandlerTest {
 
         Assert.assertTrue(
                 hasNodeTag(visitor, "^<body>.*", ElementType.REGULAR));
-        Assert.assertTrue(hasNodeTag(visitor, "^<a-tag>.*",
+        Assert.assertTrue(hasNodeTag(visitor, "^<flow-container-.*>.*",
                 ElementType.VIRTUAL_ATTACHED));
         Assert.assertTrue(hasNodeTag(visitor, "^<div>.*", ElementType.REGULAR));
         Assert.assertTrue(

--- a/flow-tests/test-eager-bootstrap/src/main/java/com/vaadin/flow/eagerbootstrap/ParameterView.java
+++ b/flow-tests/test-eager-bootstrap/src/main/java/com/vaadin/flow/eagerbootstrap/ParameterView.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.eagerbootstrap;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.BeforeEvent;
 import com.vaadin.flow.router.HasUrlParameter;
@@ -25,18 +23,11 @@ import com.vaadin.flow.router.RouterLink;
 
 @Route("parameter")
 public class ParameterView extends Div implements HasUrlParameter<String> {
-    private static AtomicInteger instanceCount = new AtomicInteger(0);
 
     private Div parameters;
 
     public ParameterView() {
         setId("view");
-
-        Div instance = new Div();
-        instance.setText(
-                "This is view instance " + instanceCount.incrementAndGet());
-        instance.setId("instance");
-        add(instance);
 
         RouterLink fooLink = new RouterLink("Navigate with parameter 'foo'",
                 ParameterView.class, "foo");

--- a/flow-tests/test-eager-bootstrap/src/main/java/com/vaadin/flow/eagerbootstrap/ParameterView.java
+++ b/flow-tests/test-eager-bootstrap/src/main/java/com/vaadin/flow/eagerbootstrap/ParameterView.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.eagerbootstrap;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.BeforeEvent;
+import com.vaadin.flow.router.HasUrlParameter;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouterLink;
+
+@Route("parameter")
+public class ParameterView extends Div implements HasUrlParameter<String> {
+    private static AtomicInteger instanceCount = new AtomicInteger(0);
+
+    private Div parameters;
+
+    public ParameterView() {
+        setId("view");
+
+        Div instance = new Div();
+        instance.setText(
+                "This is view instance " + instanceCount.incrementAndGet());
+        instance.setId("instance");
+        add(instance);
+
+        RouterLink fooLink = new RouterLink("Navigate with parameter 'foo'",
+                ParameterView.class, "foo");
+        fooLink.setId("fooLink");
+        add(fooLink);
+        add(new Div());
+        RouterLink barLink = new RouterLink("Navigate with parameter 'bar'",
+                ParameterView.class, "bar");
+        barLink.setId("barLink");
+        add(barLink);
+
+        parameters = new Div();
+        parameters.setId("parameters");
+        parameters.getStyle()
+                .setWhiteSpace(com.vaadin.flow.dom.Style.WhiteSpace.PRE);
+        add(parameters);
+
+    }
+
+    @Override
+    public void setParameter(BeforeEvent event, String parameter) {
+        parameters.setText(parameters.getText() + "\n"
+                + "setParameter called with: " + parameter);
+    }
+}

--- a/flow-tests/test-eager-bootstrap/src/test/java/com/vaadin/flow/eagerbootstrap/ParameterIT.java
+++ b/flow-tests/test-eager-bootstrap/src/test/java/com/vaadin/flow/eagerbootstrap/ParameterIT.java
@@ -12,14 +12,6 @@ public class ParameterIT extends ChromeBrowserTest {
         return "/parameter";
     }
 
-    @Test
-    public void viewInitializedOnce() {
-        openWithParameter("foo");
-        int firstInstance = getInstance();
-        openWithParameter("foo");
-        Assert.assertEquals(firstInstance + 1, getInstance());
-    }
-
     private void openWithParameter(String parameter) {
         String url = getTestURL();
         getDriver().get(url + "/" + parameter);

--- a/flow-tests/test-eager-bootstrap/src/test/java/com/vaadin/flow/eagerbootstrap/ParameterIT.java
+++ b/flow-tests/test-eager-bootstrap/src/test/java/com/vaadin/flow/eagerbootstrap/ParameterIT.java
@@ -1,0 +1,49 @@
+package com.vaadin.flow.eagerbootstrap;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class ParameterIT extends ChromeBrowserTest {
+
+    @Override
+    protected String getTestPath() {
+        return "/parameter";
+    }
+
+    @Test
+    public void viewInitializedOnce() {
+        openWithParameter("foo");
+        int firstInstance = getInstance();
+        openWithParameter("foo");
+        Assert.assertEquals(firstInstance + 1, getInstance());
+    }
+
+    private void openWithParameter(String parameter) {
+        String url = getTestURL();
+        getDriver().get(url + "/" + parameter);
+    }
+
+    @Test
+    public void setParameterCalledAsExpected() {
+        openWithParameter("foo");
+        Assert.assertEquals("setParameter called with: foo",
+                getParametersText());
+        $("*").id("barLink").click();
+        Assert.assertEquals(
+                "setParameter called with: foo\nsetParameter called with: bar",
+                getParametersText());
+    }
+
+    private String getParametersText() {
+        return $("*").id("parameters").getText();
+    }
+
+    private int getInstance() {
+        String instanceText = $("*").id("instance").getText();
+        return Integer
+                .parseInt(instanceText.replace("This is view instance ", ""));
+    }
+
+}

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/scopes/AbstractUIScopedTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/scopes/AbstractUIScopedTest.java
@@ -68,7 +68,7 @@ public abstract class AbstractUIScopedTest extends AbstractScopeTest {
         Mockito.when(appConfig.getPropertyNames())
                 .thenReturn(Collections.emptyEnumeration());
         when(service.getMainDivId(Mockito.any(), Mockito.any()))
-                .thenReturn(" - ");
+                .thenReturn("abc");
 
         final Map<String, Object> attributeMap = new HashMap<>();
 


### PR DESCRIPTION
Changes bootstrap for eager mode so that the index page contains the <flow-container-[appId]> div and the virtual child for this element is created eagerly on the server. This allows the initial render on the client side to put the content inside the flow-container instead of document body as happened before.
    
By using a convention on how the container div is created and id is set, we no longer need to communicate the element tag and id from the client.
    
Fixes #16046
Fixes #16496
