### PR TITLE
fix: prevent propagating IO errors when serving PWA icons

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PwaHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PwaHandler.java
@@ -86,7 +86,7 @@ public class PwaHandler implements RequestHandler {
                             icon.write(out);
                         } catch (UncheckedIOException ex) {
                             LoggerFactory.getLogger(PwaHandler.class)
-                                    .debug("Error serving PWA image", ex);
+                                    .debug("Error serving PWA icon", ex);
                         }
                         return true;
                     });

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PwaHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PwaHandler.java
@@ -18,11 +18,14 @@ package com.vaadin.flow.server.communication;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.function.SerializableSupplier;
 import com.vaadin.flow.server.PwaIcon;
@@ -81,6 +84,9 @@ public class PwaHandler implements RequestHandler {
                         }
                         try (OutputStream out = response.getOutputStream()) {
                             icon.write(out);
+                        } catch (UncheckedIOException ex) {
+                            LoggerFactory.getLogger(PwaHandler.class)
+                                    .debug("Error serving PWA image", ex);
                         }
                         return true;
                     });

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/PwaHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/PwaHandlerTest.java
@@ -36,11 +36,11 @@ import com.vaadin.flow.server.VaadinSession;
 
 public class PwaHandlerTest {
 
-    private VaadinSession session = Mockito.mock(VaadinSession.class);
+    private final VaadinSession session = Mockito.mock(VaadinSession.class);
 
-    private VaadinRequest request = Mockito.mock(VaadinRequest.class);
+    private final VaadinRequest request = Mockito.mock(VaadinRequest.class);
 
-    private VaadinResponse response = Mockito.mock(VaadinResponse.class);
+    private final VaadinResponse response = Mockito.mock(VaadinResponse.class);
 
     @Test
     public void handleRequest_noPwaRegistry_returnsFalse() throws IOException {

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/PwaHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/PwaHandlerTest.java
@@ -18,12 +18,17 @@ package com.vaadin.flow.server.communication;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.io.UncheckedIOException;
+import java.lang.reflect.Constructor;
+import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.server.PwaConfiguration;
+import com.vaadin.flow.server.PwaIcon;
 import com.vaadin.flow.server.PwaRegistry;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
@@ -92,5 +97,41 @@ public class PwaHandlerTest {
         Assert.assertTrue(handler.handleRequest(session, request, response));
 
         Mockito.verify(registry, Mockito.times(1)).getIcons();
+    }
+
+    @Test
+    public void handleRequest_writeIconOnResponseFailure_doesNotThrow()
+            throws Exception {
+
+        PwaRegistry registry = Mockito.mock(PwaRegistry.class);
+        PwaConfiguration configuration = Mockito.mock(PwaConfiguration.class);
+        Mockito.when(registry.getPwaConfiguration()).thenReturn(configuration);
+
+        PwaHandler handler = new PwaHandler(() -> registry);
+
+        PwaIcon icon = Mockito.spy(createIcon(registry, 100));
+        Mockito.when(registry.getIcons()).thenReturn(List.of(icon));
+        Mockito.when(configuration.isEnabled()).thenReturn(true);
+
+        Mockito.doAnswer(i -> {
+            throw new UncheckedIOException(
+                    "Failed to store the icon image into the stream provided",
+                    new IOException("Broken pipe"));
+        }).when(icon).write(ArgumentMatchers.any());
+        Mockito.when(request.getPathInfo())
+                .thenReturn("/icons/icon-100x100.png");
+
+        Assert.assertTrue(handler.handleRequest(session, request, response));
+    }
+
+    private PwaIcon createIcon(PwaRegistry registry, int size)
+            throws Exception {
+        Constructor<PwaIcon> ctor = PwaIcon.class
+                .getDeclaredConstructor(int.class, int.class, String.class);
+        ctor.setAccessible(true);
+        PwaIcon icon = ctor.newInstance(size, size,
+                PwaConfiguration.DEFAULT_ICON);
+        icon.setRegistry(registry);
+        return icon;
     }
 }


### PR DESCRIPTION
## Description

An IOException when writing a PWA icon on the HTTP response can neither be fixed nor handled and causes a lot of log spamming. This change catches the error and logs it at debug level.

Fixes #17643

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
