### PR TITLE
feat: Spreadsheet and Map metadata

### DIFF
--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-map.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-map.ts
@@ -1,0 +1,20 @@
+import { ComponentMetadata } from '../model';
+import { shapeProperties } from './defaults';
+
+export default {
+  tagName: 'vaadin-map',
+  displayName: 'Map',
+  elements: [
+    {
+      selector: 'vaadin-map',
+      displayName: 'Map',
+      properties: [
+        shapeProperties.backgroundColor,
+        shapeProperties.borderColor,
+        shapeProperties.borderWidth,
+        shapeProperties.borderRadius,
+        shapeProperties.padding
+      ]
+    }
+  ]
+} as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-spreadsheet.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-spreadsheet.ts
@@ -1,0 +1,20 @@
+import { ComponentMetadata } from '../model';
+import { shapeProperties } from './defaults';
+
+export default {
+  tagName: 'vaadin-spreadsheet',
+  displayName: 'Spreadsheet',
+  elements: [
+    {
+      selector: 'vaadin-spreadsheet',
+      displayName: 'Spreadsheet',
+      properties: [
+        shapeProperties.backgroundColor,
+        shapeProperties.borderColor,
+        shapeProperties.borderWidth,
+        shapeProperties.borderRadius,
+        shapeProperties.padding
+      ]
+    }
+  ]
+} as ComponentMetadata;


### PR DESCRIPTION
## Description

Theme Editor metadata for Spreadsheet and Map, strange issue is present but it's not blocking use of Theme Editor:

While dynamically creating `vaadin-spreadsheet` element using `document.createElement('vaadin-spreadsheet')`  I end up with:
```
Uncaught (in promise) TypeError: Cannot read properties of null (reading 'insertRule')
    at bT (spreadsheet-export.js:1478:33)
    at HV (spreadsheet-export.js:2369:288)
    at v_ (spreadsheet-export.js:377:18)
    at GP (spreadsheet-export.js:2279:132)
    at new d7 (spreadsheet-export.js:2053:124)
    at VaadinSpreadsheet.updated (vaadin-spreadsheet.js:179:18)
    at VaadinSpreadsheet._$didUpdate (reactive-element.js:868:1)
    at VaadinSpreadsheet.performUpdate (reactive-element.js:834:1)
    at VaadinSpreadsheet.scheduleUpdate (reactive-element.js:753:1)
    at VaadinSpreadsheet.__enqueueUpdate (reactive-element.js:726:1)
```

Part of https://github.com/vaadin/flow/issues/17042

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
