### PR TITLE
chore: stop collecting stats for build process sub-parts

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -213,7 +213,6 @@ public class TaskRunNpmInstall implements FallibleCommand {
     private void runNpmInstall() throws ExecutionFailedException {
         // Do possible cleaning before generating any new files.
         cleanUp();
-        long startTime = System.currentTimeMillis();
 
         Logger logger = packageUpdater.log();
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -33,7 +33,6 @@ import org.slf4j.Logger;
 
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.ExecutionFailedException;
-import com.vaadin.flow.server.Platform;
 import com.vaadin.flow.shared.util.SharedUtil;
 
 import elemental.json.JsonObject;
@@ -53,45 +52,6 @@ import static com.vaadin.flow.server.frontend.NodeUpdater.PROJECT_FOLDER;
  */
 public class TaskRunNpmInstall implements FallibleCommand {
 
-    /** Container for npm installation statistics. */
-    public static class Stats {
-        private long installTimeMs = 0;
-        private long cleanupTimeMs = 0;
-        private String packageManager = "";
-
-        /** Create an instance. */
-        private Stats() {
-        }
-
-        /**
-         * Gets the time spent running {@code npm install}.
-         *
-         * @return the time in milliseconds
-         */
-        public long getInstallTimeMs() {
-            return installTimeMs;
-        }
-
-        /**
-         * Gets the time spent doing cleanup before {@code npm install}.
-         *
-         * @return the time in milliseconds
-         */
-        public long getCleanupTimeMs() {
-            return cleanupTimeMs;
-        }
-
-        /**
-         * Gets the package manager used for installation.
-         *
-         * @return the name of the package manager
-         */
-        public String getPackageManager() {
-            return packageManager;
-        }
-
-    }
-
     private static final String MODULES_YAML = ".modules.yaml";
 
     private static final String NPM_VALIDATION_FAIL_MESSAGE = "%n%n======================================================================================================"
@@ -110,8 +70,6 @@ public class TaskRunNpmInstall implements FallibleCommand {
             + "%n 4) Deleting the following files from your Vaadin project's folder (if present):"
             + "%n        node_modules, package-lock.json, webpack.generated.js, pnpm-lock.yaml, pnpmfile.js"
             + "%n======================================================================================================%n";
-
-    private static Stats lastInstallStats = new Stats();
 
     private final NodeUpdater packageUpdater;
 
@@ -450,10 +408,6 @@ public class TaskRunNpmInstall implements FallibleCommand {
                         e);
             }
         }
-        lastInstallStats.installTimeMs = System.currentTimeMillis() - startTime;
-        lastInstallStats.packageManager = options.isEnablePnpm() ? "pnpm"
-                : "npm";
-
     }
 
     private File getPackageJsonForModule(String module) {
@@ -588,10 +542,8 @@ public class TaskRunNpmInstall implements FallibleCommand {
 
     private void cleanUp() throws ExecutionFailedException {
         if (!options.getNodeModulesFolder().exists()) {
-            lastInstallStats.cleanupTimeMs = 0;
             return;
         }
-        long startTime = System.currentTimeMillis();
 
         if (options.isCiBuild()) {
             deleteNodeModules(options.getNodeModulesFolder());
@@ -614,7 +566,6 @@ public class TaskRunNpmInstall implements FallibleCommand {
                 }
             }
         }
-        lastInstallStats.cleanupTimeMs = System.currentTimeMillis() - startTime;
     }
 
     private void deleteNodeModules(File nodeModulesFolder)
@@ -648,14 +599,4 @@ public class TaskRunNpmInstall implements FallibleCommand {
                     String.format(NPM_VALIDATION_FAIL_MESSAGE));
         }
     }
-
-    /**
-     * Returns timing information for the last operation.
-     *
-     * @return timing information
-     */
-    public static Stats getLastInstallStats() {
-        return lastInstallStats;
-    }
-
 }

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
@@ -58,8 +58,6 @@ import com.vaadin.flow.server.VaadinResponse;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.frontend.FrontendTools;
 import com.vaadin.flow.server.frontend.FrontendUtils;
-import com.vaadin.flow.server.frontend.TaskRunNpmInstall;
-import com.vaadin.flow.server.frontend.TaskRunNpmInstall.Stats;
 import com.vaadin.flow.server.startup.ApplicationConfiguration;
 
 import jakarta.servlet.ServletOutputStream;
@@ -221,24 +219,6 @@ public abstract class AbstractDevServerRunner implements DevModeHandler {
 
             long ms = (System.nanoTime() - start) / 1000000;
             getLogger().info("Started {}. Time: {}ms", getServerName(), ms);
-            Stats npmStats = TaskRunNpmInstall.getLastInstallStats();
-            if (npmStats.getInstallTimeMs() != 0) {
-                DevModeUsageStatistics.collectEvent(
-                        StatisticsConstants.EVENT_PACKAGEMANAGER_INSTALL_TIME_PREFIX
-                                + npmStats.getPackageManager(),
-                        npmStats.getInstallTimeMs());
-            }
-            if (npmStats.getCleanupTimeMs() != 0) {
-                DevModeUsageStatistics.collectEvent(
-                        StatisticsConstants.EVENT_PACKAGEMANAGER_CLEANUP_TIME_PREFIX
-                                + npmStats.getPackageManager(),
-                        npmStats.getCleanupTimeMs());
-            }
-
-            DevModeUsageStatistics.collectEvent(
-                    StatisticsConstants.EVENT_DEV_SERVER_START_PREFIX
-                            + getServerName(),
-                    ms);
         } finally {
             if (devServerProcess.get() == null) {
                 removeRunningDevServerPort();

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/stats/StatisticsConstants.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/stats/StatisticsConstants.java
@@ -29,9 +29,6 @@ public class StatisticsConstants {
      * Event tracking identifiers.
      */
     public static final String EVENT_LIVE_RELOAD = "liveReload";
-    public static final String EVENT_DEV_SERVER_START_PREFIX = "startDevserver";
-    public static final String EVENT_PACKAGEMANAGER_INSTALL_TIME_PREFIX = "packageManagerInstall";
-    public static final String EVENT_PACKAGEMANAGER_CLEANUP_TIME_PREFIX = "packageManagerCleanup";
 
     /*
      * Name of the default JSON file containing all the statistics.


### PR DESCRIPTION
Remove and stop collecting data for sub-parts of the build process: startDevserverWebpack(_count/min/max/avg)
packageManagerInstall(_count/min/max/avg)
packageManagerCleanup(_count/min/max/avg)
packageManagerInstallnpm(_count/min/max/avg)

These measurements measure an unknown percentage of the total build time. We have not been able to use them for useful decision-making.
