### PR TITLE
Revert "chore(deps): bump javaparser-core from 3.24.10 to 3.25.2"

### DIFF
--- a/vaadin-dev-server/pom.xml
+++ b/vaadin-dev-server/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.github.javaparser</groupId>
             <artifactId>javaparser-core</artifactId>
-            <version>3.25.2</version>
+            <version>3.24.10</version>
         </dependency>
 
         <!-- API dependencies -->


### PR DESCRIPTION
Reverts vaadin/flow#16485

we need to match what poi uses