### PR TITLE
chore: Upgrade Node to 18.17.1 (#17411) (CP: 24.0)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -66,11 +66,11 @@ public class FrontendTools {
      * the installed version is older than {@link #SUPPORTED_NODE_VERSION}, i.e.
      * {@value #SUPPORTED_NODE_MAJOR_VERSION}.{@value #SUPPORTED_NODE_MINOR_VERSION}.
      */
-    public static final String DEFAULT_NODE_VERSION = "v18.14.1";
+    public static final String DEFAULT_NODE_VERSION = "v18.17.1";
     /**
      * This is the version shipped with the default Node version.
      */
-    public static final String DEFAULT_NPM_VERSION = "9.3.1";
+    public static final String DEFAULT_NPM_VERSION = "9.6.7";
 
     public static final String DEFAULT_PNPM_VERSION = "8.6.11";
 


### PR DESCRIPTION
This is a node security release