### PR TITLE
test: clean npm stuff before running production module tests

### DIFF
--- a/flow-tests/test-frontend/test-npm/pom-production.xml
+++ b/flow-tests/test-frontend/test-npm/pom-production.xml
@@ -40,6 +40,21 @@
                         <goals>
                             <goal>clean</goal>
                         </goals>
+                        <configuration>
+                            <filesets>
+                                <!--
+                                Clean NPM related files to prevent errors when tests of this module
+                                are executed right after the ones from pom.xml
+                                -->
+                                <fileset>
+                                    <directory>${project.basedir}</directory>
+                                    <includes>
+                                        <include>package-lock.json</include>
+                                        <include>node_modules/**</include>
+                                    </includes>
+                                </fileset>
+                            </filesets>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
If the pom-production.xml module is executed right after the pom.xml module webpack may fail with weird npm errors.
Cleaning node_modules and package-lock.json at early lifecycle phase of the pom-production.xml seems to fix the issue