### PR TITLE
fix: prevent deadlock when push is requested during disconnect  (#17130) (CP: 2.9)

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/AtmospherePushConnectionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/AtmospherePushConnectionTest.java
@@ -234,4 +234,63 @@ public class AtmospherePushConnectionTest {
         Mockito.verify(resource, Mockito.times(1)).close();
     }
 
+    @Test
+    public void pushWhileDisconnect_preventDeadlocks() throws Exception {
+        // Similar motivation exposed in
+        // disconnect_concurrentRequests_preventDeadlocks
+        // but when a Vaadin session is unlocked as a consequence of HTTP
+        // session invalidation
+        ReentrantLock httpSessionLock = new ReentrantLock();
+        Mockito.doAnswer(i -> {
+            // simulate HTTP session lock attempt because of atmosphere resource
+            // accesses session attributes
+            // It does not wait indefinitely, but triggers an error if the lock
+            // is held by the main thread
+            if (httpSessionLock.tryLock(2, TimeUnit.SECONDS)) {
+                httpSessionLock.unlock();
+            } else {
+                throw new AssertionError(
+                        "Deadlock on AtmosphereResource.close");
+            }
+            return null;
+        }).when(resource).close();
+
+        CountDownLatch latch = new CountDownLatch(2);
+        httpSessionLock.lock();
+        CompletableFuture<Throwable> threadErrorFuture;
+        try {
+            // Simulate PUSH disconnection from a separate thread
+            threadErrorFuture = CompletableFuture
+                    .<Throwable> supplyAsync(() -> {
+                        connection.disconnect();
+                        latch.countDown();
+                        return null;
+                    }).exceptionally(t -> {
+                        if (t instanceof CompletionException) {
+                            return t.getCause();
+                        }
+                        return t;
+                    });
+            // Simulate main thread PUSH disconnection because of session
+            // invalidation, delayed a bit to allow the other thread to start
+            // disconnection
+            Thread.sleep(1);
+            vaadinSession.access(() -> {
+                connection.push();
+            });
+            latch.countDown();
+        } finally {
+            httpSessionLock.unlock();
+        }
+
+        Throwable threadError = threadErrorFuture.get(2, TimeUnit.SECONDS);
+        if (threadError != null) {
+            Assert.fail("Disconnection on spawned thread failed: "
+                    + threadError.getMessage());
+        }
+        Assert.assertTrue("Disconnect calls not completed, missing "
+                + latch.getCount() + " call", latch.await(3, TimeUnit.SECONDS));
+        Mockito.verify(resource, Mockito.times(1)).close();
+    }
+
 }


### PR DESCRIPTION
Prevents a deadlock that may happen when a servlet container holds a lock on HTTP session access and a push disconnection happens concurrently with a push operation requested when VaadinSession is unlocked after session destroyed listeners are invoked.

References #16293

Co-authored-by: Johannes Tuikkala @johannest