### PR TITLE
refactor: Collect reachable class info per entry point

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/ClassInfo.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/ClassInfo.java
@@ -1,0 +1,22 @@
+package com.vaadin.flow.server.frontend.scanner;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+public class ClassInfo {
+    String className;
+    final LinkedHashSet<String> modules = new LinkedHashSet<>();
+    final LinkedHashSet<String> scripts = new LinkedHashSet<>();
+    final transient List<CssData> css = new ArrayList<>();
+    String route = "";
+    String layout;
+    ThemeData theme = new ThemeData();
+    Set<String> children = new HashSet<>();
+
+    public ClassInfo(String className) {
+        this.className = className;
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/EntryPointData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/EntryPointData.java
@@ -16,11 +16,8 @@
 package com.vaadin.flow.server.frontend.scanner;
 
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Set;
 
 import com.vaadin.flow.component.WebComponentExporter;
@@ -37,61 +34,29 @@ import com.vaadin.flow.router.Route;
  */
 public final class EntryPointData implements Serializable {
     final String name;
-    String route = "";
-    String layout;
-    ThemeData theme = new ThemeData();
-    final LinkedHashSet<String> modules = new LinkedHashSet<>();
-    final LinkedHashSet<String> scripts = new LinkedHashSet<>();
-    final transient List<CssData> css = new ArrayList<>();
-
-    private final HashSet<String> classes = new HashSet<>();
+    Set<String> reachableClasses;
+    private LinkedHashSet<String> modules = new LinkedHashSet<>();
+    private LinkedHashSet<String> scripts = new LinkedHashSet<>();
+    private LinkedHashSet<CssData> css = new LinkedHashSet<>();
 
     EntryPointData(Class<?> clazz) {
         this.name = clazz.getName();
-    }
-
-    // For debugging
-    @Override
-    public String toString() {
-        return String.format(
-                "%n view: %s%n route: %s%n%s%n layout: %s%n modules: %s%n scripts: %s%n css: %s%n",
-                name, route, theme, layout, col2Str(modules), col2Str(scripts),
-                col2Str(css));
-    }
-
-    LinkedHashSet<String> getModules() {
-        return modules;
-    }
-
-    LinkedHashSet<String> getScripts() {
-        return scripts;
-    }
-
-    Set<String> getClasses() {
-        return classes;
-    }
-
-    ThemeData getTheme() {
-        return theme;
-    }
-
-    String getRoute() {
-        return route;
-    }
-
-    String getLayout() {
-        return layout;
     }
 
     String getName() {
         return name;
     }
 
-    LinkedHashSet<CssData> getCss() {
-        return new LinkedHashSet<>(css);
+    public LinkedHashSet<String> getModules() {
+        return modules;
     }
 
-    private String col2Str(Collection<?> s) {
-        return String.join("\n          ", String.valueOf(s));
+    public Collection<String> getScripts() {
+        return scripts;
     }
+
+    public Collection<CssData> getCss() {
+        return css;
+    }
+
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendClassVisitor.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendClassVisitor.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.server.frontend.scanner;
 
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 
 import net.bytebuddy.jar.asm.AnnotationVisitor;
@@ -54,16 +52,13 @@ final class FrontendClassVisitor extends ClassVisitor {
     static final String INCLUDE = "include";
     static final String THEME_FOR = "themeFor";
 
-    private final String className;
-    private final EntryPointData entryPoint;
     private final MethodVisitor methodVisitor;
     private final AnnotationVisitor annotationVisitor;
     private final AnnotationVisitor routeVisitor;
-    private final AnnotationVisitor themeRouteVisitor;
-    private final AnnotationVisitor themeLayoutVisitor;
+    private final AnnotationVisitor themeVisitor;
     private final AnnotationVisitor jsModuleVisitor;
     private final AnnotationVisitor jScriptVisitor;
-    private final Set<String> children = new HashSet<>();
+    private ClassInfo classInfo;
 
     private final class FrontendMethodVisitor extends MethodVisitor {
         public FrontendMethodVisitor() {
@@ -73,7 +68,7 @@ final class FrontendClassVisitor extends ClassVisitor {
         // We are interested in the new instances created inside the method
         @Override
         public void visitTypeInsn(int opcode, String type) {
-            addSignatureToClasses(children, type);
+            addSignatureToClasses(classInfo.children, type);
         }
 
         // We are interested in method instructions like
@@ -81,8 +76,8 @@ final class FrontendClassVisitor extends ClassVisitor {
         @Override
         public void visitMethodInsn(int opcode, String owner, String name,
                 String descriptor, boolean isInterface) {
-            addSignatureToClasses(children, owner);
-            addSignatureToClasses(children, descriptor);
+            addSignatureToClasses(classInfo.children, owner);
+            addSignatureToClasses(classInfo.children, descriptor);
         }
 
         // Visit instructions that stores something in a field inside the
@@ -90,8 +85,8 @@ final class FrontendClassVisitor extends ClassVisitor {
         @Override
         public void visitFieldInsn(int opcode, String owner, String name,
                 String descriptor) {
-            addSignatureToClasses(children, owner);
-            addSignatureToClasses(children, descriptor);
+            addSignatureToClasses(classInfo.children, owner);
+            addSignatureToClasses(classInfo.children, descriptor);
         }
 
         // Visit arguments, we only care those arguments that are Types,
@@ -99,7 +94,7 @@ final class FrontendClassVisitor extends ClassVisitor {
         @Override
         public void visitLdcInsn(Object value) {
             if (value instanceof Type) {
-                addSignatureToClasses(children, value.toString());
+                addSignatureToClasses(classInfo.children, value.toString());
             }
         }
 
@@ -110,15 +105,18 @@ final class FrontendClassVisitor extends ClassVisitor {
         public void visitInvokeDynamicInsn(String name, String descriptor,
                 Handle bootstrapMethodHandle,
                 Object... bootstrapMethodArguments) {
-            addSignatureToClasses(children, descriptor);
-            addSignatureToClasses(children, bootstrapMethodHandle.getOwner());
-            addSignatureToClasses(children, bootstrapMethodHandle.getDesc());
+            addSignatureToClasses(classInfo.children, descriptor);
+            addSignatureToClasses(classInfo.children,
+                    bootstrapMethodHandle.getOwner());
+            addSignatureToClasses(classInfo.children,
+                    bootstrapMethodHandle.getDesc());
             for (Object obj : bootstrapMethodArguments) {
                 if (obj instanceof Type) {
-                    addSignatureToClasses(children, obj.toString());
+                    addSignatureToClasses(classInfo.children, obj.toString());
                 } else if (obj instanceof Handle) {
                     // The owner of the Handle is the reference information
-                    addSignatureToClasses(children, ((Handle) obj).getOwner());
+                    addSignatureToClasses(classInfo.children,
+                            ((Handle) obj).getOwner());
                     // the descriptor for the Handle won't be scanned, as it
                     // adds from +10% to 40% to the execution time and does not
                     // affect the fix in itself
@@ -136,14 +134,12 @@ final class FrontendClassVisitor extends ClassVisitor {
      *
      * @param className
      *            the class to visit
-     * @param entryPoint
-     *            the entry point object that will be updated during the visit
+     * @param classInfo
+     *            data object where discovered information is stored
      */
-    FrontendClassVisitor(String className, EntryPointData entryPoint) { // NOSONAR
+    FrontendClassVisitor(ClassInfo classInfo) {
         super(Opcodes.ASM9);
-        this.className = className;
-        this.entryPoint = entryPoint;
-
+        this.classInfo = classInfo;
         // Visitor for each method in the class.
         methodVisitor = new FrontendMethodVisitor();
         // Visitor for each annotation in the class.
@@ -151,40 +147,25 @@ final class FrontendClassVisitor extends ClassVisitor {
             @Override
             public void visit(String name, Object value) {
                 if (LAYOUT.equals(name)) {
-                    entryPoint.layout = ((Type) value).getClassName();
-                    children.add(entryPoint.layout);
+                    classInfo.layout = ((Type) value).getClassName();
+                    classInfo.children.add(classInfo.layout);
                 }
                 if (VALUE.equals(name)) {
-                    entryPoint.route = value.toString();
+                    classInfo.route = value.toString();
                 }
             }
         };
         // Visitor for @Theme annotations in classes annotated with @Route
-        themeRouteVisitor = new RepeatedAnnotationVisitor() {
+        themeVisitor = new RepeatedAnnotationVisitor() {
             @Override
             public void visit(String name, Object value) {
                 if (VALUE.equals(name)) {
-                    entryPoint.theme.themeName = (String) value;
+                    classInfo.theme.themeName = (String) value;
                 } else if (THEME_CLASS.equals(name)) {
-                    entryPoint.theme.themeClass = ((Type) value).getClassName();
-                    children.add(entryPoint.theme.themeClass);
+                    classInfo.theme.themeClass = ((Type) value).getClassName();
+                    classInfo.children.add(classInfo.theme.themeClass);
                 } else if (VARIANT.equals(name)) {
-                    entryPoint.theme.variant = value.toString();
-                }
-            }
-        };
-        // Visitor for @Theme annotations in classes extending RouterLayout
-        themeLayoutVisitor = new RepeatedAnnotationVisitor() {
-            @Override
-            public void visit(String name, Object value) {
-                if (VALUE.equals(name)) {
-                    themeRouteVisitor.visit(name, value);
-                } else if (THEME_CLASS.equals(name)
-                        && entryPoint.theme.themeClass == null) {
-                    themeRouteVisitor.visit(name, value);
-                } else if (VARIANT.equals(name)
-                        && entryPoint.theme.variant.isEmpty()) {
-                    themeRouteVisitor.visit(name, value);
+                    classInfo.theme.variant = value.toString();
                 }
             }
         };
@@ -192,14 +173,14 @@ final class FrontendClassVisitor extends ClassVisitor {
         jsModuleVisitor = new RepeatedAnnotationVisitor() {
             @Override
             public void visit(String name, Object value) {
-                entryPoint.modules.add(value.toString());
+                classInfo.modules.add(value.toString());
             }
         };
         // Visitor for @JavaScript annotations
         jScriptVisitor = new RepeatedAnnotationVisitor() {
             @Override
             public void visit(String name, Object value) {
-                entryPoint.scripts.add(value.toString());
+                classInfo.scripts.add(value.toString());
             }
         };
         // Visitor all other annotations
@@ -208,7 +189,7 @@ final class FrontendClassVisitor extends ClassVisitor {
             public void visit(String name, Object value) {
                 if (value != null && !value.getClass().isPrimitive()
                         && !value.getClass().equals(String.class)) {
-                    addSignatureToClasses(children, value.toString());
+                    addSignatureToClasses(classInfo.children, value.toString());
                 }
             }
         };
@@ -218,10 +199,10 @@ final class FrontendClassVisitor extends ClassVisitor {
     @Override
     public void visit(int version, int access, String name, String signature,
             String superName, String[] interfaces) {
-        addSignatureToClasses(children, superName);
+        addSignatureToClasses(classInfo.children, superName);
 
         for (String implementedInterface : interfaces) {
-            addSignatureToClasses(children, implementedInterface);
+            addSignatureToClasses(classInfo.children, implementedInterface);
         }
     }
 
@@ -229,7 +210,7 @@ final class FrontendClassVisitor extends ClassVisitor {
     @Override
     public MethodVisitor visitMethod(int access, String name, String descriptor,
             String signature, String[] exceptions) {
-        addSignatureToClasses(children, descriptor);
+        addSignatureToClasses(classInfo.children, descriptor);
         return methodVisitor;
     }
 
@@ -237,37 +218,29 @@ final class FrontendClassVisitor extends ClassVisitor {
     @Override
     public AnnotationVisitor visitAnnotation(String descriptor,
             boolean visible) {
-        addSignatureToClasses(children, descriptor);
+        addSignatureToClasses(classInfo.children, descriptor);
 
         // We return different visitor implementations depending on the
         // annotation
-        String cname = descriptor.replace("/", ".");
-        if (className.equals(entryPoint.name)
-                && cname.contains(Route.class.getName())) {
+        String annotationClassName = descriptor.replace("/", ".");
+        if (annotationClassName.contains(Route.class.getName())) {
             return routeVisitor;
         }
-        if (cname.contains(JsModule.class.getName())) {
+        if (annotationClassName.contains(JsModule.class.getName())) {
             return jsModuleVisitor;
         }
-        if (cname.contains(JavaScript.class.getName())) {
+        if (annotationClassName.contains(JavaScript.class.getName())) {
             return jScriptVisitor;
         }
-        if (cname.contains(NoTheme.class.getName())) {
-            if (className.equals(entryPoint.name)) {
-                entryPoint.theme.notheme = true;
-            }
+        if (annotationClassName.contains(NoTheme.class.getName())) {
+            classInfo.theme.notheme = true;
             return null;
         }
-        if (cname.contains(Theme.class.getName())) {
-            if (className.equals(entryPoint.name)) {
-                return themeRouteVisitor;
-            }
-            if (className.equals(entryPoint.layout)) {
-                return themeLayoutVisitor;
-            }
+        if (annotationClassName.contains(Theme.class.getName())) {
+            return themeVisitor;
         }
-        if (cname.contains(CssImport.class.getName())) {
-            return new CssAnnotationVisitor(entryPoint.css);
+        if (annotationClassName.contains(CssImport.class.getName())) {
+            return new CssAnnotationVisitor(classInfo.css);
         }
         // default visitor
         return annotationVisitor;
@@ -277,17 +250,8 @@ final class FrontendClassVisitor extends ClassVisitor {
     @Override
     public FieldVisitor visitField(int access, String name, String descriptor,
             String signature, Object value) {
-        addSignatureToClasses(children, descriptor);
+        addSignatureToClasses(classInfo.children, descriptor);
         return null;
-    }
-
-    /**
-     * Return all discovered classes in the visit.
-     *
-     * @return used classes
-     */
-    public Set<String> getChildren() {
-        return children;
     }
 
     /**
@@ -313,6 +277,10 @@ final class FrontendClassVisitor extends ClassVisitor {
         // primitive and other mark symbols, see test for more info.
         String[] tmp = signature.replace("/", ".").split(
                 "(^\\([\\[ZBFDJICL]*|^[\\[ZBFDJICL]+|;?\\)[\\[ZBFDJICLV]*|;[\\[ZBFDJICL]*)");
-        classes.addAll(Arrays.asList(tmp));
+        for (String cls : tmp) {
+            if (!cls.isBlank()) {
+                classes.add(cls);
+            }
+        }
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
@@ -70,7 +70,8 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
     private ThemeDefinition themeDefinition;
     private AbstractTheme themeInstance;
     private final HashMap<String, String> packages = new HashMap<>();
-    private final Set<String> visited = new HashSet<>();
+    private final Map<String, ClassInfo> visitedClasses = new HashMap<>();
+
     private PwaConfiguration pwaConfiguration;
 
     /**
@@ -128,15 +129,17 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
             if (themeDefinition != null && themeDefinition.getTheme() != null) {
                 Class<? extends AbstractTheme> themeClass = themeDefinition
                         .getTheme();
-                if (!visited.contains(themeClass.getName())) {
+                if (!visitedClasses.containsKey(themeClass.getName())) {
                     addEntryPoint(themeClass);
                     visitEntryPoint(entryPoints.get(themeClass.getName()));
                 }
             }
             computePackages();
             computePwaConfiguration();
+            aggregateEntryPointInformation();
             long ms = (System.nanoTime() - start) / 1000000;
-            log().info("Visited {} classes. Took {} ms.", visited.size(), ms);
+            log().info("Visited {} classes. Took {} ms.", visitedClasses.size(),
+                    ms);
         } catch (ClassNotFoundException | InstantiationException
                 | IllegalAccessException | IOException e) {
             throw new IllegalStateException(
@@ -144,14 +147,67 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
         }
     }
 
+    private void aggregateEntryPointInformation() {
+        for (Entry<String, EntryPointData> entry : entryPoints.entrySet()) {
+            EntryPointData entryPoint = entry.getValue();
+            for (String className : entryPoint.reachableClasses) {
+                entryPoint.getModules()
+                        .addAll(visitedClasses.get(className).modules);
+                entryPoint.getCss().addAll(visitedClasses.get(className).css);
+                entryPoint.getScripts()
+                        .addAll(visitedClasses.get(className).scripts);
+            }
+        }
+
+    }
+
+    Set<String> collectReachableClasses(EntryPointData entryPointData) {
+        Set<String> classes = new HashSet<>();
+        collectReachableClasses(entryPointData.name, classes);
+
+        return classes;
+    }
+
+    private void collectReachableClasses(String name, Set<String> classes) {
+        if (classes.contains(name)) {
+            return;
+        }
+
+        ClassInfo visitedClass = visitedClasses.get(name);
+        if (visitedClass == null) {
+            if (!shouldVisit(name)) {
+                return;
+            }
+
+            throw new IllegalStateException("The class " + name
+                    + " is reachable but its info was not collected");
+        }
+
+        classes.add(name);
+        for (String className : visitedClass.children) {
+            if (!entryPoints.containsKey(className)) {
+                collectReachableClasses(className, classes);
+            }
+        }
+
+    }
+
     private void visitEntryPoints() throws IOException {
         for (Entry<String, EntryPointData> entry : entryPoints.entrySet()) {
             visitEntryPoint(entry.getValue());
         }
+
     }
 
     private void visitEntryPoint(EntryPointData entryPoint) throws IOException {
         visitClass(entryPoint.getName(), entryPoint);
+
+        entryPoint.reachableClasses = collectReachableClasses(entryPoint);
+        if (log().isDebugEnabled()) {
+            log().debug("Classes reachable from " + entryPoint.getName() + ": "
+                    + entryPoint.reachableClasses);
+        }
+
     }
 
     /**
@@ -223,7 +279,7 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
      */
     @Override
     public Set<String> getClasses() {
-        return visited;
+        return visitedClasses.keySet();
     }
 
     /**
@@ -327,29 +383,22 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
     private void computeApplicationTheme() throws ClassNotFoundException,
             InstantiationException, IllegalAccessException, IOException {
 
-        // Re-visit theme related classes, because they might be skipped
-        // when they where already added to the visited list during other
-        // entry-point visits
-        for (EntryPointData entryPoint : entryPoints.values()) {
-            if (entryPoint.getLayout() != null) {
-                visitClass(entryPoint.getLayout(), entryPoint);
-            }
-        }
-
-        List<EntryPointData> entryPointsWithTheme = entryPoints.values()
-                .stream()
+        // This really should check entry points and not all classes, but the
+        // old behavior is retained.. for now..
+        List<ClassInfo> classesWithTheme = entryPoints.values().stream()
+                .flatMap(entryPoint -> entryPoint.reachableClasses.stream())
+                .map(className -> visitedClasses.get(className))
                 // consider only entry points with theme information
                 .filter(this::hasThemeInfo).toList();
-        Set<ThemeData> themes = entryPointsWithTheme.stream()
-                .map(EntryPointData::getTheme)
+        Set<ThemeData> themes = classesWithTheme.stream()
+                .map(classInfo -> classInfo.theme)
                 // Remove duplicates by returning a set
                 .collect(Collectors.toSet());
 
         if (themes.size() > 1) {
-            String names = entryPointsWithTheme.stream()
-                    .map(data -> "found '"
-                            + getThemeDescription(data.getTheme()) + "' in '"
-                            + data.getName() + "'")
+            String names = classesWithTheme.stream()
+                    .map(data -> "found '" + getThemeDescription(data.theme)
+                            + "' in '" + data.className + "'")
                     .collect(Collectors.joining("\n      "));
             throw new IllegalStateException(
                     "\n Multiple Theme configuration is not supported:\n      "
@@ -559,22 +608,21 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
      * @return
      * @throws IOException
      */
-    private void visitClass(String className, EntryPointData entryPoint)
+    void visitClass(String className, EntryPointData entryPoint)
             throws IOException {
 
-        if (!shouldVisit(className)
-                || entryPoint.getClasses().contains(className)) {
+        if (visitedClasses.containsKey(className) || !shouldVisit(className)) {
             return;
         }
-        entryPoint.getClasses().add(className);
+        ClassInfo info = new ClassInfo(className);
+        visitedClasses.put(className, info);
 
         URL url = getUrl(className);
         if (url == null) {
             return;
         }
 
-        FrontendClassVisitor visitor = new FrontendClassVisitor(className,
-                entryPoint);
+        FrontendClassVisitor visitor = new FrontendClassVisitor(info);
         try (InputStream is = url.openStream()) {
             ClassReader cr = new ClassReader(is);
             cr.accept(visitor, ClassReader.EXPAND_FRAMES);
@@ -585,17 +633,8 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
             throw e;
         }
 
-        // all classes visited by the scanner, used for performance (#5933)
-        visited.add(className);
-
-        for (String clazz : visitor.getChildren()) {
-            // Since we only have an entry point for the app, it is all right to
-            // skip the visit to the the same class in other end-points, because
-            // we output all dependencies at once. When we implement
-            // chunks, this will need to be considered.
-            if (!visited.contains(clazz)) {
-                visitClass(clazz, entryPoint);
-            }
+        for (String clazz : info.children) {
+            visitClass(clazz, entryPoint);
         }
     }
 
@@ -626,21 +665,20 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
         return entryPoints.toString();
     }
 
-    private boolean hasThemeInfo(EntryPointData data) {
-        ThemeData theme = data.getTheme();
+    private boolean hasThemeInfo(ClassInfo classInfo) {
+        ThemeData theme = classInfo.theme;
         if (theme.getThemeClass() != null) {
             return true;
         }
 
-        if (data.getTheme().getThemeName() != null
-                && !data.getTheme().getThemeName().isBlank()) {
+        if (theme.getThemeName() != null && !theme.getThemeName().isBlank()) {
             return true;
         }
 
-        if (!data.getTheme().getVariant().isEmpty()) {
+        if (!theme.getVariant().isEmpty()) {
             return true;
         }
-        if (data.getTheme().isNotheme()) {
+        if (theme.isNotheme()) {
             return true;
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
@@ -151,11 +151,10 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
         for (Entry<String, EntryPointData> entry : entryPoints.entrySet()) {
             EntryPointData entryPoint = entry.getValue();
             for (String className : entryPoint.reachableClasses) {
-                entryPoint.getModules()
-                        .addAll(visitedClasses.get(className).modules);
-                entryPoint.getCss().addAll(visitedClasses.get(className).css);
-                entryPoint.getScripts()
-                        .addAll(visitedClasses.get(className).scripts);
+                ClassInfo classInfo = visitedClasses.get(className);
+                entryPoint.getModules().addAll(classInfo.modules);
+                entryPoint.getCss().addAll(classInfo.css);
+                entryPoint.getScripts().addAll(classInfo.scripts);
             }
         }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/ScannerDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/ScannerDependenciesTest.java
@@ -59,26 +59,26 @@ public class ScannerDependenciesTest {
     @Test
     public void should_extractClassesFromSignatures() {
         Set<String> classes = new HashSet<>();
-        FrontendClassVisitor visitor = new FrontendClassVisitor(null, null);
+        FrontendClassVisitor visitor = new FrontendClassVisitor(null);
 
         visitor.addSignatureToClasses(classes,
                 "(Lcom/vaadin/flow/component/tabs/Tabs;Ljava/lang/String;Ljava/lang/Character;CLjava/lang/Integer;ILjava/lang/Long;JLjava/lang/Double;DLjava/lang/Float;FLjava/lang/Byte;BLjava/lang/Boolean;Z)Lcom/vaadin/flow/component/button/Button;");
-        assertEquals(11, classes.size());
-        assertArrayEquals(new String[] { "", "java.lang.Float",
+        assertArrayEquals(new String[] { "java.lang.Float",
                 "com.vaadin.flow.component.button.Button",
                 "java.lang.Character", "java.lang.Long", "java.lang.Double",
                 "java.lang.Boolean", "com.vaadin.flow.component.tabs.Tabs",
                 "java.lang.String", "java.lang.Byte", "java.lang.Integer" },
                 classes.toArray());
+        int count = classes.size();
 
         visitor.addSignatureToClasses(classes,
                 "([Lcom/vaadin/flow/component/Component;)V");
-        assertEquals(12, classes.size());
+        assertEquals(count + 1, classes.size());
         assertTrue(classes.contains("com.vaadin.flow.component.Component"));
 
         visitor.addSignatureToClasses(classes,
                 "(Lcom/vaadin/flow/component/orderedlayout/FlexComponent$Alignment;[Lcom/vaadin/flow/component/Component;)");
-        assertEquals(13, classes.size());
+        assertEquals(count + 2, classes.size());
         assertTrue(classes.contains(
                 "com.vaadin.flow.component.orderedlayout.FlexComponent$Alignment"));
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/ScannerTestComponents.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/ScannerTestComponents.java
@@ -170,7 +170,6 @@ public class ScannerTestComponents {
     @NpmPackage(value = "@foo/first-view", version = "0.0.1")
     public static class FirstView extends View0 {
         Component1 component1;
-        RootViewWithMultipleTheme second;
 
         public FirstView() {
             createView();
@@ -240,15 +239,15 @@ public class ScannerTestComponents {
 
     @Theme(themeClass = Theme2.class)
     public static class ThemeExporter
-            extends WebComponentExporter<RootViewWithTheme> {
+            extends WebComponentExporter<RootViewWithoutThemeAnnotation> {
         public ThemeExporter() {
             super("root-view");
         }
 
         @Override
         public void configureInstance(
-                WebComponent<RootViewWithTheme> webComponent,
-                RootViewWithTheme component) {
+                WebComponent<RootViewWithoutThemeAnnotation> webComponent,
+                RootViewWithoutThemeAnnotation component) {
 
         }
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/ScannerThemeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/ScannerThemeTest.java
@@ -58,41 +58,19 @@ public class ScannerThemeTest {
     }
 
     @Test
-    public void should_not_takeTheme_when_NoTheme() {
-        FrontendDependencies deps = getFrontendDependencies(
-                RootViewWithoutTheme.class);
-        assertNull(deps.getThemeDefinition());
-
-        assertTrue(2 <= deps.getModules().size());
-        assertEquals(0, deps.getPackages().size());
-        assertEquals(2, deps.getScripts().size());
-    }
-
-    @Test
     public void should_takeThemeFromLayout() {
         FrontendDependencies deps = getFrontendDependencies(
                 RootViewWithLayoutTheme.class);
         assertEquals(Theme1.class, deps.getThemeDefinition().getTheme());
         assertEquals(Theme1.DARK, deps.getThemeDefinition().getVariant());
 
-        assertTrue(8 <= deps.getModules().size());
+        System.out.println(deps.getModules());
+        assertEquals(6, deps.getModules().size());
         assertEquals(1, deps.getPackages().size());
-        assertEquals(6, deps.getScripts().size());
+        assertEquals(5, deps.getScripts().size());
 
         assertTrue(deps.getPackages().containsKey("@foo/first-view"));
         assertEquals("0.0.1", deps.getPackages().get("@foo/first-view"));
-    }
-
-    @Test
-    public void should_takeThemeWhenMultipleTheme() {
-        FrontendDependencies deps = getFrontendDependencies(
-                RootViewWithMultipleTheme.class);
-        assertEquals(Theme2.class, deps.getThemeDefinition().getTheme());
-        assertEquals(Theme2.FOO, deps.getThemeDefinition().getVariant());
-
-        assertTrue(4 <= deps.getModules().size());
-        assertEquals(0, deps.getPackages().size());
-        assertEquals(2, deps.getScripts().size());
     }
 
     @Test


### PR DESCRIPTION
This changes the class visitor so that we
1. Find all entry points
2. Scan through all classes reachable from any of the entry points and store metadata for that class
3. Collect the metadata for all classes reachable for each individual entry point

It should allow us to generate an import file separately for each entry point and then lazy load scripts and css for some of the entry points