### PR TITLE
chore: replace deprecated Spring Security APIs usage

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -183,8 +183,6 @@ public abstract class VaadinWebSecurity {
         // login
         http.requestCache(cfg -> cfg.requestCache(vaadinDefaultRequestCache));
 
-        // AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry
-        // urlRegistry =
         http.authorizeHttpRequests(urlRegistry -> {
             // Vaadin internal requests must always be allowed to allow public
             // Flow pages and/or login page implemented using Flow.

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -41,8 +41,10 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.LogoutConfigurer;
 import org.springframework.security.config.annotation.web.configurers.SessionManagementConfigurer;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.web.DefaultSecurityFilterChain;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.access.AccessDeniedHandlerImpl;
@@ -133,11 +135,14 @@ public abstract class VaadinWebSecurity {
         http.logout(cfg -> {
             cfg.invalidateHttpSession(true);
             addLogoutHandlers(cfg::addLogoutHandler);
-            authenticationContext.setLogoutHandlers(
-                    cfg.getLogoutSuccessHandler(), cfg.getLogoutHandlers());
         });
-
-        return http.build();
+        DefaultSecurityFilterChain securityFilterChain = http.build();
+        LogoutConfigurer<?> logoutConfigurer = http
+                .getConfigurer(LogoutConfigurer.class);
+        authenticationContext.setLogoutHandlers(
+                logoutConfigurer.getLogoutSuccessHandler(),
+                logoutConfigurer.getLogoutHandlers());
+        return securityFilterChain;
     }
 
     /**


### PR DESCRIPTION
Replaces deprecated Spring Security APIs marked for removal in 7.0

Fixes #16872