### PR TITLE
feat: DevModeUsageStatistics: track MachineId as well

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/stats/DevModeUsageStatistics.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/stats/DevModeUsageStatistics.java
@@ -19,6 +19,7 @@ package com.vaadin.base.devserver.stats;
 import java.io.File;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.vaadin.pro.licensechecker.MachineId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -113,6 +114,8 @@ public class DevModeUsageStatistics {
                     ProjectHelpers.getProKey());
             globalData.setValue(StatisticsConstants.FIELD_USER_KEY,
                     ProjectHelpers.getUserKey());
+            globalData.setValue(StatisticsConstants.FIELD_MACHINE_ID,
+                    MachineId.get());
 
             // Update basic project statistics and save
             projectData.setValue(StatisticsConstants.FIELD_FLOW_VERSION,

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/stats/StatisticsConstants.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/stats/StatisticsConstants.java
@@ -57,6 +57,7 @@ public class StatisticsConstants {
     static final String FIELD_SOURCE_ID = "sourceId";
     static final String FIELD_PROKEY = "proKey";
     static final String FIELD_USER_KEY = "userKey";
+    static final String FIELD_MACHINE_ID = "machineId";
     static final String FIELD_PROJECTS = "projects";
     static final String VAADIN_PROJECT_SOURCE_TEXT = "Vaadin project from";
     static final String PROJECT_SOURCE_TEXT = "Project from";

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/stats/DevModeUsageStatisticsTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/stats/DevModeUsageStatisticsTest.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.vaadin.flow.testutil.TestUtils;
 
+import com.vaadin.pro.licensechecker.MachineId;
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -270,6 +271,17 @@ public class DevModeUsageStatisticsTest extends AbstractStatisticsTest {
                                                       // default
                                                       // id in both
                                                       // cases
+    }
+
+    @Test
+    public void machineId() throws Exception {
+        File mavenProjectFolder = TestUtils
+                .getTestFolder("stats-data/maven-project-folder1");
+        DevModeUsageStatistics.init(mavenProjectFolder, storage, sender);
+
+        final ObjectNode project = storage.read();
+        Assert.assertEquals(MachineId.get(),
+                project.get(StatisticsConstants.FIELD_MACHINE_ID).asText());
     }
 
     private static JsonObject wrapStats(String data) {


### PR DESCRIPTION
## Description

Add machineId to the reported stats. This allows us to connect the data to license data. Related to MAU.

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
