### PR TITLE
refactor: integrate CSS HMR into theme editor

### DIFF
--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
@@ -267,6 +267,10 @@ if (import.meta.hot) {
       })
     }
   });
+
+  import.meta.hot.on('vite:afterUpdate', (update) => {
+    document.dispatchEvent(new CustomEvent('vaadin-theme-updated', { detail: update }));
+  });
 }
 
 `;

--- a/vaadin-dev-server/frontend/theme-editor/api.ts
+++ b/vaadin-dev-server/frontend/theme-editor/api.ts
@@ -6,7 +6,6 @@ export enum Commands {
   loadComponentMetadata = 'themeEditorComponentMetadata',
   setLocalClassName = 'themeEditorLocalClassName',
   setCssRules = 'themeEditorRules',
-  loadPreview = 'themeEditorLoadPreview',
   loadRules = 'themeEditorLoadRules',
   history = 'themeEditorHistory',
   openCss = 'themeEditorOpenCss',
@@ -108,10 +107,6 @@ export class ThemeEditorApi {
 
   public setCssRules(rules: ServerCssRule[]): Promise<BaseResponse> {
     return this.sendRequest(Commands.setCssRules, { rules });
-  }
-
-  public loadPreview(): Promise<LoadPreviewResponse> {
-    return this.sendRequest(Commands.loadPreview, {});
   }
 
   public loadRules(selectors: string[]): Promise<LoadRulesResponse> {

--- a/vaadin-dev-server/frontend/theme-editor/editor.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.test.ts
@@ -210,11 +210,8 @@ describe('theme-editor', () => {
   }
 
   before(async () => {
-    getMetadataStub = sinon.stub(metadataRegistry, 'getMetadata').returns(Promise.resolve(testElementMetadata));
-  });
-
-  after(() => {
-    getMetadataStub.restore();
+    mockTheme = new CSSStyleSheet();
+    document.adoptedStyleSheets = [...document.adoptedStyleSheets, mockTheme];
   });
 
   beforeEach(async () => {

--- a/vaadin-dev-server/frontend/theme-editor/editor.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.test.ts
@@ -25,7 +25,6 @@ describe('theme-editor', () => {
     loadComponentMetadata: sinon.SinonStub;
     setLocalClassName: sinon.SinonStub;
     setCssRules: sinon.SinonStub;
-    loadPreview: sinon.SinonStub;
     loadRules: sinon.SinonStub;
     undo: sinon.SinonStub;
     redo: sinon.SinonStub;
@@ -36,7 +35,7 @@ describe('theme-editor', () => {
     push: sinon.SinonSpy;
   };
   let getMetadataStub: sinon.SinonStub;
-  let beforeSaveSpy: sinon.SinonSpy;
+  let mockTheme: CSSStyleSheet;
 
   async function editorFixture() {
     connectionMock = {
@@ -60,7 +59,6 @@ describe('theme-editor', () => {
       loadComponentMetadata: sinon.stub((editor as any).api as ThemeEditorApi, 'loadComponentMetadata'),
       setLocalClassName: sinon.stub((editor as any).api as ThemeEditorApi, 'setLocalClassName'),
       setCssRules: sinon.stub((editor as any).api as ThemeEditorApi, 'setCssRules'),
-      loadPreview: sinon.stub((editor as any).api as ThemeEditorApi, 'loadPreview'),
       loadRules: sinon.stub((editor as any).api as ThemeEditorApi, 'loadRules'),
       undo: sinon.stub((editor as any).api as ThemeEditorApi, 'undo'),
       redo: sinon.stub((editor as any).api as ThemeEditorApi, 'redo'),
@@ -70,7 +68,6 @@ describe('theme-editor', () => {
     apiMock.loadComponentMetadata.returns(Promise.resolve({ accessible: true, className: 'test-class' }));
     apiMock.setLocalClassName.returns(Promise.resolve({}));
     apiMock.setCssRules.returns(Promise.resolve({}));
-    apiMock.loadPreview.returns(Promise.resolve({ css: '' }));
     apiMock.loadRules.returns(Promise.resolve({ rules: [], accessible: true }));
     apiMock.undo.returns(Promise.resolve({}));
     apiMock.redo.returns(Promise.resolve({}));
@@ -80,9 +77,6 @@ describe('theme-editor', () => {
     historySpy = {
       push: sinon.spy((editor as any).history as ThemeEditorHistory, 'push')
     };
-
-    beforeSaveSpy = sinon.spy();
-    editor.addEventListener('before-save', beforeSaveSpy);
 
     return {
       editor,
@@ -205,17 +199,31 @@ describe('theme-editor', () => {
     });
   }
 
-  function mockPreviewResponse(css: string) {
-    return Promise.resolve({
-      css
-    });
+  function mockThemeStyles(css: string) {
+    mockTheme.replaceSync(css);
   }
+
+  async function mockHmrUpdate() {
+    document.dispatchEvent(new CustomEvent('vaadin-theme-updated'));
+    // Wait for async state updates to resolve
+    await aTimeout(0);
+  }
+
+  before(async () => {
+    getMetadataStub = sinon.stub(metadataRegistry, 'getMetadata').returns(Promise.resolve(testElementMetadata));
+  });
+
+  after(() => {
+    getMetadataStub.restore();
+  });
 
   beforeEach(async () => {
     // Reset history
     ThemeEditorHistory.clear();
+    // Reset mock theme styles
+    mockTheme.replaceSync('');
     // Reset theme preview
-    themePreview.update('');
+    themePreview.clear();
     // Mock metadata
     getMetadataStub = sinon.stub(metadataRegistry, 'getMetadata').returns(Promise.resolve(testElementMetadata));
     // Render editable test element
@@ -245,18 +253,10 @@ describe('theme-editor', () => {
   });
 
   describe('editing', () => {
-    it('should update theme preview after changing a property', async () => {
-      apiMock.loadPreview.returns(
-        Promise.resolve({
-          css: 'test-element::part(label) { color: red }'
-        })
-      );
+    it('should optimistically update theme preview after changing a property', async () => {
       await pickComponent();
-      apiMock.loadPreview.resetHistory();
-
       await editProperty('Label', 'color', 'red');
 
-      expect(apiMock.loadPreview.calledOnce).to.be.true;
       expect(getTestElementStyles().label.color).to.equal('rgb(255, 0, 0)');
     });
 
@@ -331,13 +331,6 @@ describe('theme-editor', () => {
           properties: { color: 'green' }
         }
       ]);
-    });
-
-    it('should dispatch event before saving changes', async () => {
-      await pickComponent();
-      await editProperty('Label', 'color', 'red');
-
-      expect(beforeSaveSpy.calledOnce).to.be.true;
     });
   });
 
@@ -547,26 +540,11 @@ describe('theme-editor', () => {
       // mock theme responses
       const rulesResponse = mockRulesResponse('test-element.test-class::part(label)', 'color', 'green');
       apiMock.loadRules.returns(rulesResponse);
-      const previewResponse = mockPreviewResponse('test-element::part(label) { color: green }');
-      apiMock.loadPreview.returns(previewResponse);
 
       // undo
       await undo();
 
       expect(getPropertyValue('Label', 'color')).to.equal('green');
-      expect(getTestElementStyles().label.color).to.equal('rgb(0, 128, 0)');
-    });
-
-    it('should prevent live reload on undo', async () => {
-      // edit something
-      await pickComponent();
-      await editProperty('Label', 'color', 'red');
-
-      // undo
-      beforeSaveSpy.resetHistory();
-      await undo();
-
-      expect(beforeSaveSpy.calledOnce).to.be.true;
     });
 
     it('should call redo when clicking redo button', async () => {
@@ -597,29 +575,11 @@ describe('theme-editor', () => {
       // mock theme responses
       const rulesResponse = mockRulesResponse('test-element.test-class::part(label)', 'color', 'green');
       apiMock.loadRules.returns(rulesResponse);
-      const previewResponse = mockPreviewResponse('test-element::part(label) { color: green }');
-      apiMock.loadPreview.returns(previewResponse);
 
       // redo
       await redo();
 
       expect(getPropertyValue('Label', 'color')).to.equal('green');
-      expect(getTestElementStyles().label.color).to.equal('rgb(0, 128, 0)');
-    });
-
-    it('should prevent live reload on redo', async () => {
-      // edit something
-      await pickComponent();
-      await editProperty('Label', 'color', 'red');
-
-      // undo
-      await undo();
-
-      // redo
-      beforeSaveSpy.resetHistory();
-      await redo();
-
-      expect(beforeSaveSpy.calledOnce).to.be.true;
     });
   });
 
@@ -628,67 +588,8 @@ describe('theme-editor', () => {
       await pickComponent();
       await changeThemeScope(ThemeScope.global);
       await editProperty('Label', 'color', 'red');
-      apiMock.loadPreview.returns(
-        Promise.resolve({
-          css: 'test-element::part(label) { color: red }'
-        })
-      );
+      mockThemeStyles('test-element::part(label) { color: red }');
       await changeThemeScope(ThemeScope.local);
-
-      expect(getPropertyValue('Label', 'color')).to.equal('rgb(255, 0, 0)');
-    });
-
-    it('should detect base theme on undo', async () => {
-      await pickComponent();
-      await changeThemeScope(ThemeScope.global);
-      await editProperty('Label', 'color', 'red');
-      apiMock.loadPreview.returns(
-        Promise.resolve({
-          css: 'test-element::part(label) { color: red }'
-        })
-      );
-      await changeThemeScope(ThemeScope.local);
-
-      expect(getPropertyValue('Label', 'color')).to.equal('rgb(255, 0, 0)');
-
-      apiMock.loadPreview.returns(
-        Promise.resolve({
-          css: ''
-        })
-      );
-      await undo();
-
-      expect(getPropertyValue('Label', 'color')).to.equal('rgb(0, 0, 0)');
-    });
-
-    it('should detect base theme on redo', async () => {
-      await pickComponent();
-      await changeThemeScope(ThemeScope.global);
-      await editProperty('Label', 'color', 'red');
-      apiMock.loadPreview.returns(
-        Promise.resolve({
-          css: 'test-element::part(label) { color: red }'
-        })
-      );
-      await changeThemeScope(ThemeScope.local);
-
-      expect(getPropertyValue('Label', 'color')).to.equal('rgb(255, 0, 0)');
-
-      apiMock.loadPreview.returns(
-        Promise.resolve({
-          css: ''
-        })
-      );
-      await undo();
-
-      expect(getPropertyValue('Label', 'color')).to.equal('rgb(0, 0, 0)');
-
-      apiMock.loadPreview.returns(
-        Promise.resolve({
-          css: 'test-element::part(label) { color: red }'
-        })
-      );
-      await redo();
 
       expect(getPropertyValue('Label', 'color')).to.equal('rgb(255, 0, 0)');
     });
@@ -869,22 +770,6 @@ describe('theme-editor', () => {
 
       expect(apiMock.setLocalClassName.called).to.be.false;
     });
-
-    it('should update theme preview', async () => {
-      await pickComponent();
-      expect(testElement.classList.contains('test-class')).to.be.true;
-
-      apiMock.loadPreview.resetHistory();
-      await editLocalClassName('custom-class');
-      expect(apiMock.loadPreview.calledOnce).to.be.true;
-    });
-
-    it('should prevent live reload', async () => {
-      await pickComponent();
-      await editLocalClassName('custom-class');
-
-      expect(beforeSaveSpy.calledOnce).to.be.true;
-    });
   });
 
   describe('open CSS', () => {
@@ -967,6 +852,25 @@ describe('theme-editor', () => {
 
       const propertyList = editor.shadowRoot!.querySelector('.property-list');
       expect(propertyList).to.not.exist;
+    });
+  });
+
+  describe('HMR updates', () => {
+    it('should refresh base theme when HMR update is received', async () => {
+      await pickComponent();
+      expect(getPropertyValue('Label', 'color')).to.equal('rgb(0, 0, 0)');
+
+      mockThemeStyles('test-element::part(label) { color: red }');
+      await mockHmrUpdate();
+      expect(getPropertyValue('Label', 'color')).to.equal('rgb(255, 0, 0)');
+    });
+
+    it('should clear theme preview when HMR update is received', async () => {
+      themePreview.add('test-element::part(label) { color: red }');
+      expect(getTestElementStyles().label.color).to.equal('rgb(255, 0, 0)');
+
+      await mockHmrUpdate();
+      expect(getTestElementStyles().label.color).to.equal('rgb(0, 0, 0)');
     });
   });
 });

--- a/vaadin-dev-server/frontend/theme-editor/editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.ts
@@ -201,7 +201,7 @@ export class ThemeEditor extends LitElement {
     // have changed.
     document.addEventListener('vaadin-theme-updated', () => {
       themePreview.clear();
-      this.refreshBaseTheme();
+      this.refreshTheme();
     });
   }
 
@@ -575,14 +575,6 @@ export class ThemeEditor extends LitElement {
     this.baseTheme = baseTheme;
     this.editedTheme = editedTheme;
     this.effectiveTheme = ComponentTheme.combine(baseTheme, this.editedTheme);
-  }
-
-  private async refreshBaseTheme() {
-    if (!this.context || !this.editedTheme) {
-      return;
-    }
-    this.baseTheme = await detectTheme(this.context.metadata);
-    this.effectiveTheme = ComponentTheme.combine(this.baseTheme, this.editedTheme);
   }
 
   private highlightElement(element?: HTMLElement) {

--- a/vaadin-dev-server/frontend/theme-editor/editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.ts
@@ -549,6 +549,7 @@ export class ThemeEditor extends LitElement {
       this.baseTheme = null;
       this.editedTheme = null;
       this.effectiveTheme = null;
+      return;
     }
 
     // Load rules for current scope

--- a/vaadin-dev-server/frontend/theme-editor/model.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/model.test.ts
@@ -1,5 +1,12 @@
 import { expect } from '@open-wc/testing';
-import { ComponentTheme, generateThemeRule, SelectorScope, ThemePropertyValue, ThemeScope } from './model';
+import {
+  ComponentTheme,
+  generateThemeRule,
+  generateThemeRuleCss,
+  SelectorScope,
+  ThemePropertyValue,
+  ThemeScope
+} from './model';
 import buttonMetadata from './metadata/components/vaadin-button';
 import { ComponentMetadata } from './metadata/model';
 import { ServerCssRule } from './api';
@@ -351,7 +358,7 @@ describe('model', () => {
     });
   });
 
-  describe('generateRule', () => {
+  describe('generateThemeRule', () => {
     const globalScope: SelectorScope = {
       themeScope: ThemeScope.global
     };
@@ -427,6 +434,29 @@ describe('model', () => {
 
         expect(rules).to.deep.equal(expectedRules);
       });
+    });
+  });
+
+  describe('generateThemeRuleCss', () => {
+    it('should generate CSS for theme rules', () => {
+      const rules: ServerCssRule[] = [
+        { selector: 'test-element.foo', properties: { background: 'cornflowerblue' } },
+        { selector: 'test-element.foo::part(label)', properties: { color: 'white' } },
+        {
+          selector: 'test-element.foo input[slot="input"]',
+          properties: { 'border-radius': '10px', 'border-style': 'solid' }
+        }
+      ];
+
+      const expectedCss = [
+        'test-element.foo { background: cornflowerblue; }',
+        'test-element.foo::part(label) { color: white; }',
+        'test-element.foo input[slot="input"] { border-radius: 10px; border-style: solid; }'
+      ];
+
+      const css = rules.map(generateThemeRuleCss);
+
+      expect(css).to.deep.equal(expectedCss);
     });
   });
 });

--- a/vaadin-dev-server/frontend/theme-editor/model.ts
+++ b/vaadin-dev-server/frontend/theme-editor/model.ts
@@ -173,3 +173,11 @@ export function generateThemeRule(
     properties
   };
 }
+
+export function generateThemeRuleCss(rule: ServerCssRule) {
+  const propertyCss = Object.entries(rule.properties)
+    .map(([name, value]) => `${name}: ${value};`)
+    .join(' ');
+
+  return `${rule.selector} { ${propertyCss} }`;
+}

--- a/vaadin-dev-server/frontend/theme-editor/preview.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/preview.test.ts
@@ -17,7 +17,7 @@ describe('theme-preview', () => {
     element = await fixture(html` <test-element></test-element>`);
   });
 
-  it('should apply theme preview', () => {
+  it('should add CSS to preview stylesheet', () => {
     const css = `
       test-element {
         padding: 20px;
@@ -27,24 +27,11 @@ describe('theme-preview', () => {
         color: red;
       }
     `;
-    themePreview.update(css);
+    themePreview.add(css);
 
-    const elementStyles = getElementStyles();
+    let elementStyles = getElementStyles();
     expect(elementStyles.host.padding).to.equal('20px');
     expect(elementStyles.label.color).to.equal('rgb(255, 0, 0)');
-  });
-
-  it('should update theme preview', () => {
-    const css = `
-      test-element {
-        padding: 20px;
-      }
-      
-      test-element::part(label) {
-        color: red;
-      }
-    `;
-    themePreview.update(css);
 
     const updatedCss = `
       test-element {
@@ -55,14 +42,14 @@ describe('theme-preview', () => {
         color: green;
       }
     `;
-    themePreview.update(updatedCss);
+    themePreview.add(updatedCss);
 
-    const elementStyles = getElementStyles();
+    elementStyles = getElementStyles();
     expect(elementStyles.host.padding).to.equal('30px');
     expect(elementStyles.label.color).to.equal('rgb(0, 128, 0)');
   });
 
-  it('should reset theme preview', () => {
+  it('should clear preview stylesheet', () => {
     const css = `
       test-element {
         padding: 20px;
@@ -72,10 +59,13 @@ describe('theme-preview', () => {
         color: red;
       }
     `;
-    themePreview.update(css);
-    themePreview.update('');
+    themePreview.add(css);
+    let elementStyles = getElementStyles();
+    expect(elementStyles.host.padding).to.equal('20px');
+    expect(elementStyles.label.color).to.equal('rgb(255, 0, 0)');
 
-    const elementStyles = getElementStyles();
+    themePreview.clear();
+    elementStyles = getElementStyles();
     expect(elementStyles.host.padding).to.equal('10px');
     expect(elementStyles.label.color).to.equal('rgb(0, 0, 0)');
   });

--- a/vaadin-dev-server/frontend/theme-editor/preview.ts
+++ b/vaadin-dev-server/frontend/theme-editor/preview.ts
@@ -7,9 +7,14 @@ class ThemePreview {
     return this._stylesheet!;
   }
 
-  update(css: string) {
+  add(css: string) {
     this.ensureStylesheet();
     this._stylesheet!.replaceSync(css);
+  }
+
+  clear() {
+    this.ensureStylesheet();
+    this._stylesheet!.replaceSync('');
   }
 
   previewLocalClassName(element?: HTMLElement, className?: string) {

--- a/vaadin-dev-server/frontend/vaadin-dev-tools.test.ts
+++ b/vaadin-dev-server/frontend/vaadin-dev-tools.test.ts
@@ -2,7 +2,6 @@ import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import { VaadinDevTools } from './vaadin-dev-tools';
 import './vaadin-dev-tools';
 import { ThemeEditorState } from './theme-editor/model';
-import sinon from 'sinon';
 
 describe('vaadin-dev-tools', function () {
   let devTools: VaadinDevTools;
@@ -68,69 +67,6 @@ describe('vaadin-dev-tools', function () {
 
       const themeEditorTab = getTab('theme-editor');
       expect(themeEditorTab).to.not.be.null;
-    });
-
-    describe('disabling live reload', () => {
-      let clock: sinon.SinonFakeTimers;
-
-      beforeEach(async () => {
-        clock = sinon.useFakeTimers({
-          shouldClearNativeTimers: true
-        });
-      });
-
-      afterEach(() => {
-        clock.restore();
-      });
-
-      it('should temporarily disable live reload on theme editor before save event', async () => {
-        // enable and open theme editor tab
-        sendThemeEditorStateMessage(ThemeEditorState.enabled);
-        await elementUpdated(devTools);
-
-        const themeEditorTab = getTab('theme-editor');
-        themeEditorTab.click();
-        await elementUpdated(devTools);
-
-        const editor = devTools.shadowRoot!.querySelector('vaadin-dev-tools-theme-editor')!;
-        expect(editor).to.exist;
-
-        // simulate saving
-        expect(VaadinDevTools.isActive).to.be.true;
-        editor.dispatchEvent(new CustomEvent('before-save'));
-        expect(VaadinDevTools.isActive).to.be.false;
-
-        clock.tick(2500);
-        expect(VaadinDevTools.isActive).to.be.true;
-      });
-
-      it('should extend disabling live reload when theme editor saves again', async () => {
-        // enable and open theme editor tab
-        sendThemeEditorStateMessage(ThemeEditorState.enabled);
-        await elementUpdated(devTools);
-
-        const themeEditorTab = getTab('theme-editor');
-        themeEditorTab.click();
-        await elementUpdated(devTools);
-
-        const editor = devTools.shadowRoot!.querySelector('vaadin-dev-tools-theme-editor')!;
-        expect(editor).to.exist;
-
-        // simulate saving
-        expect(VaadinDevTools.isActive).to.be.true;
-        editor.dispatchEvent(new CustomEvent('before-save'));
-        expect(VaadinDevTools.isActive).to.be.false;
-
-        clock.tick(2000);
-        editor.dispatchEvent(new CustomEvent('before-save'));
-        expect(VaadinDevTools.isActive).to.be.false;
-
-        clock.tick(1000);
-        expect(VaadinDevTools.isActive).to.be.false;
-
-        clock.tick(1500);
-        expect(VaadinDevTools.isActive).to.be.true;
-      });
     });
   });
 });

--- a/vaadin-dev-server/frontend/vaadin-dev-tools.ts
+++ b/vaadin-dev-server/frontend/vaadin-dev-tools.ts
@@ -1248,17 +1248,6 @@ export class VaadinDevTools extends LitElement {
     window.sessionStorage.setItem(VaadinDevTools.ACTIVE_KEY_IN_SESSION_STORAGE, yes ? 'true' : 'false');
   }
 
-  disableLiveReloadTemporarily() {
-    if (VaadinDevTools.isActive || this.disableLiveReloadTimeout != null) {
-      this.setActive(false);
-      clearTimeout(this.disableLiveReloadTimeout!);
-      this.disableLiveReloadTimeout = window.setTimeout(() => {
-        this.setActive(true);
-        this.disableLiveReloadTimeout = null;
-      }, 2500);
-    }
-  }
-
   getStatusColor(status: ConnectionStatus | undefined) {
     if (status === ConnectionStatus.ACTIVE) {
       return 'var(--dev-tools-green-color)';
@@ -1532,7 +1521,6 @@ export class VaadinDevTools extends LitElement {
       .themeEditorState=${this.themeEditorState}
       .pickerProvider=${() => this.componentPicker}
       .connection=${this.frontendConnection}
-      @before-save=${this.disableLiveReloadTemporarily}
     ></vaadin-dev-tools-theme-editor>`;
   }
 

--- a/vaadin-dev-server/frontend/vaadin-dev-tools.ts
+++ b/vaadin-dev-server/frontend/vaadin-dev-tools.ts
@@ -887,6 +887,7 @@ export class VaadinDevTools extends LitElement {
       if (styleTag) {
         this.log(MessageType.INFORMATION, 'Hot update of ' + path);
         styleTag.textContent = content;
+        document.dispatchEvent(new CustomEvent('vaadin-theme-updated'));
       } else {
         onReload();
       }


### PR DESCRIPTION
## Description

Integrates HMR into theme editor:
- Remove loading of the full theme editor CSS into preview stylesheet
- Instead do an optimistic update by adding CSS rules for single property updates to preview stylesheet
- Change CSS HMR to dispatch a DOM event after
  - Vite has updated style modules (Vite hot deploy mode)
  - Dev tools have updates styles (Dev bundle mode)
- Listen for that event in theme editor, and when it is triggered, remove optimistic style updates, and refresh property values shown in editor. This should ensure that the correct property values are shown in all cases (change property, clear property, change class name, undo, redo).
- Removes mechanism for preventing live reload from the dev tools

Covers both dev bundle mode and Vite hot deploy mode.

Based on the changes from https://github.com/vaadin/flow/pull/16455 and currently set to merge against it.