### PR TITLE
feat: Enable running npm ci mode (CP: 23.4)

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
@@ -185,4 +185,6 @@ internal class GradlePluginAdapter(val project: Project, private val isBeforePro
         return extension.projectBuildDir
     }
     override fun postinstallPackages(): List<String> = extension.postinstallPackages
+
+    override fun ciBuild(): Boolean = extension.ciBuild
 }

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
@@ -217,6 +217,15 @@ public open class VaadinFlowPluginExtension(project: Project) {
      */
     public var processResourcesTaskName : String? = null
 
+    /**
+     * Setting this to true will run {@code npm ci} instead of {@code npm install} when using npm.
+     *
+     * If using pnpm, the install will be run with {@code --frozen-lockfile} parameter.
+     *
+     * This makes sure that the versions in package lock file will not be overwritten and production builds are reproducible.
+     */
+    public var ciBuild: Boolean = false
+
     public fun filterClasspath(@DelegatesTo(value = ClasspathFilter::class, strategy = Closure.DELEGATE_FIRST) block: Closure<*>? = null): ClasspathFilter {
         if (block != null) {
             block.delegate = classpathFilter
@@ -262,6 +271,11 @@ public open class VaadinFlowPluginExtension(project: Project) {
             pnpmEnable = pnpmEnableProperty
         }
 
+        val ciBuildProperty: Boolean? = project.getBooleanProperty(InitParameters.CI_BUILD)
+        if (ciBuildProperty != null) {
+            ciBuild = ciBuildProperty
+        }
+
         val useGlobalPnpmProperty: Boolean? = project.getBooleanProperty(InitParameters.SERVLET_PARAMETER_GLOBAL_PNPM)
         if (useGlobalPnpmProperty != null) {
             useGlobalPnpm = useGlobalPnpmProperty
@@ -298,6 +312,7 @@ public open class VaadinFlowPluginExtension(project: Project) {
             "frontendResourcesDirectory=$frontendResourcesDirectory, " +
             "optimizeBundle=$optimizeBundle, " +
             "pnpmEnable=$pnpmEnable, " +
+            "ciBuild=$ciBuild, " +
             "useGlobalPnpm=$useGlobalPnpm, " +
             "requireHomeNodeExec=$requireHomeNodeExec, " +
             "useDeprecatedV14Bootstrapping=$useDeprecatedV14Bootstrapping, " +

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -33,6 +33,7 @@ import com.vaadin.flow.plugin.base.BuildFrontendUtil;
 import com.vaadin.flow.plugin.base.PluginAdapterBuild;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.ExecutionFailedException;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.frontend.FrontendUtils;
 import com.vaadin.flow.theme.Theme;
 
@@ -92,6 +93,19 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo
     @Parameter(defaultValue = "true")
     private boolean optimizeBundle;
 
+    /**
+     * Setting this to true will run {@code npm ci} instead of
+     * {@code npm install} when using npm.
+     *
+     * If using pnpm, the install will be run with {@code --frozen-lockfile}
+     * parameter.
+     *
+     * This makes sure that the versions in package lock file will not be
+     * overwritten and production builds are reproducible.
+     */
+    @Parameter(property = InitParameters.CI_BUILD, defaultValue = "false")
+    private boolean ciBuild;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         long start = System.nanoTime();
@@ -146,6 +160,11 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo
     public boolean runNpmInstall() {
 
         return runNpmInstall;
+    }
+
+    @Override
+    public boolean ciBuild() {
+        return ciBuild;
     }
 
 }

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
@@ -491,6 +491,7 @@ public class BuildFrontendMojoTest {
         initialBuildInfo.put(InitParameters.REQUIRE_HOME_NODE_EXECUTABLE, true);
         initialBuildInfo.put(
                 InitParameters.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE, true);
+        initialBuildInfo.put(InitParameters.CI_BUILD, true);
 
         org.apache.commons.io.FileUtils.forceMkdir(tokenFile.getParentFile());
         org.apache.commons.io.FileUtils.write(tokenFile,
@@ -516,6 +517,8 @@ public class BuildFrontendMojoTest {
                 InitParameters.SERVLET_PARAMETER_ENABLE_PNPM
                         + "should have been removed",
                 buildInfo.get(InitParameters.SERVLET_PARAMETER_ENABLE_PNPM));
+        Assert.assertNull(InitParameters.CI_BUILD + "should have been removed",
+                buildInfo.get(InitParameters.CI_BUILD));
         Assert.assertNull(
                 InitParameters.REQUIRE_HOME_NODE_EXECUTABLE
                         + "should have been removed",

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -339,7 +339,8 @@ public class BuildFrontendUtil {
                     .withNodeDownloadRoot(nodeDownloadRootURI)
                     .setNodeAutoUpdate(adapter.nodeAutoUpdate())
                     .setJavaResourceFolder(adapter.javaResourceFolder())
-                    .withPostinstallPackages(adapter.postinstallPackages());
+                    .withPostinstallPackages(adapter.postinstallPackages())
+                    .withCiBuild(adapter.ciBuild());
             new NodeTasks(options).execute();
         } catch (ExecutionFailedException exception) {
             throw exception;
@@ -603,6 +604,7 @@ public class BuildFrontendUtil {
             buildInfo.remove(GENERATED_TOKEN);
             buildInfo.remove(FRONTEND_TOKEN);
             buildInfo.remove(InitParameters.SERVLET_PARAMETER_ENABLE_PNPM);
+            buildInfo.remove(InitParameters.CI_BUILD);
             buildInfo.remove(InitParameters.REQUIRE_HOME_NODE_EXECUTABLE);
             buildInfo.remove(
                     InitParameters.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE);

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBuild.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBuild.java
@@ -65,4 +65,16 @@ public interface PluginAdapterBuild extends PluginAdapterBase {
      */
     boolean runNpmInstall();
 
+    /**
+     * Setting this to true will run {@code npm ci} instead of
+     * {@code npm install} when using npm.
+     *
+     * If using pnpm, the install will be run with {@code --frozen-lockfile}
+     * parameter.
+     *
+     * This makes sure that the package lock file will not be overwritten.
+     *
+     * @return true if ci build should be enabled
+     */
+    boolean ciBuild();
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -221,4 +221,9 @@ public class InitParameters implements Serializable {
      * @since
      */
     public static final String ADDITIONAL_POSTINSTALL_PACKAGES = "npm.postinstallPackages";
+
+    /**
+     * Configuration name for enabling ci build for npm/pnpm.
+     */
+    public static final String CI_BUILD = "ci.build";
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -143,7 +143,7 @@ public class NodeTasks implements FallibleCommand {
                         options.enablePnpm, options.requireHomeNodeExec,
                         options.nodeVersion, options.nodeDownloadRoot,
                         options.useGlobalPnpm, options.nodeAutoUpdate,
-                        options.postinstallPackages));
+                        options.postinstallPackages, options.isCiBuild()));
 
                 commands.add(new TaskInstallWebpackPlugins(
                         new File(options.npmFolder, options.buildDirectory)));

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/Options.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/Options.java
@@ -65,6 +65,8 @@ public class Options implements Serializable {
 
     boolean enablePnpm = Constants.ENABLE_PNPM_DEFAULT;
 
+    private boolean ciBuild;
+
     boolean useGlobalPnpm = false;
 
     File endpointSourceFolder;
@@ -477,6 +479,21 @@ public class Options implements Serializable {
     }
 
     /**
+     * Enables ci build.
+     * <p>
+     * "npm ci" will be used instead of "npm install". "--frozen-lockfile" will
+     * be used if pnpm is used instead of npm.
+     *
+     * @param ciBuild
+     *            true to enable ci build
+     * @return the builder, for chaining
+     */
+    public Options withCiBuild(boolean ciBuild) {
+        this.ciBuild = ciBuild;
+        return this;
+    }
+
+    /**
      * Uses globally installed pnpm tool for frontend packages installation.
      *
      * @param useGlobalPnpm
@@ -646,5 +663,9 @@ public class Options implements Serializable {
 
     public ClassFinder getClassFinder() {
         return classFinder;
+    }
+
+    public boolean isCiBuild() {
+        return ciBuild;
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -424,7 +424,7 @@ public class FrontendUtilsTest {
         new TaskRunNpmInstall(nodeUpdater, false, false,
                 FrontendTools.DEFAULT_NODE_VERSION,
                 URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT), false,
-                false, Collections.emptyList()).execute();
+                false, Collections.emptyList(), false).execute();
 
         FrontendUtils.deleteNodeModules(new File(npmFolder, "node_modules"));
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -142,12 +142,12 @@ public class TaskRunNpmInstallTest {
 
         ensurePackageJson();
 
-        task = createTask(new ArrayList<>(), true);
         task.execute();
         Mockito.verify(logger).info(getRunningMsg());
 
         deleteDirectory(nodeModules);
 
+        task = createTask(new ArrayList<>(), true);
         task.execute();
         Mockito.verify(logger).info(getRunningMsg());
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -155,7 +155,7 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
                 new TaskRunNpmInstall(getNodeUpdater(), true, true,
                         FrontendTools.DEFAULT_NODE_VERSION,
                         URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT),
-                        false, false, POSTINSTALL_PACKAGES));
+                        false, false, POSTINSTALL_PACKAGES, false));
     }
 
     @Test
@@ -636,28 +636,52 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
                         "postinstall-file.txt").exists());
     }
 
+    @Test
+    public void runPnpmInstallAndCi_emptyDir_pnpmInstallAndCiIsExecuted()
+            throws ExecutionFailedException, IOException {
+        TaskRunNpmInstall task = createTask();
+
+        File nodeModules = getNodeUpdater().nodeModulesFolder;
+        nodeModules.mkdir();
+        getNodeUpdater().modified = false;
+
+        task.execute();
+        Mockito.verify(logger).info(getRunningMsg());
+
+        deleteDirectory(nodeModules);
+
+        TaskRunNpmInstall ciTask = createTask(new ArrayList<>(), true);
+        ciTask.execute();
+        Mockito.verify(logger).info(getRunningMsg());
+    }
+
     @Override
     protected String getToolName() {
         return "pnpm";
     }
 
     protected TaskRunNpmInstall createTask() {
-        return createTask(new ArrayList<>());
+        return createTask(new ArrayList<>(), false);
+    }
+
+    protected TaskRunNpmInstall createTask(List<String> additionalPostInstall) {
+        return createTask(additionalPostInstall, false);
     }
 
     @Override
-    protected TaskRunNpmInstall createTask(List<String> additionalPostInstall) {
+    protected TaskRunNpmInstall createTask(List<String> additionalPostInstall,
+            boolean ciBuild) {
         return new TaskRunNpmInstall(getNodeUpdater(), true, false,
                 FrontendTools.DEFAULT_NODE_VERSION,
                 URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT), false,
-                false, additionalPostInstall);
+                false, additionalPostInstall, ciBuild);
     }
 
     protected TaskRunNpmInstall createTask(String versionsContent) {
         return new TaskRunNpmInstall(createAndRunNodeUpdater(versionsContent),
                 true, false, FrontendTools.DEFAULT_NODE_VERSION,
                 URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT), false,
-                false, new ArrayList<>());
+                false, new ArrayList<>(), false);
     }
 
     private JsonObject getGeneratedVersionsContent(File versions,


### PR DESCRIPTION
Adds possibility to install the npm packages using npm ci instead of npm install (or for pnpm: pnpm install --frozen-lockfile) to install the exact versions in the lock file. Can be enabled with ci.build parameter when executing a production mode frontend build.

Fixes #15579

(cherry picked from commit 5607864ceefe46080aa2889078ee3081f2910979)
