### PR TITLE
feat: Record usage statistics when incremental build feature is disabled

### DIFF
--- a/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
+++ b/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
@@ -413,4 +413,9 @@ public class BuildDevBundleMojo extends AbstractMojo
         // Explicitly building dev bundle so no skipping allowed here.
         return false;
     }
+
+    @Override
+    public boolean isPrepareFrontendCacheDisabled() {
+        return false;
+    }
 }

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
@@ -187,4 +187,6 @@ internal class GradlePluginAdapter(val project: Project, private val isBeforePro
     override fun skipDevBundleBuild(): Boolean = extension.skipDevBundleBuild
 
     override fun forceProductionBuild(): Boolean = extension.forceProductionBuild
+
+    override fun isPrepareFrontendCacheDisabled(): Boolean = extension.alwaysExecutePrepareFrontend
 }

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -437,4 +437,9 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
     public boolean skipDevBundleBuild() {
         return skipDevBundleRebuild;
     }
+
+    @Override
+    public boolean isPrepareFrontendCacheDisabled() {
+        return false;
+    }
 }

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.plugin.base;
 import static com.vaadin.flow.server.Constants.CONNECT_APPLICATION_PROPERTIES_TOKEN;
 import static com.vaadin.flow.server.Constants.CONNECT_JAVA_SOURCE_FOLDER_TOKEN;
 import static com.vaadin.flow.server.Constants.CONNECT_OPEN_API_FILE_TOKEN;
+import static com.vaadin.flow.server.Constants.DISABLE_PREPARE_FRONTEND_CACHE;
 import static com.vaadin.flow.server.Constants.FRONTEND_TOKEN;
 import static com.vaadin.flow.server.Constants.JAVA_RESOURCE_FOLDER_TOKEN;
 import static com.vaadin.flow.server.Constants.NPM_TOKEN;
@@ -250,6 +251,10 @@ public class BuildFrontendUtil {
                 adapter.requireHomeNodeExec());
 
         buildInfo.put(InitParameters.BUILD_FOLDER, adapter.buildFolder());
+
+        if (adapter.isPrepareFrontendCacheDisabled()) {
+            buildInfo.put(DISABLE_PREPARE_FRONTEND_CACHE, true);
+        }
 
         try {
             FileUtils.forceMkdir(token.getParentFile());

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBase.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBase.java
@@ -279,4 +279,18 @@ public interface PluginAdapterBase {
      * @return {@code true} to skip dev bundle rebuild
      */
     boolean skipDevBundleBuild();
+
+    /**
+     * Prevents tracking state of the `vaadinPrepareFrontend` task in Gradle
+     * builds, so that it will re-run every time it is called.
+     * <p>
+     * Returns `true` if Gradle should always execute `vaadinPrepareFrontend`.
+     * <p>
+     * Defaults to `false`, meaning that the task execution is skipped when its
+     * outcomes are up-to-date, improving the overall build time.
+     * <p>
+     * For Maven builds this is always `false`, because no caching of
+     * `prepare-frontend` goal is supported.
+     */
+    boolean isPrepareFrontendCacheDisabled();
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -299,6 +299,12 @@ public final class Constants implements Serializable {
     public static final String NEEDS_BUNDLE_BUILD_FILE = Constants.VAADIN_CONFIGURATION
             + "needs-build";
 
+    /**
+     * Key for storing the value of `alwaysExecutePrepareFrontend` flag of
+     * Gradle builds in a build info (token) file.
+     */
+    public static final String DISABLE_PREPARE_FRONTEND_CACHE = "disable.prepare.frontend.cache";
+
     private Constants() {
         // prevent instantiation constants class only
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractConfigurationFactory.java
@@ -26,6 +26,7 @@ import java.util.function.Function;
 
 import org.apache.commons.io.FileUtils;
 
+import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.frontend.FrontendUtils;
@@ -35,6 +36,7 @@ import elemental.json.JsonObject;
 import static com.vaadin.flow.server.Constants.CONNECT_APPLICATION_PROPERTIES_TOKEN;
 import static com.vaadin.flow.server.Constants.CONNECT_JAVA_SOURCE_FOLDER_TOKEN;
 import static com.vaadin.flow.server.Constants.CONNECT_OPEN_API_FILE_TOKEN;
+import static com.vaadin.flow.server.Constants.DISABLE_PREPARE_FRONTEND_CACHE;
 import static com.vaadin.flow.server.Constants.EXTERNAL_STATS_FILE;
 import static com.vaadin.flow.server.Constants.EXTERNAL_STATS_FILE_TOKEN;
 import static com.vaadin.flow.server.Constants.EXTERNAL_STATS_URL;
@@ -159,6 +161,10 @@ public class AbstractConfigurationFactory implements Serializable {
         }
         if (buildInfo.hasKey(BUILD_FOLDER)) {
             params.put(BUILD_FOLDER, buildInfo.getString(BUILD_FOLDER));
+        }
+        if (buildInfo.hasKey(DISABLE_PREPARE_FRONTEND_CACHE)) {
+            UsageStatistics.markAsUsed("flow/always-execute-prepare-frontend",
+                    null);
         }
 
         setDevModePropertiesUsingTokenData(params, buildInfo);


### PR DESCRIPTION
Writes an extra parameter to the token file if Gradle's plugin prepare frontend tasks is configured to be always run, i.e. cache is disabled, and then records this flag for usage statistic tool in runtime.

This makes a new method in adapter, which is not a best way to solve the issue, but not sure how else we can pass this parameter from build time to runtime.