### PR TITLE
chore!: Bump pnpm version to a supported versions (8.3.1)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -72,7 +72,7 @@ public class FrontendTools {
      */
     public static final String DEFAULT_NPM_VERSION = "9.5.1";
 
-    public static final String DEFAULT_PNPM_VERSION = "8.3.0";
+    public static final String DEFAULT_PNPM_VERSION = "8.3.1";
 
     public static final String INSTALL_NODE_LOCALLY = "%n  $ mvn com.github.eirslett:frontend-maven-plugin:1.10.0:install-node-and-npm "
             + "-DnodeVersion=\"" + DEFAULT_NODE_VERSION + "\" ";

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -72,7 +72,7 @@ public class FrontendTools {
      */
     public static final String DEFAULT_NPM_VERSION = "9.5.1";
 
-    public static final String DEFAULT_PNPM_VERSION = "5.18.10";
+    public static final String DEFAULT_PNPM_VERSION = "8.3.0";
 
     public static final String INSTALL_NODE_LOCALLY = "%n  $ mvn com.github.eirslett:frontend-maven-plugin:1.10.0:install-node-and-npm "
             + "-DnodeVersion=\"" + DEFAULT_NODE_VERSION + "\" ";


### PR DESCRIPTION
pnpm 8 dropped node 14 support which has no impact on Flow. There are changes to the lockfile and local store format but pnpm should upgrade or redownload as needed.
