### PR TITLE
fix: update jandex-maven-plugin for JDK 21

### DIFF
--- a/flow-jandex/pom.xml
+++ b/flow-jandex/pom.xml
@@ -102,9 +102,9 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.jboss.jandex</groupId>
+                <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>1.1.1</version>
+                <version>3.1.2</version>
                 <executions>
                     <execution>
                         <id>make-index</id>


### PR DESCRIPTION
fixes #17240 