### PR TITLE
Fixes the flaky theme editor tests

### DIFF
--- a/flow-tests/test-theme-editor/src/test/java/com/vaadin/flow/uitest/ui/AbstractThemeEditorIT.java
+++ b/flow-tests/test-theme-editor/src/test/java/com/vaadin/flow/uitest/ui/AbstractThemeEditorIT.java
@@ -95,6 +95,10 @@ public abstract class AbstractThemeEditorIT extends ChromeDeviceTest {
         protected File getFrontendFolder() {
             return new File(getProjectFolder(), FrontendUtils.FRONTEND);
         }
+
+        public File getStyleSheetFileWithoutSideEffects() {
+            return new File(getThemeFile(), getCssFileName());
+        }
     }
 
     protected static class TestAbstractConfiguration


### PR DESCRIPTION
## Description

The idea is:

1. before updating a property, get a timestamp
2. update the property
3. wait until the 'lastModifiedDate' attribute of the style sheet file is changed to a value after the timestamp

This way we make sure the vaadin dev server has written the properties to the file before we try to read them.

## Type of change

- [ X ] Bugfix
- [ ] Feature

## Checklist

- [ X ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ X ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ X ] New and existing tests are passing locally with my change.
- [ X ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
