### PR TITLE
fix: prevent adding query string for empty parameters in router link href

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/QueryParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/QueryParameters.java
@@ -132,7 +132,7 @@ public class QueryParameters implements Serializable {
      * @return query parameters information
      */
     public static QueryParameters fromString(String queryString) {
-        if (queryString == null) {
+        if (queryString == null || queryString.isBlank()) {
             return empty();
         }
         return new QueryParameters(parseQueryString(queryString));

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouterLink.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouterLink.java
@@ -429,7 +429,8 @@ public class RouterLink extends Component implements HasText, HasComponents,
             url = url.substring(0, startOfQuery);
         }
         url = UrlUtil.encodeURI(url);
-        if (queryParameters != null) {
+        if (queryParameters != null
+                && !queryParameters.getParameters().isEmpty()) {
             url += '?' + queryParameters.getQueryString();
         }
         HREF.set(this, url);

--- a/flow-server/src/test/java/com/vaadin/flow/router/QueryParametersTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/QueryParametersTest.java
@@ -16,10 +16,6 @@
 
 package com.vaadin.flow.router;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -30,6 +26,10 @@ import java.util.Optional;
 
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class QueryParametersTest {
 
@@ -383,4 +383,21 @@ public class QueryParametersTest {
         Assert.assertEquals(qp1.hashCode(), qp2.hashCode());
     }
 
+    @Test
+    public void fromString_emptyString_getsEmptyParameters() {
+        QueryParameters params = QueryParameters.fromString("");
+        assertEquals(Collections.emptyMap(), params.getParameters());
+    }
+
+    @Test
+    public void fromString_blankString_getsEmptyParameters() {
+        QueryParameters params = QueryParameters.fromString("    ");
+        assertEquals(Collections.emptyMap(), params.getParameters());
+    }
+
+    @Test
+    public void fromString_nullString_getsEmptyParameters() {
+        QueryParameters params = QueryParameters.fromString(null);
+        assertEquals(Collections.emptyMap(), params.getParameters());
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterLinkTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterLinkTest.java
@@ -459,6 +459,11 @@ public class RouterLinkTest extends HasCurrentService {
         link.setQueryParameters(null);
         href = link.getHref();
         Assert.assertEquals("foo", href);
+
+        link.setQueryParameters(QueryParameters.empty());
+        href = link.getHref();
+        Assert.assertEquals("foo", href);
+
     }
 
     @Test


### PR DESCRIPTION
## Description

When an empty query parameters object is given to a RouterLink the computed href contains an empty query string.
This change prevents the addition of the query string to the href attribute when query parameters object is empty. It also fixes parsing to return an empty query parameters object for blank string.

Fixes #17287

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
