### PR TITLE
fix: add detach listener callback once for pending invocations

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -616,11 +616,11 @@ public class UIInternals implements Serializable {
                             node.addDetachListener(detachListener));
                     return detachListener;
                 });
-        listener.invocationList.add(invocation);
-
-        SerializableConsumer callback = unused -> listener
-                .onInvocationCompleted(invocation);
-        invocation.then(callback, callback);
+        if (listener.invocationList.add(invocation)) {
+            SerializableConsumer callback = unused -> listener
+                    .onInvocationCompleted(invocation);
+            invocation.then(callback, callback);
+        }
     }
 
     private class PendingJavaScriptInvocationDetachListener implements Command {


### PR DESCRIPTION
## Description

Currently, the detach listener callback is added to pending javascript invocation on every call to dumpPendingJavaScriptInvocations. This change will apply the callback only once, when the pending invocation is seen for the first time.

Fixes #17082

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
