### PR TITLE
fix: added class can be with /

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -727,8 +727,13 @@ public class VaadinServletContextInitializer
                                 // Updates cached white list and route packages
                                 Set<String> addedPackages = new HashSet<>();
                                 e.getAddedClasses().forEach(c -> {
-                                    addedPackages.add(
-                                            c.substring(0, c.lastIndexOf(".")));
+                                    if (c.contains("/")) {
+                                        c = c.replaceAll("/", ".");
+                                    }
+                                    if (c.contains(".")) {
+                                        addedPackages.add(c.substring(0,
+                                                c.lastIndexOf(".")));
+                                    }
                                 });
                                 ReloadCache.dynamicWhiteList
                                         .addAll(addedPackages);


### PR DESCRIPTION
On windows at least the added
class can come in the format
com/example/application/Hello
in which case the cache throws a
IndexOutOfBounds exception for
the range [0, -1]
