### PR TITLE
fix: Binder throws NPE and eats a relevant exception

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -1572,10 +1572,10 @@ public class Binder<BEAN> implements Serializable {
             } catch (BindingException exception) {
                 throw exception;
             } catch (Exception exception) {
-                if(binder == null) {
+                if (binder == null) {
                     throw new IllegalStateException(
                             "This binding is already unbound", exception);
-                }    
+                }
                 BindingExceptionHandler handler = binder
                         .getBindingExceptionHandler();
                 Optional<BindingException> bindingException = handler

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -1572,6 +1572,13 @@ public class Binder<BEAN> implements Serializable {
             } catch (BindingException exception) {
                 throw exception;
             } catch (Exception exception) {
+                if(binder == null) {
+                    // field was already unregistered
+                    // before swallowing the exception by
+                    // throwing an NPE, just rethrow 
+                    // the original exception
+                    throw exception;
+                }    
                 BindingExceptionHandler handler = binder
                         .getBindingExceptionHandler();
                 Optional<BindingException> bindingException = handler

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -1573,7 +1573,8 @@ public class Binder<BEAN> implements Serializable {
                 throw exception;
             } catch (Exception exception) {
                 if(binder == null) {
-                    throw new IllegalStateException("This binding is already unbound", exception);
+                    throw new IllegalStateException(
+                            "This binding is already unbound", exception);
                 }    
                 BindingExceptionHandler handler = binder
                         .getBindingExceptionHandler();

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -1573,11 +1573,7 @@ public class Binder<BEAN> implements Serializable {
                 throw exception;
             } catch (Exception exception) {
                 if(binder == null) {
-                    // field was already unregistered
-                    // before swallowing the exception by
-                    // throwing an NPE, just rethrow 
-                    // the original exception
-                    throw exception;
+                    throw new IllegalStateException("This binding is already unbound", exception);
                 }    
                 BindingExceptionHandler handler = binder
                         .getBindingExceptionHandler();


### PR DESCRIPTION
## Description

Ensure that the binder does not hide / swallow the exception when something goes wrong while fields are already unregistered.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
