### PR TITLE
fix: Not generate chunks with the same content (#17511)(CP: 24.1)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -130,8 +130,8 @@ abstract class AbstractUpdateImports implements Runnable {
                     modules.size(), scripts.size(), css.size());
         }
 
-        Map<ChunkInfo, List<String>> javascript = mergeJavascript(
-                modules, scripts);
+        Map<ChunkInfo, List<String>> javascript = mergeJavascript(modules,
+                scripts);
         Map<File, List<String>> output = process(css, javascript);
         writeOutput(output);
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleUtils.java
@@ -21,6 +21,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.io.FileUtils;
@@ -115,6 +116,20 @@ public final class BundleUtils {
      */
     public static String getChunkId(String className) {
         return StringUtil.getHash(className, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Calculates a hash for bundle JavaScript chunk containing given string
+     * lines.
+     *
+     * @param chunkLines
+     *            content of the chunk, collection of string lines
+     * @return chunk's hash
+     */
+    public static String getChunkHash(List<String> chunkLines) {
+        Collections.sort(chunkLines);
+        return StringUtil.getHash(String.join(";", chunkLines),
+                StandardCharsets.UTF_8);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/ChunkInfo.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/ChunkInfo.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.server.frontend.scanner;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Identifier for a chunk or part of the JS bundle.
@@ -65,36 +66,31 @@ public class ChunkInfo {
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((type == null) ? 0 : type.hashCode());
-        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        int result = type != null ? type.hashCode() : 0;
+        result = 31 * result + (name != null ? name.hashCode() : 0);
+        result = 31 * result
+                + (dependencyTriggers != null ? dependencyTriggers.hashCode()
+                        : 0);
+        result = 31 * result + (eager ? 1 : 0);
         return result;
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
+    public boolean equals(Object o) {
+        if (this == o)
             return true;
-        }
-        if (obj == null) {
+        if (o == null || getClass() != o.getClass())
             return false;
-        }
-        if (getClass() != obj.getClass()) {
+
+        ChunkInfo chunkInfo = (ChunkInfo) o;
+
+        if (eager != chunkInfo.eager)
             return false;
-        }
-        ChunkInfo other = (ChunkInfo) obj;
-        if (type != other.type) {
+        if (type != chunkInfo.type)
             return false;
-        }
-        if (name == null) {
-            if (other.name != null) {
-                return false;
-            }
-        } else if (!name.equals(other.name)) {
+        if (!Objects.equals(name, chunkInfo.name))
             return false;
-        }
-        return true;
+        return Objects.equals(dependencyTriggers, chunkInfo.dependencyTriggers);
     }
 
     public List<String> getDependencyTriggers() {


### PR DESCRIPTION
Checks if a chunk has already been considered for a given list of imported modules and scripts. If so, it doesn't generate a new file, but only updates the the import file, linking all the route class hashes with the same chunk file.

Also adds dependencyTriggers and eager fields to the ChunkInfo hashCode and equals, as ChunkInfo is used widely in maps.

Adds extra debug logging to AbstractUpdateImports to understand better what takes most of the time in large projects.

Related-to #17234

(cherry picked from commit 74196a047647f39f764470516d513d4314d564b9)