### PR TITLE
cp: Enable Atmosphere heartbeat (#17845) (24.2)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PushRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PushRequestHandler.java
@@ -33,7 +33,6 @@ import org.atmosphere.cpr.AtmosphereInterceptor;
 import org.atmosphere.cpr.AtmosphereRequestImpl;
 import org.atmosphere.cpr.AtmosphereResponseImpl;
 import org.atmosphere.cpr.BroadcasterConfig;
-import org.atmosphere.interceptor.HeartbeatInterceptor;
 import org.atmosphere.util.VoidAnnotationProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -205,11 +204,10 @@ public class PushRequestHandler
         atmosphere.addInitParameter(
                 ApplicationConfig.DROP_ACCESS_CONTROL_ALLOW_ORIGIN_HEADER,
                 "false");
-        // Disable heartbeat (it does not emit correct events client side)
-        // https://github.com/Atmosphere/atmosphere-javascript/issues/141
-        atmosphere.addInitParameter(
-                ApplicationConfig.DISABLE_ATMOSPHEREINTERCEPTORS,
-                HeartbeatInterceptor.class.getName());
+
+        // Set default max WS idle time to 5 minutes (300 000 ms)
+        atmosphere.addInitParameter(ApplicationConfig.WEBSOCKET_IDLETIME,
+                String.valueOf(300000));
 
         final String bufferSize = String
                 .valueOf(PushConstants.WEBSOCKET_BUFFER_SIZE);

--- a/vaadin-dev-server/frontend/connection.ts
+++ b/vaadin-dev-server/frontend/connection.ts
@@ -63,6 +63,12 @@ export class Connection extends Object {
 
   handleMessage(msg: any) {
     let json;
+
+    if (msg.data === 'X') {
+      // Atmosphere heartbeat message, should be ignored
+      return;
+    }
+
     try {
       json = JSON.parse(msg.data);
     } catch (e: any) {


### PR DESCRIPTION
* Enable Atmosphere heartbeat and ignore it in devserver

* Set default WS idle timeout to 5 minutes

---------

<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Please list all relevant dependencies in this section and provide summary of the change, motivation and context.

Fixes # (issue)

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
