### PR TITLE
fix: shouldVisit should match package exactly

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
@@ -79,9 +79,9 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
             + ".*(slf4j).*|"
             // #5803
             + "^(java|sun|oracle|elemental|javax|jakarta|oshi|"
-            + "org\\.(apache|atmosphere|jsoup|jboss|w3c|spring|joda|hibernate|glassfish|hsqldb|osgi|jooq)|"
-            + "com\\.(helger|spring|gwt|lowagie|fasterxml|sun|nimbusds|googlecode)|"
-            + "net\\.(sf|bytebuddy)"
+            + "org\\.(apache|atmosphere|jsoup|jboss|w3c|spring|joda|hibernate|glassfish|hsqldb|osgi|jooq)\\b|"
+            + "com\\.(helger|spring|gwt|lowagie|fasterxml|sun|nimbusds|googlecode)\\b|"
+            + "net\\.(sf|bytebuddy)\\b"
             + ").*|"
             + ".*(Exception)$"
             + ")");
@@ -815,7 +815,7 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
         }
     }
 
-    private boolean shouldVisit(String className) {
+    protected boolean shouldVisit(String className) {
         // We should visit only those classes that might have NpmPackage,
         // JsImport, JavaScript and HtmlImport annotations, basically
         // HasElement, and AbstractTheme classes, but that prevents the usage of

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
@@ -298,6 +298,31 @@ public class FrontendDependenciesTest {
                 "@vaadin/common-frontend/ConnectionIndicator.js");
     }
 
+    @Test // #9861
+    public void shouldVisit_shouldNotMatchOnPartOfPackage() {
+
+        FrontendDependencies dependencies = new FrontendDependencies(
+                classFinder, true);
+
+        Assert.assertTrue(
+                "second package should match fully not as starts with 'spring != springframework'",
+                dependencies.shouldVisit("org.springframework.samples"));
+        Assert.assertTrue(
+                "second package should match fully not as starts with 'spring != springframework'",
+                dependencies.shouldVisit("org.springframework"));
+        Assert.assertFalse("should not visit with only 2 packages 'org.spring'",
+                dependencies.shouldVisit("org.spring"));
+
+        Assert.assertTrue(
+                "second package should match fully not as starts with 'sun != sunny'",
+                dependencies.shouldVisit("com.sunny.app"));
+        Assert.assertTrue(
+                "second package should match fully not as starts with 'sun != sunny'",
+                dependencies.shouldVisit("com.sunny"));
+        Assert.assertFalse("should not visit with only 2 packages 'com.sun'",
+                dependencies.shouldVisit("com.sun"));
+    }
+
     public static class MyComponent extends Component {
     }
 


### PR DESCRIPTION
The shouldVisit list in frontend
dependencies should match the
packages exactly and not as
a starts with.
e.g. com.vaadiner is not a match for com.vaadin

Found investigating https://github.com/vaadin/flow/issues/17490