### PR TITLE
chore: Use asm directly for byte code scanning

### DIFF
--- a/flow-polymer-template/pom.xml
+++ b/flow-polymer-template/pom.xml
@@ -37,7 +37,10 @@
             <groupId>com.vaadin</groupId>
             <artifactId>license-checker</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+        </dependency>
 
         <!-- TESTING DEPENDENCIES -->
 
@@ -48,7 +51,7 @@
             <scope>test</scope>
         </dependency>
 
-       <dependency>
+        <dependency>
             <groupId>jakarta.platform</groupId>
             <artifactId>jakarta.jakartaee-web-api</artifactId>
             <scope>test</scope>

--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -111,10 +111,10 @@
             <version>7.0.0</version>
         </dependency>
 
-        <!-- Byte code generation -->
+        <!-- Byte code analysis -->
         <dependency>
-            <groupId>net.bytebuddy</groupId>
-            <artifactId>byte-buddy</artifactId>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
         </dependency>
 
         <!-- Small reflection library -->

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/CssAnnotationVisitor.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/CssAnnotationVisitor.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.server.frontend.scanner;
 
 import java.util.List;
 
-import net.bytebuddy.jar.asm.AnnotationVisitor;
+import org.objectweb.asm.AnnotationVisitor;
 
 import com.vaadin.flow.component.dependency.CssImport;
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendAnnotatedClassVisitor.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendAnnotatedClassVisitor.java
@@ -26,11 +26,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import net.bytebuddy.jar.asm.AnnotationVisitor;
-import net.bytebuddy.jar.asm.ClassReader;
-import net.bytebuddy.jar.asm.ClassVisitor;
-import net.bytebuddy.jar.asm.MethodVisitor;
-import net.bytebuddy.jar.asm.Opcodes;
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendClassVisitor.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendClassVisitor.java
@@ -19,13 +19,13 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import net.bytebuddy.jar.asm.AnnotationVisitor;
-import net.bytebuddy.jar.asm.ClassVisitor;
-import net.bytebuddy.jar.asm.FieldVisitor;
-import net.bytebuddy.jar.asm.Handle;
-import net.bytebuddy.jar.asm.MethodVisitor;
-import net.bytebuddy.jar.asm.Opcodes;
-import net.bytebuddy.jar.asm.Type;
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.Handle;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
 
 import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.dependency.JavaScript;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
@@ -32,9 +32,8 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import net.bytebuddy.jar.asm.ClassReader;
+import org.objectweb.asm.ClassReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/RepeatedAnnotationVisitor.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/RepeatedAnnotationVisitor.java
@@ -15,8 +15,8 @@
  */
 package com.vaadin.flow.server.frontend.scanner;
 
-import net.bytebuddy.jar.asm.AnnotationVisitor;
-import net.bytebuddy.jar.asm.Opcodes;
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.Opcodes;
 
 /**
  * An annotation visitor implementation that enables repeated annotations.

--- a/pom.xml
+++ b/pom.xml
@@ -238,6 +238,11 @@
                 <version>1.14.4</version>
             </dependency>
             <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm</artifactId>
+                <version>9.5</version>
+            </dependency>
+            <dependency>
                 <groupId>com.vaadin</groupId>
                 <artifactId>license-checker</artifactId>
                 <version>1.12.3</version>


### PR DESCRIPTION
Byte buddy includes a version of asm but it also does a lot of other things that are not used. Byte buddy is 4MB while asm is 0.2MB
