### PR TITLE
fix: Use push/splice to avoid Safari 16.4 issue

### DIFF
--- a/flow-server/src/main/resources/META-INF/frontend/theme-util.js
+++ b/flow-server/src/main/resources/META-INF/frontend/theme-util.js
@@ -46,13 +46,13 @@ const addAdoptedStyle = (cssText, target, first) => {
   const sheet = new CSSStyleSheet();
   sheet.replaceSync(cssText);
   if (first) {
-    target.adoptedStyleSheets = [sheet, ...target.adoptedStyleSheets];
+    target.adoptedStyleSheets.splice(0, 0, sheet);
   } else {
-    target.adoptedStyleSheets = [...target.adoptedStyleSheets, sheet];
+    target.adoptedStyleSheets.push(sheet);
   }
   return () => {
-    target.adoptedStyleSheets = target.adoptedStyleSheets.filter(ss => ss !== sheet);
-  }
+    target.adoptedStyleSheets.splice(target.adoptedStyleSheets.indexOf(sheet), 1);
+  };
 };
 
 const addStyleTag = (cssText, referenceComment) => {


### PR DESCRIPTION
Workaround for https://bugs.webkit.org/show_bug.cgi?id=254844

Fixes #16909
