### PR TITLE
docs: clarify that new validation mechanism is disabled by default

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
@@ -481,7 +481,10 @@ public interface DeploymentConfiguration extends Serializable {
      * Whether the full experience validation is enforced for Flow components.
      * <p>
      * The full experience validation integrates client, constraint and binder
-     * validation into a seamless chain. For more detailed information, please refer to:
+     * validation into a seamless chain. By default, it's disabled, which means
+     * that components aren't validated on blur, for example.
+     * <p>
+     * For more detailed information, please refer to:
      * https://github.com/vaadin/platform/issues/3066#issuecomment-1598771284
      *
      * @return {@code true} if enabled, {@code false} otherwise.

--- a/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
@@ -480,9 +480,10 @@ public interface DeploymentConfiguration extends Serializable {
     /**
      * Whether the full experience validation is enforced for Flow components.
      * <p>
-     * The full experience validation integrates client, constraint and binder
-     * validation into a seamless chain. By default, it's disabled, which means
-     * that components aren't validated on blur, for example.
+     * The full experience validation integrates web component's own validation,
+     * server-side component's constraints and Binder validation into a seamless
+     * chain. By default, it's disabled, which means that components aren't
+     * validated on blur, for example.
      * <p>
      * For more detailed information, please refer to:
      * https://github.com/vaadin/platform/issues/3066#issuecomment-1598771284

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -228,8 +228,11 @@ public class InitParameters implements Serializable {
     public static final String CI_BUILD = "ci.build";
 
     /**
-     * A property that enforces full experience validation for Flow components by
-     * integrating client, constraint, and binder validation into a seamless chain.
+     * A property that enforces full experience validation for Flow components.
+     * <p>
+     * The full experience validation integrates client, constraint and binder
+     * validation into a seamless chain. By default, it's disabled, which means
+     * that components aren't validated on blur, for example.
      * <p>
      * For more detailed information, please refer to:
      * https://github.com/vaadin/platform/issues/3066#issuecomment-1598771284

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -230,9 +230,10 @@ public class InitParameters implements Serializable {
     /**
      * A property that enforces full experience validation for Flow components.
      * <p>
-     * The full experience validation integrates client, constraint and binder
-     * validation into a seamless chain. By default, it's disabled, which means
-     * that components aren't validated on blur, for example.
+     * The full experience validation integrates web component's own validation,
+     * server-side component's constraints and Binder validation into a seamless
+     * chain. By default, it's disabled, which means that components aren't
+     * validated on blur, for example.
      * <p>
      * For more detailed information, please refer to:
      * https://github.com/vaadin/platform/issues/3066#issuecomment-1598771284


### PR DESCRIPTION
## Description

The PR clarifies in JavaDoc that the new validation mechanism is disabled by default in Vaadin 14.

A follow-up to https://github.com/vaadin/flow/pull/17056

## Type of change

- [x] Docs
