### PR TITLE
test: fix flakyness in FrontendLiveReloadIT

### DIFF
--- a/flow-tests/test-live-reload/src/test/java/com/vaadin/flow/uitest/ui/AbstractLiveReloadIT.java
+++ b/flow-tests/test-live-reload/src/test/java/com/vaadin/flow/uitest/ui/AbstractLiveReloadIT.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.uitest.ui;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.StaleElementReferenceException;
 
 import com.vaadin.flow.testutil.ChromeDeviceTest;
 
@@ -42,8 +43,12 @@ public abstract class AbstractLiveReloadIT extends ChromeDeviceTest {
 
     protected void waitForLiveReload() {
         waitUntil(d -> {
-            final String newViewId = getAttachId();
-            return !initialAttachId.equals(newViewId);
+            try {
+                final String newViewId = getAttachId();
+                return !initialAttachId.equals(newViewId);
+            } catch (StaleElementReferenceException ex) {
+                return false;
+            }
         });
     }
 


### PR DESCRIPTION
While waiting for live reload, the searched element may become stale before being able to get its attributes.
Catching the exception allows the test to continue and succeed once the reload is completed.
