### PR TITLE
Revert "feat!: add DataProvider API for refreshing without clearing selection (#16650)"

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataProvider.java
@@ -73,11 +73,6 @@ public abstract class AbstractDataProvider<T, F> implements DataProvider<T, F> {
     }
 
     @Override
-    public void refreshItems(boolean clearSelection) {
-        fireEvent(new DataChangeEvent<>(this, clearSelection));
-    }
-
-    @Override
     public void refreshItem(T item, boolean refreshChildren) {
         fireEvent(new DataRefreshEvent<>(this, item, refreshChildren));
     }

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataChangeEvent.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataChangeEvent.java
@@ -33,7 +33,6 @@ import com.vaadin.flow.server.Command;
  */
 public class DataChangeEvent<T> extends EventObject {
 
-    private final boolean clearSelection;
     private Command unregisterListenerCommand = null;
 
     /**
@@ -110,38 +109,12 @@ public class DataChangeEvent<T> extends EventObject {
      *            the data provider, not null
      */
     public DataChangeEvent(DataProvider<T, ?> source) {
-        this(source, true);
-    }
-
-    /**
-     * Creates a new {@code DataChangeEvent} event originating from the given
-     * data provider.
-     *
-     * @param source
-     *            the data provider, not null
-     * @param clearSelection
-     *            <code>true</code> is a signal to clear selection and
-     *            <code>false</code> is to keep it
-     */
-    public DataChangeEvent(DataProvider<T, ?> source, boolean clearSelection) {
         super(source);
-        this.clearSelection = clearSelection;
     }
 
     @Override
     public DataProvider<T, ?> getSource() {
         return (DataProvider<T, ?>) super.getSource();
-    }
-
-    /**
-     * Gets the boolean to signal if this event was initiated to clear selection
-     * or keep it.
-     *
-     * @return <code>true</code> is a signal to clear selection and
-     *         <code>false</code> is to keep it
-     */
-    public boolean isClearSelection() {
-        return this.clearSelection;
     }
 
     /**

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataProvider.java
@@ -129,32 +129,8 @@ public interface DataProvider<T, F> extends Serializable {
     /**
      * Refreshes all data based on currently available data in the underlying
      * provider.
-     *
-     * @deprecated Use {@link #refreshItems(boolean)} with argument
-     *             <code>true</code> instead
      */
-    @Deprecated
     void refreshAll();
-
-    /**
-     * Refreshes all items based on currently available data in the underlying
-     * provider by firing {@link DataChangeEvent} with
-     * <code>clearSelection</code> boolean parameter to signal listeners to
-     * either clear selection or keep it.
-     *
-     * @param clearSelection
-     *            <code>true</code> is a signal to clear selection and
-     *            <code>false</code> is to keep it
-     */
-    void refreshItems(boolean clearSelection);
-
-    /**
-     * Shortcut to {@link #refreshItems(boolean)} with argument
-     * <code>false</code> to refresh items and keep selection.
-     */
-    default void refreshItems() {
-        refreshItems(false);
-    }
 
     /**
      * Gets an identifier for the given item. This identifier is used by the
@@ -180,9 +156,8 @@ public interface DataProvider<T, F> extends Serializable {
      * Adds a data provider listener. The listener is called when some piece of
      * data is updated.
      * <p>
-     * The {@link #refreshAll()}, {@link #refreshItems(boolean)} and
-     * {@link #refreshItems()} methods fires {@link DataChangeEvent} each time
-     * when they are called. It allows to update UI components when user changes
+     * The {@link #refreshAll()} method fires {@link DataChangeEvent} each time
+     * when it's called. It allows to update UI components when user changes
      * something in the underlying data.
      *
      * @see #refreshAll()

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataProviderWrapper.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataProviderWrapper.java
@@ -65,11 +65,6 @@ public abstract class DataProviderWrapper<T, F, M>
     }
 
     @Override
-    public void refreshItems(boolean clearSelection) {
-        dataProvider.refreshItems(clearSelection);
-    }
-
-    @Override
     public void refreshItem(T item) {
         dataProvider.refreshItem(item);
     }

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractDataProviderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractDataProviderTest.java
@@ -61,35 +61,6 @@ public class AbstractDataProviderTest {
         dataProvider.refreshAll();
         Assert.assertNotNull(event.get());
         Assert.assertEquals(dataProvider, event.get().getSource());
-        Assert.assertTrue(event.get().isClearSelection());
-    }
-
-    @Test
-    public void refreshItems_withClearSelectionFalse_notifyListeners() {
-        TestDataProvider dataProvider = new TestDataProvider();
-        AtomicReference<DataChangeEvent<Object>> event = new AtomicReference<>();
-        dataProvider.addDataProviderListener(ev -> {
-            Assert.assertNull(event.get());
-            event.set(ev);
-        });
-        dataProvider.refreshItems(false);
-        Assert.assertNotNull(event.get());
-        Assert.assertEquals(dataProvider, event.get().getSource());
-        Assert.assertFalse(event.get().isClearSelection());
-    }
-
-    @Test
-    public void refreshItems_withClearSelectionTrue_notifyListeners() {
-        TestDataProvider dataProvider = new TestDataProvider();
-        AtomicReference<DataChangeEvent<Object>> event = new AtomicReference<>();
-        dataProvider.addDataProviderListener(ev -> {
-            Assert.assertNull(event.get());
-            event.set(ev);
-        });
-        dataProvider.refreshItems(true);
-        Assert.assertNotNull(event.get());
-        Assert.assertEquals(dataProvider, event.get().getSource());
-        Assert.assertTrue(event.get().isClearSelection());
     }
 
     @Test


### PR DESCRIPTION
Reverts recent DataProvider API changes, because it's not yet finally decided how the API should look like for setting components to erase or not the selection upon data refresh.
Also, we almost lost a train to include it to the Vaadin 24.1, so the suggestion is to make better API and use cases elaboration and target this feature to Vaadin 24.2.

Issue to follow up https://github.com/vaadin/platform/issues/3640.

This reverts commit 9d2b7b19a924f1dc580423e5f8ad340f2e71c3aa.
