### PR TITLE
fix: Accept css if not building bundle

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -654,7 +654,7 @@ abstract class AbstractUpdateImports implements Runnable {
         } else {
             addLines(lines, String.format(INJECT_CSS, i, cssImport));
         }
-        return found;
+        return found || !options.isBundleBuild();
     }
 
     private String notFoundMessage(Set<String> files, String prefix,


### PR DESCRIPTION
File found can be ignored if not
building bundle due to accepted bundle.

Fixes #16885
