### PR TITLE
Add meta data for tab and tabsheet

### DIFF
--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-tab.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-tab.ts
@@ -1,0 +1,40 @@
+import { ComponentMetadata } from '../model';
+import { shapeProperties, textProperties } from './defaults';
+import { html } from 'lit';
+
+export default {
+  tagName: 'vaadin-tab',
+  displayName: 'Tab',
+  description: html`You are styling selected tab only, if you wish to style all tabs please pick
+    <code>vaadin-tabs</code> instead.`,
+  notAccessibleDescription: html`If you wish to style all tabs please pick <code>vaadin-tabs</code> instead.`,
+  elements: [
+    {
+      selector: 'vaadin-tab',
+      displayName: 'Tab item',
+      properties: [
+        textProperties.textColor,
+        textProperties.fontSize,
+        textProperties.fontWeight,
+        shapeProperties.backgroundColor,
+        shapeProperties.padding
+      ]
+    },
+    {
+      selector: 'vaadin-tab[selected]',
+      displayName: 'Tab item (selected)',
+      properties: [
+        textProperties.textColor,
+        textProperties.fontSize,
+        textProperties.fontWeight,
+        shapeProperties.backgroundColor,
+        shapeProperties.padding
+      ]
+    },
+    {
+      selector: 'vaadin-tab::before',
+      displayName: 'Selection indicator',
+      properties: [shapeProperties.backgroundColor]
+    }
+  ]
+} as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-tabs.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-tabs.ts
@@ -1,0 +1,34 @@
+import { ComponentMetadata } from '../model';
+import { iconProperties, shapeProperties, textProperties } from './defaults';
+
+export default {
+  tagName: 'vaadin-tabs',
+  displayName: 'Tabs',
+  elements: [
+    {
+      selector: 'vaadin-tabs',
+      displayName: 'Tabs',
+      properties: [shapeProperties.padding]
+    },
+    {
+      selector: 'vaadin-tabs vaadin-tab',
+      displayName: 'Tab item',
+      properties: [
+        textProperties.fontSize,
+        textProperties.fontWeight,
+        shapeProperties.backgroundColor,
+        shapeProperties.padding
+      ]
+    },
+    {
+      selector: 'vaadin-tabs::part(back-button)',
+      displayName: 'Back button',
+      properties: [iconProperties.iconColor, iconProperties.iconSize]
+    },
+    {
+      selector: 'vaadin-tabs::part(forward-button)',
+      displayName: 'Forward button',
+      properties: [iconProperties.iconColor, iconProperties.iconSize]
+    }
+  ]
+} as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-tabs.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-tabs.ts
@@ -33,6 +33,11 @@ export default {
       ]
     },
     {
+      selector: 'vaadin-tabs > vaadin-tab::before',
+      displayName: 'Selection indicator',
+      properties: [shapeProperties.backgroundColor]
+    },
+    {
       selector: 'vaadin-tabs::part(back-button)',
       displayName: 'Back button',
       properties: [iconProperties.iconColor, iconProperties.iconSize]
@@ -41,11 +46,6 @@ export default {
       selector: 'vaadin-tabs::part(forward-button)',
       displayName: 'Forward button',
       properties: [iconProperties.iconColor, iconProperties.iconSize]
-    },
-    {
-      selector: 'vaadin-tabs > vaadin-tab::before',
-      displayName: 'Selection indicator',
-      properties: [shapeProperties.backgroundColor]
     }
   ]
 } as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-tabs.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-tabs.ts
@@ -14,6 +14,18 @@ export default {
       selector: 'vaadin-tabs vaadin-tab',
       displayName: 'Tab item',
       properties: [
+        textProperties.textColor,
+        textProperties.fontSize,
+        textProperties.fontWeight,
+        shapeProperties.backgroundColor,
+        shapeProperties.padding
+      ]
+    },
+    {
+      selector: 'vaadin-tabs > vaadin-tab[selected]',
+      displayName: 'Tab item (selected)',
+      properties: [
+        textProperties.textColor,
         textProperties.fontSize,
         textProperties.fontWeight,
         shapeProperties.backgroundColor,
@@ -29,6 +41,11 @@ export default {
       selector: 'vaadin-tabs::part(forward-button)',
       displayName: 'Forward button',
       properties: [iconProperties.iconColor, iconProperties.iconSize]
+    },
+    {
+      selector: 'vaadin-tabs > vaadin-tab::before',
+      displayName: 'Selection indicator',
+      properties: [shapeProperties.backgroundColor]
     }
   ]
 } as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-tabsheet.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-tabsheet.ts
@@ -1,0 +1,20 @@
+import { ComponentMetadata } from '../model';
+import { shapeProperties } from './defaults';
+
+export default {
+  tagName: 'vaadin-tabsheet',
+  displayName: 'Sheet',
+  elements: [
+    {
+      selector: 'vaadin-tabsheet',
+      displayName: 'Sheet',
+      properties: [
+        shapeProperties.padding,
+        shapeProperties.backgroundColor,
+        shapeProperties.borderWidth,
+        shapeProperties.borderColor,
+        shapeProperties.borderRadius
+      ]
+    }
+  ]
+} as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-tabsheet.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-tabsheet.ts
@@ -3,11 +3,11 @@ import { shapeProperties } from './defaults';
 
 export default {
   tagName: 'vaadin-tabsheet',
-  displayName: 'Sheet',
+  displayName: 'TabSheet',
   elements: [
     {
       selector: 'vaadin-tabsheet',
-      displayName: 'Sheet',
+      displayName: 'TabSheet',
       properties: [
         shapeProperties.padding,
         shapeProperties.backgroundColor,


### PR DESCRIPTION
### Findings working on Tabs

1. There isn’t support for box-shadow as editor property, the divider on Tabs uses box-shadows

2. There isn’t a way to specify style properties for variants, the divider on Tabs uses box-shadows but vertical variant needs a different sets value to style the width and the horizontal variant also needs a different set of values.

3. There isn't a way to set the `width`, and `color` of the Tab divider because the values are defined together as a single CSS property - `box-shadow: inset 0 -1px 0 0 var(--lumo-contrast-10pct);`. It will need some method to expose only the `width` and `color` to user in the editor for styling while it adds the other values and assign it to the `box-shadow`.

4. There isn’t support for multiple css selectors. To style the selected tab indicator, you will need to use `:host::before, :host::after` to apply styles.

5. There isn’t support to style multiple tab items together using multiple selectors.

6. Using CSS child selector `vaadin-tabs vaadin-tab`, editor doesn’t show the default css values but only shows new values set by editor.

7. There isn’t support to set style for states, changing the inactive color for tab item overrides the color for the tab item when selected

8. Editor cannot select disabled tab item

9. Style properties for Tab item has been moved to the `vaadin-tabs`, leaving `vaadin-tab` empty when selected for styling. It needs a custom message to inform the user to style from the parent component or disable select for child component.

10. When a tab item has a `vaadin-icon`, changing it's color overrides the color because it has higher specificity.