### PR TITLE
test: disable deserialization test on OSGi

### DIFF
--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/SerializeShortcutIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/SerializeShortcutIT.java
@@ -17,11 +17,14 @@ package com.vaadin.flow.uitest.ui;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
+import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
+@Category(IgnoreOSGi.class)
 public class SerializeShortcutIT extends ChromeBrowserTest {
 
     @Test


### PR DESCRIPTION
On OSGi environments, deserialization requires custom class loading handling, so the tests fail with a ClassNotFoundException.