### PR TITLE
feat: Improve error messages in Text methods

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/Text.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Text.java
@@ -105,4 +105,91 @@ public class Text extends Component implements HasText {
                 + "represent an HTML Element but a text Node on the client side.");
     }
 
+    /**
+     * The method is not supported for the {@link Text} class.
+     * <p>
+     * Always throws an {@link UnsupportedOperationException}.
+     *
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public void addClassName(String className) {
+        throw new UnsupportedOperationException("Cannot add a class to the "
+                + getClass().getSimpleName() + " component because it doesn't "
+                + "represent an HTML Element but a text Node on the client side.");
+    }
+
+    /**
+     * The method is not supported for the {@link Text} class.
+     * <p>
+     * Always throws an {@link UnsupportedOperationException}.
+     *
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public boolean removeClassName(String className) {
+        throw new UnsupportedOperationException(
+                "Cannot remove a class from the "
+                + getClass().getSimpleName() + " component because it doesn't "
+                + "represent an HTML Element but a text Node on the client side.");
+    }
+
+    /**
+     * The method is not supported for the {@link Text} class.
+     * <p>
+     * Always throws an {@link UnsupportedOperationException}.
+     *
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public void setClassName(String className) {
+        throw new UnsupportedOperationException("Cannot set the "
+                + getClass().getSimpleName()
+                + " component class because it doesn't "
+                + "represent an HTML Element but a text Node on the client side.");
+    }
+
+    /**
+     * The method is not supported for the {@link Text} class.
+     * <p>
+     * Always throws an {@link UnsupportedOperationException}.
+     *
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public void setClassName(String className, boolean set) {
+        throw new UnsupportedOperationException("Cannot set the "
+                + getClass().getSimpleName()
+                + " component class because it doesn't "
+                + "represent an HTML Element but a text Node on the client side.");
+    }
+
+    /**
+     * The method is not supported for the {@link Text} class.
+     * <p>
+     * Always throws an {@link UnsupportedOperationException}.
+     *
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public void addClassNames(String... classNames) {
+        throw new UnsupportedOperationException("Cannot add classes to the "
+                + getClass().getSimpleName() + " component because it doesn't "
+                + "represent an HTML Element but a text Node on the client side.");
+    }
+
+    /**
+     * The method is not supported for the {@link Text} class.
+     * <p>
+     * Always throws an {@link UnsupportedOperationException}.
+     *
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public void removeClassNames(String... classNames) {
+        throw new UnsupportedOperationException(
+                "Cannot remove classes from the " + getClass().getSimpleName()
+                        + " component because it doesn't "
+                        + "represent an HTML Element but a text Node on the client side.");
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/Text.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Text.java
@@ -129,9 +129,9 @@ public class Text extends Component implements HasText {
     @Override
     public boolean removeClassName(String className) {
         throw new UnsupportedOperationException(
-                "Cannot remove a class from the "
-                + getClass().getSimpleName() + " component because it doesn't "
-                + "represent an HTML Element but a text Node on the client side.");
+                "Cannot remove a class from the " + getClass().getSimpleName()
+                        + " component because it doesn't "
+                        + "represent an HTML Element but a text Node on the client side.");
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/component/TextTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/TextTest.java
@@ -91,6 +91,82 @@ public class TextTest {
         new Text("").setVisible(false);
     }
 
+    @Test
+    public void addClassName_throwsWithMeaningfulMessage() {
+        exception.expect(UnsupportedOperationException.class);
+
+        exception.expectMessage(CoreMatchers.allOf(
+                CoreMatchers.containsString("Cannot add a class to the Text"),
+                CoreMatchers.containsString(
+                        "because it doesn't represent an HTML Element")));
+
+        new Text("").addClassName("foo");
+    }
+
+    @Test
+    public void addClassNames_throwsWithMeaningfulMessage() {
+        exception.expect(UnsupportedOperationException.class);
+
+        exception.expectMessage(CoreMatchers.allOf(
+                CoreMatchers.containsString("Cannot add classes to the Text"),
+                CoreMatchers.containsString(
+                        "because it doesn't represent an HTML Element")));
+
+        new Text("").addClassNames("foor", "bar");
+    }
+
+    @Test
+    public void removeClassName_throwsWithMeaningfulMessage() {
+        exception.expect(UnsupportedOperationException.class);
+
+        exception.expectMessage(CoreMatchers.allOf(
+                CoreMatchers
+                        .containsString("Cannot remove a class from the Text"),
+                CoreMatchers.containsString(
+                        "because it doesn't represent an HTML Element")));
+
+        new Text("").removeClassName("foo");
+    }
+
+    @Test
+    public void removeClassNames_throwsWithMeaningfulMessage() {
+        exception.expect(UnsupportedOperationException.class);
+
+        exception.expectMessage(CoreMatchers.allOf(
+                CoreMatchers
+                        .containsString("Cannot remove classes from the Text"),
+                CoreMatchers.containsString(
+                        "because it doesn't represent an HTML Element")));
+
+        new Text("").removeClassNames("foo", "bar");
+    }
+
+    @Test
+    public void setClassName_throwsWithMeaningfulMessage() {
+        exception.expect(UnsupportedOperationException.class);
+
+        exception.expectMessage(CoreMatchers.allOf(
+                CoreMatchers
+                        .containsString("Cannot set the Text component class"),
+                CoreMatchers.containsString(
+                        "because it doesn't represent an HTML Element")));
+
+        new Text("").setClassName("foo");
+    }
+
+    @Test
+    public void setClassName_withBooleanParameter_throwsWithMeaningfulMessage() {
+        exception.expect(UnsupportedOperationException.class);
+
+        exception.expectMessage(CoreMatchers.allOf(
+                CoreMatchers
+                        .containsString("Cannot set the Text component class"),
+                CoreMatchers.containsString(
+                        "because it doesn't represent an HTML Element")));
+
+        new Text("").setClassName("foo", true);
+    }
+
     private void assertExceptionOnSetProperty(String property) {
         exception.expect(UnsupportedOperationException.class);
 


### PR DESCRIPTION
Make sure that calling methods inherited from HasStyles and that doesn't make sense in Text, throw a UnsupportedOperationException with a descritive message. The methods that got better error messages are those that could update a component:

- addClassName
- removeClassName
- setClassName
- addClassNames
- removeClassNames

Fixes #16646