### PR TITLE
test: do not delete custom vite.config.ts on clean

### DIFF
--- a/flow-tests/test-express-build/test-dev-bundle-frontend-add-on/pom.xml
+++ b/flow-tests/test-express-build/test-dev-bundle-frontend-add-on/pom.xml
@@ -120,7 +120,7 @@
                             <directory>${project.basedir}</directory>
                             <includes>
                                 <include>package*.json</include>
-                                <include>vite.*.ts</include>
+                                <include>vite.generated.ts</include>
                                 <include>types.d.ts</include>
                                 <include>tsconfig.json</include>
                             </includes>


### PR DESCRIPTION
Module `test-dev-bundle-frontend-add-on` contains a custom `vite.config.ts`, but if a `clean` is performed before executing the tests it is deleted and there are test failures