### PR TITLE
fix: disable Java live reload if theme editor is opened

### DIFF
--- a/vaadin-dev-server/frontend/theme-editor/editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.ts
@@ -214,6 +214,8 @@ export class ThemeEditor extends LitElement {
       themePreview.clear();
       this.refreshTheme();
     });
+
+    this.dispatchEvent(new CustomEvent('before-open'));
   }
 
   protected update(changedProperties: PropertyValues) {
@@ -233,6 +235,8 @@ export class ThemeEditor extends LitElement {
     super.disconnectedCallback();
 
     this.removeElementHighlight(this.context?.component.element);
+
+    this.dispatchEvent(new CustomEvent('after-close'));
   }
 
   render() {

--- a/vaadin-dev-server/frontend/vaadin-dev-tools.ts
+++ b/vaadin-dev-server/frontend/vaadin-dev-tools.ts
@@ -848,8 +848,6 @@ export class VaadinDevTools extends LitElement {
 
   private transitionDuration: number = 0;
 
-  disableLiveReloadTimeout: number | null = null;
-
   elementTelemetry() {
     let data = {};
     try {
@@ -1517,12 +1515,22 @@ export class VaadinDevTools extends LitElement {
     </div>`;
   }
 
+  disableJavaLiveReload() {
+    this.javaConnection?.setActive(false);
+  }
+
+  enableJavaLiveReload() {
+    this.javaConnection?.setActive(true);
+  }
+
   renderThemeEditor() {
     return html` <vaadin-dev-tools-theme-editor
       .expanded=${this.expanded}
       .themeEditorState=${this.themeEditorState}
       .pickerProvider=${() => this.componentPicker}
       .connection=${this.frontendConnection}
+      @before-open=${this.disableJavaLiveReload}
+      @after-close=${this.enableJavaLiveReload}
     ></vaadin-dev-tools-theme-editor>`;
   }
 


### PR DESCRIPTION
Enabled Java live reload closes theme editor which in turn leads to loosing user context.

Fixes #16864

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
