### PR TITLE
fix: removed babel/plugin-proposal-object-rest-spread

### DIFF
--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -266,9 +266,6 @@ module.exports = {
         plugins: [
           // workaround for Safari 10 scope issue (https://bugs.webkit.org/show_bug.cgi?id=159270)
           "@babel/plugin-transform-block-scoping",
-
-          // Edge does not support spread '...' syntax in object literals (#7321)
-          "@babel/plugin-proposal-object-rest-spread"
         ],
 
         presetOptions: {


### PR DESCRIPTION
Removed 'babel/plugin-proposal-object-rest-spread' from 'webpack.generated.config.js'. Edge version starting from 79 has support for 'Spread in object literals' and therefore this babel plugin is not needed anymore. 'babel/plugin-proposal-object-rest-spread' was renamed to 'plugin-transform-object-rest-spread' which caused build issues.

Fixes: #16905