### PR TITLE
feat: Add Platform.getHillaVersion()

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/Platform.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Platform.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.server;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.util.Optional;
+import java.util.Properties;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -57,6 +58,28 @@ public class Platform implements Serializable {
                     .error("Unable to determine version information", e);
         }
 
+        return Optional.empty();
+    }
+
+    /**
+     * Returns Hilla version.
+     *
+     * @return Hilla version if Hilla is on the classpath; null if Hilla is not
+     *         on the classpath.
+     */
+    public static Optional<String> getHillaVersion() {
+        try (final InputStream hillaPomProperties = Thread.currentThread()
+                .getContextClassLoader().getResourceAsStream(
+                        "META-INF/maven/dev.hilla/hilla/pom.properties")) {
+            if (hillaPomProperties != null) {
+                final Properties properties = new Properties();
+                properties.load(hillaPomProperties);
+                return Optional.of(properties.getProperty("version"));
+            }
+        } catch (Exception e) {
+            LoggerFactory.getLogger(Platform.class)
+                    .error("Unable to determine Hilla version", e);
+        }
         return Optional.empty();
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/PlatformTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/PlatformTest.java
@@ -1,0 +1,67 @@
+package com.vaadin.flow.server;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class PlatformTest {
+    private ClassLoader oldContextClassLoader;
+
+    @Rule
+    public TemporaryFolder temporary = new TemporaryFolder();
+
+    @Before
+    public void rememberContextClassLoader() {
+        oldContextClassLoader = Thread.currentThread().getContextClassLoader();
+    }
+
+    @After
+    public void restoreContextClassLoader() {
+        Thread.currentThread().setContextClassLoader(oldContextClassLoader);
+    }
+
+    private void fakeHilla(String hillaVersion) throws IOException {
+        if (hillaVersion == null) {
+            Thread.currentThread().setContextClassLoader(oldContextClassLoader);
+            return;
+        }
+        final Path hillaJar = temporary.newFolder().toPath();
+        final Path pomProperties = hillaJar
+                .resolve("META-INF/maven/dev.hilla/hilla/pom.properties");
+        Files.createDirectories(pomProperties.getParent());
+        Files.writeString(pomProperties, "version=" + hillaVersion);
+        final URLClassLoader classLoader = new URLClassLoader(
+                new URL[] { hillaJar.toUri().toURL() }, oldContextClassLoader);
+        Thread.currentThread().setContextClassLoader(classLoader);
+    }
+
+    @Test
+    public void testGetVaadinVersionReturnsNullWhenVaadinNotOnClasspath() {
+        assertNull(Platform.getVaadinVersion().orElse(null));
+    }
+
+    @Test
+    public void testGetHillaVersionReturnsNullWhenHillaNotOnClasspath() {
+        assertNull(Platform.getHillaVersion().orElse(null));
+    }
+
+    @Test
+    public void testGetHillaVersionReturnsVersionWhenHillaOnClasspath()
+            throws Exception {
+        fakeHilla("2.1.0");
+        assertEquals("2.1.0", Platform.getHillaVersion().orElse(null));
+        fakeHilla("2.0.6");
+        assertEquals("2.0.6", Platform.getHillaVersion().orElse(null));
+    }
+}


### PR DESCRIPTION
## Description

Adds the counterpart of `Platform.getVaadinVersion()` which detects Hilla version (if Hilla is on classpath). Works also with hybrid apps where both Vaadin and Hilla is on the classpath.

New feature, no flow issue assigned.

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
