### PR TITLE
chore: use stream PIPE redirect for npm process executions

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuild.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuild.java
@@ -925,8 +925,8 @@ public class TaskRunDevBundleBuild implements FallibleCommand {
         Process process = null;
         try {
             builder.directory(options.getNpmFolder());
-            builder.redirectInput(ProcessBuilder.Redirect.INHERIT);
-            builder.redirectError(ProcessBuilder.Redirect.INHERIT);
+            builder.redirectInput(ProcessBuilder.Redirect.PIPE);
+            builder.redirectErrorStream(true);
 
             process = builder.start();
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -481,8 +481,8 @@ public class TaskRunNpmInstall implements FallibleCommand {
         builder.environment().put("ADBLOCK", "1");
         builder.environment().put("NO_UPDATE_NOTIFIER", "1");
         builder.directory(workingDirectory);
-        builder.redirectInput(ProcessBuilder.Redirect.INHERIT);
-        builder.redirectError(ProcessBuilder.Redirect.INHERIT);
+        builder.redirectInput(ProcessBuilder.Redirect.PIPE);
+        builder.redirectErrorStream(true);
 
         Process process = builder.start();
 


### PR DESCRIPTION
Using PIPE instead of INHERIT prevents corrupted stream errors with maven
surefire and failsafe plugins.