### PR TITLE
fix: improve LitTemplateParser to find correct content

### DIFF
--- a/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/BundleLitParser.java
+++ b/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/BundleLitParser.java
@@ -42,10 +42,27 @@ public final class BundleLitParser {
             .getLogger(BundleLitParser.class);
 
     /**
-     * Lit template pattern matches the template getter
+     * Lit template pattern matches the render function
      *
      * <pre>
-     *     render() {
+     * render() {
+     *
+     * }
+     * </pre>
+     *
+     * <p>
+     * <code>render\(\)[\s]*\{</code> finds the template getter method and
+     * <code>[\s\S]*\}</code> ensures everything is captured until the last
+     * <code>}</code> character.
+     */
+    private static final Pattern LIT_TEMPLATE_PATTERN = Pattern
+            .compile("render\\(\\)[\\s]*\\{[\\s\\S]*\\}");
+
+    /**
+     * Lit template pattern for html matches the return statement with html
+     * template.
+     *
+     * <pre>
      *       return html`
      *         &lt;style&gt;
      *           .response { margin-top: 10px`; }
@@ -58,17 +75,12 @@ public final class BundleLitParser {
      * </pre>
      *
      * <p>
-     * <code>render\(\)[\s]*\{</code> finds the template getter method
-     * <p>
-     * <code>[\s\S]*return[\s]*html[\s]*(\`)</code> finds the return statement
+     * <code>return[\s]*html[\s]*(\`)</code> finds the return statement
      * <p>
      * </p>
-     * <code>([\s\S]*)</code> captures all text until we encounter the end
+     * <code>([\s\S]*?)</code> captures all text until we encounter the end
      * character with <code>\1;}</code> e.g. <code>';}</code>
      */
-    private static final Pattern LIT_TEMPLATE_PATTERN = Pattern
-            .compile("render\\(\\)[\\s]*\\{[\\s\\S]*\\}");
-
     private static final Pattern LIT_TEMPLATE_PATTERN_HTML = Pattern
             .compile("return[\\s]*html[\\s]*(\\`)([\\s\\S]*?)\\1;[\\s]*\\}");
 

--- a/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/BundleLitParser.java
+++ b/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/BundleLitParser.java
@@ -66,8 +66,11 @@ public final class BundleLitParser {
      * <code>([\s\S]*)</code> captures all text until we encounter the end
      * character with <code>\1;}</code> e.g. <code>';}</code>
      */
-    private static final Pattern LIT_TEMPLATE_PATTERN = Pattern.compile(
-            "render\\(\\)[\\s]*\\{[\\s\\S]*return[\\s]*html[\\s]*(\\`)([\\s\\S]*?)\\1;[\\s]*\\}");
+    private static final Pattern LIT_TEMPLATE_PATTERN = Pattern
+            .compile("render\\(\\)[\\s]*\\{[\\s\\S]*\\}");
+
+    private static final Pattern LIT_TEMPLATE_PATTERN_HTML = Pattern
+            .compile("return[\\s]*html[\\s]*(\\`)([\\s\\S]*?)\\1;[\\s]*\\}");
 
     private static final String TEMPLATE_TAG_NAME = "template";
 
@@ -87,26 +90,32 @@ public final class BundleLitParser {
             String source) {
         Document templateDocument = null;
         String content = StringUtil.removeComments(source);
-        Matcher templateMatcher = LIT_TEMPLATE_PATTERN.matcher(content);
+        Matcher renderMatcher = LIT_TEMPLATE_PATTERN.matcher(content);
 
-        // GroupCount should be 2 as the first group contains `|'|" depending
-        // on what was in template return html' and the second is the
-        // template contents.
-        if (templateMatcher.find() && templateMatcher.groupCount() == 2) {
-            String group = templateMatcher.group(2);
-            LOGGER.trace("Found regular Lit template content was {}", group);
+        if (renderMatcher.find()) {
+            String renderGroup = renderMatcher.group(0);
+            Matcher templateMatcher = LIT_TEMPLATE_PATTERN_HTML
+                    .matcher(renderGroup);
+            // GroupCount should be at least 3 as the first group contains whole
+            // content and second group contains `|'|". Third group contains
+            // first "return html'" template contents.
+            if (templateMatcher.find() && templateMatcher.groupCount() >= 2) {
+                String group = templateMatcher.group(2);
+                LOGGER.trace("Found regular Lit template content was {}",
+                        group);
 
-            templateDocument = Jsoup.parse(group);
-            LOGGER.trace("The parsed template document was {}",
-                    templateDocument);
-            Element template = templateDocument
-                    .createElement(TEMPLATE_TAG_NAME);
-            Element body = templateDocument.body();
-            templateDocument.body().children().stream()
-                    .filter(node -> !node.equals(body))
-                    .forEach(template::appendChild);
+                templateDocument = Jsoup.parse(group);
+                LOGGER.trace("The parsed template document was {}",
+                        templateDocument);
+                Element template = templateDocument
+                        .createElement(TEMPLATE_TAG_NAME);
+                Element body = templateDocument.body();
+                templateDocument.body().children().stream()
+                        .filter(node -> !node.equals(body))
+                        .forEach(template::appendChild);
 
-            return template;
+                return template;
+            }
         }
         LOGGER.warn("No lit template data found in {} sources.", fileName);
         return null;

--- a/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/BundleLitParser.java
+++ b/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/BundleLitParser.java
@@ -42,7 +42,8 @@ public final class BundleLitParser {
             .getLogger(BundleLitParser.class);
 
     /**
-     * Lit template pattern matches the render function
+     * Lit template pattern matches from the <code>render() {</code> until the
+     * last <code>}</code> character.
      *
      * <pre>
      * render() {
@@ -60,7 +61,7 @@ public final class BundleLitParser {
 
     /**
      * Lit template pattern for html matches the return statement with html
-     * template.
+     * template. Used for the first match from <code>render() {</code>.
      *
      * <pre>
      *       return html`
@@ -108,8 +109,8 @@ public final class BundleLitParser {
             String renderGroup = renderMatcher.group(0);
             Matcher templateMatcher = LIT_TEMPLATE_PATTERN_HTML
                     .matcher(renderGroup);
-            // GroupCount should be at least 3 as the first group contains whole
-            // content and second group contains `|'|". Third group contains
+            // GroupCount should be at least 2 as the first group contains
+            // `|'|". Second group contains
             // first "return html'" template contents.
             if (templateMatcher.find() && templateMatcher.groupCount() >= 2) {
                 String group = templateMatcher.group(2);

--- a/flow-lit-template/src/test/java/com/vaadin/flow/component/littemplate/BundleLitParserTest.java
+++ b/flow-lit-template/src/test/java/com/vaadin/flow/component/littemplate/BundleLitParserTest.java
@@ -92,4 +92,73 @@ public class BundleLitParserTest {
         Assert.assertEquals(1,
                 element.getElementsByTag("timer-element").size());
     }
+
+    @Test
+    public void parseTemplate_codeWithHtmlBeforeRender_templateProperlyParsed() {
+        final Element element = BundleLitParser.parseLitTemplateElement("in.ts",
+        // @formatter:off
+                "import { html, LitElement } from 'lit';\n"
+                        + "\n"
+                        + "export class HelloLit extends LitElement {\n"
+                        + "\n"
+                        + "  helper() {\n"
+                        + "    return html`<span>helper</span>`;\n"
+                        + "  }\n"
+                        + "  render() {\n"
+                        + "    const athleteTimerStyles = { \n"
+                        + "      display:  this.currentAthleteMode && !this.decisionVisible ? \"grid\" : \"none\",\n"
+                        + "    }\n"
+                        + "    return html`\n"
+                        + "      <div>Some content</div>`;\n"
+                        + "      <span class=\"timer athleteTimer\" style=\"${styleMap(athleteTimerStyles)}\">\n"
+                        + "        <timer-element id=\"athleteTimer\"></timer-element>\n"
+                        + "      </span>\n"
+                        + "      `;"
+                        + "  }\n"
+                        + "}\n"
+                        + "\n"
+                        + "customElements.define('hello-lit', HelloLit);");
+        // @formatter:on
+
+        Assert.assertEquals(4, element.getAllElements().size());
+        Assert.assertEquals(1, element.getElementsByTag("div").size());
+        Assert.assertEquals(1, element.getElementsByTag("span").size());
+        Assert.assertEquals(1,
+                element.getElementsByTag("timer-element").size());
+    }
+
+    @Test
+    public void parseTemplate_codeWithHtmlAfterRender_templateProperlyParsed() {
+        final Element element = BundleLitParser.parseLitTemplateElement("in.ts",
+        // @formatter:off
+                "import { html, LitElement } from 'lit';\n"
+                        + "\n"
+                        + "export class HelloLit extends LitElement {\n"
+                        + "\n"
+                        + "  render() {\n"
+                        + "    const athleteTimerStyles = { \n"
+                        + "      display:  this.currentAthleteMode && !this.decisionVisible ? \"grid\" : \"none\",\n"
+                        + "    }\n"
+                        + "    return html`\n"
+                        + "      <div>Some content</div>`;\n"
+                        + "      <span class=\"timer athleteTimer\" style=\"${styleMap(athleteTimerStyles)}\">\n"
+                        + "        <timer-element id=\"athleteTimer\"></timer-element>\n"
+                        + "      </span>\n"
+                        + "      `;"
+                        + "  }\n"
+                        + "  helper() {\n"
+                        + "    return html`<span>helper</span>`;\n"
+                        + "  }\n"
+                        + "}\n"
+                        + "\n"
+                        + "customElements.define('hello-lit', HelloLit);");
+        // @formatter:on
+
+        Assert.assertEquals(4, element.getAllElements().size());
+        Assert.assertEquals(1, element.getElementsByTag("div").size());
+        Assert.assertEquals(1, element.getElementsByTag("span").size());
+        Assert.assertEquals(1,
+                element.getElementsByTag("timer-element").size());
+    }
+
 }


### PR DESCRIPTION
Changes regex in LitTemplateParser to find correct template content in case when lit template code contains "return html`" template also after the render function.

Fixes: #17721