### PR TITLE
test: add optional assert with reload time threshold

### DIFF
--- a/flow-tests/vaadin-spring-tests/test-spring-boot-reload-time/src/test/java/org/vaadin/example/SpringDevToolsReloadViewIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-reload-time/src/test/java/org/vaadin/example/SpringDevToolsReloadViewIT.java
@@ -45,6 +45,13 @@ public class SpringDevToolsReloadViewIT extends ChromeBrowserTest {
         System.out.printf(
                 "##teamcity[buildStatisticValue key='%s,nativebutton,spring-boot-devtools-reload-time' value='%s']%n",
                 getVaadinMajorMinorVersion(), result);
+
+        if (getReloadTimeAssertThreshold() != null) {
+            Assert.assertTrue(Double
+                    .parseDouble(result) <= getReloadTimeAssertThreshold());
+        }
+
+        optionalAssertByReloadThreshold(result);
     }
 
     @Test
@@ -63,6 +70,8 @@ public class SpringDevToolsReloadViewIT extends ChromeBrowserTest {
         System.out.printf(
                 "##teamcity[buildStatisticValue key='%s,orderedlayout,spring-boot-devtools-reload-time' value='%s']%n",
                 getVaadinMajorMinorVersion(), result);
+
+        optionalAssertByReloadThreshold(result);
     }
 
     private void triggerReload() {
@@ -82,7 +91,26 @@ public class SpringDevToolsReloadViewIT extends ChromeBrowserTest {
                 reloadTimeInMsText.indexOf("]"));
     }
 
+    private void optionalAssertByReloadThreshold(String reloadTime) {
+        if (getReloadTimeAssertThreshold() != null) {
+            Assert.assertTrue(String.format(
+                    "Reload time %sms was above the threshold %sms. It should stay within the threshold set to system property 'vaadin.test.reload-time-assert-threshold'.",
+                    reloadTime, getReloadTimeAssertThreshold()),
+                    Double.parseDouble(
+                            reloadTime) <= getReloadTimeAssertThreshold());
+        }
+    }
+
     private String getVaadinMajorMinorVersion() {
         return Version.getMajorVersion() + "." + Version.getMinorVersion();
+    }
+
+    private Double getReloadTimeAssertThreshold() {
+        String value = System
+                .getProperty("vaadin.test.reload-time-assert-threshold", null);
+        if (value != null) {
+            return Double.parseDouble(value);
+        }
+        return null;
     }
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-reload-time/src/test/java/org/vaadin/example/SpringDevToolsReloadViewIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-reload-time/src/test/java/org/vaadin/example/SpringDevToolsReloadViewIT.java
@@ -46,11 +46,6 @@ public class SpringDevToolsReloadViewIT extends ChromeBrowserTest {
                 "##teamcity[buildStatisticValue key='%s,nativebutton,spring-boot-devtools-reload-time' value='%s']%n",
                 getVaadinMajorMinorVersion(), result);
 
-        if (getReloadTimeAssertThreshold() != null) {
-            Assert.assertTrue(Double
-                    .parseDouble(result) <= getReloadTimeAssertThreshold());
-        }
-
         optionalAssertByReloadThreshold(result);
     }
 


### PR DESCRIPTION
Adds `vaadin.test.reload-time-assert-threshold` system property for Vaadin reload time tests. When value is set, tests will fail if reload time result goes outside the threshold.