### PR TITLE
fix: Run the IndexHtmlRequestListener after the whole page is complete

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
@@ -150,9 +150,6 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
 
         redirectToOldBrowserPageWhenNeeded(indexDocument);
 
-        // modify the page based on registered IndexHtmlRequestListener:
-        service.modifyIndexHtmlResponse(indexHtmlResponse);
-
         if (!config.isProductionMode()) {
             // Ensure no older tools incorrectly detect a bundle as production
             // mode
@@ -169,6 +166,10 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
 
             addLicenseChecker(indexDocument);
         }
+
+        // this invokes any custom listeners and should be run when the whole
+        // page is constructed
+        service.modifyIndexHtmlResponse(indexHtmlResponse);
 
         try {
             response.getOutputStream()

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
@@ -318,7 +318,7 @@ public class IndexHtmlRequestHandlerTest {
                 .toString(StandardCharsets.UTF_8.name());
         Document document = Jsoup.parse(indexHtml);
         Elements scripts = document.head().getElementsByTag("script");
-        int expectedScripts = 4;
+        int expectedScripts = 2;
         Assert.assertEquals(expectedScripts, scripts.size());
         Assert.assertEquals("testing.1",
                 scripts.get(expectedScripts - 2).attr("src"));


### PR DESCRIPTION
This ensures you can overwrite all parts of the index page in listeners
