### PR TITLE
fix: support accept property in StreamReceiverHandler

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
@@ -456,7 +456,17 @@ public class StreamReceiverHandler implements Serializable {
             return false;
         }
         for (String acceptValue : accept.split(",")) {
-            if (acceptValue.trim().equals(mimeType)) {
+            String trimmedAcceptValue = acceptValue.trim();
+            if (trimmedAcceptValue.equals("*/*")) {
+                return false;
+            }
+            if (trimmedAcceptValue.endsWith("/*")) {
+                if (mimeType.startsWith(trimmedAcceptValue.substring(0,
+                        trimmedAcceptValue.length() - 1))) {
+                    return false;
+                }
+            }
+            if (trimmedAcceptValue.equals(mimeType)) {
                 return false;
             }
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.server.communication;
 
-import javax.naming.SizeLimitExceededException;
-
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.BufferedWriter;
@@ -407,7 +405,8 @@ public class StreamReceiverHandler implements Serializable {
                 throw new UploadException("Warning: file upload ignored for "
                         + node.getId() + " because the component was disabled");
             }
-            if (isMimeTypeDisallowedByAcceptProperty(node, mimeType)) {
+            if (isMimeTypeOrFileExtensionDisallowedByAcceptProperty(node,
+                    mimeType, filename)) {
                 throw new UploadException("Warning: file upload ignored for "
                         + node.getId() + " because the mime type " + mimeType
                         + " is not allowed by the accept property");
@@ -440,8 +439,9 @@ public class StreamReceiverHandler implements Serializable {
         return false;
     }
 
-    private boolean isMimeTypeDisallowedByAcceptProperty(StateNode stateNode,
-            String mimeType) {
+    private boolean isMimeTypeOrFileExtensionDisallowedByAcceptProperty(
+            StateNode stateNode, String mimeType,
+            String filenameWithExtension) {
         if (stateNode == null) {
             return false;
         }
@@ -468,6 +468,10 @@ public class StreamReceiverHandler implements Serializable {
             }
             if (trimmedAcceptValue.equals(mimeType)) {
                 return false;
+            }
+            if (filenameWithExtension != null
+                    && trimmedAcceptValue.startsWith(".")) {
+                return !filenameWithExtension.endsWith(trimmedAcceptValue);
             }
         }
         return true;

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
@@ -42,6 +42,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.Pair;
 import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.server.ErrorEvent;
@@ -406,6 +407,11 @@ public class StreamReceiverHandler implements Serializable {
                 throw new UploadException("Warning: file upload ignored for "
                         + node.getId() + " because the component was disabled");
             }
+            if (isMimeTypeDisallowedByAcceptProperty(node, mimeType)) {
+                throw new UploadException("Warning: file upload ignored for "
+                        + node.getId() + " because the mime type " + mimeType
+                        + " is not allowed by the accept property");
+            }
         } finally {
             session.unlock();
         }
@@ -432,6 +438,29 @@ public class StreamReceiverHandler implements Serializable {
             }
         }
         return false;
+    }
+
+    private boolean isMimeTypeDisallowedByAcceptProperty(StateNode stateNode,
+            String mimeType) {
+        if (stateNode == null) {
+            return false;
+        }
+        Element element;
+        try {
+            element = Element.get(stateNode);
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+        String accept = element.getProperty("accept");
+        if (accept == null || accept.isBlank()) {
+            return false;
+        }
+        for (String acceptValue : accept.split(",")) {
+            if (acceptValue.trim().equals(mimeType)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**


### PR DESCRIPTION
StreamReceiverHandler understands `accept` property of the target element to block unwanted mime types. `accept` property takes comma separated list of mime types like 'text/plain, text/html'.