### PR TITLE
fix: Fix HasLazyDataView.setItems error message to be compliant with the current API

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/HasLazyDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/HasLazyDataView.java
@@ -62,9 +62,9 @@ public interface HasLazyDataView<T, F, V extends LazyDataView<T>>
                             + " component to fetch the count of the items or a data"
                             + " provider that implements the size query. Provide the "
                             + "callback for fetching item count with%n"
-                            + "component.getLazyDataView().withDefinedSize(CallbackDataProvider.CountCallback);"
+                            + "component.getLazyDataView().setItemCountCallback(CallbackDataProvider.CountCallback);"
                             + "%nor switch to undefined size with%n"
-                            + "component.getLazyDataView().withUndefinedSize();");
+                            + "component.getLazyDataView().setItemCountUnknown();");
         }));
         V lazyDataView = getLazyDataView();
         lazyDataView.setItemCountUnknown();


### PR DESCRIPTION
## Description
In HasLazyDataView.setItems the error message says:

"Trying to use exact size with a lazy loading component without either providing a count callback for the component to fetch the count of the items or a data provider that implements the size query. Provide the callback for fetching item count with
component.getLazyDataView().withDefinedSize(CallbackDataProvider.CountCallback);
or switch to undefined size with
component.getLazyDataView().withUndefinedSize();"

Since 2020 the API has changed. This PR teaches developers the current API.

Fixes #17062

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
