### PR TITLE
fix: postpone commands scheduled with runWhenAttached for detached nodes

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
@@ -956,8 +956,9 @@ public class StateNode implements Serializable {
      *            the command to run immediately or when the node is attached
      */
     public void runWhenAttached(SerializableConsumer<UI> command) {
-
-        if (isAttached()) {
+        // Execute immediately only if the node han not been detached
+        // during current roundtrip
+        if (isAttached() && (!wasAttached || !this.hasBeenDetached)) {
             command.accept(getUI());
         } else {
             addAttachListener(new Command() {

--- a/flow-server/src/test/java/com/vaadin/flow/internal/StateNodeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/StateNodeTest.java
@@ -569,6 +569,29 @@ public class StateNodeTest {
     }
 
     @Test
+    public void runWhenAttachedNodeDetachedInSameRoundTrip() {
+        StateTree tree = createStateTree();
+        AtomicInteger commandRun = new AtomicInteger(0);
+        StateNode node = createEmptyNode();
+        setParent(node, tree.getRootNode());
+        node.removeFromTree();
+
+        node.runWhenAttached(ui -> {
+            Assert.assertEquals(tree.getUI(), ui);
+            commandRun.incrementAndGet();
+        });
+
+        Assert.assertEquals(0, commandRun.get());
+
+        setParent(node, tree.getRootNode());
+        Assert.assertEquals(1, commandRun.get());
+
+        setParent(node, null);
+        setParent(node, tree.getRootNode());
+        Assert.assertEquals(1, commandRun.get());
+    }
+
+    @Test
     public void requiredFeatures() {
         StateNode stateNode = new StateNode(
                 Arrays.asList(ElementClassList.class, ElementPropertyMap.class),


### PR DESCRIPTION
## Description

When detach listeners are called, the node still has a parent set, causing commands scheduled with runWhenAttached to be executed immediately. This change make runWhenAttached postpone the command by registering an attach listener, if the node has been detached during the same roundtrip.

Fixes vaadin/flow-components#1434
Fixes #18020

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
