### PR TITLE
fix: Do not run NodeTasks in parallel

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -352,6 +352,7 @@ public class NodeTasks implements FallibleCommand {
                 break;
             }
 
+            boolean loggedWaiting = false;
             try {
                 Optional<ProcessHandle> processHandle = ProcessHandle
                         .of(lockInfo.pid());
@@ -359,6 +360,12 @@ public class NodeTasks implements FallibleCommand {
                 if (processHandle.isPresent()
                         && processHandle.get().info().commandLine().orElse("")
                                 .equals(lockInfo.commandLine())) {
+                    if (!loggedWaiting) {
+                        getLogger().info("Waiting for a previous instance of "
+                                + getClass().getSimpleName() + " (pid: "
+                                + lockInfo.pid() + ") to finish...");
+                        loggedWaiting = true;
+                    }
                     Thread.sleep(500);
                 } else {
                     // The process has died without removing the lock file

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -343,8 +343,16 @@ public class NodeTasks implements FallibleCommand {
 
     private void getLock() {
         while (lockFile.toFile().exists()) {
+            NodeTasksLockInfo lockInfo;
             try {
-                NodeTasksLockInfo lockInfo = readLockFile();
+                lockInfo = readLockFile();
+            } catch (Exception e) {
+                getLogger().error("Error waiting for another "
+                        + getClass().getSimpleName() + " process to finish", e);
+                break;
+            }
+
+            try {
                 Optional<ProcessHandle> processHandle = ProcessHandle
                         .of(lockInfo.pid());
 
@@ -358,7 +366,8 @@ public class NodeTasks implements FallibleCommand {
                 }
             } catch (Exception e) {
                 getLogger().error("Error waiting for another "
-                        + getClass().getSimpleName() + " process to finish", e);
+                        + getClass().getSimpleName() + " process (pid: "
+                        + lockInfo.pid() + ") to finish", e);
             }
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -391,13 +391,15 @@ public class NodeTasks implements FallibleCommand {
         try {
             writeLockFile();
         } catch (IOException e) {
-            getLogger().error("Error writing lock file ({})", lockFile.toFile().getAbsolutePath(), e);
+            getLogger().error("Error writing lock file ({})",
+                    lockFile.toFile().getAbsolutePath(), e);
         }
     }
 
     private void releaseLock() {
         if (!lockFile.toFile().exists()) {
-            getLogger().warn("Somebody else has removed the lock file ({})", lockFile.toFile().getAbsolutePath());
+            getLogger().warn("Somebody else has removed the lock file ({})",
+                    lockFile.toFile().getAbsolutePath());
             return;
         }
 
@@ -405,12 +407,14 @@ public class NodeTasks implements FallibleCommand {
             long pid = readLockFile().pid();
             if (pid != ProcessHandle.current().pid()) {
                 getLogger().warn(
-                        "Another process ({}) has overwritten the lock file ({})",pid, lockFile.toFile().getAbsolutePath());
+                        "Another process ({}) has overwritten the lock file ({})",
+                        pid, lockFile.toFile().getAbsolutePath());
                 return;
             }
             lockFile.toFile().delete();
         } catch (Exception e) {
-            getLogger().error("Error releasing lock file ({})", lockFile.toFile().getAbsolutePath());
+            getLogger().error("Error releasing lock file ({})",
+                    lockFile.toFile().getAbsolutePath());
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -391,13 +391,13 @@ public class NodeTasks implements FallibleCommand {
         try {
             writeLockFile();
         } catch (IOException e) {
-            getLogger().error("Error writing lock file ({})", lockFile, e);
+            getLogger().error("Error writing lock file ({})", lockFile.toFile().getAbsolutePath(), e);
         }
     }
 
     private void releaseLock() {
         if (!lockFile.toFile().exists()) {
-            getLogger().warn("Somebody else has removed the lock file");
+            getLogger().warn("Somebody else has removed the lock file ({})", lockFile.toFile().getAbsolutePath());
             return;
         }
 
@@ -405,13 +405,12 @@ public class NodeTasks implements FallibleCommand {
             long pid = readLockFile().pid();
             if (pid != ProcessHandle.current().pid()) {
                 getLogger().warn(
-                        "Another process ({}) has overwritten the lock file",
-                        pid);
+                        "Another process ({}) has overwritten the lock file ({})",pid, lockFile.toFile().getAbsolutePath());
                 return;
             }
             lockFile.toFile().delete();
         } catch (Exception e) {
-            getLogger().error("Error releasing lock file", e);
+            getLogger().error("Error releasing lock file ({})", lockFile.toFile().getAbsolutePath());
         }
     }
 


### PR DESCRIPTION
This should prevent issues when a Spring Boot application is restarted almost immediately after startup. Previously roughly this happened:
1. Start app
2. Start npm install
3. Restart app
4. Clean node_modules while npm install is still running
5. Fail

Now it should be
1. Start app
2. Start npm install
3. Restart app
4. Wait for npm install to finish
5. npm install finishes but might log some exception as the app was restarted
6. run node tasks including npm install from the restarted app
7. It should work
