### PR TITLE
Component picker opacity changes when mouse hover on info

### DIFF
--- a/vaadin-dev-server/frontend/component-picker.ts
+++ b/vaadin-dev-server/frontend/component-picker.ts
@@ -52,6 +52,10 @@ export class ComponentPicker extends LitElement {
       }
     `
   ];
+  constructor() {
+    super();
+    this.mouseMoveEvent = this.mouseMoveEvent.bind(this);
+  }
 
   connectedCallback() {
     super.connectedCallback();
@@ -64,10 +68,15 @@ export class ComponentPicker extends LitElement {
       background: rgba(158,44,198,0.25);
     }`);
     document.adoptedStyleSheets = [...document.adoptedStyleSheets, globalStyles];
-
     this.overlayElement = document.createElement('div');
     this.overlayElement.classList.add('vaadin-dev-tools-highlight-overlay');
+    this.addEventListener('mousemove', this.mouseMoveEvent);
   }
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.removeEventListener('mousemove', this.mouseMoveEvent);
+  }
+
   render() {
     if (!this.active) {
       this.style.display = 'none';
@@ -120,6 +129,27 @@ export class ComponentPicker extends LitElement {
         requestAnimationFrame(() => this.shim.focus());
       } else if (wasActive && !isActive) {
         this.highlight(undefined);
+      }
+    }
+  }
+
+  mouseMoveEvent(e: MouseEvent) {
+    if (!this.active) {
+      this.style.display = 'none';
+      return;
+    }
+    const pickerInfo = this.shadowRoot?.querySelector('.component-picker-info');
+    if (pickerInfo) {
+      const pickerRect = pickerInfo.getBoundingClientRect();
+      if (
+        e.x > pickerRect.x &&
+        e.x < pickerRect.x + pickerRect.width &&
+        e.y > pickerRect.y &&
+        e.y <= pickerRect.y + pickerRect.height
+      ) {
+        (pickerInfo as HTMLElement).style.opacity = '0.1';
+      } else {
+        (pickerInfo as HTMLElement).style.opacity = '1.0';
       }
     }
   }


### PR DESCRIPTION
Component picker info hides the elements behind it and makes it hard to pick them. The mouse hover selector does not work because of `pointer-events:none` property. As a solution, I added a mouse move event listener to detect if pointer hovers the info div. 


## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [X] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
