### PR TITLE
fix: copy package-lock from bundle in hotdeploy

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -149,6 +149,8 @@ public class NodeTasks implements FallibleCommand {
                         UsageStatistics.markAsUsed("flow/dev-bundle", null);
                     }
                 }
+            } else if (options.isFrontendHotdeploy()) {
+                BundleUtils.copyPackageLockFromBundle(options);
             }
 
             if (options.isGenerateEmbeddableWebComponents()) {


### PR DESCRIPTION
Copy the package-lock.json from
the dev bundle in frontend
hotdeploy mode if no package-lock
is available.
