### PR TITLE
fix: add slot=label attribute as legit use-case for the deprecated Label

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Label.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Label.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.html;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import com.vaadin.flow.component.AttachEvent;
@@ -150,8 +151,14 @@ public class Label extends HtmlContainer {
                         // Label was not associated with a for-attribute
                         // AND
                         // Label was not associated by adding a nested component
+                        // AND
+                        // Label has no attribute slot=label
+                        // (used e.g. in flow-components/FormLayout)
                         if (getFor().isEmpty()
-                                && getChildren().findAny().isEmpty()) {
+                                && getChildren().findAny().isEmpty()
+                                && !Objects.equals(
+                                        getElement().getAttribute("slot"),
+                                        "label")) {
                             LoggerFactory.getLogger(Label.class.getName()).warn(
                                     "The Label '{}' was not associated with a component. "
                                             + "Labels should not be used for loose text on the page. "


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

To reduce the false positive warnings when the deprecated `Label` component is used by the `flow-components` with proper client-side logic to associate the field with the `Label`. The attribute `slot=label` is also added to the list of valid use-cases.

Related to https://github.com/vaadin/flow-components/issues/5171 and https://github.com/vaadin/flow/pull/16708#issuecomment-1600736263

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.