### PR TITLE
test: add tests classifier to test-jar unpack configuration

### DIFF
--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-methodsecurity/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-methodsecurity/pom.xml
@@ -247,6 +247,7 @@
                                     <artifactId>vaadin-test-spring-helpers</artifactId>
                                     <version>${project.version}</version>
                                     <type>test-jar</type>
+                                    <classifier>tests</classifier>
                                     <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
                                 </artifactItem>
                             </artifactItems>

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/pom.xml
@@ -247,6 +247,7 @@
                                     <artifactId>vaadin-test-spring-helpers</artifactId>
                                     <version>${project.version}</version>
                                     <type>test-jar</type>
+                                    <classifier>tests</classifier>
                                     <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
                                 </artifactItem>
                             </artifactItems>


### PR DESCRIPTION
Seldom the unpack goal selects the wrong test artifact, without the 'tests' classifier, causing the build to fail because of classes not found. A related issue happens on IntelliJ IDEA, where the super class in the hierarchy cannot be found.
This change adds the 'tests' classifier to the unpack configuration to identify the correct artifact.