### PR TITLE
chore: gradle plugin test cleanup

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscMultiModuleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscMultiModuleTest.kt
@@ -52,7 +52,7 @@ class MiscMultiModuleTest : AbstractGradleTest() {
                 }
 
                 vaadin {
-                    nodeAutoUpdate = true // test the vaadin{} block by changing some innocent property
+                    nodeAutoUpdate = true // test the vaadin{} block by changing some innocent property with limited side-effect
                 }
             }
         """.trimIndent())
@@ -96,7 +96,7 @@ class MiscMultiModuleTest : AbstractGradleTest() {
                 }
 
                 vaadin {
-                    nodeAutoUpdate = true // test the vaadin{} block by changing some innocent property
+                    nodeAutoUpdate = true // test the vaadin{} block by changing some innocent property with limited side-effect
                 }
             }
         """.trimIndent())

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscMultiModuleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscMultiModuleTest.kt
@@ -52,7 +52,7 @@ class MiscMultiModuleTest : AbstractGradleTest() {
                 }
 
                 vaadin {
-                    pnpmEnable = true
+                    nodeAutoUpdate = true // test the vaadin{} block by changing some innocent property
                 }
             }
         """.trimIndent())
@@ -96,7 +96,7 @@ class MiscMultiModuleTest : AbstractGradleTest() {
                 }
 
                 vaadin {
-                    pnpmEnable = true
+                    nodeAutoUpdate = true // test the vaadin{} block by changing some innocent property
                 }
             }
         """.trimIndent())

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
@@ -206,7 +206,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
             }
             def jettyVersion = "11.0.12"
             vaadin {
-                nodeAutoUpdate = true // test the vaadin{} block by changing some innocent property
+                nodeAutoUpdate = true // test the vaadin{} block by changing some innocent property with limited side-effect
             }
             dependencies {
                 implementation("com.vaadin:flow:$flowVersion")

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
@@ -206,7 +206,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
             }
             def jettyVersion = "11.0.12"
             vaadin {
-                pnpmEnable = true
+                nodeAutoUpdate = true // test the vaadin{} block by changing some innocent property
             }
             dependencies {
                 implementation("com.vaadin:flow:$flowVersion")
@@ -546,7 +546,6 @@ class MiscSingleModuleTest : AbstractGradleTest() {
                 implementation("com.vaadin:flow:$flowVersion")
             }
             vaadin {
-                pnpmEnable = true
                 filterClasspath {
                     include("com.vaadin:flow-*")
                     exclude("com.vaadin:flow-data")

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/TestUtils.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/TestUtils.kt
@@ -331,11 +331,3 @@ class TestProject(val gradleVersion: String = if(JavaVersion.current().majorVers
         return jar
     }
 }
-
-/**
- * Similar to [File.deleteRecursively] but throws informative [IOException] instead of
- * just returning false on error. uses Java 8 [Files.deleteIfExists] to delete files and folders.
- */
-fun Path.deleteRecursively() {
-    toFile().walkBottomUp().forEach { Files.deleteIfExists(it.toPath()) }
-}

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
@@ -51,7 +51,7 @@ class VaadinSmokeTest : AbstractGradleTest() {
                 implementation("org.slf4j:slf4j-simple:$slf4jVersion")
             }
             vaadin {
-                nodeAutoUpdate = true // test the vaadin{} block by changing some innocent property
+                nodeAutoUpdate = true // test the vaadin{} block by changing some innocent property with limited side-effect
             }
         """)
     }

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
@@ -51,7 +51,7 @@ class VaadinSmokeTest : AbstractGradleTest() {
                 implementation("org.slf4j:slf4j-simple:$slf4jVersion")
             }
             vaadin {
-                pnpmEnable = true
+                nodeAutoUpdate = true // test the vaadin{} block by changing some innocent property
             }
         """)
     }
@@ -374,5 +374,4 @@ class VaadinSmokeTest : AbstractGradleTest() {
             )
         }
     }
-
 }


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Historically we have used the `vaadin { pnpmEnable = true }` stanza to test that the `vaadin{}` block works properly in the gradle build. However, the `pnpmEnable = true` may have unintended side-effects and may even fail the build, which is definitely not what the original purpose of the test was.

Therefore we have switched the property to `nodeAutoUpdate = true` which has little-to-no side-effect, and we have added an accompanied remark, clearly explaining the intended purpose of the test.

Also the unused `Path.deleteRecursively()` function is removed.

Doesn't fix any particular issue, it's just a chore.

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
