### PR TITLE
fix: use dark color scheme for dev tools

### DIFF
--- a/vaadin-dev-server/frontend/vaadin-dev-tools.ts
+++ b/vaadin-dev-server/frontend/vaadin-dev-tools.ts
@@ -105,6 +105,7 @@ export class VaadinDevTools extends LitElement {
           -webkit-user-select: none;
           -moz-user-select: none;
           user-select: none;
+          color-scheme: dark;
 
           position: fixed;
           z-index: 20000;


### PR DESCRIPTION
Allow the browser to adapt any native controls (like scrollbars) to the dark color scheme.

Before:
<img width="497" alt="Screenshot 2023-07-03 at 12 45 45" src="https://github.com/vaadin/flow/assets/66382/073e8efc-db4e-403d-938a-7864bbc17093">


After: 
<img width="494" alt="Screenshot 2023-07-03 at 12 46 15" src="https://github.com/vaadin/flow/assets/66382/ddfeba1e-3e29-4284-815d-7593d53aa63e">
