### PR TITLE
fix: revert addClickShortcut to not reset focus by default

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
@@ -142,7 +142,6 @@ public interface ClickNotifier<T extends Component> extends Serializable {
                 () -> new Component[] { thisComponent.getUI().get() },
                 event -> ComponentUtil.fireEvent(thisComponent,
                         new ClickEvent<>(thisComponent)),
-                key).withModifiers(keyModifiers).allowBrowserDefault()
-                .resetFocusOnActiveElement();
+                key).withModifiers(keyModifiers).allowBrowserDefault();
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
@@ -334,7 +334,7 @@ public class ShortcutRegistrationTest {
         assertFalse("Allows propagation was not false",
                 registration.isEventPropagationAllowed());
 
-        assertTrue("Reset focus on active element was not set to true",
+        assertFalse("Reset focus on active element was not set to false",
                 registration.isResetFocusOnActiveElement());
     }
 

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShadowRootShortcutsWithValueChangeModeView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShadowRootShortcutsWithValueChangeModeView.java
@@ -63,9 +63,10 @@ public class ShadowRootShortcutsWithValueChangeModeView extends Div
         // clickShortcutWorks
         button.setText(
                 "Button triggered by CTRL + ALT + S and CTRL + ENTER (with reset focus)");
-        button.addClickShortcut(Key.KEY_S, KeyModifier.CONTROL, KeyModifier.ALT)
-                .setResetFocusOnActiveElement(false);
-        button.addClickShortcut(Key.ENTER, KeyModifier.CONTROL);
+        button.addClickShortcut(Key.KEY_S, KeyModifier.CONTROL,
+                KeyModifier.ALT);
+        button.addClickShortcut(Key.ENTER, KeyModifier.CONTROL)
+                .setResetFocusOnActiveElement(true);
         button.addClickListener(e -> value.setText(input.getValue()));
 
         shadowRoot.appendChild(shadowDiv);

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsView.java
@@ -178,9 +178,6 @@ public class ShortcutsView extends Div {
         // this matches the default of other shortcuts but changes
         // the default of the click shortcut
         reg.setBrowserDefaultAllowed(false);
-        // setting setResetFocusOnActiveElement(false) to test browser default
-        // allowed feature alone.
-        reg.setResetFocusOnActiveElement(false);
 
         wrapper1.add(clickInput1, clickButton1);
         wrapper2.add(clickInput2, clickButton2);
@@ -223,11 +220,11 @@ public class ShortcutsView extends Div {
                         + "," + clickInput6.getValue()));
         clickButton4.addClickShortcut(Key.ENTER)
                 .listenOn(clickInput5, clickInput6)
-                // by default addClickShortcut sets setResetFocusOnActiveElement
+                // sets setResetFocusOnActiveElement
                 // to true and this will cause input value change being
                 // triggered no matter what
                 // setBrowserDefaultAllowed is.
-                .setBrowserDefaultAllowed(false);
+                .resetFocusOnActiveElement().setBrowserDefaultAllowed(false);
 
         NativeButton clickButton5 = new NativeButton("CB5",
                 event -> actual.setValue("click5: " + clickInput7.getValue()));
@@ -235,7 +232,6 @@ public class ShortcutsView extends Div {
         // this matches the default of other shortcuts but changes
         // the default of the click shortcut
         reg.setBrowserDefaultAllowed(false);
-        reg.setResetFocusOnActiveElement(false);
 
         wrapper4.add(clickInput5, clickInput6, clickInput7, clickButton4,
                 clickButton5);

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsWithValueChangeModeView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsWithValueChangeModeView.java
@@ -53,9 +53,10 @@ public class ShortcutsWithValueChangeModeView extends Div
         // clickShortcutWorks
         button.setText(
                 "Button triggered by CTRL + ALT + S and CTRL + ENTER (with reset focus)");
-        button.addClickShortcut(Key.KEY_S, KeyModifier.CONTROL, KeyModifier.ALT)
-                .setResetFocusOnActiveElement(false);
-        button.addClickShortcut(Key.ENTER, KeyModifier.CONTROL);
+        button.addClickShortcut(Key.KEY_S, KeyModifier.CONTROL,
+                KeyModifier.ALT);
+        button.addClickShortcut(Key.ENTER, KeyModifier.CONTROL)
+                .setResetFocusOnActiveElement(true);
         button.addClickListener(e -> value.setText(input.getValue()));
 
         add(input, button, value);


### PR DESCRIPTION
Removes a call `setResetFocusOnActiveElement(true)` in `addClickShortcut` method in `ClickNotifier` to revert default behavior changes from https://github.com/vaadin/flow/pull/17826.