### PR TITLE
chore: Bump npm dependencies

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
@@ -10,13 +10,13 @@
   "license": "Apache-2.0",
   "dependencies": {},
   "devDependencies": {
-    "vite": "4.4.11",
-    "@vitejs/plugin-react": "4.0.4",
-    "@rollup/plugin-replace": "5.0.2",
-    "@rollup/pluginutils": "5.0.2",
+    "vite": "4.5.0",
+    "@vitejs/plugin-react": "4.1.0",
+    "@rollup/plugin-replace": "5.0.4",
+    "@rollup/pluginutils": "5.0.5",
     "rollup-plugin-visualizer": "5.9.2",
     "rollup-plugin-brotli": "3.1.0",
-    "vite-plugin-checker": "0.6.1",
+    "vite-plugin-checker": "0.6.2",
     "workbox-build": "7.0.0",
     "transform-ast": "2.4.4"
   }


### PR DESCRIPTION
@rollup/plugin-replace to 5.0.4
@rollup/pluginutils to 5.0.5
@vitejs/plugin-react to 4.1.0
vite to 4.5.0
vite-plugin-checker to 0.6.2
