### PR TITLE
chore: run dev tools frontend tests with maven

### DIFF
--- a/vaadin-dev-server/package.json
+++ b/vaadin-dev-server/package.json
@@ -2,8 +2,8 @@
   "scripts": {
     "build": "vite build",
     "start": "web-dev-server --node-resolve",
-    "test": "web-test-runner --node-resolve",
-    "test-watch": "web-test-runner --node-resolve --watch",
+    "test": "web-test-runner --node-resolve --playwright",
+    "test-watch": "web-test-runner --node-resolve --playwright --watch",
     "patch-app": "node patch-application.js",
     "prettier": "prettier --write frontend"
   },
@@ -16,6 +16,7 @@
     "@web/dev-server": "^0.1.35",
     "@web/dev-server-esbuild": "^0.3.3",
     "@web/test-runner": "^0.15.0",
+    "@web/test-runner-playwright": "^0.9.0",
     "prettier": "^2.8.4",
     "sinon": "^15.0.1",
     "vite": "^4.1.4"

--- a/vaadin-dev-server/pom.xml
+++ b/vaadin-dev-server/pom.xml
@@ -129,6 +129,19 @@
                             </arguments>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>run-tests</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>npm</executable>
+                            <arguments>
+                                <argument>test</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>


### PR DESCRIPTION
## Description

Run dev tools frontend tests in Maven `verify` phase. The setup is adopted from the `flow-client` module.

![Bildschirmfoto 2023-04-05 um 16 03 24](https://user-images.githubusercontent.com/357820/230105701-b4840133-8b9d-4288-9254-39bf010b5424.png)
