### PR TITLE
fix: do not register requests while flush in progress

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -1129,6 +1129,9 @@ public class DataCommunicator<T> implements Serializable {
         if (forced) {
             return true;
         }
+        // New requests that are not forced are not registered while a flush
+        // is in progress. This prevents infinite loop in cases including
+        // @PreserveOnRefresh.
         return !flushInProgress && (flushRequest == null || !flushRequest.canExecute(stateNode));
     }
 
@@ -1146,6 +1149,8 @@ public class DataCommunicator<T> implements Serializable {
     }
 
     private boolean shouldRequestFlushUpdatedData() {
+        // New requests are not registered while a flush is in progress. This
+        // prevents infinite loop in cases including @PreserveOnRefresh.
         return !flushUpdatedDataInProgress && (flushUpdatedDataRequest == null ||
                 !flushUpdatedDataRequest.canExecute(stateNode));
     }

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -1132,27 +1132,27 @@ public class DataCommunicator<T> implements Serializable {
         // New requests that are not forced are not registered while a flush
         // is in progress. This prevents infinite loop in cases including
         // @PreserveOnRefresh.
-        return !flushInProgress && (flushRequest == null || !flushRequest.canExecute(stateNode));
+        return !flushInProgress && (flushRequest == null
+                || !flushRequest.canExecute(stateNode));
     }
 
     private void requestFlushUpdatedData() {
         if (!shouldRequestFlushUpdatedData()) {
             return;
         }
-        flushUpdatedDataRequest = FlushRequest.register(stateNode,
-                context -> {
-                    flushUpdatedDataInProgress = true;
-                    flushUpdatedData();
-                    flushUpdatedDataRequest = null;
-                    flushUpdatedDataInProgress = false;
-                });
+        flushUpdatedDataRequest = FlushRequest.register(stateNode, context -> {
+            flushUpdatedDataInProgress = true;
+            flushUpdatedData();
+            flushUpdatedDataRequest = null;
+            flushUpdatedDataInProgress = false;
+        });
     }
 
     private boolean shouldRequestFlushUpdatedData() {
         // New requests are not registered while a flush is in progress. This
         // prevents infinite loop in cases including @PreserveOnRefresh.
-        return !flushUpdatedDataInProgress && (flushUpdatedDataRequest == null ||
-                !flushUpdatedDataRequest.canExecute(stateNode));
+        return !flushUpdatedDataInProgress && (flushUpdatedDataRequest == null
+                || !flushUpdatedDataRequest.canExecute(stateNode));
     }
 
     private void flush() {

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -1118,8 +1118,8 @@ public class DataCommunicator<T> implements Serializable {
                     arrayUpdater.initialize();
                 }
                 flush();
-                flushRequest = null;
             } finally {
+                flushRequest = null;
                 flushInProgress = false;
             }
         });
@@ -1147,8 +1147,8 @@ public class DataCommunicator<T> implements Serializable {
             flushUpdatedDataInProgress = true;
             try {
                 flushUpdatedData();
-                flushUpdatedDataRequest = null;
             } finally {
+                flushUpdatedDataRequest = null;
                 flushUpdatedDataInProgress = false;
             }
         });

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -1112,13 +1112,16 @@ public class DataCommunicator<T> implements Serializable {
         }
         flushRequest = FlushRequest.register(stateNode, context -> {
             flushInProgress = true;
-            if (!context.isClientSideInitialized()) {
-                reset();
-                arrayUpdater.initialize();
+            try {
+                if (!context.isClientSideInitialized()) {
+                    reset();
+                    arrayUpdater.initialize();
+                }
+                flush();
+                flushRequest = null;
+            } finally {
+                flushInProgress = false;
             }
-            flush();
-            flushRequest = null;
-            flushInProgress = false;
         });
     }
 
@@ -1142,9 +1145,12 @@ public class DataCommunicator<T> implements Serializable {
         }
         flushUpdatedDataRequest = FlushRequest.register(stateNode, context -> {
             flushUpdatedDataInProgress = true;
-            flushUpdatedData();
-            flushUpdatedDataRequest = null;
-            flushUpdatedDataInProgress = false;
+            try {
+                flushUpdatedData();
+                flushUpdatedDataRequest = null;
+            } finally {
+                flushUpdatedDataInProgress = false;
+            }
         });
     }
 

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
@@ -248,9 +248,9 @@ public class DataCommunicatorTest {
     @Test
     public void setFlushRequest_remove_setFlushRequest_reattach_noEndlessFlushLoop() {
         AtomicInteger listenerInvocationCounter = new AtomicInteger(0);
-        dataCommunicator = new DataCommunicator<>(dataGenerator,
-                arrayUpdater, data -> {
-        }, element.getNode()) {
+        dataCommunicator = new DataCommunicator<>(dataGenerator, arrayUpdater,
+                data -> {
+                }, element.getNode()) {
             @Override
             public void reset() {
                 Assert.assertTrue("Should not fall into endless reset loop",

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
@@ -246,15 +246,28 @@ public class DataCommunicatorTest {
     }
 
     @Test
-    public void rename() {
+    public void setFlushRequest_remove_setFlushRequest_reattach_noEndlessFlushLoop() {
+        AtomicInteger listenerInvocationCounter = new AtomicInteger(0);
+        dataCommunicator = new DataCommunicator<>(dataGenerator,
+                arrayUpdater, data -> {
+        }, element.getNode()) {
+            @Override
+            public void reset() {
+                Assert.assertTrue("Should not fall into endless reset loop",
+                        listenerInvocationCounter.incrementAndGet() < 5);
+                super.reset();
+            }
+        };
+
         // No flush requests initially
         fakeClientCommunication();
-        // Any flush request
-        dataCommunicator.reset();
 
+        dataCommunicator.reset();
         element.removeFromTree();
         dataCommunicator.reset();
         ui.getElement().appendChild(element);
+
+        listenerInvocationCounter.set(0);
 
         fakeClientCommunication();
     }

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
@@ -246,6 +246,20 @@ public class DataCommunicatorTest {
     }
 
     @Test
+    public void rename() {
+        // No flush requests initially
+        fakeClientCommunication();
+        // Any flush request
+        dataCommunicator.reset();
+
+        element.removeFromTree();
+        dataCommunicator.reset();
+        ui.getElement().appendChild(element);
+
+        fakeClientCommunication();
+    }
+
+    @Test
     public void setDataProvider_keyMapperIsReset() {
         dataCommunicator.setDataProvider(createDataProvider(), null);
         dataCommunicator.setRequestedRange(0, 50);


### PR DESCRIPTION
## Description

Similar to an [issue](https://github.com/vaadin/flow/issues/14435) that was [fixed](https://github.com/vaadin/flow/pull/14647) before, there is a new [issue](https://github.com/vaadin/flow-components/issues/4674) regarding endless loops triggered under certain conditions. The issue was originally reported for  `ComboBox`. However, the behaviour can be reproduced with a `Grid` as well, since the underlying issue is with the `DataCommunicator`. Even if the example or the test is not considered best practice, the endless loop should still be avoided.

This PR replaces the flush request canceling approach using a "flush in progress" flag. While a registered flush is triggered, until it ends, no other flush requests will be registered. With this change, any edge cases regarding registering multiple flush requests during the same round-trip should be dealt properly.

Fixes related Flow component [issue](https://github.com/vaadin/flow-components/issues/4674).

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.