### PR TITLE
Fix the support for Java 17 (Theme editor)

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/editor/Editor.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/editor/Editor.java
@@ -1,5 +1,6 @@
 package com.vaadin.base.devserver.editor;
 
+import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.Position;
 import com.github.javaparser.Range;
 import com.github.javaparser.StaticJavaParser;
@@ -33,6 +34,7 @@ import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.stmt.Statement;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
+import com.github.javaparser.utils.SourceRoot;
 import com.vaadin.base.devserver.themeeditor.utils.StatementLineNumberVisitor;
 import com.vaadin.flow.shared.util.SharedUtil;
 import org.apache.commons.io.IOUtils;
@@ -1097,6 +1099,10 @@ public class Editor {
     }
 
     protected CompilationUnit parseSource(String source) {
+        ParserConfiguration parserConfiguration = new ParserConfiguration();
+        parserConfiguration
+                .setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17);
+        StaticJavaParser.setConfiguration(parserConfiguration);
         return LexicalPreservingPrinter.setup(StaticJavaParser.parse(source));
     }
 

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/editor/AddComponentTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/editor/AddComponentTest.java
@@ -123,6 +123,7 @@ public class AddComponentTest extends AbstractClassBasedTest {
                 "Button helloWorld = new Button(\"Hello world\");");
         assertTestFileContains("add(helloWorld)");
     }
+
     @Test
     public void addTwiceToEmptyView() throws Exception {
         setupTestClass("EmptyView");

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/editor/AddComponentTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/editor/AddComponentTest.java
@@ -105,6 +105,24 @@ public class AddComponentTest extends AbstractClassBasedTest {
         assertTestFileContains("add(helloWorld)");
     }
 
+    /**
+     * Test if the Switch expression is supported (Java 17 support)
+     *
+     * @throws Exception
+     */
+    @Test
+    public void addToEmptyViewWithSwitch() throws Exception {
+        setupTestClass("EmptyViewWithSwitch");
+        // Create is the constructor
+        int create = getLineNumber(testFile, "public EmptyView() {");
+        int attach = create;
+        editor.addComponent(testFile, create, attach, Where.INSIDE,
+                ComponentType.BUTTON, "Hello world");
+
+        assertTestFileContains(
+                "Button helloWorld = new Button(\"Hello world\");");
+        assertTestFileContains("add(helloWorld)");
+    }
     @Test
     public void addTwiceToEmptyView() throws Exception {
         setupTestClass("EmptyView");

--- a/vaadin-dev-server/src/test/resources/com/vaadin/base/devserver/editor/inputs/EmptyViewWithSwitch.java
+++ b/vaadin-dev-server/src/test/resources/com/vaadin/base/devserver/editor/inputs/EmptyViewWithSwitch.java
@@ -1,0 +1,20 @@
+package com.vaadin.base.devserver.editor.inputs;
+
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+
+@Route(value = "empty")
+public class EmptyView extends HorizontalLayout {
+
+    public EmptyView() {
+    }
+
+    private String testSwitch(String value) {
+        return switch (value) {
+            case "test" -> "test";
+            case "prod" -> "Production";
+            default -> "N/A";
+        };
+    }
+}


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Please list all relevant dependencies in this section and provide summary of the change, motivation and context.

Fixes #17834  (issue)

Add the parser configuration in the Editor class to allow the switch expression to be parsed 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
