### PR TITLE
fix: npm install task should use ClassFinder

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -193,7 +193,7 @@ public class TaskRunNpmInstall implements FallibleCommand {
 
             final Map<String, String> updates = new HashMap<>();
             updates.put(HASH_KEY, hash);
-            Platform.getVaadinVersion()
+            TaskUpdatePackages.getVaadinVersion(packageUpdater.finder)
                     .ifPresent(s -> updates.put(VAADIN_VERSION, s));
             updates.put(PROJECT_FOLDER,
                     options.getNpmFolder().getAbsolutePath());

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -356,7 +356,7 @@ public class TaskUpdatePackages extends NodeUpdater {
     private boolean isPlatformVersionUpdated() throws IOException {
         // if no record of current version is present, version is not
         // considered updated
-        Optional<String> platformVersion = getVaadinVersion();
+        Optional<String> platformVersion = getVaadinVersion(finder);
         if (platformVersion.isPresent()
                 && options.getNodeModulesFolder().exists()) {
             JsonObject vaadinJsonContents = getVaadinJsonContents();
@@ -371,7 +371,7 @@ public class TaskUpdatePackages extends NodeUpdater {
         return false;
     }
 
-    protected Optional<String> getVaadinVersion() {
+    static Optional<String> getVaadinVersion(ClassFinder finder) {
         URL coreVersionsResource = finder
                 .getResource(Constants.VAADIN_CORE_VERSIONS_JSON);
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
@@ -562,7 +562,7 @@ public class TaskUpdatePackagesNpmTest {
         FileUtils.write(versionJsonFile, versionJsonString,
                 StandardCharsets.UTF_8);
 
-        Optional<String> vaadinVersion = task.getVaadinVersion();
+        Optional<String> vaadinVersion = task.getVaadinVersion(finder);
 
         Assert.assertTrue("versions.json should have had the platform field",
                 vaadinVersion.isPresent());
@@ -575,7 +575,7 @@ public class TaskUpdatePackagesNpmTest {
         //@formatter:on
         FileUtils.write(versionJsonFile, versionJsonString,
                 StandardCharsets.UTF_8);
-        vaadinVersion = task.getVaadinVersion();
+        vaadinVersion = task.getVaadinVersion(finder);
 
         Assert.assertFalse("versions.json should not contain platform version",
                 vaadinVersion.isPresent());
@@ -588,7 +588,7 @@ public class TaskUpdatePackagesNpmTest {
         final TaskUpdatePackages task = createTask(
                 createApplicationDependencies());
 
-        Optional<String> vaadinVersion = task.getVaadinVersion();
+        Optional<String> vaadinVersion = task.getVaadinVersion(finder);
 
         Assert.assertFalse("versions.json should not contain platform version",
                 vaadinVersion.isPresent());


### PR DESCRIPTION
The TaskRunNpmInstall should use ClassFinder
to load the vaadin-core-versions.json

Fixes #16032
