### PR TITLE
test: Add more measurements in reload time tests

### DIFF
--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/README.MD
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/README.MD
@@ -33,3 +33,10 @@ Default is 0.
 in `frontend/generated-js` folder. Javascript in the file defines a simple
 web-component with
 Lit. Web component is added to the DOM of the route. Default is 0.
+
+### Other properties for the integration test
+
+`route.hierarchy.enabled`: When 'true', adds a route with hierarchical
+structure.
+Route is mapped like '
+catalog/product/0' (or with alias 'catalog/prod/0'). 'false' by default.

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/README.MD
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/README.MD
@@ -16,7 +16,20 @@ How to run tests locally:
 mvn verify -pl :test-spring-boot-multimodule-reload-time-ui -Pbenchmark -Dvaadin.test.codegen.maven.plugin.routes=1000
 ```
 
-Properties for code generator:
+### Properties for code generator
 
 `vaadin.test.codegen.maven.plugin.routes`: number of generated routes. Default is 500.
+
 `vaadin.test.codegen.maven.plugin.services.per.route`: number of generated Spring components per route. Default is 1.
+
+`vaadin.test.codegen.maven.plugin.cssimports.per.route`: number of generated
+@CssImport + .css combos per route. CSS files are generated
+in `frontend/generated-css` folder. CSS file has a rule that is used by the
+route.
+Default is 0.
+
+`vaadin.test.codegen.maven.plugin.jsmodules.per.route`: number of generated
+@JsModule + .js combos per route. JS files are generated
+in `frontend/generated-js` folder. Javascript in the file defines a simple
+web-component with
+Lit. Web component is added to the DOM of the route. Default is 0.

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/java/com/vaadin/flow/spring/test/CodeGeneratorMojo.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/java/com/vaadin/flow/spring/test/CodeGeneratorMojo.java
@@ -184,7 +184,7 @@ public class CodeGeneratorMojo extends AbstractMojo {
             throws IOException {
         JavaSpringServiceContext context = new JavaSpringServiceContext();
         context.setPackages(apiPackage);
-        context.setClassName("Service" + owner.getClassName() + index);
+        context.setClassName("Service" + owner.getClassName() + "_" + index);
         context.setScope(scope);
         context.setVariableName("serviceVariable" + index);
 

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/java/com/vaadin/flow/spring/test/CodeGeneratorMojo.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/java/com/vaadin/flow/spring/test/CodeGeneratorMojo.java
@@ -107,8 +107,9 @@ public class CodeGeneratorMojo extends AbstractMojo {
         // start by deleting existing package
         FileUtils.deleteDirectory(new File(
                 output.toString() + "/" + apiPackage.replace(".", "/")));
-        // ... and generated frontend css
+        // ... and generated frontend css and js
         FileUtils.deleteDirectory(new File(project.getBasedir().toString() + "/frontend/generated-css"));
+        FileUtils.deleteDirectory(new File(project.getBasedir().toString() + "/frontend/generated-js"));
 
         int servicesGeneratedTotal = 0;
         int cssImportsGeneratedTotal = 0;

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/java/com/vaadin/flow/spring/test/CodeGeneratorMojo.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/java/com/vaadin/flow/spring/test/CodeGeneratorMojo.java
@@ -123,6 +123,10 @@ public class CodeGeneratorMojo extends AbstractMojo {
         getLog().info(String.format(
                 "Generated %s route(s) / %s Spring service(s) / %s CssImport(s) / %s JsModule(s) in total.",
                 numberOfRoutes, servicesGeneratedTotal, cssImportsGeneratedTotal, jsModulesGeneratedTotal));
+        if(numberOfRoutes > 0 && (cssImportsGeneratedTotal > 0 || jsModulesGeneratedTotal > 0)) {
+            getLog().info("Frontend files generated in "
+                    + project.getBasedir().toString() + "/frontend");
+        }
     }
 
     private List<JavaSpringServiceContext> generateServices(

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/java/com/vaadin/flow/spring/test/CodeGeneratorMojo.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/java/com/vaadin/flow/spring/test/CodeGeneratorMojo.java
@@ -108,8 +108,10 @@ public class CodeGeneratorMojo extends AbstractMojo {
         FileUtils.deleteDirectory(new File(
                 output.toString() + "/" + apiPackage.replace(".", "/")));
         // ... and generated frontend css and js
-        FileUtils.deleteDirectory(new File(project.getBasedir().toString() + "/frontend/generated-css"));
-        FileUtils.deleteDirectory(new File(project.getBasedir().toString() + "/frontend/generated-js"));
+        FileUtils.deleteDirectory(new File(
+                project.getBasedir().toString() + "/frontend/generated-css"));
+        FileUtils.deleteDirectory(new File(
+                project.getBasedir().toString() + "/frontend/generated-js"));
 
         int servicesGeneratedTotal = 0;
         int cssImportsGeneratedTotal = 0;
@@ -122,8 +124,10 @@ public class CodeGeneratorMojo extends AbstractMojo {
         }
         getLog().info(String.format(
                 "Generated %s route(s) / %s Spring service(s) / %s CssImport(s) / %s JsModule(s) in total.",
-                numberOfRoutes, servicesGeneratedTotal, cssImportsGeneratedTotal, jsModulesGeneratedTotal));
-        if(numberOfRoutes > 0 && (cssImportsGeneratedTotal > 0 || jsModulesGeneratedTotal > 0)) {
+                numberOfRoutes, servicesGeneratedTotal,
+                cssImportsGeneratedTotal, jsModulesGeneratedTotal));
+        if (numberOfRoutes > 0 && (cssImportsGeneratedTotal > 0
+                || jsModulesGeneratedTotal > 0)) {
             getLog().info("Frontend files generated in "
                     + project.getBasedir().toString() + "/frontend");
         }
@@ -138,8 +142,8 @@ public class CodeGeneratorMojo extends AbstractMojo {
         return result;
     }
 
-    private List<CssImportContext> generateCssImports(
-            JavaClassContext owner, int numberOfCssImports) throws IOException {
+    private List<CssImportContext> generateCssImports(JavaClassContext owner,
+            int numberOfCssImports) throws IOException {
         var result = new ArrayList<CssImportContext>();
         for (int index = 0; index < numberOfCssImports; index++) {
             result.add(generateCssImport(owner, index));
@@ -147,8 +151,8 @@ public class CodeGeneratorMojo extends AbstractMojo {
         return result;
     }
 
-    private List<JsModuleContext> generateJsModules(
-            JavaClassContext owner, int numberOfJsModules) throws IOException {
+    private List<JsModuleContext> generateJsModules(JavaClassContext owner,
+            int numberOfJsModules) throws IOException {
         var result = new ArrayList<JsModuleContext>();
         for (int index = 0; index < numberOfJsModules; index++) {
             result.add(generateJsModule(owner, index));
@@ -168,10 +172,12 @@ public class CodeGeneratorMojo extends AbstractMojo {
                 numberOfGeneratedServicesPerRoute);
         context.setServices(services);
 
-        var cssImports = generateCssImports(context, numberOfGeneratedCssImportsPerRoute);
+        var cssImports = generateCssImports(context,
+                numberOfGeneratedCssImportsPerRoute);
         context.setCssImports(cssImports);
 
-        var jsModules = generateJsModules(context, numberOfGeneratedJsModulesPerRoute);
+        var jsModules = generateJsModules(context,
+                numberOfGeneratedJsModulesPerRoute);
         context.setJsModules(jsModules);
 
         generateJavaFileByMustacheTemplate(context, ROUTE_JAVA_TEMPLATE);
@@ -192,28 +198,33 @@ public class CodeGeneratorMojo extends AbstractMojo {
         return context;
     }
 
-    private CssImportContext generateCssImport(
-            JavaClassContext owner, int index)
-            throws IOException {
+    private CssImportContext generateCssImport(JavaClassContext owner,
+            int index) throws IOException {
         CssImportContext context = new CssImportContext();
-        context.setTargetStyleName("css-import-" + owner.getClassName().toLowerCase(Locale.ROOT) + "-" + index);
-        context.setValue("./generated-css/" + context.getTargetStyleName() + ".css");
+        context.setTargetStyleName("css-import-"
+                + owner.getClassName().toLowerCase(Locale.ROOT) + "-" + index);
+        context.setValue(
+                "./generated-css/" + context.getTargetStyleName() + ".css");
 
-        generateFrontendFileByMustacheTemplate(context, CSS_IMPORT_TEMPLATE, getFrontendPath(context.getValue()));
+        generateFrontendFileByMustacheTemplate(context, CSS_IMPORT_TEMPLATE,
+                getFrontendPath(context.getValue()));
         return context;
     }
 
-    private JsModuleContext generateJsModule(
-            JavaClassContext owner, int index)
+    private JsModuleContext generateJsModule(JavaClassContext owner, int index)
             throws IOException {
         JsModuleContext context = new JsModuleContext();
-        context.setTag("js-module-" + owner.getClassName().toLowerCase(Locale.ROOT) + "-" + index);
+        context.setTag("js-module-"
+                + owner.getClassName().toLowerCase(Locale.ROOT) + "-" + index);
         context.setValue("./generated-js/" + context.getTag() + ".js");
-        context.setName(Stream.of(context.getTag().split("-"))
-                .map(str -> str.substring(0, 1).toUpperCase(Locale.ROOT) + str.substring(1))
-                .collect(Collectors.joining()));
+        context.setName(
+                Stream.of(context.getTag().split("-"))
+                        .map(str -> str.substring(0, 1).toUpperCase(Locale.ROOT)
+                                + str.substring(1))
+                        .collect(Collectors.joining()));
 
-        generateFrontendFileByMustacheTemplate(context, JS_MODULE_TEMPLATE, getFrontendPath(context.getValue()));
+        generateFrontendFileByMustacheTemplate(context, JS_MODULE_TEMPLATE,
+                getFrontendPath(context.getValue()));
         return context;
     }
 
@@ -229,13 +240,16 @@ public class CodeGeneratorMojo extends AbstractMojo {
         return value.startsWith("./") ? value.substring(2) : value;
     }
 
-    private void generateFrontendFileByMustacheTemplate(Object context, String templateFileName, String frontEndFilePath) throws IOException {
-        File newFile = new File(
-                project.getBasedir().toString() + "/frontend/" + frontEndFilePath);
+    private void generateFrontendFileByMustacheTemplate(Object context,
+            String templateFileName, String frontEndFilePath)
+            throws IOException {
+        File newFile = new File(project.getBasedir().toString() + "/frontend/"
+                + frontEndFilePath);
         generateFileByMustacheTemplate(context, templateFileName, newFile);
     }
 
-    private void generateFileByMustacheTemplate(Object context, String templateFileName, File newFile) throws IOException {
+    private void generateFileByMustacheTemplate(Object context,
+            String templateFileName, File newFile) throws IOException {
         newFile.getParentFile().mkdirs();
         try (FileWriter writer = new FileWriter(newFile,
                 StandardCharsets.UTF_8)) {

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/java/com/vaadin/flow/spring/test/CodeGeneratorMojo.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/java/com/vaadin/flow/spring/test/CodeGeneratorMojo.java
@@ -19,11 +19,12 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.IntStream;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.samskivert.mustache.Mustache;
 import org.apache.commons.io.FileUtils;
@@ -40,6 +41,8 @@ public class CodeGeneratorMojo extends AbstractMojo {
 
     public static final String ROUTE_JAVA_TEMPLATE = "route-java.mustache";
     public static final String SERVICE_JAVA_TEMPLATE = "service-java.mustache";
+    public static final String CSS_IMPORT_TEMPLATE = "css-import.mustache";
+    public static final String JS_MODULE_TEMPLATE = "js-module.mustache";
 
     /**
      * Output directory.
@@ -58,6 +61,12 @@ public class CodeGeneratorMojo extends AbstractMojo {
 
     @Parameter(name = "numberOfGeneratedServicesPerRoute", property = "vaadin.test.codegen.maven.plugin.services.per.route", defaultValue = "1")
     private int numberOfGeneratedServicesPerRoute;
+
+    @Parameter(name = "numberOfGeneratedCssImportsPerRoute", property = "vaadin.test.codegen.maven.plugin.cssimports.per.route", defaultValue = "0")
+    private int numberOfGeneratedCssImportsPerRoute;
+
+    @Parameter(name = "numberOfGeneratedJsModulesPerRoute", property = "vaadin.test.codegen.maven.plugin.jsmodules.per.route", defaultValue = "0")
+    private int numberOfGeneratedJsModulesPerRoute;
 
     /**
      * Skip the execution.
@@ -98,15 +107,21 @@ public class CodeGeneratorMojo extends AbstractMojo {
         // start by deleting existing package
         FileUtils.deleteDirectory(new File(
                 output.toString() + "/" + apiPackage.replace(".", "/")));
+        // ... and generated frontend css
+        FileUtils.deleteDirectory(new File(project.getBasedir().toString() + "/frontend/generated-css"));
 
         int servicesGeneratedTotal = 0;
+        int cssImportsGeneratedTotal = 0;
+        int jsModulesGeneratedTotal = 0;
         for (int index = 0; index < numberOfRoutes; index++) {
-            servicesGeneratedTotal += generateRoute(routePrefix, index)
-                    .getServices().size();
+            var context = generateRoute(routePrefix, index);
+            servicesGeneratedTotal += context.getServices().size();
+            cssImportsGeneratedTotal += context.getCssImports().size();
+            jsModulesGeneratedTotal += context.getJsModules().size();
         }
         getLog().info(String.format(
-                "Generated %s route(s) with %s Spring service(s) in total.",
-                numberOfRoutes, servicesGeneratedTotal));
+                "Generated %s route(s) / %s Spring service(s) / %s CssImport(s) / %s JsModule(s) in total.",
+                numberOfRoutes, servicesGeneratedTotal, cssImportsGeneratedTotal, jsModulesGeneratedTotal));
     }
 
     private List<JavaSpringServiceContext> generateServices(
@@ -114,6 +129,24 @@ public class CodeGeneratorMojo extends AbstractMojo {
         var result = new ArrayList<JavaSpringServiceContext>();
         for (int index = 0; index < numberOfServices; index++) {
             result.add(generateSpringComponent(owner, "singleton", index));
+        }
+        return result;
+    }
+
+    private List<CssImportContext> generateCssImports(
+            JavaClassContext owner, int numberOfCssImports) throws IOException {
+        var result = new ArrayList<CssImportContext>();
+        for (int index = 0; index < numberOfCssImports; index++) {
+            result.add(generateCssImport(owner, index));
+        }
+        return result;
+    }
+
+    private List<JsModuleContext> generateJsModules(
+            JavaClassContext owner, int numberOfJsModules) throws IOException {
+        var result = new ArrayList<JsModuleContext>();
+        for (int index = 0; index < numberOfJsModules; index++) {
+            result.add(generateJsModule(owner, index));
         }
         return result;
     }
@@ -129,6 +162,12 @@ public class CodeGeneratorMojo extends AbstractMojo {
         var services = generateServices(context,
                 numberOfGeneratedServicesPerRoute);
         context.setServices(services);
+
+        var cssImports = generateCssImports(context, numberOfGeneratedCssImportsPerRoute);
+        context.setCssImports(cssImports);
+
+        var jsModules = generateJsModules(context, numberOfGeneratedJsModulesPerRoute);
+        context.setJsModules(jsModules);
 
         generateJavaFileByMustacheTemplate(context, ROUTE_JAVA_TEMPLATE);
 
@@ -148,11 +187,50 @@ public class CodeGeneratorMojo extends AbstractMojo {
         return context;
     }
 
+    private CssImportContext generateCssImport(
+            JavaClassContext owner, int index)
+            throws IOException {
+        CssImportContext context = new CssImportContext();
+        context.setTargetStyleName("css-import-" + owner.getClassName().toLowerCase(Locale.ROOT) + "-" + index);
+        context.setValue("./generated-css/" + context.getTargetStyleName() + ".css");
+
+        generateFrontendFileByMustacheTemplate(context, CSS_IMPORT_TEMPLATE, getFrontendPath(context.getValue()));
+        return context;
+    }
+
+    private JsModuleContext generateJsModule(
+            JavaClassContext owner, int index)
+            throws IOException {
+        JsModuleContext context = new JsModuleContext();
+        context.setTag("js-module-" + owner.getClassName().toLowerCase(Locale.ROOT) + "-" + index);
+        context.setValue("./generated-js/" + context.getTag() + ".js");
+        context.setName(Stream.of(context.getTag().split("-"))
+                .map(str -> str.substring(0, 1).toUpperCase(Locale.ROOT) + str.substring(1))
+                .collect(Collectors.joining()));
+
+        generateFrontendFileByMustacheTemplate(context, JS_MODULE_TEMPLATE, getFrontendPath(context.getValue()));
+        return context;
+    }
+
     private void generateJavaFileByMustacheTemplate(JavaClassContext context,
             String templateFileName) throws IOException {
         File newFile = new File(
                 output.toString() + "/" + apiPackage.replace(".", "/") + "/"
                         + context.getClassName() + ".java");
+        generateFileByMustacheTemplate(context, templateFileName, newFile);
+    }
+
+    private static String getFrontendPath(String value) {
+        return value.startsWith("./") ? value.substring(2) : value;
+    }
+
+    private void generateFrontendFileByMustacheTemplate(Object context, String templateFileName, String frontEndFilePath) throws IOException {
+        File newFile = new File(
+                project.getBasedir().toString() + "/frontend/" + frontEndFilePath);
+        generateFileByMustacheTemplate(context, templateFileName, newFile);
+    }
+
+    private void generateFileByMustacheTemplate(Object context, String templateFileName, File newFile) throws IOException {
         newFile.getParentFile().mkdirs();
         try (FileWriter writer = new FileWriter(newFile,
                 StandardCharsets.UTF_8)) {

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/java/com/vaadin/flow/spring/test/CssImportContext.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/java/com/vaadin/flow/spring/test/CssImportContext.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package com.vaadin.flow.spring.test;
+
+public class CssImportContext {
+
+    private String targetStyleName;
+
+    private String value;
+
+    public String getTargetStyleName() {
+        return targetStyleName;
+    }
+
+    public void setTargetStyleName(String targetStyleName) {
+        this.targetStyleName = targetStyleName;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/java/com/vaadin/flow/spring/test/CssImportContext.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/java/com/vaadin/flow/spring/test/CssImportContext.java
@@ -1,11 +1,18 @@
 /*
  * Copyright 2000-2023 Vaadin Ltd.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
-
 package com.vaadin.flow.spring.test;
 
 public class CssImportContext {

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/java/com/vaadin/flow/spring/test/JavaRouteContext.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/java/com/vaadin/flow/spring/test/JavaRouteContext.java
@@ -21,17 +21,37 @@ import java.util.List;
 
 public class JavaRouteContext extends JavaClassContext {
     String route;
+
+    String styleName;
+
     List<JavaSpringServiceContext> services = Collections.emptyList();
+
+    List<CssImportContext> cssImports = Collections.emptyList();
+
+    List<JsModuleContext> jsModules = Collections.emptyList();
 
     public List<JavaSpringServiceContext> getServices() {
         return services;
     }
 
     public void setServices(List<JavaSpringServiceContext> services) {
-        this.services = services;
-        if (this.services == null) {
-            this.services = Collections.emptyList();
-        }
+        this.services = services != null ? services : Collections.emptyList();
+    }
+
+    public List<JsModuleContext> getJsModules() {
+        return jsModules;
+    }
+
+    public void setJsModules(List<JsModuleContext> jsModules) {
+        this.jsModules = jsModules != null ? jsModules : Collections.emptyList();;
+    }
+
+    public String getStyleName() {
+        return styleName;
+    }
+
+    public void setStyleName(String styleName) {
+        this.styleName = styleName;
     }
 
     public String getRoute() {
@@ -40,5 +60,13 @@ public class JavaRouteContext extends JavaClassContext {
 
     public void setRoute(String route) {
         this.route = route;
+    }
+
+    public List<CssImportContext> getCssImports() {
+        return cssImports;
+    }
+
+    public void setCssImports(List<CssImportContext> cssImports) {
+        this.cssImports = cssImports != null ? cssImports : Collections.emptyList();
     }
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/java/com/vaadin/flow/spring/test/JavaRouteContext.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/java/com/vaadin/flow/spring/test/JavaRouteContext.java
@@ -43,7 +43,9 @@ public class JavaRouteContext extends JavaClassContext {
     }
 
     public void setJsModules(List<JsModuleContext> jsModules) {
-        this.jsModules = jsModules != null ? jsModules : Collections.emptyList();;
+        this.jsModules = jsModules != null ? jsModules
+                : Collections.emptyList();
+        ;
     }
 
     public String getStyleName() {
@@ -67,6 +69,7 @@ public class JavaRouteContext extends JavaClassContext {
     }
 
     public void setCssImports(List<CssImportContext> cssImports) {
-        this.cssImports = cssImports != null ? cssImports : Collections.emptyList();
+        this.cssImports = cssImports != null ? cssImports
+                : Collections.emptyList();
     }
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/java/com/vaadin/flow/spring/test/JsModuleContext.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/java/com/vaadin/flow/spring/test/JsModuleContext.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package com.vaadin.flow.spring.test;
+
+public class JsModuleContext {
+
+    private String value;
+
+    private String tag;
+
+    private String name;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public String getTag() {
+        return tag;
+    }
+
+    public void setTag(String tag) {
+        this.tag = tag;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/java/com/vaadin/flow/spring/test/JsModuleContext.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/java/com/vaadin/flow/spring/test/JsModuleContext.java
@@ -1,11 +1,18 @@
 /*
  * Copyright 2000-2023 Vaadin Ltd.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
-
 package com.vaadin.flow.spring.test;
 
 public class JsModuleContext {

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/resources/css-import.mustache
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/resources/css-import.mustache
@@ -1,0 +1,4 @@
+.{{targetStyleName}} {
+    height: 100%;
+    background-color: lightgreen;
+}

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/resources/js-module.mustache
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/resources/js-module.mustache
@@ -1,0 +1,9 @@
+import { LitElement, html } from 'lit';
+
+export class {{name}} extends LitElement {
+  render() {
+    return html`<span>This is the {{tag}} web-component from frontend/generated-js</span>`;
+  }
+}
+
+customElements.define('{{tag}}', {{name}});

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/resources/route-java.mustache
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/resources/route-java.mustache
@@ -15,15 +15,38 @@
  */
 package {{packages}};
 
+import com.vaadin.flow.component.dependency.CssImport;
+import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.router.Route;
 import org.springframework.beans.factory.annotation.Autowired;
 
+{{#jsModules}}
+@JsModule("{{value}}")
+{{/jsModules}}
+{{#cssImports}}
+@CssImport("{{value}}")
+{{/cssImports}}
 @Route("{{route}}")
 public class {{className}} extends Div {
 
     {{#services}}
-        @Autowired
-        private {{packages}}.{{className}} {{variableName}};
+    @Autowired
+    private {{packages}}.{{className}} {{variableName}};
     {{/services}}
+
+    public {{className}}() {
+        {{#styleName}}
+        addClassName("{{styleName}}");
+        {{/styleName}}
+
+        {{#cssImports}}
+        addClassName("{{targetStyleName}}");
+        {{/cssImports}}
+
+        {{#jsModules}}
+        getElement().appendChild(new Element("{{tag}}"));
+        {{/jsModules}}
+    }
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/pom.xml
@@ -13,6 +13,7 @@
     <packaging>jar</packaging>
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <route.hierarchy.enabled>false</route.hierarchy.enabled>
     </properties>
 
     <dependencies>
@@ -94,6 +95,9 @@
                     <wait>500</wait>
                     <maxAttempts>240</maxAttempts>
                     <jmxPort>9009</jmxPort>
+                    <systemPropertyVariables>
+                        <route.hierarchy.enabled>${route.hierarchy.enabled}</route.hierarchy.enabled>
+                    </systemPropertyVariables>
                 </configuration>
                 <executions>
                     <execution>

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/main/java/com/vaadin/flow/spring/test/ApplicationServiceInitListener.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/main/java/com/vaadin/flow/spring/test/ApplicationServiceInitListener.java
@@ -1,11 +1,18 @@
 /*
  * Copyright 2000-2023 Vaadin Ltd.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
-
 package com.vaadin.flow.spring.test;
 
 import org.springframework.stereotype.Component;

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/main/java/com/vaadin/flow/spring/test/ApplicationServiceInitListener.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/main/java/com/vaadin/flow/spring/test/ApplicationServiceInitListener.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package com.vaadin.flow.spring.test;
+
+import org.springframework.stereotype.Component;
+
+import com.vaadin.flow.router.RouteConfiguration;
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinServiceInitListener;
+import com.vaadin.flow.spring.test.store.ProductView;
+
+@Component
+public class ApplicationServiceInitListener
+        implements VaadinServiceInitListener {
+
+    @Override
+    public void serviceInit(ServiceInitEvent event) {
+
+        if ("true".equalsIgnoreCase(
+                System.getProperty("route.hierarchy.enabled", "false"))) {
+            System.out.println(
+                    "Route hierarchy is enabled. Registering additional route with hierarchical structure like 'catalog/product/0'.");
+            RouteConfiguration.forApplicationScope()
+                    .setAnnotatedRoute(ProductView.class);
+        }
+    }
+}

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/main/java/com/vaadin/flow/spring/test/SpringDevToolsReloadUtils.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/main/java/com/vaadin/flow/spring/test/SpringDevToolsReloadUtils.java
@@ -15,6 +15,13 @@
  */
 package com.vaadin.flow.spring.test;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.NativeButton;
 
@@ -29,5 +36,23 @@ public class SpringDevToolsReloadUtils {
                 });
         startTriggerButton.setId("start-button");
         return startTriggerButton;
+    }
+
+    public static String runAndCalculateAverageResult(
+            int numberOfTimesToRunTest, Supplier<String> test) {
+        var allResults = new ArrayList<BigDecimal>();
+        IntStream.range(0, numberOfTimesToRunTest).forEach(index -> allResults
+                .add(BigDecimal.valueOf(Double.parseDouble(test.get()))));
+        System.out.printf("Test run %s times. All results: [%s]%n",
+                numberOfTimesToRunTest,
+                allResults.stream().map(BigDecimal::toString)
+                        .collect(Collectors.joining(",")));
+
+        var result = allResults.stream().reduce(BigDecimal::add)
+                .orElse(BigDecimal.ZERO)
+                .divide(BigDecimal.valueOf(allResults.size()),
+                        RoundingMode.UNNECESSARY);
+
+        return result.toString();
     }
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/main/java/com/vaadin/flow/spring/test/store/CatalogLayout.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/main/java/com/vaadin/flow/spring/test/store/CatalogLayout.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package com.vaadin.flow.spring.test.store;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.ParentLayout;
+import com.vaadin.flow.router.RoutePrefix;
+import com.vaadin.flow.router.RouterLayout;
+import com.vaadin.flow.router.RouterLink;
+import com.vaadin.flow.spring.test.MainLayout;
+
+@RoutePrefix("catalog")
+@ParentLayout(MainLayout.class)
+public class CatalogLayout extends VerticalLayout implements RouterLayout {
+
+    private VerticalLayout rightSideLayout;
+
+    public CatalogLayout() {
+        rightSideLayout = new VerticalLayout();
+
+        add(new H1("Product Catalog"));
+
+        var leftSideLayout = new VerticalLayout();
+        var layout = new HorizontalLayout();
+        layout.setWidthFull();
+        layout.addAndExpand(leftSideLayout, rightSideLayout);
+
+        for (int index = 0; index < 10; index++) {
+            leftSideLayout.add(new RouterLink("Product " + index,
+                    ProductView.class, index));
+        }
+        add(layout);
+    }
+
+    @Override
+    public void showRouterLayoutContent(HasElement content) {
+        rightSideLayout.removeAll();
+        if (content != null) {
+            rightSideLayout.getElement().appendChild(content.getElement());
+        }
+    }
+
+}

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/main/java/com/vaadin/flow/spring/test/store/CatalogLayout.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/main/java/com/vaadin/flow/spring/test/store/CatalogLayout.java
@@ -1,11 +1,18 @@
 /*
  * Copyright 2000-2023 Vaadin Ltd.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
-
 package com.vaadin.flow.spring.test.store;
 
 import com.vaadin.flow.component.Component;

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/main/java/com/vaadin/flow/spring/test/store/ProductView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/main/java/com/vaadin/flow/spring/test/store/ProductView.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package com.vaadin.flow.spring.test.store;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H2;
+import com.vaadin.flow.component.html.Hr;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.BeforeEvent;
+import com.vaadin.flow.router.HasUrlParameter;
+import com.vaadin.flow.router.OptionalParameter;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouteAlias;
+import com.vaadin.flow.spring.test.SpringDevToolsReloadUtils;
+
+@Route(value = "product", layout = CatalogLayout.class, registerAtStartup = false)
+@RouteAlias(value = "prod", layout = CatalogLayout.class)
+public class ProductView extends VerticalLayout
+        implements HasUrlParameter<Integer> {
+
+    private Div productDetails;
+
+    public ProductView() {
+        productDetails = new Div();
+        productDetails.setWidthFull();
+        add(new H2("Product Details"));
+        add(productDetails);
+    }
+
+    @Override
+    public void setParameter(BeforeEvent beforeEvent,
+            @OptionalParameter Integer parameter) {
+        productDetails.removeAll();
+        productDetails.add(String.format("Showing product " + parameter));
+        productDetails.add(new Hr());
+
+        Span result = new Span();
+        result.setId("result");
+        result.setVisible(false);
+
+        NativeButton startTriggerButton = SpringDevToolsReloadUtils
+                .createReloadTriggerButton();
+
+        productDetails.add(startTriggerButton, result);
+
+        startTriggerButton.getElement()
+                .addEventListener("componentready", event -> {
+
+                    System.out.println("result: " + event.getEventData()
+                            .getNumber("event.detail.result"));
+
+                    result.setText(String.format(
+                            "Reload time by class change was [%s] ms",
+                            event.getEventData()
+                                    .getNumber("event.detail.result")));
+                    result.setVisible(true);
+
+                }).addEventData("event.detail.result");
+
+        UI.getCurrent().getPage().executeJs(
+                "window.benchmark.measureRender($0);", startTriggerButton);
+    }
+}

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/main/java/com/vaadin/flow/spring/test/store/ProductView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/main/java/com/vaadin/flow/spring/test/store/ProductView.java
@@ -1,11 +1,18 @@
 /*
  * Copyright 2000-2023 Vaadin Ltd.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
-
 package com.vaadin.flow.spring.test.store;
 
 import com.vaadin.flow.component.UI;

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/test/java/org/vaadin/example/SpringDevToolsReloadViewIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/test/java/org/vaadin/example/SpringDevToolsReloadViewIT.java
@@ -22,6 +22,7 @@ import com.vaadin.flow.testutil.ChromeBrowserTest;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 /**
  * Class for testing reload time of "larger" (size is configurable and test is
@@ -42,9 +43,12 @@ public class SpringDevToolsReloadViewIT extends ChromeBrowserTest {
             open("/app");
         }
 
-        waitForElementPresent(By.id("start-button"));
+        waitUntil(ExpectedConditions
+                .presenceOfElementLocated(By.id("start-button")), 20);
         triggerReload();
-        waitForElementVisible(By.id("result"));
+        waitUntil(
+                ExpectedConditions.visibilityOfElementLocated(By.id("result")),
+                20);
 
         return assertAndGetReloadTimeResult();
     }

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/test/java/org/vaadin/example/SpringDevToolsReloadViewIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/test/java/org/vaadin/example/SpringDevToolsReloadViewIT.java
@@ -16,6 +16,8 @@
 package org.vaadin.example;
 
 import com.vaadin.flow.server.Version;
+import com.vaadin.flow.spring.test.AppShell;
+import com.vaadin.flow.spring.test.SpringDevToolsReloadUtils;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
 import org.junit.Assert;
@@ -36,14 +38,24 @@ public class SpringDevToolsReloadViewIT extends ChromeBrowserTest {
         triggerReload();
         waitForElementVisible(By.id("result"));
 
+        printTestResultToLog();
+    }
+
+    private void printTestResultToLog() {
         System.out.printf(
                 "##teamcity[buildStatisticValue key='%s,app,%s-routes,%s-services-per-route,spring-boot-devtools-reload-time' value='%s']%n",
                 getVaadinMajorMinorVersion(),
-                System.getProperty("vaadin.test.codegen.maven.plugin.routes",
-                        "500"),
-                System.getProperty(
-                        "vaadin.test.codegen.maven.plugin.services.per.route",
-                        "1"),
+                (hasRouteHierarchy() ? ",route-hierarchy-enabled" : ""),
+                getNumberOfGeneratedRoutesProperty(),
+                getNumberOfGeneratedServicesPerRouteProperty(),
+                (hasCssImports()
+                        ? "," + getNumberOfGeneratedCssImportsPerRouteProperty()
+                                + "-css-imports-per-route"
+                        : ""),
+                (hasJsModules()
+                        ? "," + getNumberOfGeneratedJsModulesPerRouteProperty()
+                                + "-js-modules-per-route"
+                        : ""),
                 assertAndGetReloadTimeResult());
     }
 
@@ -66,5 +78,40 @@ public class SpringDevToolsReloadViewIT extends ChromeBrowserTest {
 
     private String getVaadinMajorMinorVersion() {
         return Version.getMajorVersion() + "." + Version.getMinorVersion();
+    }
+
+    private String getNumberOfGeneratedRoutesProperty() {
+        return System.getProperty("vaadin.test.codegen.maven.plugin.routes",
+                "500");
+    }
+
+    private String getNumberOfGeneratedServicesPerRouteProperty() {
+        return System.getProperty(
+                "vaadin.test.codegen.maven.plugin.services.per.route", "1");
+    }
+
+    private String getNumberOfGeneratedCssImportsPerRouteProperty() {
+        return System.getProperty(
+                "vvaadin.test.codegen.maven.plugin.cssimports.per.route", "0");
+    }
+
+    private String getNumberOfGeneratedJsModulesPerRouteProperty() {
+        return System.getProperty(
+                "vaadin.test.codegen.maven.plugin.jsmodules.per.route", "0");
+    }
+
+    private boolean hasCssImports() {
+        String value = getNumberOfGeneratedCssImportsPerRouteProperty();
+        return Integer.parseInt(value) > 0;
+    }
+
+    private boolean hasJsModules() {
+        String value = getNumberOfGeneratedJsModulesPerRouteProperty();
+        return Integer.parseInt(value) > 0;
+    }
+
+    private boolean hasRouteHierarchy() {
+        return "true".equalsIgnoreCase(
+                System.getProperty("route.hierarchy.enabled", "false"));
     }
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/test/java/org/vaadin/example/SpringDevToolsReloadViewIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/test/java/org/vaadin/example/SpringDevToolsReloadViewIT.java
@@ -16,7 +16,6 @@
 package org.vaadin.example;
 
 import com.vaadin.flow.server.Version;
-import com.vaadin.flow.spring.test.AppShell;
 import com.vaadin.flow.spring.test.SpringDevToolsReloadUtils;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
@@ -32,16 +31,25 @@ public class SpringDevToolsReloadViewIT extends ChromeBrowserTest {
 
     @Test
     public void testSpringBootReloadTime_withLargerApp() {
-        open("/app");
+        printTestResultToLog(SpringDevToolsReloadUtils
+                .runAndCalculateAverageResult(5, this::runTestReturnResult));
+    }
+
+    private String runTestReturnResult() {
+        if (hasRouteHierarchy()) {
+            open("/catalog/prod/0");
+        } else {
+            open("/app");
+        }
 
         waitForElementPresent(By.id("start-button"));
         triggerReload();
         waitForElementVisible(By.id("result"));
 
-        printTestResultToLog();
+        return assertAndGetReloadTimeResult();
     }
 
-    private void printTestResultToLog() {
+    private void printTestResultToLog(String result) {
         System.out.printf(
                 "##teamcity[buildStatisticValue key='%s,app,%s-routes,%s-services-per-route,spring-boot-devtools-reload-time' value='%s']%n",
                 getVaadinMajorMinorVersion(),
@@ -56,7 +64,7 @@ public class SpringDevToolsReloadViewIT extends ChromeBrowserTest {
                         ? "," + getNumberOfGeneratedJsModulesPerRouteProperty()
                                 + "-js-modules-per-route"
                         : ""),
-                assertAndGetReloadTimeResult());
+                result);
     }
 
     private void triggerReload() {
@@ -92,7 +100,7 @@ public class SpringDevToolsReloadViewIT extends ChromeBrowserTest {
 
     private String getNumberOfGeneratedCssImportsPerRouteProperty() {
         return System.getProperty(
-                "vvaadin.test.codegen.maven.plugin.cssimports.per.route", "0");
+                "vaadin.test.codegen.maven.plugin.cssimports.per.route", "0");
     }
 
     private String getNumberOfGeneratedJsModulesPerRouteProperty() {

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-reload-time/src/main/java/com/vaadin/flow/spring/test/SpringDevToolsReloadUtils.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-reload-time/src/main/java/com/vaadin/flow/spring/test/SpringDevToolsReloadUtils.java
@@ -15,6 +15,13 @@
  */
 package com.vaadin.flow.spring.test;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.NativeButton;
 
@@ -29,5 +36,23 @@ public class SpringDevToolsReloadUtils {
                 });
         startTriggerButton.setId("start-button");
         return startTriggerButton;
+    }
+
+    public static String runAndCalculateAverageResult(
+            int numberOfTimesToRunTest, Supplier<String> test) {
+        var allResults = new ArrayList<BigDecimal>();
+        IntStream.range(0, numberOfTimesToRunTest).forEach(index -> allResults
+                .add(BigDecimal.valueOf(Double.parseDouble(test.get()))));
+        System.out.printf("Test run %s times. All results: [%s]%n",
+                numberOfTimesToRunTest,
+                allResults.stream().map(BigDecimal::toString)
+                        .collect(Collectors.joining(",")));
+
+        var result = allResults.stream().reduce(BigDecimal::add)
+                .orElse(BigDecimal.ZERO)
+                .divide(BigDecimal.valueOf(allResults.size()),
+                        RoundingMode.UNNECESSARY);
+
+        return result.toString();
     }
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-reload-time/src/test/java/org/vaadin/example/SpringDevToolsReloadViewIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-reload-time/src/test/java/org/vaadin/example/SpringDevToolsReloadViewIT.java
@@ -16,6 +16,7 @@
 package org.vaadin.example;
 
 import com.vaadin.flow.server.Version;
+import com.vaadin.flow.spring.test.SpringDevToolsReloadUtils;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
 import org.junit.Assert;
@@ -30,28 +31,38 @@ public class SpringDevToolsReloadViewIT extends ChromeBrowserTest {
 
     @Test
     public void testSpringBootReloadTime_withNativeButton() {
-        open("/reload-nativebutton-test");
+        String result = SpringDevToolsReloadUtils
+                .runAndCalculateAverageResult(5, () -> {
+                    open("/reload-nativebutton-test");
 
-        waitForElementPresent(By.id("start-button"));
-        triggerReload();
-        waitForElementVisible(By.id("result"));
+                    waitForElementPresent(By.id("start-button"));
+                    triggerReload();
+                    waitForElementVisible(By.id("result"));
+
+                    return assertAndGetReloadTimeResult();
+                });
 
         System.out.printf(
                 "##teamcity[buildStatisticValue key='%s,nativebutton,spring-boot-devtools-reload-time' value='%s']%n",
-                getVaadinMajorMinorVersion(), assertAndGetReloadTimeResult());
+                getVaadinMajorMinorVersion(), result);
     }
 
     @Test
     public void testSpringBootReloadTime_withHorizontalLayout() {
-        open("/reload-layout-test");
+        String result = SpringDevToolsReloadUtils
+                .runAndCalculateAverageResult(5, () -> {
+                    open("/reload-layout-test");
 
-        waitForElementPresent(By.id("start-button"));
-        triggerReload();
-        waitForElementVisible(By.id("result"));
+                    waitForElementPresent(By.id("start-button"));
+                    triggerReload();
+                    waitForElementVisible(By.id("result"));
+
+                    return assertAndGetReloadTimeResult();
+                });
 
         System.out.printf(
                 "##teamcity[buildStatisticValue key='%s,orderedlayout,spring-boot-devtools-reload-time' value='%s']%n",
-                getVaadinMajorMinorVersion(), assertAndGetReloadTimeResult());
+                getVaadinMajorMinorVersion(), result);
     }
 
     private void triggerReload() {


### PR DESCRIPTION
Adds three new system properties for `test-spring-boot-multimodule-reload-time`:
- `vaadin.test.codegen.maven.plugin.cssimports.per.route`
- `vaadin.test.codegen.maven.plugin.jsmodules.per.route`
- `route.hierarchy.enabled`
Updated README.MD to describe each property.

Updates each reload time test to run five times and report average result for the TeamCity.