### PR TITLE
feat: overlay resolver, metadata for overlay components

### DIFF
--- a/vaadin-dev-server/frontend/component-picker.ts
+++ b/vaadin-dev-server/frontend/component-picker.ts
@@ -4,6 +4,7 @@ import { ComponentReference, getComponents } from './component-util.js';
 import './shim.js';
 import { Shim } from './shim.js';
 import { popupStyles } from './styles';
+import { componentResolver } from './theme-editor/components/component-resolver';
 
 export interface PickerOptions {
   infoTemplate: TemplateResult;
@@ -143,7 +144,7 @@ export class ComponentPicker extends LitElement {
     }
   }
   shimMove(e: CustomEvent) {
-    const targetElement = e.detail.target;
+    const targetElement = componentResolver.resolveElement(e.detail.target);
 
     this.components = getComponents(targetElement);
     this.selected = this.components.length - 1;

--- a/vaadin-dev-server/frontend/component-picker.ts
+++ b/vaadin-dev-server/frontend/component-picker.ts
@@ -4,7 +4,7 @@ import { ComponentReference, getComponents } from './component-util.js';
 import './shim.js';
 import { Shim } from './shim.js';
 import { popupStyles } from './styles';
-import { componentResolver } from './theme-editor/components/component-resolver';
+import { componentHighlightResolver, componentResolver } from './theme-editor/components/component-resolver';
 
 export interface PickerOptions {
   infoTemplate: TemplateResult;
@@ -109,7 +109,7 @@ export class ComponentPicker extends LitElement {
   update(changedProperties: PropertyValues): void {
     super.update(changedProperties);
     if (changedProperties.has('selected') || changedProperties.has('components')) {
-      this.highlight(this.components[this.selected]?.element);
+      this.highlight(this.components[this.selected]);
     }
     if (changedProperties.has('active')) {
       const wasActive = changedProperties.get('active');
@@ -148,6 +148,7 @@ export class ComponentPicker extends LitElement {
 
     this.components = getComponents(targetElement);
     this.selected = this.components.length - 1;
+    this.components[this.selected].highlightElement = componentHighlightResolver.resolveElement(e.detail.target);
   }
   shimClick(_e: CustomEvent) {
     this.pickSelectedComponent();
@@ -166,7 +167,8 @@ export class ComponentPicker extends LitElement {
     this.close();
   }
 
-  highlight(element: HTMLElement | undefined) {
+  highlight(componentRef: ComponentReference | undefined) {
+    let element = componentRef?.highlightElement ?? componentRef?.element;
     if (this.highlighted !== element) {
       if (element) {
         const clientRect = element.getBoundingClientRect();

--- a/vaadin-dev-server/frontend/component-util.ts
+++ b/vaadin-dev-server/frontend/component-util.ts
@@ -2,6 +2,7 @@ export type ComponentReference = {
   nodeId: number;
   uiId: number;
   element?: HTMLElement;
+  highlightElement?: HTMLElement;
 };
 
 export function getComponents(element: HTMLElement): ComponentReference[] {

--- a/vaadin-dev-server/frontend/theme-editor/components/component-resolver.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/component-resolver.ts
@@ -3,47 +3,86 @@
  *
  * Used with overlays that have different HTMLElements visible than present in node tree.
  *
- * MatcherResolvers cannot be added to component metadata as they are dynamically imported after being picked.
+ * Resolvers cannot be added to component metadata as component metadata is dynamically imported after being picked.
  */
 
-const _cookieConsentMatcherResolver = <MatcherResolver>{
-  matches: (element: HTMLElement) => {
-    return element.classList.contains('cc-banner');
-  },
-  resolves: (_element: HTMLElement) => <HTMLElement>document.querySelector('vaadin-cookie-consent')
+type Resolver = {
+  // returns source Vaadin element for given picked element
+  resolve: (element: HTMLElement) => HTMLElement | undefined;
 };
 
-const _loginFormOverlayMatcherResolver = <MatcherResolver>{
-  matches: (element: HTMLElement) => {
-    return element.localName === 'vaadin-login-overlay-wrapper';
-  },
-  resolves: (_element: HTMLElement) => <HTMLElement>document.querySelector('vaadin-login-overlay')
+const _cookieConsentResolver: Resolver = {
+  resolve: (element: HTMLElement) => {
+    const matcher = (element: HTMLElement) => element.classList.contains('cc-banner');
+    const matched = _isMatchingRecursive(matcher, element);
+    return matched ? <HTMLElement>document.querySelector('vaadin-cookie-consent') : undefined;
+  }
 };
 
-const _matcherResolvers = <MatcherResolver[]>[_cookieConsentMatcherResolver, _loginFormOverlayMatcherResolver];
+const _loginFormOverlayResolver: Resolver = {
+  resolve: (element: HTMLElement) => {
+    const matcher = (element: HTMLElement) => element.localName === 'vaadin-login-overlay-wrapper';
+    const matched = _isMatchingRecursive(matcher, element);
+    return matched ? <HTMLElement>document.querySelector('vaadin-login-overlay') : undefined;
+  }
+};
 
-type MatcherResolver = {
-  matches: (element: HTMLElement) => boolean;
-  resolves: (element: HTMLElement) => HTMLElement;
+const _dialogOverlayResolver: Resolver = {
+  resolve: (element: HTMLElement) => {
+    // @ts-ignore explicit usage of Polymer property
+    return element.localName === 'vaadin-dialog-overlay' ? <HTMLElement>_element['__dataHost'] : undefined;
+  }
+};
+
+const _confirmDialogOverlayResolver: Resolver = {
+  resolve: (element: HTMLElement) => {
+    const matcher = (element: HTMLElement) => element.localName === 'vaadin-confirm-dialog-overlay';
+    const matched = _isMatchingRecursive(matcher, element);
+    // @ts-ignore explicit usage of Polymer property
+    return matched ? <HTMLElement>matched['__dataHost'] : undefined;
+  }
+};
+
+const _notificationOverlayResolver: Resolver = {
+  resolve: (element: HTMLElement) => {
+    const matcher = (element: HTMLElement) => element.localName === 'vaadin-notification-card';
+    const matched = _isMatchingRecursive(matcher, element);
+    // @ts-ignore explicit usage of Polymer property
+    return matched ? <HTMLElement>matched['__dataHost'] : undefined;
+  }
+};
+
+const _resolvers = <Resolver[]>[
+  _cookieConsentResolver,
+  _loginFormOverlayResolver,
+  _dialogOverlayResolver,
+  _confirmDialogOverlayResolver,
+  _notificationOverlayResolver
+];
+
+// finds matching element or its parent
+const _isMatchingRecursive = function (
+  matcher: (element: HTMLElement) => boolean,
+  element: HTMLElement
+): HTMLElement | undefined {
+  if (matcher(element)) {
+    return element;
+  } else if (element.parentNode && element.parentNode instanceof HTMLElement) {
+    return _isMatchingRecursive(matcher, element.parentNode);
+  } else {
+    return undefined;
+  }
 };
 
 class ComponentResolver {
   resolveElement(element: HTMLElement) {
-    const resolved = _matcherResolvers
-      .filter((mr) => this._isMatchingRecursive(mr.matches, element))
-      .map((mr) => mr.resolves(element))
-      .pop();
-    return resolved ?? element;
-  }
-
-  _isMatchingRecursive(matcher: (element: HTMLElement) => boolean, element: HTMLElement): HTMLElement | undefined {
-    if (matcher(element)) {
-      return element;
-    } else if (element.parentNode && element.parentNode instanceof HTMLElement) {
-      return this._isMatchingRecursive(matcher, element.parentNode);
-    } else {
-      return undefined;
+    for (const i in _resolvers) {
+      let resolved: HTMLElement | undefined = element;
+      if ((resolved = _resolvers[i].resolve(element)) !== undefined) {
+        return resolved;
+      }
     }
+    return element;
   }
 }
 

--- a/vaadin-dev-server/frontend/theme-editor/components/component-resolver.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/component-resolver.ts
@@ -1,0 +1,50 @@
+/**
+ * Resolves HTMLElement that should be considered instead of directly picked element.
+ *
+ * Used with overlays that have different HTMLElements visible than present in node tree.
+ *
+ * MatcherResolvers cannot be added to component metadata as they are dynamically imported after being picked.
+ */
+
+const _cookieConsentMatcherResolver = <MatcherResolver>{
+  matches: (element: HTMLElement) => {
+    return element.classList.contains('cc-banner');
+  },
+  resolves: (_element: HTMLElement) => <HTMLElement>document.querySelector('vaadin-cookie-consent')
+};
+
+const _loginFormOverlayMatcherResolver = <MatcherResolver>{
+  matches: (element: HTMLElement) => {
+    return element.localName === 'vaadin-login-overlay-wrapper';
+  },
+  resolves: (_element: HTMLElement) => <HTMLElement>document.querySelector('vaadin-login-overlay')
+};
+
+const _matcherResolvers = <MatcherResolver[]>[_cookieConsentMatcherResolver, _loginFormOverlayMatcherResolver];
+
+type MatcherResolver = {
+  matches: (element: HTMLElement) => boolean;
+  resolves: (element: HTMLElement) => HTMLElement;
+};
+
+class ComponentResolver {
+  resolveElement(element: HTMLElement) {
+    const resolved = _matcherResolvers
+      .filter((mr) => this._isMatchingRecursive(mr.matches, element))
+      .map((mr) => mr.resolves(element))
+      .pop();
+    return resolved ?? element;
+  }
+
+  _isMatchingRecursive(matcher: (element: HTMLElement) => boolean, element: HTMLElement): HTMLElement | undefined {
+    if (matcher(element)) {
+      return element;
+    } else if (element.parentNode && element.parentNode instanceof HTMLElement) {
+      return this._isMatchingRecursive(matcher, element.parentNode);
+    } else {
+      return undefined;
+    }
+  }
+}
+
+export const componentResolver = new ComponentResolver();

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/defaults.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/defaults.ts
@@ -1,4 +1,4 @@
-import { EditorType } from '../model';
+import { CssPropertyMetadata, EditorType } from '../model';
 import { presets } from './presets';
 
 export const textProperties = {
@@ -102,3 +102,20 @@ export const iconProperties = {
     icon: 'font'
   }
 };
+
+export const standardShapeProperties = <CssPropertyMetadata[]>[
+  shapeProperties.backgroundColor,
+  shapeProperties.borderColor,
+  shapeProperties.borderWidth,
+  shapeProperties.borderRadius,
+  shapeProperties.padding
+];
+
+export const standardTextProperties = <CssPropertyMetadata[]>[
+  textProperties.textColor,
+  textProperties.fontSize,
+  textProperties.fontWeight,
+  textProperties.fontStyle
+];
+
+export const standardIconProperties = <CssPropertyMetadata[]>[iconProperties.iconColor, iconProperties.iconSize];

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-big-decimal-field.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-big-decimal-field.ts
@@ -1,11 +1,11 @@
 import { ComponentMetadata } from '../model';
 import {
-  clearButtonProperties,
   errorMessageProperties,
   helperTextProperties,
   inputFieldProperties,
   labelProperties
 } from './vaadin-text-field';
+import { standardButtonProperties } from './vaadin-button';
 
 export default {
   tagName: 'vaadin-big-decimal-field',
@@ -34,7 +34,7 @@ export default {
     {
       selector: 'vaadin-big-decimal-field::part(clear-button)',
       displayName: 'Clear button',
-      properties: clearButtonProperties
+      properties: standardButtonProperties
     }
   ]
 } as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-button.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-button.ts
@@ -1,8 +1,8 @@
 import { ComponentMetadata, CssPropertyMetadata, EditorType } from '../model';
 import { presets } from './presets';
-import { fieldProperties, shapeProperties, textProperties } from './defaults';
+import { fieldProperties, shapeProperties, standardTextProperties } from './defaults';
 
-export const buttonProperties: CssPropertyMetadata[] = [
+export const standardButtonProperties: CssPropertyMetadata[] = [
   shapeProperties.backgroundColor,
   shapeProperties.borderColor,
   shapeProperties.borderWidth,
@@ -24,12 +24,12 @@ export default {
     {
       selector: 'vaadin-button',
       displayName: 'Host',
-      properties: buttonProperties
+      properties: standardButtonProperties
     },
     {
       selector: 'vaadin-button::part(label)',
       displayName: 'Label',
-      properties: [textProperties.textColor, textProperties.fontSize, textProperties.fontWeight]
+      properties: standardTextProperties
     }
   ]
 } as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-confirm-dialog.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-confirm-dialog.ts
@@ -1,0 +1,70 @@
+import { ComponentMetadata } from '../model';
+import { standardShapeProperties, standardTextProperties } from './defaults';
+import { standardButtonProperties } from './vaadin-button';
+
+export default {
+  tagName: 'vaadin-confirm-dialog',
+  displayName: 'Confirm Dialog',
+  elements: [
+    {
+      selector: 'vaadin-confirm-dialog-overlay::part(backdrop)',
+      displayName: 'Modality curtain (backdrop)',
+      properties: standardShapeProperties
+    },
+    {
+      selector: 'vaadin-confirm-dialog-overlay::part(overlay)',
+      displayName: 'Dialog surface',
+      properties: standardShapeProperties
+    },
+    {
+      selector: 'vaadin-confirm-dialog-overlay::part(header)',
+      displayName: 'Header',
+      properties: [...standardShapeProperties, ...standardTextProperties]
+    },
+    {
+      selector: 'vaadin-confirm-dialog-overlay::part(content)',
+      displayName: 'Content',
+      properties: standardShapeProperties
+    },
+    {
+      selector: 'vaadin-confirm-dialog-overlay::part(message)',
+      displayName: 'Message',
+      properties: standardTextProperties
+    },
+    {
+      selector: 'vaadin-confirm-dialog-overlay::part(footer)',
+      displayName: 'Footer',
+      properties: standardShapeProperties
+    },
+    {
+      selector: 'vaadin-confirm-dialog-overlay > [slot="confirm-button"]',
+      displayName: 'Confirm button',
+      properties: standardButtonProperties
+    },
+    {
+      selector: 'vaadin-confirm-dialog-overlay > [slot="confirm-button"]::part(label)',
+      displayName: 'Confirm button label',
+      properties: standardTextProperties
+    },
+    {
+      selector: 'vaadin-confirm-dialog-overlay > [slot="reject-button"]',
+      displayName: 'Reject button',
+      properties: standardButtonProperties
+    },
+    {
+      selector: 'vaadin-confirm-dialog-overlay > [slot="reject-button"]::part(label)',
+      displayName: 'Reject button label',
+      properties: standardTextProperties
+    },
+    {
+      selector: 'vaadin-confirm-dialog-overlay > [slot="cancel-button"]',
+      displayName: 'Cancel button',
+      properties: standardButtonProperties
+    },
+    {
+      selector: 'vaadin-confirm-dialog-overlay > [slot="cancel-button"]::part(label)',
+      displayName: 'Cancel button label',
+      properties: standardTextProperties
+    }
+  ]
+} as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-cookie-consent.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-cookie-consent.ts
@@ -1,0 +1,24 @@
+import { ComponentMetadata } from '../model';
+import { standardShapeProperties, standardTextProperties } from './defaults';
+
+export default {
+  tagName: 'vaadin-cookie-consent',
+  displayName: 'Cookie Consent',
+  elements: [
+    {
+      selector: 'div.cc-banner',
+      displayName: 'Banner',
+      properties: standardShapeProperties
+    },
+    {
+      selector: 'div.cc-banner span.cc-message',
+      displayName: 'Message',
+      properties: standardTextProperties
+    },
+    {
+      selector: 'div.cc-banner a.cc-btn',
+      displayName: 'Button',
+      properties: [...standardShapeProperties, ...standardTextProperties]
+    }
+  ]
+} as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-dialog.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-dialog.ts
@@ -1,0 +1,39 @@
+import { ComponentMetadata } from '../model';
+import { standardShapeProperties, standardTextProperties } from './defaults';
+
+export default {
+  tagName: 'vaadin-dialog',
+  displayName: 'Dialog',
+  elements: [
+    {
+      selector: 'vaadin-dialog-overlay::part(backdrop)',
+      displayName: 'Modality curtain (backdrop)',
+      properties: standardShapeProperties
+    },
+    {
+      selector: 'vaadin-dialog-overlay::part(overlay)',
+      displayName: 'Dialog surface',
+      properties: standardShapeProperties
+    },
+    {
+      selector: 'vaadin-dialog-overlay::part(header)',
+      displayName: 'Header',
+      properties: standardShapeProperties
+    },
+    {
+      selector: 'vaadin-dialog-overlay::part(title)',
+      displayName: 'Title',
+      properties: standardTextProperties
+    },
+    {
+      selector: 'vaadin-dialog-overlay::part(content)',
+      displayName: 'Content',
+      properties: standardShapeProperties
+    },
+    {
+      selector: 'vaadin-dialog-overlay::part(footer)',
+      displayName: 'Footer',
+      properties: standardShapeProperties
+    }
+  ]
+} as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-email-field.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-email-field.ts
@@ -1,11 +1,11 @@
 import { ComponentMetadata } from '../model';
 import {
-  clearButtonProperties,
   errorMessageProperties,
   helperTextProperties,
   inputFieldProperties,
   labelProperties
 } from './vaadin-text-field';
+import { standardButtonProperties } from './vaadin-button';
 
 export default {
   tagName: 'vaadin-email-field',
@@ -34,7 +34,7 @@ export default {
     {
       selector: 'vaadin-email-field::part(clear-button)',
       displayName: 'Clear button',
-      properties: clearButtonProperties
+      properties: standardButtonProperties
     }
   ]
 } as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-integer-field.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-integer-field.ts
@@ -1,12 +1,12 @@
 import { ComponentMetadata } from '../model';
 import {
-  clearButtonProperties,
   errorMessageProperties,
   helperTextProperties,
   inputFieldProperties,
   labelProperties
 } from './vaadin-text-field';
 import { iconProperties } from './defaults';
+import { standardButtonProperties } from './vaadin-button';
 
 export default {
   tagName: 'vaadin-integer-field',
@@ -35,7 +35,7 @@ export default {
     {
       selector: 'vaadin-integer-field::part(clear-button)',
       displayName: 'Clear button',
-      properties: clearButtonProperties
+      properties: standardButtonProperties
     },
     {
       selector: 'vaadin-integer-field::part(decrease-button)',

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-login-form.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-login-form.ts
@@ -1,0 +1,91 @@
+import { ComponentMetadata } from '../model';
+import { standardIconProperties, standardShapeProperties, standardTextProperties } from './defaults';
+import {
+  errorMessageProperties,
+  helperTextProperties,
+  inputFieldProperties,
+  labelProperties
+} from './vaadin-text-field';
+import { standardButtonProperties } from './vaadin-button';
+
+export default {
+  tagName: 'vaadin-login-form',
+  displayName: 'Login',
+  elements: [
+    {
+      selector: 'vaadin-login-form',
+      displayName: 'Login form root component',
+      properties: standardShapeProperties
+    },
+    {
+      selector: 'vaadin-login-form vaadin-login-form-wrapper',
+      displayName: 'Login form',
+      properties: standardShapeProperties
+    },
+    {
+      selector: 'vaadin-login-form vaadin-login-form-wrapper::part(form-title)',
+      displayName: 'Form title',
+      properties: standardTextProperties
+    },
+    {
+      selector: 'vaadin-login-form vaadin-login-form-wrapper::part(error-message)',
+      displayName: 'Error message section',
+      properties: standardShapeProperties
+    },
+    {
+      selector: 'vaadin-login-form vaadin-login-form-wrapper::part(error-message-title)',
+      displayName: 'Error message heading',
+      properties: standardTextProperties
+    },
+    {
+      selector: 'vaadin-login-form vaadin-login-form-wrapper::part(error-message-description)',
+      displayName: 'Error message description',
+      properties: standardTextProperties
+    },
+    {
+      selector: 'vaadin-login-form vaadin-login-form-wrapper [required]::part(input-field)',
+      displayName: 'Input field',
+      properties: inputFieldProperties
+    },
+    {
+      selector: 'vaadin-login-form vaadin-login-form-wrapper [required]::part(label)',
+      displayName: 'Label',
+      properties: labelProperties
+    },
+    {
+      selector: 'vaadin-login-form vaadin-login-form-wrapper [required]::part(helper-text)',
+      displayName: 'Helper text',
+      properties: helperTextProperties
+    },
+    {
+      selector: 'vaadin-login-form vaadin-login-form-wrapper [required]::part(error-message)',
+      displayName: 'Error message',
+      properties: errorMessageProperties
+    },
+    {
+      selector: 'vaadin-login-form vaadin-password-field::part(reveal-button)',
+      displayName: 'Reveal button',
+      properties: standardIconProperties
+    },
+    {
+      selector: 'vaadin-login-form vaadin-button[theme~="submit"]',
+      displayName: 'Log In Button',
+      properties: standardButtonProperties
+    },
+    {
+      selector: 'vaadin-login-form vaadin-button[theme~="submit"]::part(label)',
+      displayName: 'Log In Button Label',
+      properties: standardTextProperties
+    },
+    {
+      selector: 'vaadin-login-form [slot="forgot-password"]',
+      displayName: 'Forgot password button',
+      properties: standardButtonProperties
+    },
+    {
+      selector: 'vaadin-login-form [slot="forgot-password"]::part(label)',
+      displayName: 'Forgot password button label',
+      properties: standardTextProperties
+    }
+  ]
+} as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-login-overlay.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-login-overlay.ts
@@ -1,0 +1,115 @@
+import { ComponentMetadata } from '../model';
+import { shapeProperties, standardIconProperties, standardShapeProperties, standardTextProperties } from './defaults';
+import {
+  errorMessageProperties,
+  helperTextProperties,
+  inputFieldProperties,
+  labelProperties
+} from './vaadin-text-field';
+import { standardButtonProperties } from './vaadin-button';
+
+export default {
+  tagName: 'vaadin-login-overlay',
+  displayName: 'Cookie Consent',
+  elements: [
+    {
+      selector: 'vaadin-login-overlay-wrapper::part(backdrop)',
+      displayName: 'Overlay backdrop / modality curtain',
+      properties: [shapeProperties.backgroundColor]
+    },
+    {
+      selector: 'vaadin-login-overlay-wrapper::part(card)',
+      displayName: 'Overlay card',
+      properties: standardShapeProperties
+    },
+    {
+      selector: 'vaadin-login-overlay-wrapper::part(brand)',
+      displayName: 'Card header',
+      properties: standardShapeProperties
+    },
+    {
+      selector: 'vaadin-login-overlay-wrapper::part(title)',
+      displayName: 'Title',
+      properties: standardTextProperties
+    },
+    {
+      selector: 'vaadin-login-overlay-wrapper::part(description)',
+      displayName: 'Description',
+      properties: standardTextProperties
+    },
+    {
+      selector: 'vaadin-login-overlay-wrapper vaadin-login-form vaadin-login-form-wrapper',
+      displayName: 'Login form',
+      properties: standardShapeProperties
+    },
+    {
+      selector: 'vaadin-login-overlay-wrapper vaadin-login-form vaadin-login-form-wrapper::part(form-title)',
+      displayName: 'Form title',
+      properties: standardTextProperties
+    },
+    {
+      selector: 'vaadin-login-overlay-wrapper vaadin-login-form vaadin-login-form-wrapper::part(error-message)',
+      displayName: 'Error message section',
+      properties: standardShapeProperties
+    },
+    {
+      selector: 'vaadin-login-overlay-wrapper vaadin-login-form vaadin-login-form-wrapper::part(error-message-title)',
+      displayName: 'Error message heading',
+      properties: standardTextProperties
+    },
+    {
+      selector:
+        'vaadin-login-overlay-wrapper vaadin-login-form vaadin-login-form-wrapper::part(error-message-description)',
+      displayName: 'Error message description',
+      properties: standardTextProperties
+    },
+    {
+      selector:
+        'vaadin-login-overlay-wrapper vaadin-login-form vaadin-login-form-wrapper [required]::part(input-field)',
+      displayName: 'Input field',
+      properties: inputFieldProperties
+    },
+    {
+      selector: 'vaadin-login-overlay-wrapper vaadin-login-form vaadin-login-form-wrapper [required]::part(label)',
+      displayName: 'Input field label',
+      properties: labelProperties
+    },
+    {
+      selector:
+        'vaadin-login-overlay-wrapper vaadin-login-form vaadin-login-form-wrapper [required]::part(helper-text)',
+      displayName: 'Input field helper text',
+      properties: helperTextProperties
+    },
+    {
+      selector:
+        'vaadin-login-overlay-wrapper vaadin-login-form vaadin-login-form-wrapper [required]::part(error-message)',
+      displayName: 'Input field error message',
+      properties: errorMessageProperties
+    },
+    {
+      selector: 'vaadin-login-overlay-wrapper vaadin-login-form vaadin-password-field::part(reveal-button)',
+      displayName: 'Password field reveal button',
+      properties: standardIconProperties
+    },
+    {
+      selector: 'vaadin-login-overlay-wrapper vaadin-login-form vaadin-button[theme~="submit"]',
+      displayName: 'Log In Button',
+      properties: standardButtonProperties
+    },
+    {
+      selector: 'vaadin-login-overlay-wrapper vaadin-login-form vaadin-button[theme~="submit"]::part(label)',
+      displayName: 'Log In Button Label',
+      properties: standardTextProperties
+    },
+    {
+      selector: 'vaadin-login-overlay-wrapper vaadin-login-form [slot="forgot-password"]',
+      displayName: 'Forgot password button',
+      properties: standardButtonProperties
+    },
+    {
+      selector: 'vaadin-login-overlay-wrapper vaadin-login-form [slot="forgot-password"]::part(label)',
+      displayName: 'Forgot password button label',
+      properties: standardTextProperties
+    }
+  ]
+} as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-login-overlay.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-login-overlay.ts
@@ -10,7 +10,7 @@ import { standardButtonProperties } from './vaadin-button';
 
 export default {
   tagName: 'vaadin-login-overlay',
-  displayName: 'Cookie Consent',
+  displayName: 'Login Overlay',
   elements: [
     {
       selector: 'vaadin-login-overlay-wrapper::part(backdrop)',

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-notification.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-notification.ts
@@ -1,0 +1,19 @@
+import { ComponentMetadata } from '../model';
+import { standardShapeProperties, standardTextProperties } from './defaults';
+
+export default {
+  tagName: 'vaadin-notification',
+  displayName: 'Notification',
+  elements: [
+    {
+      selector: 'vaadin-notification-card::part(overlay)',
+      displayName: 'Notification card',
+      properties: standardShapeProperties
+    },
+    {
+      selector: 'vaadin-notification-card::part(content)',
+      displayName: 'Content',
+      properties: standardTextProperties
+    }
+  ]
+} as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-number-field.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-number-field.ts
@@ -1,12 +1,12 @@
 import { ComponentMetadata } from '../model';
 import {
-  clearButtonProperties,
   errorMessageProperties,
   helperTextProperties,
   inputFieldProperties,
   labelProperties
 } from './vaadin-text-field';
 import { iconProperties } from './defaults';
+import { standardButtonProperties } from './vaadin-button';
 
 export default {
   tagName: 'vaadin-number-field',
@@ -35,7 +35,7 @@ export default {
     {
       selector: 'vaadin-number-field::part(clear-button)',
       displayName: 'Clear button',
-      properties: clearButtonProperties
+      properties: standardButtonProperties
     },
     {
       selector: 'vaadin-number-field::part(increase-button)',

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-password-field.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-password-field.ts
@@ -1,12 +1,12 @@
 import { ComponentMetadata } from '../model';
 import {
-  clearButtonProperties,
   errorMessageProperties,
   helperTextProperties,
   inputFieldProperties,
   labelProperties
 } from './vaadin-text-field';
 import { iconProperties } from './defaults';
+import { standardButtonProperties } from './vaadin-button';
 
 export default {
   tagName: 'vaadin-password-field',
@@ -35,7 +35,7 @@ export default {
     {
       selector: 'vaadin-password-field::part(clear-button)',
       displayName: 'Clear button',
-      properties: clearButtonProperties
+      properties: standardButtonProperties
     },
     {
       selector: 'vaadin-password-field::part(reveal-button)',

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-text-area.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-text-area.ts
@@ -1,11 +1,11 @@
 import { ComponentMetadata } from '../model';
 import {
-  clearButtonProperties,
   errorMessageProperties,
   helperTextProperties,
   inputFieldProperties,
   labelProperties
 } from './vaadin-text-field';
+import { standardButtonProperties } from './vaadin-button';
 
 export default {
   tagName: 'vaadin-text-area',
@@ -34,7 +34,7 @@ export default {
     {
       selector: 'vaadin-text-area::part(clear-button)',
       displayName: 'Clear button',
-      properties: clearButtonProperties
+      properties: standardButtonProperties
     }
   ]
 } as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-text-field.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-text-field.ts
@@ -1,5 +1,5 @@
 import { ComponentMetadata, CssPropertyMetadata } from '../model';
-import { fieldProperties, iconProperties, shapeProperties, textProperties } from './defaults';
+import { fieldProperties, shapeProperties, standardIconProperties, textProperties } from './defaults';
 
 export const inputFieldProperties: CssPropertyMetadata[] = [
   shapeProperties.backgroundColor,
@@ -31,8 +31,6 @@ export const errorMessageProperties: CssPropertyMetadata[] = [
   textProperties.fontWeight
 ];
 
-export const clearButtonProperties: CssPropertyMetadata[] = [iconProperties.iconColor, iconProperties.iconSize];
-
 export default {
   tagName: 'vaadin-text-field',
   displayName: 'TextField',
@@ -60,7 +58,7 @@ export default {
     {
       selector: 'vaadin-text-field::part(clear-button)',
       displayName: 'Clear button',
-      properties: clearButtonProperties
+      properties: standardIconProperties
     }
   ]
 } as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-upload.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-upload.ts
@@ -1,5 +1,5 @@
 import { ComponentMetadata } from '../model';
-import { buttonProperties } from './vaadin-button';
+import { standardButtonProperties } from './vaadin-button';
 import { shapeProperties, textProperties } from './defaults';
 
 export default {
@@ -9,7 +9,7 @@ export default {
     {
       selector: 'vaadin-upload > vaadin-button',
       displayName: 'Upload button',
-      properties: buttonProperties
+      properties: standardButtonProperties
     },
     {
       selector: 'vaadin-upload > vaadin-button::part(label)',


### PR DESCRIPTION
## Description

There are components that cannot be picked directly due to being rendered in overlay:
- `vaadin-cookie-consent`
- `vaadin-login-overlay`
- `vaadin-dialog`
- `vaadin-confirm-dialog`
- `vaadin-notification`

After moving mouse over such components, they not present in node tree and are not recognized by picker. 

Resolver has been introduced to match and resolve proper Vaadin components that are present in node tree and can be styled.

In addition to above highlighting of overlay elements is also used using highlight resolver as highlighted element is different than hovered.

## Demo

https://github.com/vaadin/flow/assets/106965834/2741e0b1-753b-4efa-b0ec-73f2091d7a53

## Type of change

- [x] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
