### PR TITLE
fix: CssBundler should check all groups

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/CssBundler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/CssBundler.java
@@ -58,7 +58,7 @@ public class CssBundler {
 
         Matcher urlMatcher = urlPattern.matcher(content);
         content = urlMatcher.replaceAll(result -> {
-            String url = getNonNullGroup(result, 2, 3);
+            String url = getNonNullGroup(result, 2, 3, 4);
             if (url == null || url.trim().endsWith(".css")) {
                 // These are handled below
                 return Matcher.quoteReplacement(urlMatcher.group());

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/CssBundlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/CssBundlerTest.java
@@ -73,6 +73,20 @@ public class CssBundlerTest {
                 "background-image: url('VAADIN/themes/my-theme/foo/bar.png');",
                 CssBundler.inlineImports(themeFolder,
                         getThemeFile("styles.css")));
+
+        writeCss("background-image: url(\"foo/bar.png\");", "styles.css");
+
+        Assert.assertEquals(
+                "background-image: url('VAADIN/themes/my-theme/foo/bar.png');",
+                CssBundler.inlineImports(themeFolder,
+                        getThemeFile("styles.css")));
+
+        writeCss("background-image: url(foo/bar.png);", "styles.css");
+
+        Assert.assertEquals(
+                "background-image: url('VAADIN/themes/my-theme/foo/bar.png');",
+                CssBundler.inlineImports(themeFolder,
+                        getThemeFile("styles.css")));
     }
 
     @Test


### PR DESCRIPTION
Add the fourth url group to
be checked when going through
url strings.

Fixes #17314
