### PR TITLE
fix: do not have server sources in client

### DIFF
--- a/flow-client/pom.xml
+++ b/flow-client/pom.xml
@@ -56,6 +56,19 @@
             <groupId>com.vaadin</groupId>
             <artifactId>flow-server</artifactId>
             <version>${project.version}</version>
+            <classifier>sources</classifier>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.vaadin.servletdetector</groupId>
+                    <artifactId>throw-if-servlet3</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-server</artifactId>
+            <version>${project.version}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -181,9 +194,6 @@
                     <include>version.txt</include>
                 </includes>
                 <filtering>true</filtering>
-            </resource>
-            <resource>
-                <directory>../flow-server/src/main/java</directory>
             </resource>
         </resources>
 


### PR DESCRIPTION
add flow-server sources as
a sources dependency instead
of a src resource.

Closes #17020
