### PR TITLE
fix: suggest single goal for scaffolding Hilla apps

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/router/NoRoutesError_hilla.html
+++ b/flow-server/src/main/resources/com/vaadin/flow/router/NoRoutesError_hilla.html
@@ -1,19 +1,11 @@
 <div style="margin: 2rem;">
     <h3>No routes found</h3>
-    <p>You can bootstrap a basic frontend by using one of the commands below.</p>
+    <p>You can bootstrap a basic frontend by using one of these commands:</p>
 
-    <p>For React:</p>
     <pre>
-    gradle hillaInitReactApp
+    gradle hillaInitApp
 
-    mvn hilla:init-react-app
-    </pre>
-
-    <p>For Lit:</p>
-    <pre>
-    gradle hillaInitLitApp
-
-    mvn hilla:init-lit-app
+    mvn hilla:init-app
     </pre>
 
     <p>Learn more at <a href="https://hilla.dev/docs">https://hilla.dev/docs</a>.</p>


### PR DESCRIPTION
A single Maven goal/Gradle task is suggested for Hilla, as the framework used depends on the contents of `pom.xml`/`build.gradle`.