### PR TITLE
test: Add tests for dev mode client-side logging; Clarify prod mode test

### DIFF
--- a/flow-tests/test-dev-mode/src/main/java/com/vaadin/flow/uitest/ui/frontend/BrowserLoggingView.java
+++ b/flow-tests/test-dev-mode/src/main/java/com/vaadin/flow/uitest/ui/frontend/BrowserLoggingView.java
@@ -20,6 +20,7 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.NativeLabel;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.shared.ui.LoadMode;
 import com.vaadin.flow.uitest.servlet.ViewTestLayout;
@@ -29,6 +30,10 @@ import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 @JavaScript(value = "./consoleLoggingProxy.js", loadMode = LoadMode.INLINE)
 public class BrowserLoggingView extends Div {
     public BrowserLoggingView() {
+        NativeLabel label = new NativeLabel("Just a label");
+        label.setId("elementId");
+        add(label);
+
         NativeButton causeException = new NativeButton(
                 "Cause client side exception", e -> {
                     getUI().get().getPage().executeJs("null.foo");

--- a/flow-tests/test-dev-mode/src/main/java/com/vaadin/flow/uitest/ui/frontend/BrowserLoggingView.java
+++ b/flow-tests/test-dev-mode/src/main/java/com/vaadin/flow/uitest/ui/frontend/BrowserLoggingView.java
@@ -19,7 +19,7 @@ package com.vaadin.flow.uitest.ui.frontend;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.NativeLabel;
+import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.shared.ui.LoadMode;
 import com.vaadin.flow.uitest.servlet.ViewTestLayout;
@@ -29,8 +29,11 @@ import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 @JavaScript(value = "./consoleLoggingProxy.js", loadMode = LoadMode.INLINE)
 public class BrowserLoggingView extends Div {
     public BrowserLoggingView() {
-        NativeLabel label = new NativeLabel("Just a label");
-        label.setId("elementId");
-        add(label);
+        NativeButton causeException = new NativeButton(
+                "Cause client side exception", e -> {
+                    getUI().get().getPage().executeJs("null.foo");
+                });
+        causeException.setId("exception");
+        add(causeException);
     }
 }

--- a/flow-tests/test-dev-mode/src/test/java/com/vaadin/flow/uitest/ui/frontend/BrowserLoggingIT.java
+++ b/flow-tests/test-dev-mode/src/test/java/com/vaadin/flow/uitest/ui/frontend/BrowserLoggingIT.java
@@ -33,7 +33,7 @@ import static org.hamcrest.number.OrderingComparison.greaterThan;
 public class BrowserLoggingIT extends ChromeBrowserTest {
 
     @Test
-    public void nonProductionModeHasLogEntries() {
+    public void developmentModeHasLogEntries() {
         open();
         waitForElementPresent(By.id("exception"));
 
@@ -43,7 +43,7 @@ public class BrowserLoggingIT extends ChromeBrowserTest {
                 "return window.allLogMessages;");
 
         assertThat(
-                "Flow in non-production mode should output something into the console",
+                "Flow in development mode should output something into the console",
                 logMessages.size(), greaterThan(0));
 
         // Check for "Scheduling heartbeat in" msg (= debug level)

--- a/flow-tests/test-dev-mode/src/test/java/com/vaadin/flow/uitest/ui/frontend/BrowserLoggingIT.java
+++ b/flow-tests/test-dev-mode/src/test/java/com/vaadin/flow/uitest/ui/frontend/BrowserLoggingIT.java
@@ -16,13 +16,15 @@
 
 package com.vaadin.flow.uitest.ui.frontend;
 
+import java.util.ArrayList;
+
 import org.junit.Test;
 import org.openqa.selenium.By;
 
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
-import static org.junit.Assert.assertThat;
 
 /**
  * @author Vaadin Ltd
@@ -33,15 +35,30 @@ public class BrowserLoggingIT extends ChromeBrowserTest {
     @Test
     public void nonProductionModeHasLogEntries() {
         open();
-        waitForElementPresent(By.id("elementId"));
+        waitForElementPresent(By.id("exception"));
+
+        findElement(By.id("exception")).click();
+
+        ArrayList<Object> logMessages = (ArrayList<Object>) executeScript(
+                "return window.allLogMessages;");
 
         assertThat(
-                "Flow in production mode should output nothing into the console",
-                getLogEntriesCount(), greaterThan(0L));
-    }
+                "Flow in non-production mode should output something into the console",
+                logMessages.size(), greaterThan(0));
 
-    private Long getLogEntriesCount() {
-        // see java script imported in corresponding test view
-        return (Long) executeScript("return window.allLogMessages.length;");
+        // Check for "Scheduling heartbeat in" msg (= debug level)
+        assertThat("Expected debug message not found in log",
+                logMessages.stream().anyMatch(msg -> String.valueOf(msg)
+                        .contains("Scheduling heartbeat in")));
+
+        // Check for "Setting heartbeat interval to" msg (= info level)
+        assertThat("Expected info message not found in log",
+                logMessages.stream().anyMatch(msg -> String.valueOf(msg)
+                        .contains("Setting heartbeat interval to")));
+
+        // Check for exception thrown msg (= error level)
+        assertThat("Expected error message not found in log", logMessages
+                .stream().anyMatch(msg -> String.valueOf(msg).contains(
+                        "Exception is thrown during JavaScript execution.")));
     }
 }

--- a/flow-tests/test-misc/frontend/consoleLoggingProxy.js
+++ b/flow-tests/test-misc/frontend/consoleLoggingProxy.js
@@ -32,6 +32,6 @@ const console = (function(oldConsole) {
 window.console = console;
 
 window.addEventListener("error", function (e) {
-  window.console.trace(e);
+  window.console.trace(e.error.message);
   return false;
 });

--- a/flow-tests/test-misc/src/test/java/com/vaadin/flow/misc/ui/ExceptionLoggingIT.java
+++ b/flow-tests/test-misc/src/test/java/com/vaadin/flow/misc/ui/ExceptionLoggingIT.java
@@ -30,10 +30,12 @@ public class ExceptionLoggingIT extends ChromeBrowserTest {
         open();
         findElement(By.id("exception")).click();
 
+        // Checking that the log count is exactly 1 also ensures that no info or
+        // debug level messages were logged before the exception message.
         assertThat("Flow in production mode should output exception to console",
                 getLogEntriesCount(), is(1L));
         assertThat("Error message should have contained 'foo'",
-                getErrorMessage().contains("foo"));
+                checkFirstErrorMessageContains("foo"));
     }
 
     @Test
@@ -41,19 +43,21 @@ public class ExceptionLoggingIT extends ChromeBrowserTest {
         open();
         findElement(By.id("externalException")).click();
 
+        // Checking that the log count is exactly 1 also ensures that no info or
+        // debug level messages were logged before the exception message.
         assertThat("Flow in production mode should output exception to console",
                 getLogEntriesCount(), is(1L));
         assertThat("Error message should have contained 'bar'",
-                getErrorMessage().contains("bar"));
+                checkFirstErrorMessageContains("bar"));
     }
 
     private Long getLogEntriesCount() {
         return (Long) executeScript("return window.allLogMessages.length;");
     }
 
-    private String getErrorMessage() {
-        return (String) executeScript(
-                "return window.allLogMessages[0].error.message;");
+    private boolean checkFirstErrorMessageContains(String shouldContain) {
+        return ((String) executeScript("return window.allLogMessages[0];"))
+                .contains(shouldContain);
     }
 
     @Override


### PR DESCRIPTION
Could not find a way to hook into methods of `com.vaadin.client.Console` without exporting them to JS  which we do not want. So only debug, info and error level output is checked via known log messages.