### PR TITLE
feat: clean app devBundle with clean-frontend

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinCleanTask.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinCleanTask.kt
@@ -17,6 +17,7 @@ package com.vaadin.gradle
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
+import com.vaadin.flow.server.Constants
 
 /**
  * Cleans everything Vaadin-related. Useful if npm fails to run after Vaadin
@@ -45,7 +46,7 @@ public open class VaadinCleanTask : DefaultTask() {
     init {
         group = "Vaadin"
         description = "Cleans the project completely and removes 'generated' folders, node_modules, src/main/dev-bundle, webpack.generated.js, " +
-                "tsconfig.json, types.d.ts, pnpm-lock.yaml, pnpmfile.js and package-lock.json"
+                "vite.generated.js, tsconfig.json, types.d.ts, pnpm-lock.yaml, pnpmfile.js and package-lock.json"
 
         dependsOn("clean")
     }
@@ -61,6 +62,7 @@ public open class VaadinCleanTask : DefaultTask() {
                 "${project.projectDir}/${Constants.DEV_BUNDLE_LOCATION}",
                 "${project.projectDir}/package-lock.json",
                 "${project.projectDir}/webpack.generated.js",
+                "${project.projectDir}/vite.generated.js",
                 "${project.projectDir}/pnpm-lock.yaml", // used by Vaadin 14.2+ pnpm
                 "${project.projectDir}/pnpmfile.js", // used by Vaadin 14.2+ pnpm
                 "${project.projectDir}/tsconfig.json", // used by Vaadin 15+

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinCleanTask.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinCleanTask.kt
@@ -44,7 +44,7 @@ import org.gradle.api.tasks.TaskAction
 public open class VaadinCleanTask : DefaultTask() {
     init {
         group = "Vaadin"
-        description = "Cleans the project completely and removes 'generated' folders, node_modules, webpack.generated.js, " +
+        description = "Cleans the project completely and removes 'generated' folders, node_modules, src/main/dev-bundle, webpack.generated.js, " +
                 "tsconfig.json, types.d.ts, pnpm-lock.yaml, pnpmfile.js and package-lock.json"
 
         dependsOn("clean")
@@ -58,6 +58,7 @@ public open class VaadinCleanTask : DefaultTask() {
                 extension.generatedTsFolder.absolutePath,
                 extension.frontendDirectory.resolve("generated").absolutePath,
                 "${project.projectDir}/node_modules",
+                "${project.projectDir}/${Constants.DEV_BUNDLE_LOCATION}",
                 "${project.projectDir}/package-lock.json",
                 "${project.projectDir}/webpack.generated.js",
                 "${project.projectDir}/pnpm-lock.yaml", // used by Vaadin 14.2+ pnpm

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/CleanFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/CleanFrontendMojo.java
@@ -26,6 +26,7 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 
+import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.frontend.FrontendUtils;
 
 import elemental.json.Json;
@@ -110,6 +111,27 @@ public class CleanFrontendMojo extends FlowModeAbstractMojo {
         } catch (IOException e) {
             throw new MojoFailureException(
                     "Failed to clean 'package.json' file", e);
+        }
+
+        removeDevBundle();
+    }
+
+    /**
+     * Try removing the application dev-bundle folder if it exists.
+     * <p>
+     * Log a warning if there was an issue removing the folder.
+     */
+    private void removeDevBundle() {
+        File devBundleDir = new File(npmFolder(),
+                Constants.DEV_BUNDLE_LOCATION);
+        try {
+            if (devBundleDir.exists()) {
+                FrontendUtils.deleteDirectory(devBundleDir);
+            }
+        } catch (IOException exception) {
+            getLog().debug("Exception removing dev-bundle", exception);
+            getLog().error("Failed to remove '" + devBundleDir.getAbsolutePath()
+                    + "'. Please remove it manually.");
         }
     }
 

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/CleanFrontendMojoTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/CleanFrontendMojoTest.java
@@ -121,13 +121,13 @@ public class CleanFrontendMojoTest {
 
     @Test
     public void should_removeDevBundleFolder() throws MojoFailureException {
-        final File nodeModules = new File(projectBase,
+        final File devBundleDir = new File(projectBase,
                 Constants.DEV_BUNDLE_LOCATION);
         Assert.assertTrue("Failed to create 'dev-bundle'",
-                nodeModules.mkdirs());
+                devBundleDir.mkdirs());
         mojo.execute();
         Assert.assertFalse("'dev-bundle' was not removed.",
-                nodeModules.exists());
+                devBundleDir.exists());
     }
 
     @Test

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/CleanFrontendMojoTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/CleanFrontendMojoTest.java
@@ -120,6 +120,17 @@ public class CleanFrontendMojoTest {
     }
 
     @Test
+    public void should_removeDevBundleFolder() throws MojoFailureException {
+        final File nodeModules = new File(projectBase,
+                Constants.DEV_BUNDLE_LOCATION);
+        Assert.assertTrue("Failed to create 'dev-bundle'",
+                nodeModules.mkdirs());
+        mojo.execute();
+        Assert.assertFalse("'dev-bundle' was not removed.",
+                nodeModules.exists());
+    }
+
+    @Test
     public void should_removeFrontendGeneratedFolder()
             throws MojoFailureException, IOException {
         Assert.assertTrue("Failed to create 'frontend/generated'",


### PR DESCRIPTION
When running the clean-frontend target
remove also application dev bundle
from the project.

Part of #16888
