### PR TITLE
fix: Fix regression when sync id check is disabled

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/LongPollingCacheFilter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/LongPollingCacheFilter.java
@@ -76,7 +76,10 @@ public class LongPollingCacheFilter
             String uuid = r.uuid();
             int lastSeenOnClient = session.getAttribute(SEEN_SERVER_SYNC_ID,
                     Integer.class);
-            if (pushMessage.alreadySeen(lastSeenOnClient)) {
+            if (lastSeenOnClient == -1) {
+                return new BroadcastAction(BroadcastAction.ACTION.CONTINUE,
+                        message);
+            } else if (pushMessage.alreadySeen(lastSeenOnClient)) {
                 getLogger().trace(
                         "Discarding message {} for resource {} as client already seen {}. {}",
                         pushMessage.serverSyncId, uuid, lastSeenOnClient,

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/LongPollingCacheFilterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/LongPollingCacheFilterTest.java
@@ -82,6 +82,19 @@ public class LongPollingCacheFilterTest {
     }
 
     @Test
+    public void filter_syncIdCheckDisabled_continueWithCurrentMessage() {
+        setTransport(AtmosphereResource.TRANSPORT.LONG_POLLING);
+        setSeenServerSyncIdHeader(-1);
+        BroadcastAction action = filter.filter("broadcasterId", resource,
+                originalMessage, message);
+        Assert.assertEquals(ACTION.CONTINUE, action.action());
+        Assert.assertSame(
+                "Message should not be altered by filter if server sync id header is missing",
+                message, action.message());
+        verifyMessageIsNotCached();
+    }
+
+    @Test
     public void filter_missingLastSeenServerSyncId_continueWithCurrentMessage() {
         setTransport(AtmosphereResource.TRANSPORT.LONG_POLLING);
         simulatePushConnection();

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/LongPollingCacheFilterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/LongPollingCacheFilterTest.java
@@ -89,7 +89,7 @@ public class LongPollingCacheFilterTest {
                 originalMessage, message);
         Assert.assertEquals(ACTION.CONTINUE, action.action());
         Assert.assertSame(
-                "Message should not be altered by filter if server sync id header is missing",
+                "Message should not be altered by filter if syncId check is disabled",
                 message, action.message());
         verifyMessageIsNotCached();
     }


### PR DESCRIPTION
Fixes: https://github.com/vaadin/flow/issues/17237