### PR TITLE
refactor: Rename endpoint to entry point when scanning classes

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/EntryPointData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/EntryPointData.java
@@ -23,17 +23,19 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.vaadin.flow.component.WebComponentExporter;
 import com.vaadin.flow.router.Route;
 
 /**
- * A simple container with the information related to an application end-point,
- * i.e. those classes annotated with the {@link Route} annotation.
+ * A simple container with the information related to an application entry
+ * point, i.e. those classes annotated with the {@link Route} annotation,
+ * extending {@link WebComponentExporter} and a bunch of more internal classes.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
  * @since 2.0
  */
-public final class EndPointData implements Serializable {
+public final class EntryPointData implements Serializable {
     final String name;
     String route = "";
     String layout;
@@ -45,7 +47,7 @@ public final class EndPointData implements Serializable {
 
     private final HashSet<String> classes = new HashSet<>();
 
-    EndPointData(Class<?> clazz) {
+    EntryPointData(Class<?> clazz) {
         this.name = clazz.getName();
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendClassVisitor.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendClassVisitor.java
@@ -55,7 +55,7 @@ final class FrontendClassVisitor extends ClassVisitor {
     static final String THEME_FOR = "themeFor";
 
     private final String className;
-    private final EndPointData endPoint;
+    private final EntryPointData entryPoint;
     private final MethodVisitor methodVisitor;
     private final AnnotationVisitor annotationVisitor;
     private final AnnotationVisitor routeVisitor;
@@ -136,16 +136,16 @@ final class FrontendClassVisitor extends ClassVisitor {
      *
      * @param className
      *            the class to visit
-     * @param endPoint
-     *            the end-point object that will be updated during the visit
+     * @param entryPoint
+     *            the entry point object that will be updated during the visit
      * @param themeScope
      *            whether we are visiting from Theme
      */
-    FrontendClassVisitor(String className, EndPointData endPoint,
+    FrontendClassVisitor(String className, EntryPointData entryPoint,
             boolean themeScope) { // NOSONAR
         super(Opcodes.ASM9);
         this.className = className;
-        this.endPoint = endPoint;
+        this.entryPoint = entryPoint;
 
         // Visitor for each method in the class.
         methodVisitor = new FrontendMethodVisitor();
@@ -154,11 +154,11 @@ final class FrontendClassVisitor extends ClassVisitor {
             @Override
             public void visit(String name, Object value) {
                 if (LAYOUT.equals(name)) {
-                    endPoint.layout = ((Type) value).getClassName();
-                    children.add(endPoint.layout);
+                    entryPoint.layout = ((Type) value).getClassName();
+                    children.add(entryPoint.layout);
                 }
                 if (VALUE.equals(name)) {
-                    endPoint.route = value.toString();
+                    entryPoint.route = value.toString();
                 }
             }
         };
@@ -167,12 +167,12 @@ final class FrontendClassVisitor extends ClassVisitor {
             @Override
             public void visit(String name, Object value) {
                 if (VALUE.equals(name)) {
-                    endPoint.theme.themeName = (String) value;
+                    entryPoint.theme.themeName = (String) value;
                 } else if (THEME_CLASS.equals(name)) {
-                    endPoint.theme.themeClass = ((Type) value).getClassName();
-                    children.add(endPoint.theme.themeClass);
+                    entryPoint.theme.themeClass = ((Type) value).getClassName();
+                    children.add(entryPoint.theme.themeClass);
                 } else if (VARIANT.equals(name)) {
-                    endPoint.theme.variant = value.toString();
+                    entryPoint.theme.variant = value.toString();
                 }
             }
         };
@@ -183,10 +183,10 @@ final class FrontendClassVisitor extends ClassVisitor {
                 if (VALUE.equals(name)) {
                     themeRouteVisitor.visit(name, value);
                 } else if (THEME_CLASS.equals(name)
-                        && endPoint.theme.themeClass == null) {
+                        && entryPoint.theme.themeClass == null) {
                     themeRouteVisitor.visit(name, value);
                 } else if (VARIANT.equals(name)
-                        && endPoint.theme.variant.isEmpty()) {
+                        && entryPoint.theme.variant.isEmpty()) {
                     themeRouteVisitor.visit(name, value);
                 }
             }
@@ -196,9 +196,9 @@ final class FrontendClassVisitor extends ClassVisitor {
             @Override
             public void visit(String name, Object value) {
                 if (themeScope) {
-                    endPoint.themeModules.add(value.toString());
+                    entryPoint.themeModules.add(value.toString());
                 } else {
-                    endPoint.modules.add(value.toString());
+                    entryPoint.modules.add(value.toString());
                 }
             }
         };
@@ -206,7 +206,7 @@ final class FrontendClassVisitor extends ClassVisitor {
         jScriptVisitor = new RepeatedAnnotationVisitor() {
             @Override
             public void visit(String name, Object value) {
-                endPoint.scripts.add(value.toString());
+                entryPoint.scripts.add(value.toString());
             }
         };
         // Visitor all other annotations
@@ -249,7 +249,7 @@ final class FrontendClassVisitor extends ClassVisitor {
         // We return different visitor implementations depending on the
         // annotation
         String cname = descriptor.replace("/", ".");
-        if (className.equals(endPoint.name)
+        if (className.equals(entryPoint.name)
                 && cname.contains(Route.class.getName())) {
             return routeVisitor;
         }
@@ -260,21 +260,21 @@ final class FrontendClassVisitor extends ClassVisitor {
             return jScriptVisitor;
         }
         if (cname.contains(NoTheme.class.getName())) {
-            if (className.equals(endPoint.name)) {
-                endPoint.theme.notheme = true;
+            if (className.equals(entryPoint.name)) {
+                entryPoint.theme.notheme = true;
             }
             return null;
         }
         if (cname.contains(Theme.class.getName())) {
-            if (className.equals(endPoint.name)) {
+            if (className.equals(entryPoint.name)) {
                 return themeRouteVisitor;
             }
-            if (className.equals(endPoint.layout)) {
+            if (className.equals(entryPoint.layout)) {
                 return themeLayoutVisitor;
             }
         }
         if (cname.contains(CssImport.class.getName())) {
-            return new CssAnnotationVisitor(endPoint.css);
+            return new CssAnnotationVisitor(entryPoint.css);
         }
         // default visitor
         return annotationVisitor;

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
@@ -93,7 +93,7 @@ public class FrontendDependenciesTest {
     }
 
     @Test
-    public void routedComponent_endpointsAreCollected() {
+    public void routedComponent_entryPointsAreCollected() {
         Mockito.when(classFinder.getAnnotatedClasses(Route.class))
                 .thenReturn(Collections.singleton(RouteComponent.class));
         FrontendDependencies dependencies = new FrontendDependencies(
@@ -108,7 +108,7 @@ public class FrontendDependenciesTest {
     }
 
     @Test
-    public void appShellConfigurator_collectedAsEndpoint()
+    public void appShellConfigurator_collectedAsEntryPoint()
             throws ClassNotFoundException {
         Mockito.when(classFinder.getSubTypesOf(AppShellConfigurator.class))
                 .thenReturn(Collections.singleton(MyAppShell.class));
@@ -119,10 +119,10 @@ public class FrontendDependenciesTest {
                 classFinder, false);
 
         Assert.assertEquals("UI and AppShell should be found", 2,
-                dependencies.getEndPoints().size());
+                dependencies.getEntryPoints().size());
 
         AbstractTheme theme = dependencies.getTheme();
-        Assert.assertNotNull("Theme not found in endpoint", theme);
+        Assert.assertNotNull("Theme not found in entry point", theme);
 
         ThemeDefinition themeDefinition = dependencies.getThemeDefinition();
         Assert.assertNotNull("ThemeDefinition is not filled", themeDefinition);
@@ -193,7 +193,7 @@ public class FrontendDependenciesTest {
     }
 
     @Test
-    public void hasErrorParameterComponent_endpointIsCollected() {
+    public void hasErrorParameterComponent_entryPointIsCollected() {
         Mockito.when(classFinder.getSubTypesOf(HasErrorParameter.class))
                 .thenReturn(Collections.singleton(ErrorComponent.class));
         FrontendDependencies dependencies = new FrontendDependencies(
@@ -208,7 +208,7 @@ public class FrontendDependenciesTest {
     }
 
     @Test
-    public void componentInsideUiInitListener_endpointsAreCollected() {
+    public void componentInsideUiInitListener_entryPointsAreCollected() {
         Mockito.when(classFinder.getSubTypesOf(UIInitListener.class))
                 .thenReturn(Collections.singleton(MyUIInitListener.class));
         FrontendDependencies dependencies = new FrontendDependencies(
@@ -223,7 +223,7 @@ public class FrontendDependenciesTest {
     }
 
     @Test
-    public void componentInsideUiInitListenerInsideServiceInitListener_endpointsAreCollected() {
+    public void componentInsideUiInitListenerInsideServiceInitListener_entryPointsAreCollected() {
         Mockito.when(classFinder.getSubTypesOf(VaadinServiceInitListener.class))
                 .thenReturn(Collections.singleton(MyServiceListener.class));
         FrontendDependencies dependencies = new FrontendDependencies(
@@ -295,20 +295,20 @@ public class FrontendDependenciesTest {
     }
 
     @Test // #9861
-    public void collectEndpoints_uiIsAlwaysCollected() {
+    public void collectEntryPoints_uiIsAlwaysCollected() {
         FrontendDependencies dependencies = new FrontendDependencies(
                 classFinder, false);
 
         Assert.assertEquals("UI should be visited found", 1,
-                dependencies.getEndPoints().size());
+                dependencies.getEntryPoints().size());
     }
 
     @Test // #9861
-    public void classInMultipleEndpoints_collectEndpointsNotOverrideInitial() {
-        // Reference found through first endpoint
+    public void classInMultipleEntryPoints_collectEntryPointsNotOverrideInitial() {
+        // Reference found through first entry point
         Mockito.when(classFinder.getAnnotatedClasses(Route.class))
                 .thenReturn(Collections.singleton(TestRoute.class));
-        // Reference found through second endpoint, should not clear
+        // Reference found through second entry point, should not clear
         Mockito.when(classFinder.getSubTypesOf(HasErrorParameter.class))
                 .thenReturn(Collections.singleton(TestRoute.class));
 
@@ -322,11 +322,11 @@ public class FrontendDependenciesTest {
     }
 
     @Test // #9861
-    public void visitedExporter_previousEndpointsNotOverridden()
+    public void visitedExporter_previousEntryPointsNotOverridden()
             throws InstantiationException, IllegalAccessException {
 
         FakeLumo.class.newInstance();
-        // Reference found through first endpoint
+        // Reference found through first entry point
         Mockito.when(classFinder.getAnnotatedClasses(Route.class))
                 .thenReturn(Collections.singleton(ReferenceExporter.class));
         // Re-visit through exporter.
@@ -339,7 +339,7 @@ public class FrontendDependenciesTest {
 
         List<String> modules = dependencies.getModules();
 
-        Assert.assertEquals(3, dependencies.getEndPoints().size());
+        Assert.assertEquals(3, dependencies.getEntryPoints().size());
         Assert.assertEquals("Should contain UI and Referenced modules", 2,
                 modules.size());
         Assert.assertTrue(modules.contains("reference.js"));

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/ScannerCssTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/ScannerCssTest.java
@@ -22,16 +22,16 @@ public class ScannerCssTest {
     public void should_visitCssImports() throws Exception {
         FrontendDependencies deps = getFrontendDependencies(CssClass1.class,
                 CssClass2.class);
-        assertEquals(3, deps.getEndPoints().size());
-        for (EndPointData endPoint : deps.getEndPoints()) {
-            if (endPoint.name.equals(UI.class.getName())) {
+        assertEquals(3, deps.getEntryPoints().size());
+        for (EntryPointData entryPoint : deps.getEntryPoints()) {
+            if (entryPoint.name.equals(UI.class.getName())) {
                 continue;
             }
-            assertEquals("Wrong amount of css in " + endPoint.getName(), 4,
-                    endPoint.getCss().size());
+            assertEquals("Wrong amount of css in " + entryPoint.getName(), 4,
+                    entryPoint.getCss().size());
 
             assertThat(
-                    endPoint.getCss().stream().map(CssData::toString)
+                    entryPoint.getCss().stream().map(CssData::toString)
                             .collect(Collectors.toList()),
                     containsInAnyOrder("value: ./foo.css",
                             "value: ./foo.css include:bar",
@@ -44,17 +44,17 @@ public class ScannerCssTest {
     @Test
     public void should_gatherCssImportsInOrderPerClass() throws Exception {
         FrontendDependencies deps = getFrontendDependencies(CssClass3.class);
-        assertEquals(2, deps.getEndPoints().size());
-        for (EndPointData endPoint : deps.getEndPoints()) {
-            if (endPoint.name.equals(UI.class.getName())) {
+        assertEquals(2, deps.getEntryPoints().size());
+        for (EntryPointData entryPoint : deps.getEntryPoints()) {
+            if (entryPoint.name.equals(UI.class.getName())) {
                 continue;
             }
-            assertEquals("Wrong amount of css in " + endPoint.getName(), 4,
-                    endPoint.getCss().size());
+            assertEquals("Wrong amount of css in " + entryPoint.getName(), 4,
+                    entryPoint.getCss().size());
 
             // verifies #6523 as sufficiently complex names can get mixed up
             assertThat(
-                    endPoint.getCss().stream().map(CssData::toString)
+                    entryPoint.getCss().stream().map(CssData::toString)
                             .collect(Collectors.toList()),
                     contains("value: ./foo.css", "value: ./bar.css",
                             "value: ./foofoo.css", "value: ./foobar.css"));

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/ScannerDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/ScannerDependenciesTest.java
@@ -164,14 +164,15 @@ public class ScannerDependenciesTest {
     public void should_notVisitNonAnnotatredClasses() {
         FrontendDependencies deps = getFrontendDependencies(
                 UnAnnotatedClass.class);
-        assertEquals("Only UI should be found", 1, deps.getEndPoints().size());
+        assertEquals("Only UI should be found", 1,
+                deps.getEntryPoints().size());
     }
 
     @Test
     public void should_cacheVisitedClasses() {
         FrontendDependencies deps = getFrontendDependencies(
                 RoutedClassWithoutAnnotations.class);
-        assertEquals(2, deps.getEndPoints().size());
+        assertEquals(2, deps.getEntryPoints().size());
         assertTrue("Should cache visited classes",
                 deps.getClasses().size() > 2);
         assertTrue(deps.getClasses().contains(Route.class.getName()));
@@ -189,7 +190,7 @@ public class ScannerDependenciesTest {
         // Visit a route that extends an extra routed class
         FrontendDependencies deps = getFrontendDependencies(RoutedClass.class);
         assertEquals("Should find RoutedClass and UI", 2,
-                deps.getEndPoints().size());
+                deps.getEntryPoints().size());
         int visitedClassesAmount = deps.getClasses().size();
         for (Class<?> clz : visited) {
             assertTrue("should cache " + clz.getName(),
@@ -202,7 +203,7 @@ public class ScannerDependenciesTest {
         deps = getFrontendDependencies(RoutedClassWithoutAnnotations.class,
                 RoutedClass.class);
         assertEquals("Should contain UI, RoutedClass and its parent", 3,
-                deps.getEndPoints().size());
+                deps.getEntryPoints().size());
         assertEquals(visitedClassesAmount, deps.getClasses().size());
         for (Class<?> clz : visited) {
             assertTrue("should cache " + clz.getName(),

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/ScannerThemeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/ScannerThemeTest.java
@@ -183,12 +183,12 @@ public class ScannerThemeTest {
         FrontendDependencies deps = getFrontendDependencies(
                 RootViewWithLayoutTheme.class, RootView2WithLayoutTheme.class);
         assertEquals(Theme1.class, deps.getThemeDefinition().getTheme());
-        for (EndPointData endPoint : deps.getEndPoints()) {
-            if (endPoint.getName().equals(UI.class.getName())) {
+        for (EntryPointData entryPoint : deps.getEntryPoints()) {
+            if (entryPoint.getName().equals(UI.class.getName())) {
                 continue;
             }
             assertEquals(Theme1.class.getName(),
-                    endPoint.getTheme().getThemeClass());
+                    entryPoint.getTheme().getThemeClass());
         }
         ;
     }


### PR DESCRIPTION
Google finds a definition like "An endpoint is a remote computing device that communicates back and forth with a network to which it is connected." which is not what a @Route annotated class is, and even less what a service init listener is..

Endpoint is already used in Hilla for something close to what the definition describes