### PR TITLE
fix: forward/reroute when query parameters changed

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -658,9 +658,15 @@ public abstract class AbstractNavigationStateRenderer
         if (beforeEvent.hasExternalForwardUrl()) {
             return Optional.of(forwardToExternalUrl(event, beforeEvent));
         }
+
+        boolean queryParameterChanged = beforeEvent.hasRedirectQueryParameters()
+                && !beforeEvent.getRedirectQueryParameters()
+                        .equals(event.getLocation().getQueryParameters());
+
         if (beforeEvent.hasForwardTarget() && (!isSameNavigationState(
                 beforeEvent.getForwardTargetType(),
                 beforeEvent.getForwardTargetRouteParameters())
+                || queryParameterChanged
                 || !(navigationState.getResolvedPath() != null
                         && navigationState.getResolvedPath()
                                 .equals(beforeEvent.getForwardUrl())))) {
@@ -668,8 +674,9 @@ public abstract class AbstractNavigationStateRenderer
         }
 
         if (beforeEvent.hasRerouteTarget()
-                && !isSameNavigationState(beforeEvent.getRerouteTargetType(),
-                        beforeEvent.getRerouteTargetRouteParameters())) {
+                && (!isSameNavigationState(beforeEvent.getRerouteTargetType(),
+                        beforeEvent.getRerouteTargetRouteParameters())
+                        || queryParameterChanged)) {
             return Optional.of(reroute(event, beforeEvent));
         }
 


### PR DESCRIPTION
## Description

Forward and reroute should run even when targeting same target but with different query parameters.

Fixes #17639

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
