### PR TITLE
chore: use pre-compiled regex when possible

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -37,6 +37,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.UnaryOperator;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -89,7 +91,7 @@ abstract class AbstractUpdateImports implements Runnable {
             + "%n" + "registerStyles('%s', $css_%1$d%s);";
 
     private static final String IMPORT_TEMPLATE = "import '%s';";
-
+    private static final Pattern STARTING_DOT_SLASH = Pattern.compile("^\\./+");
     final Options options;
 
     private FrontendDependenciesScanner scanner;
@@ -427,7 +429,8 @@ abstract class AbstractUpdateImports implements Runnable {
 
             // We only should check here those paths starting with './' when all
             // flow components have the './' prefix
-            String resource = resolved.replaceFirst("^\\./+", "");
+            String resource = STARTING_DOT_SLASH.matcher(resolved)
+                    .replaceFirst("");
             if (hasMetaInfResource(resource)) {
                 if (!resolved.startsWith("./")) {
                     getLogger().warn(
@@ -488,6 +491,22 @@ abstract class AbstractUpdateImports implements Runnable {
         Set<String> resourceNotFound = new HashSet<>();
         Set<String> es6ImportPaths = new LinkedHashSet<>();
         AbstractTheme theme = scanner.getTheme();
+
+        UnaryOperator<String> convertToLocalPath;
+        if (theme != null) {
+            // (#5964) Allows:
+            // - custom @Theme with files placed in /frontend
+            // - customize an already themed component
+            // @vaadin/vaadin-grid/theme/lumo/vaadin-grid.js ->
+            // theme/lumo/vaadin-grid.js
+            String themePath = theme.getThemeUrl();
+            Pattern themePattern = Pattern.compile("@.+" + themePath);
+            convertToLocalPath = path -> themePattern.matcher(path)
+                    .replaceFirst(themePath);
+        } else {
+            convertToLocalPath = UnaryOperator.identity();
+        }
+
         Set<String> visited = new HashSet<>();
 
         for (String originalModulePath : modules) {
@@ -496,15 +515,8 @@ abstract class AbstractUpdateImports implements Runnable {
             if (theme != null
                     && translatedModulePath.contains(theme.getBaseUrl())) {
                 translatedModulePath = theme.translateUrl(translatedModulePath);
-                String themePath = theme.getThemeUrl();
-
-                // (#5964) Allows:
-                // - custom @Theme with files placed in /frontend
-                // - customize an already themed component
-                // @vaadin/vaadin-grid/theme/lumo/vaadin-grid.js ->
-                // theme/lumo/vaadin-grid.js
-                localModulePath = translatedModulePath
-                        .replaceFirst("@.+" + themePath, themePath);
+                localModulePath = convertToLocalPath
+                        .apply(translatedModulePath);
             }
 
             if (localModulePath != null
@@ -759,7 +771,8 @@ abstract class AbstractUpdateImports implements Runnable {
                         "Use the './' prefix for files in the '{}' folder: '{}', please update your annotations.",
                         options.getFrontendDirectory(), jsImport);
             }
-            return FRONTEND_FOLDER_ALIAS + jsImport.replaceFirst("^\\./", "");
+            return FRONTEND_FOLDER_ALIAS
+                    + STARTING_DOT_SLASH.matcher(jsImport).replaceFirst("");
         }
         return jsImport;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendClassVisitor.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendClassVisitor.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.server.frontend.scanner;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassVisitor;
@@ -42,6 +43,8 @@ import com.vaadin.flow.theme.Theme;
  */
 final class FrontendClassVisitor extends ClassVisitor {
 
+    private static final Pattern SIGNATURE_PATTERN = Pattern.compile(
+            "(^\\([\\[ZBFDJICL]*|^[\\[ZBFDJICL]+|;?\\)[\\[ZBFDJICLV]*|;[\\[ZBFDJICL]*)");
     private static final String VARIANT = "variant";
     private static final String LAYOUT = "layout";
     static final String VALUE = "value";
@@ -317,8 +320,7 @@ final class FrontendClassVisitor extends ClassVisitor {
         }
         // This regular expression is able to split the signature and remove
         // primitive and other mark symbols, see test for more info.
-        String[] tmp = signature.replace("/", ".").split(
-                "(^\\([\\[ZBFDJICL]*|^[\\[ZBFDJICL]+|;?\\)[\\[ZBFDJICLV]*|;[\\[ZBFDJICL]*)");
+        String[] tmp = SIGNATURE_PATTERN.split(signature.replace("/", "."));
         for (String cls : tmp) {
             if (!cls.isBlank()) {
                 classes.add(cls);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
@@ -233,8 +233,8 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
 
         entryPoint.reachableClasses = collectReachableClasses(entryPoint);
         if (log().isDebugEnabled()) {
-            log().debug("Classes reachable from " + entryPoint.getName() + ": "
-                    + entryPoint.reachableClasses);
+            log().debug("Classes reachable from {}: {}", entryPoint.getName(),
+                    entryPoint.reachableClasses);
         }
 
     }


### PR DESCRIPTION
## Description

This change uses precompiled regex for string replacements and searches, to improve performance when expressions are used inside loops.

Part of #17234

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
