### PR TITLE
Feat/theme editor vaadin-board and vaadin-form-layout

### DIFF
--- a/vaadin-dev-server/frontend/theme-editor/editor.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.test.ts
@@ -371,7 +371,7 @@ describe('theme-editor', () => {
 
       const propertyList = editor.shadowRoot!.querySelector('.property-list');
       expect(propertyList).to.not.exist;
-      expect(editor.shadowRoot!.textContent).to.contain('The selected Test element can not be styled locally');
+      expect(editor.shadowRoot!.textContent).to.contain('The selected Test element cannot be styled locally');
     });
 
     it('should show local class name editor if instance is accessible', async () => {

--- a/vaadin-dev-server/frontend/theme-editor/editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.ts
@@ -313,7 +313,7 @@ export class ThemeEditor extends LitElement {
             </div>`
           : ''}
         <div class="notice">
-          The selected ${componentName} can not be styled locally. Currently, theme editor only supports styling
+          The selected ${componentName} cannot be styled locally. Currently, Theme Editor only supports styling
           instances that are assigned to a local variable, like so:
           <pre><code>Button saveButton = new Button("Save");</code></pre>
           If you want to modify the code so that it satisfies this requirement,

--- a/vaadin-dev-server/frontend/theme-editor/editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.ts
@@ -89,6 +89,17 @@ export class ThemeEditor extends LitElement {
         color: var(--dev-tools-text-color-emphasis);
       }
 
+      .hint vaadin-icon {
+        color: var(--dev-tools-green-color);
+        font-size: var(--lumo-icon-size-m);
+      }
+
+      .hint {
+        display: flex;
+        align-items: center;
+        gap: var(--theme-editor-section-horizontal-padding);
+      }
+
       .header {
         flex: 0 0 auto;
         border-bottom: solid 1px rgba(0, 0, 0, 0.2);
@@ -295,6 +306,12 @@ export class ThemeEditor extends LitElement {
     if (inaccessible) {
       const componentName = this.context.metadata.displayName;
       return html`
+        ${this.context.metadata.notAccessibleDescription
+          ? html`<div class="notice hint" style="padding-bottom: 0;">
+              <vaadin-icon icon="vaadin:lightbulb"></vaadin-icon>
+              <div>${this.context.metadata.notAccessibleDescription}</div>
+            </div>`
+          : ''}
         <div class="notice">
           The selected ${componentName} can not be styled locally. Currently, theme editor only supports styling
           instances that are assigned to a local variable, like so:
@@ -307,13 +324,19 @@ export class ThemeEditor extends LitElement {
       `;
     }
 
-    return html` <vaadin-dev-tools-theme-property-list
-      class="property-list"
-      .metadata=${this.context.metadata}
-      .theme=${this.effectiveTheme}
-      @theme-property-value-change=${this.handlePropertyChange}
-      @open-css=${this.handleOpenCss}
-    ></vaadin-dev-tools-theme-property-list>`;
+    return html` ${this.context.metadata.description
+        ? html`<div class="notice hint">
+            <vaadin-icon icon="vaadin:lightbulb"></vaadin-icon>
+            <div>${this.context.metadata.description}</div>
+          </div>`
+        : ''}
+      <vaadin-dev-tools-theme-property-list
+        class="property-list"
+        .metadata=${this.context.metadata}
+        .theme=${this.effectiveTheme}
+        @theme-property-value-change=${this.handlePropertyChange}
+        @open-css=${this.handleOpenCss}
+      ></vaadin-dev-tools-theme-property-list>`;
   }
 
   handleShowComponent() {

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-accordion-heading.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-accordion-heading.ts
@@ -1,5 +1,5 @@
 import { ComponentMetadata } from '../model';
-import { iconProperties, shapeProperties, textProperties } from "./defaults";
+import { iconProperties, shapeProperties, textProperties } from './defaults';
 
 export default {
   tagName: 'vaadin-accordion-heading',
@@ -8,11 +8,7 @@ export default {
     {
       selector: 'vaadin-accordion-heading',
       displayName: 'Heading',
-      properties: [
-        textProperties.textColor,
-        textProperties.fontSize,
-        shapeProperties.padding
-      ]
+      properties: [textProperties.textColor, textProperties.fontSize, shapeProperties.padding]
     },
     {
       selector: 'vaadin-accordion-heading::part(toggle)',

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-accordion-panel.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-accordion-panel.ts
@@ -1,5 +1,5 @@
 import { ComponentMetadata } from '../model';
-import { shapeProperties } from "./defaults";
+import { shapeProperties } from './defaults';
 
 export default {
   tagName: 'vaadin-accordion-panel',
@@ -12,7 +12,7 @@ export default {
         shapeProperties.backgroundColor,
         shapeProperties.borderColor,
         shapeProperties.borderWidth,
-        shapeProperties.borderRadius,
+        shapeProperties.borderRadius
       ]
     }
   ]

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-board-row.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-board-row.ts
@@ -1,0 +1,25 @@
+import { ComponentMetadata } from '../model';
+import { shapeProperties } from './defaults';
+import { html } from 'lit';
+
+export default {
+  tagName: 'vaadin-board-row',
+  description: html`You are styling selected row only, if you wish to style all rows of given board please pick
+    <code>vaadin-board</code> instead.`,
+  notAccessibleDescription: html`If you wish to style all rows of current board please pick
+    <code>vaadin-board</code> instead.`,
+  displayName: 'BoardRow',
+  elements: [
+    {
+      selector: 'vaadin-board-row',
+      displayName: 'Layout',
+      properties: [
+        shapeProperties.backgroundColor,
+        shapeProperties.borderColor,
+        shapeProperties.borderWidth,
+        shapeProperties.borderRadius,
+        shapeProperties.padding
+      ]
+    }
+  ]
+} as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-board.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-board.ts
@@ -1,0 +1,31 @@
+import { ComponentMetadata } from '../model';
+import { shapeProperties } from './defaults';
+
+export default {
+  tagName: 'vaadin-board',
+  displayName: 'Board',
+  elements: [
+    {
+      selector: 'vaadin-board',
+      displayName: 'Layout',
+      properties: [
+        shapeProperties.backgroundColor,
+        shapeProperties.borderColor,
+        shapeProperties.borderWidth,
+        shapeProperties.borderRadius,
+        shapeProperties.padding
+      ]
+    },
+    {
+      selector: 'vaadin-board vaadin-board-row',
+      displayName: 'Row',
+      properties: [
+        shapeProperties.backgroundColor,
+        shapeProperties.borderColor,
+        shapeProperties.borderWidth,
+        shapeProperties.borderRadius,
+        shapeProperties.padding
+      ]
+    }
+  ]
+} as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-date-picker.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-date-picker.ts
@@ -4,8 +4,8 @@ import {
   helperTextProperties,
   inputFieldProperties,
   labelProperties
-} from "./vaadin-text-field";
-import { iconProperties, shapeProperties, textProperties } from "./defaults";
+} from './vaadin-text-field';
+import { iconProperties, shapeProperties, textProperties } from './defaults';
 
 export default {
   tagName: 'vaadin-date-picker',

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-date-time-picker.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-date-time-picker.ts
@@ -1,9 +1,5 @@
 import { ComponentMetadata } from '../model';
-import {
-  errorMessageProperties,
-  helperTextProperties,
-  labelProperties
-} from "./vaadin-text-field";
+import { errorMessageProperties, helperTextProperties, labelProperties } from './vaadin-text-field';
 
 export default {
   tagName: 'vaadin-date-time-picker',
@@ -23,6 +19,6 @@ export default {
       selector: 'vaadin-date-time-picker::part(error-message)',
       displayName: 'Error message',
       properties: errorMessageProperties
-    },
+    }
   ]
 } as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-details-summary.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-details-summary.ts
@@ -1,5 +1,5 @@
 import { ComponentMetadata } from '../model';
-import { iconProperties, shapeProperties, textProperties } from "./defaults";
+import { iconProperties, shapeProperties, textProperties } from './defaults';
 
 export default {
   tagName: 'vaadin-details-summary',
@@ -8,11 +8,7 @@ export default {
     {
       selector: 'vaadin-details-summary',
       displayName: 'Summary',
-      properties: [
-        textProperties.textColor,
-        textProperties.fontSize,
-        shapeProperties.padding
-      ]
+      properties: [textProperties.textColor, textProperties.fontSize, shapeProperties.padding]
     },
     {
       selector: 'vaadin-details-summary::part(toggle)',

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-form-layout.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-form-layout.ts
@@ -1,0 +1,20 @@
+import { ComponentMetadata } from '../model';
+import { shapeProperties } from './defaults';
+
+export default {
+  tagName: 'vaadin-form-layout',
+  displayName: 'FormLayout',
+  elements: [
+    {
+      selector: 'vaadin-form-layout',
+      displayName: 'Layout',
+      properties: [
+        shapeProperties.backgroundColor,
+        shapeProperties.borderColor,
+        shapeProperties.borderWidth,
+        shapeProperties.borderRadius,
+        shapeProperties.padding
+      ]
+    }
+  ]
+} as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-list-box.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-list-box.ts
@@ -1,5 +1,5 @@
 import { ComponentMetadata } from '../model';
-import {fieldProperties, shapeProperties, textProperties} from "./defaults";
+import { fieldProperties, shapeProperties, textProperties } from './defaults';
 
 export default {
   tagName: 'vaadin-list-box',

--- a/vaadin-dev-server/frontend/theme-editor/metadata/model.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/model.ts
@@ -1,3 +1,5 @@
+import { TemplateResult } from 'lit';
+
 export enum EditorType {
   text = 'text',
   checkbox = 'checkbox',
@@ -28,7 +30,8 @@ export interface ComponentElementMetadata {
 export interface ComponentMetadata {
   tagName: string;
   displayName: string;
-  description?: string;
+  description?: TemplateResult;
+  notAccessibleDescription?: TemplateResult;
   elements: ComponentElementMetadata[];
   setupElement?: (element: any) => Promise<void>;
   cleanupElement?: (element: any) => Promise<void>;


### PR DESCRIPTION
## Description

Added metadata for vaadin-board (also for vaadin-board-row) and vaadin-form-layout.

Added possibility to define additional information for specific components:

In case component is accessible:
<img alt="image" src="https://github.com/vaadin/flow/assets/106965834/71f736b4-f48b-4703-b7cb-f0ff34079fac">

And when component is not accessible:
<img  alt="image" src="https://github.com/vaadin/flow/assets/106965834/7c086fbb-5cb1-4abf-83e4-5f90a080d733">

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.


Part of https://github.com/vaadin/flow/issues/17042
