### PR TITLE
fix: Allow dev tools window to grow

### DIFF
--- a/vaadin-dev-server/frontend/vaadin-dev-tools.ts
+++ b/vaadin-dev-server/frontend/vaadin-dev-tools.ts
@@ -317,9 +317,9 @@ export class VaadinDevTools extends LitElement {
 
         .window {
           border-radius: var(--dev-tools-border-radius);
-          overflow: hidden;
+          overflow: auto;
           margin: 0.5rem;
-          width: 30rem;
+          min-width: 30rem;
           max-width: calc(100% - 1rem);
           max-height: calc(100vh - 1rem);
           flex-shrink: 1;


### PR DESCRIPTION
If there are many tabs, they should be shown. If we still run out of space, allow scrolling
