### PR TITLE
chore: Change log level to debug

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -360,7 +360,7 @@ public abstract class NodeUpdater implements FallibleCommand {
         }
 
         if (added > 0) {
-            log().info("Added {} default dependencies to main package.json",
+            log().debug("Added {} default dependencies to main package.json",
                     added);
         }
         return added > 0;


### PR DESCRIPTION
Avoids excessive logging on each startup:
```
c.v.f.s.frontend.TaskRunDevBundleBuild   : Checking if a development mode bundle build is needed
c.v.f.s.f.TaskRunDevBundleBuild$1        : Added 19 default dependencies to main package.json
c.v.f.s.frontend.TaskRunDevBundleBuild   : A development mode bundle build is not needed
c.v.f.s.f.TaskGeneratePackageJson        : Added 19 default dependencies to main package.json
c.v.f.s.frontend.TaskCopyFrontendFiles   : Copying frontend resources from jar files ...
c.v.f.s.frontend.TaskCopyFrontendFiles   : Visited 21 resources. Took 15 ms.
```
