### PR TITLE
fix: prevent installing pnpm if not required

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/PrepareFrontendInputProperties.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/PrepareFrontendInputProperties.kt
@@ -240,6 +240,9 @@ public class PrepareFrontendInputProperties public constructor(project: Project)
     @Input
     @Optional
     public fun getPnpmExecutablePath(): String? {
+        if (!extension.pnpmEnable) {
+            return null
+        }
         val pnpmExecutable = tools.pnpmExecutable ?: return null
         return pnpmExecutable.stream()
             .collect(Collectors.joining(" "))


### PR DESCRIPTION
## Description

To check if the prepare frontend task is up-to-date, the Flow gradle plugin also tracks the pnpm executable paths. However, getting the paths triggers the installation of pnpm, even if the tool is not enabled in configuaration.

This change only tracks pnpm paths if the tool is explicitly enabled.

Fixes #17967

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
