### PR TITLE
chore!: Upgrade to Vite 5

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
@@ -11,7 +11,7 @@
   "dependencies": {},
   "devDependencies": {
     "vite": "5.0.0",
-    "@vitejs/plugin-react": "4.1.1",
+    "@vitejs/plugin-react": "4.2.0",
     "@rollup/plugin-replace": "5.0.4",
     "@rollup/pluginutils": "5.0.5",
     "rollup-plugin-visualizer": "5.9.2",

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "dependencies": {},
   "devDependencies": {
-    "vite": "4.5.0",
+    "vite": "5.0.0",
     "@vitejs/plugin-react": "4.1.1",
     "@rollup/plugin-replace": "5.0.4",
     "@rollup/pluginutils": "5.0.5",

--- a/flow-server/src/main/resources/plugins/rollup-plugin-postcss-lit-custom/rollup-plugin-postcss-lit.js
+++ b/flow-server/src/main/resources/plugins/rollup-plugin-postcss-lit-custom/rollup-plugin-postcss-lit.js
@@ -28,7 +28,7 @@ SOFTWARE.
 import { createFilter } from '@rollup/pluginutils';
 import transformAst from 'transform-ast';
 
-const assetUrlRE = /__VITE_ASSET__([a-z\d]{8})__(?:\$_(.*?)__)?/g;
+const assetUrlRE = /__VITE_ASSET__([\w$]+)__(?:\$_(.*?)__)?/g
 
 const escape = (str) =>
   str


### PR DESCRIPTION
Vite 5 is based on Rollup v4. The major breaking change there is dropping support for Node < 18 which does not affect Flow. There might be other potential plugin issues though.

Vite 5 also drops support for accidentally importing styles twice, i.e.
```ts
import styles from 'hello.css'
```

To import styles and apply globally, you should do

```ts
import 'hello.css'
```

and to import styles as a string you need to do
```ts
import styles from 'hello.css?inline';
```
