### PR TITLE
fix: improve error message when a component is moved from one UI to another.

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentTracker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentTracker.java
@@ -132,6 +132,11 @@ public class ComponentTracker {
             return javaFile;
         }
 
+        @Override
+        public String toString() {
+            return "Component '" + className + "' at '" + filename + "' ("
+                    + methodName + " LINE " + lineNumber + ")";
+        }
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -129,14 +129,9 @@ public class Element extends Node<Element> {
     public static Element get(StateNode node) {
         assert node != null;
 
-        if (node.hasFeature(TextNodeMap.class)) {
-            return get(node, BasicTextElementStateProvider.get());
-        } else if (node.hasFeature(ElementData.class)) {
-            return get(node, BasicElementStateProvider.get());
-        } else {
-            throw new IllegalArgumentException(
-                    "Node is not valid as an element");
-        }
+        return ElementUtil.from(node)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Node is not valid as an element"));
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/dom/ElementUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/ElementUtil.java
@@ -20,6 +20,11 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
+import com.vaadin.flow.dom.impl.BasicElementStateProvider;
+import com.vaadin.flow.dom.impl.BasicTextElementStateProvider;
+import com.vaadin.flow.internal.StateNode;
+import com.vaadin.flow.internal.nodefeature.ElementData;
+import com.vaadin.flow.internal.nodefeature.TextNodeMap;
 import org.jsoup.nodes.DataNode;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Node;
@@ -355,4 +360,25 @@ public class ElementUtil {
         }
     }
 
+    /**
+     * Gets the element mapped to the given state node.
+     *
+     * @param node
+     *            the state node, not <code>null</code>
+     * @return the element for the node, or an empty Optional if the state node
+     *         is not mapped to any particular element.
+     */
+    public static Optional<Element> from(StateNode node) {
+        assert node != null;
+
+        if (node.hasFeature(TextNodeMap.class)) {
+            return Optional
+                    .of(Element.get(node, BasicTextElementStateProvider.get()));
+        } else if (node.hasFeature(ElementData.class)) {
+            return Optional
+                    .of(Element.get(node, BasicElementStateProvider.get()));
+        } else {
+            return Optional.empty();
+        }
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
@@ -801,9 +801,13 @@ public class StateNode implements Serializable {
         }
         final ComponentTracker.Location createLocation = ComponentTracker
                 .findCreate(component);
+        final ComponentTracker.Location attachLocation = ComponentTracker
+                .findAttach(component);
         if (createLocation != null) {
-            return createLocation.toString(); // this includes the component
-                                              // class as well
+            // this includes the component class as well, no need to explicitly
+            // include it in the error message
+            return "created: " + createLocation + ", attached: "
+                    + attachLocation;
         }
         // createLocation may be null in production mode. Just return the
         // component's toString() which should provide enough information to the

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
@@ -778,7 +778,7 @@ public class StateNode implements Serializable {
                                 + "node from its current state tree by calling "
                                 + "removeFromTree. This usually happens when a "
                                 + "component is moved from one UI to another, "
-                                + "which is not a good idea. This may be caused "
+                                + "which is not recommended. This may be caused "
                                 + "by assigning components to static members or "
                                 + "spring singleton scoped beans and referencing "
                                 + "them from multiple UIs. Offending component: "
@@ -808,7 +808,7 @@ public class StateNode implements Serializable {
             return "created: " + createLocation + ", attached: "
                     + attachLocation;
         }
-        // createLocation may be null in production mode. Just return the
+        // createLocation is null in production mode. Just return the
         // component's toString() which should provide enough information to the
         // programmer.
         return component.toString();

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
@@ -803,9 +803,8 @@ public class StateNode implements Serializable {
                 .findCreate(component);
         final ComponentTracker.Location attachLocation = ComponentTracker
                 .findAttach(component);
-        if (createLocation != null) {
-            // this includes the component class as well, no need to explicitly
-            // include it in the error message
+        if (createLocation != null || attachLocation != null) {
+            // the location.toString() includes the component class as well
             return "created: " + createLocation + ", attached: "
                     + attachLocation;
         }

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
@@ -1944,7 +1944,7 @@ public class ComponentTest {
                         + "intentional, first remove the node from its current "
                         + "state tree by calling removeFromTree. This usually "
                         + "happens when a component is moved from one UI to another, "
-                        + "which is not a good idea. This may be caused by "
+                        + "which is not recommended. This may be caused by "
                         + "assigning components to static members or spring "
                         + "singleton scoped beans and referencing them from "
                         + "multiple UIs. Offending component: com.vaadin.flow."

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
@@ -156,6 +156,7 @@ public class ComponentTest {
     private Component shadowChild;
     private UI testUI;
     private MockServletServiceSessionSetup mocks;
+    private VaadinSession session;
 
     public interface TracksAttachDetach {
         default void track() {
@@ -281,6 +282,17 @@ public class ComponentTest {
         }
     }
 
+    private UI createMockedUI() {
+        UI ui = new UI() {
+            @Override
+            public VaadinSession getSession() {
+                return session;
+            }
+        };
+        ui.getInternals().setSession(session);
+        return ui;
+    }
+
     @Before
     public void setup() throws Exception {
         divWithTextComponent = new TestComponent(
@@ -295,14 +307,8 @@ public class ComponentTest {
 
         mocks = new MockServletServiceSessionSetup();
 
-        VaadinSession session = mocks.getSession();
-        ui = new UI() {
-            @Override
-            public VaadinSession getSession() {
-                return session;
-            }
-        };
-        ui.getInternals().setSession(session);
+        session = mocks.getSession();
+        ui = createMockedUI();
 
         UI.setCurrent(ui);
     }
@@ -1924,4 +1930,24 @@ public class ComponentTest {
                 "scrollIntoView({\"behavior\":\"smooth\",\"block\":\"end\",\"inline\":\"center\"})");
     }
 
+    @Test
+    public void cannotMoveComponentsToOtherUI() {
+        // tests https://github.com/vaadin/flow/issues/9376
+        final UI otherUI = createMockedUI();
+        final TestButton button = new TestButton();
+        otherUI.add(button);
+
+        IllegalStateException ex = Assert.assertThrows(
+                IllegalStateException.class, () -> ui.add(button));
+        Assert.assertTrue(ex.getMessage(), ex.getMessage().startsWith(
+                "Can't move a node from one state tree to another. If this is "
+                        + "intentional, first remove the node from its current "
+                        + "state tree by calling removeFromTree. This usually "
+                        + "happens when a component is moved from one UI to another, "
+                        + "which is not a good idea. This may be caused by "
+                        + "assigning components to static members or spring "
+                        + "singleton scoped beans and referencing them from "
+                        + "multiple UIs. Offending component: com.vaadin.flow."
+                        + "component.ComponentTest$TestButton@"));
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementUtilTest.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.dom;
 
 import java.util.Optional;
 
+import com.vaadin.flow.internal.nodefeature.ElementPropertyMap;
 import org.mockito.Mockito;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Node;
@@ -248,6 +249,21 @@ public class ElementUtilTest {
     @Test
     public void parentInert_siblingIgnoresInheritingInert_siblingInert() {
         final Element sibling = ElementFactory.createDiv();
+    }
+
+    @Test
+    public void elementsUpdateSameData() {
+        Element te = new Element("testelem");
+        Element e = ElementUtil.from(te.getNode()).orElse(null);
+
+        // Elements must be equal but not necessarily the same
+        Assert.assertEquals(te, e);
+    }
+
+    @Test
+    public void getElementFromInvalidNode() {
+        StateNode node = new StateNode(ElementPropertyMap.class);
+        Assert.assertFalse(ElementUtil.from(node).isPresent());
     }
 
     private void setupElementHierarchy() {


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Improve error message when a component is moved from one UI to another.

Fixes #9376 

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
