### PR TITLE
fix: set Lookup attribute to servlet context from OSGi servlet context

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.util.Properties;
 
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.CurrentInstance;
 import com.vaadin.flow.server.HandlerHelper.RequestType;
@@ -548,7 +549,8 @@ public class VaadinServlet extends HttpServlet {
             synchronized (getServletContext()) {
                 ArrayList<String> attributes = Collections
                         .list(getServletContext().getAttributeNames());
-                if (attributes.isEmpty()) {
+                if (attributes.isEmpty()
+                        || !attributes.contains(Lookup.class.getName())) {
                     ArrayList<String> list = Collections
                             .list(osgiServletContext.getAttributeNames());
                     list.forEach(attr -> getServletContext().setAttribute(attr,

--- a/flow-server/src/test/java/com/vaadin/flow/server/OSGiVaadinServletTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/OSGiVaadinServletTest.java
@@ -93,7 +93,6 @@ public class OSGiVaadinServletTest {
             protected DeploymentConfiguration createDeploymentConfiguration() {
                 return Mockito.mock(DeploymentConfiguration.class);
             }
-    
             @Override
             protected VaadinServletService createServletService(
                     DeploymentConfiguration deploymentConfiguration)

--- a/flow-server/src/test/java/com/vaadin/flow/server/OSGiVaadinServletTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/OSGiVaadinServletTest.java
@@ -95,8 +95,7 @@ public class OSGiVaadinServletTest {
             }
             @Override
             protected VaadinServletService createServletService(
-                    DeploymentConfiguration deploymentConfiguration)
-                    throws ServiceException {
+                    DeploymentConfiguration deploymentConfiguration) {
                 VaadinServletService service = Mockito
                         .mock(VaadinServletService.class);
                 Mockito.when(service.getDeploymentConfiguration())

--- a/flow-server/src/test/java/com/vaadin/flow/server/OSGiVaadinServletTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/OSGiVaadinServletTest.java
@@ -20,6 +20,7 @@ import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.List;
 
 import org.junit.Test;
@@ -44,14 +45,10 @@ public class OSGiVaadinServletTest {
 
         ServletConfig config = Mockito.mock(ServletConfig.class);
 
-        ServletContext servletContext = Mockito.mock(ServletContext.class);
-        Mockito.when(config.getServletContext()).thenReturn(servletContext);
-        Mockito.when(servletContext.getAttributeNames())
-                .thenReturn(Collections.emptyEnumeration());
+        ServletContext servletContext = mockServletContext(config,
+                Collections.emptyEnumeration());
 
-        VaadinServlet servlet = createVaadinServletStub();
-
-        servlet.init(config);
+        initVaadinServletStub(config);
 
         Mockito.verify(servletContext).setAttribute(Lookup.class.getName(),
                 context.getAttribute(Lookup.class.getName()));
@@ -72,14 +69,10 @@ public class OSGiVaadinServletTest {
 
         ServletConfig config = Mockito.mock(ServletConfig.class);
 
-        ServletContext servletContext = Mockito.mock(ServletContext.class);
-        Mockito.when(config.getServletContext()).thenReturn(servletContext);
-        Mockito.when(servletContext.getAttributeNames())
-                .thenReturn(Collections.enumeration(servletContextAttributes));
+        ServletContext servletContext = mockServletContext(config,
+                Collections.enumeration(servletContextAttributes));
 
-        VaadinServlet servlet = createVaadinServletStub();
-
-        servlet.init(config);
+        initVaadinServletStub(config);
 
         Mockito.verify(servletContext).setAttribute(Lookup.class.getName(),
                 context.getAttribute(Lookup.class.getName()));
@@ -87,7 +80,17 @@ public class OSGiVaadinServletTest {
                 "bar");
     }
 
-    private VaadinServlet createVaadinServletStub() {
+    private ServletContext mockServletContext(ServletConfig config,
+            Enumeration<String> servletContextAttributes) {
+        ServletContext servletContext = Mockito.mock(ServletContext.class);
+        Mockito.when(config.getServletContext()).thenReturn(servletContext);
+        Mockito.when(servletContext.getAttributeNames())
+                .thenReturn(servletContextAttributes);
+        return servletContext;
+    }
+
+    private void initVaadinServletStub(ServletConfig config)
+            throws ServletException {
         VaadinServlet servlet = new VaadinServlet() {
             @Override
             protected DeploymentConfiguration createDeploymentConfiguration() {
@@ -103,6 +106,6 @@ public class OSGiVaadinServletTest {
                 return service;
             }
         };
-        return servlet;
+        servlet.init(config);
     }
 }


### PR DESCRIPTION
This change ensures that Lookup is set in servlet context attributes when initializing VaadinServlet in OSGi environment.

Fixes: vaadin/base-starter-flow-osgi/issues/296
