### PR TITLE
test: ignore properties from mixin interfaces in component tests

### DIFF
--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/ComponentTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/ComponentTest.java
@@ -408,6 +408,12 @@ public abstract class ComponentTest {
     private void assertProperty(PropertyDescriptor descriptor) {
         if (descriptor.getReadMethod() != null
                 && descriptor.getWriteMethod() != null) {
+            // JDK 21 detects properties also from interface default methods
+            // Test setup can safely ignore properties from mixin interfaces
+            if (descriptor.getReadMethod().isDefault()
+                    && descriptor.getWriteMethod().isDefault()) {
+                return;
+            }
             if (!hasProperty(descriptor.getName())) {
                 throw new IllegalStateException("Property information for '"
                         + descriptor.getName() + "' missing");


### PR DESCRIPTION
Fixes #17295