### PR TITLE
fix: fixed issue with using child selector, accordion metadata updates

### DIFF
--- a/vaadin-dev-server/frontend/theme-editor/editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.ts
@@ -306,7 +306,7 @@ export class ThemeEditor extends LitElement {
     if (inaccessible) {
       const componentName = this.context.metadata.displayName;
       return html`
-        ${this.context.metadata.notAccessibleDescription
+        ${this.context.metadata.notAccessibleDescription && this.context.scope === ThemeScope.local
           ? html`<div class="notice hint" style="padding-bottom: 0;">
               <vaadin-icon icon="vaadin:lightbulb"></vaadin-icon>
               <div>${this.context.metadata.notAccessibleDescription}</div>
@@ -324,7 +324,7 @@ export class ThemeEditor extends LitElement {
       `;
     }
 
-    return html` ${this.context.metadata.description
+    return html` ${this.context.metadata.description && this.context.scope === ThemeScope.local
         ? html`<div class="notice hint">
             <vaadin-icon icon="vaadin:lightbulb"></vaadin-icon>
             <div>${this.context.metadata.description}</div>

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-accordion-heading.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-accordion-heading.ts
@@ -1,19 +1,19 @@
 import { ComponentMetadata } from '../model';
-import { iconProperties, shapeProperties, textProperties } from './defaults';
+import { html } from 'lit';
+import { shapeProperties, textProperties } from './defaults';
 
 export default {
   tagName: 'vaadin-accordion-heading',
   displayName: 'AccordionHeading',
+  description: html`You are trying to style selected heading only, if you wish to style all panel headings of given
+    accordion please pick <code>vaadin-accordion</code> instead.`,
+  notAccessibleDescription: html`If you wish to style all panel headings of current accordion please pick
+    <code>vaadin-accordion</code> instead.`,
   elements: [
     {
       selector: 'vaadin-accordion-heading',
       displayName: 'Heading',
       properties: [textProperties.textColor, textProperties.fontSize, shapeProperties.padding]
-    },
-    {
-      selector: 'vaadin-accordion-heading::part(toggle)',
-      displayName: 'Toggle',
-      properties: [iconProperties.iconColor, iconProperties.iconSize]
     }
   ]
 } as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-accordion-heading.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-accordion-heading.ts
@@ -1,6 +1,6 @@
 import { ComponentMetadata } from '../model';
 import { html } from 'lit';
-import { shapeProperties, textProperties } from './defaults';
+import { iconProperties, shapeProperties, textProperties } from './defaults';
 
 export default {
   tagName: 'vaadin-accordion-heading',
@@ -14,6 +14,11 @@ export default {
       selector: 'vaadin-accordion-heading',
       displayName: 'Heading',
       properties: [textProperties.textColor, textProperties.fontSize, shapeProperties.padding]
+    },
+    {
+      selector: 'vaadin-accordion-heading::part(toggle)',
+      displayName: 'Toggle',
+      properties: [iconProperties.iconColor, iconProperties.iconSize]
     }
   ]
 } as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-accordion-panel.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-accordion-panel.ts
@@ -1,9 +1,14 @@
 import { ComponentMetadata } from '../model';
 import { shapeProperties } from './defaults';
+import { html } from 'lit';
 
 export default {
   tagName: 'vaadin-accordion-panel',
   displayName: 'AccordionPanel',
+  description: html`You are styling selected panel only, if you wish to style all panel of given accordion please pick
+    <code>vaadin-accordion</code> instead.`,
+  notAccessibleDescription: html`If you wish to style all panels of current accordion please pick
+    <code>vaadin-accordion</code> instead.`,
   elements: [
     {
       selector: 'vaadin-accordion-panel',

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-accordion.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-accordion.ts
@@ -1,0 +1,29 @@
+import { ComponentMetadata } from '../model';
+import { iconProperties, shapeProperties, textProperties } from './defaults';
+
+export default {
+  tagName: 'vaadin-accordion',
+  displayName: 'Accordion',
+  elements: [
+    {
+      selector: 'vaadin-accordion > vaadin-accordion-panel > vaadin-accordion-heading',
+      displayName: 'Heading',
+      properties: [textProperties.textColor, textProperties.fontSize, shapeProperties.padding]
+    },
+    {
+      selector: 'vaadin-accordion > vaadin-accordion-panel > vaadin-accordion-heading::part(toggle)',
+      displayName: 'Toggle',
+      properties: [iconProperties.iconColor, iconProperties.iconSize]
+    },
+    {
+      selector: 'vaadin-accordion > vaadin-accordion-panel',
+      displayName: 'Panel',
+      properties: [
+        shapeProperties.backgroundColor,
+        shapeProperties.borderColor,
+        shapeProperties.borderWidth,
+        shapeProperties.borderRadius
+      ]
+    }
+  ]
+} as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/model.ts
+++ b/vaadin-dev-server/frontend/theme-editor/model.ts
@@ -108,7 +108,7 @@ export class ComponentTheme {
 
     metadata.elements.forEach((element) => {
       const scopedSelector = createScopedSelector(element, scope);
-      const elementRule = rules.find((rule) => rule.selector === scopedSelector);
+      const elementRule = rules.find((rule) => rule.selector === scopedSelector.replace(/ > /g, '>'));
 
       if (elementRule) {
         element.properties.forEach((property) => {


### PR DESCRIPTION
## Description

Fixed issue of string comparison while comparing CSS Selectors ('>' vs ' > '). Updates `vaadin-accordion` metadata.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.


Part of https://github.com/vaadin/flow/issues/17042