### PR TITLE
fix: Theme injection in Safari with polyfill

### DIFF
--- a/flow-server/src/main/resources/META-INF/frontend/theme-util.js
+++ b/flow-server/src/main/resources/META-INF/frontend/theme-util.js
@@ -1,5 +1,8 @@
 import stripCssComments from 'strip-css-comments';
 
+// Safari 15 - 16.3, polyfilled
+const polyfilledSafari = CSSStyleSheet.toString().includes('document.createElement');
+
 const createLinkReferences = (css, target) => {
   // Unresolved urls are written as '@import url(text);' or '@import "text";' to the css
   // media query can be present on @media tag or on @import directive after url
@@ -42,9 +45,23 @@ const createLinkReferences = (css, target) => {
   return styleCss;
 };
 
+const addAdoptedStyleSafariPolyfill = (sheet, target, first) => {
+  if (first) {
+    target.adoptedStyleSheets = [sheet, ...target.adoptedStyleSheets];
+  } else {
+    target.adoptedStyleSheets = [...target.adoptedStyleSheets, sheet];
+  }
+  return () => {
+    target.adoptedStyleSheets = target.adoptedStyleSheets.filter((ss) => ss !== sheet);
+  };
+};
+
 const addAdoptedStyle = (cssText, target, first) => {
   const sheet = new CSSStyleSheet();
   sheet.replaceSync(cssText);
+  if (polyfilledSafari) {
+    return addAdoptedStyleSafariPolyfill(sheet, target, first);
+  }
   if (first) {
     target.adoptedStyleSheets.splice(0, 0, sheet);
   } else {


### PR DESCRIPTION
The polyfill does not support push or splice, see https://github.com/calebdwilliams/construct-style-sheets/issues/124
