### PR TITLE
chore: explictly use ant path matchers in VaadinWebSecurity

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -431,7 +431,8 @@ public abstract class VaadinWebSecurity {
                     getVaadinSavedRequestAwareAuthenticationSuccessHandler(
                             http));
         });
-        http.csrf(cfg -> cfg.ignoringRequestMatchers(completeLoginPath));
+        http.csrf(cfg -> cfg.ignoringRequestMatchers(
+                new AntPathRequestMatcher(completeLoginPath)));
         configureLogout(http, logoutSuccessUrl);
         http.exceptionHandling(cfg -> cfg.defaultAuthenticationEntryPointFor(
                 new LoginUrlAuthenticationEntryPoint(completeLoginPath),


### PR DESCRIPTION
Spring security configurers accepting strings matcher may fail to detect if the parameter is a Spring MVC pattern or not. This change update VaadinWebSecurity to explictly use ant path request matchers.
