### PR TITLE
test: downgrade vaadin-radio-button to 1.6.0

### DIFF
--- a/flow-tests/test-themes/src/main/java/com/vaadin/flow/uitest/ui/theme/MyLitField.java
+++ b/flow-tests/test-themes/src/main/java/com/vaadin/flow/uitest/ui/theme/MyLitField.java
@@ -25,14 +25,14 @@ import com.vaadin.flow.component.dependency.NpmPackage;
  */
 @JsModule("@vaadin/vaadin-radio-button/vaadin-radio-button.js")
 @Tag("vaadin-radio-button")
-@NpmPackage(value = "@vaadin/vaadin-radio-button", version = "2.0.0-alpha1")
+@NpmPackage(value = "@vaadin/vaadin-radio-button", version = "1.6.0")
 public class MyLitField extends Component {
 
     /**
      * Set the component id.
      *
      * @param id
-     *     value to set
+     *            value to set
      * @return this component
      */
     public Component withId(String id) {


### PR DESCRIPTION
Fixes an issue with two versions of polymer library imported twice in the bundle