### PR TITLE
chore: Upgrade default Node to 20.6.0

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -66,11 +66,11 @@ public class FrontendTools {
      * the installed version is older than {@link #SUPPORTED_NODE_VERSION}, i.e.
      * {@value #SUPPORTED_NODE_MAJOR_VERSION}.{@value #SUPPORTED_NODE_MINOR_VERSION}.
      */
-    public static final String DEFAULT_NODE_VERSION = "v18.17.1";
+    public static final String DEFAULT_NODE_VERSION = "v20.6.0";
     /**
      * This is the version shipped with the default Node version.
      */
-    public static final String DEFAULT_NPM_VERSION = "9.6.7";
+    public static final String DEFAULT_NPM_VERSION = "9.8.1";
 
     public static final String DEFAULT_PNPM_VERSION = "8.6.11";
 


### PR DESCRIPTION
Node 20 will become the LTS on 2023-10-24 and 24.2 is targeted for 2023-10-18
