### PR TITLE
test: fix open url to use correct servlet

### DIFF
--- a/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/AbstractBaseIT.java
+++ b/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/AbstractBaseIT.java
@@ -1,0 +1,14 @@
+package com.vaadin.flow.uitest.ui.theme;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+abstract class AbstractBaseIT extends ChromeBrowserTest {
+
+    @Override
+    protected String getTestPath() {
+        String path = super.getTestPath();
+        String view = "view/";
+        return path.replace(view, "path/");
+    }
+
+}

--- a/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/CssLoadingIT.java
+++ b/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/CssLoadingIT.java
@@ -68,4 +68,12 @@ public class CssLoadingIT extends ChromeBrowserTest {
         Assert.assertEquals(expectedMargin,
                 $(ParagraphElement.class).id(elementId).getCssValue("margin"));
     }
+
+    @Override
+    protected String getTestPath() {
+        String path = super.getTestPath();
+        String view = "view/";
+        return path.replace(view, "path/");
+    }
+
 }

--- a/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/CssLoadingIT.java
+++ b/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/CssLoadingIT.java
@@ -29,7 +29,7 @@ import com.vaadin.flow.testutil.ChromeBrowserTest;
  * The expected priority is: Lumo styles < @CssImport < page.addStylesheet
  * < @Stylehseet < parent theme < current theme (app theme)
  */
-public class CssLoadingIT extends ChromeBrowserTest {
+public class CssLoadingIT extends AbstractBaseIT {
 
     private static final String BLUE_RGBA = "rgba(0, 0, 255, 1)";
     private static final String GREEN_RGBA = "rgba(0, 255, 0, 1)";
@@ -67,13 +67,6 @@ public class CssLoadingIT extends ChromeBrowserTest {
                 .id(elementId).getCssValue("font-size"));
         Assert.assertEquals(expectedMargin,
                 $(ParagraphElement.class).id(elementId).getCssValue("margin"));
-    }
-
-    @Override
-    protected String getTestPath() {
-        String path = super.getTestPath();
-        String view = "view/";
-        return path.replace(view, "path/");
     }
 
 }

--- a/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
+++ b/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
@@ -45,7 +45,7 @@ import static com.vaadin.flow.uitest.ui.theme.ThemeView.OCTOPUSS_ID;
 import static com.vaadin.flow.uitest.ui.theme.ThemeView.SNOWFLAKE_ID;
 import static com.vaadin.flow.uitest.ui.theme.ThemeView.SUB_COMPONENT_ID;
 
-public class ThemeIT extends ChromeBrowserTest {
+public class ThemeIT extends AbstractBaseIT {
 
     @Test
     public void typeScriptCssImport_stylesAreApplied() {
@@ -287,13 +287,6 @@ public class ThemeIT extends ChromeBrowserTest {
                 .contains("https://fonts.googleapis.com/css?family=Itim"));
         Assert.assertFalse("Found import that webpack should have resolved",
                 linkUrls.contains("sub-css/sub.css"));
-    }
-
-    @Override
-    protected String getTestPath() {
-        String path = super.getTestPath();
-        String view = "view/";
-        return path.replace(view, "path/");
     }
 
     private String getCssPseudoElementValue(String elementId,

--- a/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeWebpackIT.java
+++ b/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeWebpackIT.java
@@ -42,7 +42,7 @@ import static com.vaadin.flow.uitest.ui.theme.ThemeView.SNOWFLAKE_ID;
 import static com.vaadin.flow.uitest.ui.theme.ThemeView.SUB_COMPONENT_ID;
 
 @Ignore("Webpack specific test")
-public class ThemeWebpackIT extends ChromeBrowserTest {
+public class ThemeWebpackIT extends AbstractBaseIT {
 
     @Test
     public void typeScriptCssImport_stylesAreApplied() {


### PR DESCRIPTION
The CSS loadin test is using a development mode servlet instead of the production mode.
This change fixes the url provided to the web driver in order to use the expected Vaadin servlet.