### PR TITLE
fix: fix property detection for generic return type

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/AbstractBeanPropertyDefinition.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/AbstractBeanPropertyDefinition.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.data.binder;
 
 import java.beans.PropertyDescriptor;
+import java.lang.reflect.TypeVariable;
 
 import com.vaadin.flow.internal.ReflectTools;
 import com.vaadin.flow.shared.util.SharedUtil;
@@ -56,7 +57,6 @@ public abstract class AbstractBeanPropertyDefinition<T, V>
         this.propertySet = propertySet;
         this.propertyHolderType = propertyHolderType;
         this.descriptor = descriptor;
-
         if (descriptor.getReadMethod() == null) {
             throw new IllegalArgumentException(
                     "Bean property has no accessible getter: "
@@ -70,6 +70,12 @@ public abstract class AbstractBeanPropertyDefinition<T, V>
     public Class<V> getType() {
         return (Class<V>) ReflectTools
                 .convertPrimitiveType(descriptor.getPropertyType());
+    }
+
+    @Override
+    public boolean isGenericType() {
+        return descriptor.getReadMethod()
+                .getGenericReturnType() instanceof TypeVariable<?>;
     }
 
     @Override

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/BeanPropertySet.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/BeanPropertySet.java
@@ -335,7 +335,8 @@ public class BeanPropertySet<T> implements PropertySet<T> {
 
     private PropertyDefinition<T, ?> mergePropertyDefinitions(
             PropertyDefinition<T, ?> def1, PropertyDefinition<T, ?> def2) {
-        if (!def1.getType().equals(def2.getType())) {
+        if (!def1.getType().equals(def2.getType())
+                && !(def1.isGenericType() || def2.isGenericType())) {
             throw new IllegalStateException(String.format(
                     "Two property definition for property %s are discovered with different types: %s and %s",
                     def1.getName(), def1.getType(), def2.getType()));
@@ -347,7 +348,7 @@ public class BeanPropertySet<T> implements PropertySet<T> {
                     def1.getName(), def1.getPropertyHolderType(),
                     def2.getPropertyHolderType()));
         }
-        return def1;
+        return def1.isGenericType() ? def2 : def1;
     }
 
     private BeanPropertySet(InstanceKey<T> instanceKey,

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/PropertyDefinition.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/PropertyDefinition.java
@@ -55,6 +55,15 @@ public interface PropertyDefinition<T, V> extends Serializable {
     Class<V> getType();
 
     /**
+     * Gets whether the type of this property references a generic type (thus
+     * {@link #getType()} will return {@link Object}) or a concrete type.
+     *
+     * @return {@code true} if the type of this property references a generic
+     *         type, {@code false} otherwise
+     */
+    boolean isGenericType();
+
+    /**
      * Gets the type of the class containing this property.
      *
      * @return the property type. not <code>null</code>

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderCustomPropertySetTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderCustomPropertySetTest.java
@@ -61,6 +61,11 @@ public class BinderCustomPropertySetTest {
         }
 
         @Override
+        public boolean isGenericType() {
+            return false;
+        }
+
+        @Override
         public Class<?> getPropertyHolderType() {
             return Map.class;
         }


### PR DESCRIPTION
## Description

BeanPropertySet fails to merge property definition when a class inherits and overrides a getter with a generic return type.
This change checks for return type equality only if both property definitions have not a generic return type.
When merging property definitions, the non-generic definition is taken.

Fixes #16838
## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
