### PR TITLE
chore: Upgrade webdrivermanager and delete node modules properly

### DIFF
--- a/flow-tests/test-npm-only-features/test-npm-no-buildmojo/pom.xml
+++ b/flow-tests/test-npm-only-features/test-npm-no-buildmojo/pom.xml
@@ -64,10 +64,9 @@
                 <configuration>
                     <filesets>
                         <fileset>
-                            <directory>${project.basedir}/node_modules</directory>
+                            <directory>${project.basedir}</directory>
                             <includes>
-                                <include>@polymer/**/*</include>
-                                <include>@vaadin/**/*</include>
+                                <include>/node_modules/**</include>
                             </includes>
                             <followSymlinks>false</followSymlinks>
                         </fileset>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <maven.clean.plugin.version>3.2.0</maven.clean.plugin.version>
         <maven.exec.plugin.version>1.6.0</maven.exec.plugin.version>
         <testbench.version>7.1.0</testbench.version>
-        <webdrivermanager.version>5.1.1</webdrivermanager.version>
+        <webdrivermanager.version>5.3.3</webdrivermanager.version>
         <jetty.version>9.4.43.v20210629</jetty.version>
         <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>
 


### PR DESCRIPTION
This fixes errors when running `flow-test-npm-no-buildmojo` locally:
- JNA version conflict, with the newer WDM the JNA version is the same as in the license-checker, so no conflicts,
- Removes the whole node_modules directory, otherwise it causes packages compilation errors within running `mvn verify`