### PR TITLE
feature: provide an API to make router ignore an anchor

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
@@ -47,6 +47,7 @@ public class Anchor extends HtmlContainer
             .optionalAttributeWithDefault("target",
                     AnchorTarget.DEFAULT.getValue());
 
+    private static final String ROUTER_IGNORE_ATTRIBUTE = "router-ignore";
     private Serializable href;
 
     /**
@@ -176,7 +177,7 @@ public class Anchor extends HtmlContainer
     /**
      * The routing mechanism in Vaadin by default intercepts all anchor elements
      * with relative URL. This method can be used make the router ignore this
-     * anchor and this way make this anchor behave normally and cause a full 
+     * anchor and this way make this anchor behave normally and cause a full
      * page load.
      *
      * @param ignore
@@ -184,7 +185,15 @@ public class Anchor extends HtmlContainer
      *            web application routing mechanism in Vaadin.
      */
     public void setRouterIgnore(boolean ignore) {
-        getElement().setAttribute("router-ignore", true);
+        getElement().setAttribute(ROUTER_IGNORE_ATTRIBUTE, true);
+    }
+
+    /**
+     * @return true if this anchor should be ignored by the Vaadin router and
+     *         behave normally.
+     */
+    public boolean isRouterIgnore() {
+        return getElement().hasAttribute(ROUTER_IGNORE_ATTRIBUTE);
     }
 
     /**

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
@@ -47,7 +47,6 @@ public class Anchor extends HtmlContainer
             .optionalAttributeWithDefault("target",
                     AnchorTarget.DEFAULT.getValue());
 
-    private static final String ROUTER_IGNORE_ATTRIBUTE = "router-ignore";
     private Serializable href;
 
     /**
@@ -170,8 +169,22 @@ public class Anchor extends HtmlContainer
      */
     public void setHref(AbstractStreamResource href) {
         this.href = href;
-        getElement().setAttribute(ROUTER_IGNORE_ATTRIBUTE, true);
+        setRouterIgnore(true);
         assignHrefAttribute();
+    }
+
+    /**
+     * The routing mechanism in Vaadin by default intercepts all anchor elements
+     * with relative URL. This method can be used make the router ignore this
+     * anchor and this way make this anchor behave normally and cause a full 
+     * page load.
+     *
+     * @param ignore
+     *            true if this link should not be intercepted by the single-page
+     *            web application routing mechanism in Vaadin.
+     */
+    public void setRouterIgnore(boolean ignore) {
+        getElement().setAttribute("router-ignore", true);
     }
 
     /**

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
@@ -185,7 +185,7 @@ public class Anchor extends HtmlContainer
      *            web application routing mechanism in Vaadin.
      */
     public void setRouterIgnore(boolean ignore) {
-        getElement().setAttribute(ROUTER_IGNORE_ATTRIBUTE, true);
+        getElement().setAttribute(ROUTER_IGNORE_ATTRIBUTE, ignore);
     }
 
     /**

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
@@ -138,6 +138,8 @@ public class AnchorTest extends ComponentTest {
     protected void addProperties() {
         addStringProperty("href", "", false);
         addOptionalStringProperty("target");
+        addProperty("routerIgnore", boolean.class, false, true, false, true,
+                "router-ignore");
     }
 
     @Test

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/ComponentProperty.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/ComponentProperty.java
@@ -23,6 +23,7 @@ import com.vaadin.flow.shared.util.SharedUtil;
 
 public class ComponentProperty {
     public String name;
+    public String propertyOrAttributeTag;
     public Object defaultValue, otherValue;
     public boolean optional;
     public boolean removeDefault;
@@ -34,11 +35,16 @@ public class ComponentProperty {
             boolean optional, boolean removeDefault) {
         this.componentType = componentType;
         this.name = name;
+        this.propertyOrAttributeTag = name;
         this.type = type;
         this.defaultValue = defaultValue;
         this.optional = optional;
         this.removeDefault = removeDefault;
         this.otherValue = otherValue == null ? name + name : otherValue;
+    }
+
+    public void setPropertyOrAttributeTag(String propertyOrAttributeTag) {
+        this.propertyOrAttributeTag = propertyOrAttributeTag;
     }
 
     public boolean isOptional() {

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/ComponentTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/ComponentTest.java
@@ -109,6 +109,16 @@ public abstract class ComponentTest {
                 isOptional, removeDefault));
     }
 
+    protected <U> void addProperty(String propertyName, Class<U> propertyType,
+            U defaultValue, U otherValue, boolean isOptional,
+            boolean removeDefault, String propertyOrAttributeTag) {
+        ComponentProperty property = new ComponentProperty(
+                getComponent().getClass(), propertyName, propertyType,
+                defaultValue, otherValue, isOptional, removeDefault);
+        property.setPropertyOrAttributeTag(propertyOrAttributeTag);
+        properties.add(property);
+    }
+
     protected Component createComponent() throws InstantiationException,
             IllegalAccessException, ClassNotFoundException {
         String componentClass = getClass().getName().replace("Test", "");
@@ -370,7 +380,8 @@ public abstract class ComponentTest {
                 Assert.assertEquals(property.otherValue,
                         property.getUsingGetter(component));
             }
-            assertPropertyOrAttribute(component, property.name);
+            assertPropertyOrAttribute(component,
+                    property.propertyOrAttributeTag);
         }
     }
 


### PR DESCRIPTION
## Description

Anchors in Vaadin are simply broken if the url happens to be relative. With this API that can be fixed.

Fixes #17617

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
