### PR TITLE
fix: synchronize cache maps in SpringLookupInitializer

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringLookupInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringLookupInitializer.java
@@ -20,6 +20,7 @@ import jakarta.servlet.ServletException;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiFunction;
@@ -71,8 +72,9 @@ public class SpringLookupInitializer extends LookupInitializer {
                 Map<Class<?>, Collection<Class<?>>> services) {
             super(services, factory);
             this.context = context;
-            this.cachedServices = new HashMap<>();
-            this.cacheableServices = new HashMap<>();
+            this.cachedServices = Collections.synchronizedMap(new HashMap<>());
+            this.cacheableServices = Collections
+                    .synchronizedMap(new HashMap<>());
         }
 
         private <T> boolean isCacheableService(Class<T> serviceClass) {


### PR DESCRIPTION
To avoid possibility to get ConcurrentModificationException.

Related to: https://github.com/vaadin/flow/pull/17604