### PR TITLE
chore: update vaadin-parent to 2.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-parent</artifactId>
-        <version>2.0.5</version>
+        <version>2.2.1</version>
     </parent>
 
     <modules>


### PR DESCRIPTION
the older version uses a wrong vaadin-prerelease target. 