### PR TITLE
fix: ignore pending JS invocations for invisible node in UI dirty check

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -1098,8 +1098,8 @@ public class UIInternals implements Serializable {
      *         <code>false</code> otherwise
      */
     public boolean isDirty() {
-        return getStateTree().isDirty()
-                || getPendingJavaScriptInvocations().count() != 0;
+        return getStateTree().isDirty() || getPendingJavaScriptInvocations()
+                .anyMatch(invocation -> invocation.getOwner().isVisible());
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/UIInternalsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/UIInternalsTest.java
@@ -451,6 +451,76 @@ public class UIInternalsTest {
                 internals.getPendingJavaScriptInvocations().count());
     }
 
+    @Test
+    public void isDirty_noPendingJsInvocation_returnsFalse() {
+        StateNode node1 = Mockito.spy(new StateNode(ElementData.class));
+        StateNode node2 = Mockito.spy(new StateNode(ElementData.class));
+        node2.getFeature(ElementData.class).setVisible(false);
+        ElementChildrenList childrenList = internals.getStateTree()
+                .getRootNode().getFeature(ElementChildrenList.class);
+        childrenList.add(0, node1);
+        childrenList.add(1, node2);
+
+        Assert.assertTrue("Nodes added, expecting dirty UI",
+                internals.isDirty());
+        internals.getStateTree().collectChanges(node -> {
+        });
+        internals.dumpPendingJavaScriptInvocations();
+
+        Assert.assertFalse("Changes collected, expecting UI not to be dirty",
+                internals.isDirty());
+    }
+
+    @Test
+    public void isDirty_pendingJsInvocationReadyToSend_returnsTrue() {
+        StateNode node1 = Mockito.spy(new StateNode(ElementData.class));
+        StateNode node2 = Mockito.spy(new StateNode(ElementData.class));
+        node2.getFeature(ElementData.class).setVisible(false);
+        ElementChildrenList childrenList = internals.getStateTree()
+                .getRootNode().getFeature(ElementChildrenList.class);
+        childrenList.add(0, node1);
+        childrenList.add(1, node2);
+
+        internals.addJavaScriptInvocation(new PendingJavaScriptInvocation(node1,
+                new UIInternals.JavaScriptInvocation("")));
+
+        Assert.assertTrue("Pending JS invocations, expecting dirty UI",
+                internals.isDirty());
+        internals.getStateTree().collectChanges(node -> {
+        });
+        internals.dumpPendingJavaScriptInvocations();
+
+        Assert.assertFalse(
+                "No pending JS invocations to send to the client, expecting UI not to be dirty",
+                internals.isDirty());
+    }
+
+    @Test
+    public void isDirty_pendingJsInvocationNotReadyToSend_returnsFalse() {
+        StateNode node1 = Mockito.spy(new StateNode(ElementData.class));
+        StateNode node2 = Mockito.spy(new StateNode(ElementData.class));
+        node2.getFeature(ElementData.class).setVisible(false);
+        ElementChildrenList childrenList = internals.getStateTree()
+                .getRootNode().getFeature(ElementChildrenList.class);
+        childrenList.add(0, node1);
+        childrenList.add(1, node2);
+
+        internals.addJavaScriptInvocation(new PendingJavaScriptInvocation(node1,
+                new UIInternals.JavaScriptInvocation("")));
+        internals.addJavaScriptInvocation(new PendingJavaScriptInvocation(node2,
+                new UIInternals.JavaScriptInvocation("")));
+
+        Assert.assertTrue("Pending JS invocations, expecting dirty UI",
+                internals.isDirty());
+        internals.getStateTree().collectChanges(node -> {
+        });
+        internals.dumpPendingJavaScriptInvocations();
+
+        Assert.assertFalse(
+                "No pending JS invocations to send to the client, expecting UI not to be dirty",
+                internals.isDirty());
+    }
+
     private PushConfiguration setUpInitialPush() {
         DeploymentConfiguration config = Mockito
                 .mock(DeploymentConfiguration.class);


### PR DESCRIPTION
## Description

UI dirty check currently takes into account also pending JS invocation for invisible node, that however will not be sent to the client. This change updates the check to only consider JS invocation that should be effectively sent to the browser.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
