### PR TITLE
feat: show a more helpful page when opening an application without routes

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteNotFoundError.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteNotFoundError.java
@@ -85,9 +85,6 @@ public class RouteNotFoundError extends Component
                 } else {
                     template = readHtmlFile("NoRoutesError_dev.html");
                 }
-
-                var logMessage = stripHTML(template);
-                getLogger().info(logMessage);
             } else {
                 template = readHtmlFile("RouteNotFoundError_dev.html");
 
@@ -106,12 +103,6 @@ public class RouteNotFoundError extends Component
 
         getElement().setChild(0, new Html(template).getElement());
         return HttpStatusCode.NOT_FOUND.getCode();
-    }
-
-    private static String stripHTML(String html) {
-        return html.lines().map(line -> line.replaceAll("<[^>]+>", ""))
-                .map(String::trim).filter(line -> !line.isEmpty())
-                .collect(Collectors.joining("\n"));
     }
 
     private static Logger getLogger() {

--- a/flow-server/src/main/resources/com/vaadin/flow/router/NoRoutesError_dev.html
+++ b/flow-server/src/main/resources/com/vaadin/flow/router/NoRoutesError_dev.html
@@ -1,0 +1,14 @@
+<div style="margin: 2rem;">
+    <h3>No views found</h3>
+    <p>Add a view to get started. Here's a simple Hello World:</p>
+    <pre>
+    @Route("") // map view to the root
+    class MainView extends VerticalLayout {
+      MainView() {
+        add(new H1("Hello, world"));
+      }
+    }
+    </pre>
+
+    <p>Learn more at <a href="https://vaadin.com/docs">https://vaadin.com/docs</a>.</p>
+</div>

--- a/flow-server/src/main/resources/com/vaadin/flow/router/NoRoutesError_hilla.html
+++ b/flow-server/src/main/resources/com/vaadin/flow/router/NoRoutesError_hilla.html
@@ -1,0 +1,20 @@
+<div style="margin: 2rem;">
+    <h3>No routes found</h3>
+    <p>You can bootstrap a basic frontend by using one of the commands below.</p>
+
+    <p>For React:</p>
+    <pre>
+    gradle hillaInitReactApp
+
+    mvn hilla:init-react-app
+    </pre>
+
+    <p>For Lit:</p>
+    <pre>
+    gradle hillaInitLitApp
+
+    mvn hilla:init-lit-app
+    </pre>
+
+    <p>Learn more at <a href="https://hilla.dev/docs">https://hilla.dev/docs</a>.</p>
+</div>

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouteNotFoundErrorTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouteNotFoundErrorTest.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.router;
 
 import java.util.Collections;
+import java.util.List;
 
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
@@ -40,21 +41,7 @@ public class RouteNotFoundErrorTest {
     public void setErrorParameter_productionMode_pathContainRoutesTemplate_renderedElementHasNoRoutes() {
 
         RouteNotFoundError page = new RouteNotFoundError();
-
-        BeforeEnterEvent event = Mockito.mock(BeforeEnterEvent.class);
-        Location location = Mockito.mock(Location.class);
-        Mockito.when(location.getPath()).thenReturn("{{routes}}");
-        Mockito.when(event.getLocation()).thenReturn(location);
-
-        UI ui = Mockito.mock(UI.class);
-        VaadinSession session = Mockito.mock(VaadinSession.class);
-        Mockito.when(ui.getSession()).thenReturn(session);
-        DeploymentConfiguration config = Mockito
-                .mock(DeploymentConfiguration.class);
-        Mockito.when(session.getConfiguration()).thenReturn(config);
-        Mockito.when(config.isProductionMode()).thenReturn(true);
-
-        Mockito.when(event.getUI()).thenReturn(ui);
+        BeforeEnterEvent event = createEvent(true);
 
         ErrorParameter<NotFoundException> param = new ErrorParameter<NotFoundException>(
                 NotFoundException.class, new NotFoundException());
@@ -75,6 +62,44 @@ public class RouteNotFoundErrorTest {
 
         MatcherAssert.assertThat(page.getElement().toString(),
                 CoreMatchers.not(CoreMatchers.containsString("bar")));
+    }
+
+    @Test
+    public void setErrorParameter_devMode_noRoutes() {
+        RouteNotFoundError page = new RouteNotFoundError();
+        BeforeEnterEvent event = createEvent(false);
+
+        ErrorParameter<NotFoundException> param = new ErrorParameter<>(
+                NotFoundException.class, new NotFoundException());
+
+        Router router = Mockito.mock(Router.class);
+        Mockito.when(event.getSource()).thenReturn(router);
+        RouteRegistry registry = Mockito.mock(RouteRegistry.class);
+        Mockito.when(router.getRegistry()).thenReturn(registry);
+        Mockito.when(registry.getRegisteredRoutes()).thenReturn(List.of());
+
+        event.getSource().getRegistry().getRegisteredRoutes();
+
+        page.setErrorParameter(event, param);
+
+        MatcherAssert.assertThat(page.getElement().toString(),
+                CoreMatchers.containsString("No views found"));
+    }
+
+    private BeforeEnterEvent createEvent(boolean productionMode) {
+        BeforeEnterEvent event = Mockito.mock(BeforeEnterEvent.class);
+        Location location = Mockito.mock(Location.class);
+        Mockito.when(location.getPath()).thenReturn("{{routes}}");
+        Mockito.when(event.getLocation()).thenReturn(location);
+        UI ui = Mockito.mock(UI.class);
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        Mockito.when(ui.getSession()).thenReturn(session);
+        DeploymentConfiguration config = Mockito
+                .mock(DeploymentConfiguration.class);
+        Mockito.when(session.getConfiguration()).thenReturn(config);
+        Mockito.when(config.isProductionMode()).thenReturn(productionMode);
+        Mockito.when(event.getUI()).thenReturn(ui);
+        return event;
     }
 
 }


### PR DESCRIPTION
## Description

This is mostly useful for application geneerated on start.spring.io.

Different message are shown for Flow and Hilla applications.

Nothing changes in production and for applications already having some routes.

Fixes #16432

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue.
