### PR TITLE
feat: More eager cleanup for UIs using Beacon API

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
@@ -141,7 +141,7 @@ public class ApplicationConnection {
             // with browser buttons
             // Chrome discards our state as beforeunload is used
             // As state is most likely cleared on the server already (especially
-            // now with beacon API request, it is probably
+            // now with Beacon API request, it is probably
             // better resyncronize the state (would happen on first server
             // visit)
             Browser.getWindow().getLocation().reload();

--- a/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
@@ -29,6 +29,7 @@ import com.vaadin.client.flow.dom.DomApi;
 import com.vaadin.client.flow.util.NativeFunction;
 
 import elemental.client.Browser;
+import elemental.dom.Document;
 import elemental.dom.Element;
 import elemental.dom.Node;
 
@@ -131,6 +132,21 @@ public class ApplicationConnection {
             registry.getRequestResponseTracker().startRequest();
             registry.getMessageHandler().handleMessage(initialUidl);
         }
+
+        Browser.getWindow().addEventListener("pagehide", e -> {
+            registry.getMessageSender().sendUnloadBeacon();
+        });
+
+        Browser.getWindow().addEventListener("pageshow", e -> {
+            // Currently only Safari gets here, sometimes when going back/foward
+            // with browser buttons
+            // Chrome discards our state as beforeunload is used
+            // As state is most likely cleared on the server already (especially
+            // now with beacon API request, it is probably
+            // better resyncronize the state (would happen on first server
+            // visit)
+            Browser.getWindow().getLocation().reload();
+        });
     }
 
     /**

--- a/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
@@ -29,7 +29,6 @@ import com.vaadin.client.flow.dom.DomApi;
 import com.vaadin.client.flow.util.NativeFunction;
 
 import elemental.client.Browser;
-import elemental.dom.Document;
 import elemental.dom.Element;
 import elemental.dom.Node;
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/AtmospherePushConnection.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/AtmospherePushConnection.java
@@ -349,9 +349,14 @@ public class AtmospherePushConnection implements PushConnection {
                 try {
                     outgoingMessage.get(1000, TimeUnit.MILLISECONDS);
                 } catch (TimeoutException e) {
-                    getLogger().info(
-                            "Timeout waiting for messages to be sent to client before disconnect",
-                            e);
+                    if (ui.isClosing()) {
+                        getLogger().debug(
+                                "Something was not sent to client on an UI that was already closed by beacon reqeuest or similar. This seems to happen with Safari occassionally when navigating away from a UI.");
+                    } else {
+                        getLogger().info(
+                                "Timeout waiting for messages to be sent to client before disconnect",
+                                e);
+                    }
                 } catch (Exception e) {
                     getLogger().info(
                             "Error waiting for messages to be sent to client before disconnect",

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/AtmospherePushConnection.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/AtmospherePushConnection.java
@@ -351,7 +351,7 @@ public class AtmospherePushConnection implements PushConnection {
                 } catch (TimeoutException e) {
                     if (ui.isClosing()) {
                         getLogger().debug(
-                                "Something was not sent to client on an UI that was already closed by beacon reqeuest or similar. This seems to happen with Safari occassionally when navigating away from a UI.");
+                                "Something was not sent to client on an UI that was already closed by beacon request or similar. This seems to happen with Safari occassionally when navigating away from a UI.");
                     } else {
                         getLogger().info(
                                 "Timeout waiting for messages to be sent to client before disconnect",

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
@@ -347,8 +347,6 @@ public class ServerRpcHandler implements Serializable {
             if (isPreserveOnRefreshTarget(ui)) {
                 getLogger().debug(
                         "Eager UI close ignorer for PreserveOnRefresh view");
-                // TODO We could defer cleanup and check if this was a reload or
-                // not
             } else {
                 ui.close();
                 getLogger().debug("UI closed with a beacon request");

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
@@ -346,7 +346,7 @@ public class ServerRpcHandler implements Serializable {
         if (rpcRequest.isUnloadBeaconRequest()) {
             if (isPreserveOnRefreshTarget(ui)) {
                 getLogger().debug(
-                        "Eager UI close ignorer for PreserveOnRefresh view");
+                        "Eager UI close ignored for @PreserveOnRefresh view");
             } else {
                 ui.close();
                 getLogger().debug("UI closed with a beacon request");

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
@@ -346,6 +346,7 @@ public class ServerRpcHandler implements Serializable {
         }
         if (rpcRequest.isUnloadBeaconRequest()) {
             ui.close();
+            getLogger().debug("UI closed with a beacon request");
         }
 
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
@@ -189,6 +189,10 @@ public class ServerRpcHandler implements Serializable {
             return json;
         }
 
+        private boolean isUnloadBeaconRequest() {
+            return json.hasKey(ApplicationConstants.UNLOAD_BEACON);
+        }
+
     }
 
     private static final int MAX_BUFFER_SIZE = 64 * 1024;
@@ -340,6 +344,10 @@ public class ServerRpcHandler implements Serializable {
             // signature for source and binary compatibility
             throw new ResynchronizationRequiredException();
         }
+        if (rpcRequest.isUnloadBeaconRequest()) {
+            ui.close();
+        }
+
     }
 
     private String getMessageDetails(RpcRequest rpcRequest) {

--- a/flow-server/src/main/java/com/vaadin/flow/shared/ApplicationConstants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/ApplicationConstants.java
@@ -214,4 +214,10 @@ public class ApplicationConstants implements Serializable {
      */
     public static final String DEV_TOOLS_ENABLED = "devToolsEnabled";
 
+    /**
+     * The name of the parameter used for notifying the server that user closed
+     * the tab/window or navigated away.
+     */
+    public static final String UNLOAD_BEACON = "UNLOAD";
+
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/UIsCollectedWithBeaconAPIView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/UIsCollectedWithBeaconAPIView.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "com.vaadin.flow.uitest.ui.CountUIsView")
+public class CountUIsView extends Div {
+
+    public CountUIsView() {
+        Div count = new Div();
+        add(count);
+        count.setId("uis");
+
+        // Don't show the UIs number right away on the component CTOR. Make it
+        // explicit via action. At this point all UIs should be already
+        // initialized
+        NativeButton showUisNumber = new NativeButton("Show created UIs number",
+                event -> count.setText(String.valueOf(
+                        TestingServiceInitListener.getNotNavigatedUis())));
+        add(showUisNumber);
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/UIsCollectedWithBeaconAPIView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/UIsCollectedWithBeaconAPIView.java
@@ -15,24 +15,36 @@
  */
 package com.vaadin.flow.uitest.ui;
 
+import com.vaadin.flow.component.DetachEvent;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.Route;
 
-@Route(value = "com.vaadin.flow.uitest.ui.CountUIsView")
-public class CountUIsView extends Div {
+@Route(value = "com.vaadin.flow.uitest.ui.UIsCollectedWithBeaconAPIView")
+public class UIsCollectedWithBeaconAPIView extends Div {
 
-    public CountUIsView() {
-        Div count = new Div();
+    static int viewcount = 0;
+
+    Div count = new Div();
+
+    public UIsCollectedWithBeaconAPIView() {
+        viewcount++;
         add(count);
         count.setId("uis");
-
-        // Don't show the UIs number right away on the component CTOR. Make it
-        // explicit via action. At this point all UIs should be already
-        // initialized
-        NativeButton showUisNumber = new NativeButton("Show created UIs number",
-                event -> count.setText(String.valueOf(
-                        TestingServiceInitListener.getNotNavigatedUis())));
+        NativeButton showUisNumber = new NativeButton("Update",
+                event -> updateCount());
         add(showUisNumber);
+        updateCount();
     }
+
+    private void updateCount() {
+        count.setText("" + viewcount);
+    }
+
+    @Override
+    protected void onDetach(DetachEvent detachEvent) {
+        super.onDetach(detachEvent);
+        viewcount--;
+    }
+
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/LocaleChangeIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/LocaleChangeIT.java
@@ -27,6 +27,7 @@ import com.vaadin.flow.testutil.ChromeBrowserTest;
 import static com.vaadin.flow.uitest.ui.LocaleChangeView.CHANGE_LOCALE_BUTTON_ID;
 import static com.vaadin.flow.uitest.ui.LocaleChangeView.SAME_UI_RESULT_ID;
 import static com.vaadin.flow.uitest.ui.LocaleChangeView.SHOW_RESULTS_BUTTON_ID;
+import org.openqa.selenium.WindowType;
 
 public class LocaleChangeIT extends ChromeBrowserTest {
 
@@ -34,7 +35,10 @@ public class LocaleChangeIT extends ChromeBrowserTest {
     public void setSessionLocale_currentUIInstanceUpdatedUponEachLocaleUpdate() {
         final int openedUI = 3;
 
-        IntStream.range(0, openedUI).forEach(i -> open());
+        IntStream.range(0, openedUI).forEach(i -> {
+            driver.switchTo().newWindow(WindowType.TAB);
+            open();
+        });
 
         waitForElementPresent(By.id(CHANGE_LOCALE_BUTTON_ID));
         findElement(By.id(CHANGE_LOCALE_BUTTON_ID)).click();

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/UIsCollectedWithBeaconAPIIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/UIsCollectedWithBeaconAPIIT.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.component.html.testbench.NativeButtonElement;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+import com.vaadin.testbench.parallel.BrowserUtil;
+
+public class CountUIsIT extends ChromeBrowserTest {
+
+    @Test
+    @Ignore("Ignored because the test is flaky: https://github.com/vaadin/flow/issues/10493")
+    public void countUisNumer_onlyOneUIShouldBeInitiialized() {
+        if (!BrowserUtil.isChrome(getDesiredCapabilities())) {
+            // limit this test for being executed in one browser only
+            return;
+        }
+        open();
+
+        $(NativeButtonElement.class).first().click();
+
+        WebElement uisCount = findElement(By.id("uis"));
+        int count = Integer.parseInt(uisCount.getText());
+
+        // there should not be any UI instance which is created but never has
+        // been navigated (no any enter event into a navigation target)
+        Assert.assertEquals(0, count);
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/UIsCollectedWithBeaconAPIIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/UIsCollectedWithBeaconAPIIT.java
@@ -25,14 +25,14 @@ import com.vaadin.flow.testutil.ChromeBrowserTest;
 public class UIsCollectedWithBeaconAPIIT extends ChromeBrowserTest {
 
     @Test
-    public void firstRun() {
-        open_ui_and_expect_1();
+    public void beaconHandling_navigateAwayFromApplication_uiClosedEarly() {
+        openUiAndExpect1();
         goToGoogle();
         // If previous UI is not properly detached, following will fail
-        open_ui_and_expect_1();
+        openUiAndExpect1();
     }
 
-    protected void open_ui_and_expect_1() throws NumberFormatException {
+    private void openUiAndExpect1() throws NumberFormatException {
         open();
         WebElement uisCount = findElement(By.id("uis"));
         int count = Integer.parseInt(uisCount.getText());

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/UIsCollectedWithBeaconAPIIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/UIsCollectedWithBeaconAPIIT.java
@@ -16,33 +16,32 @@
 package com.vaadin.flow.uitest.ui;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.flow.component.html.testbench.NativeButtonElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
-import com.vaadin.testbench.parallel.BrowserUtil;
 
-public class CountUIsIT extends ChromeBrowserTest {
+public class UIsCollectedWithBeaconAPIIT extends ChromeBrowserTest {
 
     @Test
-    @Ignore("Ignored because the test is flaky: https://github.com/vaadin/flow/issues/10493")
-    public void countUisNumer_onlyOneUIShouldBeInitiialized() {
-        if (!BrowserUtil.isChrome(getDesiredCapabilities())) {
-            // limit this test for being executed in one browser only
-            return;
-        }
+    public void firstRun() {
+        open_ui_and_expect_1();
+        goToGoogle();
+        // If previous UI is not properly detached, following will fail
+        open_ui_and_expect_1();
+    }
+
+    protected void open_ui_and_expect_1() throws NumberFormatException {
         open();
-
-        $(NativeButtonElement.class).first().click();
-
         WebElement uisCount = findElement(By.id("uis"));
         int count = Integer.parseInt(uisCount.getText());
-
-        // there should not be any UI instance which is created but never has
-        // been navigated (no any enter event into a navigation target)
-        Assert.assertEquals(0, count);
+        Assert.assertEquals(1, count);
     }
+
+    private void goToGoogle() {
+        getDriver().get("https://google.com/");
+        Assert.assertTrue(getDriver().getPageSource().contains("Google"));
+    }
+
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/routescope/PreserveOnRefreshIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/routescope/PreserveOnRefreshIT.java
@@ -35,7 +35,7 @@ public class PreserveOnRefreshIT extends AbstractSpringTest {
         String beanCall = findElement(By.id("preserve-on-refresh")).getText();
 
         // refresh
-        open();
+        getDriver().navigate().refresh();
 
         Assert.assertEquals("Bean is not preserved after refresh", beanCall,
                 findElement(By.id("preserve-on-refresh")).getText());


### PR DESCRIPTION
Notifies server about closed UIs using a beacon request on pagehide event.

At the same time unifies behaviour in certain edge cases, where Safari maintained the state when brought back from page cache. Previously Safari in some situations kept the state.

Tested manually with Safari, Chrome, Firefox and validated results using VisualVM.

Closes #6293 

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
