### PR TITLE
fix: Remove frontend directory from prepare frontend output list

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/PrepareFrontendOutputProperties.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/PrepareFrontendOutputProperties.kt
@@ -75,11 +75,6 @@ public class PrepareFrontendOutputProperties public constructor(project: Project
     }
 
     @OutputDirectory
-    public fun getFrontendDirectory(): File {
-        return extension.frontendDirectory
-    }
-
-    @OutputDirectory
     public fun getGeneratedTsFolder(): File {
         return extension.generatedTsFolder
     }


### PR DESCRIPTION
This removes the frontend folder from watch list of the `VaadinPrepareFrontendTask`, because it overlaps with frontend/generated folder, causing cache problems:
```
Caching disabled for task ':vaadinPrepareFrontend' because:
  Gradle does not know how file 'frontend/styles' was created (output property 'taskOutputProperties.frontendDirectory'). Task output caching requires exclusive access to output paths to guarantee correctness (i.e. multiple tasks are not allowed to produce output in the same location).
```
Files in the frontend folder are project-specific and handled outside of prepare-frontend task.