### PR TITLE
fix: HtmlComponentSmokeTest.testAllHtmlComponents() casting dynamically problem

### DIFF
--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
@@ -231,9 +231,8 @@ public class HtmlComponentSmokeTest {
             }
 
             Object getterValue = getter.invoke(instance);
-            Optional<?> getterValueOpt = ((Optional<?>) getterValue);
-            if (isOptional && getterValueOpt.isPresent()) {
-                getterValue = getterValueOpt.get();
+            if (isOptional && ((Optional<?>) getterValue).isPresent()) {
+                getterValue = ((Optional<?>) getterValue).get();
             }
             Assert.assertEquals(getter + " should return the set value",
                     testValue, getterValue);


### PR DESCRIPTION
## Description

Fixing this exception.
```
java.lang.ClassCastException: java.lang.Boolean cannot be cast to java.util.Optional
  at com.vaadin.flow.component.html.HtmlComponentSmokeTest.testSetter(HtmlComponentSmokeTest.java:234)
  at com.vaadin.flow.component.html.HtmlComponentSmokeTest.lambda$testSetters$3(HtmlComponentSmokeTest.java:138)
  at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:184)
  at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
  at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
  at java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948)
  at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
  at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
  at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
  at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
  at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
  at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:418)
  at com.vaadin.flow.component.html.HtmlComponentSmokeTest.testSetters(HtmlComponentSmokeTest.java:138)
  at com.vaadin.flow.component.html.HtmlComponentSmokeTest.smokeTestComponent(HtmlComponentSmokeTest.java:100)
```

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.