### PR TITLE
fix: detach should be sent for node

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternalUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternalUpdater.java
@@ -85,7 +85,7 @@ public interface UIInternalUpdater extends Serializable {
         final List<Element> uiChildren = oldUI.getElement().getChildren()
                 .collect(Collectors.toList());
         uiChildren.forEach(element -> {
-            element.removeFromTree();
+            element.removeFromTree(false);
             newUI.getElement().appendChild(element);
         });
     }

--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentUI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentUI.java
@@ -201,7 +201,7 @@ public class WebComponentUI extends UI {
 
         Optional<Element> old = getRegistry().get(hash);
         if (old.isPresent()) {
-            elementToAttach = old.get().removeFromTree();
+            elementToAttach = old.get().removeFromTree(false);
         }
 
         // did not have an element in the cache, create a new one

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -525,7 +525,10 @@ public class Element extends Node<Element> {
      * @return this element
      */
     public Element removeFromTree() {
+        return removeFromTree(true);
+    }
 
+    public Element removeFromTree(boolean sendDetach) {
         Node<?> parent = getParentNode();
         if (parent != null) {
             if (parent.getChildren().anyMatch(Predicate.isEqual(this))) {
@@ -535,7 +538,7 @@ public class Element extends Node<Element> {
                 parent.removeVirtualChild(this);
             }
         }
-        getNode().removeFromTree();
+        getNode().removeFromTree(sendDetach);
         return this;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -521,6 +521,9 @@ public class Element extends Node<Element> {
 
     /**
      * Removes this element from its parent and state tree.
+     * <p>
+     * This will send a detach event for the node, fully releasing it on the
+     * client.
      *
      * @return this element
      */
@@ -528,6 +531,19 @@ public class Element extends Node<Element> {
         return removeFromTree(true);
     }
 
+    /**
+     * Removes this element from its parent and state tree.
+     * <p>
+     * sendDetach can be given as false to fully reset the node and not send a
+     * detach event. This for instance when having preserveOnRefresh that only
+     * moves the node.
+     * <p>
+     * This method is meant for internal use only.
+     *
+     * @param sendDetach
+     *            if the detach event should be sent to the client
+     * @return this element
+     */
     public Element removeFromTree(boolean sendDetach) {
         Node<?> parent = getParentNode();
         if (parent != null) {

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
@@ -159,7 +159,6 @@ public class StateNode implements Serializable {
     private StateNode parent;
 
     private int id = -1;
-    private int old_id = -1;
 
     // Only the root node is attached at this point
     private boolean wasAttached = isAttached();
@@ -409,12 +408,17 @@ public class StateNode implements Serializable {
     /**
      * Resets the node to the initial state where it is not owned by a state
      * tree.
+     * <p>
+     * If the node should detach on the client keep attached state and node id
+     * to send event to client.
+     *
+     * @param shouldDetach
+     *            if true, keep node id and attached state
      */
     private void reset(boolean shouldDetach) {
         owner = NullOwner.get();
         hasBeenAttached = false;
         hasBeenDetached = false;
-        // old_id = id;
         if (!shouldDetach) {
             id = -1;
             wasAttached = false;

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
@@ -401,10 +401,14 @@ public class StateNode implements Serializable {
      */
     private void reset() {
         owner = NullOwner.get();
-        id = -1;
-        wasAttached = false;
         hasBeenAttached = false;
         hasBeenDetached = false;
+        // Do not clear ID and wasAttached state as we need to inform client
+        // that it should detach. Id is cleared after collectChanges detach.
+        if (!wasAttached) {
+            id = -1;
+            wasAttached = false;
+        }
     }
 
     /**
@@ -627,6 +631,9 @@ public class StateNode implements Serializable {
                 forEachFeature(NodeFeature::generateChangesFromEmpty);
             } else {
                 collector.accept(new NodeDetachChange(this));
+                if (getOwner().equals(NullOwner.get())) {
+                    id = -1;
+                }
             }
             wasAttached = isAttached;
         }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
@@ -38,7 +38,6 @@ import java.util.stream.Stream;
 
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.UI;
-import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.StateTree.BeforeClientResponseEntry;
 import com.vaadin.flow.internal.StateTree.ExecutionRegistration;

--- a/flow-server/src/main/java/com/vaadin/flow/internal/change/NodeDetachChange.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/change/NodeDetachChange.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.internal.change;
 
 import com.vaadin.flow.internal.ConstantPool;
 import com.vaadin.flow.internal.StateNode;
-import com.vaadin.flow.server.Command;
 import com.vaadin.flow.shared.JsonConstants;
 
 import elemental.json.JsonObject;

--- a/flow-server/src/main/java/com/vaadin/flow/internal/change/NodeDetachChange.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/change/NodeDetachChange.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.internal.change;
 
 import com.vaadin.flow.internal.ConstantPool;
 import com.vaadin.flow.internal.StateNode;
+import com.vaadin.flow.server.Command;
 import com.vaadin.flow.shared.JsonConstants;
 
 import elemental.json.JsonObject;

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -817,7 +817,7 @@ public abstract class AbstractNavigationStateRenderer
                 }
 
                 // Remove the top-level component from the tree
-                root.getElement().removeFromTree();
+                root.getElement().removeFromTree(false);
 
                 // Transfer all remaining UI child elements (typically dialogs
                 // and notifications) to the new UI

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
@@ -287,7 +287,7 @@ public class ShortcutRegistrationTest {
         ui.close();
         components[0] = newUI;
 
-        owner.getElement().removeFromTree();
+        owner.getElement().removeFromTree(false);
         newUI.add(owner);
 
         ArgumentCaptor<SerializableConsumer> captor = ArgumentCaptor
@@ -621,7 +621,7 @@ public class ShortcutRegistrationTest {
         ui.close();
         components[0] = newUI;
 
-        owner.getElement().removeFromTree();
+        owner.getElement().removeFromTree(false);
         newUI.add(owner);
 
         verify(newUI, atLeastOnce()).beforeClientResponse(eq(owner),

--- a/flow-server/src/test/java/com/vaadin/flow/internal/StateNodeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/StateNodeTest.java
@@ -1355,6 +1355,70 @@ public class StateNodeTest {
     }
 
     /**
+     * #17695: removeFromTree removes StateTree reference and resets descendant
+     * nodes, sends detach event.
+     */
+    @Test
+    public void removeFromTree_nodeAttachedThenDetached_detachEventCollected() {
+        // given grandParent -> parent -> child
+        StateNode grandParent = createParentNode("grandParent");
+        StateNode parent = createParentNode("parent");
+        addChild(grandParent, parent);
+
+        TestStateTree tree = new TestStateTree();
+        addChild(tree.getRootNode(), grandParent);
+
+        parent.collectChanges(change -> {
+            Assert.assertTrue("Expected attach event for node",
+                    change instanceof NodeAttachChange);
+        });
+
+        // when parent is removed from the tree
+        parent.removeFromTree(true);
+
+        // then parent's parent is null
+        Assert.assertNull(parent.getParent());
+        Assert.assertNotEquals(parent.getId(), -1);
+
+        parent.collectChanges(change -> {
+            Assert.assertTrue("Expected detach event for reset node",
+                    change instanceof NodeDetachChange);
+        });
+    }
+
+    /**
+     * #17695: removeFromTree removes StateTree reference and resets descendant
+     * nodes, sends detach event.
+     */
+    @Test
+    public void removeFromTree_nodeAttached_detachedFullReset_noDetachEventCollected() {
+        // given grandParent -> parent -> child
+        StateNode grandParent = createParentNode("grandParent");
+        StateNode parent = createParentNode("parent");
+        addChild(grandParent, parent);
+
+        TestStateTree tree = new TestStateTree();
+        addChild(tree.getRootNode(), grandParent);
+
+        parent.collectChanges(change -> {
+            Assert.assertTrue("Expected attach event for node",
+                    change instanceof NodeAttachChange);
+        });
+
+        // remove from tree with reset all.
+        parent.removeFromTree();
+
+        // then parent's parent is null
+        Assert.assertNull(parent.getParent());
+        Assert.assertEquals(parent.getId(), -1);
+
+        parent.collectChanges(change -> {
+            Assert.fail(
+                    "No changes should be collected for detached reset node.");
+        });
+    }
+
+    /**
      * #5316: removeFromTree when invoked from a DetachListener removes
      * StateTree reference and resets descendant nodes.
      */


### PR DESCRIPTION
Do not clean the node id or
hasAttached state too early as
then we do not send the detach
event for the node.

Fixes #17653
