### PR TITLE
fix: consume output from postinstall executions

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -445,6 +445,31 @@ public class TaskRunNpmInstallTest {
                         "postinstall-file.txt").exists());
     }
 
+    // https://github.com/vaadin/flow/issues/17663
+    @Test(timeout = 10000)
+    public void runNpmInstall_postInstallWritingLotsOfOutput_processDoesNotStuck()
+            throws ExecutionFailedException, IOException {
+        setupEsbuildAndFooInstallation();
+
+        File nodeModules = options.getNodeModulesFolder();
+        File fooPackageJson = new File(
+                new File(nodeModules.getParentFile(), "fake-foo"),
+                "package.json");
+        String fooPackageJsonContents = IOUtils.toString(
+                getClass().getResourceAsStream(
+                        "fake-package-with-postinstall-writing-to-console.json"),
+                StandardCharsets.UTF_8);
+        FileUtils.write(fooPackageJson, fooPackageJsonContents,
+                StandardCharsets.UTF_8);
+
+        task = createTask(Collections.singletonList("foo"));
+        task.execute();
+
+        Assert.assertTrue("Postinstall for 'foo' was not run",
+                new File(new File(options.getNodeModulesFolder(), "foo"),
+                        "postinstall-console-file.txt").exists());
+    }
+
     @Test
     public void shouldRunNpmInstallWhenFolderChanges() throws Exception {
         setupEsbuildAndFooInstallation();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import net.jcip.annotations.NotThreadSafe;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -389,6 +390,31 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         Assert.assertTrue("Postinstall for 'foo' was not run",
                 new File(new File(options.getNodeModulesFolder(), "foo"),
                         "postinstall-file.txt").exists());
+    }
+
+    // https://github.com/vaadin/flow/issues/17663
+    @Test(timeout = 10000)
+    public void runNpmInstall_postInstallWritingLotsOfOutput_processDoesNotStuck()
+            throws ExecutionFailedException, IOException {
+        setupEsbuildAndFooInstallation();
+
+        File nodeModules = options.getNodeModulesFolder();
+        File fooPackageJson = new File(
+                new File(nodeModules.getParentFile(), "fake-foo"),
+                "package.json");
+        String fooPackageJsonContents = IOUtils.toString(
+                getClass().getResourceAsStream(
+                        "fake-package-with-postinstall-writing-to-console.json"),
+                StandardCharsets.UTF_8);
+        FileUtils.write(fooPackageJson, fooPackageJsonContents,
+                StandardCharsets.UTF_8);
+
+        TaskRunNpmInstall task = createTask(Collections.singletonList("foo"));
+        task.execute();
+
+        Assert.assertTrue("Postinstall for 'foo' was not run",
+                new File(new File(options.getNodeModulesFolder(), "foo"),
+                        "postinstall-console-file.txt").exists());
     }
 
     @Test

--- a/flow-server/src/test/resources/com/vaadin/flow/server/frontend/fake-package-with-postinstall-writing-to-console.json
+++ b/flow-server/src/test/resources/com/vaadin/flow/server/frontend/fake-package-with-postinstall-writing-to-console.json
@@ -1,0 +1,12 @@
+{
+    "name": "esbuild",
+    "version": "0.12.29",
+    "description": "An extremely fast JavaScript bundler and minifier.",
+    "repository": "https://github.com/evanw/esbuild",
+    "scripts": {
+        "postinstall": "node -e \"for (var i = 0; i < 100000; i++) { process.stdout.write('Line on stdout\\n'); process.stderr.write('Line on stderr\\n'); } ; fs.writeFileSync('postinstall-console-file.txt','generated')\""
+    },
+    "main": "lib/main.js",
+    "types": "lib/main.d.ts",
+    "license": "MIT"
+}


### PR DESCRIPTION
## Description

Execution of postintall tasks can lead to a deadlock if the subprocess produces more output on stdout than can fit in the pipe buffer. This change ensures that the output of the subprocess if correctly consumed.

Fixes #17663

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
