### PR TITLE
fix: page calculation when not equally divisible

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/Query.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/Query.java
@@ -151,7 +151,7 @@ public class Query<T, F> implements Serializable {
      * <p>
      * This is an alias for {@link #getLimit()} if the page offset can be evenly
      * divided by the limit. Else the page size will be increased to evenly
-     * divide offset so the items skip for page will go to the corrent item.
+     * divide offset so the items skip for page will go to the correct item.
      *
      * @return the page size used for data access
      */

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/Query.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/Query.java
@@ -147,8 +147,11 @@ public class Query<T, F> implements Serializable {
      * Returns the page size that should be returned. The amount of items can be
      * smaller if there is no more items available in the backend.
      * <p>
-     * Vaadin asks data from the backend in paged manner. This is an alias for
-     * {@link #getLimit()}. As long as the size is evenly divisible.
+     * Vaadin asks data from the backend in paged manner.
+     * <p>
+     * This is an alias for {@link #getLimit()} if the page offset can be evenly
+     * divided by the limit. Else the page size will be increased to evenly
+     * divide offset so the items skip for page will go to the corrent item.
      *
      * @return the page size used for data access
      */

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
@@ -1325,6 +1325,35 @@ public class DataCommunicatorTest {
     }
 
     @Test
+    public void fetchFromProvider_itemCountLessThanTwoPages_correctItemsReturned() {
+        List<Item> items = new ArrayList<>();
+        for (int i = 1; i <= 113; i++) {
+            items.add(new Item(i));
+        }
+
+        DataProvider<Item, Void> dataProvider = DataProvider
+                .fromCallbacks(query -> {
+                    int offset = query.getPage() * query.getPageSize();
+                    int end = offset + query.getPageSize();
+                    if (end > items.size()) {
+                        end = items.size();
+                    }
+                    return items.subList(offset, end).stream();
+                }, query -> items.size());
+        dataCommunicator.setDataProvider(dataProvider, null);
+        dataCommunicator.setPageSize(50);
+
+        dataCommunicator.setDataProvider(dataProvider, null);
+        // request second page with correct db size.
+        Stream<Item> itemStream = dataCommunicator.fetchFromProvider(100, 13);
+        List<Item> itemList = itemStream.toList();
+
+        Assert.assertEquals(13, itemList.size());
+        Assert.assertEquals(new Item(101), itemList.get(0));
+
+    }
+
+    @Test
     public void fetchEnabled_getItemCount_stillReturnsItemsCount() {
         dataCommunicator.setFetchEnabled(false);
         Assert.assertEquals(0, dataCommunicator.getItemCount());


### PR DESCRIPTION
Fix the query page and pageSize for
cases where the offset is not
equally divisible with the limit/pageSize.

Fixes #17750