### PR TITLE
fix: set restart monitor before checking for dev server connection

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
@@ -176,6 +176,10 @@ public abstract class AbstractDevServerRunner implements DevModeHandler {
     }
 
     void doStartDevModeServer() throws ExecutionFailedException {
+        waitForRestart = DevServerOutputTracker.activeServerRestartGuard();
+        if (waitForRestart != null) {
+            getLogger().debug("RestartMonitor is active");
+        }
         // If port is defined, means that the dev server is already running
         if (port > 0) {
             if (!checkConnection()) {
@@ -537,10 +541,6 @@ public abstract class AbstractDevServerRunner implements DevModeHandler {
         // Save running port for next usage
         saveRunningDevServerPort();
         watchDog.set(null);
-        waitForRestart = DevServerOutputTracker.activeServerRestartGuard();
-        if (waitForRestart != null) {
-            getLogger().debug("RestartMonitor is active");
-        }
     }
 
     private void saveRunningDevServerPort() {

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/RestartMonitorTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/RestartMonitorTest.java
@@ -40,7 +40,7 @@ public class RestartMonitorTest {
         CompletableFuture.runAsync(() -> simulateTask(latch));
         Assert.assertTrue(
                 "Not restarting, execution should not have been blocked",
-                latch.await(5, TimeUnit.MILLISECONDS));
+                latch.await(10, TimeUnit.MILLISECONDS));
     }
 
     @Test


### PR DESCRIPTION
## Description

If hot reload is enabled, e.g. with Spring Dev Tools, during Java server restart the check for active dev-server connection may temporarily fail because the dev-server is restarting.
This change finds and sets the currently active restart monitor before checking for dev-server connection, so that the check will wait for a potential restart to complete.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
