### PR TITLE
chore: support for dialog, confirm-dialog and notification metadata, …

### DIFF
--- a/vaadin-dev-server/frontend/theme-editor/components/component-resolver.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/component-resolver.ts
@@ -3,47 +3,86 @@
  *
  * Used with overlays that have different HTMLElements visible than present in node tree.
  *
- * MatcherResolvers cannot be added to component metadata as they are dynamically imported after being picked.
+ * Resolvers cannot be added to component metadata as component metadata is dynamically imported after being picked.
  */
 
-const _cookieConsentMatcherResolver = <MatcherResolver>{
-  matches: (element: HTMLElement) => {
-    return element.classList.contains('cc-banner');
-  },
-  resolves: (_element: HTMLElement) => <HTMLElement>document.querySelector('vaadin-cookie-consent')
+type Resolver = {
+  // returns source Vaadin element for given picked element
+  resolve: (element: HTMLElement) => HTMLElement | undefined;
 };
 
-const _loginFormOverlayMatcherResolver = <MatcherResolver>{
-  matches: (element: HTMLElement) => {
-    return element.localName === 'vaadin-login-overlay-wrapper';
-  },
-  resolves: (_element: HTMLElement) => <HTMLElement>document.querySelector('vaadin-login-overlay')
+const _cookieConsentResolver: Resolver = {
+  resolve: (element: HTMLElement) => {
+    const matcher = (element: HTMLElement) => element.classList.contains('cc-banner');
+    const matched = _isMatchingRecursive(matcher, element);
+    return matched ? <HTMLElement>document.querySelector('vaadin-cookie-consent') : undefined;
+  }
 };
 
-const _matcherResolvers = <MatcherResolver[]>[_cookieConsentMatcherResolver, _loginFormOverlayMatcherResolver];
+const _loginFormOverlayResolver: Resolver = {
+  resolve: (element: HTMLElement) => {
+    const matcher = (element: HTMLElement) => element.localName === 'vaadin-login-overlay-wrapper';
+    const matched = _isMatchingRecursive(matcher, element);
+    return matched ? <HTMLElement>document.querySelector('vaadin-login-overlay') : undefined;
+  }
+};
 
-type MatcherResolver = {
-  matches: (element: HTMLElement) => boolean;
-  resolves: (element: HTMLElement) => HTMLElement;
+const _dialogOverlayResolver: Resolver = {
+  resolve: (element: HTMLElement) => {
+    // @ts-ignore explicit usage of Polymer property
+    return element.localName === 'vaadin-dialog-overlay' ? <HTMLElement>_element['__dataHost'] : undefined;
+  }
+};
+
+const _confirmDialogOverlayResolver: Resolver = {
+  resolve: (element: HTMLElement) => {
+    const matcher = (element: HTMLElement) => element.localName === 'vaadin-confirm-dialog-overlay';
+    const matched = _isMatchingRecursive(matcher, element);
+    // @ts-ignore explicit usage of Polymer property
+    return matched ? <HTMLElement>matched['__dataHost'] : undefined;
+  }
+};
+
+const _notificationOverlayResolver: Resolver = {
+  resolve: (element: HTMLElement) => {
+    const matcher = (element: HTMLElement) => element.localName === 'vaadin-notification-card';
+    const matched = _isMatchingRecursive(matcher, element);
+    // @ts-ignore explicit usage of Polymer property
+    return matched ? <HTMLElement>matched['__dataHost'] : undefined;
+  }
+};
+
+const _resolvers = <Resolver[]>[
+  _cookieConsentResolver,
+  _loginFormOverlayResolver,
+  _dialogOverlayResolver,
+  _confirmDialogOverlayResolver,
+  _notificationOverlayResolver
+];
+
+// finds matching element or its parent
+const _isMatchingRecursive = function (
+  matcher: (element: HTMLElement) => boolean,
+  element: HTMLElement
+): HTMLElement | undefined {
+  if (matcher(element)) {
+    return element;
+  } else if (element.parentNode && element.parentNode instanceof HTMLElement) {
+    return _isMatchingRecursive(matcher, element.parentNode);
+  } else {
+    return undefined;
+  }
 };
 
 class ComponentResolver {
   resolveElement(element: HTMLElement) {
-    const resolved = _matcherResolvers
-      .filter((mr) => this._isMatchingRecursive(mr.matches, element))
-      .map((mr) => mr.resolves(element))
-      .pop();
-    return resolved ?? element;
-  }
-
-  _isMatchingRecursive(matcher: (element: HTMLElement) => boolean, element: HTMLElement): HTMLElement | undefined {
-    if (matcher(element)) {
-      return element;
-    } else if (element.parentNode && element.parentNode instanceof HTMLElement) {
-      return this._isMatchingRecursive(matcher, element.parentNode);
-    } else {
-      return undefined;
+    for (const i in _resolvers) {
+      let resolved: HTMLElement | undefined = element;
+      if ((resolved = _resolvers[i].resolve(element)) !== undefined) {
+        return resolved;
+      }
     }
+    return element;
   }
 }
 

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-confirm-dialog.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-confirm-dialog.ts
@@ -1,0 +1,70 @@
+import { ComponentMetadata } from '../model';
+import { standardShapeProperties, standardTextProperties } from './defaults';
+import { standardButtonProperties } from './vaadin-button';
+
+export default {
+  tagName: 'vaadin-confirm-dialog',
+  displayName: 'Confirm Dialog',
+  elements: [
+    {
+      selector: 'vaadin-confirm-dialog-overlay::part(backdrop)',
+      displayName: 'Modality curtain (backdrop)',
+      properties: standardShapeProperties
+    },
+    {
+      selector: 'vaadin-confirm-dialog-overlay::part(overlay)',
+      displayName: 'Dialog surface',
+      properties: standardShapeProperties
+    },
+    {
+      selector: 'vaadin-confirm-dialog-overlay::part(header)',
+      displayName: 'Header',
+      properties: [...standardShapeProperties, ...standardTextProperties]
+    },
+    {
+      selector: 'vaadin-confirm-dialog-overlay::part(content)',
+      displayName: 'Content',
+      properties: standardShapeProperties
+    },
+    {
+      selector: 'vaadin-confirm-dialog-overlay::part(message)',
+      displayName: 'Message',
+      properties: standardTextProperties
+    },
+    {
+      selector: 'vaadin-confirm-dialog-overlay::part(footer)',
+      displayName: 'Footer',
+      properties: standardShapeProperties
+    },
+    {
+      selector: 'vaadin-confirm-dialog-overlay > [slot="confirm-button"]',
+      displayName: 'Confirm button',
+      properties: standardButtonProperties
+    },
+    {
+      selector: 'vaadin-confirm-dialog-overlay > [slot="confirm-button"]::part(label)',
+      displayName: 'Confirm button label',
+      properties: standardTextProperties
+    },
+    {
+      selector: 'vaadin-confirm-dialog-overlay > [slot="reject-button"]',
+      displayName: 'Reject button',
+      properties: standardButtonProperties
+    },
+    {
+      selector: 'vaadin-confirm-dialog-overlay > [slot="reject-button"]::part(label)',
+      displayName: 'Reject button label',
+      properties: standardTextProperties
+    },
+    {
+      selector: 'vaadin-confirm-dialog-overlay > [slot="cancel-button"]',
+      displayName: 'Cancel button',
+      properties: standardButtonProperties
+    },
+    {
+      selector: 'vaadin-confirm-dialog-overlay > [slot="cancel-button"]::part(label)',
+      displayName: 'Cancel button label',
+      properties: standardTextProperties
+    }
+  ]
+} as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-dialog.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-dialog.ts
@@ -1,0 +1,39 @@
+import { ComponentMetadata } from '../model';
+import { standardShapeProperties, standardTextProperties } from './defaults';
+
+export default {
+  tagName: 'vaadin-dialog',
+  displayName: 'Dialog',
+  elements: [
+    {
+      selector: 'vaadin-dialog-overlay::part(backdrop)',
+      displayName: 'Modality curtain (backdrop)',
+      properties: standardShapeProperties
+    },
+    {
+      selector: 'vaadin-dialog-overlay::part(overlay)',
+      displayName: 'Dialog surface',
+      properties: standardShapeProperties
+    },
+    {
+      selector: 'vaadin-dialog-overlay::part(header)',
+      displayName: 'Header',
+      properties: standardShapeProperties
+    },
+    {
+      selector: 'vaadin-dialog-overlay::part(title)',
+      displayName: 'Title',
+      properties: standardTextProperties
+    },
+    {
+      selector: 'vaadin-dialog-overlay::part(content)',
+      displayName: 'Content',
+      properties: standardShapeProperties
+    },
+    {
+      selector: 'vaadin-dialog-overlay::part(footer)',
+      displayName: 'Footer',
+      properties: standardShapeProperties
+    }
+  ]
+} as ComponentMetadata;

--- a/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-notification.ts
+++ b/vaadin-dev-server/frontend/theme-editor/metadata/components/vaadin-notification.ts
@@ -1,0 +1,19 @@
+import { ComponentMetadata } from '../model';
+import { standardShapeProperties, standardTextProperties } from './defaults';
+
+export default {
+  tagName: 'vaadin-notification',
+  displayName: 'Notification',
+  elements: [
+    {
+      selector: 'vaadin-notification-card::part(overlay)',
+      displayName: 'Notification card',
+      properties: standardShapeProperties
+    },
+    {
+      selector: 'vaadin-notification-card::part(content)',
+      displayName: 'Content',
+      properties: standardTextProperties
+    }
+  ]
+} as ComponentMetadata;


### PR DESCRIPTION
## Description

Support for Dialog, Confirm Dialog and Notification metadata. Requires https://github.com/vaadin/flow/pull/17343 to be merged (change base after that).

Part of https://github.com/vaadin/flow/issues/17042

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
