### PR TITLE
fix: path difference on windows

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/ThemeValidationUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/ThemeValidationUtil.java
@@ -181,7 +181,8 @@ public class ThemeValidationUtil {
                                 hashesWithNoComponentCssMatches,
                                 frontendDirectory, themeFile))
                         .map(f -> frontendDirectory.toPath()
-                                .relativize(f.toPath()).toString())
+                                .relativize(f.toPath()).toString()
+                                .replaceAll("\\\\", "/"))
                         .collect(Collectors
                                 .toCollection(() -> themeComponentsCssFiles));
             }
@@ -377,7 +378,8 @@ public class ThemeValidationUtil {
             Map<String, String> bundledHashes, File frontendFolder,
             File frontendResource) {
         String relativePath = frontendFolder.toPath()
-                .relativize(frontendResource.toPath()).toString();
+                .relativize(frontendResource.toPath()).toString()
+                .replaceAll("\\\\", "/");
         boolean presentInBundle = bundledHashes.containsKey(relativePath);
         if (presentInBundle) {
             final String contentHash;


### PR DESCRIPTION
Fix the path when using
windows so that it matches
the stats file path.

Fixes #17998
