### PR TITLE
fix: set kotlin language version

### DIFF
--- a/flow-plugins/flow-gradle-plugin/build.gradle
+++ b/flow-plugins/flow-gradle-plugin/build.gradle
@@ -196,6 +196,9 @@ functionalTest {
 }
 
 kotlin {
+    jvmToolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
     explicitApi()
 }
 


### PR DESCRIPTION
Set the kotlin language version
to be the same as java.

Fixes #17574
