### PR TITLE
Unused import cleanup

### DIFF
--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.plugin.maven;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.plugin.MojoExecutionException;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -31,8 +31,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.LoggerFactory;

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -22,8 +22,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.MatcherAssert;

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/stats/ProjectHelpers.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/stats/ProjectHelpers.java
@@ -24,8 +24,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.util.UUID;
 import java.util.stream.Stream;


### PR DESCRIPTION
## Description

Copying @Artur's idea. I saw some unused imports lately. (Reference PR: https://github.com/vaadin/flow/pull/16612)

So:
1. `find . -type f -name "*.java"|xargs java -jar google-java-format-1.16.0-all-deps.jar --fix-imports-only --skip-sorting-imports -rgit then add "**/*.java"s`
2. `git add "**/*.java"`

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed a self-review and correct misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
