### PR TITLE
fix: Disable the Vite public directory to not interfere with a folder named 'public'

### DIFF
--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -665,6 +665,7 @@ export const vaadinConfig: UserConfigFn = (env) => {
   return {
     root: frontendFolder,
     base: '',
+    publicDir: false,
     resolve: {
       alias: {
         '@vaadin/flow-frontend': jarResourcesFolder,


### PR DESCRIPTION
If you create a `src/main/resources/static/public` folder with static files, you will see a lot of
```
files in the public directory are served at the root path.
Instead of /public/images/logo.jpg, use /images/logo.jpg.
```
when trying to access the files. This is because the default "publcDir" of Vite is "public" and the Vite server is queried for resources before loading from the class loader
