### PR TITLE
chore: Do not output warning in development mode

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleUtils.java
@@ -74,7 +74,6 @@ public final class BundleUtils {
         URL statsUrl = BundleUtils.class.getClassLoader()
                 .getResource("META-INF/VAADIN/config/stats.json");
         if (statsUrl == null) {
-            getLogger().warn("No META-INF/VAADIN/config/stats.json found");
             return Json.createObject();
         }
         try {


### PR DESCRIPTION
As UIInternals always tries to load the bundle info, we cannot warn as never exists in development mode
