### PR TITLE
chore: Upgrade vite plugin checker to 0.6.1

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
@@ -16,7 +16,7 @@
     "@rollup/pluginutils": "5.0.2",
     "rollup-plugin-visualizer": "5.9.2",
     "rollup-plugin-brotli": "3.1.0",
-    "vite-plugin-checker": "0.6.0",
+    "vite-plugin-checker": "0.6.1",
     "workbox-build": "7.0.0",
     "transform-ast": "2.4.4"
   }

--- a/flow-tests/test-frontend/vite-basics/src/test/java/com/vaadin/viteapp/BasicsIT.java
+++ b/flow-tests/test-frontend/vite-basics/src/test/java/com/vaadin/viteapp/BasicsIT.java
@@ -22,7 +22,8 @@ public class BasicsIT extends ViteDevModeIT {
         Assert.assertEquals("good", executeScript("return window.bad()"));
         Thread.sleep(2000); // Checking is async so it sometimes needs some time
         Assert.assertFalse("There should be no error overlay",
-                $("vite-plugin-checker-error-overlay").exists());
+                $("vite-plugin-checker-error-overlay").first().$("main")
+                        .exists());
     }
 
     @Test


### PR DESCRIPTION
This version has a UI rewritten with Vue and always includes the custom overlay element in the DOM
