### PR TITLE
Feat/theme editor license check

### DIFF
--- a/vaadin-dev-server/frontend/connection.ts
+++ b/vaadin-dev-server/frontend/connection.ts
@@ -60,6 +60,9 @@ export class Connection extends Object {
     // eslint-disable-next-line no-console
     console.error('Unknown message received from the live reload server:', message);
   }
+  onLicenseCheckResult(_: any) {
+    // Intentionally empty.
+  }
 
   handleMessage(msg: any) {
     let json;
@@ -82,10 +85,13 @@ export class Connection extends Object {
       }
     } else if (json.command === 'license-check-ok') {
       licenseCheckOk(json.data);
+      this.onLicenseCheckResult(json);
     } else if (json.command === 'license-check-failed') {
       licenseCheckFailed(json.data);
+      this.onLicenseCheckResult(json);
     } else if (json.command === 'license-check-nokey') {
       licenseCheckNoKey(json.data);
+      this.onLicenseCheckResult(json);
     } else {
       this.onMessage(json);
     }

--- a/vaadin-dev-server/frontend/theme-editor/editor.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.test.ts
@@ -263,7 +263,7 @@ describe('theme-editor', () => {
       }
       await elementUpdated(editor);
       expect(findPickerButton()).to.exist;
-      expect(editor.shadowRoot!.innerHTML).to.not.contain('Theme editor requires a Vaadin Pro (or higher) subscription');
+      expect(editor.shadowRoot!.innerHTML).to.not.contain('Theme Editor requires a Vaadin Prime (or higher) subscription');
     });
     it('should show license requirement message', async ()=> {
       editor.settings = {
@@ -274,7 +274,7 @@ describe('theme-editor', () => {
       }
       await elementUpdated(editor);
       expect(findPickerButton()).to.not.exist;
-      expect(editor.shadowRoot!.innerHTML).to.contain('Theme editor requires a Vaadin Pro (or higher) subscription');
+      expect(editor.shadowRoot!.innerHTML).to.contain('Theme Editor requires a Vaadin Prime (or higher) subscription');
       expect(editor.shadowRoot!.querySelector('a')).to.be.exist;
       expect(editor.shadowRoot!.querySelector('a')!['href']).to.contain('https://vaadin.com/pro/validate-license');
     });

--- a/vaadin-dev-server/frontend/theme-editor/editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.ts
@@ -10,6 +10,8 @@ import {
   generateThemeRuleCss,
   SelectorScope,
   ThemeContext,
+  ThemeEditorLicense,
+  ThemeEditorSettings,
   ThemeEditorState,
   ThemeScope
 } from './model';
@@ -42,7 +44,7 @@ export class ThemeEditor extends LitElement {
   @property({})
   public expanded: boolean = false;
   @property({})
-  public themeEditorState: ThemeEditorState = ThemeEditorState.enabled;
+  public settings!: ThemeEditorSettings;
   @property({})
   public pickerProvider!: PickerProvider;
   @property({})
@@ -224,8 +226,24 @@ export class ThemeEditor extends LitElement {
     this.removeElementHighlight(this.context?.component.element);
   }
 
+  renderMissingLicenseNotice() {
+    return html`
+      <div class="notice">
+        Theme editor requires a Vaadin Pro (or higher) subscription.
+        <br />
+        Please
+        <a href=${this.settings.licenseUrl}>log in or sign up for an account</a>.
+      </div>
+    `;
+  }
   render() {
-    if (this.themeEditorState === ThemeEditorState.missing_theme) {
+    if(this.settings.license === ThemeEditorLicense.notChecked){
+      return null;
+    }
+    if(this.settings.license === ThemeEditorLicense.invalid){
+      return this.renderMissingLicenseNotice();
+    }
+    if (this.settings.state === ThemeEditorState.missing_theme) {
       return this.renderMissingThemeNotice();
     }
 

--- a/vaadin-dev-server/frontend/theme-editor/editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.ts
@@ -229,7 +229,7 @@ export class ThemeEditor extends LitElement {
   renderMissingLicenseNotice() {
     return html`
       <div class="notice">
-        Theme editor requires a Vaadin Pro (or higher) subscription.
+        Theme Editor requires a Vaadin Prime (or higher) subscription.
         <br />
         Please
         <a href=${this.settings.licenseUrl}>log in or sign up for an account</a>.

--- a/vaadin-dev-server/frontend/theme-editor/model.ts
+++ b/vaadin-dev-server/frontend/theme-editor/model.ts
@@ -12,7 +12,17 @@ export enum ThemeScope {
   local = 'local',
   global = 'global'
 }
+export enum ThemeEditorLicense {
+  notChecked,
+  ok,
+  invalid
+}
 
+export interface ThemeEditorSettings {
+  state: ThemeEditorState;
+  license: ThemeEditorLicense;
+  licenseUrl?: string;
+}
 export interface SelectorScope {
   themeScope: ThemeScope;
   localClassName?: string;

--- a/vaadin-dev-server/frontend/vaadin-dev-tools.ts
+++ b/vaadin-dev-server/frontend/vaadin-dev-tools.ts
@@ -991,7 +991,7 @@ export class VaadinDevTools extends LitElement {
       if (isFlowApp && this.themeEditorSettings.state !== ThemeEditorState.disabled) {
         this.tabs.push({
           id: 'theme-editor',
-          title: 'Theme Editor (Preview)',
+          title: 'Theme Editor',
           render: () => this.renderThemeEditor(),
           activate: () => this.checkLicense({name: 'vaadin-dev-tools-theme-editor', version: '0.0.1'})
         });


### PR DESCRIPTION
# 🚧 DO NOT MERGE 🚧

## Description

Implemented license checker to the theme editor. If a valid license is not found, a message is displayed to warn the user to log in or signup. 

![login_sign-up-theme-editor](https://github.com/vaadin/flow/assets/100126447/51a0e595-5eb1-48a9-b969-199a2671e8e9)


User can use the theme editor once receives a valid license without restarting the server.

In addition to that, Theme Editor's label is renamed as `Theme Editor`

Fixes #17279 

## Type of change

- [ ] Bugfix
- [X] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [X] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
