### PR TITLE
fix: TaskUpdatePackages should use finder

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
@@ -78,6 +78,7 @@ public abstract class AbstractNodeUpdatePackagesTest
     private File mainNodeModules;
     private File packageLock;
     private Options options;
+    private File versions;
 
     @Before
     public void setup() throws Exception {
@@ -90,7 +91,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         packageCreator = new TaskGeneratePackageJson(options);
 
         classFinder = Mockito.spy(getClassFinder());
-        File versions = temporaryFolder.newFile();
+        versions = temporaryFolder.newFile();
         FileUtils.write(versions, "{}", StandardCharsets.UTF_8);
         Mockito.when(
                 classFinder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
@@ -343,13 +344,9 @@ public abstract class AbstractNodeUpdatePackagesTest
         packageUpdater.updateVaadinJsonContents(
                 Collections.singletonMap(VAADIN_VERSION, "1.1.1"));
 
-        try (MockedStatic<Platform> platform = Mockito
-                .mockStatic(Platform.class)) {
-            platform.when(Platform::getVaadinVersion)
-                    .thenReturn(Optional.of("1.2.3"));
-            packageUpdater.execute();
-            assertCleanUp();
-        }
+        FileUtils.write(versions, "{\"platform\": \"1.2.3\"}", StandardCharsets.UTF_8);
+        packageUpdater.execute();
+        assertCleanUp();
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
@@ -344,7 +344,8 @@ public abstract class AbstractNodeUpdatePackagesTest
         packageUpdater.updateVaadinJsonContents(
                 Collections.singletonMap(VAADIN_VERSION, "1.1.1"));
 
-        FileUtils.write(versions, "{\"platform\": \"1.2.3\"}", StandardCharsets.UTF_8);
+        FileUtils.write(versions, "{\"platform\": \"1.2.3\"}",
+                StandardCharsets.UTF_8);
         packageUpdater.execute();
         assertCleanUp();
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
@@ -35,6 +35,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
@@ -546,6 +547,51 @@ public class TaskUpdatePackagesNpmTest {
 
         Assert.assertFalse(newPackageJson.hasKey("overrides")
                 && newPackageJson.getObject("overrides").hasKey("localdep"));
+    }
+
+    @Test
+    public void platformVersion_returnsExpectedVersion() throws IOException {
+        final TaskUpdatePackages task = createTask(
+                createApplicationDependencies());
+
+        //@formatter:off
+        String versionJsonString = "{"
+                        + "  \"platform\": \"21.0.0\"\n"
+                        + "}\n";
+        //@formatter:on
+        FileUtils.write(versionJsonFile, versionJsonString,
+                StandardCharsets.UTF_8);
+
+        Optional<String> vaadinVersion = task.getVaadinVersion();
+
+        Assert.assertTrue("versions.json should have had the platform field",
+                vaadinVersion.isPresent());
+        Assert.assertEquals("Received faulty version", "21.0.0",
+                vaadinVersion.get());
+
+        //@formatter:off
+        versionJsonString = "{"
+                + "}\n";
+        //@formatter:on
+        FileUtils.write(versionJsonFile, versionJsonString,
+                StandardCharsets.UTF_8);
+        vaadinVersion = task.getVaadinVersion();
+
+        Assert.assertFalse("versions.json should not contain platform version",
+                vaadinVersion.isPresent());
+    }
+
+    @Test
+    public void noVersionsJson_getVersionsDoesntThrow() {
+        Mockito.when(finder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
+                .thenReturn(null);
+        final TaskUpdatePackages task = createTask(
+                createApplicationDependencies());
+
+        Optional<String> vaadinVersion = task.getVaadinVersion();
+
+        Assert.assertFalse("versions.json should not contain platform version",
+                vaadinVersion.isPresent());
     }
 
     private void createBasicVaadinVersionsJson() {


### PR DESCRIPTION
The tasks should use finder for getting
resources instead of using a XYZ.class.getClassLoader() as 
that doesn't contain required content.

This fixes the issue that a production build in maven/gradle 
prints out `Unable to determine version information. No vaadin-core-versions.json found`

Fixes #16032