### PR TITLE
Revert "chore(deps): bump biz.aQute.bnd:bnd-maven-plugin from 6.4.0 to 7.0.0 (#17792)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <osgi.bundle.version>
             ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}
         </osgi.bundle.version>
-        <bnd.version>7.0.0</bnd.version>
+        <bnd.version>6.4.0</bnd.version>
         <osgi.core.version>7.0.0</osgi.core.version>
         <osgi.compendium.version>7.0.0</osgi.compendium.version>
         <osgi.annotation.version>8.1.0</osgi.annotation.version>


### PR DESCRIPTION
This reverts commit 236156bf232040ae6c75fa045deebaa38d400573.

