### PR TITLE
feat: fail fast when plugin is used with an unsupported version of Gradle

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/TestUtils.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/TestUtils.kt
@@ -211,7 +211,7 @@ object OsUtils {
  * Used to test the plugin. Contains helpful utility methods to manipulate folders
  * and files in the project.
  */
-class TestProject {
+class TestProject(val gradleVersion: String = VaadinPlugin.GRADLE_MINIMUM_SUPPORTED_VERSION) {
     /**
      * The project root dir.
      */
@@ -227,12 +227,13 @@ class TestProject {
      */
     val settingsFile: File get() = File(dir, "settings.gradle")
 
+
     private fun createGradleRunner(): GradleRunner = GradleRunner.create()
         .withProjectDir(dir)
         .withPluginClasspath()
         .withDebug(true) // use --debug to catch ReflectionsException: https://github.com/vaadin/vaadin-gradle-plugin/issues/99
         .forwardOutput()   // a must, otherwise ./gradlew check freezes on windows!
-        .withGradleVersion("7.6.1")
+        .withGradleVersion(gradleVersion)
 
     override fun toString(): String = "TestProject(dir=$dir)"
 

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
@@ -344,7 +344,7 @@ class VaadinSmokeTest : AbstractGradleTest() {
 
         // Cannot test versions older than 7.6 because of Java version
         // incompatibilities with dependencies thar makes the build fail before
-        //the plugin is applied
+        // the plugin is applied
         for (unsupportedVersion in arrayOf("7.6")) {
             setupProjectForGradleVersion(unsupportedVersion)
             val result = testProject.buildAndFail("vaadinClean")

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
@@ -15,16 +15,16 @@
  */
 package com.vaadin.gradle
 
+import java.io.File
+import kotlin.test.assertContains
+import kotlin.test.expect
 import com.vaadin.flow.server.InitParameters
 import elemental.json.JsonObject
 import elemental.json.impl.JsonUtil
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
-import java.io.File
-import kotlin.test.expect
 
 /**
  * The most basic tests. If these fail, the plugin is completely broken and all
@@ -325,4 +325,33 @@ class VaadinSmokeTest : AbstractGradleTest() {
         expect(true, cssFile.toString()) { cssFile.exists() }
 
     }
+
+    @Test
+    fun pluginShouldFailWithUnsupportedGradleVersion() {
+        // Works with supported version
+        var result = testProject.build("vaadinClean")
+        result.expectTaskSucceded("vaadinClean")
+        testProject.delete()
+
+        // Cannot test versions older than 7.6 because of Java version
+        // incompatibilities with dependencies thar makes the build fail before
+        //the plugin is applied
+        val unsupportedVersion = "7.6"
+        testProject = TestProject(unsupportedVersion)
+        setup()
+        result = testProject.buildAndFail("vaadinClean")
+        assertContains(
+            result.output,
+            "requires Gradle ${VaadinPlugin.GRADLE_MINIMUM_SUPPORTED_VERSION} or later",
+            true,
+            "Expecting plugin execution to fail for version ${unsupportedVersion} " +
+                    "as it is lower than the supported one (${VaadinPlugin.GRADLE_MINIMUM_SUPPORTED_VERSION})"
+        )
+        assertContains(
+            result.output,
+            "current version is ${unsupportedVersion}"
+        )
+        testProject.delete()
+    }
+
 }

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
@@ -328,30 +328,38 @@ class VaadinSmokeTest : AbstractGradleTest() {
 
     @Test
     fun pluginShouldFailWithUnsupportedGradleVersion() {
-        // Works with supported version
-        var result = testProject.build("vaadinClean")
-        result.expectTaskSucceded("vaadinClean")
-        testProject.delete()
+
+        fun setupProjectForGradleVersion(version: String) {
+            testProject.delete()
+            testProject = TestProject(version)
+            setup()
+        }
+
+        // Works with supported versions
+        for (supportedVersion in arrayOf(VaadinPlugin.GRADLE_MINIMUM_SUPPORTED_VERSION, "7.6.2", "8.1", "8.2") ) {
+            setupProjectForGradleVersion(supportedVersion)
+            val result = testProject.build("vaadinClean")
+            result.expectTaskSucceded("vaadinClean")
+        }
 
         // Cannot test versions older than 7.6 because of Java version
         // incompatibilities with dependencies thar makes the build fail before
         //the plugin is applied
-        val unsupportedVersion = "7.6"
-        testProject = TestProject(unsupportedVersion)
-        setup()
-        result = testProject.buildAndFail("vaadinClean")
-        assertContains(
-            result.output,
-            "requires Gradle ${VaadinPlugin.GRADLE_MINIMUM_SUPPORTED_VERSION} or later",
-            true,
-            "Expecting plugin execution to fail for version ${unsupportedVersion} " +
-                    "as it is lower than the supported one (${VaadinPlugin.GRADLE_MINIMUM_SUPPORTED_VERSION})"
-        )
-        assertContains(
-            result.output,
-            "current version is ${unsupportedVersion}"
-        )
-        testProject.delete()
+        for (unsupportedVersion in arrayOf("7.6")) {
+            setupProjectForGradleVersion(unsupportedVersion)
+            val result = testProject.buildAndFail("vaadinClean")
+            assertContains(
+                result.output,
+                "requires Gradle ${VaadinPlugin.GRADLE_MINIMUM_SUPPORTED_VERSION} or later",
+                true,
+                "Expecting plugin execution to fail for version ${unsupportedVersion} " +
+                        "as it is lower than the supported one (${VaadinPlugin.GRADLE_MINIMUM_SUPPORTED_VERSION})"
+            )
+            assertContains(
+                result.output,
+                "current version is ${unsupportedVersion}"
+            )
+        }
     }
 
 }

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinPlugin.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinPlugin.kt
@@ -15,18 +15,26 @@
  */
 package com.vaadin.gradle
 
+import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.bundling.Jar
+import org.gradle.util.GradleVersion
 
 /**
  * The main class of the Vaadin Gradle Plugin.
  * @author mavi@vaadin.com
  */
 public class VaadinPlugin : Plugin<Project> {
+    public companion object {
+        public const val GRADLE_MINIMUM_SUPPORTED_VERSION: String = "7.6.1"
+    }
+
     override fun apply(project: Project) {
+        verifyGradleVersion()
+
         // we need Java Plugin conventions so that we can ensure the order of tasks
         project.pluginManager.apply(JavaPlugin::class.java)
         var extensionName = "vaadin"
@@ -59,6 +67,18 @@ public class VaadinPlugin : Plugin<Project> {
                     task.dependsOn("vaadinBuildFrontend")
                 }
             }
+        }
+    }
+
+    private fun verifyGradleVersion() {
+        val currentVersion = GradleVersion.current();
+        val supportedVersion =
+            GradleVersion.version(GRADLE_MINIMUM_SUPPORTED_VERSION)
+        if (currentVersion < supportedVersion) {
+            throw GradleException(
+                "Vaadin plugin requires Gradle ${GRADLE_MINIMUM_SUPPORTED_VERSION} or later. "
+                        + "The current version is ${currentVersion.version}."
+            )
         }
     }
 }


### PR DESCRIPTION
## Description

Checks the gradle version when applying the plugin and fails fast if the current gradle version is unsupported.

Closes #16149

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
