### PR TITLE
chore: cache JS imported paths during chunk generation

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -491,7 +491,6 @@ abstract class AbstractUpdateImports implements Runnable {
     }
 
     private Set<String> getUniqueEs6ImportPaths(Collection<String> modules) {
-        long start = System.nanoTime();
         Set<String> npmNotFound = new HashSet<>();
         Set<String> resourceNotFound = new HashSet<>();
         Set<String> es6ImportPaths = new LinkedHashSet<>();


### PR DESCRIPTION
In a production build, for every chunk the JS files are parsed to extract the imported paths. There are checks to ensure that a module is visited only once, but this works on a chunk level.
This change caches the JS imports extraction results, so that a single JS file is visited only once during the build.

Part of #17234