### PR TITLE
feat: theme editor grid and treegrid support, fixed issue with javapa…

### DIFF
--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-grid.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-grid.ts
@@ -1,0 +1,75 @@
+import { ComponentMetadata, CssPropertyMetadata, EditorType } from '../model';
+import { iconProperties, shapeProperties, textProperties } from './defaults';
+import { checkboxElement, checkedCheckboxElement } from './vaadin-checkbox';
+
+export const cellProperties: CssPropertyMetadata[] = [
+  textProperties.textColor,
+  textProperties.fontSize,
+  textProperties.fontWeight,
+  textProperties.fontStyle,
+  shapeProperties.backgroundColor
+];
+
+export default {
+  tagName: 'vaadin-grid',
+  displayName: 'Grid',
+  elements: [
+    {
+      selector: 'vaadin-grid',
+      displayName: 'Grid',
+      properties: [shapeProperties.borderColor, shapeProperties.borderWidth]
+    },
+    {
+      selector: 'vaadin-grid::part(cell)',
+      displayName: 'Cell (any)',
+      properties: cellProperties
+    },
+    {
+      selector: 'vaadin-grid::part(header-cell)',
+      displayName: 'Header row cell',
+      properties: [
+        textProperties.textColor,
+        // hack to overcome slotted vaadin-grid-cell-content
+        { ...textProperties.fontSize, propertyName: '--lumo-font-size-s' },
+        // textProperties.fontWeight, -- cannot be styled in single block
+        textProperties.fontStyle,
+        shapeProperties.backgroundColor
+      ]
+    },
+    {
+      selector: 'vaadin-grid::part(even-row-cell)',
+      displayName: 'Cell in even row',
+      properties: cellProperties
+    },
+    {
+      selector: 'vaadin-grid::part(odd-row-cell)',
+      displayName: 'Cell in odd row',
+      properties: cellProperties
+    },
+    {
+      selector: 'vaadin-grid::part(selected-row-cell)',
+      displayName: 'Cell in selected row',
+      properties: cellProperties
+    },
+    {
+      selector: 'vaadin-grid vaadin-grid-cell-content > vaadin-checkbox::part(checkbox)',
+      displayName: 'Row selection checkbox',
+      properties: checkboxElement.properties
+    },
+    {
+      selector: 'vaadin-grid vaadin-grid-cell-content > vaadin-checkbox[checked]::part(checkbox)',
+      displayName: 'Row selection checkbox (when checked)',
+      properties: checkedCheckboxElement.properties
+    },
+    {
+      selector: 'vaadin-grid vaadin-grid-cell-content > vaadin-checkbox::part(checkbox)::after',
+      displayName: 'Row selection checkbox checkmark',
+      properties: [iconProperties.iconColor]
+    },
+    {
+      selector: 'vaadin-grid vaadin-grid-tree-toggle::part(toggle)',
+      displayName: 'Expand icon (for tree grid)',
+      properties: [iconProperties.iconColor]
+    }
+  ]
+} as ComponentMetadata;

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/JavaSourceModifier.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/JavaSourceModifier.java
@@ -1,5 +1,6 @@
 package com.vaadin.base.devserver.themeeditor;
 
+import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.comments.LineComment;
@@ -345,7 +346,11 @@ public class JavaSourceModifier extends Editor {
     protected CompilationUnit getCompilationUnit(Component component) {
         ComponentTracker.Location createLocation = getCreateLocation(component);
         File sourceFolder = getSourceFolder(createLocation);
-        SourceRoot root = new SourceRoot(sourceFolder.toPath());
+        ParserConfiguration parserConfiguration = new ParserConfiguration();
+        parserConfiguration
+                .setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17);
+        SourceRoot root = new SourceRoot(sourceFolder.toPath(),
+                parserConfiguration);
         return LexicalPreservingPrinter
                 .setup(root.parse("", createLocation.filename()));
     }


### PR DESCRIPTION
## Description

- added Theme Editor metadata for Grid and TreeGrid
- set language level to Java17 on javaparser configuration to support Records

Part of https://github.com/vaadin/flow/issues/17042

## Type of change

- [x] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
