### PR TITLE
feat: add parameter to force prod build

### DIFF
--- a/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
+++ b/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
@@ -210,6 +210,11 @@ public class BuildDevBundleMojo extends AbstractMojo
         return false; // ci build not applicable for dev mode
     }
 
+    @Override
+    public boolean forceProductionBuild() {
+        return false; // not applicable for dev bundle generation.
+    }
+
     /**
      * Generates a List of ClasspathElements (Run and CompileTime) from a
      * MavenProject.

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
@@ -185,4 +185,6 @@ internal class GradlePluginAdapter(val project: Project, private val isBeforePro
     override fun ciBuild(): Boolean = extension.ciBuild
 
     override fun skipDevBundleBuild(): Boolean = extension.skipDevBundleBuild
+
+    override fun forceProductionBuild(): Boolean = extension.forceProductionBuild
 }

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
@@ -228,6 +228,16 @@ public open class VaadinFlowPluginExtension(project: Project) {
      */
     public var skipDevBundleBuild: Boolean = false
 
+
+    /**
+     * Setting this to `true` will force a build of the production build
+     * even if there is a default production bundle that could be used.
+     *
+     * Created production bundle optimization is defined by
+     * [.optimizeBundle] parameter.
+     */
+    public var forceProductionBuild: Boolean = false
+
     public fun filterClasspath(@DelegatesTo(value = ClasspathFilter::class, strategy = Closure.DELEGATE_FIRST) block: Closure<*>? = null): ClasspathFilter {
         if (block != null) {
             block.delegate = classpathFilter

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -108,6 +108,16 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo
     @Parameter(property = InitParameters.CI_BUILD, defaultValue = "false")
     private boolean ciBuild;
 
+    /**
+     * Setting this to {@code true} will force a build of the production build
+     * even if there is a default production bundle that could be used.
+     *
+     * Created production bundle optimization is defined by
+     * {@link #optimizeBundle} parameter.
+     */
+    @Parameter(property = InitParameters.FORCE_PRODUCTION_BUILD, defaultValue = "false")
+    private boolean forceProductionBuild;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         long start = System.nanoTime();
@@ -170,6 +180,11 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo
     @Override
     public boolean ciBuild() {
         return ciBuild;
+    }
+
+    @Override
+    public boolean forceProductionBuild() {
+        return forceProductionBuild;
     }
 
 }

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
@@ -179,6 +179,8 @@ public class BuildFrontendMojoTest {
         ReflectionUtils.setVariableValueInObject(mojo, "generateBundle", false);
         ReflectionUtils.setVariableValueInObject(mojo, "runNpmInstall", false);
         ReflectionUtils.setVariableValueInObject(mojo, "optimizeBundle", true);
+        ReflectionUtils.setVariableValueInObject(mojo, "forceProductionBuild",
+                false);
 
         ReflectionUtils.setVariableValueInObject(mojo, "openApiJsonFile",
                 openApiJsonFile);

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -321,7 +321,8 @@ public class BuildFrontendUtil {
                     .setNodeAutoUpdate(adapter.nodeAutoUpdate())
                     .setJavaResourceFolder(adapter.javaResourceFolder())
                     .withPostinstallPackages(adapter.postinstallPackages())
-                    .withCiBuild(adapter.ciBuild());
+                    .withCiBuild(adapter.ciBuild())
+                    .withForceProductionBuild(adapter.forceProductionBuild());
             new NodeTasks(options).execute();
         } catch (ExecutionFailedException exception) {
             throw exception;

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBuild.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBuild.java
@@ -17,6 +17,8 @@ package com.vaadin.flow.plugin.base;
 
 import java.io.File;
 
+import com.vaadin.flow.server.InitParameters;
+
 /**
  * Gives access to plugin-specific implementations and configurations.
  *
@@ -76,4 +78,13 @@ public interface PluginAdapterBuild extends PluginAdapterBase {
      * @return true if ci build should be enabled
      */
     boolean ciBuild();
+
+    /**
+     * Setting this to {@code true} will force a build of the production build
+     * even if there is a default production bundle that could be used.
+     *
+     * Created production bundle optimization is defined by
+     * {@link #optimizeBundle} parameter.
+     */
+    boolean forceProductionBuild();
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -217,7 +217,7 @@ public class InitParameters implements Serializable {
     public static final String SKIP_DEV_BUNDLE_REBUILD = "skip.dev.bundle";
 
     /**
-     * Configuration name for forcing optimized productio bundle build.
+     * Configuration name for forcing optimized production bundle build.
      */
-    public static final String FORCE_PRODUCTION_BUILD = "force.production.bundle";
+    public static final String FORCE_PRODUCTION_BUILD = "force.production.build";
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -215,4 +215,9 @@ public class InitParameters implements Serializable {
      * Configuration name for disabling dev bundle rebuild.
      */
     public static final String SKIP_DEV_BUNDLE_REBUILD = "skip.dev.bundle";
+
+    /**
+     * Configuration name for forcing optimized productio bundle build.
+     */
+    public static final String FORCE_PRODUCTION_BUILD = "force.production.bundle";
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleValidationUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleValidationUtil.java
@@ -25,6 +25,7 @@ import com.vaadin.flow.component.WebComponentExporter;
 import com.vaadin.flow.component.WebComponentExporterFactory;
 import com.vaadin.flow.internal.StringUtil;
 import com.vaadin.flow.internal.UsageStatistics;
+import com.vaadin.flow.internal.hilla.EndpointRequestUtil;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.Mode;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
@@ -69,8 +70,13 @@ public final class BundleValidationUtil {
         try {
             boolean needsBuild;
             if (Mode.PRODUCTION == mode) {
-                needsBuild = needsBuildProdBundle(options, frontendDependencies,
-                        finder);
+                if (options.isForceProductionBuild()
+                        || EndpointRequestUtil.isHillaAvailable()) {
+                    needsBuild = true;
+                } else {
+                    needsBuild = needsBuildProdBundle(options,
+                            frontendDependencies, finder);
+                }
             } else if (Mode.DEVELOPMENT_BUNDLE == mode) {
                 needsBuild = needsBuildDevBundle(options, frontendDependencies,
                         finder);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleValidationUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleValidationUtil.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -72,10 +73,13 @@ public final class BundleValidationUtil {
             if (Mode.PRODUCTION == mode) {
                 if (options.isForceProductionBuild()
                         || EndpointRequestUtil.isHillaAvailable()) {
-                    needsBuild = true;
+                    getLogger().info("Frontend build requested.");
+                    saveResultInFile(true, options);
+                    return true;
                 } else {
                     needsBuild = needsBuildProdBundle(options,
                             frontendDependencies, finder);
+                    saveResultInFile(needsBuild, options);
                 }
             } else if (Mode.DEVELOPMENT_BUNDLE == mode) {
                 needsBuild = needsBuildDevBundle(options, frontendDependencies,
@@ -84,10 +88,6 @@ public final class BundleValidationUtil {
                 return false;
             } else {
                 throw new IllegalArgumentException("Unexpected mode");
-            }
-
-            if (options.isProductionMode()) {
-                saveResultInFile(needsBuild, options);
             }
 
             if (needsBuild) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -110,8 +110,10 @@ public class NodeTasks implements FallibleCommand {
                             featureFlags);
 
             if (options.isProductionMode()) {
-                boolean needBuild = BundleValidationUtil.needsBuild(options,
-                        frontendDependencies, classFinder, Mode.PRODUCTION);
+                boolean needBuild = options.isForceProductionBuild()
+                        || BundleValidationUtil.needsBuild(options,
+                                frontendDependencies, classFinder,
+                                Mode.PRODUCTION);
                 options.withRunNpmInstall(needBuild);
                 options.withBundleBuild(needBuild);
                 if (!needBuild) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -110,10 +110,8 @@ public class NodeTasks implements FallibleCommand {
                             featureFlags);
 
             if (options.isProductionMode()) {
-                boolean needBuild = options.isForceProductionBuild()
-                        || BundleValidationUtil.needsBuild(options,
-                                frontendDependencies, classFinder,
-                                Mode.PRODUCTION);
+                boolean needBuild = BundleValidationUtil.needsBuild(options,
+                        frontendDependencies, classFinder, Mode.PRODUCTION);
                 options.withRunNpmInstall(needBuild);
                 options.withBundleBuild(needBuild);
                 if (!needBuild) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/Options.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/Options.java
@@ -64,6 +64,8 @@ public class Options implements Serializable {
 
     private boolean ciBuild;
 
+    private boolean forceProductionBuild;
+
     private boolean useGlobalPnpm = false;
 
     private File frontendGeneratedFolder;
@@ -409,6 +411,15 @@ public class Options implements Serializable {
     }
 
     /**
+     * Setting this to {@code true} will force a build of the production build
+     * even if there is a default production bundle that could be used.
+     */
+    public Options withForceProductionBuild(boolean forceProductionBuild) {
+        this.forceProductionBuild = forceProductionBuild;
+        return this;
+    }
+
+    /**
      * Uses globally installed pnpm tool for frontend packages installation.
      *
      * @param useGlobalPnpm
@@ -719,6 +730,10 @@ public class Options implements Serializable {
 
     public boolean isCiBuild() {
         return ciBuild;
+    }
+
+    public boolean isForceProductionBuild() {
+        return forceProductionBuild;
     }
 
     public boolean isUseGlobalPnpm() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/BundleValidationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/BundleValidationTest.java
@@ -111,6 +111,11 @@ public class BundleValidationTest {
         frontendUtils.close();
         devBundleUtils.close();
         bundleUtils.close();
+        File needsBuildFile = new File(options.getResourceOutputDirectory(),
+                Constants.NEEDS_BUNDLE_BUILD_FILE);
+        if(needsBuildFile.exists()) {
+            needsBuildFile.delete();
+        }
     }
 
     private JsonObject getBasicStats() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/BundleValidationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/BundleValidationTest.java
@@ -113,7 +113,7 @@ public class BundleValidationTest {
         bundleUtils.close();
         File needsBuildFile = new File(options.getResourceOutputDirectory(),
                 Constants.NEEDS_BUNDLE_BUILD_FILE);
-        if(needsBuildFile.exists()) {
+        if (needsBuildFile.exists()) {
             needsBuildFile.delete();
         }
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/BundleValidationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/BundleValidationTest.java
@@ -1604,6 +1604,19 @@ public class BundleValidationTest {
         Assert.assertFalse("Rebuild should be skipped", needsBuild);
     }
 
+    @Test
+    public void forceProductionBundle_bundleRequired() {
+        Assume.assumeTrue(mode == Mode.PRODUCTION);
+
+        options.withForceProductionBuild(true);
+
+        final boolean needsBuild = BundleValidationUtil.needsBuild(options,
+                Mockito.mock(FrontendDependenciesScanner.class), finder, mode);
+        Assert.assertTrue(
+                "Production bundle required due to force.production.bundle flag.",
+                needsBuild);
+    }
+
     private void createPackageJsonStub(String content) throws IOException {
         File packageJson = new File(temporaryFolder.getRoot(),
                 Constants.PACKAGE_JSON);

--- a/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/src/test/java/com/vaadin/flow/uitest/ui/theme/CssLoadingIT.java
+++ b/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/src/test/java/com/vaadin/flow/uitest/ui/theme/CssLoadingIT.java
@@ -45,7 +45,7 @@ public class CssLoadingIT extends ChromeBrowserTest {
                 STYLESHEET_LUMO_FONT_SIZE_M,
                 executeScript(
                         "return getComputedStyle(arguments[0]).getPropertyValue('--lumo-font-size-m')",
-                        htmlElement));
+                        htmlElement).toString().trim());
     }
 
     @Test

--- a/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/src/test/java/com/vaadin/flow/uitest/ui/theme/CssLoadingIT.java
+++ b/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/src/test/java/com/vaadin/flow/uitest/ui/theme/CssLoadingIT.java
@@ -34,7 +34,7 @@ public class CssLoadingIT extends ChromeBrowserTest {
     private static final String BLUE_RGBA = "rgba(0, 0, 255, 1)";
     private static final String GREEN_RGBA = "rgba(0, 255, 0, 1)";
     private static final String YELLOW_RGBA = "rgba(255, 255, 0, 1)";
-    private static final String STYLESHEET_LUMO_FONT_SIZE_M = " 1.1rem";
+    private static final String STYLESHEET_LUMO_FONT_SIZE_M = "1.1rem";
 
     @Test
     public void CssImport_overrides_Lumo() {

--- a/flow-tests/test-express-build/test-prod-bundle/pom.xml
+++ b/flow-tests/test-express-build/test-prod-bundle/pom.xml
@@ -73,6 +73,9 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <forceProductionBuild>true</forceProductionBuild>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>


### PR DESCRIPTION
Add a parameter that forces a
production bundle build even
when an applicable bundle exists.

Closes #16752
