### PR TITLE
chore: Remove unnecessary mkdirp dependency

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
@@ -17,7 +17,6 @@
     "rollup-plugin-visualizer": "5.9.0",
     "rollup-plugin-brotli": "3.1.0",
     "vite-plugin-checker": "0.5.5",
-    "mkdirp": "1.0.4",
     "workbox-build": "7.0.0",
     "transform-ast": "2.4.4"
   }

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-copy.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-copy.js
@@ -21,10 +21,8 @@
 import { readdirSync, statSync, mkdirSync, existsSync, copyFileSync } from 'fs';
 import { resolve, basename, relative, extname } from 'path';
 import glob from 'glob';
-import mkdirp from 'mkdirp';
 
 const { sync } = glob;
-const { sync: mkdirpSync } = mkdirp;
 
 const ignoredFileExtensions = ['.css', '.js', '.json'];
 
@@ -43,13 +41,13 @@ function copyThemeResources(themeFolder, projectStaticAssetsOutputFolder, logger
 
   // Only create assets folder if there are files to copy.
   if (collection.files.length > 0) {
-    mkdirpSync(staticAssetsThemeFolder);
+    mkdirSync(staticAssetsThemeFolder, { recursive: true });
     // create folders with
     collection.directories.forEach((directory) => {
       const relativeDirectory = relative(themeFolder, directory);
       const targetDirectory = resolve(staticAssetsThemeFolder, relativeDirectory);
 
-      mkdirpSync(targetDirectory);
+      mkdirSync(targetDirectory, { recursive: true });
     });
 
     collection.files.forEach((file) => {
@@ -195,12 +193,11 @@ function copyFileIfAbsentOrNewer(fileToCopy, copyTarget, logger) {
 // This may happen for example when an IDE creates a temporary file
 // and then immediately deletes it
 function handleNoSuchFileError(file, error, logger) {
-    if (error.code === 'ENOENT') {
-        logger.warn('Ignoring not existing file ' + file +
-            '. File may have been deleted during theme processing.');
-    } else {
-        throw error;
-    }
+  if (error.code === 'ENOENT') {
+    logger.warn('Ignoring not existing file ' + file + '. File may have been deleted during theme processing.');
+  } else {
+    throw error;
+  }
 }
 
-export {checkModules, copyStaticAssets, copyThemeResources};
+export { checkModules, copyStaticAssets, copyThemeResources };

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -135,7 +135,6 @@ public class NodeUpdaterTest {
         expectedDependencies.add("@rollup/pluginutils");
         expectedDependencies.add("rollup-plugin-visualizer");
         expectedDependencies.add("vite-plugin-checker");
-        expectedDependencies.add("mkdirp");
         expectedDependencies.add("workbox-build");
         expectedDependencies.add("transform-ast");
         expectedDependencies.add("strip-css-comments");


### PR DESCRIPTION
mkdirSync in Node has had recursive:true support since Node 10
