### PR TITLE
chore: Upgrade pnpm to latest 8.6.11

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -72,7 +72,7 @@ public class FrontendTools {
      */
     public static final String DEFAULT_NPM_VERSION = "9.5.1";
 
-    public static final String DEFAULT_PNPM_VERSION = "8.3.1";
+    public static final String DEFAULT_PNPM_VERSION = "8.6.11";
 
     public static final String INSTALL_NODE_LOCALLY = "%n  $ mvn com.github.eirslett:frontend-maven-plugin:1.10.0:install-node-and-npm "
             + "-DnodeVersion=\"" + DEFAULT_NODE_VERSION + "\" ";


### PR DESCRIPTION
Tested with Node.js 18 (V24.2, 24.1, 24.0, 23.3) using spring skeleton starter.
Flow 9.1 and 2.10 need either
- upgrade to pnpm 7.33.5 and update supported Node version to 14,
- or upgrade to pnpm 8.6.11 and update supported Node version to 16,
because Node 12 is not compatible with pnpm >= 7, see https://pnpm.io/installation#compatibility.