### PR TITLE
Do not touch package.json files unless content has changed

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -478,7 +478,7 @@ public abstract class NodeUpdater implements FallibleCommand {
                 || options.isBundleBuild()) {
             log().debug("writing file {}.", packageFile.getAbsolutePath());
             FileUtils.forceMkdirParent(packageFile);
-            FileUtils.writeStringToFile(packageFile, content, UTF_8.name());
+            FileIOUtils.writeIfChanged(packageFile, content);
         }
         return content;
     }
@@ -506,7 +506,7 @@ public abstract class NodeUpdater implements FallibleCommand {
         File vaadinJsonFile = getVaadinJsonFile();
         FileUtils.forceMkdirParent(vaadinJsonFile);
         String content = stringify(fileContent, 2) + "\n";
-        FileUtils.writeStringToFile(vaadinJsonFile, content, UTF_8.name());
+        FileIOUtils.writeIfChanged(vaadinJsonFile, content);
     }
 
     Logger log() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
@@ -861,8 +861,7 @@ public abstract class AbstractNodeUpdatePackagesTest
 
     void writePackageJson(File packageJsonFile, JsonObject packageJson)
             throws IOException {
-        FileUtils.writeStringToFile(packageJsonFile, packageJson.toJson(),
-                UTF_8.name());
+        FileIOUtils.writeIfChanged(packageJsonFile, packageJson.toJson());
     }
 
 }


### PR DESCRIPTION
In some cases, at least the `package.json` file is overwritten with the same content it already had. This causes the timestamp to be updated, which in some environments causes file fingerprint to differ. 

Fixes https://github.com/vaadin/flow/issues/17941 