### PR TITLE
chore: remove not needed deploy.plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,6 @@
         <maven.surefire.plugin.version>3.1.2</maven.surefire.plugin.version>
         <maven.failsafe.plugin.version>3.1.2</maven.failsafe.plugin.version>
         <maven.war.plugin.version>3.4.0</maven.war.plugin.version>
-        <maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
         <maven.resources.plugin.version>3.0.2</maven.resources.plugin.version>
         <maven.clean.plugin.version>3.3.1</maven.clean.plugin.version>
         <maven.exec.plugin.version>1.6.0</maven.exec.plugin.version>


### PR DESCRIPTION
this version of plugin doesn't allow deployAtEnd