### PR TITLE
fix: readding component that on detach removes components

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/dom/Node.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Node.java
@@ -383,6 +383,11 @@ public abstract class Node<N extends Node<N>> implements Serializable {
                 }
             }
             child.removeFromParent();
+            // If detach of component removes other components adjust insert
+            // target
+            if (insertIndex > getChildCount()) {
+                insertIndex = getChildCount();
+            }
             getStateProvider().insertChild(node, insertIndex, child);
             ensureChildHasParent(child, true);
         }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/AbstractNodeStateProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/AbstractNodeStateProvider.java
@@ -100,7 +100,9 @@ public abstract class AbstractNodeStateProvider
     @Override
     public void insertChild(StateNode node, int index, Element child) {
         assert index >= 0;
-        assert index <= getChildCount(node); // == if adding as last
+        // == if adding as last
+        assert index <= getChildCount(node)
+                : "index " + index + " outside range " + getChildCount(node);
 
         getChildrenFeature(node).add(index, child.getNode());
         if (child.getComponent().isPresent()) {

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
@@ -681,6 +681,25 @@ public class ComponentTest {
     }
 
     @Test
+    public void testAttachDetach_children() {
+        UI ui = new UI();
+        TestComponentContainer parent = new TestComponentContainer();
+        TestComponent child1 = new TestComponent();
+        TestComponent child2 = new TestComponent();
+        TestComponent child3 = new TestComponent();
+        parent.addAttachListener(e -> ui.add(child1, child2, child3));
+        parent.addDetachListener(e -> ui.remove(child1, child2, child3));
+
+        ui.add(parent);
+
+        Assert.assertEquals(4, ui.getChildren().count());
+
+        ui.add(parent);
+
+        Assert.assertEquals(4, ui.getChildren().count());
+    }
+
+    @Test
     public void testDetachListener_eventOrder_childFirst() {
         UI ui = new UI();
         TestComponentContainer parent = new TestComponentContainer();


### PR DESCRIPTION
Fixes the case where a component is readded
to the same parent and at the same time
in a detachListener removes components from
the parent.

Fixes #16741
