### PR TITLE
fix: Allow platform dependencies to be linked

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -327,9 +327,18 @@ public class TaskUpdatePackages extends NodeUpdater {
         // packages exist at this point
         assert vaadinDeps != null : "vaadin{ dependencies { } } should exist";
         assert packageJsonDeps != null : "dependencies { } should exist";
+
+        FrontendVersion packageJsonVersion;
+        try {
+            packageJsonVersion = new FrontendVersion(
+                    packageJsonDeps.getString(pkg));
+        } catch (Exception e) {
+            // Overridden to a file link in package.json, do not change
+            return false;
+        }
+
         if (!packageJsonDeps.hasKey(pkg) || !vaadinDeps.hasKey(pkg)
-                || !platformPinnedVersion.equals(
-                        new FrontendVersion(packageJsonDeps.getString(pkg)))
+                || !platformPinnedVersion.equals(packageJsonVersion)
                 || !platformPinnedVersion.equals(
                         new FrontendVersion(vaadinDeps.getString(pkg)))) {
             packageJsonDeps.put(pkg, platformPinnedVersion.getFullVersion());

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
@@ -361,7 +361,7 @@ public class TaskUpdatePackagesNpmTest {
 
         verifyVersions(PLATFORM_DIALOG_VERSION, "file:../foobar",
                 PLATFORM_OVERLAY_VERSION);
-        verifyVersionLockingWithNpmOverrides(true, true, true);
+        verifyVersionLockingWithNpmOverrides(true, false, true);
     }
 
     // #11025

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
@@ -343,11 +343,11 @@ public class TaskUpdatePackagesNpmTest {
     }
 
     @Test
-    public void npmIsInUse_packageJsonHasBadVersion_pinnedVersionUsed()
+    public void npmIsInUse_packageJsonHasNonNumericVersion_versionNotOverridden()
             throws IOException {
         final JsonObject packageJson = getOrCreatePackageJson();
         JsonObject dependencies = packageJson.getObject(DEPENDENCIES);
-        dependencies.put(VAADIN_ELEMENT_MIXIN, "asdfasagqae4rat");
+        dependencies.put(VAADIN_ELEMENT_MIXIN, "file:../foobar");
         FileUtils.writeStringToFile(new File(npmFolder, PACKAGE_JSON),
                 packageJson.toJson(), StandardCharsets.UTF_8);
 
@@ -359,7 +359,7 @@ public class TaskUpdatePackagesNpmTest {
 
         Assert.assertTrue("Updates not picked", task.modified);
 
-        verifyVersions(PLATFORM_DIALOG_VERSION, PLATFORM_ELEMENT_MIXIN_VERSION,
+        verifyVersions(PLATFORM_DIALOG_VERSION, "file:../foobar",
                 PLATFORM_OVERLAY_VERSION);
         verifyVersionLockingWithNpmOverrides(true, true, true);
     }


### PR DESCRIPTION
Do not fail if a managed version is linked to a local copy and thus the version cannot be parsed
