### PR TITLE
fix: Move flow-server to provided scope

### DIFF
--- a/flow-plugins/flow-dev-bundle-plugin/pom.xml
+++ b/flow-plugins/flow-dev-bundle-plugin/pom.xml
@@ -18,6 +18,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-server</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <version>${maven.version}</version>

--- a/flow-plugins/flow-gradle-plugin/build.gradle
+++ b/flow-plugins/flow-gradle-plugin/build.gradle
@@ -65,6 +65,7 @@ dependencies {
     implementation('org.jetbrains.kotlin:kotlin-stdlib:1.7.20')
 
     implementation("com.vaadin:flow-plugin-base:${pom.parent.version}")
+    compileOnly("com.vaadin:flow-server:${pom.parent.version}")
 
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.jetbrains.kotlin:kotlin-test:1.7.20")

--- a/flow-plugins/flow-maven-plugin/pom.xml
+++ b/flow-plugins/flow-maven-plugin/pom.xml
@@ -18,6 +18,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-server</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <version>${maven.version}</version>

--- a/flow-plugins/flow-plugin-base/pom.xml
+++ b/flow-plugins/flow-plugin-base/pom.xml
@@ -16,6 +16,7 @@
             <groupId>com.vaadin</groupId>
             <artifactId>flow-server</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>


### PR DESCRIPTION
Move flow-server to provided scope
for plugin-base.
Gradle plugin now has flow-server
in the compileOnly scope so
that updating flow-server version
is simpler.
Both gradle and maven have now
easier update on flow-server version
when it is not dependent
on the released plugin.
