### PR TITLE
perf: optimize SpringLookup lookup time by caching

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/RouteUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/RouteUtil.java
@@ -284,11 +284,7 @@ public class RouteUtil {
         RoutePathProvider provider = null;
         Lookup lookup = context.getAttribute(Lookup.class);
         if (lookup != null) {
-            provider = context.getAttribute(RoutePathProvider.class);
-            if (provider == null) {
-                provider = lookup.lookup(RoutePathProvider.class);
-                context.setAttribute(RoutePathProvider.class, provider);
-            }
+            provider = lookup.lookup(RoutePathProvider.class);
             assert provider != null;
         }
         if (provider == null) {

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/RouteUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/RouteUtil.java
@@ -284,7 +284,11 @@ public class RouteUtil {
         RoutePathProvider provider = null;
         Lookup lookup = context.getAttribute(Lookup.class);
         if (lookup != null) {
-            provider = lookup.lookup(RoutePathProvider.class);
+            provider = context.getAttribute(RoutePathProvider.class);
+            if (provider == null) {
+                provider = lookup.lookup(RoutePathProvider.class);
+                context.setAttribute(RoutePathProvider.class, provider);
+            }
             assert provider != null;
         }
         if (provider == null) {


### PR DESCRIPTION
Cache `RoutePathProvider` in `SpringLookup` for faster lookup time especially for `RouteUtil#resolve` method, but also for all default (and subclasses of default) implementations of services defined in `LookupInitializer.getDefaultImplementations()`.