### PR TITLE
chore: Add 9.2.0 as unsupported npm version

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -107,6 +107,9 @@ public class FrontendTools {
             + FrontendUtils.DISABLE_CHECK //
             + MSG_SUFFIX;
 
+    private static final List<FrontendVersion> BAD_NPM_VERSIONS = Collections
+            .singletonList(new FrontendVersion("9.2.0"));
+
     private static final FrontendVersion WHITESPACE_ACCEPTING_NPM_VERSION = new FrontendVersion(
             7, 0);
 
@@ -624,6 +627,7 @@ public class FrontendTools {
                     getNpmExecutable(false).get(0));
             FrontendUtils.validateToolVersion("npm", foundNpmVersion,
                     SUPPORTED_NPM_VERSION);
+            checkForFaultyNpmVersion(foundNpmVersion);
         } catch (UnknownVersionException e) {
             getLogger().warn("Error checking if npm is new enough", e);
         }
@@ -697,6 +701,15 @@ public class FrontendTools {
         proxyList.addAll(readProxySettingsFromEnvironmentVariables());
 
         return proxyList;
+    }
+
+    void checkForFaultyNpmVersion(FrontendVersion npmVersion) {
+        if (BAD_NPM_VERSIONS.contains(npmVersion)) {
+            String badNpmVersion = buildBadVersionString("npm",
+                    npmVersion.getFullVersion(),
+                    "by updating your global npm installation with `npm install -g npm@latest`");
+            throw new IllegalStateException(badNpmVersion);
+        }
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -17,13 +17,13 @@ package com.vaadin.flow.server.frontend;
 
 import static com.vaadin.flow.server.frontend.FrontendTools.NPM_BIN_PATH;
 import static com.vaadin.flow.testutil.FrontendStubs.createStubNode;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
@@ -51,7 +51,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
-import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.function.SerializableSupplier;
 import com.vaadin.flow.internal.Pair;
@@ -61,6 +60,9 @@ import com.vaadin.flow.testcategory.SlowTests;
 import com.vaadin.flow.testutil.FrontendStubs;
 
 import net.jcip.annotations.NotThreadSafe;
+import org.slf4j.LoggerFactory;
+
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @NotThreadSafe
 @Category(SlowTests.class)
@@ -432,6 +434,11 @@ public class FrontendToolsTest {
         tools.getNpmExecutable();
 
         Assert.assertFalse(file.exists());
+    }
+
+    @Test
+    public void knownFaultyNpmVersionThrowsException() {
+        assertFaultyNpmVersion(new FrontendVersion(9, 2, 0));
     }
 
     @Test
@@ -880,6 +887,38 @@ public class FrontendToolsTest {
         assertThat(npmExecutable.get(0), containsString(path.get()));
         assertThat(npmExecutable.get(0), containsString(DEFAULT_NODE));
         assertThat(npmExecutable.get(1), containsString(NPM_CLI_STRING));
+    }
+
+    private void assertFaultyNpmVersion(FrontendVersion version) {
+        try {
+            tools.checkForFaultyNpmVersion(version);
+            Assert.fail("No exception was thrown for bad npm version");
+        } catch (IllegalStateException e) {
+            Assert.assertTrue(
+                    "Faulty version " + version.getFullVersion()
+                            + " returned wrong exception message",
+                    e.getMessage()
+                            .contains("Your installed 'npm' version ("
+                                    + version.getFullVersion()
+                                    + ") is known to have problems."));
+        }
+    }
+
+    private void createFakePnpm(String defaultPnpmVersion) throws Exception {
+        final String npxPath = NPM_BIN_PATH + "npx-cli.js";
+        File npxJs = new File(baseDir, npxPath);
+        FileUtils.forceMkdir(npxJs.getParentFile());
+
+        FileWriter fileWriter = new FileWriter(npxJs);
+        try {
+            fileWriter.write(
+                    "pnpmVersion = process.argv.filter(a=>a.startsWith('pnpm')).map(a=>a.substring(5))[0] || '"
+                            + defaultPnpmVersion + "'\n"
+                            + "if (process.argv.includes('--version') || process.argv.includes('-v')) {\n"
+                            + "    console.log(pnpmVersion);\n" + "}\n");
+        } finally {
+            fileWriter.close();
+        }
     }
 
     private void installGlobalPnpm(String pnpmVersion) {


### PR DESCRIPTION
Add check for known bad npm
version so that the user
knows to update if using that
exact version.
