### PR TITLE
fix: RouteAlias hides Route value

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/ConfiguredRoutes.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/ConfiguredRoutes.java
@@ -457,6 +457,10 @@ public class ConfiguredRoutes implements Serializable {
     private static Collection<String> getOrderedTemplates(
             Class<? extends Component> navigationTarget, RouteModel model) {
         final Collection<String> templates = model.getRoutes().keySet();
+        // No need to check route if one or no template.
+        if (templates.size() <= 1) {
+            return templates;
+        }
 
         // Bring actual route to front of collection
         if (navigationTarget.isAnnotationPresent(Route.class)) {

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/ConfiguredRoutesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/ConfiguredRoutesTest.java
@@ -3,6 +3,8 @@ package com.vaadin.flow.router.internal;
 import java.util.Arrays;
 import java.util.EnumSet;
 
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouteParam;
 import com.vaadin.flow.router.RouteParameterFormatOption;
 import com.vaadin.flow.router.RouteParameterRegex;
 import org.junit.Assert;
@@ -10,6 +12,7 @@ import org.junit.Test;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.router.RouteParameters;
 import com.vaadin.flow.router.RouterLayout;
 
 public class ConfiguredRoutesTest {
@@ -166,6 +169,26 @@ public class ConfiguredRoutesTest {
                         + RouteParameterRegex.LONG + "/:/:thinking|of|U|and|I",
                 config.getTemplate(BaseTarget.class,
                         EnumSet.of(RouteParameterFormatOption.REGEX)));
+    }
+
+    @Test
+    public void configuration_provides_formatted_url_for_route_not_routeAlias() {
+        ConfigureRoutes config = new ConfigureRoutes();
+
+        config.setRoute(RouteTarget.class.getAnnotation(Route.class).value(),
+                RouteTarget.class);
+        config.setRoute("", RouteTarget.class);
+
+        String targetUrl = config.getTargetUrl(RouteTarget.class,
+                new RouteParameters(new RouteParam("message", "hello")));
+
+        Assert.assertEquals("Route should be matched and not RouteAlias",
+                "home/hello", targetUrl);
+    }
+
+    @Tag("div")
+    @Route("/home/:message?")
+    public static class RouteTarget extends Component {
     }
 
     @Tag("div")


### PR DESCRIPTION
Specifically check Route annotation route 
first for match when going through templates.

Fixes #9969
