### PR TITLE
fix: mark execute as synchronized to prevent concurrent execution

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -81,7 +81,7 @@ public class TaskUpdatePackages extends NodeUpdater {
     }
 
     @Override
-    public void execute() {
+    public synchronized void execute() {
         try {
             Map<String, String> scannedApplicationDependencies = frontDeps
                     .getPackages();


### PR DESCRIPTION
## Description

This assures that no concurrent
executions of this task result
in running multiple `npm install`
when something triggers the build
after the another build is in
progress.

Fixes vaadin/hilla#1309

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
