### PR TITLE
fix: Change from ? extends Component to ? for VS Code

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/LoadDependenciesOnStartup.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/LoadDependenciesOnStartup.java
@@ -20,7 +20,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.page.AppShellConfigurator;
 
 /**
@@ -55,6 +54,6 @@ public @interface LoadDependenciesOnStartup {
      * @return a collection of views to load eagerly or an empty array to load
      *         all dependencies eagerly
      */
-    Class<? extends Component>[] value() default {};
+    Class<?>[] value() default {};
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/LoadDependenciesOnStartup.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/LoadDependenciesOnStartup.java
@@ -20,6 +20,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.page.AppShellConfigurator;
 
 /**
@@ -50,6 +51,9 @@ public @interface LoadDependenciesOnStartup {
     /**
      * The views for which to load dependencies when the application is opened
      * for the first time.
+     * <p>
+     * Note that all classes must extend {@link Component}. The the type is
+     * {@code Class<?>} because of a VS Code issue.
      *
      * @return a collection of views to load eagerly or an empty array to load
      *         all dependencies eagerly


### PR DESCRIPTION
VS Code refuses to understand that a View which extends a Component can be used with the annotation when it is `Class<? extends Component>`. VS Code is broken here but this is a workaround to make VS Code work.
