### PR TITLE
fix: prevent dev tools interactions from closing application overlays (CP: 24.0)

### DIFF
--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/vaadin-dev-tools.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/vaadin-dev-tools.ts
@@ -1,7 +1,7 @@
 import { css, html, LitElement, nothing } from 'lit';
 import { property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
-import {ComponentReference, deepContains} from './component-util.js';
+import { ComponentReference } from './component-util.js';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { copy } from './copy-to-clipboard.js';

--- a/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/vaadin-dev-tools.ts
+++ b/vaadin-dev-server/src/main/resources/META-INF/frontend/vaadin-dev-tools/vaadin-dev-tools.ts
@@ -1,7 +1,7 @@
 import { css, html, LitElement, nothing } from 'lit';
 import { property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
-import { ComponentReference } from './component-util.js';
+import {ComponentReference, deepContains} from './component-util.js';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { copy } from './copy-to-clipboard.js';
@@ -1175,7 +1175,18 @@ export class VaadinDevTools extends LitElement {
     windowAny.Vaadin.devTools = Object.assign(this, windowAny.Vaadin.devTools);
 
     licenseInit();
+
+    // Prevent application overlays from closing when interacting with the dev tools
+    document.documentElement.addEventListener('vaadin-overlay-outside-click', (event: Event) => {
+      // Prevent closing the overlay if click is within the dev tools
+      const sourceEvent = (event as any).detail.sourceEvent;
+      const composedPath = sourceEvent.composedPath();
+      if (composedPath.includes(this)) {
+        event.preventDefault();
+      }
+    });
   }
+
   format(o: any): string {
     return o.toString();
   }


### PR DESCRIPTION
## Description

Cherry-pick of https://github.com/vaadin/flow/pull/16545

Removed the special handling of overlays in the dev tools, as there are none in v24.0. There are also no type defs for overlays classes.