### PR TITLE
chore: Make UsageStatistics.entries final

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/UsageStatistics.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/UsageStatistics.java
@@ -70,7 +70,7 @@ public class UsageStatistics {
         }
     }
 
-    private static ConcurrentHashMap<String, UsageEntry> entries = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<String, UsageEntry> entries = new ConcurrentHashMap<>();
     static {
         setupDefaultEntries();
     }


### PR DESCRIPTION
## Description

Current code is thread-safe under JMM as guaranteed by the class initialization lock. However, semantically-wise, since the field won't change, it's safer to explicitly state the intent.

No associated issue.

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
