### PR TITLE
revert: update jandex-maven-plugin for JDK 21 (#17291) (#17323)

### DIFF
--- a/flow-jandex/pom.xml
+++ b/flow-jandex/pom.xml
@@ -107,9 +107,9 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>io.smallrye</groupId>
+                <groupId>org.jboss.jandex</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>1.1.1</version>
                 <executions>
                     <execution>
                         <id>make-index</id>


### PR DESCRIPTION
This reverts commit bf2d96977071813ab13a96fbf023dfb1766dcc13.

The index produced by this plugin is not supported by Quarkus 2, that fails with errors similar to "Can't read index version 11; this IndexReader only supports index versions 2-3,6-10"