### PR TITLE
fix: changed suggested classname to dash-case

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/shared/util/SharedUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/util/SharedUtil.java
@@ -292,7 +292,7 @@ public class SharedUtil implements Serializable {
      *
      * @param camelCaseString
      *            The input string in camelCase format
-     * @return A human friendly version of the input
+     * @return A dash separated version of the input
      */
     public static String camelCaseToDashSeparated(String camelCaseString) {
         if (camelCaseString == null) {
@@ -311,23 +311,27 @@ public class SharedUtil implements Serializable {
     }
 
     /**
-     * Converts a UpperCamelCase string into dash ("-") separated.
+     * Converts a UpperCamelCase string into dash ("-") separated lowercase.
      * <p>
      * Examples:
      * <p>
      * {@literal foo} becomes {@literal foo} {@literal fooBar} becomes
      * {@literal foo-bar} {@literal MyBeanContainer} becomes
      * {@literal my-bean-container} {@literal AwesomeURLFactory} becomes
-     * {@literal awesome-uRL-factory} {@literal someUriAction} becomes
+     * {@literal awesome-url-factory} {@literal someUriAction} becomes
      * {@literal some-uri-action}
      *
      * @param upperCamelCaseString
      *            The input string in UpperCamelCase format
-     * @return A human friendly version of the input
+     * @return A dash separated lowercase version of the input
      */
-    public static String upperCamelCaseToDashSeparated(
+    public static String upperCamelCaseToDashSeparatedLowerCase(
             String upperCamelCaseString) {
-        return camelCaseToDashSeparated(firstToLower(upperCamelCaseString));
+        if (upperCamelCaseString == null) {
+            return null;
+        }
+        return camelCaseToDashSeparated(firstToLower(upperCamelCaseString))
+                .toLowerCase();
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/shared/util/SharedUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/util/SharedUtil.java
@@ -311,6 +311,26 @@ public class SharedUtil implements Serializable {
     }
 
     /**
+     * Converts a UpperCamelCase string into dash ("-") separated.
+     * <p>
+     * Examples:
+     * <p>
+     * {@literal foo} becomes {@literal foo} {@literal fooBar} becomes
+     * {@literal foo-bar} {@literal MyBeanContainer} becomes
+     * {@literal my-bean-container} {@literal AwesomeURLFactory} becomes
+     * {@literal awesome-uRL-factory} {@literal someUriAction} becomes
+     * {@literal some-uri-action}
+     *
+     * @param upperCamelCaseString
+     *            The input string in UpperCamelCase format
+     * @return A human friendly version of the input
+     */
+    public static String upperCamelCaseToDashSeparated(
+            String upperCamelCaseString) {
+        return camelCaseToDashSeparated(firstToLower(upperCamelCaseString));
+    }
+
+    /**
      * Prepend the given url with the prefix if it is not absolute and doesn't
      * have a protocol.
      *

--- a/flow-server/src/test/java/com/vaadin/flow/shared/util/SharedUtilTests.java
+++ b/flow-server/src/test/java/com/vaadin/flow/shared/util/SharedUtilTests.java
@@ -128,24 +128,25 @@ public class SharedUtilTests {
     }
 
     @Test
-    public void upperCamelCaseToDashSeparated() {
+    public void upperCamelCaseToDashSeparatedLowerCase() {
         Assert.assertEquals(null,
-                SharedUtil.upperCamelCaseToDashSeparated(null));
-        Assert.assertEquals("", SharedUtil.upperCamelCaseToDashSeparated(""));
+                SharedUtil.upperCamelCaseToDashSeparatedLowerCase(null));
+        Assert.assertEquals("",
+                SharedUtil.upperCamelCaseToDashSeparatedLowerCase(""));
         Assert.assertEquals("foo",
-                SharedUtil.upperCamelCaseToDashSeparated("foo"));
+                SharedUtil.upperCamelCaseToDashSeparatedLowerCase("foo"));
         Assert.assertEquals("foo-bar",
-                SharedUtil.upperCamelCaseToDashSeparated("fooBar"));
+                SharedUtil.upperCamelCaseToDashSeparatedLowerCase("fooBar"));
         Assert.assertEquals("foo--bar",
-                SharedUtil.upperCamelCaseToDashSeparated("foo--bar"));
+                SharedUtil.upperCamelCaseToDashSeparatedLowerCase("foo--bar"));
         Assert.assertEquals("foo-bar-baz",
-                SharedUtil.upperCamelCaseToDashSeparated("fooBarBaz"));
-        Assert.assertEquals("my-bean-container",
-                SharedUtil.upperCamelCaseToDashSeparated("MyBeanContainer"));
-        Assert.assertEquals("awesome-uRL-factory",
-                SharedUtil.upperCamelCaseToDashSeparated("AwesomeURLFactory"));
-        Assert.assertEquals("some-uri-action",
-                SharedUtil.upperCamelCaseToDashSeparated("someUriAction"));
+                SharedUtil.upperCamelCaseToDashSeparatedLowerCase("fooBarBaz"));
+        Assert.assertEquals("my-bean-container", SharedUtil
+                .upperCamelCaseToDashSeparatedLowerCase("MyBeanContainer"));
+        Assert.assertEquals("awesome-url-factory", SharedUtil
+                .upperCamelCaseToDashSeparatedLowerCase("AwesomeURLFactory"));
+        Assert.assertEquals("some-uri-action", SharedUtil
+                .upperCamelCaseToDashSeparatedLowerCase("someUriAction"));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/shared/util/SharedUtilTests.java
+++ b/flow-server/src/test/java/com/vaadin/flow/shared/util/SharedUtilTests.java
@@ -128,6 +128,27 @@ public class SharedUtilTests {
     }
 
     @Test
+    public void upperCamelCaseToDashSeparated() {
+        Assert.assertEquals(null,
+                SharedUtil.upperCamelCaseToDashSeparated(null));
+        Assert.assertEquals("", SharedUtil.upperCamelCaseToDashSeparated(""));
+        Assert.assertEquals("foo",
+                SharedUtil.upperCamelCaseToDashSeparated("foo"));
+        Assert.assertEquals("foo-bar",
+                SharedUtil.upperCamelCaseToDashSeparated("fooBar"));
+        Assert.assertEquals("foo--bar",
+                SharedUtil.upperCamelCaseToDashSeparated("foo--bar"));
+        Assert.assertEquals("foo-bar-baz",
+                SharedUtil.upperCamelCaseToDashSeparated("fooBarBaz"));
+        Assert.assertEquals("my-bean-container",
+                SharedUtil.upperCamelCaseToDashSeparated("MyBeanContainer"));
+        Assert.assertEquals("awesome-uRL-factory",
+                SharedUtil.upperCamelCaseToDashSeparated("AwesomeURLFactory"));
+        Assert.assertEquals("some-uri-action",
+                SharedUtil.upperCamelCaseToDashSeparated("someUriAction"));
+    }
+
+    @Test
     public void methodUppercaseWithTurkishLocale() {
         Locale defaultLocale = Locale.getDefault();
         try {

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/JavaSourceModifier.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/JavaSourceModifier.java
@@ -266,9 +266,10 @@ public class JavaSourceModifier extends Editor {
                 Component component = getComponent(session, uiId, nodeId);
                 ComponentTracker.Location createLocation = getCreateLocation(
                         component);
-                String fileName = SharedUtil.upperCamelCaseToDashSeparated(
-                        createLocation.filename().substring(0,
-                                createLocation.filename().indexOf(".")));
+                String fileName = SharedUtil
+                        .upperCamelCaseToDashSeparatedLowerCase(createLocation
+                                .filename().substring(0, createLocation
+                                        .filename().indexOf(".")));
                 String tagName = component.getElement().getTag()
                         .replace("vaadin-", "");
 

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/JavaSourceModifier.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/JavaSourceModifier.java
@@ -25,6 +25,7 @@ import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.server.VaadinContext;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.startup.ApplicationConfiguration;
+import com.vaadin.flow.shared.util.SharedUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -265,8 +266,9 @@ public class JavaSourceModifier extends Editor {
                 Component component = getComponent(session, uiId, nodeId);
                 ComponentTracker.Location createLocation = getCreateLocation(
                         component);
-                String fileName = createLocation.filename().substring(0,
-                        createLocation.filename().indexOf("."));
+                String fileName = SharedUtil.upperCamelCaseToDashSeparated(
+                        createLocation.filename().substring(0,
+                                createLocation.filename().indexOf(".")));
                 String tagName = component.getElement().getTag()
                         .replace("vaadin-", "");
 

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/themeeditor/JavaSourceModifierTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/themeeditor/JavaSourceModifierTest.java
@@ -176,7 +176,7 @@ public class JavaSourceModifierTest extends AbstractThemeEditorTest {
         Assert.assertNotNull(suggestedClassName);
         // suggested classname is derived from tag; span is used in mocks
         // because TextField is not available
-        Assert.assertEquals("TestView-span-1", suggestedClassName);
+        Assert.assertEquals("test-view-span-1", suggestedClassName);
 
         // set suggested classname
         modifier.setLocalClassName(0, nodeId, suggestedClassName);
@@ -193,7 +193,7 @@ public class JavaSourceModifierTest extends AbstractThemeEditorTest {
         // suggest new classname
         suggestedClassName = modifier.getSuggestedClassName(0, nodeId);
         Assert.assertNotNull(suggestedClassName);
-        Assert.assertEquals("TestView-span-2", suggestedClassName);
+        Assert.assertEquals("test-view-span-2", suggestedClassName);
 
         // update suggested classname
         modifier.setLocalClassName(0, nodeId, suggestedClassName);

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/themeeditor/ThemeEditorMessageHandlerTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/themeeditor/ThemeEditorMessageHandlerTest.java
@@ -115,7 +115,7 @@ public class ThemeEditorMessageHandlerTest extends AbstractThemeEditorTest {
         Assert.assertTrue(metadataResponse.isAccessible());
         Assert.assertNull(metadataResponse.getClassName());
         Assert.assertNotNull(metadataResponse.getSuggestedClassName());
-        Assert.assertEquals("TestView-span-1",
+        Assert.assertEquals("test-view-span-1",
                 metadataResponse.getSuggestedClassName());
     }
 


### PR DESCRIPTION
## Description

Changed suggested classname prefix from UpperCamelCase to lower-dash-case.

<img width="500" alt="image" src="https://github.com/vaadin/flow/assets/106965834/dc1e740f-c922-48c6-a70a-120ed1a6416c">


Fixes #16865

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
