### PR TITLE
fix: Do not force chokidar version

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -160,10 +160,6 @@ public class TaskUpdatePackages extends NodeUpdater {
             return true;
         }
 
-        if ("chokidar".equals(dependency)) {
-            // Explicitly lock this to avoid getting chokidar 2 with issues
-            return true;
-        }
         return false;
     }
 

--- a/flow-server/src/main/resources/pnpmfile.js
+++ b/flow-server/src/main/resources/pnpmfile.js
@@ -27,11 +27,5 @@ function readPackage(pkg) {
     }
   }
 
-  // Forcing chokidar version for now until new babel version is available
-  // check out https://github.com/babel/babel/issues/11488
-  if (pkg.dependencies.chokidar) {
-    pkg.dependencies.chokidar = '^3.4.0';
-  }
-
   return pkg;
 }


### PR DESCRIPTION
The old chokidar version was used by webpack 4...
