### PR TITLE
fix: Serve correct bootstrap

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
@@ -18,6 +18,8 @@ package com.vaadin.flow.server.communication;
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 
@@ -35,6 +37,7 @@ import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.BootstrapHandlerHelper;
 import com.vaadin.flow.internal.BrowserLiveReload;
 import com.vaadin.flow.internal.BrowserLiveReloadAccessor;
+import com.vaadin.flow.internal.JsonUtils;
 import com.vaadin.flow.internal.LocaleUtil;
 import com.vaadin.flow.internal.UsageStatisticsExporter;
 import com.vaadin.flow.internal.springcsrf.SpringCsrfTokenUtil;
@@ -54,6 +57,7 @@ import com.vaadin.flow.server.frontend.ThemeUtils;
 import com.vaadin.flow.server.startup.ApplicationConfiguration;
 
 import elemental.json.Json;
+import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 import elemental.json.impl.JsonUtil;
 
@@ -436,10 +440,25 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
             // When running without a frontend server, the index.html comes
             // directly from the frontend folder and the JS entrypoint(s) need
             // to be added
-            addGeneratedIndexContent(config, indexHtmlDocument);
+            addGeneratedIndexContent(indexHtmlDocument, getStatsJson(config));
         }
         modifyIndexHtmlForVite(indexHtmlDocument);
         return indexHtmlDocument;
+    }
+
+    protected static void addGeneratedIndexContent(Document targetDocument,
+            JsonObject statsJson) {
+
+        JsonArray indexHtmlGeneratedRows = statsJson
+                .getArray("indexHtmlGenerated");
+        List<String> toAdd = new ArrayList<>();
+
+        toAdd.addAll(JsonUtils.stream(indexHtmlGeneratedRows)
+                .map(value -> value.asString()).toList());
+
+        for (String row : toAdd) {
+            targetDocument.head().append(row);
+        }
     }
 
     private static void modifyIndexHtmlForVite(Document indexHtmlDocument) {

--- a/flow-tests/test-express-build/test-embedding-express-build/src/main/java/com/vaadin/flow/webcomponent/MyView.java
+++ b/flow-tests/test-express-build/test-embedding-express-build/src/main/java/com/vaadin/flow/webcomponent/MyView.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.webcomponent;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.Route;
+
+@Route("com.vaadin.flow.webcomponent.MyView")
+public class MyView extends Div {
+
+    static final String APP_TEXT_ID = "app_text";
+
+    public MyView() {
+        final Span textSpan = new Span("This is the application view");
+        textSpan.setId(APP_TEXT_ID);
+        add(textSpan);
+    }
+
+}

--- a/flow-tests/test-express-build/test-embedding-express-build/src/test/java/com/vaadin/flow/webcomponent/MyViewIT.java
+++ b/flow-tests/test-express-build/test-embedding-express-build/src/test/java/com/vaadin/flow/webcomponent/MyViewIT.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.webcomponent;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.html.testbench.SpanElement;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+import static com.vaadin.flow.webcomponent.MyView.APP_TEXT_ID;
+
+public class MyViewIT extends ChromeBrowserTest {
+
+    @Override
+    protected String getTestPath() {
+        return "/com.vaadin.flow.webcomponent.MyView";
+    }
+
+    @Test
+    public void applicationOpens_withEmbeddedComponents() {
+        open();
+
+        $(SpanElement.class).waitForFirst();
+        SpanElement spanWithText = $(SpanElement.class).id(APP_TEXT_ID);
+
+        Assert.assertTrue(
+                spanWithText.getText().equals("This is the application view"));
+
+        checkLogsForErrors();
+    }
+
+}


### PR DESCRIPTION
When having a project with
application and WebComponents
the served bootstrap should be
served by the correct bootstrap
handler and not by what is available.

Fixes #17346
