### PR TITLE
fix: Use correct path in Vite websocket requests

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/ViteHandler.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/ViteHandler.java
@@ -158,7 +158,7 @@ public final class ViteHandler extends AbstractDevServerRunner {
      *
      * @return the url path to the /VAADIN folder, relative to the host root
      */
-    private String getPathToVaadin() {
+    public String getPathToVaadin() {
         return getContextPath() + getPathToVaadinInContext();
     }
 

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketConnection.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketConnection.java
@@ -53,6 +53,8 @@ public class ViteWebsocketConnection implements Listener {
      *
      * @param port
      *            the port Vite is running on
+     * @param path
+     *            the path Vite is using
      * @param subProtocol
      *            the sub protocol to use
      * @param onMessage
@@ -65,13 +67,13 @@ public class ViteWebsocketConnection implements Listener {
      * @throws ExecutionException
      *             if there is a problem with the connection
      */
-    public ViteWebsocketConnection(int port, String subProtocol,
+    public ViteWebsocketConnection(int port, String path, String subProtocol,
             Consumer<String> onMessage, Runnable onClose)
             throws InterruptedException, ExecutionException {
         this.onMessage = onMessage;
         this.onClose = onClose;
         String wsHost = ViteHandler.DEV_SERVER_HOST.replace("http://", "ws://");
-        URI uri = URI.create(wsHost + ":" + port + "/VAADIN/");
+        URI uri = URI.create(wsHost + ":" + port + path);
         clientWebSocket = HttpClient.newHttpClient().newWebSocketBuilder()
                 .subprotocols(subProtocol).buildAsync(uri, this).get();
         getLogger().debug("Connecting to {} using the {} protocol", uri,

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketEndpoint.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketEndpoint.java
@@ -92,7 +92,7 @@ public class ViteWebsocketEndpoint extends Endpoint {
                 .get(VITE_HANDLER);
         ViteWebsocketProxy proxy;
         try {
-            proxy = new ViteWebsocketProxy(session, viteHandler.getPort());
+            proxy = new ViteWebsocketProxy(session, viteHandler.getPort(), viteHandler.getPathToVaadin());
             proxies.put(session.getId(), proxy);
             session.addMessageHandler(proxy);
         } catch (Exception e) {

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketProxy.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketProxy.java
@@ -44,14 +44,16 @@ public class ViteWebsocketProxy implements MessageHandler.Whole<String> {
      *            the websocket connection from the browser
      * @param vitePort
      *            the port the Vite server is running on
+     * @param vitePath
+     *            the path Vite is using
      * @throws ExecutionException
      *             if there is a problem with the connection
      * @throws InterruptedException
      *             if there is a problem with the connection
      */
-    public ViteWebsocketProxy(Session browserSession, Integer vitePort)
-            throws InterruptedException, ExecutionException {
-        viteConnection = new ViteWebsocketConnection(vitePort,
+    public ViteWebsocketProxy(Session browserSession, Integer vitePort,
+            String vitePath) throws InterruptedException, ExecutionException {
+        viteConnection = new ViteWebsocketConnection(vitePort, vitePath,
                 browserSession.getNegotiatedSubprotocol(),
                 msg -> browserSession.getAsyncRemote().sendText(msg, result -> {
                     if (result.isOK()) {


### PR DESCRIPTION
When the browser is using http://localhost:8888/context/view/VAADIN and Vite is running on http://localhost:60075/context/view/VAADIN/ then the WS proxy request must go to http://localhost:60075/context/view/VAADIN/ and not http://localhost:60075/VAADIN/
