### PR TITLE
chore: upgrade jackson.version to 2.15.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,8 +89,8 @@
         <hibernate.validator.version>8.0.0.Final</hibernate.validator.version>
         <slf4j.version>2.0.7</slf4j.version>
         <polymer.version>2.6.1</polymer.version>
-        <jackson.version>2.15.1</jackson.version>
-        <jackson.databind.version>2.15.1</jackson.databind.version>
+        <jackson.version>2.15.2</jackson.version>
+        <jackson.databind.version>2.15.2</jackson.databind.version>
         <jakarta.validation.version>3.0.2</jakarta.validation.version>
         <jakarta.annotation.api.version>2.1.1</jakarta.annotation.api.version>
         <jaxb.version>4.0.2</jaxb.version>


### PR DESCRIPTION
2.15.1 is faulty version. as this reported issues. https://github.com/FasterXML/jackson-core/issues/1027

hilla is using this version as it was aligned from flow.

