### PR TITLE
Add meta data for message list

### DIFF
--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-message-list.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-message-list.ts
@@ -6,8 +6,19 @@ export default {
   displayName: 'MessageList',
   elements: [
     {
+      selector: 'vaadin-message-list',
+      displayName: 'Root element',
+      properties: [
+        shapeProperties.backgroundColor,
+        shapeProperties.borderColor,
+        shapeProperties.borderWidth,
+        shapeProperties.borderRadius,
+        shapeProperties.padding
+      ]
+    },
+    {
       selector: 'vaadin-message-list::part(list)',
-      displayName: 'List',
+      displayName: 'Internal list layout',
       properties: [
         shapeProperties.backgroundColor,
         shapeProperties.borderColor,
@@ -50,6 +61,27 @@ export default {
     {
       selector: 'vaadin-message-list vaadin-message::part(message)',
       displayName: 'Text',
+      properties: [
+        textProperties.textColor,
+        textProperties.fontSize,
+        textProperties.fontWeight,
+        textProperties.fontStyle
+      ]
+    },
+    {
+      selector: 'vaadin-message-list vaadin-message > vaadin-avatar',
+      displayName: 'Avatar',
+      properties: [
+        shapeProperties.backgroundColor,
+        shapeProperties.borderColor,
+        shapeProperties.borderWidth,
+        shapeProperties.borderRadius,
+        shapeProperties.padding
+      ]
+    },
+    {
+      selector: 'vaadin-message-list vaadin-message > vaadin-avatar::part(abbr)',
+      displayName: 'Avatar abbreviation',
       properties: [
         textProperties.textColor,
         textProperties.fontSize,

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-message-list.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-message-list.ts
@@ -1,0 +1,61 @@
+import { ComponentMetadata } from '../model';
+import { shapeProperties, textProperties } from './defaults';
+
+export default {
+  tagName: 'vaadin-message-list',
+  displayName: 'MessageList',
+  elements: [
+    {
+      selector: 'vaadin-message-list::part(list)',
+      displayName: 'List',
+      properties: [
+        shapeProperties.backgroundColor,
+        shapeProperties.borderColor,
+        shapeProperties.borderWidth,
+        shapeProperties.borderRadius,
+        shapeProperties.padding
+      ]
+    },
+    {
+      selector: 'vaadin-message-list vaadin-message',
+      displayName: 'Message item',
+      properties: [
+        shapeProperties.backgroundColor,
+        shapeProperties.borderColor,
+        shapeProperties.borderWidth,
+        shapeProperties.borderRadius,
+        shapeProperties.padding
+      ]
+    },
+    {
+      selector: 'vaadin-message-list vaadin-message::part(name)',
+      displayName: 'Name',
+      properties: [
+        textProperties.textColor,
+        textProperties.fontSize,
+        textProperties.fontWeight,
+        textProperties.fontStyle
+      ]
+    },
+    {
+      selector: 'vaadin-message-list vaadin-message::part(time)',
+      displayName: 'Time',
+      properties: [
+        textProperties.textColor,
+        textProperties.fontSize,
+        textProperties.fontWeight,
+        textProperties.fontStyle
+      ]
+    },
+    {
+      selector: 'vaadin-message-list vaadin-message::part(message)',
+      displayName: 'Text',
+      properties: [
+        textProperties.textColor,
+        textProperties.fontSize,
+        textProperties.fontWeight,
+        textProperties.fontStyle
+      ]
+    }
+  ]
+} as ComponentMetadata;


### PR DESCRIPTION
### Finding on Message input

1. It will be more helpful to be able to set `border-bottom` for the message item other that border around the entire message item. shapeProperties only have `border-width`, would be helpful to have `border-bottom-width`

2. The default style values for `vaadin-message`, `::part(name)`, `::part(title)` and `::part(message)` are empty until you update the style with a new value

3. Avatar component `vaadin-message > vaadin-avatar` cannot be styled as a child component and vaadin avatar cannot be selected to be styled individually since it’s a slot not a direct shadow child element to `vaadin-message`.