### PR TITLE
fix: remove natural order sorting of jsmodules and javascript imports

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -279,7 +279,7 @@ abstract class AbstractUpdateImports implements Runnable {
                         && !module.startsWith(
                                 ApplicationConstants.BASE_PROTOCOL_PREFIX))
                 .filter(module -> !UrlUtil.isExternal(module))
-                .map(module -> resolveResource(module)).sorted()
+                .map(module -> resolveResource(module))
                 .collect(Collectors.toList());
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
@@ -39,7 +39,6 @@ import java.util.stream.Stream;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -54,7 +53,6 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.dependency.JavaScript;
-import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.page.AppShellConfigurator;
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.router.Route;
@@ -497,7 +495,8 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
 
     }
 
-    public void assertFullSortOrder(boolean uiImportSeparated)
+    public void assertFullSortOrder(boolean uiImportSeparated,
+            List<String> expectedJsModuleImports)
             throws MalformedURLException {
         Class[] testClasses = { MainView.class,
                 NodeTestComponents.TranslatedImports.class,
@@ -519,11 +518,11 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
         List<String> expectedImports = new ArrayList<>();
         List<String> uiAndGeneratedImports = new ArrayList<>();
 
-        getAnntotationsAsStream(JsModule.class, testClasses)
-                .map(JsModule::value).sorted().map(this::updateToImport)
-                .forEach(expectedImports::add);
+        // JsModules
+        expectedImports.addAll(expectedJsModuleImports);
+
         getAnntotationsAsStream(JavaScript.class, testClasses)
-                .map(JavaScript::value).map(this::updateToImport).sorted()
+                .map(JavaScript::value).map(this::updateToImport)
                 .forEach(expectedImports::add);
 
         if (uiImportSeparated) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTestComponents.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTestComponents.java
@@ -215,6 +215,7 @@ public class NodeTestComponents extends NodeUpdateTestUtil {
     @JavaScript("javascript/a.js")
     @JavaScript("javascript/b.js")
     @JavaScript("javascript/c.js")
+    @JsModule("jsmodule/h.js")
     @JsModule("jsmodule/g.js")
     public static class JavaScriptOrder extends Component {
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/UpdateImportsWithByteCodeScannerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/UpdateImportsWithByteCodeScannerTest.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -37,6 +38,7 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.internal.DependencyTrigger;
 import com.vaadin.flow.server.LoadDependenciesOnStartup;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
+import com.vaadin.flow.server.frontend.scanner.DepsTests;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 
 public class UpdateImportsWithByteCodeScannerTest
@@ -50,7 +52,20 @@ public class UpdateImportsWithByteCodeScannerTest
 
     @Test
     public void assertFullSortOrder() throws MalformedURLException {
-        super.assertFullSortOrder(true);
+        List<String> expectedJsModuleImports = new ArrayList<>();
+        expectedJsModuleImports.add(
+                "import '@vaadin/vaadin-mixed-component/src/vaadin-mixed-component.js';");
+        expectedJsModuleImports.add(
+                "import '@vaadin/vaadin-mixed-component/src/vaadin-something-else.js';");
+        expectedJsModuleImports.add(
+                "import '@vaadin/vaadin-mixed-component/src/vaadin-something-else';");
+        expectedJsModuleImports.add(
+                "import '@vaadin/vaadin-mixed-component/src/vaadin-custom-themed-component.js';");
+        expectedJsModuleImports.add("import 'jsmodule/h.js';");
+        expectedJsModuleImports.add("import 'jsmodule/g.js';");
+        expectedJsModuleImports.add("import 'Frontend/local-p3-template.js';");
+        expectedJsModuleImports.add("import '" + DepsTests.UI_IMPORT + "';");
+        super.assertFullSortOrder(true, expectedJsModuleImports);
     }
 
     @JavaScript("./lazy-component-javascript.js")
@@ -61,7 +76,8 @@ public class UpdateImportsWithByteCodeScannerTest
     }
 
     @JavaScript("./eager-component-javascript.js")
-    @JsModule("./eager-component-jsmodule.js")
+    @JsModule("./eager-component-jsmodule-2.js")
+    @JsModule("./eager-component-jsmodule-1.js")
     @CssImport("./eager-component-cssimport.css")
     public static class EagerComponent extends Component {
 
@@ -177,7 +193,8 @@ public class UpdateImportsWithByteCodeScannerTest
         assertImports(mainImportContent, lazyChunkContent,
                 new String[] { "Frontend/eager-component-cssimport.css",
                         "Frontend/eager-component-javascript.js",
-                        "Frontend/eager-component-jsmodule.js" },
+                        "Frontend/eager-component-jsmodule-2.js",
+                        "Frontend/eager-component-jsmodule-1.js" },
                 new String[] { "Frontend/lazy-component-cssimport.css",
                         "Frontend/lazy-component-javascript.js",
                         "Frontend/lazy-component-jsmodule.js", });
@@ -193,7 +210,9 @@ public class UpdateImportsWithByteCodeScannerTest
         createExpectedImport(frontendDirectory, nodeModulesPath,
                 "./eager-component-javascript.js");
         createExpectedImport(frontendDirectory, nodeModulesPath,
-                "./eager-component-jsmodule.js");
+                "./eager-component-jsmodule-2.js");
+        createExpectedImport(frontendDirectory, nodeModulesPath,
+                "./eager-component-jsmodule-1.js");
         createExpectedImport(frontendDirectory, nodeModulesPath,
                 "./eager-component-cssimport.css");
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/UpdateImportsWithFullCPScannerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/UpdateImportsWithFullCPScannerTest.java
@@ -16,10 +16,13 @@
 package com.vaadin.flow.server.frontend;
 
 import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.Test;
 
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
+import com.vaadin.flow.server.frontend.scanner.DepsTests;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 
 public class UpdateImportsWithFullCPScannerTest
@@ -33,6 +36,19 @@ public class UpdateImportsWithFullCPScannerTest
 
     @Test
     public void assertFullSortOrder() throws MalformedURLException {
-        super.assertFullSortOrder(false);
+        List<String> expectedJsModuleImports = new ArrayList<>();
+        expectedJsModuleImports.add(
+                "import '@vaadin/vaadin-mixed-component/src/vaadin-mixed-component.js';");
+        expectedJsModuleImports.add(
+                "import '@vaadin/vaadin-mixed-component/src/vaadin-something-else.js';");
+        expectedJsModuleImports.add(
+                "import '@vaadin/vaadin-mixed-component/src/vaadin-something-else';");
+        expectedJsModuleImports.add(
+                "import '@vaadin/vaadin-mixed-component/src/vaadin-custom-themed-component.js';");
+        expectedJsModuleImports.add("import 'Frontend/local-p3-template.js';");
+        expectedJsModuleImports.add("import 'jsmodule/h.js';");
+        expectedJsModuleImports.add("import 'jsmodule/g.js';");
+        expectedJsModuleImports.add("import '" + DepsTests.UI_IMPORT + "';");
+        super.assertFullSortOrder(false, expectedJsModuleImports);
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/DepsTests.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/DepsTests.java
@@ -5,6 +5,8 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.junit.Assert;
 
@@ -37,6 +39,13 @@ public class DepsTests {
             actualUrls.get(key).removeIf(imp -> imp.equals(UI_IMPORT));
         }
         assertImports(actualUrls, expectedUrls);
+    }
+
+    public static void assertImportsWithFilter(
+            Map<ChunkInfo, List<String>> actualUrls,
+            Predicate<String> filter, String... expectedUrls) {
+        Assert.assertEquals(List.of(expectedUrls), merge(actualUrls).stream()
+                .filter(filter).collect(Collectors.toList()));
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
@@ -37,10 +37,10 @@ import com.vaadin.flow.router.ErrorParameter;
 import com.vaadin.flow.router.HasErrorParameter;
 import com.vaadin.flow.router.NotFoundException;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.router.internal.DependencyTrigger;
 import com.vaadin.flow.server.UIInitListener;
 import com.vaadin.flow.server.VaadinServiceInitListener;
 import com.vaadin.flow.server.frontend.scanner.samples.ErrorComponent;
+import com.vaadin.flow.server.frontend.scanner.samples.JsModuleOrderComponent;
 import com.vaadin.flow.server.frontend.scanner.samples.JsOrderComponent;
 import com.vaadin.flow.server.frontend.scanner.samples.MyServiceListener;
 import com.vaadin.flow.server.frontend.scanner.samples.MyUIInitListener;
@@ -211,6 +211,18 @@ public class FrontendDependenciesTest {
 
         DepsTests.assertImports(dependencies.getScripts(), "a.js", "b.js",
                 "c.js");
+    }
+
+    @Test
+    public void jsModuleOrderIsPreserved() {
+        Mockito.when(classFinder.getAnnotatedClasses(Route.class))
+                .thenReturn(
+                        Collections.singleton(JsModuleOrderComponent.class));
+        FrontendDependencies dependencies = new FrontendDependencies(
+                classFinder, false);
+
+        DepsTests.assertImportsExcludingUI(dependencies.getModules(), "c.js", "b.js",
+                "a.js");
     }
 
     // flow #6524

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScannerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScannerTest.java
@@ -211,6 +211,25 @@ public class FullDependenciesScannerTest {
     }
 
     @Test
+    public void getScripts_returnAllJsModules_orderPerClassIsPreserved_getClassesReturnAllJSAnnotatedComponents()
+            throws ClassNotFoundException {
+        List<String> expectedModulesInOrder = new ArrayList<>();
+        expectedModulesInOrder.add("jsmodule/h.js");
+        expectedModulesInOrder.add("jsmodule/g.js");
+        FrontendDependenciesScanner scanner = setUpAnnotationScanner(
+                JsModule.class);
+        DepsTests.assertImportsWithFilter(scanner.getModules(),
+                jsmodule -> expectedModulesInOrder.contains(jsmodule),
+                expectedModulesInOrder.toArray(String[]::new));
+
+        Set<String> visitedClasses = scanner.getClasses();
+        Assert.assertTrue(
+                visitedClasses.contains(VaadinBowerComponent.class.getName()));
+        Assert.assertTrue(
+                visitedClasses.contains(JavaScriptOrder.class.getName()));
+    }
+
+    @Test
     public void getCss_returnAllCss_orderPerClassIsPreserved_getClassesReturnAllCssAnnotatedComponents()
             throws ClassNotFoundException {
         FrontendDependenciesScanner scanner = setUpAnnotationScanner(
@@ -238,7 +257,7 @@ public class FullDependenciesScannerTest {
             throws ClassNotFoundException {
         FrontendDependenciesScanner scanner = setUpAnnotationScanner(
                 JsModule.class);
-        DepsTests.assertImportCount(19, scanner.getModules());
+        DepsTests.assertImportCount(20, scanner.getModules());
         assertJsModules(DepsTests.merge(scanner.getModules()));
 
         Set<String> classes = scanner.getClasses();
@@ -288,7 +307,7 @@ public class FullDependenciesScannerTest {
                     return null;
                 }, null);
 
-        DepsTests.assertImportCount(25, scanner.getModules());
+        DepsTests.assertImportCount(26, scanner.getModules());
         List<String> modules = DepsTests.merge(scanner.getModules());
         assertJsModules(modules);
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/ScannerDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/ScannerDependenciesTest.java
@@ -15,6 +15,7 @@ import com.vaadin.flow.server.frontend.scanner.ScannerTestComponents.BridgeClass
 import com.vaadin.flow.server.frontend.scanner.ScannerTestComponents.Component0;
 import com.vaadin.flow.server.frontend.scanner.ScannerTestComponents.Component1;
 import com.vaadin.flow.server.frontend.scanner.ScannerTestComponents.Component2;
+import com.vaadin.flow.server.frontend.scanner.ScannerTestComponents.DynamicComponentClassWithTwoImports;
 import com.vaadin.flow.server.frontend.scanner.ScannerTestComponents.FirstView;
 import com.vaadin.flow.server.frontend.scanner.ScannerTestComponents.RouteWithNestedDynamicRouteClass;
 import com.vaadin.flow.server.frontend.scanner.ScannerTestComponents.RouteWithService;
@@ -207,6 +208,14 @@ public class ScannerDependenciesTest {
             assertTrue("should cache " + clz.getName(),
                     deps.getClasses().contains(clz.getName()));
         }
+    }
+
+    @Test
+    public void should_visitDynamicRouteWithTwoImports() {
+        FrontendDependencies deps = getFrontendDependencies(
+                DynamicComponentClassWithTwoImports.class);
+        DepsTests.assertImportsExcludingUI(deps.getModules(),
+                "dynamic-component.js", "another-dynamic-component.js");
     }
 
     @Test // #5509

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/ScannerTestComponents.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/ScannerTestComponents.java
@@ -293,6 +293,12 @@ public class ScannerTestComponents {
     public static class DynamicComponentClass extends Component {
     }
 
+    @Route("route-3")
+    @JsModule("dynamic-component.js")
+    @JsModule("another-dynamic-component.js")
+    public static class DynamicComponentClassWithTwoImports extends Component {
+    }
+
     @JsModule("dynamic-layout.js")
     public static class DynamicLayoutClass implements RouterLayout {
         @Override

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/samples/JsModuleOrderComponent.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/samples/JsModuleOrderComponent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.frontend.scanner.samples;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.router.Route;
+
+@Route("foo")
+@JsModule("c.js")
+@JsModule("b.js")
+@JsModule("a.js")
+public class JsModuleOrderComponent extends Component {
+
+}


### PR DESCRIPTION
Removes sorting of jsmodule and javascript imports in natural order in generated-flow-imports.js. Sorting is removed only for imports added via JsModule and Javascript annotation. Natural order was not in line with the promised order described in these annotations, which is to keep the same order as the annotations were on the class. However, order is only guaranteed on a class level.

Fixes: #15825
