### PR TITLE
chore: bump byte-buddy to 1.14.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
             <dependency>
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy</artifactId>
-                <version>1.12.23</version>
+                <version>1.14.9</version>
             </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>


### PR DESCRIPTION
Bump byte-buddy to a more recent version to support builds using Java 21 

Fixes #17828