### PR TITLE
test: replace chrome mobile profile with custom settings

### DIFF
--- a/flow-test-util/src/main/java/com/vaadin/flow/testutil/ChromeDeviceTest.java
+++ b/flow-test-util/src/main/java/com/vaadin/flow/testutil/ChromeDeviceTest.java
@@ -97,7 +97,8 @@ public class ChromeDeviceTest extends ViewOrUITest {
     protected ChromeOptions customizeChromeOptions(
             ChromeOptions chromeOptions) {
         final Map<String, Object> mobileEmulationParams = new HashMap<>();
-        mobileEmulationParams.put("deviceName", "Laptop with touch");
+        mobileEmulationParams.put("deviceMetrics",
+                Map.of("width", 1280, "height", 950, "pixelRatio", 1));
 
         chromeOptions.setExperimentalOption("mobileEmulation",
                 mobileEmulationParams);


### PR DESCRIPTION
Prevents PWA test failures with Chrome 119 because of 'invalid argument: Empty userAgent invalid with userAgentMetadata provided'