### PR TITLE
fix: pre-compile visitable classes regex pattern

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -72,6 +73,19 @@ import static com.vaadin.flow.server.frontend.scanner.FrontendClassVisitor.VERSI
  * @since 2.0
  */
 public class FrontendDependencies extends AbstractDependenciesScanner {
+
+    //@formatter:off
+    private static final Pattern VISITABLE_CLASS_PATTERN = Pattern.compile("(^$|"
+            + ".*(slf4j).*|"
+            // #5803
+            + "^(java|sun|oracle|elemental|javax|jakarta|oshi|"
+            + "org\\.(apache|atmosphere|jsoup|jboss|w3c|spring|joda|hibernate|glassfish|hsqldb|osgi|jooq)|"
+            + "com\\.(helger|spring|gwt|lowagie|fasterxml|sun|nimbusds|googlecode)|"
+            + "net\\.(sf|bytebuddy)"
+            + ").*|"
+            + ".*(Exception)$"
+            + ")");
+    //@formatter:on
 
     private final HashMap<String, EntryPointData> entryPoints = new LinkedHashMap<>();
     private ThemeDefinition themeDefinition;
@@ -798,15 +812,8 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
         // factories. This is the reason of having just a blacklist of some
         // common name-spaces that would not have components.
         // We also exclude Feature-Flag classes
-        return className != null && // @formatter:off
-                !isExperimental(className) &&
-                !className.matches(
-                    "(^$|"
-                    + ".*(slf4j).*|"
-                    // #5803
-                    + "^(java|sun|elemental|javax|jakarta|oshi|org.(apache|atmosphere|jsoup|jboss|w3c|spring|joda|hibernate|glassfish|hsqldb)|com.(helger|spring|gwt|lowagie|fasterxml|sun|nimbusds)|net.(sf|bytebuddy)).*|"
-                    + ".*(Exception)$"
-                    + ")"); // @formatter:on
+        return className != null && !isExperimental(className)
+                && !VISITABLE_CLASS_PATTERN.matcher(className).matches();
     }
 
     private URL getUrl(String className) {


### PR DESCRIPTION
## Description

Pre compiles the regex pattern to improve build frontend performance during the bytecode scan and collection of reachable classes. Also adds some package exclusions for well knonw libraries that should not be visited.

Part of #17234

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
