### PR TITLE
refactor: fix for picking elements that have inaccessible source file

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/JavaSourceModifier.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/JavaSourceModifier.java
@@ -219,12 +219,12 @@ public class JavaSourceModifier extends Editor {
         try {
             VaadinSession session = getSession();
             getSession().access(() -> {
-                Component component = getComponent(session, uiId, nodeId);
-                CompilationUnit cu = getCompilationUnit(component);
                 try {
+                    Component component = getComponent(session, uiId, nodeId);
+                    CompilationUnit cu = getCompilationUnit(component);
                     findModificationWhere(cu, component);
                     holder.accessible = true;
-                } catch (ThemeEditorException ex) {
+                } catch (ThemeEditorException | IllegalArgumentException ex) {
                     holder.accessible = false;
                 }
             }).get(5, TimeUnit.SECONDS);

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/JavaSourceModifier.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/JavaSourceModifier.java
@@ -13,6 +13,7 @@ import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.stmt.Statement;
 import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
 import com.github.javaparser.utils.SourceRoot;
+import com.vaadin.base.devserver.AbstractDevServerRunner;
 import com.vaadin.base.devserver.editor.Editor;
 import com.vaadin.base.devserver.editor.Where;
 import com.vaadin.base.devserver.themeeditor.utils.LineNumberVisitor;
@@ -25,6 +26,8 @@ import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.server.VaadinContext;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.startup.ApplicationConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -224,7 +227,8 @@ public class JavaSourceModifier extends Editor {
                     CompilationUnit cu = getCompilationUnit(component);
                     findModificationWhere(cu, component);
                     holder.accessible = true;
-                } catch (ThemeEditorException | IllegalArgumentException ex) {
+                } catch (Exception ex) {
+                    getLogger().warn(ex.getMessage(), ex);
                     holder.accessible = false;
                 }
             }).get(5, TimeUnit.SECONDS);
@@ -365,6 +369,10 @@ public class JavaSourceModifier extends Editor {
             throw new ThemeEditorException("Cannot find component.");
         }
         return node;
+    }
+
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(JavaSourceModifier.class);
     }
 
 }

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/JavaSourceModifier.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/JavaSourceModifier.java
@@ -13,7 +13,6 @@ import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.stmt.Statement;
 import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
 import com.github.javaparser.utils.SourceRoot;
-import com.vaadin.base.devserver.AbstractDevServerRunner;
 import com.vaadin.base.devserver.editor.Editor;
 import com.vaadin.base.devserver.editor.Where;
 import com.vaadin.base.devserver.themeeditor.utils.LineNumberVisitor;


### PR DESCRIPTION
## Description

While picking component that has inaccessible source files (like `<body>`) nasty exception has been thrown. Generic component inaccessible message is now presented to the user.

<img width="486" alt="image" src="https://user-images.githubusercontent.com/106965834/230077052-3e8da0f9-42ab-4818-a6b8-6075b5b3dc81.png">
