### PR TITLE
fix: Use earlier atmospehere version

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -21,7 +21,7 @@ import java.io.Serializable;
 public final class Constants implements Serializable {
 
     // Keep the version number in sync with flow-push/pom.xml
-    public static final String REQUIRED_ATMOSPHERE_RUNTIME_VERSION = "2.7.3.slf4jvaadin5";
+    public static final String REQUIRED_ATMOSPHERE_RUNTIME_VERSION = "2.4.30.slf4jvaadin2";
 
     /**
      * The prefix used for System property parameters.

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <!-- Used in OSGi manifests -->
         <jsoup.version>1.15.3</jsoup.version>
         <!-- Note that this should be kept in sync with the class Constants -->
-        <atmosphere.runtime.version>2.7.3.slf4jvaadin5</atmosphere.runtime.version>
+        <atmosphere.runtime.version>2.4.30.slf4jvaadin2</atmosphere.runtime.version>
 
         <!-- OSGi -->
         <!-- Note: the parserVersion value is set by build-helper-maven-plugin -->


### PR DESCRIPTION
Downgrade to atmosphere version
2.4.30.slf4jvaadin2 for osgi
compatibility.
