### PR TITLE
fix: prevent PWA registry lookup when VaadinServlet is not initialized

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
@@ -211,6 +211,11 @@ public class VaadinServletService extends VaadinService {
     @Override
     protected PwaRegistry getPwaRegistry() {
         return Optional.ofNullable(getServlet())
+                // VaadinServlet.getServletConfig can return null if the servlet
+                // is not yet initialized or has been destroyed
+                // It may happen for example during Spring hot deploy restarts
+                // and in this case getServletContext will throw an NPE
+                .filter(s -> s.getServletConfig() != null)
                 .map(GenericServlet::getServletContext)
                 .map(PwaRegistry::getInstance).orElse(null);
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletServiceTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletServiceTest.java
@@ -146,6 +146,31 @@ public class VaadinServletServiceTest {
         Assert.assertSame(loader, service.getClassLoader());
     }
 
+    @Test
+    public void getPwaRegistry_servletInitialized_getsRegistry() {
+        MockServletServiceSessionSetup.TestVaadinServlet vaadinServlet = Mockito
+                .spy(mocks.getServlet());
+        // Restore original behavior of getServletContext
+        Mockito.when(vaadinServlet.getServletContext()).thenAnswer(
+                i -> vaadinServlet.getServletConfig().getServletContext());
+        VaadinServletService service = new VaadinServletService(vaadinServlet,
+                mocks.getDeploymentConfiguration());
+        Assert.assertNotNull(service.getPwaRegistry());
+    }
+
+    @Test
+    public void getPwaRegistry_servletNotInitialized_getsNull() {
+        MockServletServiceSessionSetup.TestVaadinServlet vaadinServlet = Mockito
+                .spy(mocks.getServlet());
+        // Restore original behavior of getServletContext
+        Mockito.when(vaadinServlet.getServletContext()).thenAnswer(
+                i -> vaadinServlet.getServletConfig().getServletContext());
+        VaadinServletService service = new VaadinServletService(vaadinServlet,
+                mocks.getDeploymentConfiguration());
+        vaadinServlet.destroy();
+        Assert.assertNull(service.getPwaRegistry());
+    }
+
     private String testLocation(String base, String contextPath,
             String servletPath, String pathInfo) throws Exception {
 


### PR DESCRIPTION
## Description

When Java hot reload is enabled, it is possible that VaadinServlet will receive requests even if its destroy method has been invoked. When this happens, getting the PWA registry may fail with an NPE because of VaadinServlet optimizations for servlet initialization. This change prevents getting the PWA registry if the VaadinServlet is not initialized or has been destroyed

Fixes #17137

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
