### PR TITLE
feat: reset focus on active element in ShortcutRegistration

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
@@ -142,6 +142,7 @@ public interface ClickNotifier<T extends Component> extends Serializable {
                 () -> new Component[] { thisComponent.getUI().get() },
                 event -> ComponentUtil.fireEvent(thisComponent,
                         new ClickEvent<>(thisComponent)),
-                key).withModifiers(keyModifiers).allowBrowserDefault();
+                key).withModifiers(keyModifiers).allowBrowserDefault()
+                .resetFocusOnActiveElement();
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
@@ -149,6 +149,17 @@ public class ShortcutRegistrationTest {
     }
 
     @Test
+    public void resetFocusOnActiveElementValuesDefaultToTrue() {
+        ShortcutRegistration registration = new ShortcutRegistration(
+                lifecycleOwner, () -> listenOn, event -> {
+                }, Key.KEY_A);
+
+        assertFalse(registration.isResetFocusOnActiveElement());
+        registration.resetFocusOnActiveElement();
+        assertTrue(registration.isResetFocusOnActiveElement());
+    }
+
+    @Test
     public void bindLifecycleToChangesLifecycleOwner() {
         Component newOwner = mock(Component.class);
 
@@ -174,6 +185,7 @@ public class ShortcutRegistrationTest {
 
         registration.setBrowserDefaultAllowed(true);
         registration.setEventPropagationAllowed(true);
+        registration.setResetFocusOnActiveElement(true);
 
         clientResponse();
 
@@ -181,9 +193,12 @@ public class ShortcutRegistrationTest {
                 registration.isBrowserDefaultAllowed());
         assertTrue("Allow propagation was not set to true",
                 registration.isBrowserDefaultAllowed());
+        assertTrue("Reset focus on active element was not set to true",
+                registration.isResetFocusOnActiveElement());
 
         registration.setBrowserDefaultAllowed(false);
         registration.setEventPropagationAllowed(false);
+        registration.setResetFocusOnActiveElement(false);
 
         clientResponse();
 
@@ -191,6 +206,8 @@ public class ShortcutRegistrationTest {
                 registration.isBrowserDefaultAllowed());
         assertFalse("Allow propagation was not set to false",
                 registration.isEventPropagationAllowed());
+        assertFalse("Reset focus on active element was not set to false",
+                registration.isResetFocusOnActiveElement());
     }
 
     @Test
@@ -316,6 +333,9 @@ public class ShortcutRegistrationTest {
 
         assertFalse("Allows propagation was not false",
                 registration.isEventPropagationAllowed());
+
+        assertFalse("Reset focus on active element was not set to false",
+                registration.isResetFocusOnActiveElement());
     }
 
     @Test
@@ -330,6 +350,9 @@ public class ShortcutRegistrationTest {
 
         assertFalse("Allows propagation was not false",
                 registration.isEventPropagationAllowed());
+
+        assertFalse("Reset focus on active element was not set to false",
+                registration.isResetFocusOnActiveElement());
     }
 
     @Test
@@ -399,6 +422,11 @@ public class ShortcutRegistrationTest {
                 expression.contains("event.stopPropagation();"));
         Assert.assertTrue("JS execution string missing the key" + key,
                 expression.contains(key.getKeys().get(0)));
+        Assert.assertFalse(
+                "JS execution string should not have blur() and focus() on active element in it"
+                        + expression,
+                expression.contains(
+                        ShortcutRegistration.FOCUS_ACTIVE_ELEMENT_JS));
 
         fixture.registration.remove();
 
@@ -424,6 +452,25 @@ public class ShortcutRegistrationTest {
                 "JS execution string should NOT have event.preventDefault() in it"
                         + expression,
                 expression.contains("event.preventDefault();"));
+    }
+
+    @Test
+    public void listenOnComponentHasElementLocatorJs_resetFocusOnActiveElement_JsExecutionResetFocusOnActiveElement() {
+        final ElementLocatorTestFixture fixture = new ElementLocatorTestFixture();
+        final Key key = Key.KEY_A;
+        fixture.createNewShortcut(key).resetFocusOnActiveElement();
+
+        List<PendingJavaScriptInvocation> pendingJavaScriptInvocations = fixture
+                .writeResponse();
+
+        final PendingJavaScriptInvocation js = pendingJavaScriptInvocations
+                .get(0);
+        final String expression = js.getInvocation().getExpression();
+        Assert.assertTrue(
+                "JS execution string should have blur() and focus() on active element in it"
+                        + expression,
+                expression.contains(
+                        ShortcutRegistration.FOCUS_ACTIVE_ELEMENT_JS));
     }
 
     @Test

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShadowRootShortcutsWithValueChangeModeView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShadowRootShortcutsWithValueChangeModeView.java
@@ -23,21 +23,31 @@ import com.vaadin.flow.component.html.Input;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.data.value.ValueChangeMode;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.ElementFactory;
+import com.vaadin.flow.dom.ShadowRoot;
 import com.vaadin.flow.router.AfterNavigationEvent;
 import com.vaadin.flow.router.AfterNavigationObserver;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 
-@Route(value = "com.vaadin.flow.uitest.ui.ShortcutsWithValueChangeModeView", layout = ViewTestLayout.class)
-public class ShortcutsWithValueChangeModeView extends Div
+@Route(value = "com.vaadin.flow.uitest.ui.ShadowRootShortcutsWithValueChangeModeView", layout = ViewTestLayout.class)
+public class ShadowRootShortcutsWithValueChangeModeView extends Div
         implements AfterNavigationObserver {
 
     private final Input input;
 
-    public ShortcutsWithValueChangeModeView() {
+    public ShadowRootShortcutsWithValueChangeModeView() {
+        setId("test-element");
+
+        ShadowRoot shadowRoot = getElement().attachShadow();
+        Element shadowDiv = ElementFactory.createDiv();
+        shadowDiv.setText("Div inside shadow DOM");
+        shadowDiv.setAttribute("id", "shadow-div");
 
         input = new Input();
         input.setId("input");
+        shadowDiv.appendChild(input.getElement());
 
         NativeButton button = new NativeButton("Report value");
         button.setId("button");
@@ -56,10 +66,12 @@ public class ShortcutsWithValueChangeModeView extends Div
         button.addClickShortcut(Key.KEY_S, KeyModifier.CONTROL,
                 KeyModifier.ALT);
         button.addClickShortcut(Key.ENTER, KeyModifier.CONTROL)
-                .resetFocusOnActiveElement();
+                .resetFocusOnActiveElement();// .listenOn(button);
         button.addClickListener(e -> value.setText(input.getValue()));
 
-        add(input, button, value);
+        shadowRoot.appendChild(shadowDiv);
+        shadowRoot.appendChild(button.getElement());
+        shadowRoot.appendChild(value.getElement());
     }
 
     @Override

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ShadowRootShortcutsWithValueChangeModeIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ShadowRootShortcutsWithValueChangeModeIT.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.Keys;
+
+import com.vaadin.flow.component.html.testbench.DivElement;
+import com.vaadin.flow.component.html.testbench.InputTextElement;
+import com.vaadin.flow.component.html.testbench.ParagraphElement;
+import com.vaadin.flow.data.value.ValueChangeMode;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class ShadowRootShortcutsWithValueChangeModeIT
+        extends ChromeBrowserTest {
+
+    private String text = "Some text";
+
+    @Test
+    public void onChangeValueChange_shortcutExecution_valueNotSentToServer() {
+        assertValueCommittedOnShortcutExecution(ValueChangeMode.ON_CHANGE,
+                false);
+        DivElement div = $(DivElement.class).id("test-element");
+
+        // trigger change event and check value
+        InputTextElement input = div.$(InputTextElement.class).id("input");
+        input.sendKeys(Keys.ENTER);
+        triggerShortcut(true);
+    }
+
+    @Test
+    public void onChangeValueChange_shortcutExecution_resetFocusOnActiveElement_valueSentToServer() {
+        open(ValueChangeMode.ON_CHANGE.name());
+
+        DivElement div = $(DivElement.class).id("test-element");
+        InputTextElement input = div.$(InputTextElement.class).id("input");
+        input.focus();
+        input.sendKeys(text);
+
+        doTriggerShortcut(true, Keys.CONTROL, Keys.ENTER);
+    }
+
+    private void assertValueCommittedOnShortcutExecution(ValueChangeMode mode,
+            boolean expectValue) {
+        open(mode.name());
+
+        DivElement div = $(DivElement.class).id("test-element");
+        InputTextElement input = div.$(InputTextElement.class).id("input");
+        input.focus();
+        input.sendKeys(text);
+
+        triggerShortcut(expectValue);
+    }
+
+    private void triggerShortcut(boolean expectValue) {
+        doTriggerShortcut(expectValue, Keys.CONTROL, Keys.ALT, "s");
+    }
+
+    private void doTriggerShortcut(boolean expectValue, CharSequence... keys) {
+        ShortcutsWithValueChangeModeIT.sendKeys(driver, keys);
+
+        DivElement div = $(DivElement.class).id("test-element");
+        String paragraphText = div.$(ParagraphElement.class).id("value")
+                .getText();
+
+        if (expectValue) {
+            Assert.assertEquals(
+                    "Expecting input value to be in sync with server value",
+                    text, paragraphText);
+        } else {
+            Assert.assertEquals(
+                    "Expecting input value not to be synced with server", "",
+                    paragraphText);
+        }
+    }
+
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ShortcutsWithValueChangeModeIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ShortcutsWithValueChangeModeIT.java
@@ -23,6 +23,7 @@ import java.util.stream.Stream;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.interactions.Actions;
 
 import com.vaadin.flow.component.html.testbench.InputTextElement;
@@ -65,6 +66,17 @@ public class ShortcutsWithValueChangeModeIT extends ChromeBrowserTest {
     }
 
     @Test
+    public void onChangeValueChange_shortcutExecution_resetFocusOnActiveElement_valueSentToServer() {
+        open(ValueChangeMode.ON_CHANGE.name());
+
+        InputTextElement input = $(InputTextElement.class).id("input");
+        input.focus();
+        input.sendKeys(text);
+
+        doTriggerShortcut(true, Keys.CONTROL, Keys.ENTER);
+    }
+
+    @Test
     public void onBlurValueChange_shortcutExecution_valueNotSentToServer() {
         assertValueCommittedOnShortcutExecution(ValueChangeMode.ON_BLUR, false);
         // trigger blur event and check value
@@ -85,7 +97,11 @@ public class ShortcutsWithValueChangeModeIT extends ChromeBrowserTest {
     }
 
     private void triggerShortcut(boolean expectValue) {
-        sendKeys(Keys.CONTROL, Keys.ALT, "s");
+        doTriggerShortcut(expectValue, Keys.CONTROL, Keys.ALT, "s");
+    }
+
+    private void doTriggerShortcut(boolean expectValue, CharSequence... keys) {
+        sendKeys(driver, keys);
 
         String paragraphText = $(ParagraphElement.class).id("value").getText();
 
@@ -100,7 +116,7 @@ public class ShortcutsWithValueChangeModeIT extends ChromeBrowserTest {
         }
     }
 
-    private void sendKeys(CharSequence... keys) {
+    public static void sendKeys(WebDriver driver, CharSequence... keys) {
         Actions actions = new Actions(driver);
         for (CharSequence keySeq : keys) {
             if (modifiers.contains(keySeq)) {
@@ -113,10 +129,10 @@ public class ShortcutsWithValueChangeModeIT extends ChromeBrowserTest {
         // Implementation that worked for driver < 75.beta:
         // new Actions(driver).sendKeys(keys).build().perform();
         // if keys are not reset, alt will remain down and start flip-flopping
-        resetKeys();
+        resetKeys(driver);
     }
 
-    private void resetKeys() {
+    public static void resetKeys(WebDriver driver) {
         Actions actions = new Actions(driver);
         modifiers.forEach(actions::keyUp);
         actions.build().perform();


### PR DESCRIPTION
Adds `setResetFocusOnActiveElement`, `resetFocusOnActiveElement` and `isResetFocusOnActiveElement` to `ShortcutRegistration` class to optionally reset focus on active element (focused element in browser). Resetting means calling `blur()` and `focus()` on the active element to ensure that input fields with `ValueChangeMode` `ON_CHANGE` will fire value change event before shortcut handler is run. Updates `ClickNotifier#addClickShortcut(Key,KeyModifier...)` to reset focus on active element by default for click shortcuts.

Fixes: #5959
