### PR TITLE
Jetty 12 filesystem fix

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
@@ -131,8 +131,6 @@ public class StaticFileServer implements StaticFileHandler {
                 return Files.isDirectory(path);
             } catch (IOException e) {
                 getLogger().debug("failed to read jar file contents", e);
-            } finally {
-                closeFileSystem(resourceURI);
             }
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.server;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -623,6 +624,11 @@ public class VaadinServlet extends HttpServlet {
     @Override
     public void destroy() {
         super.destroy();
+        if(staticFileHandler instanceof final StaticFileServer staticFileServer) {
+            for(final URI resourceUri : StaticFileServer.openFileSystems.keySet()) {
+                staticFileServer.closeFileSystem(resourceUri);
+            }
+        }
         if (getService() != null) {
             getService().destroy();
         }

--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -246,6 +246,7 @@
         <module>test-common</module>
         <module>test-lumo</module>
         <module>test-express-build</module>
+      <module>test-embedded-jetty-12</module>
     </modules>
 
     <profiles>

--- a/flow-tests/test-embedded-jetty-12/pom.xml
+++ b/flow-tests/test-embedded-jetty-12/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>flow-tests</artifactId>
+    <groupId>com.vaadin</groupId>
+    <version>24.2-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>test-embedded-jetty-12</artifactId>
+  <packaging>jar</packaging>
+
+  <properties>
+    <maven.deploy.skip>true</maven.deploy.skip>
+
+    <jetty.version>12.0.0.beta1</jetty.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-bom</artifactId>
+        <version>${jetty.version}</version>
+
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.vaadin</groupId>
+      <artifactId>flow-test-resources</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.vaadin</groupId>
+      <artifactId>vaadin-dev-server</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-client</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-webapp</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+      <artifactId>jetty-ee10-websocket-jakarta-server</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/test/webapp</directory>
+        <targetPath>webapp</targetPath>
+      </resource>
+    </resources>
+
+    <plugins>
+      <plugin>
+        <groupId>com.vaadin</groupId>
+        <artifactId>flow-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/flow-tests/test-embedded-jetty-12/src/test/java/com/vaadin/flow/server/StaticFileServerTests.java
+++ b/flow-tests/test-embedded-jetty-12/src/test/java/com/vaadin/flow/server/StaticFileServerTests.java
@@ -1,0 +1,120 @@
+package com.vaadin.flow.server;
+
+import org.eclipse.jetty.client.ContentResponse;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.transport.HttpClientTransportOverHTTP;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.servlet.ServletHolder;
+import org.eclipse.jetty.ee10.webapp.WebAppContext;
+import org.eclipse.jetty.io.ClientConnector;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.SocketAddressResolver;
+import org.eclipse.jetty.util.resource.ResourceFactory;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.eclipse.jetty.util.thread.ScheduledExecutorScheduler;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+public final class StaticFileServerTests {
+
+  private Server server;
+
+  private ServerConnector connector;
+
+  private HttpClient client;
+
+  private void start() throws Exception {
+    startServer();
+    startClient();
+  }
+
+  private void startServer() throws Exception {
+    server = new Server(new QueuedThreadPool());
+    connector = new ServerConnector(server);
+
+    connector.setPort(0);
+
+    server.addConnector(connector);
+    server.setHandler(createContext());
+
+    server.start();
+  }
+
+  private ServletContextHandler createContext() {
+    final WebAppContext context = new WebAppContext();
+
+    context.setBaseResource(ResourceFactory.root().newResource(StaticFileServerTests.class.getResource("/webapp")));
+    context.setContextPath("/");
+    context.setExtractWAR(false);
+
+    final ServletHolder vaadinServletHolder = context.addServlet(VaadinServlet.class, "/*");
+
+    vaadinServletHolder.setInitOrder(1);
+    vaadinServletHolder.setInitParameter("pushMode", "automatic");
+
+    context.setAttribute("org.eclipse.jetty.server.webapp.ContainerIncludeJarPattern", ".*\\.jar|.*/classes/.*");
+    context.setConfigurationDiscovered(true);
+    context.setParentLoaderPriority(true);
+
+    return context;
+  }
+
+  private void startClient() throws Exception {
+    final ClientConnector connector = new ClientConnector();
+
+    connector.setSelectors(1);
+    connector.setExecutor(new QueuedThreadPool());
+    connector.setScheduler(new ScheduledExecutorScheduler("client-scheduler", false));
+
+    client = new HttpClient(new HttpClientTransportOverHTTP(connector));
+
+    client.setSocketAddressResolver(new SocketAddressResolver.Sync());
+
+    client.start();
+  }
+
+  @Test
+  public void serveJarResourceTwice() throws Exception {
+    start();
+
+    client.setConnectBlocking(true);
+
+    String content = null;
+
+    for(int i = 0; i < 2; i++) {
+      final ContentResponse response = client.GET("http://localhost:" + connector.getLocalPort() + "/VAADIN/static/push/vaadinPush.js");
+
+      Assert.assertNotNull(response);
+      Assert.assertEquals(200, response.getStatus());
+
+      if(content == null) {
+        content = response.getContentAsString();
+      } else {
+        Assert.assertEquals(content, response.getContentAsString());
+      }
+    }
+  }
+
+  @After
+  public void disposeClient() throws Exception
+  {
+    if(client != null) {
+      client.stop();
+
+      client = null;
+    }
+  }
+
+  @After
+  public void disposeServer() throws Exception
+  {
+    if(server != null) {
+      server.stop();
+
+      server = null;
+    }
+  }
+
+}


### PR DESCRIPTION
## Description

As we know, Vaadin 24 requires Servlet 6 under the new Jakarta namespace. Those using Jetty must upgrade to Jetty 12, which is currently in beta with a stable version about a month away. Jetty 12 introduced a new resource API which caused issues for Vaadin's static file server. Please see details in the linked issue.

Fixes https://github.com/vaadin/flow/issues/16908

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
<br/>
Thank you for the opportunity to contribute to Vaadin!

\- Oliver