### PR TITLE
fix: Use default XOR CSRF token mechanism in Spring

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -15,6 +15,12 @@
  */
 package com.vaadin.flow.spring.security;
 
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import javax.crypto.SecretKey;
+
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.LinkedHashMap;
@@ -23,8 +29,6 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import javax.crypto.SecretKey;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -54,7 +58,6 @@ import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.security.web.authentication.logout.SimpleUrlLogoutSuccessHandler;
 import org.springframework.security.web.context.SecurityContextRepository;
 import org.springframework.security.web.csrf.CsrfException;
-import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 import org.springframework.security.web.savedrequest.RequestCache;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.AnyRequestMatcher;
@@ -70,10 +73,6 @@ import com.vaadin.flow.server.HandlerHelper;
 import com.vaadin.flow.server.VaadinServletContext;
 import com.vaadin.flow.server.auth.ViewAccessChecker;
 import com.vaadin.flow.spring.security.stateless.VaadinStatelessSecurityConfigurer;
-
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Provides basic Vaadin component-based security configuration for the project.
@@ -177,11 +176,6 @@ public abstract class VaadinWebSecurity {
                 .defaultAuthenticationEntryPointFor(
                         new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED),
                         requestUtil::isEndpointRequest);
-
-        // Enforce the deprecated CSRF handler temporarily
-        // to make Hilla auth work.
-        http.csrf(csrf -> csrf.csrfTokenRequestHandler(
-                new CsrfTokenRequestAttributeHandler()));
 
         // Vaadin has its own CSRF protection.
         // Spring CSRF is not compatible with Vaadin internal requests

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/stateless/VaadinStatelessSecurityConfigurer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/stateless/VaadinStatelessSecurityConfigurer.java
@@ -34,7 +34,9 @@ import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.web.context.SecurityContextRepository;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.csrf.CsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfTokenRequestHandler;
 import org.springframework.security.web.csrf.LazyCsrfTokenRepository;
+import org.springframework.security.web.csrf.XorCsrfTokenRequestAttributeHandler;
 import org.springframework.security.web.savedrequest.CookieRequestCache;
 import org.springframework.security.web.savedrequest.RequestCache;
 
@@ -98,7 +100,13 @@ public final class VaadinStatelessSecurityConfigurer<H extends HttpSecurityBuild
             // session (double-submit cookie pattern)
             CsrfTokenRepository csrfTokenRepository = CookieCsrfTokenRepository
                     .withHttpOnlyFalse();
+            XorCsrfTokenRequestAttributeHandler delegate = new XorCsrfTokenRequestAttributeHandler();
+
+            CsrfTokenRequestHandler requestHandler = delegate::handle;
+
             csrf.csrfTokenRepository(csrfTokenRepository);
+            csrf.csrfTokenRequestHandler(requestHandler);
+
             http.getSharedObject(
                     VaadinSavedRequestAwareAuthenticationSuccessHandler.class)
                     .setCsrfTokenRepository(csrfTokenRepository);

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/stateless/VaadinStatelessSecurityConfigurer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/stateless/VaadinStatelessSecurityConfigurer.java
@@ -100,10 +100,11 @@ public final class VaadinStatelessSecurityConfigurer<H extends HttpSecurityBuild
             // session (double-submit cookie pattern)
             CsrfTokenRepository csrfTokenRepository = CookieCsrfTokenRepository
                     .withHttpOnlyFalse();
+
+            // This XorCsrfTokenRequestAttributeHandler pattern is copied from
+            // https://docs.spring.io/spring-security/reference/5.8/migration/servlet/exploits.html#_i_am_using_angularjs_or_another_javascript_framework
             XorCsrfTokenRequestAttributeHandler delegate = new XorCsrfTokenRequestAttributeHandler();
-
             CsrfTokenRequestHandler requestHandler = delegate::handle;
-
             csrf.csrfTokenRepository(csrfTokenRepository);
             csrf.csrfTokenRequestHandler(requestHandler);
 


### PR DESCRIPTION
The stateless configuration is copied from https://docs.spring.io/spring-security/reference/5.8/migration/servlet/exploits.html#_i_am_using_angularjs_or_another_javascript_framework

Fixes #14923
