### PR TITLE
docs: Update mixin interface JavaDoc

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/PrepareFrontendOutputProperties.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/PrepareFrontendOutputProperties.kt
@@ -75,11 +75,6 @@ public class PrepareFrontendOutputProperties public constructor(project: Project
     }
 
     @OutputDirectory
-    public fun getFrontendDirectory(): File {
-        return extension.frontendDirectory
-    }
-
-    @OutputDirectory
     public fun getGeneratedTsFolder(): File {
         return extension.generatedTsFolder
     }

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasComponents.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasComponents.java
@@ -32,9 +32,9 @@ import com.vaadin.flow.dom.Element;
  * interface provides an explicit API for components that explicitly supports
  * adding and removing arbitrary child components.
  * <p>
- * {@link HasComponents} should generally be implemented by layouts or
- * components whose primary function is to host child components. It shouldn't
- * be for example implemented by non-layout components such as fields.
+ * {@link HasComponents} is generally implemented by layouts or components whose
+ * primary function is to host child components. It isn't for example
+ * implemented by non-layout components such as fields.
  * <p>
  * The default implementations assume that children are attached to
  * {@link #getElement()}. Override all methods in this interface if the

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasComponents.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasComponents.java
@@ -32,6 +32,10 @@ import com.vaadin.flow.dom.Element;
  * interface provides an explicit API for components that explicitly supports
  * adding and removing arbitrary child components.
  * <p>
+ * {@link HasComponents} should generally be implemented by layouts or
+ * components whose primary function is to host child components. It shouldn't
+ * be for example implemented by non-layout components such as fields.
+ * <p>
  * The default implementations assume that children are attached to
  * {@link #getElement()}. Override all methods in this interface if the
  * components should be added to some other element.

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasHelper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasHelper.java
@@ -25,6 +25,7 @@ import com.vaadin.flow.dom.Element;
  * <p>
  * Root element should be a web component that uses slot for example in the
  * following way:
+ *
  * <pre>{@code
  *     <field-with-helper>
  *         <shadow-root>
@@ -35,6 +36,7 @@ import com.vaadin.flow.dom.Element;
  *         <span slot="helper">${helperText}</span>
  *     </field-with-helper>
  * }</pre>
+ *
  * @author Vaadin Ltd
  * @since 2.4
  */

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasHelper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasHelper.java
@@ -22,7 +22,19 @@ import com.vaadin.flow.dom.Element;
 /**
  * Mixin interface for field components that have helper text as property and
  * slots for inserting components.
- *
+ * <p>
+ * Root element should be a web component that uses slot for example in the
+ * following way:
+ * <pre>{@code
+ *     <field-with-helper>
+ *         <shadow-root>
+ *             ...
+ *             <slot name="helper"></slot>
+ *             ...
+ *         </shadow-root>
+ *         <span slot="helper">${helperText}</span>
+ *     </field-with-helper>
+ * }</pre>
  * @author Vaadin Ltd
  * @since 2.4
  */

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasLabel.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasLabel.java
@@ -24,8 +24,8 @@ import com.vaadin.flow.dom.ElementConstants;
  * for {@link #getElement()}. Override all methods in this interface if the text
  * should be added to some other element.
  * <p>
- * Root element should be a web component with a structure that supports
- * the 'label' property:
+ * Root element should be a web component with a structure that supports the
+ * 'label' property:
  *
  * <pre>{@code
  *     <field-with-label>

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasLabel.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasLabel.java
@@ -23,7 +23,17 @@ import com.vaadin.flow.dom.ElementConstants;
  * The default implementations set the label of the component to the given text
  * for {@link #getElement()}. Override all methods in this interface if the text
  * should be added to some other element.
- *
+ * <p>
+ * Example of a web component as a root element with a structure that supports
+ * the 'label' property:
+ * <pre>{@code
+ *     <field-with-label>
+ *         <shadow-root>
+ *             <input type="checkbox" id="input"/>
+ *             <label for="input">${label}</label>
+ *         </shadow-root>
+ *     </field-with-label>
+ * }</pre>
  *
  * @author Vaadin Ltd
  * @since

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasLabel.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasLabel.java
@@ -24,7 +24,7 @@ import com.vaadin.flow.dom.ElementConstants;
  * for {@link #getElement()}. Override all methods in this interface if the text
  * should be added to some other element.
  * <p>
- * Example of a web component as a root element with a structure that supports
+ * Root element should be a web component with a structure that supports
  * the 'label' property:
  *
  * <pre>{@code

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasLabel.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasLabel.java
@@ -26,6 +26,7 @@ import com.vaadin.flow.dom.ElementConstants;
  * <p>
  * Example of a web component as a root element with a structure that supports
  * the 'label' property:
+ *
  * <pre>{@code
  *     <field-with-label>
  *         <shadow-root>

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasSize.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasSize.java
@@ -22,7 +22,9 @@ import com.vaadin.flow.dom.ElementConstants;
 
 /**
  * Any component implementing this interface supports setting the size of the
- * component using {@link #setWidth(String)} and {@link #setHeight(String)}. The
+ * component using {@link #setWidth(String)}, {@link #setHeight(String)},
+ * {@link #setMaxWidth(String)}, {@link #setMaxHeight(String)},
+ * {@link #setMinWidth(String)}, and {@link #setMinHeight(String)}. The
  * sizes are set on the element as inline styles, i.e. using
  * {@link Element#getStyle()}.
  *

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasSize.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasSize.java
@@ -24,8 +24,8 @@ import com.vaadin.flow.dom.ElementConstants;
  * Any component implementing this interface supports setting the size of the
  * component using {@link #setWidth(String)}, {@link #setHeight(String)},
  * {@link #setMaxWidth(String)}, {@link #setMaxHeight(String)},
- * {@link #setMinWidth(String)}, and {@link #setMinHeight(String)}. The
- * sizes are set on the element as inline styles, i.e. using
+ * {@link #setMinWidth(String)}, and {@link #setMinHeight(String)}. The sizes
+ * are set on the element as inline styles, i.e. using
  * {@link Element#getStyle()}.
  *
  * @author Vaadin Ltd

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasStyle.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasStyle.java
@@ -24,7 +24,7 @@ import com.vaadin.flow.dom.Style;
 /**
  * Represents {@link Component} which has class attribute and inline styles.
  * <p>
- * Interface can be used with any root element.
+ * Implementation of {@link #getElement()} may return any type of element.
  *
  * @author Vaadin Ltd
  * @since 1.0

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasStyle.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasStyle.java
@@ -24,7 +24,10 @@ import com.vaadin.flow.dom.Style;
 /**
  * Represents {@link Component} which has class attribute and inline styles.
  * <p>
- * Implementation of {@link #getElement()} may return any type of element.
+ * Implementation of {@link #getElement()} should return HTML element or web
+ * component that supports <a href=
+ * "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style">inline
+ * style attribute</a>.
  *
  * @author Vaadin Ltd
  * @since 1.0

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasStyle.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasStyle.java
@@ -23,6 +23,8 @@ import com.vaadin.flow.dom.Style;
 
 /**
  * Represents {@link Component} which has class attribute and inline styles.
+ * <p>
+ * Interface can be used with any root element.
  *
  * @author Vaadin Ltd
  * @since 1.0

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasText.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasText.java
@@ -22,12 +22,12 @@ import java.util.stream.Stream;
 /**
  * A component that supports text content.
  * <p>
- * {@link HasText} should be implemented by components whose primary function is
- * to have textual content. It shouldn't be implemented for example by layouts
- * since {@link #setText(String)} will remove all existing child components and
- * child elements. To mix text and child components in a component that also
- * supports child components, use {@link HasComponents#add(Component...)} with
- * the {@link Text} component for the textual parts.
+ * {@link HasText} is generally implemented by components whose primary function
+ * is to have textual content. It isn't implemented for example by layouts since
+ * {@link #setText(String)} will remove all existing child components and child
+ * elements. To mix text and child components in a component that also supports
+ * child components, use {@link HasComponents#add(Component...)} with the
+ * {@link Text} component for the textual parts.
  * <p>
  * The default implementations set the text as text content of
  * {@link #getElement()}. Override all methods in this interface if the text

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasText.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasText.java
@@ -22,6 +22,13 @@ import java.util.stream.Stream;
 /**
  * A component that supports text content.
  * <p>
+ * {@link HasText} should be implemented by components whose primary function is
+ * to have textual content. It shouldn't be implemented for example by layouts
+ * since {@link #setText(String)} will remove all existing child components and
+ * child elements. To mix text and child components in a component that also
+ * supports child components, use {@link HasComponents#add(Component...)} with
+ * the {@link Text} component for the textual parts.
+ * <p>
  * The default implementations set the text as text content of
  * {@link #getElement()}. Override all methods in this interface if the text
  * should be added to some other element.

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasTheme.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasTheme.java
@@ -22,6 +22,8 @@ import com.vaadin.flow.dom.ThemeList;
 
 /**
  * Represents {@link Component} which has theme attribute.
+ * <p>
+ * Interface can be used with any root element.
  *
  * @author Vaadin Ltd
  * @since 1.0

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasTheme.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasTheme.java
@@ -23,7 +23,7 @@ import com.vaadin.flow.dom.ThemeList;
 /**
  * Represents {@link Component} which has theme attribute.
  * <p>
- * Interface can be used with any root element.
+ * Implementation of {@link #getElement()} may return any type of element.
  *
  * @author Vaadin Ltd
  * @since 1.0

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasValidation.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasValidation.java
@@ -20,6 +20,9 @@ import java.io.Serializable;
 
 /**
  * A component that supports input validation.
+ * <p>
+ * {@link HasValidation} should be implemented by component when used with
+ * a Binder and input is validated with a Binder.
  *
  * @author Vaadin Ltd
  * @since 1.0.

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasValidation.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasValidation.java
@@ -21,8 +21,8 @@ import java.io.Serializable;
 /**
  * A component that supports input validation.
  * <p>
- * {@link HasValidation} should be implemented by component when used with
- * a Binder and input is validated with a Binder.
+ * {@link HasValidation} should be implemented by component when used with a
+ * Binder and input is validated with a Binder.
  *
  * @author Vaadin Ltd
  * @since 1.0.

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasValidation.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasValidation.java
@@ -21,8 +21,8 @@ import java.io.Serializable;
 /**
  * A component that supports input validation.
  * <p>
- * {@link HasValidation} should be implemented by component when used with a
- * Binder and input is validated with a Binder.
+ * {@link HasValidation} is implemented by component when used with a Binder and
+ * input is validated with a Binder.
  *
  * @author Vaadin Ltd
  * @since 1.0.


### PR DESCRIPTION
Improved documentation of Has* mixin interfaces. Added more details when to use some of the interfaces and when not.

Related-to: #10761
