### PR TITLE
fix: add addCssBlock function when needed

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -66,6 +66,10 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.FRONTEND_FOLDER_ALIA
  */
 abstract class AbstractUpdateImports implements Runnable {
 
+    private static final String CSS_PREPARE = "function addCssBlock(block) {\n"
+            + " const tpl = document.createElement('template');\n"
+            + " tpl.innerHTML = block;\n"
+            + " document.head.appendChild(tpl.content);\n" + "}";
     private static final String IMPORT_INJECT = "import { injectGlobalCss } from 'Frontend/generated/jar-resources/theme-util.js';\n";
 
     private static final String CSS_IMPORT = "import $cssFromFile_%d from '%s';%n";
@@ -653,6 +657,9 @@ abstract class AbstractUpdateImports implements Runnable {
             addLines(lines, String.format(REGISTER_STYLES_FOR_TEMPLATE, i,
                     cssImport, themeFor, optionals));
         } else if (cssData.getInclude() != null) {
+            if (!lines.contains("function addCssBlock(block) {")) {
+                addLines(lines, CSS_PREPARE);
+            }
             String include = cssData.getInclude() != null
                     ? " include=\"" + cssData.getInclude() + "\""
                     : "";

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdateImportsTest.java
@@ -136,6 +136,7 @@ public abstract class AbstractNodeUpdateImportsTest extends NodeUpdateTestUtil {
                 "injectGlobalCss($cssFromFile_0.toString(), 'CSSImport end', document);");
         expectedLines.add(
                 "injectGlobalCss($cssFromFile_1.toString(), 'CSSImport end', document);");
+        expectedLines.add("function addCssBlock(block) {");
         expectedLines.add(
                 "addCssBlock(`<style include=\"bar\">${$css_2}</style>`);");
         expectedLines.add("registerStyles('', $css_3, {moduleId: 'baz'});");


### PR DESCRIPTION
The addCssBlock function
should be added when ever
a cssimport with inclue is added

Fixes #16979
