### PR TITLE
fix: prevent deadlock on concurrent push disconnection

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/AtmospherePushConnectionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/AtmospherePushConnectionTest.java
@@ -20,8 +20,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.atmosphere.cpr.AtmosphereResource;
 import org.atmosphere.cpr.Broadcaster;
@@ -126,6 +128,96 @@ public class AtmospherePushConnectionTest {
                 latch.await(2, TimeUnit.SECONDS));
         Mockito.verify(broadcaster).broadcast(ArgumentMatchers.any(),
                 ArgumentMatchers.eq(resource));
+    }
+
+    @Test
+    public void disconnect_concurrentRequests_preventDeadlocks()
+            throws Exception {
+        UI ui = Mockito.spy(new UI());
+        MockVaadinSession vaadinSession = new MockVaadinSession();
+        Mockito.when(ui.getSession()).thenReturn(vaadinSession);
+        Broadcaster broadcaster = Mockito.mock(Broadcaster.class);
+        AtmosphereResource resource = Mockito.mock(AtmosphereResource.class);
+        Mockito.when(resource.getBroadcaster()).thenReturn(broadcaster);
+
+        AtmospherePushConnection connection = new AtmospherePushConnection(ui);
+        connection.connect(resource);
+
+        // A deadlock may happen when an HTTP session is invalidated in a
+        // thread, causing VaadinSession and UIs to be closed and push
+        // connections to be disconnected, but a push disconnection is
+        // concurrently requested by another thread.
+        // This happens for example with MPR and Vaadin 8: when HTTP session is
+        // invalidated Flow closes UI and disconnects PUSH. At the same time V8
+        // VaadinSession is nullified on the V8 UI, that in turn spawns a thread
+        // to disconnect PUSH connection.
+        // So, there are two concurrent calls to disconnect; one of those
+        // acquires the AtmospherePushConnection lock and the other one waits
+        // for it to be released.
+        // Unfortunately, it may happen that HTTP session operation also require
+        // locks.
+        // In the above case, a lock is held by the thread that is performing
+        // session invalidation, but when AtmospherePushConnection.disconnect is
+        // invoked on the other thread, it calls AtmosphereResource.close that
+        // tries to access the HTTP session attributes, but it gets stuck
+        // waiting for the HTTP session lock to be released.
+        // At the end, there's a thread holding the AtmosphereConnection lock
+        // unable to release it because it cannot complete disconnection due to
+        // the HTTP session lock, that is however hold by the other thread that
+        // is waiting for AtmosphereConnection lock to be released.
+        ReentrantLock sessionLock = new ReentrantLock();
+        Mockito.doAnswer(i -> {
+            // simulate HTTP session lock attempt because of atmosphere resource
+            // accesses session attributes
+            // It does not wait indefinitely, but triggers an error if the lock
+            // is held by the main thread
+            System.out.println("Atmosphere resource : locking session...");
+            if (sessionLock.tryLock(2, TimeUnit.SECONDS)) {
+                System.out.println("Atmosphere resource : session locked");
+                sessionLock.unlock();
+                System.out
+                        .println("Atmosphere resource : session lock released");
+            } else {
+                throw new AssertionError(
+                        "Deadlock on AtmosphereResource.close");
+            }
+            return null;
+        }).when(resource).close();
+
+        CountDownLatch latch = new CountDownLatch(2);
+        sessionLock.lock();
+        CompletableFuture<Throwable> threadErrorFuture;
+        try {
+            // Simulate PUSH disconnection from a separate thread
+            threadErrorFuture = CompletableFuture
+                    .<Throwable> supplyAsync(() -> {
+                        connection.disconnect();
+                        latch.countDown();
+                        return null;
+                    }).exceptionally(t -> {
+                        if (t instanceof CompletionException) {
+                            return t.getCause();
+                        }
+                        return t;
+                    });
+            // Simulate main thread PUSH disconnection because of session
+            // invalidation, delayed a bit to allow the other thread to start
+            // disconnection
+            Thread.sleep(1);
+            connection.disconnect();
+            latch.countDown();
+        } finally {
+            sessionLock.unlock();
+        }
+
+        Throwable threadError = threadErrorFuture.get(2, TimeUnit.SECONDS);
+        if (threadError != null) {
+            Assert.fail("Disconnection on spawned thread failed: "
+                    + threadError.getMessage());
+        }
+        Assert.assertTrue("Disconnect calls not completed, missing "
+                + latch.getCount() + " call", latch.await(3, TimeUnit.SECONDS));
+        Mockito.verify(resource, Mockito.times(1)).close();
     }
 
 }


### PR DESCRIPTION
## Description

If the AtmospherePushConnection.disconnect method is invoked concurrently by multiple threads, a deadlock may happen if the servlet container somehow locks HTTP session, as closing AtmosphereResource may cause accesses to the HTTP session.
For example is a thread (A) is invalidating the HTTP session, thus closing Vaadin UIs and disconnecting push, and another thread (B) is also requesting a push disconnect, then B will be blocked when closing the atmosphere resource by the lock on the session held by A, but A is actually waiting to acquire the lock on AtmospherePushConnection held by B, causing the deadlock.
This change allows a single thread to perform the disconnect operation, in order to avoid potential deadlocks.

Fixes #16293

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
