### PR TITLE
Fix vaadin.launch-browser=true and HTTPS #15496

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/DevModeBrowserLauncher.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/DevModeBrowserLauncher.java
@@ -45,7 +45,8 @@ public class DevModeBrowserLauncher
 
     static String getUrl(GenericWebApplicationContext app) {
         String port = app.getEnvironment().getProperty("server.port");
-        String sslEnabled = app.getEnvironment().getProperty("server.ssl.enabled");
+        String sslEnabled = app.getEnvironment()
+                .getProperty("server.ssl.enabled");
         String proto;
         if (sslEnabled != null && sslEnabled.equals("true")) {
             proto = "https";

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/DevModeBrowserLauncher.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/DevModeBrowserLauncher.java
@@ -43,6 +43,48 @@ public class DevModeBrowserLauncher
             String[] arguments) {
     }
 
+    static String getUrl(GenericWebApplicationContext app) {
+        String port = app.getEnvironment().getProperty("server.port");
+        String sslEnabled = app.getEnvironment().getProperty("server.ssl.enabled");
+        String proto;
+        if (sslEnabled != null && sslEnabled.equals("true")) {
+            proto = "https";
+        } else {
+            proto = "http";
+        }
+        String host = proto + "://localhost:" + port;
+
+        String path = "/";
+        String vaadinServletMapping = RootMappedCondition
+                .getUrlMapping(app.getEnvironment());
+
+        ServletContext servletContext = app.getServletContext();
+        if (servletContext != null) {
+            String contextPath = servletContext.getContextPath();
+            if (contextPath != null && !contextPath.isEmpty()) {
+                path = contextPath + "/";
+            }
+        }
+
+        if (vaadinServletMapping != null && !vaadinServletMapping.isEmpty()) {
+            if (vaadinServletMapping.startsWith("/")) {
+                vaadinServletMapping = vaadinServletMapping.substring(1);
+            }
+            if (vaadinServletMapping.endsWith("*")) {
+                vaadinServletMapping = vaadinServletMapping.substring(0,
+                        vaadinServletMapping.length() - 1);
+
+            }
+            path += vaadinServletMapping;
+        }
+
+        return host + path;
+    }
+
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(DevModeBrowserLauncher.class);
+    }
+
     @Override
     public void ready(ConfigurableApplicationContext context,
             Duration timeTaken) {
@@ -85,41 +127,6 @@ public class DevModeBrowserLauncher
             devModeHandlerManager
                     .launchBrowserInDevelopmentMode(getUrl(webAppContext));
         }
-    }
-
-    static String getUrl(GenericWebApplicationContext app) {
-        String port = app.getEnvironment().getProperty("server.port");
-        String host = "http://localhost:" + port;
-
-        String path = "/";
-        String vaadinServletMapping = RootMappedCondition
-                .getUrlMapping(app.getEnvironment());
-
-        ServletContext servletContext = app.getServletContext();
-        if (servletContext != null) {
-            String contextPath = servletContext.getContextPath();
-            if (contextPath != null && !contextPath.isEmpty()) {
-                path = contextPath + "/";
-            }
-        }
-
-        if (vaadinServletMapping != null && !vaadinServletMapping.isEmpty()) {
-            if (vaadinServletMapping.startsWith("/")) {
-                vaadinServletMapping = vaadinServletMapping.substring(1);
-            }
-            if (vaadinServletMapping.endsWith("*")) {
-                vaadinServletMapping = vaadinServletMapping.substring(0,
-                        vaadinServletMapping.length() - 1);
-
-            }
-            path += vaadinServletMapping;
-        }
-
-        return host + path;
-    }
-
-    private static Logger getLogger() {
-        return LoggerFactory.getLogger(DevModeBrowserLauncher.class);
     }
 
 }

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/DevModeBrowserLauncher.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/DevModeBrowserLauncher.java
@@ -43,49 +43,6 @@ public class DevModeBrowserLauncher
             String[] arguments) {
     }
 
-    static String getUrl(GenericWebApplicationContext app) {
-        String port = app.getEnvironment().getProperty("server.port");
-        String sslEnabled = app.getEnvironment()
-                .getProperty("server.ssl.enabled");
-        String proto;
-        if (sslEnabled != null && sslEnabled.equals("true")) {
-            proto = "https";
-        } else {
-            proto = "http";
-        }
-        String host = proto + "://localhost:" + port;
-
-        String path = "/";
-        String vaadinServletMapping = RootMappedCondition
-                .getUrlMapping(app.getEnvironment());
-
-        ServletContext servletContext = app.getServletContext();
-        if (servletContext != null) {
-            String contextPath = servletContext.getContextPath();
-            if (contextPath != null && !contextPath.isEmpty()) {
-                path = contextPath + "/";
-            }
-        }
-
-        if (vaadinServletMapping != null && !vaadinServletMapping.isEmpty()) {
-            if (vaadinServletMapping.startsWith("/")) {
-                vaadinServletMapping = vaadinServletMapping.substring(1);
-            }
-            if (vaadinServletMapping.endsWith("*")) {
-                vaadinServletMapping = vaadinServletMapping.substring(0,
-                        vaadinServletMapping.length() - 1);
-
-            }
-            path += vaadinServletMapping;
-        }
-
-        return host + path;
-    }
-
-    private static Logger getLogger() {
-        return LoggerFactory.getLogger(DevModeBrowserLauncher.class);
-    }
-
     @Override
     public void ready(ConfigurableApplicationContext context,
             Duration timeTaken) {
@@ -128,6 +85,49 @@ public class DevModeBrowserLauncher
             devModeHandlerManager
                     .launchBrowserInDevelopmentMode(getUrl(webAppContext));
         }
+    }
+
+    static String getUrl(GenericWebApplicationContext app) {
+        String port = app.getEnvironment().getProperty("server.port");
+        String sslEnabled = app.getEnvironment()
+                .getProperty("server.ssl.enabled");
+        String proto;
+        if (sslEnabled != null && sslEnabled.equals("true")) {
+            proto = "https";
+        } else {
+            proto = "http";
+        }
+        String host = proto + "://localhost:" + port;
+
+        String path = "/";
+        String vaadinServletMapping = RootMappedCondition
+                .getUrlMapping(app.getEnvironment());
+
+        ServletContext servletContext = app.getServletContext();
+        if (servletContext != null) {
+            String contextPath = servletContext.getContextPath();
+            if (contextPath != null && !contextPath.isEmpty()) {
+                path = contextPath + "/";
+            }
+        }
+
+        if (vaadinServletMapping != null && !vaadinServletMapping.isEmpty()) {
+            if (vaadinServletMapping.startsWith("/")) {
+                vaadinServletMapping = vaadinServletMapping.substring(1);
+            }
+            if (vaadinServletMapping.endsWith("*")) {
+                vaadinServletMapping = vaadinServletMapping.substring(0,
+                        vaadinServletMapping.length() - 1);
+
+            }
+            path += vaadinServletMapping;
+        }
+
+        return host + path;
+    }
+
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(DevModeBrowserLauncher.class);
     }
 
 }

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/DevModeBrowserLauncherHttpsProtoTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/DevModeBrowserLauncherHttpsProtoTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource(properties = { "server.port = 1235",
-        "server.ssl.enable = true" })
+        "server.ssl.enabled = true" })
 public class DevModeBrowserLauncherHttpsProtoTest
         extends AbstractDevModeBrowserLauncherTest {
 

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/DevModeBrowserLauncherHttpsProtoTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/DevModeBrowserLauncherHttpsProtoTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.spring;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource(properties = { "server.port = 1235",
+        "server.ssl.enable = true" })
+public class DevModeBrowserLauncherHttpsProtoTest
+        extends AbstractDevModeBrowserLauncherTest {
+
+    @Test
+    public void getUrl_withHttpsProto_givesUrlWithHttpsInUrl() {
+        String url = DevModeBrowserLauncher.getUrl(app);
+        Assertions.assertEquals("https://localhost:1235/", url);
+    }
+}


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Fixes #15496 vaadin.launch-browser=true and HTTPS 

This fix brings the behavior of the feature "opening browser" according to the application settings that can be used SSL in a development environment.

I can't check it locally because mvn verify is broken on my development host.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
