### PR TITLE
In theme-editor, adds a test for vaadin-accordion component

### DIFF
--- a/flow-tests/test-theme-editor/pom.xml
+++ b/flow-tests/test-theme-editor/pom.xml
@@ -60,6 +60,11 @@
             <artifactId>vaadin-checkbox-flow</artifactId>
             <version>${vaadin.components.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-accordion-flow</artifactId>
+            <version>${vaadin.components.version}</version>
+        </dependency>
 
     </dependencies>
 

--- a/flow-tests/test-theme-editor/src/main/java/com/vaadin/flow/uitest/ui/ThemeEditorView.java
+++ b/flow-tests/test-theme-editor/src/main/java/com/vaadin/flow/uitest/ui/ThemeEditorView.java
@@ -15,9 +15,11 @@
  */
 package com.vaadin.flow.uitest.ui;
 
+import com.vaadin.flow.component.accordion.Accordion;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.router.Route;
@@ -37,5 +39,11 @@ public class ThemeEditorView extends Div {
         Checkbox checkbox = new Checkbox("The checkbox");
         checkbox.setId("checkbox");
         add(new Div(checkbox));
+
+        Accordion accordion = new Accordion();
+        accordion.setId("accordion");
+        accordion.add("A", new Span("Info for A"));
+        accordion.add("B", new Span("Info for B"));
+        add(new Div(accordion));
     }
 }

--- a/flow-tests/test-theme-editor/src/test/java/com/vaadin/flow/uitest/ui/testbench/DevToolsComponentPickerElement.java
+++ b/flow-tests/test-theme-editor/src/test/java/com/vaadin/flow/uitest/ui/testbench/DevToolsComponentPickerElement.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.testbench;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+@Element("vaadin-dev-tools-component-picker")
+public class DevToolsComponentPickerElement extends TestBenchElement {
+    public List<String> getOptions() {
+        TestBenchElement optionsContainer = getOptionsContainer();
+        return optionsContainer.$("div").all().stream()
+                .map(d -> d.getText().strip()).collect(Collectors.toList());
+    }
+
+    public String getSelectedOption() {
+        TestBenchElement optionsContainer = getOptionsContainer();
+        return optionsContainer.$("div").attribute("class", "selected")
+                .waitForFirst().getText().strip();
+    }
+
+    private TestBenchElement getOptionsContainer() {
+        TestBenchElement componentsInfo = this.$("div")
+                .attributeContains("class", "component-picker-components-info")
+                .first();
+        TestBenchElement optionsContainer = componentsInfo.$("div")
+                .waitForFirst();
+        return optionsContainer;
+    }
+
+    public void moveToElement(WebElement findElement) {
+        Map<String, Object> data = new HashMap<>();
+
+        Map<String, Object> details = new HashMap<>();
+        details.put("target", findElement);
+
+        data.put("detail", details);
+
+        TestBenchElement shim = this.$("vaadin-dev-tools-shim").first();
+        shim.dispatchEvent("shim-mousemove", data);
+    }
+
+    public void moveToOption(String option) {
+        List<String> options = getOptions();
+        if (!options.contains(option)) {
+            throw new RuntimeException(
+                    String.format("'%s' is not a valid option", option));
+        }
+        while (!getSelectedOption().equals(option)) {
+            moveUp();
+        }
+    }
+
+    public void selectOption(String option) {
+        moveToOption(option);
+        pressEnter();
+    }
+
+    private void pressEnter() {
+        new Actions(getDriver()).keyDown(Keys.ENTER).perform();
+    }
+
+    private void moveUp() {
+        new Actions(getDriver()).keyDown(Keys.ARROW_UP).perform();
+        new Actions(getDriver()).keyUp(Keys.ARROW_UP).perform();
+    }
+}

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/utils/CssRule.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/themeeditor/utils/CssRule.java
@@ -5,6 +5,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import com.helger.css.ECSSVersion;
+import com.helger.css.decl.CascadingStyleSheet;
+import com.helger.css.reader.CSSReader;
+
 public class CssRule implements Cloneable {
 
     private String selector;
@@ -53,8 +57,12 @@ public class CssRule implements Cloneable {
         if (o == null || getClass() != o.getClass())
             return false;
         CssRule cssRule = (CssRule) o;
-        return Objects.equals(selector, cssRule.selector)
-                && Objects.equals(properties, cssRule.properties);
+        return Objects.equals(toCascadingStyleSheet(),
+                cssRule.toCascadingStyleSheet());
+    }
+
+    private CascadingStyleSheet toCascadingStyleSheet() {
+        return CSSReader.readFromString(cssRepr(), ECSSVersion.LATEST);
     }
 
     @Override
@@ -62,12 +70,18 @@ public class CssRule implements Cloneable {
         return Objects.hash(selector, properties);
     }
 
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder("CssRule[");
+    private String cssRepr() {
+        StringBuilder sb = new StringBuilder();
         sb.append(selector + "{");
         properties.forEach(
                 (k, v) -> sb.append(k).append(":").append(v).append(";"));
-        return sb.append("}]").toString();
+        return sb.append("}").toString();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("CssRule[");
+        sb.append(cssRepr());
+        return sb.append("]").toString();
     }
 }


### PR DESCRIPTION
## Description

Adds a test for the editing of vaadin-accordion in theme-editor.

It is not possible to directly select the vaadin-accordion component directly by clicking on it, so the test is using the ComponentPicker component to navigate to the vaadin-accordion by using the keyboard.

This commit also contains:

-  a fix for a flakyness when a test tries to retrieve the CssRule related with a CssSelector
- normalization of the CssRule content inside the CssRule.equals(...) method.

## Type of change

- [ ] Bugfix
- [ X ] Feature

## Checklist

- [ X ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ X ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ X ] I have added tests to ensure my change is effective and works as intended.
- [ X ] New and existing tests are passing locally with my change.
- [ X ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
