### PR TITLE
fix: Do not trigger extra TS checks

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/default/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/default/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "async": "3.2.2",
     "glob": "7.2.3",
-    "typescript": "4.9.3",
+    "typescript": "4.9.5",
     "workbox-core": "6.5.4",
     "workbox-precaching": "6.5.4",
     "strip-css-comments": "5.0.0"


### PR DESCRIPTION
Fixes the sometimes constant output stream of 
```
[TypeScript] Found 0 errors. Watching for file changes.
```

The relevant fix in TypeScript is https://github.com/microsoft/TypeScript/pull/51626
