### PR TITLE
fix: fail when adding null component event listener

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentEventBus.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentEventBus.java
@@ -141,6 +141,11 @@ public class ComponentEventBus implements Serializable {
             Class<T> eventType, ComponentEventListener<T> listener,
             Consumer<DomListenerRegistration> domListenerConsumer) {
 
+        if (listener == null) {
+            throw new IllegalArgumentException(
+                    "component event listener cannot be null");
+        }
+
         ListenerWrapper<T> wrapper = new ListenerWrapper<>(listener);
 
         boolean isDomEvent = addDomTriggerIfNeeded(eventType, wrapper);

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentEventBusTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentEventBusTest.java
@@ -21,7 +21,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -40,6 +42,9 @@ import elemental.json.Json;
 import elemental.json.JsonObject;
 
 public class ComponentEventBusTest {
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
 
     private static class EventTracker<T extends ComponentEvent<?>>
             implements ComponentEventListener<T> {
@@ -743,14 +748,10 @@ public class ComponentEventBusTest {
 
     @Test
     public void addListener_nullListener_failFast() {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("component event listener cannot be null");
+
         final TestButton button = new TestButton();
-        try {
-            button.addListener(ServerEvent.class, null);
-            Assert.fail(
-                    "Expecting an exception to be thrown for null listener");
-        } catch (IllegalArgumentException ex) {
-            Assert.assertTrue(
-                    ex.getMessage().contains("component event listener"));
-        }
+        button.addListener(ServerEvent.class, null);
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentEventBusTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentEventBusTest.java
@@ -740,4 +740,17 @@ public class ComponentEventBusTest {
             util.verifyNoInteractions();
         }
     }
+
+    @Test
+    public void addListener_nullListener_failFast() {
+        final TestButton button = new TestButton();
+        try {
+            button.addListener(ServerEvent.class, null);
+            Assert.fail(
+                    "Expecting an exception to be thrown for null listener");
+        } catch (IllegalArgumentException ex) {
+            Assert.assertTrue(
+                    ex.getMessage().contains("component event listener"));
+        }
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
@@ -585,10 +585,10 @@ public class ShortcutRegistrationTest {
 
         Registration registration = Mockito.mock(Registration.class);
         AtomicInteger count = new AtomicInteger();
-        Mockito.when(ui.addDetachListener(any())).thenAnswer(invocation -> {
+        Mockito.doAnswer(invocation -> {
             count.incrementAndGet();
             return registration;
-        });
+        }).when(ui).addDetachListener(any());
 
         Component[] components = new Component[] { ui };
 


### PR DESCRIPTION
## Description

Currently, it is possible to add component event listeners pointing to a null reference. At runtime an NPE is thrown, but for an internal wrapper class, making difficult to spot where the null reference comes from. This change will throw immediately if null is given as a component event listener.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
