### PR TITLE
chore!: Add vaadin. prefix to recently added properties

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,7 +1,7 @@
 name: Flow Validation
 on:
   push:
-    branches: [main, '24.0', '23.3', '23.2',  '23.1', '9.0']
+    branches: [main, '24.1', '24.0', '23.3', '9.1']
   workflow_dispatch:
   pull_request_target:
     types: [opened, synchronize, reopened, edited]

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
@@ -283,6 +283,11 @@ public open class VaadinFlowPluginExtension(project: Project) {
             ciBuild = ciBuildProperty
         }
 
+        val forceProductionBuildProperty: Boolean? = project.getBooleanProperty(InitParameters.FORCE_PRODUCTION_BUILD)
+        if (forceProductionBuildProperty != null) {
+            forceProductionBuild = forceProductionBuildProperty
+        }
+
         val useGlobalPnpmProperty: Boolean? = project.getBooleanProperty(InitParameters.SERVLET_PARAMETER_GLOBAL_PNPM)
         if (useGlobalPnpmProperty != null) {
             useGlobalPnpm = useGlobalPnpmProperty
@@ -319,6 +324,7 @@ public open class VaadinFlowPluginExtension(project: Project) {
             "optimizeBundle=$optimizeBundle, " +
             "pnpmEnable=$pnpmEnable, " +
             "ciBuild=$ciBuild, " +
+            "forceProductionBuild=$forceProductionBuild, " +
             "useGlobalPnpm=$useGlobalPnpm, " +
             "requireHomeNodeExec=$requireHomeNodeExec, " +
             "eagerServerLoad=$eagerServerLoad, " +

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -215,7 +215,7 @@ public class InitParameters implements Serializable {
     /**
      * Configuration name for enabling ci build for npm/pnpm.
      */
-    public static final String CI_BUILD = "ci.build";
+    public static final String CI_BUILD = "vaadin.ci.build";
 
     /**
      * Configuration name for disabling dev bundle rebuild.
@@ -225,5 +225,5 @@ public class InitParameters implements Serializable {
     /**
      * Configuration name for forcing optimized production bundle build.
      */
-    public static final String FORCE_PRODUCTION_BUILD = "force.production.build";
+    public static final String FORCE_PRODUCTION_BUILD = "vaadin.force.production.build";
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -220,7 +220,7 @@ public class InitParameters implements Serializable {
     /**
      * Configuration name for disabling dev bundle rebuild.
      */
-    public static final String SKIP_DEV_BUNDLE_REBUILD = "skip.dev.bundle";
+    public static final String SKIP_DEV_BUNDLE_REBUILD = "vaadin.skip.dev.bundle";
 
     /**
      * Configuration name for forcing optimized production bundle build.


### PR DESCRIPTION
Add `vaadin.` prefix to `ci.build` and `force.production.build` properties added in 24.1 to satisfy naming rules.

Also see https://github.com/vaadin/docs/pull/2450

Fixes https://github.com/vaadin/flow/issues/16880

