### PR TITLE
LitTemplateParser finds wrong content for render template

### DIFF
--- a/flow-lit-template/src/test/java/com/vaadin/flow/component/littemplate/BundleLitParserTest.java
+++ b/flow-lit-template/src/test/java/com/vaadin/flow/component/littemplate/BundleLitParserTest.java
@@ -92,4 +92,72 @@ public class BundleLitParserTest {
         Assert.assertEquals(1,
                 element.getElementsByTag("timer-element").size());
     }
+
+    @Test
+    public void parseTemplate_codeInRenderBeforeHtml_templateProperlyParsed2() {
+        final Element element = BundleLitParser.parseLitTemplateElement("in.ts",
+        // @formatter:off
+                         "import { html, LitElement } from 'lit';\n"
+                        + "\n"
+                        + "export class HelloLit extends LitElement {\n"
+                        + "\n"
+                        + "  helper() {\n"
+                        + "    return html`<span>helper</span>`;\n"
+                        + "  }\n"
+                        + "  render() {\n"
+                        + "    const athleteTimerStyles = { \n"
+                        + "      display:  this.currentAthleteMode && !this.decisionVisible ? \"grid\" : \"none\",\n"
+                        + "    }\n"
+                        + "    return html`\n"
+                        + "      <div>Some content</div>`;\n"
+                        + "      <span class=\"timer athleteTimer\" style=\"${styleMap(athleteTimerStyles)}\">\n"
+                        + "        <timer-element id=\"athleteTimer\"></timer-element>\n"
+                        + "      </span>\n"
+                        + "      `;"
+                        + "  }\n"
+                        + "}\n"
+                        + "\n"
+                        + "customElements.define('hello-lit', HelloLit);");
+         // @formatter:on
+
+        Assert.assertEquals(4, element.getAllElements().size());
+        Assert.assertEquals(1, element.getElementsByTag("div").size());
+        Assert.assertEquals(1, element.getElementsByTag("span").size());
+        Assert.assertEquals(1,
+                element.getElementsByTag("timer-element").size());
+    }
+
+    @Test
+    public void parseTemplate_codeInRenderBeforeHtml_templateProperlyParsed3() {
+        final Element element = BundleLitParser.parseLitTemplateElement("in.ts",
+        // @formatter:off
+                         "import { html, LitElement } from 'lit';\n"
+                        + "\n"
+                        + "export class HelloLit extends LitElement {\n"
+                        + "\n"
+                        + "  render() {\n"
+                        + "    const athleteTimerStyles = { \n"
+                        + "      display:  this.currentAthleteMode && !this.decisionVisible ? \"grid\" : \"none\",\n"
+                        + "    }\n"
+                        + "    return html`\n"
+                        + "      <div>Some content</div>`;\n"
+                        + "      <span class=\"timer athleteTimer\" style=\"${styleMap(athleteTimerStyles)}\">\n"
+                        + "        <timer-element id=\"athleteTimer\"></timer-element>\n"
+                        + "      </span>\n"
+                        + "      `;"
+                        + "  }\n"
+                        + "  helper() {\n"
+                        + "    return html`<span>helper</span>`;\n"
+                        + "  }\n"
+                        + "}\n"
+                        + "\n"
+                        + "customElements.define('hello-lit', HelloLit);");
+         // @formatter:on
+
+        Assert.assertEquals(4, element.getAllElements().size());
+        Assert.assertEquals(1, element.getElementsByTag("div").size());
+        Assert.assertEquals(1, element.getElementsByTag("span").size());
+        Assert.assertEquals(1,
+                element.getElementsByTag("timer-element").size());
+    }
 }


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

This is PR is not made to get merged. But you can reuse the added unit tests.

Please have a look at the added tests. i copied parseTemplate_codeInRenderBeforeHtml_templateProperlyParsed and inserted an helper method in the template. One ahead another one behind. The latter one fails. The template parser now returns the content of the helper method instead the one of the render method.

Please list all relevant dependencies in this section and provide summary of the change, motivation and context.

maybe caused by #17469 (#17457) 


## Type of change

- [ x] Bugfix
- [ -] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
