### PR TITLE
chore: change synchronizedMap to ConcurrentHashMap

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringLookupInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringLookupInitializer.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -72,9 +73,8 @@ public class SpringLookupInitializer extends LookupInitializer {
                 Map<Class<?>, Collection<Class<?>>> services) {
             super(services, factory);
             this.context = context;
-            this.cachedServices = Collections.synchronizedMap(new HashMap<>());
-            this.cacheableServices = Collections
-                    .synchronizedMap(new HashMap<>());
+            this.cachedServices = new ConcurrentHashMap<>();
+            this.cacheableServices = new ConcurrentHashMap<>();
         }
 
         private <T> boolean isCacheableService(Class<T> serviceClass) {


### PR DESCRIPTION
For better non-blocking read-performance for lookups with SpringLookup.

Reload to: https://github.com/vaadin/flow/pull/17668