### PR TITLE
fix: Do not try to write readme if no compression

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuild.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuild.java
@@ -238,6 +238,9 @@ public class TaskRunDevBundleBuild implements FallibleCommand {
     }
 
     private void addReadme() {
+        if (!options.isCompressBundle()) {
+            return;
+        }
         File devBundleFolder = new File(options.getNpmFolder(),
                 Constants.BUNDLE_LOCATION);
         assert devBundleFolder.exists();


### PR DESCRIPTION
When not compressing the devBundle
skip writing of readme.md as folder
doesn't exist.
