### PR TITLE
fix: reject emails with double dot between domain and tld

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/validator/EmailValidator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/validator/EmailValidator.java
@@ -26,9 +26,9 @@ package com.vaadin.flow.data.validator;
 @SuppressWarnings("serial")
 public class EmailValidator extends RegexpValidator {
 
-    private static final String PATTERN = "^" + "([a-zA-Z0-9_\\.\\-+])+" // local
-            + "@" + "[a-zA-Z0-9-.]+" // domain
-            + "\\." + "[a-zA-Z0-9-]{2,}" // tld
+    public static final String PATTERN = "^" + "([a-zA-Z0-9_\\.\\-+])+" // local
+            + "@" + "([a-zA-Z0-9-]+\\.)+" // domain with the dot separator
+            + "[a-zA-Z0-9-]{2,}" // before tld
             + "$";
 
     private final boolean allowEmptyValue;

--- a/flow-data/src/test/java/com/vaadin/flow/data/validator/EmailValidatorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/validator/EmailValidatorTest.java
@@ -100,6 +100,13 @@ public class EmailValidatorTest extends ValidatorTestBase {
                 false));
     }
 
+    @Test
+    public void testDomainWithDotDotFails() {
+        EmailValidator v = validator("domains containing dot dot should fail");
+        assertFails("hello@sample..com", v);
+        assertFails("hello@samp..le..com", v);
+    }
+
     private EmailValidator validator(String errorMessage) {
         return new EmailValidator(errorMessage);
     }


### PR DESCRIPTION
## Description

As indicated in issue #17333, this PR changes the validation pattern of an email address by invalidating the dot-dot in the domain name.

The pattern is now public in order to reference it in EmaiField and remove duplicate code (see https://github.com/vaadin/flow-components/pull/5320)

Fixes #17333

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
