### PR TITLE
fix: improve error message when a component is moved from one UI to another. (#18019) (CP: 24.1)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentTracker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentTracker.java
@@ -110,6 +110,12 @@ public class ComponentTracker {
             result = 31 * result + lineNumber;
             return result;
         }
+
+        @Override
+        public String toString() {
+            return "Component '" + className + "' at '" + filename + "' ("
+                    + methodName + " LINE " + lineNumber + ")";
+        }
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -129,14 +129,9 @@ public class Element extends Node<Element> {
     public static Element get(StateNode node) {
         assert node != null;
 
-        if (node.hasFeature(TextNodeMap.class)) {
-            return get(node, BasicTextElementStateProvider.get());
-        } else if (node.hasFeature(ElementData.class)) {
-            return get(node, BasicElementStateProvider.get());
-        } else {
-            throw new IllegalArgumentException(
-                    "Node is not valid as an element");
-        }
+        return ElementUtil.from(node)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Node is not valid as an element"));
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/dom/ElementUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/ElementUtil.java
@@ -20,6 +20,11 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
+import com.vaadin.flow.dom.impl.BasicElementStateProvider;
+import com.vaadin.flow.dom.impl.BasicTextElementStateProvider;
+import com.vaadin.flow.internal.StateNode;
+import com.vaadin.flow.internal.nodefeature.ElementData;
+import com.vaadin.flow.internal.nodefeature.TextNodeMap;
 import org.jsoup.nodes.DataNode;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Node;
@@ -355,4 +360,25 @@ public class ElementUtil {
         }
     }
 
+    /**
+     * Gets the element mapped to the given state node.
+     *
+     * @param node
+     *            the state node, not <code>null</code>
+     * @return the element for the node, or an empty Optional if the state node
+     *         is not mapped to any particular element.
+     */
+    public static Optional<Element> from(StateNode node) {
+        assert node != null;
+
+        if (node.hasFeature(TextNodeMap.class)) {
+            return Optional
+                    .of(Element.get(node, BasicTextElementStateProvider.get()));
+        } else if (node.hasFeature(ElementData.class)) {
+            return Optional
+                    .of(Element.get(node, BasicElementStateProvider.get()));
+        } else {
+            return Optional.empty();
+        }
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
@@ -36,9 +36,13 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
+import com.vaadin.flow.component.internal.ComponentTracker;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.ElementUtil;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.StateTree.BeforeClientResponseEntry;
 import com.vaadin.flow.internal.StateTree.ExecutionRegistration;
@@ -747,16 +751,49 @@ public class StateNode implements Serializable {
                     ((StateTree) getOwner()).getUI(),
                     ReplacedViaPreserveOnRefresh.class) == null;
             if (isOwnerAttached || isNotReplaced) {
+                // provide a more verbose error message:
+                // https://github.com/vaadin/flow/issues/9376
+
                 throw new IllegalStateException(
                         "Can't move a node from one state tree to another. "
                                 + "If this is intentional, first remove the "
                                 + "node from its current state tree by calling "
-                                + "removeFromTree");
+                                + "removeFromTree. This usually happens when a "
+                                + "component is moved from one UI to another, "
+                                + "which is not recommended. This may be caused "
+                                + "by assigning components to static members or "
+                                + "spring singleton scoped beans and referencing "
+                                + "them from multiple UIs. Offending component: "
+                                + formatOwnerComponentToString());
             } else {
                 id = -1;
             }
         }
         owner = tree;
+    }
+
+    private String formatOwnerComponentToString() {
+        final Element ownerElement = ElementUtil.from(this).orElse(null);
+        if (ownerElement == null) {
+            return "unknown element";
+        }
+        final Component component = ownerElement.getComponent().orElse(null);
+        if (component == null) {
+            return "element " + ownerElement + ", no component";
+        }
+        final ComponentTracker.Location createLocation = ComponentTracker
+                .findCreate(component);
+        final ComponentTracker.Location attachLocation = ComponentTracker
+                .findAttach(component);
+        if (createLocation != null || attachLocation != null) {
+            // the location.toString() includes the component class as well
+            return "created: " + createLocation + ", attached: "
+                    + attachLocation;
+        }
+        // createLocation is null in production mode. Just return the
+        // component's toString() which should provide enough information to the
+        // programmer.
+        return component.toString();
     }
 
     private boolean handleOnAttach() {

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -30,6 +31,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.component.internal.ComponentTracker;
 import com.vaadin.flow.i18n.I18NProvider;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
@@ -295,6 +297,7 @@ public class ComponentTest {
 
     @Before
     public void setup() throws Exception {
+        resetComponentTrackerProductionMode();
         divWithTextComponent = new TestComponent(
                 ElementFactory.createDiv("Test component"));
         parentDivComponent = new TestComponent(ElementFactory.createDiv());
@@ -314,9 +317,10 @@ public class ComponentTest {
     }
 
     @After
-    public void tearDown() {
+    public void tearDown() throws Exception {
         UI.setCurrent(null);
         mocks.cleanup();
+        resetComponentTrackerProductionMode();
     }
 
     @Test
@@ -1950,4 +1954,13 @@ public class ComponentTest {
                         + "multiple UIs. Offending component: com.vaadin.flow."
                         + "component.ComponentTest$TestButton@"));
     }
+
+    private void resetComponentTrackerProductionMode() throws Exception {
+        Field productionMode = ComponentTracker.class
+                .getDeclaredField("productionMode");
+        productionMode.setAccessible(true);
+        productionMode.set(null, null);
+        productionMode.setAccessible(false);
+    }
+
 }

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementUtilTest.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.dom;
 
 import java.util.Optional;
 
+import com.vaadin.flow.internal.nodefeature.ElementPropertyMap;
 import org.mockito.Mockito;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Node;
@@ -248,6 +249,21 @@ public class ElementUtilTest {
     @Test
     public void parentInert_siblingIgnoresInheritingInert_siblingInert() {
         final Element sibling = ElementFactory.createDiv();
+    }
+
+    @Test
+    public void elementsUpdateSameData() {
+        Element te = new Element("testelem");
+        Element e = ElementUtil.from(te.getNode()).orElse(null);
+
+        // Elements must be equal but not necessarily the same
+        Assert.assertEquals(te, e);
+    }
+
+    @Test
+    public void getElementFromInvalidNode() {
+        StateNode node = new StateNode(ElementPropertyMap.class);
+        Assert.assertFalse(ElementUtil.from(node).isPresent());
     }
 
     private void setupElementHierarchy() {


### PR DESCRIPTION

* feat: Add ElementUtil.from(StateNode) which returns Optional<Element>

Sister function for Element.get(StateNode), but returns an empty Optional instead of throwing an exception

* fix: improve error message when a component is moved from one UI to another.

Fixes #9376

* chore: mention both createLocation and attachLocation in the exception message

* chore: mention both createLocation and attachLocation in the exception message

* chore: minor fixes in messages