### PR TITLE
chore: fix typo when appending new line

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -1107,7 +1107,8 @@ public class FrontendTools {
             String... extraUpdateInstructions) {
         StringBuilder extraInstructions = new StringBuilder();
         for (String instruction : extraUpdateInstructions) {
-            extraInstructions.append("\n  - or ").append(instruction);
+            extraInstructions.append(System.lineSeparator()).append("  - or ")
+                    .append(instruction);
         }
         return String.format(BAD_VERSION, tool, version,
                 extraInstructions.toString(),

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -1107,7 +1107,7 @@ public class FrontendTools {
             String... extraUpdateInstructions) {
         StringBuilder extraInstructions = new StringBuilder();
         for (String instruction : extraUpdateInstructions) {
-            extraInstructions.append("%n  - or ").append(instruction);
+            extraInstructions.append("\n  - or ").append(instruction);
         }
         return String.format(BAD_VERSION, tool, version,
                 extraInstructions.toString(),


### PR DESCRIPTION
This fixes the following bad formatted message (notice %n after globally):

```
======================================================================================================
Your installed 'npm' version (9.2.0) is known to have problems.
Please update to a new one either:
  - by following the https://nodejs.org/en/download/ guide to install it globally%n  - or by updating your global npm installation with `npm install -g npm@latest`
  - or by running the frontend-maven-plugin goal to install it in this project:
  $ mvn com.github.eirslett:frontend-maven-plugin:1.10.0:install-node-and-npm -DnodeVersion="v20.8.0"

You can disable the version check using -Dvaadin.ignoreVersionChecks=true
======================================================================================================
```