### PR TITLE
chore: Rename Collaboration Engine to Kit in feature flag

### DIFF
--- a/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
+++ b/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
@@ -55,7 +55,7 @@ public class FeatureFlags implements Serializable {
             false,
             "com.vaadin.flow.server.frontend.NodeTestComponents$ExampleExperimentalComponent");
     public static final Feature COLLABORATION_ENGINE_BACKEND = new Feature(
-            "Collaboration Engine backend for clustering support",
+            "Collaboration Kit backend for clustering support",
             "collaborationEngineBackend",
             "https://github.com/vaadin/platform/issues/1988", true, null);
     public static final Feature THEME_EDITOR = new Feature(


### PR DESCRIPTION
This renames "Collaboration Engine" to "Collaboration Kit" in the `COLLABORATION_ENGINE_BACKEND` feature flag description. I'm not sure if changing the constant name and feature ID would be breaking changes, so I left them as they were.