### PR TITLE
refactor: show notice if styling component is not supported

### DIFF
--- a/vaadin-dev-server/frontend/theme-editor/editor.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.test.ts
@@ -208,24 +208,22 @@ describe('theme-editor', () => {
     });
   }
 
-  before(async () => {
-    getMetadataStub = sinon.stub(metadataRegistry, 'getMetadata').returns(Promise.resolve(testElementMetadata));
-  });
-
-  after(() => {
-    getMetadataStub.restore();
-  });
-
   beforeEach(async () => {
     // Reset history
     ThemeEditorHistory.clear();
     // Reset theme preview
     themePreview.update('');
+    // Mock metadata
+    getMetadataStub = sinon.stub(metadataRegistry, 'getMetadata').returns(Promise.resolve(testElementMetadata));
     // Render editable test element
     testElement = await fixture(html` <test-element></test-element>`);
     // Render editor
     const fixtureResult = await editorFixture();
     editor = fixtureResult.editor;
+  });
+
+  afterEach(() => {
+    getMetadataStub.restore();
   });
 
   describe('theme editor states', () => {
@@ -952,6 +950,20 @@ describe('theme-editor', () => {
         expect(apiMock.openCss.calledOnce).to.be.true;
         expect(apiMock.openCss.args).to.deep.equal([['test-element::part(label)']]);
       });
+    });
+  });
+
+  describe('picking components', () => {
+    it('should show notice if there is no metadata', async () => {
+      getMetadataStub.returns(Promise.resolve(null));
+      await pickComponent();
+
+      const notice = editor.shadowRoot!.querySelector('.notice') as HTMLElement;
+      expect(notice).to.exist;
+      expect(notice.textContent).to.contain('Styling <test-element> components is not supported at the moment.');
+
+      const propertyList = editor.shadowRoot!.querySelector('.property-list');
+      expect(propertyList).to.not.exist;
     });
   });
 });

--- a/vaadin-dev-server/frontend/theme-editor/editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.ts
@@ -224,7 +224,7 @@ export class ThemeEditor extends LitElement {
         <div class="picker-row">
           ${this.renderPicker()}
           <div class="actions">
-            ${this.context
+            ${this.context?.metadata
               ? html` <vaadin-dev-tools-theme-scope-selector
                   .value=${this.context.scope}
                   .metadata=${this.context.metadata}
@@ -271,6 +271,14 @@ export class ThemeEditor extends LitElement {
   renderPropertyList() {
     if (!this.context) {
       return null;
+    }
+
+    // If there is no metadata, then we have a component that is not supported
+    if (!this.context.metadata) {
+      const tagName = this.context.component.element!.localName;
+      return html`
+        <div class="notice">Styling <code>&lt;${tagName}&gt;</code> components is not supported at the moment.</div>
+      `;
     }
 
     const inaccessible = this.context.scope === ThemeScope.local && !this.context.accessible;
@@ -328,7 +336,7 @@ export class ThemeEditor extends LitElement {
   renderPicker() {
     let label: TemplateResult;
 
-    if (this.context) {
+    if (this.context?.metadata) {
       const componentDisplayName =
         this.context.scope === ThemeScope.local
           ? this.context.metadata.displayName
@@ -411,7 +419,7 @@ export class ThemeEditor extends LitElement {
       pickCallback: async (component) => {
         const metadata = await metadataRegistry.getMetadata(component);
         if (!metadata) {
-          this.context = null;
+          this.context = { component, scope: this.context?.scope || ThemeScope.local };
           this.baseTheme = null;
           this.editedTheme = null;
           this.effectiveTheme = null;
@@ -524,7 +532,7 @@ export class ThemeEditor extends LitElement {
 
   private async refreshTheme(newContext?: ThemeContext) {
     const context = newContext || this.context;
-    if (!context) {
+    if (!context || !context.metadata) {
       return;
     }
 

--- a/vaadin-dev-server/frontend/theme-editor/model.ts
+++ b/vaadin-dev-server/frontend/theme-editor/model.ts
@@ -20,7 +20,7 @@ export interface SelectorScope {
 
 export interface ThemeContext {
   scope: ThemeScope;
-  metadata: ComponentMetadata;
+  metadata?: ComponentMetadata;
   component: ComponentReference;
   accessible?: boolean;
   localClassName?: string;


### PR DESCRIPTION
## Description

Shows a notice if a component is not supported by the theme editor. This should currently only affect Vaadin components that do not have metadata.

![Bildschirmfoto 2023-04-05 um 12 41 16](https://user-images.githubusercontent.com/357820/230058795-65571f19-1f22-4196-8192-69275be47da1.png)
