### PR TITLE
fix: update role checkers to work in same way

### DIFF
--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/AdminView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/AdminView.java
@@ -2,7 +2,6 @@ package com.vaadin.flow.spring.flowsecurity.views;
 
 import jakarta.annotation.security.RolesAllowed;
 
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import com.vaadin.flow.component.UI;

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/AdminView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/AdminView.java
@@ -2,6 +2,11 @@ package com.vaadin.flow.spring.flowsecurity.views;
 
 import jakarta.annotation.security.RolesAllowed;
 
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
@@ -14,6 +19,8 @@ import com.vaadin.flow.spring.flowsecurity.SecurityUtils;
 @RolesAllowed("admin")
 public class AdminView extends VerticalLayout {
 
+    public final static String ROLE_PREFIX_TEST_BUTTON_ID = "role-prefix-test-button";
+
     public AdminView(SecurityUtils securityUtils) {
         H1 welcome = new H1("Welcome to the admin page, "
                 + securityUtils.getAuthenticatedUserInfo().getFullName());
@@ -23,5 +30,21 @@ public class AdminView extends VerticalLayout {
         div.setText(
                 "This page is full of dangerous controls and secret information");
         add(div);
+
+        Button accessRolePrefixedAdminPageFromThread = new Button(
+                "Access ROLE_ prefixed admin view from another thread");
+        accessRolePrefixedAdminPageFromThread.setId(ROLE_PREFIX_TEST_BUTTON_ID);
+        accessRolePrefixedAdminPageFromThread.addClickListener(event -> {
+            UI ui = event.getSource().getUI().get();
+            Executors.newFixedThreadPool(1).submit(() -> {
+                try {
+                    TimeUnit.MILLISECONDS.sleep(100);
+                    ui.access(() -> ui.navigate(RolePrefixedAdminView.class));
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            });
+        });
+        add(accessRolePrefixedAdminPageFromThread);
     }
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/AdminView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/AdminView.java
@@ -36,14 +36,14 @@ public class AdminView extends VerticalLayout {
         accessRolePrefixedAdminPageFromThread.setId(ROLE_PREFIX_TEST_BUTTON_ID);
         accessRolePrefixedAdminPageFromThread.addClickListener(event -> {
             UI ui = event.getSource().getUI().get();
-            Executors.newFixedThreadPool(1).submit(() -> {
+            new Thread(() -> {
                 try {
                     TimeUnit.MILLISECONDS.sleep(100);
                     ui.access(() -> ui.navigate(RolePrefixedAdminView.class));
                 } catch (InterruptedException e) {
-                    e.printStackTrace();
                 }
-            });
+
+            }).start();
         });
         add(accessRolePrefixedAdminPageFromThread);
     }

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/RolePrefixedAdminView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/RolePrefixedAdminView.java
@@ -1,0 +1,27 @@
+package com.vaadin.flow.spring.flowsecurity.views;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.spring.flowsecurity.SecurityUtils;
+
+import jakarta.annotation.security.RolesAllowed;
+
+@Route(value = "another_admin", layout = MainView.class)
+@PageTitle("Another Admin View")
+@RolesAllowed("ROLE_admin")
+public class RolePrefixedAdminView extends VerticalLayout {
+
+    public RolePrefixedAdminView(SecurityUtils securityUtils) {
+        H1 welcome = new H1("Welcome to the another admin page, "
+                + securityUtils.getAuthenticatedUserInfo().getFullName());
+        welcome.setId("welcome");
+        add(welcome);
+        Div div = new Div();
+        div.setText(
+                "This page is full of dangerous controls and secret information");
+        add(div);
+    }
+}

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AbstractIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AbstractIT.java
@@ -132,6 +132,14 @@ public abstract class AbstractIT extends AbstractSpringTest {
                 welcomeText);
     }
 
+    protected void assertRolePrefixedAdminPageShown(String fullName) {
+        assertPathShown("another_admin");
+        TestBenchElement welcome = waitUntil(driver -> $("*").id("welcome"));
+        String welcomeText = welcome.getText();
+        Assert.assertEquals("Welcome to the another admin page, " + fullName,
+                welcomeText);
+    }
+
     protected void assertPathShown(String path) {
 
         waitUntil(driver -> {

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AppViewIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AppViewIT.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 
 import com.vaadin.flow.component.button.testbench.ButtonElement;
 import com.vaadin.flow.component.upload.testbench.UploadElement;
+import com.vaadin.flow.spring.flowsecurity.views.AdminView;
 import com.vaadin.flow.spring.flowsecurity.views.PublicView;
 import com.vaadin.testbench.TestBenchElement;
 
@@ -34,6 +35,11 @@ public class AppViewIT extends AbstractIT {
 
     private void clickLogout() {
         getMainView().$(ButtonElement.class).id("logout").click();
+    }
+
+    private void clickAccessRolePrefixedAdminPageFromThread() {
+        getMainView().$(ButtonElement.class)
+                .id(AdminView.ROLE_PREFIX_TEST_BUTTON_ID).click();
     }
 
     @Test
@@ -120,6 +126,16 @@ public class AppViewIT extends AbstractIT {
         assertPathShown(LOGIN_PATH);
         loginAdmin();
         assertAdminPageShown(ADMIN_FULLNAME);
+    }
+
+    @Test
+    public void redirect_to_role_prefixed_admin_view_after_login() {
+        open("admin");
+        assertPathShown(LOGIN_PATH);
+        loginAdmin();
+        assertAdminPageShown(ADMIN_FULLNAME);
+        clickAccessRolePrefixedAdminPageFromThread();
+        assertRolePrefixedAdminPageShown(ADMIN_FULLNAME);
     }
 
     @Test

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/AuthenticationUtil.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/AuthenticationUtil.java
@@ -29,17 +29,41 @@ public class AuthenticationUtil {
 
     /**
      * Gets a function for checking if the authenticated user from the Spring
-     * SecurityContextHolder is in a given role.
+     * SecurityContextHolder is in a given role. Given role is always prefixed
+     * with 'ROLE_'.
      *
      * @return a function for checking if the given user has the given role
      */
     public static Function<String, Boolean> getSecurityHolderRoleChecker() {
+        return getSecurityHolderRoleChecker("ROLE_");
+    }
+
+    /**
+     * Gets a function for checking if the authenticated user from the Spring
+     * SecurityContextHolder is in a given role.
+     *
+     * @param rolePrefix
+     *            Prefix for the given role.
+     * @return a function for checking if the given user has the given role
+     */
+    public static Function<String, Boolean> getSecurityHolderRoleChecker(
+            String rolePrefix) {
         Authentication authentication = getSecurityHolderAuthentication();
         if (authentication == null) {
             return role -> false;
         }
-        return role -> authentication.getAuthorities().stream()
-                .anyMatch(grantedAuthority -> grantedAuthority.getAuthority()
-                        .equals("ROLE_" + role));
+
+        return role -> {
+            String roleWithPrefix;
+            if (rolePrefix != null && role != null
+                    && !role.startsWith(rolePrefix)) {
+                roleWithPrefix = rolePrefix + role;
+            } else {
+                roleWithPrefix = role;
+            }
+            return authentication.getAuthorities().stream()
+                    .anyMatch(grantedAuthority -> grantedAuthority
+                            .getAuthority().equals(roleWithPrefix));
+        };
     }
 }

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringSecurityAutoConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringSecurityAutoConfiguration.java
@@ -19,6 +19,7 @@ import com.vaadin.flow.server.auth.AccessAnnotationChecker;
 import com.vaadin.flow.server.auth.ViewAccessChecker;
 import com.vaadin.flow.spring.security.RequestUtil;
 import com.vaadin.flow.spring.security.VaadinDefaultRequestCache;
+import com.vaadin.flow.spring.security.VaadinRolePrefixHolder;
 import com.vaadin.flow.spring.security.ViewAccessCheckerInitializer;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -95,5 +96,15 @@ public class SpringSecurityAutoConfiguration {
     @Bean
     public RequestUtil requestUtil() {
         return new RequestUtil();
+    }
+
+    /**
+     * Makes role prefix holder available for security configuration.
+     *
+     * @return the role prefix holder
+     */
+    @Bean
+    public VaadinRolePrefixHolder vaadinRolePrefixHolder() {
+        return new VaadinRolePrefixHolder(null);
     }
 }

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringSecurityAutoConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringSecurityAutoConfiguration.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.spring;
 
+import java.util.Optional;
+
 import com.vaadin.flow.server.auth.AccessAnnotationChecker;
 import com.vaadin.flow.server.auth.ViewAccessChecker;
 import com.vaadin.flow.spring.security.RequestUtil;
@@ -28,6 +30,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.core.GrantedAuthorityDefaults;
 
 /**
  * Spring boot auto-configuration class for Flow.
@@ -101,10 +104,17 @@ public class SpringSecurityAutoConfiguration {
     /**
      * Makes role prefix holder available for security configuration.
      *
+     * @param grantedAuthorityDefaults
+     *            Optional granted authority defaults bean for the default role
+     *            prefix
      * @return the role prefix holder
      */
     @Bean
-    public VaadinRolePrefixHolder vaadinRolePrefixHolder() {
-        return new VaadinRolePrefixHolder(null);
+    @ConditionalOnMissingBean
+    public VaadinRolePrefixHolder vaadinRolePrefixHolder(
+            Optional<GrantedAuthorityDefaults> grantedAuthorityDefaults) {
+        return new VaadinRolePrefixHolder(grantedAuthorityDefaults
+                .map(GrantedAuthorityDefaults::getRolePrefix).orElse(null));
     }
+
 }

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringViewAccessChecker.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringViewAccessChecker.java
@@ -55,8 +55,7 @@ public class SpringViewAccessChecker extends ViewAccessChecker {
         Optional.ofNullable(VaadinService.getCurrent())
                 .map(service -> service.getContext().getAttribute(Lookup.class))
                 .map(lookup -> lookup.lookup(VaadinRolePrefixHolder.class))
-                .filter(prefixHolder -> prefixHolder.getRolePrefix() == null)
-                .ifPresent(
+                .filter(prefixHolder -> !prefixHolder.isSet()).ifPresent(
                         prefixHolder -> prefixHolder.resetRolePrefix(request));
 
         return super.getRolesChecker(request);

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringViewAccessChecker.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringViewAccessChecker.java
@@ -41,8 +41,8 @@ public class SpringViewAccessChecker extends ViewAccessChecker {
     @Override
     protected Function<String, Boolean> getRolesChecker(VaadinRequest request) {
         if (request == null) {
-            return Optional
-                    .ofNullable(VaadinService.getCurrent().getContext()
+            return Optional.ofNullable(VaadinService.getCurrent())
+                    .map(service -> service.getContext()
                             .getAttribute(Lookup.class))
                     .map(lookup -> lookup.lookup(VaadinRolePrefixHolder.class))
                     .map(VaadinRolePrefixHolder::getRolePrefix)
@@ -52,8 +52,8 @@ public class SpringViewAccessChecker extends ViewAccessChecker {
         }
 
         // Update active role prefix if it's not set yet.
-        Optional.ofNullable(VaadinService.getCurrent().getContext()
-                .getAttribute(Lookup.class))
+        Optional.ofNullable(VaadinService.getCurrent())
+                .map(service -> service.getContext().getAttribute(Lookup.class))
                 .map(lookup -> lookup.lookup(VaadinRolePrefixHolder.class))
                 .filter(prefixHolder -> prefixHolder.getRolePrefix() == null)
                 .ifPresent(

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringViewAccessChecker.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringViewAccessChecker.java
@@ -1,11 +1,15 @@
 package com.vaadin.flow.spring;
 
 import java.security.Principal;
+import java.util.Optional;
 import java.util.function.Function;
 
+import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.auth.AccessAnnotationChecker;
 import com.vaadin.flow.server.auth.ViewAccessChecker;
+import com.vaadin.flow.spring.security.VaadinRolePrefixHolder;
 
 /**
  * A Spring specific view access checker that falls back to Spring mechanisms
@@ -37,8 +41,24 @@ public class SpringViewAccessChecker extends ViewAccessChecker {
     @Override
     protected Function<String, Boolean> getRolesChecker(VaadinRequest request) {
         if (request == null) {
-            return AuthenticationUtil.getSecurityHolderRoleChecker();
+            return Optional
+                    .ofNullable(VaadinService.getCurrent().getContext()
+                            .getAttribute(Lookup.class))
+                    .map(lookup -> lookup.lookup(VaadinRolePrefixHolder.class))
+                    .map(VaadinRolePrefixHolder::getRolePrefix)
+                    .map(AuthenticationUtil::getSecurityHolderRoleChecker)
+                    .orElseGet(
+                            AuthenticationUtil::getSecurityHolderRoleChecker);
         }
+
+        // Update active role prefix if it's not set yet.
+        Optional.ofNullable(VaadinService.getCurrent().getContext()
+                .getAttribute(Lookup.class))
+                .map(lookup -> lookup.lookup(VaadinRolePrefixHolder.class))
+                .filter(prefixHolder -> prefixHolder.getRolePrefix() == null)
+                .ifPresent(
+                        prefixHolder -> prefixHolder.resetRolePrefix(request));
+
         return super.getRolesChecker(request);
     }
 

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinRolePrefixHolder.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinRolePrefixHolder.java
@@ -44,6 +44,8 @@ public class VaadinRolePrefixHolder implements Serializable {
 
     private String rolePrefix;
 
+    private boolean rolePrefixSet;
+
     /**
      * Construct {@link VaadinRolePrefixHolder} with a role prefix.
      *
@@ -52,6 +54,7 @@ public class VaadinRolePrefixHolder implements Serializable {
      */
     public VaadinRolePrefixHolder(String rolePrefix) {
         this.rolePrefix = rolePrefix;
+        this.rolePrefixSet = this.rolePrefix != null;
     }
 
     /**
@@ -61,6 +64,15 @@ public class VaadinRolePrefixHolder implements Serializable {
      */
     public String getRolePrefix() {
         return rolePrefix;
+    }
+
+    /**
+     * Gets boolean flag indicating if role prefix is set or not.
+     *
+     * @return true when role prefix is set, false otherwise.
+     */
+    public boolean isSet() {
+        return rolePrefixSet;
     }
 
     /**
@@ -122,6 +134,7 @@ public class VaadinRolePrefixHolder implements Serializable {
                         e);
             }
         }
+        this.rolePrefixSet = true;
     }
 
     private SecurityContextHolderAwareRequestWrapper findSecurityContextHolderAwareRequestWrapper(

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinRolePrefixHolder.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinRolePrefixHolder.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.spring.security;
 
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletRequestWrapper;
+import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.util.HashSet;
 import java.util.Set;
@@ -37,7 +38,7 @@ import com.vaadin.flow.server.VaadinServletRequest;
  * {@link com.vaadin.flow.spring.AuthenticationUtil} to check roles in the same
  * way with same role prefix.
  */
-public class VaadinRolePrefixHolder {
+public class VaadinRolePrefixHolder implements Serializable {
 
     private String rolePrefix;
 

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinRolePrefixHolder.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinRolePrefixHolder.java
@@ -80,7 +80,7 @@ public class VaadinRolePrefixHolder implements Serializable {
      * {@link VaadinServletRequest} and a chain of
      * {@link ServletRequestWrapper}s to find
      * {@link SecurityContextHolderAwareRequestWrapper} with the role prefix.
-     * Method doesn't do anything if role is not found.
+     * Method doesn't do anything if role prefix is not found.
      *
      * @param request
      *            Vaadin request used to find active role prefix.
@@ -93,7 +93,7 @@ public class VaadinRolePrefixHolder implements Serializable {
 
     /**
      * Reset role prefix from the given {@link DefaultSecurityFilterChain}.
-     * Method doesn't do anything if role is not found.
+     * Method doesn't do anything if role prefix is not found.
      *
      * @param defaultSecurityFilterChain
      *            Default security filter chain used to find active role prefix.

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinRolePrefixHolder.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinRolePrefixHolder.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.spring.security;
+
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletRequestWrapper;
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.util.FieldUtils;
+import org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestWrapper;
+
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinServletRequest;
+
+/**
+ * Holds role prefix accessible outside an active request. Role prefix should
+ * match with {@link SecurityContextHolderAwareRequestWrapper} in Spring
+ * Security context aware environments to allow utilities like
+ * {@link com.vaadin.flow.spring.AuthenticationUtil} to check roles in the same
+ * way with same role prefix.
+ */
+public class VaadinRolePrefixHolder {
+
+    private String rolePrefix;
+
+    /**
+     * Construct {@link VaadinRolePrefixHolder} with a role prefix.
+     *
+     * @param rolePrefix
+     *            Role prefix.
+     */
+    public VaadinRolePrefixHolder(String rolePrefix) {
+        this.rolePrefix = rolePrefix;
+    }
+
+    /**
+     * Return role prefix. May be null.
+     *
+     * @return Role prefix
+     */
+    public String getRolePrefix() {
+        return rolePrefix;
+    }
+
+    /**
+     * Reset role prefix from the given request. Works only with a
+     * {@link VaadinServletRequest} and a chain of
+     * {@link ServletRequestWrapper}s to find
+     * {@link SecurityContextHolderAwareRequestWrapper} with the role prefix.
+     * Method doesn't do anything if role is not found.
+     *
+     * @param request
+     *            Vaadin request used to find active role prefix.
+     */
+    public void resetRolePrefix(VaadinRequest request) {
+        SecurityContextHolderAwareRequestWrapper requestWrapper = findSecurityContextHolderAwareRequestWrapper(
+                request);
+        if (requestWrapper != null) {
+            try {
+                Field field = FieldUtils.getField(
+                        SecurityContextHolderAwareRequestWrapper.class,
+                        "rolePrefix");
+                field.setAccessible(true);
+                rolePrefix = (String) field.get(requestWrapper);
+            } catch (IllegalAccessException e) {
+                getLogger().warn(
+                        "Could not read SecurityContextHolderAwareRequestWrapper#rolePrefix field.",
+                        e);
+            }
+        }
+    }
+
+    private SecurityContextHolderAwareRequestWrapper findSecurityContextHolderAwareRequestWrapper(
+            VaadinRequest request) {
+        if (request instanceof VaadinServletRequest) {
+            ServletRequest servletRequest = ((VaadinServletRequest) request)
+                    .getRequest();
+            Set<Object> checkedWrappers = new HashSet<>();
+            while (servletRequest instanceof ServletRequestWrapper
+                    && !checkedWrappers.contains(servletRequest)) {
+                checkedWrappers.add(servletRequest);
+                if (SecurityContextHolderAwareRequestWrapper.class
+                        .isAssignableFrom(servletRequest.getClass())) {
+                    return (SecurityContextHolderAwareRequestWrapper) servletRequest;
+                }
+                servletRequest = ((ServletRequestWrapper) servletRequest)
+                        .getRequest();
+            }
+        }
+        return null;
+    }
+
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(VaadinRolePrefixHolder.class);
+    }
+}

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -114,6 +114,9 @@ public abstract class VaadinWebSecurity {
     @Autowired
     private ViewAccessChecker viewAccessChecker;
 
+    @Autowired
+    private VaadinRolePrefixHolder vaadinRolePrefixHolder;
+
     @Value("#{servletContext.contextPath}")
     private String servletContextPath;
 
@@ -137,6 +140,8 @@ public abstract class VaadinWebSecurity {
             addLogoutHandlers(cfg::addLogoutHandler);
         });
         DefaultSecurityFilterChain securityFilterChain = http.build();
+        vaadinRolePrefixHolder.resetRolePrefix(securityFilterChain);
+
         LogoutConfigurer<?> logoutConfigurer = http
                 .getConfigurer(LogoutConfigurer.class);
         authenticationContext.setLogoutHandlers(

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -114,7 +114,7 @@ public abstract class VaadinWebSecurity {
     @Autowired
     private ViewAccessChecker viewAccessChecker;
 
-    @Autowired
+    @Autowired(required = false)
     private VaadinRolePrefixHolder vaadinRolePrefixHolder;
 
     @Value("#{servletContext.contextPath}")
@@ -140,7 +140,9 @@ public abstract class VaadinWebSecurity {
             addLogoutHandlers(cfg::addLogoutHandler);
         });
         DefaultSecurityFilterChain securityFilterChain = http.build();
-        vaadinRolePrefixHolder.resetRolePrefix(securityFilterChain);
+        Optional.ofNullable(vaadinRolePrefixHolder)
+                .ifPresent(vaadinRolePrefixHolder -> vaadinRolePrefixHolder
+                        .resetRolePrefix(securityFilterChain));
 
         LogoutConfigurer<?> logoutConfigurer = http
                 .getConfigurer(LogoutConfigurer.class);


### PR DESCRIPTION
Added `AuthenticationUtil#getSecurityHolderRoleChecker(String rolePrefix)` method that works now in same way as `SecurityContextHolderAwareRequestWrapper#isGranted(String role)`. Role prefix is set and read in `VaadinRolePrefixHolder` bean by `SpringViewAccessChecker#getRolesChecker(VaadinRequest)`.

Fixes: https://github.com/vaadin/flow/issues/17629