### PR TITLE
test: fix horizontal-layout npm package version

### DIFF
--- a/flow-tests/test-express-build/test-prod-bundle/src/main/java/com/vaadin/prodbundle/FakeAppConf.java
+++ b/flow-tests/test-express-build/test-prod-bundle/src/main/java/com/vaadin/prodbundle/FakeAppConf.java
@@ -20,13 +20,14 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.page.AppShellConfigurator;
 import com.vaadin.flow.server.PWA;
 import com.vaadin.flow.theme.Theme;
+import com.vaadin.flow.uitest.ui.dependencies.TestVersion;
 
 @Theme("vaadin-prod-bundle")
 @PWA(name = "vaadin-prod-bundle", shortName = "vaadin-prod-bundle")
 @JsModule("@vaadin-component-factory/vcf-nav")
 @NpmPackage(value = "@vaadin-component-factory/vcf-nav", version = "1.0.6")
 @JsModule("@vaadin/horizontal-layout")
-@NpmPackage(value = "@vaadin/horizontal-layout", version = "24.1.0")
+@NpmPackage(value = "@vaadin/horizontal-layout", version = TestVersion.VAADIN)
 public class FakeAppConf implements AppShellConfigurator {
 
 }


### PR DESCRIPTION
The test production bundle is using an older npm package version that may produce failure during Vite build.
This change updates the production bundle to use the correct version of vaadin npm package for testing.