### PR TITLE
fix: send markAsUsed only when Theme Editor is opened first time

### DIFF
--- a/vaadin-dev-server/frontend/theme-editor/editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.ts
@@ -72,7 +72,9 @@ export class ThemeEditor extends LitElement {
   @state()
   private effectiveTheme: ComponentTheme | null = null;
 
-  private undoRedoListener;
+  private markedAsUsed = false;
+
+  private undoRedoListener: any;
 
   static get styles() {
     return css`
@@ -204,11 +206,16 @@ export class ThemeEditor extends LitElement {
     `;
   }
 
+  public activate() {
+    if (!this.markedAsUsed) {
+      this.api.markAsUsed().then(() => {this.markedAsUsed = true});
+    }
+  }
+
   protected firstUpdated() {
     this.api = new ThemeEditorApi(this.connection);
     this.history = new ThemeEditorHistory(this.api);
     this.historyActions = this.history.allowedActions;
-    this.api.markAsUsed();
 
     this.undoRedoListener = (evt: KeyboardEvent) => {
       const isZKey = evt.key === 'Z' || evt.key === 'z';

--- a/vaadin-dev-server/frontend/theme-editor/editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.ts
@@ -206,12 +206,6 @@ export class ThemeEditor extends LitElement {
     `;
   }
 
-  public activate() {
-    if (!this.markedAsUsed) {
-      this.api.markAsUsed().then(() => {this.markedAsUsed = true});
-    }
-  }
-
   protected firstUpdated() {
     this.api = new ThemeEditorApi(this.connection);
     this.history = new ThemeEditorHistory(this.api);
@@ -581,6 +575,9 @@ export class ThemeEditor extends LitElement {
     }
 
     const componentResponse = await this.api.loadComponentMetadata(component);
+    if (!this.markedAsUsed) {
+      this.api.markAsUsed().then(() => {this.markedAsUsed = true});
+    }
     themePreview.previewLocalClassName(component.element, componentResponse.className);
 
     await this.refreshTheme({

--- a/vaadin-dev-server/frontend/vaadin-dev-tools.ts
+++ b/vaadin-dev-server/frontend/vaadin-dev-tools.ts
@@ -74,7 +74,6 @@ interface Tab {
   title: string;
   render: (() => TemplateResult) | string;
   element?: HTMLElement;
-  activate?: () => void;
   handleMessage?: MessageHandler;
 }
 
@@ -1373,15 +1372,15 @@ export class VaadinDevTools extends LitElement {
                 @click=${() => {
                   const currentTab = this.tabs.find((tab) => tab.id === this.activeTab);
                   if (currentTab && currentTab.element) {
-                    const deactivateMethod = (currentTab.element as any)?.deactivate;
+                    const deactivateMethod = (currentTab.element?.firstElementChild as any)?.deactivate;
                     if (deactivateMethod) {
-                      deactivateMethod.call(currentTab.element);
+                      deactivateMethod.call(currentTab.element?.firstElementChild);
                     }
                   }
                   this.activeTab = tab.id;
-                  const activateMethod = (tab.element as any).activate;
+                  const activateMethod = (tab.element?.firstElementChild as any).activate;
                   if (activateMethod) {
-                    activateMethod.call(tab.element);
+                    activateMethod.call(tab.element?.firstElementChild);
                   }
                 }}
               >

--- a/vaadin-dev-server/frontend/vaadin-dev-tools.ts
+++ b/vaadin-dev-server/frontend/vaadin-dev-tools.ts
@@ -1372,15 +1372,17 @@ export class VaadinDevTools extends LitElement {
                 @click=${() => {
                   const currentTab = this.tabs.find((tab) => tab.id === this.activeTab);
                   if (currentTab && currentTab.element) {
-                    const deactivateMethod = (currentTab.element?.firstElementChild as any)?.deactivate;
+                    const currentTabElement: any = (typeof currentTab.render === 'function' ? currentTab.element!.firstElementChild : currentTab.element);
+                    const deactivateMethod = currentTabElement?.deactivate;
                     if (deactivateMethod) {
-                      deactivateMethod.call(currentTab.element?.firstElementChild);
+                      deactivateMethod.call(currentTabElement);
                     }
                   }
                   this.activeTab = tab.id;
-                  const activateMethod = (tab.element?.firstElementChild as any).activate;
+                  const tabElement: any = (typeof tab.render === 'function' ? tab.element!.firstElementChild : tab.element);
+                  const activateMethod = tabElement.activate;
                   if (activateMethod) {
-                    activateMethod.call(tab.element?.firstElementChild);
+                    activateMethod.call(tabElement);
                   }
                 }}
               >


### PR DESCRIPTION
## Description

Fixed ThemeEditor tracking to send markAsUsed only when user first time opens Theme Editor tab.

Fixed issues related to calling activate and deactivate methods on dev-tools plugins.

Fixes #17934

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.