### PR TITLE
Spring Boot DevTools reload caching

### DIFF
--- a/flow-client/pom.xml
+++ b/flow-client/pom.xml
@@ -151,7 +151,7 @@
         <dependency>
             <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.core.contenttype</artifactId>
-            <version>3.9.0</version>
+            <version>3.9.100</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/flow-client/pom.xml
+++ b/flow-client/pom.xml
@@ -126,7 +126,7 @@
         <dependency>
             <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.equinox.preferences</artifactId>
-            <version>3.10.200</version>
+            <version>3.10.300</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/flow-plugins/flow-dev-bundle-plugin/pom.xml
+++ b/flow-plugins/flow-dev-bundle-plugin/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.23.0</version>
+            <version>1.24.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>

--- a/flow-plugins/flow-gradle-plugin/build.gradle
+++ b/flow-plugins/flow-gradle-plugin/build.gradle
@@ -196,6 +196,9 @@ functionalTest {
 }
 
 kotlin {
+    jvmToolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
     explicitApi()
 }
 

--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -134,7 +134,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.23.0</version>
+            <version>1.24.0</version>
         </dependency>
         <!-- TESTING DEPENDENCIES -->
         <dependency>

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -667,12 +667,9 @@ public abstract class AbstractNavigationStateRenderer
             return Optional.of(forward(event, beforeEvent));
         }
 
-        if (beforeEvent.hasRerouteTarget() && (!isSameNavigationState(
-                beforeEvent.getRerouteTargetType(),
-                beforeEvent.getRerouteTargetRouteParameters())
-                || !(navigationState.getResolvedPath() != null
-                        && navigationState.getResolvedPath()
-                                .equals(beforeEvent.getRerouteUrl())))) {
+        if (beforeEvent.hasRerouteTarget()
+                && !isSameNavigationState(beforeEvent.getRerouteTargetType(),
+                        beforeEvent.getRerouteTargetRouteParameters())) {
             return Optional.of(reroute(event, beforeEvent));
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -658,19 +658,21 @@ public abstract class AbstractNavigationStateRenderer
         if (beforeEvent.hasExternalForwardUrl()) {
             return Optional.of(forwardToExternalUrl(event, beforeEvent));
         }
-        if (beforeEvent.hasForwardTarget()
-                && (!isSameNavigationState(beforeEvent.getForwardTargetType(),
-                        beforeEvent.getForwardTargetRouteParameters())
-                        || !navigationState.getResolvedPath()
-                                .equals(beforeEvent.getForwardUrl()))) {
+        if (beforeEvent.hasForwardTarget() && (!isSameNavigationState(
+                beforeEvent.getForwardTargetType(),
+                beforeEvent.getForwardTargetRouteParameters())
+                || !(navigationState.getResolvedPath() != null
+                        && navigationState.getResolvedPath()
+                                .equals(beforeEvent.getForwardUrl())))) {
             return Optional.of(forward(event, beforeEvent));
         }
 
-        if (beforeEvent.hasRerouteTarget()
-                && (!isSameNavigationState(beforeEvent.getRerouteTargetType(),
-                        beforeEvent.getRerouteTargetRouteParameters())
-                        || !navigationState.getResolvedPath()
-                                .equals(beforeEvent.getRerouteUrl()))) {
+        if (beforeEvent.hasRerouteTarget() && (!isSameNavigationState(
+                beforeEvent.getRerouteTargetType(),
+                beforeEvent.getRerouteTargetRouteParameters())
+                || !(navigationState.getResolvedPath() != null
+                        && navigationState.getResolvedPath()
+                                .equals(beforeEvent.getRerouteUrl())))) {
             return Optional.of(reroute(event, beforeEvent));
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -327,16 +327,35 @@ public class TaskUpdatePackages extends NodeUpdater {
         // packages exist at this point
         assert vaadinDeps != null : "vaadin{ dependencies { } } should exist";
         assert packageJsonDeps != null : "dependencies { } should exist";
-        if (!packageJsonDeps.hasKey(pkg) || !vaadinDeps.hasKey(pkg)
-                || !platformPinnedVersion.equals(
-                        new FrontendVersion(packageJsonDeps.getString(pkg)))
-                || !platformPinnedVersion.equals(
-                        new FrontendVersion(vaadinDeps.getString(pkg)))) {
-            packageJsonDeps.put(pkg, platformPinnedVersion.getFullVersion());
-            vaadinDeps.put(pkg, platformPinnedVersion.getFullVersion());
-            return true;
+
+        FrontendVersion packageJsonVersion = null, vaadinDepsVersion = null;
+        try {
+            if (packageJsonDeps.hasKey(pkg)) {
+                packageJsonVersion = new FrontendVersion(
+                        packageJsonDeps.getString(pkg));
+            }
+        } catch (NumberFormatException e) {
+            // Overridden to a file link in package.json, do not change
+            return false;
         }
-        return false;
+        try {
+            if (vaadinDeps.hasKey(pkg)) {
+                vaadinDepsVersion = new FrontendVersion(
+                        vaadinDeps.getString(pkg));
+            }
+        } catch (NumberFormatException e) {
+            // Vaadin defines a non-numeric version. Not sure what the case
+            // would be but probably it should be pinned like any other version
+        }
+
+        if (platformPinnedVersion.equals(packageJsonVersion)
+                && platformPinnedVersion.equals(vaadinDepsVersion)) {
+            return false;
+        }
+
+        packageJsonDeps.put(pkg, platformPinnedVersion.getFullVersion());
+        vaadinDeps.put(pkg, platformPinnedVersion.getFullVersion());
+        return true;
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletDeployer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletDeployer.java
@@ -182,43 +182,6 @@ public class ServletDeployer implements ServletContextListener {
             logger.info(servletCreationMessage);
             ServletRegistration vaadinServlet = findVaadinServlet(
                     servletContext);
-            logAppStartupToConsole(servletContext,
-                    servletCreation == VaadinServletCreation.SERVLET_CREATED
-                            || vaadinServlet != null
-                                    && "com.vaadin.cdi.CdiServletDeployer"
-                                            .equals(vaadinServlet.getName()));
-        }
-    }
-
-    /**
-     * Prints to sysout a notification to the user that the application has been
-     * deployed.
-     * <p>
-     * This method is public so that it can be called in add-ons that map
-     * servlet automatically but don't use this class for that.
-     *
-     * @param servletContext
-     *            the deployed servlet context
-     * @param servletAutomaticallyCreated
-     *            whether the servlet was automatically created
-     * @since
-     */
-    public static void logAppStartupToConsole(ServletContext servletContext,
-            boolean servletAutomaticallyCreated) {
-        // non-production mode - highlight that application is available
-        if (servletAutomaticallyCreated) {
-            // context path is either "" or "/something"
-            String contextPath = servletContext.getContextPath();
-            contextPath = contextPath.isEmpty() ? "/" : contextPath;
-
-            FrontendUtils.console(FrontendUtils.BRIGHT_BLUE, String.format(
-                    "Vaadin application has been deployed and started to the context path \"%s\".%n",
-                    contextPath));
-        } else {
-            // if the user has mapped their own servlet, they will know where to
-            // find it
-            FrontendUtils.console(FrontendUtils.BRIGHT_BLUE, String.format(
-                    "Vaadin application has been deployed and started.%n"));
         }
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
@@ -343,11 +343,11 @@ public class TaskUpdatePackagesNpmTest {
     }
 
     @Test
-    public void npmIsInUse_packageJsonHasBadVersion_pinnedVersionUsed()
+    public void npmIsInUse_packageJsonHasNonNumericVersion_versionNotOverridden()
             throws IOException {
         final JsonObject packageJson = getOrCreatePackageJson();
         JsonObject dependencies = packageJson.getObject(DEPENDENCIES);
-        dependencies.put(VAADIN_ELEMENT_MIXIN, "asdfasagqae4rat");
+        dependencies.put(VAADIN_ELEMENT_MIXIN, "file:../foobar");
         FileUtils.writeStringToFile(new File(npmFolder, PACKAGE_JSON),
                 packageJson.toJson(), StandardCharsets.UTF_8);
 
@@ -359,9 +359,9 @@ public class TaskUpdatePackagesNpmTest {
 
         Assert.assertTrue("Updates not picked", task.modified);
 
-        verifyVersions(PLATFORM_DIALOG_VERSION, PLATFORM_ELEMENT_MIXIN_VERSION,
+        verifyVersions(PLATFORM_DIALOG_VERSION, "file:../foobar",
                 PLATFORM_OVERLAY_VERSION);
-        verifyVersionLockingWithNpmOverrides(true, true, true);
+        verifyVersionLockingWithNpmOverrides(true, false, true);
     }
 
     // #11025

--- a/flow-test-util/pom.xml
+++ b/flow-test-util/pom.xml
@@ -16,7 +16,6 @@
     <properties>
         <license.skipDownloadLicenses>true</license.skipDownloadLicenses>
         <sonar.skip>true</sonar.skip>
-        <selenium.version>4.12.0</selenium.version>
     </properties>
 
     <dependencies>
@@ -41,34 +40,10 @@
             <version>${testbench.version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.seleniumhq.selenium</groupId>
-                    <artifactId>selenium-remote-driver</artifactId>
+                    <groupId>org.asynchttpclient</groupId>
+                    <artifactId>async-http-client</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-remote-driver</artifactId>
-            <version>${selenium.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
         </dependency>
 
         <!-- override scope for junit -->

--- a/flow-tests/test-theme-editor/pom.xml
+++ b/flow-tests/test-theme-editor/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-button-flow</artifactId>
-            <version>24.1.8</version>
+            <version>24.1.9</version>
         </dependency>
     </dependencies>
 

--- a/flow-tests/test-theme-editor/src/test/java/com/vaadin/flow/uitest/ui/AbstractThemeEditorIT.java
+++ b/flow-tests/test-theme-editor/src/test/java/com/vaadin/flow/uitest/ui/AbstractThemeEditorIT.java
@@ -15,9 +15,55 @@
  */
 package com.vaadin.flow.uitest.ui;
 
+import java.io.File;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import com.vaadin.base.devserver.themeeditor.ThemeModifier;
+import com.vaadin.flow.server.VaadinContext;
+import com.vaadin.flow.server.frontend.FrontendUtils;
 import com.vaadin.flow.testutil.ChromeDeviceTest;
+import com.vaadin.flow.testutil.TestUtils;
 
 public abstract class AbstractThemeEditorIT extends ChromeDeviceTest {
+    VaadinContext mockContext = new VaadinContext() {
+
+        Map<String, Object> attributes = new HashMap<>();
+
+        @Override
+        public <T> T getAttribute(Class<T> type,
+                Supplier<T> defaultValueSupplier) {
+            Object result = attributes.get(type.getName());
+            if (result == null && defaultValueSupplier != null) {
+                result = defaultValueSupplier.get();
+                attributes.put(type.getName(), result);
+            }
+            return type.cast(result);
+        }
+
+        @Override
+        public <T> void setAttribute(Class<T> clazz, T value) {
+            attributes.put(clazz.getName(), value);
+        }
+
+        @Override
+        public void removeAttribute(Class<?> clazz) {
+            attributes.remove(clazz.getName());
+        }
+
+        @Override
+        public Enumeration<String> getContextParameterNames() {
+            return Collections.enumeration(Collections.emptyList());
+        }
+
+        @Override
+        public String getContextParameter(String name) {
+            return null;
+        }
+    };
 
     @Override
     protected String getTestPath() {
@@ -27,4 +73,21 @@ public abstract class AbstractThemeEditorIT extends ChromeDeviceTest {
     protected void open() {
         open((String[]) null);
     }
+
+    protected class TestThemeModifier extends ThemeModifier {
+
+        public TestThemeModifier() {
+            super(mockContext);
+        }
+
+        @Override
+        protected File getFrontendFolder() {
+            File currentFolder = TestUtils.getTestFolder("com");
+            while (!new File(currentFolder, FrontendUtils.FRONTEND).exists()) {
+                currentFolder = currentFolder.getParentFile();
+            }
+            return new File(currentFolder, FrontendUtils.FRONTEND);
+        }
+    }
+
 }

--- a/flow-tests/test-theme-editor/src/test/java/com/vaadin/flow/uitest/ui/ThemeEditorIT.java
+++ b/flow-tests/test-theme-editor/src/test/java/com/vaadin/flow/uitest/ui/ThemeEditorIT.java
@@ -15,13 +15,20 @@
  */
 package com.vaadin.flow.uitest.ui;
 
+import com.vaadin.base.devserver.themeeditor.ThemeModifier;
+import com.vaadin.base.devserver.themeeditor.utils.CssRule;
 import com.vaadin.flow.internal.JsonUtils;
 import com.vaadin.flow.testutil.DevToolsElement;
+import com.vaadin.flow.uitest.ui.testbench.DevToolsCheckboxPropertyEditorElement;
+import com.vaadin.flow.uitest.ui.testbench.DevToolsThemeClassNameEditorElement;
+import com.vaadin.flow.uitest.ui.testbench.DevToolsThemeColorPropertyEditorElement;
+import com.vaadin.flow.uitest.ui.testbench.DevToolsThemeRangePropertyEditorElement;
 import com.vaadin.testbench.TestBenchElement;
 import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 import net.jcip.annotations.NotThreadSafe;
+import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -33,8 +40,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import static junit.framework.TestCase.fail;
 
@@ -69,8 +79,13 @@ public class ThemeEditorIT extends AbstractThemeEditorIT {
 
         new Actions(getDriver()).click(findElement(By.id("button"))).perform();
 
+        DevToolsThemeClassNameEditorElement classNameEditor = themeEditor
+                .$(DevToolsThemeClassNameEditorElement.class).waitForFirst();
+        String cssClassName = classNameEditor.getValue();
+
         TestBenchElement propertiesList = themeEditor
                 .$("vaadin-dev-tools" + "-theme-property-list").waitForFirst();
+
         List<TestBenchElement> propertyEditors = propertiesList.$("*")
                 .hasAttribute("data-testid").all();
 
@@ -82,12 +97,94 @@ public class ThemeEditorIT extends AbstractThemeEditorIT {
         }
 
         for (Metadata metadata : buttonMetadata) {
+            Map<String, String> cssProperties = new HashMap<>();
             for (Property property : metadata.getProperties()) {
                 if (!dataTestIds.contains(property.getPropertyName())) {
                     fail();
                 }
+                Optional<String> oValue = updateProperty(propertiesList,
+                        property);
+                if (!oValue.isEmpty()) {
+                    String value = oValue.get();
+                    cssProperties.put(property.getPropertyName(), value);
+                    // ouch...
+                    if (property.getPropertyName().equals("border-width")
+                            && !value.equals("0px")) {
+                        cssProperties.put("border-style", "solid");
+                    }
+                }
+            }
+            String cssSelector = createSelector(metadata, cssClassName);
+            Optional<CssRule> oActual = getCssRuleFromFile(cssSelector);
+            if (oActual.isEmpty()) {
+                Assert.assertEquals(cssSelector, "");
+            } else {
+                CssRule expected = new CssRule(cssSelector, cssProperties);
+                CssRule actual = oActual.get();
+                Assert.assertEquals(expected, actual);
             }
         }
+    }
+
+    private String createSelector(Metadata metadata, String cssClassName) {
+        if (hasPseudoElement(metadata.getSelector())) {
+            return addCssClassNameToSelectorWithPseudoElement(
+                    metadata.getSelector(), cssClassName);
+        } else {
+            return String.format("%s.%s", metadata.getSelector(), cssClassName);
+        }
+    }
+
+    private String addCssClassNameToSelectorWithPseudoElement(String selector,
+            String cssClassName) {
+        return selector.replaceFirst("(.+)::(.+)",
+                String.format("$1.%s::$2", cssClassName));
+    }
+
+    private boolean hasPseudoElement(String selector) {
+        return selector.matches(".+::.+");
+    }
+
+    private Optional<CssRule> getCssRuleFromFile(String selector) {
+        ThemeModifier themeModifier = new TestThemeModifier();
+        List<CssRule> cssRules = themeModifier.getCssRules(List.of(selector));
+        if (cssRules.isEmpty()) {
+            return Optional.empty();
+        } else {
+            return Optional.of(cssRules.get(0));
+        }
+    }
+
+    private Optional<String> updateProperty(TestBenchElement container,
+            Property property) {
+        TestBenchElement element = container.$("*")
+                .attribute("data-testid", property.getPropertyName()).first();
+        switch (property.getEditorType()) {
+        case "color": {
+            DevToolsThemeColorPropertyEditorElement colorEditor = element
+                    .wrap(DevToolsThemeColorPropertyEditorElement.class);
+            String value = "rgba(116, 219, 0, 1)";
+            colorEditor.setValue(value);
+            // TODO: we should normalize the value inside CssRule equals
+            // comparison...
+            return Optional.of(value.replaceAll(" ", ""));
+        }
+        case "checkbox": {
+            DevToolsCheckboxPropertyEditorElement checkboxEditor = element
+                    .wrap(DevToolsCheckboxPropertyEditorElement.class);
+            checkboxEditor.setChecked(true);
+            String value = checkboxEditor.getCheckedValue();
+            return Optional.of(value);
+        }
+        case "range": {
+            DevToolsThemeRangePropertyEditorElement rangeEditor = element
+                    .wrap(DevToolsThemeRangePropertyEditorElement.class);
+            String value = "3px";
+            rangeEditor.setValue(value);
+            return Optional.of(value);
+        }
+        }
+        return Optional.empty();
     }
 
     private List<Metadata> extractMetadata(Path metadataFilePath)

--- a/flow-tests/test-theme-editor/src/test/java/com/vaadin/flow/uitest/ui/testbench/DevToolsCheckboxPropertyEditorElement.java
+++ b/flow-tests/test-theme-editor/src/test/java/com/vaadin/flow/uitest/ui/testbench/DevToolsCheckboxPropertyEditorElement.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.testbench;
+
+import java.util.Collections;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+@Element("vaadin-dev-tools-theme-checkbox-property-editor")
+public class DevToolsCheckboxPropertyEditorElement extends TestBenchElement {
+    public void setChecked(boolean checked) {
+        TestBenchElement checkbox = this.$("input").first();
+        checkbox.setProperty("checked", checked);
+        checkbox.dispatchEvent("input",
+                Collections.singletonMap("bubbles", true));
+        checkbox.dispatchEvent("change",
+                Collections.singletonMap("bubbles", true));
+    }
+
+    public String getValue() {
+        TestBenchElement checkbox = this.$("input").first();
+        return checkbox.getPropertyString("value");
+    }
+
+    public String getCheckedValue() {
+        return getPropertyString("propertyMetadata", "checkedValue");
+    }
+}

--- a/flow-tests/test-theme-editor/src/test/java/com/vaadin/flow/uitest/ui/testbench/DevToolsThemeClassNameEditorElement.java
+++ b/flow-tests/test-theme-editor/src/test/java/com/vaadin/flow/uitest/ui/testbench/DevToolsThemeClassNameEditorElement.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+@Element("vaadin-dev-tools-theme-class-name-editor")
+public class DevToolsThemeClassNameEditorElement extends TestBenchElement {
+    public String getValue() {
+        DevToolsThemeTextInputElement textInput = this
+                .$(DevToolsThemeTextInputElement.class).first();
+        return textInput.getValue();
+
+    }
+
+    public void setValue(String value) {
+        DevToolsThemeTextInputElement textInput = this
+                .$(DevToolsThemeTextInputElement.class).first();
+        textInput.setValue(value);
+    }
+}

--- a/flow-tests/test-theme-editor/src/test/java/com/vaadin/flow/uitest/ui/testbench/DevToolsThemeColorPropertyEditorElement.java
+++ b/flow-tests/test-theme-editor/src/test/java/com/vaadin/flow/uitest/ui/testbench/DevToolsThemeColorPropertyEditorElement.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+@Element("vaadin-dev-tools-theme-color-property-editor")
+public class DevToolsThemeColorPropertyEditorElement extends TestBenchElement {
+    public void setValue(String value) {
+        DevToolsThemeTextInputElement textInput = this
+                .$(DevToolsThemeTextInputElement.class).first();
+        textInput.setValue(value);
+    }
+}

--- a/flow-tests/test-theme-editor/src/test/java/com/vaadin/flow/uitest/ui/testbench/DevToolsThemeRangePropertyEditorElement.java
+++ b/flow-tests/test-theme-editor/src/test/java/com/vaadin/flow/uitest/ui/testbench/DevToolsThemeRangePropertyEditorElement.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+@Element("vaadin-dev-tools-theme-range-property-editor")
+public class DevToolsThemeRangePropertyEditorElement extends TestBenchElement {
+    public void setValue(String value) {
+        DevToolsThemeTextInputElement textInput = this
+                .$(DevToolsThemeTextInputElement.class).first();
+        textInput.setValue(value);
+    }
+}

--- a/flow-tests/test-theme-editor/src/test/java/com/vaadin/flow/uitest/ui/testbench/DevToolsThemeTextInputElement.java
+++ b/flow-tests/test-theme-editor/src/test/java/com/vaadin/flow/uitest/ui/testbench/DevToolsThemeTextInputElement.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.testbench;
+
+import java.util.Collections;
+
+import com.vaadin.testbench.HasStringValueProperty;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+@Element("vaadin-dev-tools-theme-text-input")
+public class DevToolsThemeTextInputElement extends TestBenchElement
+        implements HasStringValueProperty {
+    @Override
+    public void setValue(String value) {
+        TestBenchElement input = $("input").first();
+        input.setProperty("value", value);
+        input.dispatchEvent("input", Collections.singletonMap("bubbles", true));
+        input.dispatchEvent("change",
+                Collections.singletonMap("bubbles", true));
+    }
+}

--- a/flow-tests/vaadin-spring-tests/pom.xml
+++ b/flow-tests/vaadin-spring-tests/pom.xml
@@ -340,6 +340,7 @@
             <modules>
                 <module>test-spring-boot-reload-time</module>
                 <module>test-spring-boot-multimodule-reload-time</module>
+                <module>test-plain-spring-boot-reload-time</module>
             </modules>
         </profile>
 

--- a/flow-tests/vaadin-spring-tests/pom.xml
+++ b/flow-tests/vaadin-spring-tests/pom.xml
@@ -171,7 +171,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.4.0</version>
+                    <version>3.4.1</version>
                     <dependencies>
                         <dependency>
                             <groupId>de.skuzzle.enforcer</groupId>

--- a/flow-tests/vaadin-spring-tests/pom.xml
+++ b/flow-tests/vaadin-spring-tests/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <component.version>24.1.8</component.version>
+        <component.version>24.1.9</component.version>
         <nimbus-jose-jwt.version>9.31</nimbus-jose-jwt.version>
     </properties>
 

--- a/flow-tests/vaadin-spring-tests/test-plain-spring-boot-reload-time/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-plain-spring-boot-reload-time/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.vaadin</groupId>
+        <artifactId>vaadin-spring-tests</artifactId>
+        <version>24.2-SNAPSHOT</version>
+    </parent>
+    <artifactId>test-plain-spring-boot-reload-time</artifactId>
+    <name>Testing reload time of a plain Spring boot project</name>
+    <packaging>jar</packaging>
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-test-resources</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-test-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <defaultGoal>spring-boot:run</defaultGoal>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
+                <configuration>
+                    <jvmArguments>-Xdebug
+                        -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5825
+                    </jvmArguments>
+                    <wait>500</wait>
+                    <maxAttempts>240</maxAttempts>
+                    <jmxPort>9009</jmxPort>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>start-server</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>stop-server</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/flow-tests/vaadin-spring-tests/test-plain-spring-boot-reload-time/src/main/java/com/vaadin/flow/spring/test/Application.java
+++ b/flow-tests/vaadin-spring-tests/test-plain-spring-boot-reload-time/src/main/java/com/vaadin/flow/spring/test/Application.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.spring.test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * The entry point of the Spring Boot application.
+ *
+ */
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+    public static void triggerReload() {
+        try {
+            String classFile = Application.class.getName().replace(".", "/")
+                    + ".class";
+            touch(new File("target/classes/" + classFile));
+        } catch (IOException ioException) {
+            throw new UncheckedIOException(ioException);
+        }
+
+    }
+
+    private static void touch(File file) throws IOException {
+        if (!file.exists()) {
+            file.createNewFile();
+        }
+        file.setLastModified(System.currentTimeMillis());
+    }
+}

--- a/flow-tests/vaadin-spring-tests/test-plain-spring-boot-reload-time/src/main/java/com/vaadin/flow/spring/test/HelloWorldController.java
+++ b/flow-tests/vaadin-spring-tests/test-plain-spring-boot-reload-time/src/main/java/com/vaadin/flow/spring/test/HelloWorldController.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.spring.test;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Controller for page.html to measure reload time of Hello world Spring boot
+ * app. page.html uses benchmark.js to do the actual measuring. Page is mapped
+ * to '/' path. POST to '/start' will trigger reload by touching Application
+ * Java file.
+ */
+@Controller
+public class HelloWorldController {
+
+    private final ReadyStatusController readyStatusController;
+
+    public HelloWorldController(ReadyStatusController readyStatusController) {
+        this.readyStatusController = readyStatusController;
+    }
+
+    @GetMapping("/")
+    public String page(Model model) {
+        return "page";
+    }
+
+    /**
+     * Triggers reload by touching Application Java file. As browser is not
+     * reloading itself, this method marks {@link ReadyStatusController} ready
+     * state to false. Client starts polling '/isready' until bean is reloaded
+     * and returns true and then client reloads itself.
+     */
+    @PostMapping("/start")
+    @ResponseStatus(HttpStatus.OK)
+    public void start() {
+        readyStatusController.setReady(false);
+        Application.triggerReload();
+    }
+
+}

--- a/flow-tests/vaadin-spring-tests/test-plain-spring-boot-reload-time/src/main/java/com/vaadin/flow/spring/test/ReadyStatusController.java
+++ b/flow-tests/vaadin-spring-tests/test-plain-spring-boot-reload-time/src/main/java/com/vaadin/flow/spring/test/ReadyStatusController.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.spring.test;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ReadyStatusController {
+
+    private boolean ready = true;
+
+    public ReadyStatusController() {
+        System.out.println("ReadyStatusController created.");
+    }
+
+    public void setReady(boolean ready) {
+        this.ready = ready;
+        System.out.println("ReadyStatusController.setReady(" + ready + ")");
+    }
+
+    @GetMapping("/isready")
+    public String isReady() {
+        if (ready) {
+            System.out.println("ReadyStatusController.isReady() returns "
+                    + String.valueOf(ready));
+        }
+        return String.valueOf(ready);
+    }
+}

--- a/flow-tests/vaadin-spring-tests/test-plain-spring-boot-reload-time/src/main/java/com/vaadin/flow/spring/test/SpringDevToolsReloadUtils.java
+++ b/flow-tests/vaadin-spring-tests/test-plain-spring-boot-reload-time/src/main/java/com/vaadin/flow/spring/test/SpringDevToolsReloadUtils.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.spring.test;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class SpringDevToolsReloadUtils {
+
+    public static String runAndCalculateAverageResult(
+            int numberOfTimesToRunTest, Supplier<String> test) {
+        var allResults = new ArrayList<BigDecimal>();
+        IntStream.range(0, numberOfTimesToRunTest).forEach(index -> allResults
+                .add(BigDecimal.valueOf(Double.parseDouble(test.get()))));
+        System.out.printf("Test run %s times. All results: [%s]%n",
+                numberOfTimesToRunTest,
+                allResults.stream().map(BigDecimal::toString)
+                        .collect(Collectors.joining(",")));
+
+        var result = allResults.stream().reduce(BigDecimal::add)
+                .orElse(BigDecimal.ZERO)
+                .divide(BigDecimal.valueOf(allResults.size()),
+                        RoundingMode.UNNECESSARY);
+
+        return result.toString();
+    }
+}

--- a/flow-tests/vaadin-spring-tests/test-plain-spring-boot-reload-time/src/main/resources/application.properties
+++ b/flow-tests/vaadin-spring-tests/test-plain-spring-boot-reload-time/src/main/resources/application.properties
@@ -1,0 +1,9 @@
+server.servlet.context-path=/
+server.port=8888
+spring.devtools.restart.poll-interval=100ms
+spring.devtools.restart.quiet-period=50ms
+
+spring.thymeleaf.cache=false
+spring.thymeleaf.enabled=true
+spring.thymeleaf.prefix=classpath:/templates/
+spring.thymeleaf.suffix=.html

--- a/flow-tests/vaadin-spring-tests/test-plain-spring-boot-reload-time/src/main/resources/static/benchmark.js
+++ b/flow-tests/vaadin-spring-tests/test-plain-spring-boot-reload-time/src/main/resources/static/benchmark.js
@@ -1,0 +1,65 @@
+const style = document.createElement("style");
+style.textContent = "@keyframes element-rendered { } button { animation: element-rendered; }";
+document.head.appendChild(style);
+window.layout = window.layout || {};
+
+function reportResult(component, result) {
+    console.log('Result debug: ' + component + ' time: ' + result);
+    component.dispatchEvent(new CustomEvent("componentready", { "detail": { "result": result } }));
+}
+
+window.benchmark = {};
+window.benchmark.start = 0;
+
+window.benchmark.whenRendered = (component) => {
+  return new Promise((resolve) => {
+    let readyTimer;
+    const listener = () => {
+      const endTime = Date.now();
+      readyTimer && clearTimeout(readyTimer);
+      readyTimer = setTimeout(() => {
+        const thisReadyTimer = readyTimer;
+        requestIdleCallback(() => {
+          if (thisReadyTimer === readyTimer) {
+            component.removeEventListener("animationstart", listener);
+            resolve({
+                "component": component,
+                "endTime": endTime
+                });
+          }
+        });
+        // The timeout needs to be large enough so everything gets rendered
+        // but small enough so the tests won't take forever. This resolves with
+        // the timestamp of the listener's last invocation.
+        // Timeout is not added to the resulted timestamp.
+      }, 1000);
+    };
+
+    component.addEventListener("animationstart", listener);
+  });
+};
+
+/**
+* Mark benchmark started by resetting start timer.
+*/
+window.benchmark.start = () => {
+    localStorage.setItem("benchmark.start", Date.now());
+}
+
+/**
+ * Marks the end timestamp when the component is fully rendered and reports the
+ * test result if benchmark is started.
+ */
+window.benchmark.measureRender = (component) => {
+  if(!localStorage.getItem("benchmark.start")
+        || Number.isNaN(parseFloat(localStorage.getItem("benchmark.start")))) {
+    return;
+  }
+  window.benchmark
+    .whenRendered(component)
+    .then((result) => {
+            let start = parseFloat(localStorage.getItem("benchmark.start"));
+            reportResult(result.component, result.endTime - start);
+            localStorage.removeItem("benchmark.start");
+    });
+};

--- a/flow-tests/vaadin-spring-tests/test-plain-spring-boot-reload-time/src/main/resources/templates/page.html
+++ b/flow-tests/vaadin-spring-tests/test-plain-spring-boot-reload-time/src/main/resources/templates/page.html
@@ -1,0 +1,74 @@
+<html xmlns:th="http://www.w3.org/1999/xhtml" lang="en">
+
+<head>
+    <title>Page</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+
+</head>
+<body>
+    Greetings from Spring Boot!
+    <br/>
+    <br/>
+    <button id="start-button" onclick="onStart()">Click to Start</button>
+    <br/>
+    <span id="result"></span>
+    <br/>
+    <br/>
+    <span id="log"></span>
+    <br/>
+    <span id="error" style="color:red;"></span>
+
+    <script src="/benchmark.js"></script>
+    <script>
+        function onStart() {
+            document.getElementById("result").hidden = true;
+            console.log('Benchmark started.');
+            window.benchmark.start();
+
+            fetch("/start", {
+            method: "POST"
+            })
+            .then((resp) => {
+                document.getElementById("log").textContent = "Waiting page reload...";
+                let waituntilReady;
+                waituntilReady = () => {
+                    setTimeout(() => {
+                        let error = false;
+                        fetch("/isready", { method: "GET" })
+                        .then(response => {
+                            error = !response.ok;
+                            return response.text();
+                        })
+                        .then((text) => {
+                            if(text === "true") {
+                                document.getElementById("log").textContent = "Reload page now.";
+                                window.location.reload();
+                            } else if(text === "false") {
+                                document.getElementById("log").textContent += ".";
+                                waituntilReady();
+                            } else {
+                                document.getElementById("log").textContent += ".";
+                                document.getElementById("error").innerHTML += (error ? "Error: " : "Body: ") + `${text}<br/>`;
+                                waituntilReady();
+                            }
+                        })
+                        .catch((error) => {
+                            document.getElementById("log").textContent += ".";
+                            document.getElementById("error").innerHTML += `Exception: ${error.message}<br/>`;
+                            waituntilReady();
+                        });
+                    }, 40);
+                };
+                waituntilReady();
+            });
+        }
+
+        document.getElementById("start-button").addEventListener("componentready", event => {
+            console.log("componentready: " + event.detail.result);
+            document.getElementById("result").textContent = "Reload time by class change was [" + event.detail.result + "] ms";
+            document.getElementById("result").hidden = false;
+        });
+        window.benchmark.measureRender(document.getElementById("start-button"));
+    </script>
+</body>
+</html>

--- a/flow-tests/vaadin-spring-tests/test-plain-spring-boot-reload-time/src/test/java/org/vaadin/example/SpringDevToolsReloadViewIT.java
+++ b/flow-tests/vaadin-spring-tests/test-plain-spring-boot-reload-time/src/test/java/org/vaadin/example/SpringDevToolsReloadViewIT.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.vaadin.example;
+
+import com.vaadin.flow.server.Version;
+import com.vaadin.flow.spring.test.SpringDevToolsReloadUtils;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+/**
+ * Class for testing reload time of tiny Spring app triggered by spring-boot Dev
+ * Tool.
+ */
+public class SpringDevToolsReloadViewIT extends ChromeBrowserTest {
+
+    @Test
+    public void testPlainSpringBootReloadTime_withHelloWorld() {
+        String result = SpringDevToolsReloadUtils
+                .runAndCalculateAverageResult(5, () -> {
+                    open("/");
+
+                    waitUntil(ExpectedConditions.presenceOfElementLocated(
+                            By.id("start-button")), 10);
+                    triggerReload();
+                    waitUntil(ExpectedConditions
+                            .visibilityOfElementLocated(By.id("result")), 10);
+
+                    return assertAndGetReloadTimeResult();
+                });
+
+        System.out.printf(
+                "##teamcity[buildStatisticValue key='%s,plain-spring-hello-world,spring-boot-devtools-reload-time' value='%s']%n",
+                getVaadinMajorMinorVersion(), result);
+    }
+
+    private void triggerReload() {
+        findElement(By.id("start-button")).click(); // trigger for reload
+    }
+
+    private void open(String testPath) {
+        getDriver().get(getTestURL(getRootURL(), testPath, null));
+    }
+
+    private String assertAndGetReloadTimeResult() {
+        String reloadTimeInMsText = findElement(By.id("result")).getText();
+        Assert.assertNotNull(reloadTimeInMsText);
+
+        return reloadTimeInMsText.substring(reloadTimeInMsText.indexOf("[") + 1,
+                reloadTimeInMsText.indexOf("]"));
+    }
+
+    private String getVaadinMajorMinorVersion() {
+        return Version.getMajorVersion() + "." + Version.getMinorVersion();
+    }
+}

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/README.MD
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/README.MD
@@ -34,6 +34,11 @@ in `frontend/generated-js` folder. Javascript in the file defines a simple
 web-component with
 Lit. Web component is added to the DOM of the route. Default is 0.
 
+`vaadin.test.codegen.maven.plugin.include.addons`: When 'true', generates '
+addons' route that
+uses various Vaadin addons in its constructor. Only use together
+with `benchmark-directory-addons` Maven profile.
+
 ### Other properties for the integration test
 
 `route.hierarchy.enabled`: When 'true', adds a route with hierarchical

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/java/com/vaadin/flow/spring/test/CodeGeneratorMojo.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/java/com/vaadin/flow/spring/test/CodeGeneratorMojo.java
@@ -40,6 +40,7 @@ import org.apache.maven.project.MavenProject;
 public class CodeGeneratorMojo extends AbstractMojo {
 
     public static final String ROUTE_JAVA_TEMPLATE = "route-java.mustache";
+    public static final String ADDONS_ROUTE_JAVA_TEMPLATE = "addons-route-java.mustache";
     public static final String SERVICE_JAVA_TEMPLATE = "service-java.mustache";
     public static final String CSS_IMPORT_TEMPLATE = "css-import.mustache";
     public static final String JS_MODULE_TEMPLATE = "js-module.mustache";
@@ -67,6 +68,9 @@ public class CodeGeneratorMojo extends AbstractMojo {
 
     @Parameter(name = "numberOfGeneratedJsModulesPerRoute", property = "vaadin.test.codegen.maven.plugin.jsmodules.per.route", defaultValue = "0")
     private int numberOfGeneratedJsModulesPerRoute;
+
+    @Parameter(name = "includeAddons", property = "vaadin.test.codegen.maven.plugin.include.addons", defaultValue = "false")
+    private boolean includeAddons;
 
     /**
      * Skip the execution.
@@ -122,10 +126,15 @@ public class CodeGeneratorMojo extends AbstractMojo {
             cssImportsGeneratedTotal += context.getCssImports().size();
             jsModulesGeneratedTotal += context.getJsModules().size();
         }
+        if (includeAddons) {
+            generateAddonsRoute();
+        }
+
         getLog().info(String.format(
-                "Generated %s route(s) / %s Spring service(s) / %s CssImport(s) / %s JsModule(s) in total.",
+                "Generated %s route(s) / %s Spring service(s) / %s CssImport(s) / %s JsModule(s) in total.%s",
                 numberOfRoutes, servicesGeneratedTotal,
-                cssImportsGeneratedTotal, jsModulesGeneratedTotal));
+                cssImportsGeneratedTotal, jsModulesGeneratedTotal,
+                (includeAddons) ? " Generated 'addons' route." : ""));
         if (numberOfRoutes > 0 && (cssImportsGeneratedTotal > 0
                 || jsModulesGeneratedTotal > 0)) {
             getLog().info("Frontend files generated in "
@@ -183,6 +192,15 @@ public class CodeGeneratorMojo extends AbstractMojo {
         generateJavaFileByMustacheTemplate(context, ROUTE_JAVA_TEMPLATE);
 
         return context;
+    }
+
+    private void generateAddonsRoute() throws IOException {
+
+        JavaRouteContext context = new JavaRouteContext();
+        context.setPackages(apiPackage);
+        context.setClassName("AddonsRoute");
+
+        generateJavaFileByMustacheTemplate(context, ADDONS_ROUTE_JAVA_TEMPLATE);
     }
 
     private JavaSpringServiceContext generateSpringComponent(

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/resources/addons-route-java.mustache
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator/src/main/resources/addons-route-java.mustache
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package {{packages}};
+
+import com.vaadin.componentfactory.addons.inputmask.InputMask;
+import com.vaadin.componentfactory.Autocomplete;
+import com.vaadin.componentfactory.IdleNotification;
+import com.vaadin.componentfactory.lookupfield.LookupField;
+import com.vaadin.componentfactory.ToggleButton;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.flow.router.Route;
+import java.util.List;
+
+@Route("addons")
+public class AddonsRoute extends VerticalLayout {
+
+    public AddonsRoute() {
+        add(new Autocomplete(5));
+
+        var lookupField = new LookupField<String>();
+        lookupField.setDataProvider(DataProvider.ofCollection(List.of()));
+        add(lookupField);
+
+        add(new IdleNotification());
+
+        TextField phoneField = new TextField("Phone");
+        new InputMask("(000) 000-0000").extend(phoneField);
+        add(phoneField);
+
+        add(new ToggleButton());
+    }
+}

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/pom.xml
@@ -79,7 +79,78 @@
             </artifactId>
             <version>${project.version}</version>
         </dependency>
+
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>benchmark-directory-addons</id>
+<!--            Profile is meant only for measuring reload time of application with -->
+<!--            multiple dependencies to add-ons for Vaadin 24.   -->
+            <dependencies>
+                <dependency>
+                    <groupId>com.vaadin</groupId>
+                    <artifactId>vaadin-core</artifactId>
+                    <version>${component.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.vaadin.addons.componentfactory</groupId>
+                    <artifactId>vcf-input-mask</artifactId>
+                    <version>2.0.0</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>com.vaadin</groupId>
+                            <artifactId>vaadin-core</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.vaadin.componentfactory</groupId>
+                    <artifactId>idle-notification</artifactId>
+                    <version>2.0.1</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>com.vaadin</groupId>
+                            <artifactId>vaadin-core</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.vaadin.componentfactory</groupId>
+                    <artifactId>autocomplete</artifactId>
+                    <version>24.1.5</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>com.vaadin</groupId>
+                            <artifactId>vaadin-core</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.vaadin.componentfactory</groupId>
+                    <artifactId>lookup-field-flow</artifactId>
+                    <version>24.0.2</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>com.vaadin</groupId>
+                            <artifactId>vaadin-core</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.vaadin.componentfactory</groupId>
+                    <artifactId>togglebutton</artifactId>
+                    <version>3.0.0</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>com.vaadin</groupId>
+                            <artifactId>vaadin-core</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
     <build>
         <defaultGoal>spring-boot:run</defaultGoal>

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/main/resources/application.properties
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/main/resources/application.properties
@@ -1,7 +1,8 @@
 server.servlet.context-path=/
 server.port=8888
 vaadin.frontend.hotdeploy=true
-
+spring.devtools.restart.poll-interval=100ms
+spring.devtools.restart.quiet-period=50ms
 
 # To improve the performance during development. 
 # For more information https://vaadin.com/docs/flow/spring/tutorial-spring-configuration.html#special-configuration-parameters

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/test/java/org/vaadin/example/SpringDevToolsReloadViewIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/test/java/org/vaadin/example/SpringDevToolsReloadViewIT.java
@@ -55,9 +55,10 @@ public class SpringDevToolsReloadViewIT extends ChromeBrowserTest {
 
     private void printTestResultToLog(String result) {
         System.out.printf(
-                "##teamcity[buildStatisticValue key='%s,app,%s-routes,%s-services-per-route,spring-boot-devtools-reload-time' value='%s']%n",
+                "##teamcity[buildStatisticValue key='%s,app%s%s,%s-routes,%s-services-per-route%s%s,spring-boot-devtools-reload-time' value='%s']%n",
                 getVaadinMajorMinorVersion(),
                 (hasRouteHierarchy() ? ",route-hierarchy-enabled" : ""),
+                (hasIncludeAddons() ? ",include-addons" : ""),
                 getNumberOfGeneratedRoutesProperty(),
                 getNumberOfGeneratedServicesPerRouteProperty(),
                 (hasCssImports()
@@ -125,5 +126,10 @@ public class SpringDevToolsReloadViewIT extends ChromeBrowserTest {
     private boolean hasRouteHierarchy() {
         return "true".equalsIgnoreCase(
                 System.getProperty("route.hierarchy.enabled", "false"));
+    }
+
+    private boolean hasIncludeAddons() {
+        return "true".equalsIgnoreCase(System.getProperty(
+                "vaadin.test.codegen.maven.plugin.include.addons", "false"));
     }
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-reload-time/src/main/resources/application.properties
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-reload-time/src/main/resources/application.properties
@@ -1,7 +1,8 @@
 server.servlet.context-path=/
 server.port=8888
 vaadin.frontend.hotdeploy=true
-
+spring.devtools.restart.poll-interval=100ms
+spring.devtools.restart.quiet-period=50ms
 
 # To improve the performance during development. 
 # For more information https://vaadin.com/docs/flow/spring/tutorial-spring-configuration.html#special-configuration-parameters

--- a/flow-tests/vaadin-spring-tests/test-spring/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring/pom.xml
@@ -135,7 +135,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.4.1</version>
                 <executions>
                     <execution>
                         <id>enforce-banned-dependencies</id>

--- a/pom.xml
+++ b/pom.xml
@@ -366,7 +366,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.4.1</version>
             </plugin>
 
             <plugin>
@@ -466,7 +466,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.4.0</version>
+                    <version>3.4.1</version>
                     <dependencies>
                         <dependency>
                             <groupId>de.skuzzle.enforcer</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-parent</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0</version>
     </parent>
 
     <modules>

--- a/scripts/computeMatrix.js
+++ b/scripts/computeMatrix.js
@@ -8,6 +8,7 @@ const globalExclusions = [
   'flow-tests/test-multi-war/test-war1',
   'flow-tests/test-multi-war/test-war2',
   'flow-tests/test-webpush',
+  'flow-tests/vaadin-spring-tests/test-plain-spring-boot-reload-time',
   'flow-tests/vaadin-spring-tests/test-spring-boot-reload-time',
   'flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time',
   'flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/generator',

--- a/vaadin-spring/pom.xml
+++ b/vaadin-spring/pom.xml
@@ -103,6 +103,11 @@
             <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/ReloadCache.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/ReloadCache.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.spring;
 
+import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -22,7 +23,7 @@ import java.util.Set;
  * A class for holding development-time cached data. Static fields survive a
  * Spring Boot DevTools reload, so the cached data can be used after reload.
  */
-class ReloadCache {
+class ReloadCache implements Serializable {
     static Set<Class<?>> appShellClasses;
     static Set<Class<?>> lookupClasses;
     static Set<String> validResources = new HashSet<>();

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/ReloadCache.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/ReloadCache.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.spring;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A class for holding development-time cached data. Static fields survive a
+ * Spring Boot DevTools reload, so the cached data can be used after reload.
+ */
+class ReloadCache {
+    static Set<Class<?>> appShellClasses;
+    static Set<Class<?>> lookupClasses;
+    static Set<String> validResources = new HashSet<>();
+    static Set<String> skippedResources = new HashSet<>();
+    static Set<String> dynamicWhiteList;
+    static Set<String> routePackages;
+}

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/ReloadEvent.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/ReloadEvent.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.spring;
 
+import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -22,7 +23,7 @@ import java.util.Set;
  * This event is fired by {@link ReloadListener} when Spring Boot DevTools is
  * about to trigger a reload.
  */
-public class ReloadEvent {
+class ReloadEvent implements Serializable {
 
     private final Set<String> addedClasses = new HashSet<>();
     private final Set<String> changedClasses = new HashSet<>();

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/ReloadEvent.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/ReloadEvent.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.spring;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * This event is fired by {@link ReloadListener} when Spring Boot DevTools is
+ * about to trigger a reload.
+ */
+public class ReloadEvent {
+
+    private final Set<String> addedClasses = new HashSet<>();
+    private final Set<String> changedClasses = new HashSet<>();
+    private final Set<String> removedClasses = new HashSet<>();
+
+    public Set<String> getAddedClasses() {
+        return addedClasses;
+    }
+
+    public Set<String> getChangedClasses() {
+        return changedClasses;
+    }
+
+    public Set<String> getRemovedClasses() {
+        return removedClasses;
+    }
+}

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/ReloadListener.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/ReloadListener.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.spring;
 
+import java.io.Serializable;
+
 import org.springframework.boot.devtools.classpath.ClassPathChangedEvent;
 import org.springframework.context.ApplicationListener;
 
@@ -24,8 +26,8 @@ import com.vaadin.flow.function.SerializableConsumer;
  * Listens to {@link ClassPathChangedEvent} events and fires a Vaadin- specific
  * {@link ReloadEvent}.
  */
-public class ReloadListener
-        implements ApplicationListener<ClassPathChangedEvent> {
+class ReloadListener
+        implements ApplicationListener<ClassPathChangedEvent>, Serializable {
 
     private final SerializableConsumer<ReloadEvent> callback;
 

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/ReloadListener.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/ReloadListener.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.spring;
+
+import org.springframework.boot.devtools.classpath.ClassPathChangedEvent;
+import org.springframework.context.ApplicationListener;
+
+import com.vaadin.flow.function.SerializableConsumer;
+
+/**
+ * Listens to {@link ClassPathChangedEvent} events and fires a Vaadin- specific
+ * {@link ReloadEvent}.
+ */
+public class ReloadListener
+        implements ApplicationListener<ClassPathChangedEvent> {
+
+    private final SerializableConsumer<ReloadEvent> callback;
+
+    public ReloadListener(SerializableConsumer<ReloadEvent> callback) {
+        this.callback = callback;
+    }
+
+    @Override
+    public void onApplicationEvent(ClassPathChangedEvent event) {
+        ReloadEvent reloadEvent = new ReloadEvent();
+
+        event.getChangeSet().forEach(changedFiles -> {
+            changedFiles.getFiles().forEach(file -> {
+                String className = convertToClassName(file.getRelativeName());
+                if (className != null) {
+                    switch (file.getType()) {
+                    case ADD:
+                        reloadEvent.getAddedClasses().add(className);
+                        break;
+                    case DELETE:
+                        reloadEvent.getRemovedClasses().add(className);
+                        break;
+                    case MODIFY:
+                        reloadEvent.getChangedClasses().add(className);
+                        break;
+                    }
+                }
+            });
+        });
+        callback.accept(reloadEvent);
+    }
+
+    private String convertToClassName(String fileName) {
+        if (fileName.endsWith(".class")) {
+            return fileName.replace(".class", "").replace("/", ".");
+        } else {
+            return null;
+        }
+    }
+}

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinConfigurationProperties.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinConfigurationProperties.java
@@ -111,6 +111,12 @@ public class VaadinConfigurationProperties {
      */
     private List<String> excludeUrls;
 
+    /**
+     * Enables class scan caching between reloads when using Spring Boot
+     * DevTools.
+     */
+    private boolean devmodeCaching = true;
+
     public static class Frontend {
         /**
          * Whether a frontend development server (Vite) is used in development
@@ -254,6 +260,29 @@ public class VaadinConfigurationProperties {
      */
     public void setLaunchBrowser(boolean launchBrowser) {
         this.launchBrowser = launchBrowser;
+    }
+
+    /**
+     * Returns whether class scan caching between reloads when using Spring Boot
+     * DevTools should be enabled.
+     * <p>
+     *
+     * @return if class scan caching should be enabled
+     */
+    public boolean isDevmodeCaching() {
+        return launchBrowser;
+    }
+
+    /**
+     * Sets whether class scan caching between reloads when using Spring Boot
+     * DevTools should be enabled.
+     *
+     * @param devmodeCaching
+     *            {@code true} to enable class scan caching when in development
+     *            mode, {@code false} otherwise
+     */
+    public void setDevmodeCaching(boolean devmodeCaching) {
+        this.devmodeCaching = devmodeCaching;
     }
 
     /**

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -477,10 +477,6 @@ public class VaadinServletContextInitializer
                 throw new RuntimeException(
                         "Unable to initialize Vaadin DevModeHandler", e);
             }
-            // to make sure the user knows the application is ready, show
-            // notification to the user
-            ServletDeployer.logAppStartupToConsole(event.getServletContext(),
-                    true);
 
             // Make live reload port available for index.html handler
             event.getServletContext().setAttribute(

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/VaadinServletContextInitializerTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/VaadinServletContextInitializerTest.java
@@ -258,12 +258,6 @@ public class VaadinServletContextInitializerTest {
         }).when(servletContext)
                 .addListener(Mockito.any(ServletContextListener.class));
 
-        servletDeployerMock.when(() -> ServletDeployer
-                .logAppStartupToConsole(Mockito.any(), Mockito.anyBoolean()))
-                .then(answer -> {
-                    return null;
-                });
-
         return vaadinServletContextInitializerMock;
     }
 


### PR DESCRIPTION
Adds some cached data for use in case of Spring Boot DevTools reload.

- CustomResourceLoader: added a few packages to default never-scan list
- DevModeServletContextListener: Dynamically generates a white list for dev mode package scanner
- RouteServletContextListener: Dynamically generates a white list for route package scanner
- LookupInitializerListener: Cache found classes
- VaadinAppShellContextListener: Cache found classes
- CustomResourceLoader: Cache valid/skipped status of resources for later use
