### PR TITLE
chore: pinned maven enforcer plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -363,6 +363,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.3.0</version>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
maven-enforecer-plugin version is set in the pluginManagement section of the POM file, but for some reason the version is ignored when running the build with release profiles active.
This change pins the plugin version also in the plugin section.