### PR TITLE
feat: prevent logging of ignored exceptions

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/DefaultErrorHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DefaultErrorHandler.java
@@ -16,6 +16,9 @@
 
 package com.vaadin.flow.server;
 
+import java.io.EOFException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -40,7 +43,11 @@ public class DefaultErrorHandler implements ErrorHandler {
     }
 
     public DefaultErrorHandler() {
-        this.ignoredExceptions = Set.of("org.eclipse.jetty.io.EofException");
+        this.ignoredExceptions = Set.of(SocketException.class.getName(),
+                SocketTimeoutException.class.getName(),
+                EOFException.class.getName(),
+                "org.eclipse.jetty.io.EofException",
+                "org.apache.catalina.connector.ClientAbortException");
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/DefaultErrorHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DefaultErrorHandler.java
@@ -31,6 +31,24 @@ import com.vaadin.flow.router.InvalidLocationException;
 /**
  * The default implementation of {@link ErrorHandler}.
  *
+ * This implementation logs the exception at ERROR level, unless the exception
+ * is in the ignore list.
+ *
+ * By default, the following exceptions are ignored to prevent logs to be
+ * flooded by errors that are usually not raised by application logic, but are
+ * caused by external event, such as broken connections or network issues.
+ *
+ * <ul>
+ * <li>java.net.SocketException</li>
+ * <li>java.net.SocketTimeoutException</li>
+ * <li>java.io.EOFException</li>
+ * <li>org.apache.catalina.connector.ClientAbortException</li>
+ * <li>org.eclipse.jetty.io.EofException</li>
+ * </ul>
+ *
+ * If the handler logger is set to DEBUG level, all exceptions are logged,
+ * despite they are in the ignore list.
+ *
  * @author Vaadin Ltd
  * @since 1.0
  */

--- a/flow-server/src/test/java/com/vaadin/flow/server/DefaultErrorHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DefaultErrorHandlerTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.server;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.MalformedURLException;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DefaultErrorHandlerTest {
+
+    MockedStatic<LoggerFactory> loggerFactory;
+    Logger logger;
+
+    @Before
+    public void setUp() throws Exception {
+        logger = Mockito
+                .spy(LoggerFactory.getLogger(DefaultErrorHandler.class));
+        loggerFactory = Mockito.mockStatic(LoggerFactory.class);
+        loggerFactory
+                .when(() -> LoggerFactory
+                        .getLogger(DefaultErrorHandler.class.getName()))
+                .thenReturn(logger);
+        Mockito.when(logger.isDebugEnabled()).thenReturn(false);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        loggerFactory.close();
+    }
+
+    @Test
+    public void error_acceptedException_errorHandled() {
+        DefaultErrorHandler errorHandler = Mockito
+                .spy(new DefaultErrorHandler(Set.of(IOException.class.getName(),
+                        MalformedURLException.class.getName())));
+
+        Throwable throwable = new RuntimeException();
+        errorHandler.error(new ErrorEvent(throwable));
+        Mockito.verify(logger).error("", throwable);
+
+        throwable = new IllegalArgumentException();
+        errorHandler.error(new ErrorEvent(throwable));
+        Mockito.verify(logger).error("", throwable);
+    }
+
+    @Test
+    public void error_ignoredException_notHandled() {
+        DefaultErrorHandler errorHandler = Mockito
+                .spy(new DefaultErrorHandler(Set.of(IOException.class.getName(),
+                        MalformedURLException.class.getName(),
+                        "com.vaadin.flow.server.DefaultErrorHandlerTest$InnerException")));
+
+        errorHandler.error(new ErrorEvent(new IOException()));
+        errorHandler.error(new ErrorEvent(new MalformedURLException()));
+        errorHandler.error(new ErrorEvent(new InnerException()));
+
+        Mockito.verify(logger, Mockito.never()).error(
+                ArgumentMatchers.anyString(),
+                ArgumentMatchers.any(Throwable.class));
+    }
+
+    @Test
+    public void error_subclassOfIgnoredException_errorHandled() {
+        DefaultErrorHandler errorHandler = Mockito.spy(
+                new DefaultErrorHandler(Set.of(IOException.class.getName())));
+
+        Throwable throwable = new MalformedURLException();
+        errorHandler.error(new ErrorEvent(throwable));
+        Mockito.verify(logger).error("", throwable);
+    }
+
+    @Test
+    public void error_loggerAtDebugLevel_errorHandled() {
+        Mockito.reset(logger);
+        Mockito.doReturn(true).when(logger).isDebugEnabled();
+
+        DefaultErrorHandler errorHandler = Mockito
+                .spy(new DefaultErrorHandler(Set.of(IOException.class.getName(),
+                        MalformedURLException.class.getName(),
+                        "com.vaadin.flow.server.DefaultErrorHandlerTest$InnerException")));
+
+        Throwable throwable = new RuntimeException();
+        errorHandler.error(new ErrorEvent(throwable));
+        Mockito.verify(logger).error("", throwable);
+
+        throwable = new IOException();
+        errorHandler.error(new ErrorEvent(throwable));
+        Mockito.verify(logger).error("", throwable);
+
+        throwable = new MalformedURLException();
+        errorHandler.error(new ErrorEvent(throwable));
+        Mockito.verify(logger).error("", throwable);
+
+        throwable = new InnerException();
+        errorHandler.error(new ErrorEvent(throwable));
+        Mockito.verify(logger).error("", throwable);
+
+        throwable = new UncheckedIOException(new IOException());
+        errorHandler.error(new ErrorEvent(throwable));
+        Mockito.verify(logger).error("", throwable);
+    }
+
+    public static class InnerException extends Exception {
+    }
+}


### PR DESCRIPTION
## Description

Flow default error handler logs all caught exceptions. However, there may be exceptions thrown by servlet container that are meant to be tracked only at debug level (e.g. Jetty QuietException implementors).

This change prevents logging of similar 'quiet' exception, unless the DefaultErrorHandler logger level is set to debug or higher.

By default, the following exceptions are ignored:

* java.net.SocketException
* java.net.SocketTimeoutException
* java.io.EOFException
* org.apache.catalina.connector.ClientAbortException
* org.eclipse.jetty.io.EofException

Closes #16311

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
