### PR TITLE
fix: prevent deadlock when push is requested during disconnect (#17130) (CP: 9.1)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/AtmospherePushConnection.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/AtmospherePushConnection.java
@@ -180,14 +180,18 @@ public class AtmospherePushConnection implements PushConnection {
      *            false if it is a response to a client request.
      */
     public void push(boolean async) {
-        synchronized (lock) {
-            if (!isConnected()) {
-                if (async && state != State.RESPONSE_PENDING) {
-                    state = State.PUSH_PENDING;
-                } else {
-                    state = State.RESPONSE_PENDING;
-                }
+        if (disconnecting || !isConnected()) {
+            if (disconnecting) {
+                getLogger().debug(
+                        "Disconnection in progress, ignoring push request");
+            }
+            if (async && state != State.RESPONSE_PENDING) {
+                state = State.PUSH_PENDING;
             } else {
+                state = State.RESPONSE_PENDING;
+            }
+        } else {
+            synchronized (lock) {
                 try {
                     JsonObject response = new UidlWriter().createUidl(getUI(),
                             async);
@@ -317,47 +321,50 @@ public class AtmospherePushConnection implements PushConnection {
         }
 
         synchronized (lock) {
-            disconnecting = true;
-            assert isConnected();
-            if (resource == null) {
-                // Already disconnected. Should not happen but if it does,
-                // we
-                // don't
-                // want to cause NPEs
-                getLogger().debug(
-                        "AtmospherePushConnection.disconnect() called twice, this should not happen");
-                return;
-            }
-            if (resource.isResumed()) {
-                // This can happen for long polling because of
-                // http://dev.vaadin.com/ticket/16919
-                // Once that is fixed, this should never happen
-                connectionLost();
-                return;
-            }
-            if (outgoingMessage != null) {
-                // Wait for the last message to be sent before closing the
-                // connection (assumes that futures are completed in order)
-                try {
-                    outgoingMessage.get(1000, TimeUnit.MILLISECONDS);
-                } catch (TimeoutException e) {
-                    getLogger().info(
-                            "Timeout waiting for messages to be sent to client before disconnect",
-                            e);
-                } catch (Exception e) {
-                    getLogger().info(
-                            "Error waiting for messages to be sent to client before disconnect",
-                            e);
-                }
-                outgoingMessage = null;
-            }
             try {
-                resource.close();
-            } catch (IOException e) {
-                getLogger().info("Error when closing push connection", e);
+                disconnecting = true;
+                assert isConnected();
+                if (resource == null) {
+                    // Already disconnected. Should not happen but if it does,
+                    // we
+                    // don't
+                    // want to cause NPEs
+                    getLogger().debug(
+                            "AtmospherePushConnection.disconnect() called twice, this should not happen");
+                    return;
+                }
+                if (resource.isResumed()) {
+                    // This can happen for long polling because of
+                    // http://dev.vaadin.com/ticket/16919
+                    // Once that is fixed, this should never happen
+                    connectionLost();
+                    return;
+                }
+                if (outgoingMessage != null) {
+                    // Wait for the last message to be sent before closing the
+                    // connection (assumes that futures are completed in order)
+                    try {
+                        outgoingMessage.get(1000, TimeUnit.MILLISECONDS);
+                    } catch (TimeoutException e) {
+                        getLogger().info(
+                                "Timeout waiting for messages to be sent to client before disconnect",
+                                e);
+                    } catch (Exception e) {
+                        getLogger().info(
+                                "Error waiting for messages to be sent to client before disconnect",
+                                e);
+                    }
+                    outgoingMessage = null;
+                }
+                try {
+                    resource.close();
+                } catch (IOException e) {
+                    getLogger().info("Error when closing push connection", e);
+                }
+                connectionLost();
+            } finally {
+                disconnecting = false;
             }
-            connectionLost();
-            disconnecting = false;
         }
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/AtmospherePushConnectionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/AtmospherePushConnectionTest.java
@@ -226,4 +226,63 @@ public class AtmospherePushConnectionTest {
         Mockito.verify(resource, Mockito.times(1)).close();
     }
 
+    @Test
+    public void pushWhileDisconnect_preventDeadlocks() throws Exception {
+        // Similar motivation exposed in
+        // disconnect_concurrentRequests_preventDeadlocks
+        // but when a Vaadin session is unlocked as a consequence of HTTP
+        // session invalidation
+        ReentrantLock httpSessionLock = new ReentrantLock();
+        Mockito.doAnswer(i -> {
+            // simulate HTTP session lock attempt because of atmosphere resource
+            // accesses session attributes
+            // It does not wait indefinitely, but triggers an error if the lock
+            // is held by the main thread
+            if (httpSessionLock.tryLock(2, TimeUnit.SECONDS)) {
+                httpSessionLock.unlock();
+            } else {
+                throw new AssertionError(
+                        "Deadlock on AtmosphereResource.close");
+            }
+            return null;
+        }).when(resource).close();
+
+        CountDownLatch latch = new CountDownLatch(2);
+        httpSessionLock.lock();
+        CompletableFuture<Throwable> threadErrorFuture;
+        try {
+            // Simulate PUSH disconnection from a separate thread
+            threadErrorFuture = CompletableFuture
+                    .<Throwable> supplyAsync(() -> {
+                        connection.disconnect();
+                        latch.countDown();
+                        return null;
+                    }).exceptionally(t -> {
+                        if (t instanceof CompletionException) {
+                            return t.getCause();
+                        }
+                        return t;
+                    });
+            // Simulate main thread PUSH disconnection because of session
+            // invalidation, delayed a bit to allow the other thread to start
+            // disconnection
+            Thread.sleep(1);
+            vaadinSession.access(() -> {
+                connection.push();
+            });
+            latch.countDown();
+        } finally {
+            httpSessionLock.unlock();
+        }
+
+        Throwable threadError = threadErrorFuture.get(2, TimeUnit.SECONDS);
+        if (threadError != null) {
+            Assert.fail("Disconnection on spawned thread failed: "
+                    + threadError.getMessage());
+        }
+        Assert.assertTrue("Disconnect calls not completed, missing "
+                + latch.getCount() + " call", latch.await(3, TimeUnit.SECONDS));
+        Mockito.verify(resource, Mockito.times(1)).close();
+    }
+
 }


### PR DESCRIPTION
Prevents a deadlock that may happen when a servlet container holds a lock on HTTP session access and a push disconnection happens concurrently with a push operation requested when VaadinSession is unlocked after session destroyed listeners are invoked.

References #16293

Co-authored-by: Johannes Tuikkala @johannest