### PR TITLE
chore: add try/catch to PR creation in cherry pick script

### DIFF
--- a/scripts/cherryPick.js
+++ b/scripts/cherryPick.js
@@ -146,8 +146,15 @@ async function cherryPickCommits(){
       continue;
     }
     await exec(`git push origin HEAD:${branchName}`);
+    try{
+        await createPR(arrTitle[i], branchName, arrBranch[i]);	    
+    } catch (err) {
+        console.error(`Cannot create PR from ${branchName}, error : ${err}`);
+        await labelCommit(arrURL[i], `cannot create PR from ${branchName}`);
+        await postComment(arrURL[i], arrUser[i], arrMergedBy[i], arrBranch[i], err);
+        continue;
+    }
     
-    await createPR(arrTitle[i], branchName, arrBranch[i]);
     await exec(`git checkout main`);
     await exec(`git branch -D ${branchName}`);
     await labelCommit(arrURL[i], `cherry-picked-${arrBranch[i]}`);


### PR DESCRIPTION
we have found issue with branch `cherry-pick-17312-to-24.1-1690808382065`, where there is only a branch but no PR.  this try/catch is trying to prevent that. https://vaadin.slack.com/archives/C6X43FE8M/p1692165275795269?thread_ts=1692109040.675989&cid=C6X43FE8M

