### PR TITLE
chore!: Remove the themeModule concept

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/EntryPointData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/EntryPointData.java
@@ -41,7 +41,6 @@ public final class EntryPointData implements Serializable {
     String layout;
     ThemeData theme = new ThemeData();
     final LinkedHashSet<String> modules = new LinkedHashSet<>();
-    final LinkedHashSet<String> themeModules = new LinkedHashSet<>();
     final LinkedHashSet<String> scripts = new LinkedHashSet<>();
     final transient List<CssData> css = new ArrayList<>();
 
@@ -62,10 +61,6 @@ public final class EntryPointData implements Serializable {
 
     LinkedHashSet<String> getModules() {
         return modules;
-    }
-
-    LinkedHashSet<String> getThemeModules() {
-        return themeModules;
     }
 
     LinkedHashSet<String> getScripts() {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendClassVisitor.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendClassVisitor.java
@@ -138,11 +138,8 @@ final class FrontendClassVisitor extends ClassVisitor {
      *            the class to visit
      * @param entryPoint
      *            the entry point object that will be updated during the visit
-     * @param themeScope
-     *            whether we are visiting from Theme
      */
-    FrontendClassVisitor(String className, EntryPointData entryPoint,
-            boolean themeScope) { // NOSONAR
+    FrontendClassVisitor(String className, EntryPointData entryPoint) { // NOSONAR
         super(Opcodes.ASM9);
         this.className = className;
         this.entryPoint = entryPoint;
@@ -195,11 +192,7 @@ final class FrontendClassVisitor extends ClassVisitor {
         jsModuleVisitor = new RepeatedAnnotationVisitor() {
             @Override
             public void visit(String name, Object value) {
-                if (themeScope) {
-                    entryPoint.themeModules.add(value.toString());
-                } else {
-                    entryPoint.modules.add(value.toString());
-                }
+                entryPoint.modules.add(value.toString());
             }
         };
         // Visitor for @JavaScript annotations

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
@@ -125,6 +125,9 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
             collectEntryPoints(generateEmbeddableWebComponents);
             visitEntryPoints();
             computeApplicationTheme();
+            if (themeDefinition != null && themeDefinition.getTheme() != null) {
+                collectEntrypoints(themeDefinition.getTheme());
+            }
             computePackages();
             computePwaConfiguration();
             long ms = (System.nanoTime() - start) / 1000000;
@@ -386,8 +389,7 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
      *
      * @return Lumo
      */
-    private Class<? extends AbstractTheme> getDefaultTheme()
-            throws IOException {
+    Class<? extends AbstractTheme> getDefaultTheme() throws IOException {
         // No theme annotation found by the scanner
         return getLumoTheme();
     }
@@ -494,10 +496,7 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
      *            the exporter entry point class
      * @throws ClassNotFoundException
      *             if unable to load a class by class name
-     * @throws IOException
-     *             if unable to scan the class byte code
      */
-    @SuppressWarnings("unchecked")
     private void collectExporterEntrypoints(Class<?> clazz)
             throws ClassNotFoundException {
         // Because of different classLoaders we need compare against class
@@ -545,9 +544,6 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
     private void visitClass(String className, EntryPointData entryPoint)
             throws IOException {
 
-        // In theme scope, we want to revisit already visited classes to have
-        // theme modules collected separately (in turn required for module
-        // sorting, #5729)
         if (!shouldVisit(className)
                 || entryPoint.getClasses().contains(className)) {
             return;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
@@ -126,7 +126,12 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
             visitEntryPoints();
             computeApplicationTheme();
             if (themeDefinition != null && themeDefinition.getTheme() != null) {
-                collectEntrypoints(themeDefinition.getTheme());
+                Class<? extends AbstractTheme> themeClass = themeDefinition
+                        .getTheme();
+                if (!visited.contains(themeClass.getName())) {
+                    addEntryPoint(themeClass);
+                    visitEntryPoint(entryPoints.get(themeClass.getName()));
+                }
             }
             computePackages();
             computePwaConfiguration();
@@ -141,8 +146,12 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
 
     private void visitEntryPoints() throws IOException {
         for (Entry<String, EntryPointData> entry : entryPoints.entrySet()) {
-            visitClass(entry.getKey(), entry.getValue());
+            visitEntryPoint(entry.getValue());
         }
+    }
+
+    private void visitEntryPoint(EntryPointData entryPoint) throws IOException {
+        visitClass(entryPoint.getName(), entryPoint);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
@@ -327,6 +327,15 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
     private void computeApplicationTheme() throws ClassNotFoundException,
             InstantiationException, IllegalAccessException, IOException {
 
+        // Re-visit theme related classes, because they might be skipped
+        // when they where already added to the visited list during other
+        // entry-point visits
+        for (EntryPointData entryPoint : entryPoints.values()) {
+            if (entryPoint.getLayout() != null) {
+                visitClass(entryPoint.getLayout(), entryPoint);
+            }
+        }
+
         List<EntryPointData> entryPointsWithTheme = entryPoints.values()
                 .stream()
                 // consider only entry points with theme information

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
@@ -29,10 +29,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import net.bytebuddy.jar.asm.ClassReader;
 import org.slf4j.Logger;
@@ -140,7 +138,7 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
 
     private void visitEntryPoints() throws IOException {
         for (Entry<String, EntryPointData> entry : entryPoints.entrySet()) {
-            visitClass(entry.getKey(), entry.getValue(), false);
+            visitClass(entry.getKey(), entry.getValue());
         }
     }
 
@@ -165,19 +163,13 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
     }
 
     /**
-     * Get all ES6 modules needed for run the application. Modules that are
-     * theme dependencies are guaranteed to precede other modules in the result.
+     * Get all JS modules needed for run the application.
      *
      * @return list of JS modules
      */
     @Override
     public List<String> getModules() {
-        // A module may appear in both data.getThemeModules and data.getModules,
-        // depending on how the classes were visited, hence the LinkedHashSet
         LinkedHashSet<String> all = new LinkedHashSet<>();
-        for (EntryPointData data : entryPoints.values()) {
-            all.addAll(data.getThemeModules());
-        }
         for (EntryPointData data : entryPoints.values()) {
             all.addAll(data.getModules());
         }
@@ -323,19 +315,6 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
     private void computeApplicationTheme() throws ClassNotFoundException,
             InstantiationException, IllegalAccessException, IOException {
 
-        // Re-visit theme related classes, because they might be skipped
-        // when they where already added to the visited list during other
-        // entry-point visits
-        for (EntryPointData entryPoint : entryPoints.values()) {
-            if (entryPoint.getLayout() != null) {
-                visitClass(entryPoint.getLayout(), entryPoint, false);
-            }
-            if (entryPoint.getTheme() != null) {
-                visitClass(entryPoint.getTheme().getThemeClass(), entryPoint,
-                        true);
-            }
-        }
-
         List<EntryPointData> entryPointsWithTheme = entryPoints.values()
                 .stream()
                 // consider only entry points with theme information
@@ -403,27 +382,14 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
     }
 
     /**
-     * Finds the default theme and attaches it to the given entry point as
-     * though the entry point had a {@code Theme} annotation.
+     * Finds the default theme.
      *
-     * @return Lumo or null
+     * @return Lumo
      */
     private Class<? extends AbstractTheme> getDefaultTheme()
             throws IOException {
         // No theme annotation found by the scanner
-        final Class<? extends AbstractTheme> defaultTheme = getLumoTheme();
-        // call visitClass on the default theme using the first available
-        // entry point. If no entry point is available, default theme won't be
-        // set.
-        if (defaultTheme != null) {
-            Optional<EntryPointData> entryPoint = entryPoints.values().stream()
-                    .findFirst();
-            if (entryPoint.isPresent()) {
-                visitClass(defaultTheme.getName(), entryPoint.get(), true);
-            }
-            return defaultTheme;
-        }
-        return null;
+        return getLumoTheme();
     }
 
     /**
@@ -576,14 +542,14 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
      * @return
      * @throws IOException
      */
-    private void visitClass(String className, EntryPointData entryPoint,
-            boolean themeScope) throws IOException {
+    private void visitClass(String className, EntryPointData entryPoint)
+            throws IOException {
 
         // In theme scope, we want to revisit already visited classes to have
         // theme modules collected separately (in turn required for module
         // sorting, #5729)
-        if (!shouldVisit(className) || (!themeScope
-                && entryPoint.getClasses().contains(className))) {
+        if (!shouldVisit(className)
+                || entryPoint.getClasses().contains(className)) {
             return;
         }
         entryPoint.getClasses().add(className);
@@ -594,7 +560,7 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
         }
 
         FrontendClassVisitor visitor = new FrontendClassVisitor(className,
-                entryPoint, themeScope);
+                entryPoint);
         try (InputStream is = url.openStream()) {
             ClassReader cr = new ClassReader(is);
             cr.accept(visitor, ClassReader.EXPAND_FRAMES);
@@ -614,7 +580,7 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
             // we output all dependencies at once. When we implement
             // chunks, this will need to be considered.
             if (!visited.contains(clazz)) {
-                visitClass(clazz, entryPoint, themeScope);
+                visitClass(clazz, entryPoint);
             }
         }
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScanner.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScanner.java
@@ -140,12 +140,10 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
 
         packages = discoverPackages();
 
-        Map<String, Set<String>> themeModules = new HashMap<>();
         LinkedHashSet<String> regularModules = new LinkedHashSet<>();
 
         collectAnnotationValues(
-                (clazz, module) -> handleModule(clazz, module, regularModules,
-                        themeModules),
+                (clazz, module) -> handleModule(clazz, module, regularModules),
                 JsModule.class,
                 module -> getAnnotationValueAsString(module, VALUE));
 
@@ -158,7 +156,7 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
 
         discoverTheme();
 
-        modules = calculateModules(regularModules, themeModules);
+        modules = calculateModules(regularModules);
 
         pwaConfiguration = discoverPwa();
 
@@ -414,35 +412,14 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
     }
 
     private void handleModule(Class<?> clazz, String module,
-            Set<String> modules, Map<String, Set<String>> themeModules) {
+            Set<String> modules) {
 
-        if (abstractTheme.isAssignableFrom(clazz)) {
-            Set<String> themingModules = themeModules.computeIfAbsent(
-                    clazz.getName(), cl -> new LinkedHashSet<>());
-            themingModules.add(module);
-        } else {
-            classes.add(clazz.getName());
-            modules.add(module);
-        }
+        classes.add(clazz.getName());
+        modules.add(module);
     }
 
-    private List<String> calculateModules(Set<String> modules,
-            Map<String, Set<String>> themeModules) {
-        Set<String> themingModules = themeModules
-                .get(getThemeDefinition() == null ? null
-                        : getThemeDefinition().getTheme().getName());
-        if (themingModules == null) {
-            return new ArrayList<>(modules);
-        }
-        if (getThemeDefinition() != null) {
-            classes.add(getThemeDefinition().getTheme().getName());
-        }
-        // get rid of duplicate but preserve the order
-        List<String> result = new ArrayList<>(
-                themingModules.size() + modules.size());
-        result.addAll(themingModules);
-        result.addAll(modules);
-        return result;
+    private List<String> calculateModules(Set<String> modules) {
+        return new ArrayList<>(modules);
     }
 
     private String getAnnotationValueAsString(Annotation target,

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdateImportsTest.java
@@ -220,18 +220,6 @@ public abstract class AbstractNodeUpdateImportsTest extends NodeUpdateTestUtil {
         assertContainsImports(false, "./added-import.js");
     }
 
-    @Test
-    public void addJsModules_themeModulesAreOnTop() throws Exception {
-        updater.execute();
-
-        addImports("styles/styles.js");
-
-        assertImportOrder("@vaadin/vaadin-lumo-styles/color.js",
-                "Frontend/foo.js");
-        assertImportOrder("@vaadin/vaadin-lumo-styles/color.js",
-                "styles/styles.js");
-    }
-
     private void assertContainsImports(boolean contains, String... imports)
             throws IOException {
         String content = FileUtils.readFileToString(importsFile,

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
@@ -119,7 +119,7 @@ public class FrontendDependenciesTest {
         FrontendDependencies dependencies = new FrontendDependencies(
                 classFinder, false);
 
-        Assert.assertEquals("UI, AppShell and theme should be found", 3,
+        Assert.assertEquals("UI, AppShell should be found", 2,
                 dependencies.getEntryPoints().size());
 
         AbstractTheme theme = dependencies.getTheme();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
@@ -251,19 +251,6 @@ public class FrontendDependenciesTest {
                 Arrays.asList("a.js", "b.js", "c.js"));
     }
 
-    // flow #6408
-    @Test
-    public void annotationsInRouterLayoutWontBeFlaggedAsBelongingToTheme() {
-        Mockito.when(classFinder.getAnnotatedClasses(Route.class)).thenReturn(
-                Collections.singleton(RouteComponentWithLayout.class));
-        FrontendDependencies dependencies = new FrontendDependencies(
-                classFinder, false);
-
-        List<String> modules = dependencies.getModules();
-        Assert.assertEquals("Theme's annotations should come first",
-                "theme-foo.js", modules.get(0));
-    }
-
     // flow #6524
     @Test
     public void extractsAndScansClassesFromMethodReferences() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -118,7 +119,7 @@ public class FrontendDependenciesTest {
         FrontendDependencies dependencies = new FrontendDependencies(
                 classFinder, false);
 
-        Assert.assertEquals("UI and AppShell should be found", 2,
+        Assert.assertEquals("UI, AppShell and theme should be found", 3,
                 dependencies.getEntryPoints().size());
 
         AbstractTheme theme = dependencies.getTheme();
@@ -286,8 +287,11 @@ public class FrontendDependenciesTest {
         FrontendDependencies dependencies = new FrontendDependencies(
                 classFinder, false);
 
-        Assert.assertEquals("UI should be visited found", 1,
-                dependencies.getEntryPoints().size());
+        Optional<EntryPointData> uiEndpointData = dependencies.getEntryPoints()
+                .stream().filter(entryPoint -> entryPoint.getName()
+                        .equals(UI.class.getName()))
+                .findAny();
+        Assert.assertTrue("UI should be visited", uiEndpointData.isPresent());
     }
 
     @Test // #9861
@@ -326,7 +330,7 @@ public class FrontendDependenciesTest {
 
         List<String> modules = dependencies.getModules();
 
-        Assert.assertEquals(3, dependencies.getEntryPoints().size());
+        Assert.assertEquals(4, dependencies.getEntryPoints().size());
         Assert.assertEquals("Should contain UI and Referenced modules", 2,
                 modules.size());
         Assert.assertTrue(modules.contains("reference.js"));

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScannerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScannerTest.java
@@ -253,21 +253,20 @@ public class FullDependenciesScannerTest {
     }
 
     @Test
-    public void getModules_noTheme_returnAllNoThemeModules_orderPerClassIsPreserved_getClassesReturnAllModuleAnnotatedComponents()
+    public void getModules_noTheme_returnAllModules_orderPerClassIsPreserved_getClassesReturnAllModuleAnnotatedComponents()
             throws ClassNotFoundException {
         FrontendDependenciesScanner scanner = setUpAnnotationScanner(
                 JsModule.class);
         List<String> modules = scanner.getModules();
 
-        Assert.assertEquals(19, modules.size());
+        Assert.assertEquals(25, modules.size());
 
         assertJsModules(modules);
 
         Set<String> classes = scanner.getClasses();
-        Assert.assertEquals(13, classes.size());
+        Assert.assertEquals(14, classes.size());
 
         assertJsModulesClasses(classes);
-        Assert.assertFalse(classes.contains(LumoTest.class.getName()));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/ScannerDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/ScannerDependenciesTest.java
@@ -59,8 +59,7 @@ public class ScannerDependenciesTest {
     @Test
     public void should_extractClassesFromSignatures() {
         Set<String> classes = new HashSet<>();
-        FrontendClassVisitor visitor = new FrontendClassVisitor(null, null,
-                false);
+        FrontendClassVisitor visitor = new FrontendClassVisitor(null, null);
 
         visitor.addSignatureToClasses(classes,
                 "(Lcom/vaadin/flow/component/tabs/Tabs;Ljava/lang/String;Ljava/lang/Character;CLjava/lang/Integer;ILjava/lang/Long;JLjava/lang/Double;DLjava/lang/Float;FLjava/lang/Byte;BLjava/lang/Boolean;Z)Lcom/vaadin/flow/component/button/Button;");


### PR DESCRIPTION
When splitting code into multiple chunks, there is no way to guarantee that some modules are globally loaded before others
