### PR TITLE
feat: dispatch popstate event on server-side navigation

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/page/History.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/History.java
@@ -187,8 +187,8 @@ public class History implements Serializable {
         // Second parameter is title which is currently ignored according to
         // https://developer.mozilla.org/en-US/docs/Web/API/History_API
         ui.getPage().executeJs(
-                "setTimeout(() => window.history.pushState($0, '', $1))", state,
-                pathWithQueryParameters);
+                "setTimeout(() => { window.history.pushState($0, '', $1); window.dispatchEvent(new PopStateEvent('popstate', {state: 'vaadin-router-ignore'})); })",
+                state, pathWithQueryParameters);
     }
 
     /**
@@ -226,7 +226,7 @@ public class History implements Serializable {
         // Second parameter is title which is currently ignored according to
         // https://developer.mozilla.org/en-US/docs/Web/API/History_API
         ui.getPage().executeJs(
-                "setTimeout(() => window.history.replaceState($0, '', $1))",
+                "setTimeout(() => { window.history.replaceState($0, '', $1); window.dispatchEvent(new PopStateEvent('popstate', {state: 'vaadin-router-ignore'})); })",
                 state, pathWithQueryParameters);
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
@@ -45,7 +45,7 @@ import com.vaadin.flow.server.VaadinSession;
 
 public class JavaScriptBootstrapUITest {
 
-    private static final String CLIENT_PUSHSTATE_TO = "setTimeout(() => window.history.pushState($0, '', $1))";
+    private static final String CLIENT_PUSHSTATE_TO = "setTimeout(() => { window.history.pushState($0, '', $1); window.dispatchEvent(new PopStateEvent('popstate', {state: 'vaadin-router-ignore'})); })";
 
     private MockServletServiceSessionSetup mocks;
     private UI ui;

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/HistoryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/HistoryTest.java
@@ -59,6 +59,9 @@ public class HistoryTest {
     private TestPage page = new TestPage(ui);
     private History history;
 
+    private static final String PUSH_STATE_JS = "setTimeout(() => { window.history.pushState($0, '', $1); window.dispatchEvent(new PopStateEvent('popstate', {state: 'vaadin-router-ignore'})); })";
+    private static final String REPLACE_STATE_JS = "setTimeout(() => { window.history.replaceState($0, '', $1); window.dispatchEvent(new PopStateEvent('popstate', {state: 'vaadin-router-ignore'})); })";
+
     @Before
     public void setup() {
         history = new History(ui);
@@ -68,8 +71,7 @@ public class HistoryTest {
     public void pushState_locationWithQueryParameters_queryParametersRetained() {
         history.pushState(Json.create("{foo:bar;}"), "context/view?param=4");
 
-        Assert.assertEquals("push state JS not included",
-                "setTimeout(() => window.history.pushState($0, '', $1))",
+        Assert.assertEquals("push state JS not included", PUSH_STATE_JS,
                 page.expression);
         Assert.assertEquals("push state not included", "{foo:bar;}",
                 ((JsonString) page.parameters[0]).getString());
@@ -78,8 +80,7 @@ public class HistoryTest {
 
         history.pushState(Json.create("{foo:bar;}"), "context/view/?param=4");
 
-        Assert.assertEquals("push state JS not included",
-                "setTimeout(() => window.history.pushState($0, '', $1))",
+        Assert.assertEquals("push state JS not included", PUSH_STATE_JS,
                 page.expression);
         Assert.assertEquals("push state not included", "{foo:bar;}",
                 ((JsonString) page.parameters[0]).getString());
@@ -91,8 +92,7 @@ public class HistoryTest {
     public void pushState_locationWithFragment_fragmentRetained() {
         history.pushState(null, "context/view#foobar");
 
-        Assert.assertEquals("push state JS not included",
-                "setTimeout(() => window.history.pushState($0, '', $1))",
+        Assert.assertEquals("push state JS not included", PUSH_STATE_JS,
                 page.expression);
         Assert.assertEquals(null, page.parameters[0]);
         Assert.assertEquals("fragment not retained", "context/view#foobar",
@@ -100,8 +100,7 @@ public class HistoryTest {
 
         history.pushState(null, "context/view/#foobar");
 
-        Assert.assertEquals("push state JS not included",
-                "setTimeout(() => window.history.pushState($0, '', $1))",
+        Assert.assertEquals("push state JS not included", PUSH_STATE_JS,
                 page.expression);
         Assert.assertEquals(null, page.parameters[0]);
         Assert.assertEquals("fragment not retained", "context/view/#foobar",
@@ -112,8 +111,7 @@ public class HistoryTest {
     public void pushState_locationWithQueryParametersAndFragment_QueryParametersAndFragmentRetained() {
         history.pushState(null, "context/view?foo=bar#foobar");
 
-        Assert.assertEquals("push state JS not included",
-                "setTimeout(() => window.history.pushState($0, '', $1))",
+        Assert.assertEquals("push state JS not included", PUSH_STATE_JS,
                 page.expression);
         Assert.assertEquals(null, page.parameters[0]);
         Assert.assertEquals("invalid location", "context/view?foo=bar#foobar",
@@ -121,8 +119,7 @@ public class HistoryTest {
 
         history.pushState(null, "context/view/?foo=bar#foobar");
 
-        Assert.assertEquals("push state JS not included",
-                "setTimeout(() => window.history.pushState($0, '', $1))",
+        Assert.assertEquals("push state JS not included", PUSH_STATE_JS,
                 page.expression);
         Assert.assertEquals(null, page.parameters[0]);
         Assert.assertEquals("invalid location", "context/view/?foo=bar#foobar",
@@ -133,8 +130,7 @@ public class HistoryTest {
     public void replaceState_locationWithQueryParametersAndFragment_QueryParametersAndFragmentRetained() {
         history.replaceState(null, "context/view?foo=bar#foobar");
 
-        Assert.assertEquals("push state JS not included",
-                "setTimeout(() => window.history.replaceState($0, '', $1))",
+        Assert.assertEquals("replace state JS not included", REPLACE_STATE_JS,
                 page.expression);
         Assert.assertEquals(null, page.parameters[0]);
         Assert.assertEquals("invalid location", "context/view?foo=bar#foobar",
@@ -142,8 +138,7 @@ public class HistoryTest {
 
         history.replaceState(null, "context/view/?foo=bar#foobar");
 
-        Assert.assertEquals("push state JS not included",
-                "setTimeout(() => window.history.replaceState($0, '', $1))",
+        Assert.assertEquals("replace state JS not included", REPLACE_STATE_JS,
                 page.expression);
         Assert.assertEquals(null, page.parameters[0]);
         Assert.assertEquals("invalid location", "context/view/?foo=bar#foobar",
@@ -153,8 +148,7 @@ public class HistoryTest {
     @Test // #11628
     public void replaceState_locationEmpty_pushesPeriod() {
         history.replaceState(null, "");
-        Assert.assertEquals("push state JS not included",
-                "setTimeout(() => window.history.replaceState($0, '', $1))",
+        Assert.assertEquals("replace state JS not included", REPLACE_STATE_JS,
                 page.expression);
         Assert.assertEquals(null, page.parameters[0]);
         Assert.assertEquals("location should be '.'", ".", page.parameters[1]);


### PR DESCRIPTION
## Description

Dispatch a `popstate` event when using server-side navigation, which allows components like `vaadin-side-nav` to react to location changes. The event includes the state `{state: 'vaadin-router-ignore'}`, so that Vaadin router ignores the event.

This is similar to what Vaadin router does to notify about location changes:
https://github.com/vaadin/router/blob/f5f31e00acd542fe714ea472172d17a03ba04794/src/router.js#L733-L742

Closes https://github.com/vaadin/flow/issues/17138

## Type of change

- Feature
