### PR TITLE
fix, chore: Removing some dead code (now is the perfect time: selenium 4.9.0. is more strict on being w3c)

### DIFF
--- a/flow-test-util/src/main/java/com/vaadin/flow/testutil/ChromeDeviceTest.java
+++ b/flow-test-util/src/main/java/com/vaadin/flow/testutil/ChromeDeviceTest.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.testutil;
 
-import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.lang.reflect.Field;
 import java.net.URL;
@@ -31,15 +30,11 @@ import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.mobile.NetworkConnection;
-import org.openqa.selenium.remote.Command;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
-import org.openqa.selenium.remote.Response;
 
 import com.vaadin.flow.testcategory.ChromeTests;
 import com.vaadin.testbench.TestBench;
-import com.vaadin.testbench.TestBenchDriverProxy;
 import com.vaadin.testbench.parallel.Browser;
 
 /**

--- a/flow-test-util/src/main/java/com/vaadin/flow/testutil/ChromeDeviceTest.java
+++ b/flow-test-util/src/main/java/com/vaadin/flow/testutil/ChromeDeviceTest.java
@@ -101,19 +101,11 @@ public class ChromeDeviceTest extends ViewOrUITest {
      */
     protected ChromeOptions customizeChromeOptions(
             ChromeOptions chromeOptions) {
-        // Unfortunately using offline emulation ("setNetworkConnection"
-        // session command) in Chrome requires the "networkConnectionEnabled"
-        // capability, which is:
-        // - Not W3C WebDriver API compliant, so we disable W3C protocol
-        // - device mode: mobileEmulation option with some device settings
-
         final Map<String, Object> mobileEmulationParams = new HashMap<>();
         mobileEmulationParams.put("deviceName", "Laptop with touch");
 
-        // chromeOptions.setExperimentalOption("w3c", false);
         chromeOptions.setExperimentalOption("mobileEmulation",
                 mobileEmulationParams);
-        chromeOptions.setCapability("networkConnectionEnabled", true);
 
         if (getDeploymentHostname().equals("localhost")) {
             // Use headless Chrome for running locally
@@ -140,30 +132,6 @@ public class ChromeDeviceTest extends ViewOrUITest {
     @Override
     protected List<DesiredCapabilities> getHubBrowsersToTest() {
         return getBrowserCapabilities(Browser.CHROME);
-    }
-
-    /**
-     * Change network connection type in the browser.
-     *
-     * @param connectionType
-     *            the new connection type
-     * @throws IOException
-     */
-    protected void setConnectionType(
-            NetworkConnection.ConnectionType connectionType)
-            throws IOException {
-        RemoteWebDriver driver = (RemoteWebDriver) ((TestBenchDriverProxy) getDriver())
-                .getWrappedDriver();
-        final Map<String, Integer> parameters = new HashMap<>();
-        parameters.put("type", connectionType.hashCode());
-        final Map<String, Object> connectionParams = new HashMap<>();
-        connectionParams.put("parameters", parameters);
-        Response response = driver.getCommandExecutor()
-                .execute(new Command(driver.getSessionId(),
-                        "setNetworkConnection", connectionParams));
-        if (response.getStatus() != 0) {
-            throw new RuntimeException("Unable to set connection type");
-        }
     }
 
     public void waitForServiceWorkerReady() {


### PR DESCRIPTION
## Description

`chromeOptions.setCapability("networkConnectionEnabled", true); `was deprecated, and now it was removed from Selenium, but we used it in our chromeOptions, which caused an exception now as we tried to update to the latest selenium version.

This was needed to be able to do a `setConnectionType()` in Chrome.


BUT:

I have checked and` setConnectionType() ` is not used anymore, so I am removing code parts that are not w3 compliant anymore, it was used in PWA-related IT tests back then, but not now. In that case, no point to block us from using the latest/safest selenium versions. Did we use it back then for AirPlane mode and other modes potentially? So we can delete the whole related code now, I hope.

More info:
- https://github.com/SeleniumHQ/selenium/issues/11923

MobileEmuliation seems is w3c compatible🤞: 
- https://sites.google.com/a/chromium.org/chromedriver/capabilities

Fixes # (issue):
I need this to unblock this:
- https://github.com/vaadin/flow/pull/16663

## Type of change

- [x] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed a self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria was created.
