### PR TITLE
fix: page calculation when not equally divisible (#17920)

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/Query.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/Query.java
@@ -31,6 +31,7 @@ public class Query<T, F> implements Serializable {
     private final List<QuerySortOrder> sortOrders;
     private final Comparator<T> inMemorySorting;
     private final F filter;
+    private Integer pageSize;
 
     /**
      * Constructs a Query for all rows from 0 to {@link Integer#MAX_VALUE}
@@ -112,24 +113,45 @@ public class Query<T, F> implements Serializable {
      * <p>
      * Vaadin asks data from the backend in paged manner. This shorthand
      * calculates the page index for backends using paged data access, such as
-     * Spring Data repositores.
-     * 
+     * Spring Data repositories.
+     *
      * @return the zero-based page index
      */
     public int getPage() {
-        return getOffset() / getLimit();
+        int pageSize = getPageSize();
+        int pageOffset = getOffset();
+        // If page offset is not evenly divisible with pageSize raise
+        // pageSize until it is.
+        // Else we will on the end pick the wrong items due to rounding error.
+        if (pageOffset > pageSize && pageOffset % pageSize != 0) {
+            while (pageOffset % pageSize != 0) {
+                pageSize++;
+            }
+            setPageSize(pageSize);
+        }
+        return pageOffset / pageSize;
+    }
+
+    private void setPageSize(Integer pageSize) {
+        this.pageSize = pageSize;
     }
 
     /**
      * Returns the page size that should be returned. The amount of items can be
      * smaller if there is no more items available in the backend.
      * <p>
-     * Vaadin asks data from the backend in paged manner. This is an alias for
-     * {@link #getLimit()}.
-     * 
+     * Vaadin asks data from the backend in paged manner.
+     * <p>
+     * This is an alias for {@link #getLimit()} if the page offset can be evenly
+     * divided by the limit. Else the page size will be increased to evenly
+     * divide offset so the items skip for page will go to the correct item.
+     *
      * @return the page size used for data access
      */
     public int getPageSize() {
+        if (pageSize != null) {
+            return pageSize;
+        }
         return getLimit();
     }
 

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
@@ -1312,7 +1312,7 @@ public class DataCommunicatorTest {
         dataCommunicator.setDataProvider(dataProvider, null);
         // request second page with correct db size.
         Stream<Item> itemStream = dataCommunicator.fetchFromProvider(100, 13);
-        List<Item> itemList = itemStream.toList();
+        List<Item> itemList = itemStream.collect(Collectors.toList());
 
         Assert.assertEquals(13, itemList.size());
         Assert.assertEquals(new Item(101), itemList.get(0));

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
@@ -1291,6 +1291,35 @@ public class DataCommunicatorTest {
     }
 
     @Test
+    public void fetchFromProvider_itemCountLessThanTwoPages_correctItemsReturned() {
+        List<Item> items = new ArrayList<>();
+        for (int i = 1; i <= 113; i++) {
+            items.add(new Item(i));
+        }
+
+        DataProvider<Item, Void> dataProvider = DataProvider
+                .fromCallbacks(query -> {
+                    int offset = query.getPage() * query.getPageSize();
+                    int end = offset + query.getPageSize();
+                    if (end > items.size()) {
+                        end = items.size();
+                    }
+                    return items.subList(offset, end).stream();
+                }, query -> items.size());
+        dataCommunicator.setDataProvider(dataProvider, null);
+        dataCommunicator.setPageSize(50);
+
+        dataCommunicator.setDataProvider(dataProvider, null);
+        // request second page with correct db size.
+        Stream<Item> itemStream = dataCommunicator.fetchFromProvider(100, 13);
+        List<Item> itemList = itemStream.toList();
+
+        Assert.assertEquals(13, itemList.size());
+        Assert.assertEquals(new Item(101), itemList.get(0));
+
+    }
+
+    @Test
     public void fetchEnabled_getItemCount_stillReturnsItemsCount() {
         dataCommunicator.setFetchEnabled(false);
         Assert.assertEquals(0, dataCommunicator.getItemCount());


### PR DESCRIPTION
Fix the query page and pageSize for
cases where the offset is not
equally divisible with the limit/pageSize.

Fixes #17750