### PR TITLE
chore: update atmosphere version

### DIFF
--- a/flow-server/bnd.bnd
+++ b/flow-server/bnd.bnd
@@ -3,6 +3,6 @@ Bundle-Name: Vaadin Flow Server
 Bundle-Version: ${osgi.bundle.version}
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-License: https://vaadin.com/commercial-license-and-service-terms
-Import-Package: org.atmosphere*;resolution:=optional;version='${atmosphere.runtime.version}',\
+Import-Package: org.atmosphere*;resolution:=optional;bundle-version='${atmosphere.runtime.version}',\
     org.apache.http*;resolution:=optional;,*
 Export-Package: !com.vaadin.flow.push*, com.vaadin.flow*;-noimport:=true

--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -21,7 +21,7 @@ import java.io.Serializable;
 public final class Constants implements Serializable {
 
     // Keep the version number in sync with flow-push/pom.xml
-    public static final String REQUIRED_ATMOSPHERE_RUNTIME_VERSION = "2.4.30.slf4jvaadin2";
+    public static final String REQUIRED_ATMOSPHERE_RUNTIME_VERSION = "2.7.3.slf4jvaadin5";
 
     /**
      * The prefix used for System property parameters.

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <!-- Used in OSGi manifests -->
         <jsoup.version>1.15.3</jsoup.version>
         <!-- Note that this should be kept in sync with the class Constants -->
-        <atmosphere.runtime.version>2.4.30.slf4jvaadin2</atmosphere.runtime.version>
+        <atmosphere.runtime.version>2.7.3.slf4jvaadin5</atmosphere.runtime.version>
 
         <!-- OSGi -->
         <!-- Note: the parserVersion value is set by build-helper-maven-plugin -->


### PR DESCRIPTION
The modified atmosphere-runtime:2.7.3.slf4jvaadin5 exports packages with version 2.7.3 (i.e., not 2.7.3.slf4jvaadin5).
Depend on bundle version instead of the package version.
