### PR TITLE
fix: Use build timestamp for Push script request (#17706) (CP: 2.10)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -1408,7 +1408,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             VaadinRequest request = context.getRequest();
 
             // Parameter appended to JS to bypass caches after version upgrade.
-            String versionQueryParam = "?v=" + Version.getFullVersion();
+            String versionQueryParam = "?v=" + Version.getBuildHash();
 
             // Load client-side dependencies for push support
             String pushJSPath = context.getRequest().getService()

--- a/flow-server/src/main/java/com/vaadin/flow/server/Version.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Version.java
@@ -21,6 +21,8 @@ import java.util.Properties;
 
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.flow.internal.StringUtil;
+
 /**
  * Provides information about the current version of the framework.
  *
@@ -55,14 +57,21 @@ public class Version implements Serializable {
      */
     private static final String VERSION_BUILD;
 
+    /**
+     * Build hash based on the timestamp of the build.
+     */
+    private static final String VERSION_BUILD_HASH;
+
     /* Initialize version numbers from string replaced by build-script. */
     static {
         String flowVersion = "9.9.9.INTERNAL-DEBUG-BUILD";
+        String buildTimestamp = "";
         Properties properties = new Properties();
         try {
             properties.load(
                     Version.class.getResourceAsStream("version.properties"));
             flowVersion = properties.getProperty("flow.version");
+            buildTimestamp = properties.getProperty("flow.build.timestamp");
         } catch (IOException e) {
             LoggerFactory.getLogger(Version.class.getName())
                     .warn("Unable to determine Flow version number", e);
@@ -88,6 +97,7 @@ public class Version implements Serializable {
         }
         VERSION_REVISION = revision;
         VERSION_BUILD = build;
+        VERSION_BUILD_HASH = StringUtil.getHash(buildTimestamp);
     }
 
     /**
@@ -135,6 +145,16 @@ public class Version implements Serializable {
      */
     public static String getBuildIdentifier() {
         return VERSION_BUILD;
+    }
+
+    /**
+     * Gets the version's build hash. This hash is based on build's timestamp
+     * and varies from build to build.
+     *
+     * @return version's build hash
+     */
+    public static String getBuildHash() {
+        return VERSION_BUILD_HASH;
     }
 
 }

--- a/flow-server/src/main/resources/com/vaadin/flow/server/version.properties
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/version.properties
@@ -1,1 +1,2 @@
 flow.version=${project.version}
+flow.build.timestamp=${maven.build.timestamp}


### PR DESCRIPTION
(cherry picked from commit 90245eee2280e43b2092fdfc503f326bcc4bc45d)