### PR TITLE
fix: do not create theme-editor.css on application startup

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/ThemeModifier.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/ThemeModifier.java
@@ -10,6 +10,7 @@ import com.helger.css.decl.CascadingStyleSheet;
 import com.helger.css.decl.ICSSSelectorMember;
 import com.helger.css.reader.CSSReader;
 import com.helger.css.writer.CSSWriter;
+import com.vaadin.base.devserver.themeeditor.utils.ApplicationThemeNotAccessibleException;
 import com.vaadin.base.devserver.themeeditor.utils.CssRule;
 import com.vaadin.base.devserver.themeeditor.utils.ThemeEditorException;
 import com.vaadin.flow.server.VaadinContext;
@@ -180,8 +181,8 @@ public class ThemeModifier {
 
     protected State init() {
         try {
-            getStyleSheetFile();
-        } catch (Exception ex) {
+            getThemeFile();
+        } catch (ApplicationThemeNotAccessibleException ex) {
             return State.MISSING_THEME;
         }
         return State.ENABLED;
@@ -192,12 +193,20 @@ public class ThemeModifier {
                 FrontendUtils.PROJECT_BASEDIR, null), "frontend");
     }
 
-    public File getStyleSheetFile() {
+    protected File getThemeFile() {
         File themes = new File(getFrontendFolder(), "themes");
         String themeName = getThemeName(themes);
         File theme = new File(themes, themeName);
-        File themeEditorStyles = new File(theme, getCssFileName());
 
+        if (!theme.exists() || !theme.canWrite()) {
+            throw new ApplicationThemeNotAccessibleException();
+        }
+
+        return theme;
+    }
+
+    public File getStyleSheetFile() {
+        File themeEditorStyles = new File(getThemeFile(), getCssFileName());
         if (!themeEditorStyles.exists()) {
             try {
                 if (!themeEditorStyles.createNewFile()) {

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/ThemeModifier.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/ThemeModifier.java
@@ -182,7 +182,7 @@ public class ThemeModifier {
     protected State init() {
         try {
             getThemeFile();
-        } catch (ApplicationThemeNotAccessibleException ex) {
+        } catch (Exception ex) {
             return State.MISSING_THEME;
         }
         return State.ENABLED;

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/utils/ApplicationThemeNotAccessibleException.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/utils/ApplicationThemeNotAccessibleException.java
@@ -1,0 +1,6 @@
+package com.vaadin.base.devserver.themeeditor.utils;
+
+public class ApplicationThemeNotAccessibleException
+        extends ThemeEditorException {
+
+}


### PR DESCRIPTION
## Description

Removes creation of theme-editor.css on application startup.

Fixes #17462

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.