### PR TITLE
fix: remove detach listener when javascript execution completes (#16836) (CP: 23.3)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -32,6 +32,9 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasElement;
@@ -50,9 +53,11 @@ import com.vaadin.flow.component.page.Push;
 import com.vaadin.flow.dom.ElementUtil;
 import com.vaadin.flow.dom.impl.BasicElementStateProvider;
 import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.AnnotationReader;
 import com.vaadin.flow.internal.ConstantPool;
 import com.vaadin.flow.internal.JsonCodec;
+import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.internal.StateTree;
 import com.vaadin.flow.internal.UrlUtil;
 import com.vaadin.flow.internal.nodefeature.LoadingIndicatorConfigurationMap;
@@ -71,6 +76,7 @@ import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.router.internal.AfterNavigationHandler;
 import com.vaadin.flow.router.internal.BeforeEnterHandler;
 import com.vaadin.flow.router.internal.BeforeLeaveHandler;
+import com.vaadin.flow.server.Command;
 import com.vaadin.flow.server.VaadinContext;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
@@ -79,9 +85,6 @@ import com.vaadin.flow.server.frontend.FallbackChunk;
 import com.vaadin.flow.server.frontend.FallbackChunk.CssImportData;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.shared.communication.PushMode;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Holds UI-specific methods and data which are intended for internal use by the
@@ -167,6 +170,8 @@ public class UIInternals implements Serializable {
     private long lastHeartbeatTimestamp = System.currentTimeMillis();
 
     private List<PendingJavaScriptInvocation> pendingJsInvocations = new ArrayList<>();
+
+    private final HashMap<StateNode, PendingJavaScriptInvocationDetachListener> pendingJsInvocationDetachListeners = new HashMap<>();
 
     /**
      * The related UI.
@@ -566,11 +571,6 @@ public class UIInternals implements Serializable {
             PendingJavaScriptInvocation invocation) {
         session.checkHasLock();
         pendingJsInvocations.add(invocation);
-
-        invocation.getOwner()
-                .addDetachListener(() -> pendingJsInvocations
-                        .removeIf(pendingInvocation -> pendingInvocation
-                                .equals(invocation)));
     }
 
     /**
@@ -595,8 +595,59 @@ public class UIInternals implements Serializable {
         pendingJsInvocations = getPendingJavaScriptInvocations()
                 .filter(invocation -> !invocation.getOwner().isVisible())
                 .collect(Collectors.toCollection(ArrayList::new));
-
+        pendingJsInvocations
+                .forEach(this::registerDetachListenerForPendingInvocation);
         return readyToSend;
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private void registerDetachListenerForPendingInvocation(
+            PendingJavaScriptInvocation invocation) {
+
+        PendingJavaScriptInvocationDetachListener listener = pendingJsInvocationDetachListeners
+                .computeIfAbsent(invocation.getOwner(), node -> {
+                    PendingJavaScriptInvocationDetachListener detachListener = new PendingJavaScriptInvocationDetachListener();
+                    detachListener.registration = Registration.combine(
+                            () -> pendingJsInvocationDetachListeners
+                                    .remove(node),
+                            node.addDetachListener(detachListener));
+                    return detachListener;
+                });
+        listener.invocationList.add(invocation);
+
+        SerializableConsumer callback = unused -> listener
+                .onInvocationCompleted(invocation);
+        invocation.then(callback, callback);
+    }
+
+    private class PendingJavaScriptInvocationDetachListener implements Command {
+        private final Set<PendingJavaScriptInvocation> invocationList = new HashSet<>();
+
+        private Registration registration;
+
+        @Override
+        public void execute() {
+            if (!invocationList.isEmpty()) {
+                List<PendingJavaScriptInvocation> copy = new ArrayList<>(
+                        invocationList);
+                invocationList.clear();
+                copy.forEach(this::removePendingInvocation);
+            }
+        }
+
+        private void removePendingInvocation(
+                PendingJavaScriptInvocation invocation) {
+            UIInternals.this.pendingJsInvocations.removeIf(
+                    pendingInvocation -> pendingInvocation.equals(invocation));
+            if (invocationList.isEmpty() && registration != null) {
+                registration.remove();
+            }
+        }
+
+        void onInvocationCompleted(PendingJavaScriptInvocation invocation) {
+            invocationList.remove(invocation);
+            removePendingInvocation(invocation);
+        }
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/UIInternalsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/UIInternalsTest.java
@@ -11,6 +11,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -25,6 +26,10 @@ import com.vaadin.flow.component.page.Push;
 import com.vaadin.flow.di.DefaultInstantiator;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.internal.JsonCodec;
+import com.vaadin.flow.internal.StateNode;
+import com.vaadin.flow.internal.nodefeature.ElementChildrenList;
+import com.vaadin.flow.internal.nodefeature.ElementData;
 import com.vaadin.flow.router.Location;
 import com.vaadin.flow.router.ParentLayout;
 import com.vaadin.flow.router.Route;
@@ -317,6 +322,150 @@ public class UIInternalsTest {
         Assert.assertEquals(
                 "Expected no child elements for sub layout after navigation", 0,
                 subLayout.getElement().getChildren().count());
+    }
+
+    @Test
+    public void dumpPendingJavaScriptInvocations_detachListenerRegisteredOnce() {
+        StateNode node = Mockito.spy(new StateNode(ElementData.class));
+        node.getFeature(ElementData.class).setVisible(false);
+        internals.getStateTree().getRootNode()
+                .getFeature(ElementChildrenList.class).add(0, node);
+
+        internals.addJavaScriptInvocation(new PendingJavaScriptInvocation(node,
+                new UIInternals.JavaScriptInvocation("")));
+        internals.dumpPendingJavaScriptInvocations();
+        internals.dumpPendingJavaScriptInvocations();
+        internals.dumpPendingJavaScriptInvocations();
+
+        Mockito.verify(node, Mockito.times(1))
+                .addDetachListener(ArgumentMatchers.any());
+    }
+
+    @Test
+    public void dumpPendingJavaScriptInvocations_multipleInvocationPerNode_onlyOneDetachListenerRegistered() {
+        StateNode node = Mockito.spy(new StateNode(ElementData.class));
+        node.getFeature(ElementData.class).setVisible(false);
+        internals.getStateTree().getRootNode()
+                .getFeature(ElementChildrenList.class).add(0, node);
+
+        internals.addJavaScriptInvocation(new PendingJavaScriptInvocation(node,
+                new UIInternals.JavaScriptInvocation("1")));
+        internals.addJavaScriptInvocation(new PendingJavaScriptInvocation(node,
+                new UIInternals.JavaScriptInvocation("2")));
+        internals.addJavaScriptInvocation(new PendingJavaScriptInvocation(node,
+                new UIInternals.JavaScriptInvocation("3")));
+        internals.dumpPendingJavaScriptInvocations();
+
+        Mockito.verify(node, Mockito.times(1))
+                .addDetachListener(ArgumentMatchers.any());
+    }
+
+    @Test
+    public void dumpPendingJavaScriptInvocations_registerOneDetachListenerPerNode() {
+        StateNode node1 = Mockito.spy(new StateNode(ElementData.class));
+        node1.getFeature(ElementData.class).setVisible(false);
+        internals.getStateTree().getRootNode()
+                .getFeature(ElementChildrenList.class).add(0, node1);
+        internals.addJavaScriptInvocation(new PendingJavaScriptInvocation(node1,
+                new UIInternals.JavaScriptInvocation("1")));
+
+        StateNode node2 = Mockito.spy(new StateNode(ElementData.class));
+        node2.getFeature(ElementData.class).setVisible(false);
+        internals.getStateTree().getRootNode()
+                .getFeature(ElementChildrenList.class).add(0, node2);
+        internals.addJavaScriptInvocation(new PendingJavaScriptInvocation(node2,
+                new UIInternals.JavaScriptInvocation("1")));
+
+        internals.dumpPendingJavaScriptInvocations();
+
+        Mockito.verify(node1, Mockito.times(1))
+                .addDetachListener(ArgumentMatchers.any());
+        Mockito.verify(node2, Mockito.times(1))
+                .addDetachListener(ArgumentMatchers.any());
+    }
+
+    @Test
+    public void dumpPendingJavaScriptInvocations_invocationCompletes_pendingListPurged() {
+        StateNode node = Mockito.spy(new StateNode(ElementData.class));
+        node.getFeature(ElementData.class).setVisible(false);
+        internals.getStateTree().getRootNode()
+                .getFeature(ElementChildrenList.class).add(0, node);
+
+        PendingJavaScriptInvocation invocation = new PendingJavaScriptInvocation(
+                node, new UIInternals.JavaScriptInvocation(""));
+        internals.addJavaScriptInvocation(invocation);
+        internals.dumpPendingJavaScriptInvocations();
+
+        Mockito.verify(node, Mockito.times(1))
+                .addDetachListener(ArgumentMatchers.any());
+
+        invocation.complete(JsonCodec.encodeWithTypeInfo("OK"));
+
+        Assert.assertEquals(0,
+                internals.getPendingJavaScriptInvocations().count());
+    }
+
+    @Test
+    public void dumpPendingJavaScriptInvocations_invocationFails_pendingListPurged() {
+        StateNode node = Mockito.spy(new StateNode(ElementData.class));
+        node.getFeature(ElementData.class).setVisible(false);
+        internals.getStateTree().getRootNode()
+                .getFeature(ElementChildrenList.class).add(0, node);
+
+        PendingJavaScriptInvocation invocation = new PendingJavaScriptInvocation(
+                node, new UIInternals.JavaScriptInvocation(""));
+        internals.addJavaScriptInvocation(invocation);
+        internals.dumpPendingJavaScriptInvocations();
+
+        Mockito.verify(node, Mockito.times(1))
+                .addDetachListener(ArgumentMatchers.any());
+
+        invocation.completeExceptionally(JsonCodec.encodeWithTypeInfo("ERROR"));
+
+        Assert.assertEquals(0,
+                internals.getPendingJavaScriptInvocations().count());
+    }
+
+    @Test
+    public void dumpPendingJavaScriptInvocations_invocationCanceled_pendingListPurged() {
+        StateNode node = Mockito.spy(new StateNode(ElementData.class));
+        node.getFeature(ElementData.class).setVisible(false);
+        internals.getStateTree().getRootNode()
+                .getFeature(ElementChildrenList.class).add(0, node);
+
+        PendingJavaScriptInvocation invocation = new PendingJavaScriptInvocation(
+                node, new UIInternals.JavaScriptInvocation(""));
+        internals.addJavaScriptInvocation(invocation);
+        internals.dumpPendingJavaScriptInvocations();
+
+        Mockito.verify(node, Mockito.times(1))
+                .addDetachListener(ArgumentMatchers.any());
+
+        invocation.cancelExecution();
+
+        Assert.assertEquals(0,
+                internals.getPendingJavaScriptInvocations().count());
+    }
+
+    @Test
+    public void dumpPendingJavaScriptInvocations_nodeDetached_pendingListPurged() {
+        StateNode node = Mockito.spy(new StateNode(ElementData.class));
+        node.getFeature(ElementData.class).setVisible(false);
+        internals.getStateTree().getRootNode()
+                .getFeature(ElementChildrenList.class).add(0, node);
+
+        PendingJavaScriptInvocation invocation = new PendingJavaScriptInvocation(
+                node, new UIInternals.JavaScriptInvocation(""));
+        internals.addJavaScriptInvocation(invocation);
+        internals.dumpPendingJavaScriptInvocations();
+
+        Mockito.verify(node, Mockito.times(1))
+                .addDetachListener(ArgumentMatchers.any());
+
+        node.setParent(null);
+
+        Assert.assertEquals(0,
+                internals.getPendingJavaScriptInvocations().count());
     }
 
     private PushConfiguration setUpInitialPush() {


### PR DESCRIPTION
A detach listener is added for pending javascript invocation owner nodes to clean up the queue, if the owner gets detached. This change also removes the detach listener when the javascript execution completes.