### PR TITLE
fix: prevent writing service worker on filesystem in dev mode (#17155) (CP: 24.0)

### DIFF
--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -190,10 +190,12 @@ function buildSWPlugin(opts): PluginOption {
       }
     },
     async closeBundle() {
-      await build('write', [
-        injectManifestToSWPlugin(),
-        brotli(),
-      ]);
+      if (!devMode) {
+        await build('write', [
+          injectManifestToSWPlugin(),
+          brotli(),
+        ]);
+      }
     }
   }
 }


### PR DESCRIPTION
When running in dev mode, the service worker should be served from memory and not written to the filesystem, to avoid potential endless restarts when Spring dev tools are in use.

This change fixes a regression introduced when service worker compression was implemented, that causes sw.js to be written to the filesystem also in dev mode.