### PR TITLE
Added license checker to theme editor.

### DIFF
--- a/vaadin-dev-server/frontend/connection.ts
+++ b/vaadin-dev-server/frontend/connection.ts
@@ -60,6 +60,9 @@ export class Connection extends Object {
     // eslint-disable-next-line no-console
     console.error('Unknown message received from the live reload server:', message);
   }
+  onLicenseCheckResult(_: any) {
+    // Intentionally empty.
+  }
 
   handleMessage(msg: any) {
     let json;
@@ -82,10 +85,13 @@ export class Connection extends Object {
       }
     } else if (json.command === 'license-check-ok') {
       licenseCheckOk(json.data);
+      this.onLicenseCheckResult(json);
     } else if (json.command === 'license-check-failed') {
       licenseCheckFailed(json.data);
+      this.onLicenseCheckResult(json);
     } else if (json.command === 'license-check-nokey') {
       licenseCheckNoKey(json.data);
+      this.onLicenseCheckResult(json);
     } else {
       this.onMessage(json);
     }

--- a/vaadin-dev-server/frontend/theme-editor/editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.ts
@@ -10,6 +10,8 @@ import {
   generateThemeRuleCss,
   SelectorScope,
   ThemeContext,
+  ThemeEditorLicense,
+  ThemeEditorSettings,
   ThemeEditorState,
   ThemeScope
 } from './model';
@@ -42,7 +44,7 @@ export class ThemeEditor extends LitElement {
   @property({})
   public expanded: boolean = false;
   @property({})
-  public themeEditorState: ThemeEditorState = ThemeEditorState.enabled;
+  public settings!: ThemeEditorSettings;
   @property({})
   public pickerProvider!: PickerProvider;
   @property({})
@@ -224,8 +226,24 @@ export class ThemeEditor extends LitElement {
     this.removeElementHighlight(this.context?.component.element);
   }
 
+  renderMissingLicenseNotice() {
+    return html`
+      <div class="notice">
+        Theme editor requires a Vaadin Pro (or higher) subscription.
+        <br />
+        Please
+        <a href=${this.settings.licenseUrl}>log in or sign up for an account</a>.
+      </div>
+    `;
+  }
   render() {
-    if (this.themeEditorState === ThemeEditorState.missing_theme) {
+    if(this.settings.license === ThemeEditorLicense.notChecked){
+      return null;
+    }
+    if(this.settings.license === ThemeEditorLicense.invalid){
+      return this.renderMissingLicenseNotice();
+    }
+    if (this.settings.state === ThemeEditorState.missing_theme) {
       return this.renderMissingThemeNotice();
     }
 

--- a/vaadin-dev-server/frontend/theme-editor/model.ts
+++ b/vaadin-dev-server/frontend/theme-editor/model.ts
@@ -12,7 +12,17 @@ export enum ThemeScope {
   local = 'local',
   global = 'global'
 }
+export enum ThemeEditorLicense {
+  notChecked,
+  ok,
+  invalid
+}
 
+export interface ThemeEditorSettings {
+  state: ThemeEditorState;
+  license: ThemeEditorLicense;
+  licenseUrl?: string;
+}
 export interface SelectorScope {
   themeScope: ThemeScope;
   localClassName?: string;


### PR DESCRIPTION
## Description

Implemented license checker to the theme editor. If a valid license is not found, a message is displayed to warn the user to log in or signup. 

![login_sign-up-theme-editor](https://github.com/vaadin/flow/assets/100126447/bbdf72d1-21a0-4517-b220-c6447df4449e)

User can use the theme editor once receives a valid license without restarting the server.

Fixes #17279 

## Type of change

- [ ] Bugfix
- [X] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [X] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
