### PR TITLE
fix: Not check the license for default production build

### DIFF
--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -134,8 +134,6 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo
 
         if (generateBundle() && BundleValidationUtil
                 .needsBundleBuild(servletResourceOutputDirectory())) {
-            LicenseChecker.setStrictOffline(true);
-            BuildFrontendUtil.validateLicenses(this);
             try {
                 BuildFrontendUtil.runFrontendBuild(this);
                 if (cleanFrontendFiles()) {
@@ -146,6 +144,8 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo
                 throw new MojoExecutionException(exception.getMessage(),
                         exception);
             }
+            LicenseChecker.setStrictOffline(true);
+            BuildFrontendUtil.validateLicenses(this);
         }
 
         BuildFrontendUtil.updateBuildFile(this);

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -134,6 +134,8 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo
 
         if (generateBundle() && BundleValidationUtil
                 .needsBundleBuild(servletResourceOutputDirectory())) {
+            LicenseChecker.setStrictOffline(true);
+            BuildFrontendUtil.validateLicenses(this);
             try {
                 BuildFrontendUtil.runFrontendBuild(this);
                 if (cleanFrontendFiles()) {
@@ -145,8 +147,6 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo
                         exception);
             }
         }
-        LicenseChecker.setStrictOffline(true);
-        BuildFrontendUtil.validateLicenses(this);
 
         BuildFrontendUtil.updateBuildFile(this);
 


### PR DESCRIPTION
Workaround for false license checking result leading to require license for default bundle even if no commertial components are used in the project.