### PR TITLE
fix: support downgrading dependencies based on versions.json

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonFilter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonFilter.java
@@ -82,9 +82,6 @@ class VersionsJsonFilter {
                             versions.getString(key));
                 }
                 json.put(key, userManagedDependencies.getString(key));
-            } else if (vaadinDepsVersion != null
-                    && vaadinDepsVersion.isNewerThan(version)) {
-                json.put(key, vaadinVersions.getString(key));
             } else {
                 json.put(key, versions.getString(key));
             }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonFilter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonFilter.java
@@ -71,9 +71,6 @@ class VersionsJsonFilter {
             final FrontendVersion userManagedVersion = FrontendUtils
                     .getPackageVersionFromJson(userManagedDependencies, key,
                             "/package.json -> { dependencies }");
-            final FrontendVersion vaadinDepsVersion = FrontendUtils
-                    .getPackageVersionFromJson(vaadinVersions, key,
-                            "/package.json -> { vaadin { dependencies }}");
             if (userManagedVersion != null) {
                 if (version.isNewerThan(userManagedVersion)) {
                     LoggerFactory.getLogger("Versions").warn(

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -530,7 +530,7 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
     }
 
     @Test
-    public void runPnpmInstall_frameworkCollectedVersionNewerThanPinned_installedOverlayVersionIsNotSpecifiedByPlatform()
+    public void runPnpmInstall_frameworkCollectedVersionNewerThanPinned_installedOverlayVersionIsSpecifiedByPlatform()
             throws IOException, ExecutionFailedException {
         File packageJson = new File(npmFolder, PACKAGE_JSON);
         packageJson.createNewFile();
@@ -570,11 +570,10 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         File overlayPackageJson = new File(options.getNodeModulesFolder(),
                 "@vaadin/vaadin-overlay/package.json");
 
-        // The resulting version should be the one collected from the
-        // annotations in the project
+        // The resulting version should be the one defined by the platform
         JsonObject overlayPackage = Json.parse(FileUtils
                 .readFileToString(overlayPackageJson, StandardCharsets.UTF_8));
-        Assert.assertEquals(customOverlayVersion,
+        Assert.assertEquals(PINNED_VERSION,
                 overlayPackage.getString("version"));
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
@@ -600,7 +600,8 @@ public class TaskUpdatePackagesNpmTest {
         runTestWithoutPreexistingPackageJson();
         // write new versions json and scanned deps
         final String oldPlatformVersion = "1.0.0";
-        createVaadinVersionsJson(oldPlatformVersion, oldPlatformVersion, oldPlatformVersion);
+        createVaadinVersionsJson(oldPlatformVersion, oldPlatformVersion,
+                oldPlatformVersion);
 
         final Map<String, String> applicationDependencies = createApplicationDependencies();
         final String appDependencyVersion = "1.5.0";
@@ -609,7 +610,8 @@ public class TaskUpdatePackagesNpmTest {
         task.execute();
         Assert.assertTrue("Updates not picked", task.modified);
 
-        verifyVersions(appDependencyVersion, oldPlatformVersion, oldPlatformVersion);
+        verifyVersions(appDependencyVersion, oldPlatformVersion,
+                oldPlatformVersion);
         verifyVersionLockingWithNpmOverrides(true, true, true);
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
@@ -594,6 +594,25 @@ public class TaskUpdatePackagesNpmTest {
                 vaadinVersion.isPresent());
     }
 
+    @Test
+    public void oldVersionsJson_shouldDowngrade() throws IOException {
+        // run the basic test to produce an existing package.json
+        runTestWithoutPreexistingPackageJson();
+        // write new versions json and scanned deps
+        final String oldPlatformVersion = "1.0.0";
+        createVaadinVersionsJson(oldPlatformVersion, oldPlatformVersion, oldPlatformVersion);
+
+        final Map<String, String> applicationDependencies = createApplicationDependencies();
+        final String appDependencyVersion = "1.5.0";
+        applicationDependencies.put(VAADIN_DIALOG, appDependencyVersion);
+        final TaskUpdatePackages task = createTask(applicationDependencies);
+        task.execute();
+        Assert.assertTrue("Updates not picked", task.modified);
+
+        verifyVersions(appDependencyVersion, oldPlatformVersion, oldPlatformVersion);
+        verifyVersionLockingWithNpmOverrides(true, true, true);
+    }
+
     private void createBasicVaadinVersionsJson() {
         createVaadinVersionsJson(PLATFORM_DIALOG_VERSION,
                 PLATFORM_ELEMENT_MIXIN_VERSION, PLATFORM_OVERLAY_VERSION);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/VersionsJsonFilterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/VersionsJsonFilterTest.java
@@ -224,9 +224,11 @@ public class VersionsJsonFilterTest {
         Assert.assertEquals(
                 "'upload' should be the same in package and versions", "4.2.2",
                 filteredJson.getString("@vaadin/vaadin-upload"));
-        Assert.assertEquals("'enforced' version should come from platform (upgrade)",
+        Assert.assertEquals(
+                "'enforced' version should come from platform (upgrade)",
                 "1.5.0", filteredJson.getString("enforced"));
-        Assert.assertEquals("'iron-list' version should come from platform (downgrade)",
+        Assert.assertEquals(
+                "'iron-list' version should come from platform (downgrade)",
                 "2.0.19", filteredJson.getString("@polymer/iron-list"));
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/VersionsJsonFilterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/VersionsJsonFilterTest.java
@@ -224,9 +224,9 @@ public class VersionsJsonFilterTest {
         Assert.assertEquals(
                 "'upload' should be the same in package and versions", "4.2.2",
                 filteredJson.getString("@vaadin/vaadin-upload"));
-        Assert.assertEquals("'enforced' version should come from platform",
+        Assert.assertEquals("'enforced' version should come from platform (upgrade)",
                 "1.5.0", filteredJson.getString("enforced"));
-        Assert.assertEquals("'iron-list' should be framework defined version",
-                "3.0.2", filteredJson.getString("@polymer/iron-list"));
+        Assert.assertEquals("'iron-list' version should come from platform (downgrade)",
+                "2.0.19", filteredJson.getString("@polymer/iron-list"));
     }
 }


### PR DESCRIPTION
For dependencies without custom versions in `package.json` (when `dependencies` and `vaadin.dependencies` agree), currently a pinned version from `versions.json` is not applied if it is for some reason older than the one specified in `package.json`. This effectively prevents downgrading npm package versions by changing the platform dependency version.

This change removes the downgrade prevention check.

Context: to speed up the upcoming release, Hilla platform 2.2 reverted to using stable React and Vaadin components 24.1.x before the beta1 release after using 24.2.0.alphaX during alpha releases. At the moment upgrading a Hilla application from 2.2.0.alpha10 to beta1 does not downgrade the component dependencies back to 24.1, while this is expected.