### PR TITLE
test: fix webpush integration test

### DIFF
--- a/flow-test-util/src/main/java/com/vaadin/flow/testutil/ChromeDeviceTest.java
+++ b/flow-test-util/src/main/java/com/vaadin/flow/testutil/ChromeDeviceTest.java
@@ -105,7 +105,7 @@ public class ChromeDeviceTest extends ViewOrUITest {
         if (getDeploymentHostname().equals("localhost")) {
             // Use headless Chrome for running locally
             if (!isJavaInDebugMode()) {
-                chromeOptions.addArguments("--headless", "--disable-gpu");
+                chromeOptions.addArguments("--headless=new", "--disable-gpu");
             }
         } else {
             // Enable service workers over http remote connection

--- a/flow-tests/test-webpush/src/main/java/com/vaadin/flow/webpush/WebPushView.java
+++ b/flow-tests/test-webpush/src/main/java/com/vaadin/flow/webpush/WebPushView.java
@@ -64,7 +64,9 @@ public class WebPushView extends Div {
 
         unsubscribe = new NativeButton("Unsubscribe", event -> webPush
                 .unsubscribe(event.getSource().getUI().get(), result -> {
-                    addLogEntry("Unsubscribed " + result.endpoint);
+                    String endpoint = result != null ? result.endpoint
+                            : "<unknown>";
+                    addLogEntry("Unsubscribed " + endpoint);
                     subscription = null;
                 }));
         unsubscribe.setId(UNSUBSCRIBE_ID);

--- a/flow-tests/test-webpush/src/test/java/com/vaadin/flow/webpush/WebPushIT.java
+++ b/flow-tests/test-webpush/src/test/java/com/vaadin/flow/webpush/WebPushIT.java
@@ -122,7 +122,7 @@ public class WebPushIT extends ChromeBrowserTest {
             subscribe.click();
 
             waitUntil(driver -> eventLog.$(DivElement.class).all().size() >= 2,
-                    30);
+                    60);
 
             Assert.assertEquals("Subscription should be logged", 2,
                     eventLog.$(DivElement.class).all().size());

--- a/flow-tests/test-webpush/src/test/java/com/vaadin/flow/webpush/WebPushIT.java
+++ b/flow-tests/test-webpush/src/test/java/com/vaadin/flow/webpush/WebPushIT.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.DesiredCapabilities;
 
 import com.vaadin.flow.component.html.testbench.DivElement;
 import com.vaadin.flow.component.html.testbench.NativeButtonElement;
@@ -45,17 +46,31 @@ public class WebPushIT extends ChromeBrowserTest {
 
     @Override
     protected void updateHeadlessChromeOptions(ChromeOptions chromeOptions) {
-
         // Create prefs map to store all preferences
-        Map<String, Object> prefs = new HashMap<String, Object>();
+        Map<String, Object> prefs = new HashMap<>();
 
         // Put this into prefs map to switch off browser notification
         prefs.put("profile.default_content_setting_values.notifications", 1);
         chromeOptions.setExperimentalOption("prefs", prefs);
     }
 
+    @Override
+    public void setDesiredCapabilities(
+            DesiredCapabilities desiredCapabilities) {
+        ChromeOptions opts = new ChromeOptions();
+        opts.addArguments(String.format(
+                "--unsafely-treat-insecure-origin-as-secure=%s", getRootURL()));
+        opts.addArguments("--disable-dev-shm-usage");
+
+        updateHeadlessChromeOptions(opts);
+
+        desiredCapabilities.merge(opts);
+        super.setDesiredCapabilities(desiredCapabilities);
+    }
+
     @After
     public void cleanup() {
+
         // Request remove subscription always after test.
         JavascriptExecutor jse = (JavascriptExecutor) driver;
         jse.executeScript(
@@ -106,7 +121,8 @@ public class WebPushIT extends ChromeBrowserTest {
         try {
             subscribe.click();
 
-            waitUntil(driver -> eventLog.$(DivElement.class).all().size() >= 2);
+            waitUntil(driver -> eventLog.$(DivElement.class).all().size() >= 2,
+                    30);
 
             Assert.assertEquals("Subscription should be logged", 2,
                     eventLog.$(DivElement.class).all().size());

--- a/flow-webpush/src/main/resources/META-INF/frontend/FlowWebPush.js
+++ b/flow-webpush/src/main/resources/META-INF/frontend/FlowWebPush.js
@@ -19,20 +19,26 @@ window.Vaadin.Flow = window.Vaadin.Flow || {};
 window.Vaadin.Flow.webPush = window.Vaadin.Flow.webPush || {
     subscribe: async function (publicKey) {
         const notificationPermission = await Notification.requestPermission();
-
         if (notificationPermission === 'granted') {
             const registration = await navigator.serviceWorker.getRegistration();
-            const subscription = await registration?.pushManager.subscribe({
-                userVisibleOnly: true,
-                applicationServerKey: this.urlB64ToUint8Array(publicKey),
-            });
 
-            if (subscription) {
-                console.log(subscription);
-                // console.log(JSON.parse(JSON.stringify(subscription)));
-                return JSON.parse(JSON.stringify(subscription));
+            if (registration) {
+                if (registration?.pushManager) {
+                    const subscription = await registration?.pushManager.subscribe({
+                        userVisibleOnly: true,
+                        applicationServerKey: this.urlB64ToUint8Array(publicKey),
+                    });
+
+                    if (subscription) {
+                        console.log(subscription);
+                        // console.log(JSON.parse(JSON.stringify(subscription)));
+                        return JSON.parse(JSON.stringify(subscription));
+                    }
+                    throw new Error("Subscription failed. See console for exception.");
+                }
+                throw new Error("Cannot get push manager from registration.");
             }
-            throw new Error("Subscription failed. See console for exception.");
+            throw new Error("Cannot get registration from service worker.");
         }
         throw new Error("You have blocked notifications. You need to manually enable them in your browser.");
     },
@@ -48,23 +54,23 @@ window.Vaadin.Flow.webPush = window.Vaadin.Flow.webPush || {
         return '{ "message": "No active subscription" }';
     },
 
-    registrationStatus: async function() {
+    registrationStatus: async function () {
         const registration = await navigator.serviceWorker.getRegistration();
         return !!(await registration?.pushManager.getSubscription());
     },
 
-    notificationDenied: async function() {
+    notificationDenied: async function () {
         return Notification.permission === 'denied';
     },
 
-    notificationGranted: async function() {
+    notificationGranted: async function () {
         return Notification.permission === 'granted';
     },
 
-    getSubscription: async  function() {
+    getSubscription: async function () {
         const registration = await navigator.serviceWorker.getRegistration();
         const subscription = await registration?.pushManager.getSubscription();
-        if(subscription) {
+        if (subscription) {
             return subscription;
         }
         return '{ "message": "No active subscription" }';


### PR DESCRIPTION
Webpush integration test was working fine locally, also using selenium hub, but failed on CI env.
This change fixes the test by waiting a bit longer for the subscription to complete and handling errors received a string instead of JSON objects.