### PR TITLE
feat: Use binding object to check for Binder#hasChanges

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -3035,7 +3035,7 @@ public class Binder<BEAN> implements Serializable {
     }
 
     /**
-     * Checks whether a field has uncomitted changes.
+     * Checks whether a bound field has uncomitted changes.
      *
      * @param binding
      *            Binding to be checked

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -3035,6 +3035,16 @@ public class Binder<BEAN> implements Serializable {
     }
 
     /**
+     * Checks whether a field has uncomitted changes.
+     *
+     * @param binding Binding to be checked
+     * @return true if field has been changed.
+     */
+    public boolean hasChanges(Binding<BEAN, ?> binding) {
+        return hasChanges() && changedBindings.contains(binding);
+    }
+
+    /**
      * Sets the read only state to the given value for all currently bound
      * fields.
      * <p>

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -290,7 +290,7 @@ public class Binder<BEAN> implements Serializable {
          * @throws IllegalStateException
          *             if the binding is no longer attached to a Binder.
          *
-         * @return True if field has uncommitted changes
+         * @return {@literal true} if the field the binding uses has uncommitted changes, otherwise {@literal false}.
          */
         boolean hasChanges();
     }

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -282,6 +282,18 @@ public class Binder<BEAN> implements Serializable {
          * @return A boolean value
          */
         boolean isConvertBackToPresentation();
+
+        /**
+         * Checks whether the related Binder instance has marked the field as
+         * having uncommitted changes.
+         *
+         * @throws IllegalStateException
+         *             if {@code binder} is null. Ensure that the binder has
+         *             been declared here.
+         *
+         * @return True if field has uncommitted changes
+         */
+        boolean hasChanges() throws IllegalStateException;
     }
 
     /**
@@ -1588,6 +1600,15 @@ public class Binder<BEAN> implements Serializable {
                     throw exception;
                 }
             }
+        }
+
+        @Override
+        public boolean hasChanges() throws IllegalStateException {
+            if (this.binder == null) {
+                throw new IllegalStateException();
+            }
+
+            return this.binder.hasChanges(this);
         }
     }
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -290,7 +290,8 @@ public class Binder<BEAN> implements Serializable {
          * @throws IllegalStateException
          *             if the binding is no longer attached to a Binder.
          *
-         * @return {@literal true} if the field the binding uses has uncommitted changes, otherwise {@literal false}.
+         * @return {@literal true} if the field the binding uses has uncommitted
+         *         changes, otherwise {@literal false}.
          */
         boolean hasChanges();
     }

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -3037,7 +3037,8 @@ public class Binder<BEAN> implements Serializable {
     /**
      * Checks whether a field has uncomitted changes.
      *
-     * @param binding Binding to be checked
+     * @param binding
+     *            Binding to be checked
      * @return true if field has been changed.
      */
     public boolean hasChanges(Binding<BEAN, ?> binding) {

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -1604,7 +1604,7 @@ public class Binder<BEAN> implements Serializable {
         @Override
         public boolean hasChanges() throws IllegalStateException {
             if (this.binder == null) {
-                throw new IllegalStateException();
+                throw new IllegalStateException("This Binding is no longer attached to a Binder");
             }
 
             return this.binder.hasChanges(this);

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -293,7 +293,7 @@ public class Binder<BEAN> implements Serializable {
          *
          * @return True if field has uncommitted changes
          */
-        boolean hasChanges() throws IllegalStateException;
+        boolean hasChanges();
     }
 
     /**

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -284,8 +284,8 @@ public class Binder<BEAN> implements Serializable {
         boolean isConvertBackToPresentation();
 
         /**
-         * Checks whether the related Binder instance has marked the field as
-         * having uncommitted changes.
+         * Checks whether the field that the binding uses has uncommitted
+         * changes.
          *
          * @throws IllegalStateException
          *             if the binding is no longer attached to a Binder.
@@ -1604,7 +1604,8 @@ public class Binder<BEAN> implements Serializable {
         @Override
         public boolean hasChanges() throws IllegalStateException {
             if (this.binder == null) {
-                throw new IllegalStateException("This Binding is no longer attached to a Binder");
+                throw new IllegalStateException(
+                        "This Binding is no longer attached to a Binder");
             }
 
             return this.binder.hasChanges(this);

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -206,6 +206,8 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
 
         binder.readBean(item);
         assertEquals("No name field value", "Johannes", nameField.getValue());
+        assertFalse("Field marked as changed after reading bean",
+                binder.hasChanges(binding));
 
         ageField.setValue("99");
         assertFalse("Age field caused name field change",

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -65,6 +65,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThrows;
 
 public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
 
@@ -245,6 +246,25 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
 
         assertFalse("Binder has changes after clearing all fields",
                 binding.hasChanges());
+    }
+
+    @Test
+    public void bindingInstanceHasChanges_throwsWhenBinderNotAttached() {
+        var binding = binder.forField(nameField).bind(Person::getFirstName,
+                Person::setFirstName);
+
+        binder.readBean(item);
+
+        assertFalse("Field marked as changed after reading bean",
+                binding.hasChanges());
+
+        nameField.setValue("James");
+        assertTrue("Binder did not have value changes", binding.hasChanges());
+
+        binding.unbind();
+
+        assertThrows("Expect unbound binding to throw exception",
+                IllegalStateException.class, binding::hasChanges);
     }
 
     @Test

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -208,10 +208,12 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         assertEquals("No name field value", "Johannes", nameField.getValue());
 
         ageField.setValue("99");
-        assertFalse("Age field caused name field change", binder.hasChanges(binding));
+        assertFalse("Age field caused name field change",
+                binder.hasChanges(binding));
 
         nameField.setValue("James");
-        assertTrue("Binder did not have value changes", binder.hasChanges(binding));
+        assertTrue("Binder did not have value changes",
+                binder.hasChanges(binding));
 
         binder.readBean(null);
 

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -200,6 +200,27 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
     }
 
     @Test
+    public void writeBean_setsHasChangesBindingToFalse() {
+        var binding = binder.forField(nameField).bind(Person::getFirstName,
+                Person::setFirstName);
+
+        binder.readBean(item);
+        assertEquals("No name field value", "Johannes", nameField.getValue());
+
+        ageField.setValue("99");
+        assertFalse("Age field caused name field change", binder.hasChanges(binding));
+
+        nameField.setValue("James");
+        assertTrue("Binder did not have value changes", binder.hasChanges(binding));
+
+        binder.readBean(null);
+
+        assertFalse("Binder has changes after clearing all fields",
+                binder.hasChanges(binding));
+
+    }
+
+    @Test
     public void clearReadOnlyBinder_shouldClearFields() {
         binder.forField(nameField).bind(Person::getFirstName,
                 Person::setFirstName);

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -200,7 +200,7 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
     }
 
     @Test
-    public void writeBean_setsHasChangesBindingToFalse() {
+    public void bindingHasChanges_trueWhenFieldValueChanges() {
         var binding = binder.forField(nameField).bind(Person::getFirstName,
                 Person::setFirstName);
 

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -264,7 +264,9 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         binding.unbind();
 
         assertThrows("Expect unbound binding to throw exception",
-                IllegalStateException.class, binding::hasChanges);
+                IllegalStateException.class, () -> {
+                    binding.hasChanges();
+                });
     }
 
     @Test

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -225,6 +225,29 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
     }
 
     @Test
+    public void bindingInstanceHasChanges_trueWhenFieldValueChanges() {
+        var binding = binder.forField(nameField).bind(Person::getFirstName,
+                Person::setFirstName);
+
+        binder.readBean(item);
+
+        assertEquals("No name field value", "Johannes", nameField.getValue());
+        assertFalse("Field marked as changed after reading bean",
+                binding.hasChanges());
+
+        ageField.setValue("99");
+        assertFalse("Age field caused name field change", binding.hasChanges());
+
+        nameField.setValue("James");
+        assertTrue("Binder did not have value changes", binding.hasChanges());
+
+        binder.readBean(null);
+
+        assertFalse("Binder has changes after clearing all fields",
+                binding.hasChanges());
+    }
+
+    @Test
     public void clearReadOnlyBinder_shouldClearFields() {
         binder.forField(nameField).bind(Person::getFirstName,
                 Person::setFirstName);


### PR DESCRIPTION
## Description

Allows to check whether specific binding has been changed. So far there is only a generic Binder#hasChanges, which checks all bindings. The new method allows to check whether a specific binding has changes.

Fixes #17395

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
