### PR TITLE
fix: store LastSeenServerSyncId in atmosphere resource session

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/LongPollingCacheFilter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/LongPollingCacheFilter.java
@@ -17,9 +17,11 @@
 package com.vaadin.flow.server.communication;
 
 import java.io.Serializable;
+import java.util.Optional;
 
 import org.atmosphere.cache.BroadcastMessage;
 import org.atmosphere.cpr.AtmosphereResource;
+import org.atmosphere.cpr.AtmosphereResourceSession;
 import org.atmosphere.cpr.BroadcasterCache;
 import org.atmosphere.cpr.PerRequestBroadcastFilter;
 import org.slf4j.Logger;
@@ -48,16 +50,32 @@ public class LongPollingCacheFilter
         return LoggerFactory.getLogger(LongPollingCacheFilter.class.getName());
     }
 
+    static void onConnect(AtmosphereResource resource) {
+        Integer syncId = Optional
+                .ofNullable(
+                        resource.getRequest().getHeader(SEEN_SERVER_SYNC_ID))
+                .map(Integer::parseInt).orElse(null);
+        if (resource.transport() == AtmosphereResource.TRANSPORT.LONG_POLLING
+                && syncId != null) {
+            AtmosphereResourceSession session = resource.getAtmosphereConfig()
+                    .sessionFactory().getSession(resource);
+            session.setAttribute(SEEN_SERVER_SYNC_ID, syncId);
+        }
+    }
+
     @Override
     public BroadcastAction filter(String broadcasterId, AtmosphereResource r,
             Object originalMessage, Object message) {
+        AtmosphereResourceSession session = r.getAtmosphereConfig()
+                .sessionFactory().getSession(r, false);
         if (originalMessage instanceof AtmospherePushConnection.PushMessage
                 && r.transport() == AtmosphereResource.TRANSPORT.LONG_POLLING
-                && r.getRequest().getHeader(SEEN_SERVER_SYNC_ID) != null) {
+                && session != null
+                && session.getAttribute(SEEN_SERVER_SYNC_ID) != null) {
             AtmospherePushConnection.PushMessage pushMessage = (AtmospherePushConnection.PushMessage) originalMessage;
             String uuid = r.uuid();
-            int lastSeenOnClient = Integer
-                    .parseInt(r.getRequest().getHeader(SEEN_SERVER_SYNC_ID));
+            int lastSeenOnClient = session.getAttribute(SEEN_SERVER_SYNC_ID,
+                    Integer.class);
             if (pushMessage.alreadySeen(lastSeenOnClient)) {
                 getLogger().trace(
                         "Discarding message {} for resource {} as client already seen {}. {}",

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PushHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PushHandler.java
@@ -568,6 +568,7 @@ public class PushHandler {
                             .ifPresent(liveReload -> liveReload
                                     .onConnect(resource)));
         } else {
+            LongPollingCacheFilter.onConnect(resource);
             callWithUi(resource, establishCallback);
         }
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/LongPollingCacheFilterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/LongPollingCacheFilterTest.java
@@ -19,13 +19,17 @@ package com.vaadin.flow.server.communication;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import org.atmosphere.cpr.AtmosphereConfig;
+import org.atmosphere.cpr.AtmosphereFramework;
 import org.atmosphere.cpr.AtmosphereRequest;
 import org.atmosphere.cpr.AtmosphereResource;
+import org.atmosphere.cpr.AtmosphereResourceSessionFactory;
 import org.atmosphere.cpr.BroadcastFilter.BroadcastAction;
 import org.atmosphere.cpr.BroadcastFilter.BroadcastAction.ACTION;
 import org.atmosphere.cpr.Broadcaster;
 import org.atmosphere.cpr.BroadcasterCache;
 import org.atmosphere.cpr.BroadcasterConfig;
+import org.atmosphere.cpr.DefaultAtmosphereResourceSessionFactory;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -140,9 +144,14 @@ public class LongPollingCacheFilterTest {
                 .thenReturn(broadcasterConfig);
         Mockito.when(broadcasterConfig.getBroadcasterCache()).thenReturn(cache);
 
+        AtmosphereResourceSessionFactory sessionFactory = new DefaultAtmosphereResourceSessionFactory();
+        AtmosphereConfig config = Mockito.mock(AtmosphereConfig.class);
+        Mockito.when(config.sessionFactory()).thenReturn(sessionFactory);
+
         Mockito.when(resource.getBroadcaster()).thenReturn(broadcaster);
         Mockito.when(resource.getRequest()).thenReturn(request);
         Mockito.when(resource.uuid()).thenReturn(RESOURCE_UUID);
+        Mockito.when(resource.getAtmosphereConfig()).thenReturn(config);
     }
 
     private void setTransport(AtmosphereResource.TRANSPORT transport) {
@@ -154,7 +163,7 @@ public class LongPollingCacheFilterTest {
                 .getHeader(LongPollingCacheFilter.SEEN_SERVER_SYNC_ID))
                 .thenReturn(Integer.toString(id), IntStream.of(ids)
                         .mapToObj(Integer::toString).toArray(String[]::new));
-
+        LongPollingCacheFilter.onConnect(resource);
     }
 
     private void verifyMessageIsNotCached() {


### PR DESCRIPTION
## Description

Storing the header value in AtmosphereResource session should prevent issues with long polling and servlet container that recycles requests. This change stores in the resource session the value got from client during connection so that it will be available even if the underliyng request gets nullified.

Part of #16968
Part of #16775

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
