### PR TITLE
chore: update vaadin-parent for flow 2.10 [skip ci]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-parent</artifactId>
-        <version>2.0.5</version>
+        <version>2.2.0</version>
     </parent>
 
     <modules>


### PR DESCRIPTION
in order to publish to the vaadin-prereleases



