### PR TITLE
chore: Upgrade pnpm to latest (CP: 23.3)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -67,13 +67,13 @@ public class FrontendTools {
      * the installed version is older than {@link #SUPPORTED_NODE_VERSION}, i.e.
      * {@value #SUPPORTED_NODE_MAJOR_VERSION}.{@value #SUPPORTED_NODE_MINOR_VERSION}.
      */
-    public static final String DEFAULT_NODE_VERSION = "v18.16.0";
+    public static final String DEFAULT_NODE_VERSION = "v18.16.1";
     /**
      * This is the version shipped with the default Node version.
      */
     public static final String DEFAULT_NPM_VERSION = "9.5.1";
 
-    public static final String DEFAULT_PNPM_VERSION = "5.18.10";
+    public static final String DEFAULT_PNPM_VERSION = "8.6.11";
 
     public static final String INSTALL_NODE_LOCALLY = "%n  $ mvn com.github.eirslett:frontend-maven-plugin:1.10.0:install-node-and-npm "
             + "-DnodeVersion=\"" + DEFAULT_NODE_VERSION + "\" ";


### PR DESCRIPTION
Cherry pick from main + update patch version for Node.js to be aligned with main.