### PR TITLE
Add meta data for side nav

### DIFF
--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-side-nav-item.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-side-nav-item.ts
@@ -1,5 +1,5 @@
 import { ComponentMetadata } from '../model';
-import {iconProperties, shapeProperties, textProperties} from './defaults';
+import { iconProperties, shapeProperties, textProperties } from './defaults';
 
 export default {
   tagName: 'vaadin-side-nav-item',
@@ -19,10 +19,7 @@ export default {
     {
       selector: 'vaadin-side-nav-item > [slot="prefix"]',
       displayName: 'Nav item icon',
-      properties: [
-        iconProperties.iconSize,
-        iconProperties.iconColor
-      ]
+      properties: [iconProperties.iconSize, iconProperties.iconColor]
     },
     {
       selector: 'vaadin-side-nav-item::part(item)',

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-side-nav-item.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-side-nav-item.ts
@@ -1,14 +1,48 @@
 import { ComponentMetadata } from '../model';
 import { iconProperties, shapeProperties, textProperties } from './defaults';
+import { html } from 'lit';
 
 export default {
   tagName: 'vaadin-side-nav-item',
   displayName: 'SideNavItem',
+  description: html`You are styling selected item only, if you wish to style all items of given SideNav component please
+    pick <code>vaadin-side-nav</code> instead.`,
+  notAccessibleDescription: html`If you wish to style all items of current SideNav component please pick
+    <code>vaadin-side-nav</code> instead.`,
   elements: [
     {
-      selector: 'vaadin-side-nav-item',
+      selector: 'vaadin-side-nav-item > [slot="prefix"]',
+      displayName: 'Nav item icon',
+      properties: [iconProperties.iconSize, iconProperties.iconColor]
+    },
+    {
+      selector: 'vaadin-side-nav-item[active] > [slot="prefix"]',
+      displayName: 'Nav item icon (active)',
+      properties: [iconProperties.iconSize, iconProperties.iconColor]
+    },
+    {
+      selector: 'vaadin-side-nav-item::part(item)',
       displayName: 'Nav item',
       properties: [
+        shapeProperties.backgroundColor,
+        shapeProperties.borderColor,
+        shapeProperties.borderWidth,
+        shapeProperties.borderRadius,
+        shapeProperties.padding,
+        textProperties.textColor,
+        textProperties.fontSize,
+        textProperties.fontWeight,
+        textProperties.fontStyle
+      ]
+    },
+    {
+      selector: 'vaadin-side-nav-item[active]::part(item)',
+      displayName: 'Nav item (active)',
+      properties: [
+        textProperties.textColor,
+        textProperties.fontSize,
+        textProperties.fontWeight,
+        textProperties.fontStyle,
         shapeProperties.backgroundColor,
         shapeProperties.borderColor,
         shapeProperties.borderWidth,
@@ -17,19 +51,14 @@ export default {
       ]
     },
     {
-      selector: 'vaadin-side-nav-item > [slot="prefix"]',
-      displayName: 'Nav item icon',
+      selector: 'vaadin-side-nav-item::part(toggle-button)::before',
+      displayName: 'Expand/collapse icon',
       properties: [iconProperties.iconSize, iconProperties.iconColor]
     },
     {
-      selector: 'vaadin-side-nav-item::part(item)',
-      displayName: 'Nav item label',
-      properties: [
-        textProperties.textColor,
-        textProperties.fontSize,
-        textProperties.fontWeight,
-        textProperties.fontStyle
-      ]
+      selector: 'vaadin-side-nav-item[active]::part(toggle-button)::before',
+      displayName: 'Expand/collapse icon (active)',
+      properties: [iconProperties.iconSize, iconProperties.iconColor]
     }
   ]
 } as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-side-nav-item.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-side-nav-item.ts
@@ -1,0 +1,38 @@
+import { ComponentMetadata } from '../model';
+import {iconProperties, shapeProperties, textProperties} from './defaults';
+
+export default {
+  tagName: 'vaadin-side-nav-item',
+  displayName: 'SideNavItem',
+  elements: [
+    {
+      selector: 'vaadin-side-nav-item',
+      displayName: 'Nav item',
+      properties: [
+        shapeProperties.backgroundColor,
+        shapeProperties.borderColor,
+        shapeProperties.borderWidth,
+        shapeProperties.borderRadius,
+        shapeProperties.padding
+      ]
+    },
+    {
+      selector: 'vaadin-side-nav-item > [slot="prefix"]',
+      displayName: 'Nav item icon',
+      properties: [
+        iconProperties.iconSize,
+        iconProperties.iconColor
+      ]
+    },
+    {
+      selector: 'vaadin-side-nav-item::part(item)',
+      displayName: 'Nav item label',
+      properties: [
+        textProperties.textColor,
+        textProperties.fontSize,
+        textProperties.fontWeight,
+        textProperties.fontStyle
+      ]
+    }
+  ]
+} as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-side-nav.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-side-nav.ts
@@ -1,5 +1,5 @@
 import { ComponentMetadata } from '../model';
-import {iconProperties, shapeProperties, textProperties} from './defaults';
+import { iconProperties, shapeProperties, textProperties } from './defaults';
 
 export default {
   tagName: 'vaadin-side-nav',
@@ -29,10 +29,7 @@ export default {
     {
       selector: 'vaadin-side-nav::part(label)::after',
       displayName: 'Expand/collapse icon',
-      properties: [
-        iconProperties.iconSize,
-        iconProperties.iconColor
-      ]
+      properties: [iconProperties.iconSize, iconProperties.iconColor]
     },
     {
       selector: 'vaadin-side-nav > vaadin-side-nav-item',
@@ -48,10 +45,7 @@ export default {
     {
       selector: 'vaadin-side-nav > vaadin-side-nav-item > [slot="prefix"]',
       displayName: 'Nav item icon',
-      properties: [
-        iconProperties.iconSize,
-        iconProperties.iconColor
-      ]
+      properties: [iconProperties.iconSize, iconProperties.iconColor]
     },
     {
       selector: 'vaadin-side-nav > vaadin-side-nav-item::part(item)',

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-side-nav.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-side-nav.ts
@@ -1,0 +1,67 @@
+import { ComponentMetadata } from '../model';
+import {iconProperties, shapeProperties, textProperties} from './defaults';
+
+export default {
+  tagName: 'vaadin-side-nav',
+  displayName: 'SideNav',
+  elements: [
+    {
+      selector: 'vaadin-side-nav',
+      displayName: 'Side nav',
+      properties: [
+        shapeProperties.backgroundColor,
+        shapeProperties.borderColor,
+        shapeProperties.borderWidth,
+        shapeProperties.borderRadius,
+        shapeProperties.padding
+      ]
+    },
+    {
+      selector: 'vaadin-side-nav > [slot="label"]',
+      displayName: 'Label',
+      properties: [
+        textProperties.textColor,
+        textProperties.fontSize,
+        textProperties.fontWeight,
+        textProperties.fontStyle
+      ]
+    },
+    {
+      selector: 'vaadin-side-nav::part(label)::after',
+      displayName: 'Expand/collapse icon',
+      properties: [
+        iconProperties.iconSize,
+        iconProperties.iconColor
+      ]
+    },
+    {
+      selector: 'vaadin-side-nav > vaadin-side-nav-item',
+      displayName: 'Nav item',
+      properties: [
+        shapeProperties.backgroundColor,
+        shapeProperties.borderColor,
+        shapeProperties.borderWidth,
+        shapeProperties.borderRadius,
+        shapeProperties.padding
+      ]
+    },
+    {
+      selector: 'vaadin-side-nav > vaadin-side-nav-item > [slot="prefix"]',
+      displayName: 'Nav item icon',
+      properties: [
+        iconProperties.iconSize,
+        iconProperties.iconColor
+      ]
+    },
+    {
+      selector: 'vaadin-side-nav > vaadin-side-nav-item::part(item)',
+      displayName: 'Nav item label',
+      properties: [
+        textProperties.textColor,
+        textProperties.fontSize,
+        textProperties.fontWeight,
+        textProperties.fontStyle
+      ]
+    }
+  ]
+} as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-side-nav.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-side-nav.ts
@@ -27,14 +27,38 @@ export default {
       ]
     },
     {
-      selector: 'vaadin-side-nav::part(label)::after',
-      displayName: 'Expand/collapse icon',
+      selector: 'vaadin-side-nav vaadin-side-nav-item > [slot="prefix"]',
+      displayName: 'Nav item icon',
       properties: [iconProperties.iconSize, iconProperties.iconColor]
     },
     {
-      selector: 'vaadin-side-nav > vaadin-side-nav-item',
+      selector: 'vaadin-side-nav vaadin-side-nav-item[active] > [slot="prefix"]',
+      displayName: 'Nav item icon (active)',
+      properties: [iconProperties.iconSize, iconProperties.iconColor]
+    },
+    {
+      selector: 'vaadin-side-nav vaadin-side-nav-item::part(item)',
       displayName: 'Nav item',
       properties: [
+        shapeProperties.backgroundColor,
+        shapeProperties.borderColor,
+        shapeProperties.borderWidth,
+        shapeProperties.borderRadius,
+        shapeProperties.padding,
+        textProperties.textColor,
+        textProperties.fontSize,
+        textProperties.fontWeight,
+        textProperties.fontStyle
+      ]
+    },
+    {
+      selector: 'vaadin-side-nav vaadin-side-nav-item[active]::part(item)',
+      displayName: 'Nav item (active)',
+      properties: [
+        textProperties.textColor,
+        textProperties.fontSize,
+        textProperties.fontWeight,
+        textProperties.fontStyle,
         shapeProperties.backgroundColor,
         shapeProperties.borderColor,
         shapeProperties.borderWidth,
@@ -43,19 +67,14 @@ export default {
       ]
     },
     {
-      selector: 'vaadin-side-nav > vaadin-side-nav-item > [slot="prefix"]',
-      displayName: 'Nav item icon',
+      selector: 'vaadin-side-nav vaadin-side-nav-item::part(toggle-button)::before',
+      displayName: 'Expand/collapse icon',
       properties: [iconProperties.iconSize, iconProperties.iconColor]
     },
     {
-      selector: 'vaadin-side-nav > vaadin-side-nav-item::part(item)',
-      displayName: 'Nav item label',
-      properties: [
-        textProperties.textColor,
-        textProperties.fontSize,
-        textProperties.fontWeight,
-        textProperties.fontStyle
-      ]
+      selector: 'vaadin-side-nav vaadin-side-nav-item[active]::part(toggle-button)::before',
+      displayName: 'Expand/collapse icon (active)',
+      properties: [iconProperties.iconSize, iconProperties.iconColor]
     }
   ]
 } as ComponentMetadata;


### PR DESCRIPTION
### Finding on Side Nav

1. There isn’t support for `border-width-right` or `border-width-left`, it will be more helpful to set the border style on just one side of the `vaadin-side-nav` or it's parent wrapper.

2. To ensure consistent styles for multiple `vaadin-side-nav` and `vaadin-side-nav-item` elements within a single wrapper, you need to apply global styles. This may not be very helpful when there are multiple side nav (as sub navigation).

3. To make styles consistent for all `vaadin-side-nav-item`, selectors have been moved to the parent component but styles applied on the `vaadin-side-nav-item` has flow specificity and can't override parent style.

4. Some style properties on `vaadin-side-nav-item` label ends up affecting suffix content if it’s a text, eg: badge gets `italic` style, and leading icon gets the `font size` style.