### PR TITLE
feat: in theme-editor, add tests for some components and improve the tests.

### DIFF
--- a/flow-tests/test-theme-editor/pom.xml
+++ b/flow-tests/test-theme-editor/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
         <vaadin.devmode.liveReload.enabled>true</vaadin.devmode.liveReload.enabled>
-        <vaadin.components.version>24.1.9</vaadin.components.version>
+        <vaadin.components.version>24.2-SNAPSHOT</vaadin.components.version>
     </properties>
 
     <dependencies>
@@ -53,6 +53,11 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-icons-flow</artifactId>
+            <version>${vaadin.components.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-checkbox-flow</artifactId>
             <version>${vaadin.components.version}</version>
         </dependency>
 

--- a/flow-tests/test-theme-editor/pom.xml
+++ b/flow-tests/test-theme-editor/pom.xml
@@ -15,6 +15,7 @@
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
         <vaadin.devmode.liveReload.enabled>true</vaadin.devmode.liveReload.enabled>
+        <vaadin.components.version>24.1.9</vaadin.components.version>
     </properties>
 
     <dependencies>
@@ -47,8 +48,14 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-button-flow</artifactId>
-            <version>24.1.9</version>
+            <version>${vaadin.components.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-icons-flow</artifactId>
+            <version>${vaadin.components.version}</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/flow-tests/test-theme-editor/src/main/java/com/vaadin/flow/uitest/ui/ThemeEditorView.java
+++ b/flow-tests/test-theme-editor/src/main/java/com/vaadin/flow/uitest/ui/ThemeEditorView.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.uitest.ui;
 
 import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.icon.VaadinIcon;
@@ -27,10 +28,14 @@ public class ThemeEditorView extends Div {
     public ThemeEditorView() {
         Button button = new Button("Click");
         button.setId("button");
-        add(button);
+        add(new Div(button));
 
         Icon icon = VaadinIcon.ABACUS.create();
         icon.setId("icon");
-        add(icon);
+        add(new Div(icon));
+
+        Checkbox checkbox = new Checkbox("The checkbox");
+        checkbox.setId("checkbox");
+        add(new Div(checkbox));
     }
 }

--- a/flow-tests/test-theme-editor/src/main/java/com/vaadin/flow/uitest/ui/ThemeEditorView.java
+++ b/flow-tests/test-theme-editor/src/main/java/com/vaadin/flow/uitest/ui/ThemeEditorView.java
@@ -17,6 +17,8 @@ package com.vaadin.flow.uitest.ui;
 
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.icon.Icon;
+import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 
@@ -26,5 +28,9 @@ public class ThemeEditorView extends Div {
         Button button = new Button("Click");
         button.setId("button");
         add(button);
+
+        Icon icon = VaadinIcon.ABACUS.create();
+        icon.setId("icon");
+        add(icon);
     }
 }

--- a/flow-tests/test-theme-editor/src/test/java/com/vaadin/flow/uitest/ui/AbstractThemeEditorIT.java
+++ b/flow-tests/test-theme-editor/src/test/java/com/vaadin/flow/uitest/ui/AbstractThemeEditorIT.java
@@ -16,6 +16,8 @@
 package com.vaadin.flow.uitest.ui;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -23,13 +25,14 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import com.vaadin.base.devserver.themeeditor.ThemeModifier;
+import com.vaadin.flow.server.AbstractConfiguration;
 import com.vaadin.flow.server.VaadinContext;
 import com.vaadin.flow.server.frontend.FrontendUtils;
 import com.vaadin.flow.testutil.ChromeDeviceTest;
 import com.vaadin.flow.testutil.TestUtils;
 
 public abstract class AbstractThemeEditorIT extends ChromeDeviceTest {
-    VaadinContext mockContext = new VaadinContext() {
+    private static VaadinContext mockContext = new VaadinContext() {
 
         Map<String, Object> attributes = new HashMap<>();
 
@@ -74,7 +77,15 @@ public abstract class AbstractThemeEditorIT extends ChromeDeviceTest {
         open((String[]) null);
     }
 
-    protected class TestThemeModifier extends ThemeModifier {
+    private static File getProjectFolder() {
+        File currentFolder = TestUtils.getTestFolder("com");
+        while (!new File(currentFolder, FrontendUtils.FRONTEND).exists()) {
+            currentFolder = currentFolder.getParentFile();
+        }
+        return currentFolder;
+    }
+
+    protected static class TestThemeModifier extends ThemeModifier {
 
         public TestThemeModifier() {
             super(mockContext);
@@ -82,12 +93,35 @@ public abstract class AbstractThemeEditorIT extends ChromeDeviceTest {
 
         @Override
         protected File getFrontendFolder() {
-            File currentFolder = TestUtils.getTestFolder("com");
-            while (!new File(currentFolder, FrontendUtils.FRONTEND).exists()) {
-                currentFolder = currentFolder.getParentFile();
-            }
-            return new File(currentFolder, FrontendUtils.FRONTEND);
+            return new File(getProjectFolder(), FrontendUtils.FRONTEND);
         }
     }
 
+    protected static class TestAbstractConfiguration
+            implements AbstractConfiguration {
+
+        @Override
+        public boolean isProductionMode() {
+            return false;
+        }
+
+        @Override
+        public String getStringProperty(String name, String defaultValue) {
+            return null;
+        }
+
+        @Override
+        public boolean getBooleanProperty(String name, boolean defaultValue) {
+            return false;
+        }
+
+        @Override
+        public File getJavaSourceFolder() {
+            File projectFolder = getProjectFolder();
+            Path pathToJavaSourceFolder = projectFolder.toPath()
+                    .resolve(Paths.get("src", "main", "java")).normalize();
+            return pathToJavaSourceFolder.toAbsolutePath().toFile();
+        }
+
+    }
 }


### PR DESCRIPTION
## Description

This PR adds tests for two vaadin components: vaadin-icon and vaadin-checkbox. They are used as a basis for adding test for new components.

Other changes:

- improves the tests stability by cleaning up the environment after each test is executed;
- updates the flow components version to 24.2;
- fixes how the property editors are retrieved (two different property editors might have the same 'data-testid', so we need a proper context to retrieve the correct property editor for a metadata);
- some small improvements in the errors text messages.

## Type of change

- [ ] Bugfix
- [ X ] Feature

## Checklist

- [ X ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ X ] I have added a description following the guideline.
- [ X ] The issue is created in the corresponding repository and I have referenced it.
- [ X ] I have added tests to ensure my change is effective and works as intended.
- [ X ] New and existing tests are passing locally with my change.
- [ X ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
