### PR TITLE
chore: Fix Maven deprecation warning

### DIFF
--- a/flow-client/pom.xml
+++ b/flow-client/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <artifactId>flow-client</artifactId>
     <name>Flow Client</name>
-    <description>${name}</description>
+    <description>${project.name}</description>
     <packaging>jar</packaging>
 
     <properties>

--- a/flow-data/pom.xml
+++ b/flow-data/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <artifactId>flow-data</artifactId>
     <name>Flow Data</name>
-    <description>${name}</description>
+    <description>${project.name}</description>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/flow-dnd/pom.xml
+++ b/flow-dnd/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>flow-dnd</artifactId>
     <name>Generic HTML 5 Drag and Drop support for Flow</name>
-    <description>${name}</description>
+    <description>${project.name}</description>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/flow-html-components-testbench/pom.xml
+++ b/flow-html-components-testbench/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <artifactId>flow-html-components-testbench</artifactId>
     <name>TestBench elements for Flow HTML Components</name>
-    <description>${name}</description>
+    <description>${project.name}</description>
     <packaging>jar</packaging>
 
     <properties>

--- a/flow-html-components/pom.xml
+++ b/flow-html-components/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <artifactId>flow-html-components</artifactId>
     <name>Flow HTML Components</name>
-    <description>${name}</description>
+    <description>${project.name}</description>
     <packaging>jar</packaging>
 
     <properties>

--- a/flow-lit-template/pom.xml
+++ b/flow-lit-template/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <artifactId>flow-lit-template</artifactId>
     <name>Flow Lit Templates Support</name>
-    <description>${name}</description>
+    <description>${project.name}</description>
     <packaging>jar</packaging>
 
     <properties>

--- a/flow-polymer-template/pom.xml
+++ b/flow-polymer-template/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <artifactId>flow-polymer-template</artifactId>
     <name>Flow Polymer Templates Support</name>
-    <description>${name}</description>
+    <description>${project.name}</description>
     <packaging>jar</packaging>
 
     <licenses>

--- a/flow-polymer2lit/pom.xml
+++ b/flow-polymer2lit/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <artifactId>flow-polymer2lit</artifactId>
     <name>Polymer to Lit converter</name>
-    <description>${name}</description>
+    <description>${project.name}</description>
     <packaging>jar</packaging>
 
     <properties>

--- a/flow-push/pom.xml
+++ b/flow-push/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <artifactId>flow-push</artifactId>
     <name>Flow Push</name>
-    <description>${name}</description>
+    <description>${project.name}</description>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <artifactId>flow-server</artifactId>
     <name>Flow Server</name>
-    <description>${name}</description>
+    <description>${project.name}</description>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/flow-test-generic/pom.xml
+++ b/flow-test-generic/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>flow-test-generic</artifactId>
     <name>Flow Generic Test Utilities</name>
-    <description>${name}</description>
+    <description>${project.name}</description>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/flow-test-util/pom.xml
+++ b/flow-test-util/pom.xml
@@ -10,7 +10,7 @@
 
     <artifactId>flow-test-util</artifactId>
     <name>Testing utilities for Flow</name>
-    <description>${name}</description>
+    <description>${project.name}</description>
     <packaging>jar</packaging>
 
     <properties>

--- a/flow-webpush/pom.xml
+++ b/flow-webpush/pom.xml
@@ -10,7 +10,7 @@
 
     <artifactId>flow-webpush</artifactId>
     <name>Flow WebPush</name>
-    <description>${name}</description>
+    <description>${project.name}</description>
     <packaging>jar</packaging>
 
     <properties>

--- a/vaadin-dev-server/pom.xml
+++ b/vaadin-dev-server/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <artifactId>vaadin-dev-server</artifactId>
     <name>Vaadin Development Mode Server</name>
-    <description>${name}</description>
+    <description>${project.name}</description>
     <packaging>jar</packaging>
 
     <properties>


### PR DESCRIPTION
The expression ${name} is deprecated. Please use ${project.name} instead
