### PR TITLE
refactor: Eagerly render all dev tools tabs

### DIFF
--- a/vaadin-dev-server/frontend/vaadin-dev-tools-info.ts
+++ b/vaadin-dev-server/frontend/vaadin-dev-tools-info.ts
@@ -1,0 +1,109 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { copy } from './copy-to-clipboard.js';
+
+import { LitElement, html } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { ConnectionStatus } from './connection';
+
+import { MessageType, VaadinDevTools } from './vaadin-dev-tools.js';
+
+interface ServerInfo {
+  vaadinVersion: string;
+  flowVersion: string;
+  javaVersion: string;
+  osVersion: string;
+  productName: string;
+}
+
+@customElement('vaadin-dev-tools-info')
+export class InfoTab extends LitElement {
+  @property({ type: Object })
+  private _devTools!: VaadinDevTools;
+
+  @state()
+  private serverInfo: ServerInfo = {
+    flowVersion: '',
+    vaadinVersion: '',
+    javaVersion: '',
+    osVersion: '',
+    productName: ''
+  };
+
+  protected createRenderRoot(): Element | ShadowRoot {
+    return this;
+  }
+
+  render() {
+    return html` <div class="info-tray">
+      <button class="button copy" @click=${this.copyInfoToClipboard}>Copy</button>
+      <dl>
+        <dt>${this.serverInfo.productName}</dt>
+        <dd>${this.serverInfo.vaadinVersion}</dd>
+        <dt>Flow</dt>
+        <dd>${this.serverInfo.flowVersion}</dd>
+        <dt>Java</dt>
+        <dd>${this.serverInfo.javaVersion}</dd>
+        <dt>OS</dt>
+        <dd>${this.serverInfo.osVersion}</dd>
+        <dt>Browser</dt>
+        <dd>${navigator.userAgent}</dd>
+        <dt>
+          Live reload
+          <label class="switch">
+            <input
+              id="toggle"
+              type="checkbox"
+              ?disabled=${this._devTools.liveReloadDisabled ||
+              ((this._devTools.frontendStatus === ConnectionStatus.UNAVAILABLE ||
+                this._devTools.frontendStatus === ConnectionStatus.ERROR) &&
+                (this._devTools.javaStatus === ConnectionStatus.UNAVAILABLE ||
+                  this._devTools.javaStatus === ConnectionStatus.ERROR))}
+              ?checked="${this._devTools.frontendStatus === ConnectionStatus.ACTIVE ||
+              this._devTools.javaStatus === ConnectionStatus.ACTIVE}"
+              @change=${(e: InputEvent) => this._devTools.setActive((e.target as HTMLInputElement).checked)}
+            />
+            <span class="slider"></span>
+          </label>
+        </dt>
+        <dd
+          class="live-reload-status"
+          style="--status-color: ${this._devTools.getStatusColor(this._devTools.javaStatus)}"
+        >
+          Java ${this._devTools.javaStatus}
+          ${this._devTools.backend ? `(${VaadinDevTools.BACKEND_DISPLAY_NAME[this._devTools.backend]})` : ''}
+        </dd>
+        <dd
+          class="live-reload-status"
+          style="--status-color: ${this._devTools.getStatusColor(this._devTools.frontendStatus)}"
+        >
+          Front end ${this._devTools.frontendStatus}
+        </dd>
+      </dl>
+    </div>`;
+  }
+
+  handleMessage(message: any) {
+    if (message?.command === 'serverInfo') {
+      this.serverInfo = message.data as ServerInfo;
+      return true;
+    }
+    return false;
+  }
+
+  copyInfoToClipboard() {
+    const items = this.renderRoot.querySelectorAll('.info-tray dt, .info-tray dd');
+    const text = Array.from(items)
+      .map((message) => (message.localName === 'dd' ? ': ' : '\n') + message.textContent!.trim())
+      .join('')
+      .replace(/^\n/, '');
+    copy(text);
+    this._devTools.showNotification(
+      MessageType.INFORMATION,
+      'Environment information copied to clipboard',
+      undefined,
+      undefined,
+      'versionInfoCopied'
+    );
+  }
+}

--- a/vaadin-dev-server/frontend/vaadin-dev-tools-log.ts
+++ b/vaadin-dev-server/frontend/vaadin-dev-tools-log.ts
@@ -1,0 +1,28 @@
+import { LitElement, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { VaadinDevTools } from './vaadin-dev-tools.js';
+
+@customElement('vaadin-dev-tools-log')
+export class VaadinDevToolsLog extends LitElement {
+  @property({ type: Object })
+  _devTools!: VaadinDevTools;
+
+  protected createRenderRoot(): Element | ShadowRoot {
+    return this;
+  }
+
+  activate() {
+    this._devTools.unreadErrors = false;
+    this.updateComplete.then(() => {
+      const lastMessage = this.renderRoot.querySelector('.message-tray .message:last-child');
+      if (lastMessage) {
+        lastMessage.scrollIntoView();
+      }
+    });
+  }
+  render() {
+    return html`<div class="message-tray">
+      ${this._devTools.messages.map((msg) => this._devTools.renderMessage(msg))}
+    </div>`;
+  }
+}

--- a/vaadin-dev-server/tsconfig.json
+++ b/vaadin-dev-server/tsconfig.json
@@ -23,6 +23,6 @@
     "declarationDir": "src/main/resources/META-INF/frontend/vaadin-dev-tools",
     "emitDeclarationOnly": true
   },
-  "include": ["frontend/vaadin-dev-tools.ts"],
+  "include": ["frontend/vaadin-dev-tools*.ts"],
   "exclude": []
 }


### PR DESCRIPTION
Render using function (for backwards compatibility) or tag (for future plugins). 
Always render all tabs so they can handle communication in the future

The log and info tabs are split out in this commit
