### PR TITLE
test: adjust spring.devtools.restart properties for reload time tests

### DIFF
--- a/flow-tests/vaadin-spring-tests/test-plain-spring-boot-reload-time/src/main/resources/application.properties
+++ b/flow-tests/vaadin-spring-tests/test-plain-spring-boot-reload-time/src/main/resources/application.properties
@@ -1,5 +1,7 @@
 server.servlet.context-path=/
 server.port=8888
+spring.devtools.restart.poll-interval=100ms
+spring.devtools.restart.quiet-period=50ms
 
 spring.thymeleaf.cache=false
 spring.thymeleaf.enabled=true

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/main/resources/application.properties
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/main/resources/application.properties
@@ -1,7 +1,8 @@
 server.servlet.context-path=/
 server.port=8888
 vaadin.frontend.hotdeploy=true
-
+spring.devtools.restart.poll-interval=100ms
+spring.devtools.restart.quiet-period=50ms
 
 # To improve the performance during development. 
 # For more information https://vaadin.com/docs/flow/spring/tutorial-spring-configuration.html#special-configuration-parameters

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-reload-time/src/main/resources/application.properties
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-reload-time/src/main/resources/application.properties
@@ -1,7 +1,8 @@
 server.servlet.context-path=/
 server.port=8888
 vaadin.frontend.hotdeploy=true
-
+spring.devtools.restart.poll-interval=100ms
+spring.devtools.restart.quiet-period=50ms
 
 # To improve the performance during development. 
 # For more information https://vaadin.com/docs/flow/spring/tutorial-spring-configuration.html#special-configuration-parameters


### PR DESCRIPTION
Reduced `spring.devtools.restart.poll-interval` to 100ms and `spring.devtools.restart.quiet-period` to 50ms to reduce time it takes for `FileSystemWatcher` to react to file touch in tests. This stabilizes reload time measuring results and makes reloading faster in general.
