### PR TITLE
fix: prevent writing service worker on filesystem in dev mode

### DIFF
--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -191,7 +191,9 @@ function buildSWPlugin(opts): PluginOption {
       }
     },
     async closeBundle() {
-      await build('write', [injectManifestToSWPlugin(), brotli()]);
+      if (!devMode) {
+        await build('write', [injectManifestToSWPlugin(), brotli()]);
+      }
     }
   };
 }


### PR DESCRIPTION
## Description

When running in dev mode, the service worker should be served from memory and not written to the filesystem, to avoid potential endless restarts when Spring dev tools are in use.

This change fixes a regression introduced when service worker compression was implemented, that causes sw.js to be written to the filesystem also in dev mode.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
