### PR TITLE
chore: prevent usage statistics failure when collecting info

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/stats/DevModeUsageStatistics.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/stats/DevModeUsageStatistics.java
@@ -118,7 +118,8 @@ public class DevModeUsageStatistics {
                 globalData.setValue(StatisticsConstants.FIELD_MACHINE_ID,
                         MachineId.get());
             } catch (Throwable ex) {
-                globalData.setValue(StatisticsConstants.FIELD_MACHINE_ID, "");
+                globalData.setValue(StatisticsConstants.FIELD_MACHINE_ID,
+                        "ERROR");
                 getLogger().debug("Cannot get Machine ID", ex);
             }
 

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/stats/DevModeUsageStatistics.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/stats/DevModeUsageStatistics.java
@@ -19,12 +19,12 @@ package com.vaadin.base.devserver.stats;
 import java.io.File;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.vaadin.pro.licensechecker.MachineId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.base.devserver.ServerInfo;
 import com.vaadin.flow.server.Version;
+import com.vaadin.pro.licensechecker.MachineId;
 
 import elemental.json.JsonObject;
 
@@ -114,8 +114,13 @@ public class DevModeUsageStatistics {
                     ProjectHelpers.getProKey());
             globalData.setValue(StatisticsConstants.FIELD_USER_KEY,
                     ProjectHelpers.getUserKey());
-            globalData.setValue(StatisticsConstants.FIELD_MACHINE_ID,
-                    MachineId.get());
+            try {
+                globalData.setValue(StatisticsConstants.FIELD_MACHINE_ID,
+                        MachineId.get());
+            } catch (Throwable ex) {
+                globalData.setValue(StatisticsConstants.FIELD_MACHINE_ID, "");
+                getLogger().debug("Cannot get Machine ID", ex);
+            }
 
             // Update basic project statistics and save
             projectData.setValue(StatisticsConstants.FIELD_FLOW_VERSION,


### PR DESCRIPTION
## Description

Handles potential failures due to JNA incompatibility when collecting statistic data, providing empty value as default.

Fixes vaadin/quarkus#136

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
