### PR TITLE
fix: ignore servlet registrations without server-class definition

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletDeployer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletDeployer.java
@@ -192,10 +192,12 @@ public class ServletDeployer implements ServletContextListener {
         Collection<DeploymentConfiguration> result = new ArrayList<>(
                 registrations.size());
         for (ServletRegistration registration : registrations) {
-            loadClass(context.getClassLoader(), registration.getClassName())
-                    .ifPresent(servletClass -> result.add(
-                            StubServletConfig.createDeploymentConfiguration(
-                                    context, registration, servletClass)));
+            if (registration.getClassName() != null) {
+                loadClass(context.getClassLoader(), registration.getClassName())
+                        .ifPresent(servletClass -> result.add(
+                                StubServletConfig.createDeploymentConfiguration(
+                                        context, registration, servletClass)));
+            }
         }
         return result;
     }
@@ -268,6 +270,7 @@ public class ServletDeployer implements ServletContextListener {
 
     private ServletRegistration findVaadinServlet(ServletContext context) {
         return context.getServletRegistrations().values().stream()
+                .filter(registration -> registration.getClassName() != null)
                 .filter(registration -> isVaadinServlet(
                         context.getClassLoader(), registration.getClassName()))
                 .findAny().orElse(null);


### PR DESCRIPTION
## Description

ServletDeployer performs several checks on servlet registrations to determine if the Vaadin Servlet must be registered automatically. However, as of servlet 3.0, <servlet-class> is optional in <servlet> declaration in web.xml, and in this case ServletDeployer fails with a NPE. With this change ServletDeployer ignores servlet registration without a servlet-class definition.

Fixes #17748

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
