### PR TITLE
fix: Check for null when handling exception

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateTree.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateTree.java
@@ -35,6 +35,7 @@ import com.vaadin.flow.internal.change.NodeChange;
 import com.vaadin.flow.internal.nodefeature.NodeFeature;
 import com.vaadin.flow.server.DefaultErrorHandler;
 import com.vaadin.flow.server.ErrorEvent;
+import com.vaadin.flow.server.ErrorHandler;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.communication.UidlWriter;
 import com.vaadin.flow.shared.Registration;
@@ -395,8 +396,7 @@ public class StateTree implements NodeOwner {
                                             .isClientSideInitialized());
                             entry.getExecution().accept(context);
                         } catch (Exception e) {
-                            if (getUI().getSession().getErrorHandler()
-                                    .getClass()
+                            if (getErrorHandlerClass()
                                     .equals(DefaultErrorHandler.class)) {
                                 throw e;
                             }
@@ -405,6 +405,15 @@ public class StateTree implements NodeOwner {
                         }
                     });
         }
+    }
+
+    private Class<? extends ErrorHandler> getErrorHandlerClass() {
+        UI ui = getUI();
+        VaadinSession session = ui == null ? null : ui.getSession();
+        ErrorHandler errorHandler = session == null ? null
+                : session.getErrorHandler();
+        return errorHandler == null ? DefaultErrorHandler.class
+                : errorHandler.getClass();
     }
 
     private List<StateTree.BeforeClientResponseEntry> flushCallbacks() {


### PR DESCRIPTION
For errors in beforeClientResponse
handle cases where any part to the
errorHandler is null

Fixes #17352
