### PR TITLE
fix: fix unsafe path check for URL decoded path

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/HandlerHelper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/HandlerHelper.java
@@ -448,6 +448,8 @@ public class HandlerHelper implements Serializable {
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException("An error occurred during decoding URL.",
                     e);
+        } catch (IllegalArgumentException ex) {
+            // Ignore: the path is not URLEncoded, check it as is
         }
         return PARENT_DIRECTORY_REGEX.matcher(path).find();
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
@@ -1004,6 +1004,26 @@ public class StaticFileServerTest implements Serializable {
     }
 
     @Test
+    public void serveStaticResource_uriWithPercent_isServed()
+            throws IOException {
+        String pathInfo = "/VAADIN/build/100%.pdf";
+        setupRequestURI("", "", pathInfo);
+        String fileData = "contents";
+        ClassLoader mockLoader = Mockito.mock(ClassLoader.class);
+        Mockito.when(servletService.getClassLoader()).thenReturn(mockLoader);
+
+        Mockito.when(mockLoader.getResource(WEBAPP_RESOURCE_PREFIX + pathInfo))
+                .thenReturn(createFileURLWithDataAndLength(
+                        "/" + WEBAPP_RESOURCE_PREFIX + pathInfo, fileData));
+
+        mockStatsBundles(mockLoader);
+        mockConfigurationPolyfills();
+
+        Assert.assertTrue(fileServer.serveStaticResource(request, response));
+        Assert.assertEquals(fileData, out.getOutputString());
+    }
+
+    @Test
     public void customStaticBuildResource_isServed() throws IOException {
         String pathInfo = "/VAADIN/build/my-text.txt";
         setupRequestURI("", "", pathInfo);

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/StreamResourceView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/StreamResourceView.java
@@ -43,7 +43,14 @@ public class StreamResourceView extends Div {
         plusDownload.setHref(plusResource);
         plusDownload.setId("plus-link");
 
-        add(download, plusDownload);
+        StreamResource percentResource = new StreamResource("file%.jpg",
+                () -> new ByteArrayInputStream(
+                        "foo".getBytes(StandardCharsets.UTF_8)));
+        Anchor percentDownload = new Anchor("", "Download file%.jpg");
+        percentDownload.setHref(percentResource);
+        percentDownload.setId("percent-link");
+
+        add(download, plusDownload, percentDownload);
 
         NativeButton reattach = new NativeButton("Remove and add back",
                 event -> {

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/StreamResourceIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/StreamResourceIT.java
@@ -46,6 +46,13 @@ public class StreamResourceIT extends AbstractStreamResourceIT {
     }
 
     @Test
+    public void getDynamicVaadinPercentResource() throws IOException {
+        open();
+
+        assertDownloadedContent("percent-link", "file%25.jpg");
+    }
+
+    @Test
     public void detact_attachALink_getDynamicVaadinResource()
             throws IOException {
         open();


### PR DESCRIPTION
## Description

If a path is already URL decoded but contains a percent char, the unsafe path check fails when it tries to decode it again.
The thrown IllegalArgumentException can be safely ignored, as it means that the input path is already decoded and can be checked as is.

Fixes #16561

Co-authored-by: Tatu Lund @TatuLund

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
