### PR TITLE
fix: RangeInput orientation: add support for Chrome, Edge and Safari.…

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/RangeInput.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/RangeInput.java
@@ -219,7 +219,8 @@ public class RangeInput extends AbstractSinglePropertyField<RangeInput, Double>
      * "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range#non-standard_attributes">Non-standard
      * Attribute</a>. Since the vertical orientation is not standardized yet,
      * this feature is not guaranteed to work on every browser. We found this
-     * feature to work on Firefox 120+, Chromium 119+ and Edge 119+.
+     * feature to work on Firefox 120+, Chromium 119+, Edge 119+ and Safari
+     * 17.1+.
      * <p>
      * </p>
      * The orient attribute defines the orientation of the range slider. Values

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/RangeInput.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/RangeInput.java
@@ -27,6 +27,7 @@ import com.vaadin.flow.data.value.HasValueChangeMode;
 import com.vaadin.flow.data.value.ValueChangeMode;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * Creates a new input element with type "range".
@@ -216,7 +217,9 @@ public class RangeInput extends AbstractSinglePropertyField<RangeInput, Double>
      * </p>
      * <a href=
      * "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range#non-standard_attributes">Non-standard
-     * Attribute</a>.
+     * Attribute</a>. Since the vertical orientation is not standardized yet,
+     * this feature is not guaranteed to work on every browser. We found this
+     * feature to work on Firefox 120+, Chromium 119+ and Edge 119+.
      * <p>
      * </p>
      * The orient attribute defines the orientation of the range slider. Values
@@ -228,7 +231,25 @@ public class RangeInput extends AbstractSinglePropertyField<RangeInput, Double>
      *            {@link Orientation#HORIZONTAL}.
      */
     public void setOrientation(Orientation orientation) {
+        Objects.requireNonNull(orientation);
+        // Fix support for individual browsers
+        // See
+        // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range#creating_vertical_range_controls
+        // for more details
+
+        // support for Firefox
         set(orientDescriptor, orientation.getValue());
+        if (orientation == Orientation.VERTICAL) {
+            // Support for Chrome and Safari
+            getStyle().set("-webkit-appearance", "slider-vertical");
+            getStyle().set("appearance", "slider-vertical");
+            // Support for Edge
+            getStyle().set("writing-mode", "bt-lr");
+        } else {
+            getStyle().remove("-webkit-appearance");
+            getStyle().remove("appearance");
+            getStyle().remove("writing-mode");
+        }
     }
 
     /**

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/RangeInputTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/RangeInputTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.html;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.beans.IntrospectionException;
@@ -50,5 +51,29 @@ public class RangeInputTest extends ComponentTest {
     @Override
     public void testHasAriaLabelIsImplemented() {
         super.testHasAriaLabelIsImplemented();
+    }
+
+    @Test
+    public void settingOrientationUpdatesStylesProperly() {
+        final RangeInput rangeInput = new RangeInput();
+        Assert.assertNull(rangeInput.getStyle().get("-webkit-appearance"));
+        Assert.assertNull(rangeInput.getStyle().get("appearance"));
+        Assert.assertNull(rangeInput.getStyle().get("writing-mode"));
+        Assert.assertEquals(RangeInput.Orientation.HORIZONTAL,
+                rangeInput.getOrientation());
+        rangeInput.setOrientation(RangeInput.Orientation.VERTICAL);
+        Assert.assertEquals("slider-vertical",
+                rangeInput.getStyle().get("-webkit-appearance"));
+        Assert.assertEquals("slider-vertical",
+                rangeInput.getStyle().get("appearance"));
+        Assert.assertEquals("bt-lr", rangeInput.getStyle().get("writing-mode"));
+        Assert.assertEquals(RangeInput.Orientation.VERTICAL,
+                rangeInput.getOrientation());
+        rangeInput.setOrientation(RangeInput.Orientation.HORIZONTAL);
+        Assert.assertNull(rangeInput.getStyle().get("-webkit-appearance"));
+        Assert.assertNull(rangeInput.getStyle().get("appearance"));
+        Assert.assertNull(rangeInput.getStyle().get("writing-mode"));
+        Assert.assertEquals(RangeInput.Orientation.HORIZONTAL,
+                rangeInput.getOrientation());
     }
 }


### PR DESCRIPTION
… Fixes #18096

## Description

According to https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range#creating_vertical_range_controls , additional styles are required to make the Range Input vertical on Edge, Safari and Chrome. This PR adds all necessary CSS styles.

Fixes #18096

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
