### PR TITLE
fix: throw WebPushException for sendNotification

### DIFF
--- a/flow-webpush/src/main/java/com/vaadin/flow/server/webpush/WebPush.java
+++ b/flow-webpush/src/main/java/com/vaadin/flow/server/webpush/WebPush.java
@@ -127,6 +127,8 @@ public class WebPush {
             }
         } catch (Exception e) {
             getLogger().error("Failed to send notification.", e);
+            throw new WebPushException(
+                    "Sending of web push notification failed", e);
         }
     }
 


### PR DESCRIPTION
Throw a WebPushException when
sending of notification fails.

Fixes #17942