### PR TITLE
fix: eager load css from CssImport.themeFor

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -176,7 +176,9 @@ abstract class AbstractUpdateImports implements Runnable {
         }
 
         for (Entry<ChunkInfo, List<CssData>> entry : css.entrySet()) {
-            if (isLazyRoute(entry.getKey())) {
+            boolean hasLegacyStyling = entry.getValue().stream()
+                    .anyMatch(cssData -> cssData.getThemefor() != null);
+            if (isLazyRoute(entry.getKey()) && !hasLegacyStyling) {
                 List<String> cssLines = getCssLines(entry.getValue());
                 if (!cssLines.isEmpty()) {
                     lazyCss.put(entry.getKey(), cssLines);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -176,9 +176,9 @@ abstract class AbstractUpdateImports implements Runnable {
         }
 
         for (Entry<ChunkInfo, List<CssData>> entry : css.entrySet()) {
-            boolean hasLegacyStyling = entry.getValue().stream()
+            boolean hasThemeFor = entry.getValue().stream()
                     .anyMatch(cssData -> cssData.getThemefor() != null);
-            if (isLazyRoute(entry.getKey()) && !hasLegacyStyling) {
+            if (isLazyRoute(entry.getKey()) && !hasThemeFor) {
                 List<String> cssLines = getCssLines(entry.getValue());
                 if (!cssLines.isEmpty()) {
                     lazyCss.put(entry.getKey(), cssLines);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
@@ -87,7 +87,7 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
 
     }
 
-    @Route(value = "themeform")
+    @Route(value = "themefor")
     @CssImport(value = "./foo.css", themeFor = "something")
     public static class ThemeForCssImport extends Component {
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
@@ -87,6 +87,12 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
 
     }
 
+    @Route(value = "themeform")
+    @CssImport(value = "./foo.css", themeFor = "something")
+    public static class ThemeForCssImport extends Component {
+
+    }
+
     @Route(value = "simplecss")
     @CssImport("./bar.css")
     public static class BarCssImport extends Component {
@@ -457,6 +463,29 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
         assertOnce("import $cssFromFile_0 from",
                 output.get(flowGeneratedImports));
         assertOnce("import $cssFromFile_1 from",
+                output.get(flowGeneratedImports));
+    }
+
+    @Test
+    public void themeForCssImports_eagerLoaded() throws Exception {
+        Class<?>[] testClasses = { ThemeForCssImport.class, UI.class };
+        ClassFinder classFinder = getClassFinder(testClasses);
+        updater = new UpdateImports(classFinder, getScanner(classFinder),
+                options);
+        updater.run();
+
+        Map<File, List<String>> output = updater.getOutput();
+
+        File flowGeneratedImports = FrontendUtils
+                .getFlowGeneratedImports(frontendDirectory);
+
+        assertOnce("import { injectGlobalCss } from",
+                output.get(flowGeneratedImports));
+        assertOnce("import { css, unsafeCSS, registerStyles } from",
+                output.get(flowGeneratedImports));
+        assertOnce("from 'Frontend/foo.css?inline';",
+                output.get(flowGeneratedImports));
+        assertOnce("import $cssFromFile_0 from",
                 output.get(flowGeneratedImports));
     }
 


### PR DESCRIPTION
## Description

CSS from CssImport.themeFor should be eagerly loaded, otherwise the framework tries to apply them after the web-component is already registered, resulting in an error in the browser.
Although CssImport.themeFor is not recommended with Vaadin 24 it can still be used and in some cases it is required to work around some of the limitations mentioned in vaadin/docs#2552.

This change forces CSS from CssImport.themeFor to be loaded eagerly.

Fixes #17345
Fixes #17221

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
