### PR TITLE
chore: make flow build compatible with JDK 20.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -452,7 +452,7 @@
                 <plugin>
                     <groupId>org.apache.karaf.tooling</groupId>
                     <artifactId>karaf-maven-plugin</artifactId>
-                    <version>4.3.2</version>
+                    <version>4.3.9</version>
                     <extensions>true</extensions>
                     <executions>
                         <execution>


### PR DESCRIPTION
the current plugin version 4.3.2 doesn't compile with JDK 20.0.2

fixes #17236 
