### PR TITLE
fix: use OS path separator in stats plugin

### DIFF
--- a/flow-server/src/main/resources/plugins/stats-plugin/stats-plugin.js
+++ b/flow-server/src/main/resources/plugins/stats-plugin/stats-plugin.js
@@ -51,7 +51,7 @@ class StatsPlugin {
       const npmModules = nodeModulesFolders
           .map((id) => id.replace(/.*node_modules./, ''))
           .map((id) => {
-            const parts = id.split('/');
+            const parts = id.split(path.sep);
             if (id.startsWith('@')) {
               return parts[0] + '/' + parts[1];
             } else {


### PR DESCRIPTION
## Description

The StatsPlugin uses an hard-coded forwars slash charachter to split the file identifier in path segments.
This produces wrong results when running on Windows, as the identifier contains back slashes.
This change uses node 'path.sep' as split chars

Fixes #16234

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
