### PR TITLE
fix: prevent dev tools interactions from closing application overlays

### DIFF
--- a/vaadin-dev-server/frontend/component-util.ts
+++ b/vaadin-dev-server/frontend/component-util.ts
@@ -38,3 +38,16 @@ function getComponent(element: HTMLElement): ComponentReference {
   }
   return { nodeId: -1, uiId: -1, element: undefined };
 }
+
+export function deepContains(container: HTMLElement, node: Node) {
+  if (container.contains(node)) {
+    return true;
+  }
+  let currentNode: Node | null = node;
+  const doc = node.ownerDocument;
+  // Walk from node to `this` or `document`
+  while (currentNode && currentNode !== doc && currentNode !== container) {
+    currentNode = currentNode.parentNode || (currentNode instanceof ShadowRoot ? currentNode.host : null);
+  }
+  return currentNode === container;
+}

--- a/vaadin-dev-server/frontend/theme-editor/components/editors/color-picker.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/editors/color-picker.ts
@@ -94,6 +94,7 @@ export class ColorPicker extends LitElement {
     // the overlay teleports itself to the document body
     this.overlay = document.createElement('vaadin-dev-tools-color-picker-overlay') as VaadinOverlay;
     this.overlay.renderer = this.renderOverlayContent.bind(this);
+    this.overlay.owner = this;
     this.overlay.positionTarget = this.toggle;
     this.overlay.noVerticalOverlap = true;
     this.overlay.addEventListener('vaadin-overlay-escape-press', this.handleOverlayEscape.bind(this));
@@ -249,6 +250,7 @@ export class ColorPickerOverlayContent extends LitElement {
 // Importing the interface is not possible as it breaks the Flow build
 interface VaadinOverlay extends HTMLElement {
   opened: boolean;
+  owner: HTMLElement;
   positionTarget: HTMLElement;
   noVerticalOverlap: boolean;
 

--- a/vaadin-dev-server/frontend/theme-editor/components/scope-selector.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/scope-selector.ts
@@ -14,7 +14,7 @@ export class ScopeChangeEvent extends CustomEvent<{ value: ThemeScope }> {
 injectGlobalCss(css`
   vaadin-select-overlay[theme~='vaadin-dev-tools-theme-scope-selector'] {
     --lumo-primary-color-50pct: rgba(255, 255, 255, 0.5);
-    z-index: 100000;
+    z-index: 100000 !important;
   }
 
   vaadin-select-overlay[theme~='vaadin-dev-tools-theme-scope-selector']::part(overlay) {

--- a/vaadin-dev-server/frontend/vaadin-dev-tools.ts
+++ b/vaadin-dev-server/frontend/vaadin-dev-tools.ts
@@ -4,7 +4,7 @@ import { property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { Overlay, OverlayOutsideClickEvent } from "@vaadin/overlay";
 import { ComponentPicker } from './component-picker';
-import { ComponentReference } from './component-util';
+import { ComponentReference, deepContains } from './component-util';
 import './theme-editor/editor';
 import { ThemeEditorState } from './theme-editor/model';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -1037,7 +1037,7 @@ export class VaadinDevTools extends LitElement {
       // theme editor
       const outsideClickEvent = event as OverlayOutsideClickEvent;
       const overlayOwner = (outsideClickEvent.target as Overlay).owner;
-      const containsOverlayOwner = overlayOwner ? this.deepContains(overlayOwner) : false;
+      const containsOverlayOwner = overlayOwner ? deepContains(this, overlayOwner) : false;
 
       if (containsOverlayOwner) {
         return;
@@ -1049,19 +1049,6 @@ export class VaadinDevTools extends LitElement {
         event.preventDefault();
       }
     });
-  }
-
-  deepContains(node: Node) {
-    if (this.contains(node)) {
-      return true;
-    }
-    let currentNode: Node | null = node;
-    const doc = node.ownerDocument;
-    // Walk from node to `this` or `document`
-    while (currentNode && currentNode !== doc && currentNode !== this) {
-      currentNode = currentNode.parentNode || (currentNode instanceof ShadowRoot ? currentNode.host : null);
-    }
-    return currentNode === this;
   }
 
   format(o: any): string {


### PR DESCRIPTION
## Description

Prevents application overlays from closing when clicking within the dev tools. Also makes sure that overlays that have been opened from within the dev tools, such as the color picker in the theme editor, can still be closed.

Fixes https://github.com/vaadin/flow-components/issues/4901

## Type of change

- Bugfix