### PR TITLE
fix: use OS path separator in stats plugin

### DIFF
--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -171,8 +171,7 @@ function statsExtracterPlugin(): PluginOption {
     enforce: 'post',
     async writeBundle(options: OutputOptions, bundle: { [fileName: string]: AssetInfo | ChunkInfo }) {
       const modules = Object.values(bundle).flatMap((b) => (b.modules ? Object.keys(b.modules) : []));
-      const nodeModulesFolders = modules.
-          filter((id) => id.includes('node_modules'));
+      const nodeModulesFolders = modules.filter((id) => id.includes('node_modules'));
       const npmModules = nodeModulesFolders
         .map((id) => id.replace(/.*node_modules./, ''))
         .map((id) => {

--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -171,11 +171,12 @@ function statsExtracterPlugin(): PluginOption {
     enforce: 'post',
     async writeBundle(options: OutputOptions, bundle: { [fileName: string]: AssetInfo | ChunkInfo }) {
       const modules = Object.values(bundle).flatMap((b) => (b.modules ? Object.keys(b.modules) : []));
-      const nodeModulesFolders = modules.filter((id) => id.includes('node_modules'));
+      const nodeModulesFolders = modules.
+          filter((id) => id.includes('node_modules'));
       const npmModules = nodeModulesFolders
         .map((id) => id.replace(/.*node_modules./, ''))
         .map((id) => {
-          const parts = id.split(path.sep);
+          const parts = id.split('/');
           if (id.startsWith('@')) {
             return parts[0] + '/' + parts[1];
           } else {

--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -175,7 +175,7 @@ function statsExtracterPlugin(): PluginOption {
       const npmModules = nodeModulesFolders
         .map((id) => id.replace(/.*node_modules./, ''))
         .map((id) => {
-          const parts = id.split('/');
+          const parts = id.split(path.sep);
           if (id.startsWith('@')) {
             return parts[0] + '/' + parts[1];
           } else {

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -344,7 +344,7 @@ module.exports = {
         const npmModules = nodeModulesFolders
           .map((id) => id.replace(/.*node_modules./, ''))
           .map((id) => {
-            const parts = id.split('/');
+            const parts = id.split(path.sep);
             if (id.startsWith('@')) {
               return parts[0] + '/' + parts[1];
             } else {


### PR DESCRIPTION
## Description

When Webpack generates stats.json file, it uses an hard-coded forward slash character to split the file identifier into path segments. This produces wrong results when running on Windows, as the identifier contains backslashes.
This change uses node 'path.sep' as split chars.

Fixes #16234

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
