### PR TITLE
fix: Not sort chunk lines in place

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -262,7 +262,6 @@ abstract class AbstractUpdateImports implements Runnable {
                     continue;
                 }
 
-                Collections.sort(chunkLines);
                 String chunkContentHash = BundleUtils.getChunkHash(chunkLines);
 
                 String chunkFilename = "chunk-" + chunkContentHash + ".js";

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleUtils.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -127,8 +128,9 @@ public final class BundleUtils {
      * @return chunk's hash
      */
     public static String getChunkHash(List<String> chunkLines) {
-        Collections.sort(chunkLines);
-        return StringUtil.getHash(String.join(";", chunkLines),
+        List<String> sortedChunkLines = new ArrayList<>(chunkLines);
+        Collections.sort(sortedChunkLines);
+        return StringUtil.getHash(String.join(";", sortedChunkLines),
                 StandardCharsets.UTF_8);
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/UpdateImportsWithByteCodeScannerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/UpdateImportsWithByteCodeScannerTest.java
@@ -313,11 +313,18 @@ public class UpdateImportsWithByteCodeScannerTest
         Optional<File> chunkFile = findOptionalChunkFile(output);
         Assert.assertTrue(chunkFile.isPresent());
 
-        assertOnce("import { injectGlobalCss } from",
-                output.get(chunkFile.get()));
-        assertOnce("from 'Frontend/foo.css?inline';",
-                output.get(chunkFile.get()));
-        assertOnce("import $cssFromFile_0 from", output.get(chunkFile.get()));
+        List<String> chunkLines = output.get(chunkFile.get());
+        assertOnce("import { injectGlobalCss } from", chunkLines);
+        assertOnce("from 'Frontend/foo.css?inline';", chunkLines);
+        assertOnce("import $cssFromFile_0 from", chunkLines);
+
+        // assert lines order is preserved
+        Assert.assertEquals(
+                "import { injectGlobalCss } from 'Frontend/generated/jar-resources/theme-util.js';\n",
+                chunkLines.get(0));
+        Assert.assertEquals(
+                "import { css, unsafeCSS, registerStyles } from '@vaadin/vaadin-themable-mixin';",
+                chunkLines.get(1));
     }
 
     private static Optional<File> findOptionalChunkFile(


### PR DESCRIPTION
Chunk JavaScript lines shouldn't be sorted in place.
Sorting is only needed for repeatable hash calculations.

Fixes https://github.com/vaadin/flow/issues/17573