### PR TITLE
fix: Redirect to error view by default for errors in RPC-handling

### DIFF
--- a/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
+++ b/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
@@ -433,7 +433,7 @@ public class BuildDevBundleMojo extends AbstractMojo
 
     @Override
     public boolean isErrorHandlerRedirectEnabled() {
-        return false;
+        return true;
     }
 
 }

--- a/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
+++ b/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
@@ -431,9 +431,4 @@ public class BuildDevBundleMojo extends AbstractMojo
         return false;
     }
 
-    @Override
-    public boolean isErrorHandlerRedirectEnabled() {
-        return true;
-    }
-
 }

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
@@ -198,5 +198,4 @@ internal class GradlePluginAdapter(
 
     override fun isPrepareFrontendCacheDisabled(): Boolean = config.alwaysExecutePrepareFrontend.get()
 
-    override fun isErrorHandlerRedirectEnabled(): Boolean = config.isErrorHandlerRedirect.get()
 }

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
@@ -276,7 +276,7 @@ public abstract class VaadinFlowPluginExtension {
      * can be rendered for exceptions during RPC request handling, not only limited
      * to exceptions thrown during navigation life-cycle.
      *
-     * @return `true` to enable error view rendering in RPC, `false` by default
+     * @return `true` to enable error view rendering in RPC (default), `false` otherwise
      */
     public abstract val errorHandlerRedirect: Property<Boolean>
 
@@ -421,7 +421,7 @@ internal class PluginEffectiveConfiguration(
         .convention(false)
 
     val isErrorHandlerRedirect: Provider<Boolean> = extension.errorHandlerRedirect
-        .convention(false)
+        .convention(true)
         .overrideWithSystemProperty(InitParameters.ERROR_HANDLER_REDIRECT_ENABLED)
 
     /**

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
@@ -271,15 +271,6 @@ public abstract class VaadinFlowPluginExtension {
      */
     public abstract val alwaysExecutePrepareFrontend: Property<Boolean>
 
-    /**
-     * If `true` navigation error views implementing `HasErrorParameter`
-     * can be rendered for exceptions during RPC request handling, not only limited
-     * to exceptions thrown during navigation life-cycle.
-     *
-     * @return `true` to enable error view rendering in RPC (default), `false` otherwise
-     */
-    public abstract val errorHandlerRedirect: Property<Boolean>
-
     public fun filterClasspath(@DelegatesTo(value = ClasspathFilter::class, strategy = Closure.DELEGATE_FIRST) block: Closure<*>) {
         block.delegate = classpathFilter
         block.resolveStrategy = Closure.DELEGATE_FIRST
@@ -420,10 +411,6 @@ internal class PluginEffectiveConfiguration(
     val alwaysExecutePrepareFrontend: Property<Boolean> = extension.alwaysExecutePrepareFrontend
         .convention(false)
 
-    val isErrorHandlerRedirect: Provider<Boolean> = extension.errorHandlerRedirect
-        .convention(true)
-        .overrideWithSystemProperty(InitParameters.ERROR_HANDLER_REDIRECT_ENABLED)
-
     /**
      * Finds the value of a boolean property. It searches in gradle and system properties.
      *
@@ -470,7 +457,6 @@ internal class PluginEffectiveConfiguration(
             "processResourcesTaskName=${processResourcesTaskName.get()}, " +
             "skipDevBundleBuild=${skipDevBundleBuild.get()}, " +
             "alwaysExecutePrepareFrontend=${alwaysExecutePrepareFrontend.get()}, " +
-            "isErrorHandlerRedirect=${isErrorHandlerRedirect.get()}, " +
             "frontendHotdeploy=${frontendHotdeploy.get()}" +
             ")"
     companion object {

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -226,7 +226,7 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
     @Parameter(property = InitParameters.SKIP_DEV_BUNDLE_REBUILD, defaultValue = "false")
     private boolean skipDevBundleRebuild;
 
-    @Parameter(property = InitParameters.ERROR_HANDLER_REDIRECT_ENABLED, defaultValue = "false")
+    @Parameter(property = InitParameters.ERROR_HANDLER_REDIRECT_ENABLED, defaultValue = "true")
     private boolean enableErrorHandlerRedirect;
 
     /**

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -226,9 +226,6 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
     @Parameter(property = InitParameters.SKIP_DEV_BUNDLE_REBUILD, defaultValue = "false")
     private boolean skipDevBundleRebuild;
 
-    @Parameter(property = InitParameters.ERROR_HANDLER_REDIRECT_ENABLED, defaultValue = "true")
-    private boolean enableErrorHandlerRedirect;
-
     /**
      * Generates a List of ClasspathElements (Run and CompileTime) from a
      * MavenProject.
@@ -459,8 +456,4 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
         return false;
     }
 
-    @Override
-    public boolean isErrorHandlerRedirectEnabled() {
-        return enableErrorHandlerRedirect;
-    }
 }

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -24,7 +24,6 @@ import static com.vaadin.flow.server.Constants.JAVA_RESOURCE_FOLDER_TOKEN;
 import static com.vaadin.flow.server.Constants.NPM_TOKEN;
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 import static com.vaadin.flow.server.Constants.PROJECT_FRONTEND_GENERATED_DIR_TOKEN;
-import static com.vaadin.flow.server.InitParameters.ERROR_HANDLER_REDIRECT_ENABLED;
 import static com.vaadin.flow.server.InitParameters.FRONTEND_HOTDEPLOY;
 import static com.vaadin.flow.server.InitParameters.NODE_DOWNLOAD_ROOT;
 import static com.vaadin.flow.server.InitParameters.NODE_VERSION;
@@ -215,8 +214,6 @@ public class BuildFrontendUtil {
                 TOKEN_FILE);
         JsonObject buildInfo = Json.createObject();
         buildInfo.put(SERVLET_PARAMETER_PRODUCTION_MODE, false);
-        buildInfo.put(ERROR_HANDLER_REDIRECT_ENABLED,
-                adapter.isErrorHandlerRedirectEnabled());
         buildInfo.put(SERVLET_PARAMETER_INITIAL_UIDL,
                 adapter.eagerServerLoad());
         buildInfo.put(NPM_TOKEN, adapter.npmFolder().getAbsolutePath());

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBase.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBase.java
@@ -302,13 +302,4 @@ public interface PluginAdapterBase {
      */
     boolean isPrepareFrontendCacheDisabled();
 
-    /**
-     * If {@code true} navigation error views implementing
-     * {@link com.vaadin.flow.router.HasErrorParameter} can be rendered for
-     * exceptions during RPC request handling.
-     *
-     * @return {@code true} to enable error view rendering in RPC, {@code false}
-     *         by default
-     */
-    boolean isErrorHandlerRedirectEnabled();
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/AbstractConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AbstractConfiguration.java
@@ -25,7 +25,6 @@ import com.vaadin.flow.server.frontend.BundleUtils;
 import com.vaadin.flow.server.frontend.FileIOUtils;
 import com.vaadin.flow.server.frontend.FrontendUtils;
 
-import static com.vaadin.flow.server.InitParameters.ERROR_HANDLER_REDIRECT_ENABLED;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DISABLE_XSRF_PROTECTION;
 
 /**
@@ -175,17 +174,6 @@ public interface AbstractConfiguration extends Serializable {
     default boolean isXsrfProtectionEnabled() {
         return !getBooleanProperty(SERVLET_PARAMETER_DISABLE_XSRF_PROTECTION,
                 false);
-    }
-
-    /**
-     * Return whether {@link DefaultErrorHandler} should use registered
-     * {@link com.vaadin.flow.router.HasErrorParameter} views for error handling
-     * when handler with exact match for exception is registered.
-     *
-     * @return true if error view should be rendered
-     */
-    default boolean isErrorRedirectEnabled() {
-        return getBooleanProperty(ERROR_HANDLER_REDIRECT_ENABLED, true);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/AbstractConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AbstractConfiguration.java
@@ -185,7 +185,7 @@ public interface AbstractConfiguration extends Serializable {
      * @return true if error view should be rendered
      */
     default boolean isErrorRedirectEnabled() {
-        return getBooleanProperty(ERROR_HANDLER_REDIRECT_ENABLED, false);
+        return getBooleanProperty(ERROR_HANDLER_REDIRECT_ENABLED, true);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/DefaultErrorHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DefaultErrorHandler.java
@@ -92,7 +92,7 @@ public class DefaultErrorHandler implements ErrorHandler {
         Throwable throwable = findRelevantThrowable(event.getThrowable());
         if (shouldHandle(throwable)) {
             if (ErrorHandlerUtil
-                            .handleErrorByRedirectingToErrorView(throwable)) {
+                    .handleErrorByRedirectingToErrorView(throwable)) {
                 return;
             }
             Marker marker = MarkerFactory.getMarker("INVALID_LOCATION");

--- a/flow-server/src/main/java/com/vaadin/flow/server/DefaultErrorHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DefaultErrorHandler.java
@@ -91,14 +91,9 @@ public class DefaultErrorHandler implements ErrorHandler {
     public void error(ErrorEvent event) {
         Throwable throwable = findRelevantThrowable(event.getThrowable());
         if (shouldHandle(throwable)) {
-            VaadinService service = VaadinService.getCurrent();
-            if (service != null
-                    && service.getDeploymentConfiguration()
-                            .isErrorRedirectEnabled()
-                    && ErrorHandlerUtil
+            if (ErrorHandlerUtil
                             .handleErrorByRedirectingToErrorView(throwable)) {
                 return;
-
             }
             Marker marker = MarkerFactory.getMarker("INVALID_LOCATION");
             if (throwable instanceof InvalidLocationException) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -64,7 +64,6 @@ public class InitParameters implements Serializable {
     public static final String SERVLET_PARAMETER_POLYFILLS = "module.polyfills";
     public static final String NODE_VERSION = "node.version";
     public static final String NODE_DOWNLOAD_ROOT = "node.download.root";
-    public static final String ERROR_HANDLER_REDIRECT_ENABLED = "enableErrorHandlerRedirect";
 
     /**
      * Configuration name for the parameter that determines whether Brotli

--- a/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
@@ -174,14 +174,6 @@ public class PropertyDeploymentConfiguration
     }
 
     @Override
-    public boolean isErrorRedirectEnabled() {
-        if (isOwnProperty(InitParameters.ERROR_HANDLER_REDIRECT_ENABLED)) {
-            return super.isErrorRedirectEnabled();
-        }
-        return parentConfig.isErrorRedirectEnabled();
-    }
-
-    @Override
     public boolean isUsageStatisticsEnabled() {
         return !isProductionMode() && getBooleanProperty(
                 InitParameters.SERVLET_PARAMETER_DEVMODE_STATISTICS, true);

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractConfigurationFactory.java
@@ -46,7 +46,6 @@ import static com.vaadin.flow.server.Constants.NPM_TOKEN;
 import static com.vaadin.flow.server.Constants.PROJECT_FRONTEND_GENERATED_DIR_TOKEN;
 import static com.vaadin.flow.server.Constants.VAADIN_PREFIX;
 import static com.vaadin.flow.server.InitParameters.BUILD_FOLDER;
-import static com.vaadin.flow.server.InitParameters.ERROR_HANDLER_REDIRECT_ENABLED;
 import static com.vaadin.flow.server.InitParameters.FRONTEND_HOTDEPLOY;
 import static com.vaadin.flow.server.InitParameters.NODE_DOWNLOAD_ROOT;
 import static com.vaadin.flow.server.InitParameters.NODE_VERSION;
@@ -81,10 +80,6 @@ public class AbstractConfigurationFactory implements Serializable {
         if (buildInfo.hasKey(SERVLET_PARAMETER_PRODUCTION_MODE)) {
             params.put(SERVLET_PARAMETER_PRODUCTION_MODE, String.valueOf(
                     buildInfo.getBoolean(SERVLET_PARAMETER_PRODUCTION_MODE)));
-        }
-        if (buildInfo.hasKey(ERROR_HANDLER_REDIRECT_ENABLED)) {
-            params.put(ERROR_HANDLER_REDIRECT_ENABLED, String.valueOf(
-                    buildInfo.getBoolean(ERROR_HANDLER_REDIRECT_ENABLED)));
         }
         if (buildInfo.hasKey(EXTERNAL_STATS_FILE_TOKEN)
                 || buildInfo.hasKey(EXTERNAL_STATS_URL_TOKEN)) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/ErrorHandlerUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/ErrorHandlerUtilTest.java
@@ -143,8 +143,6 @@ public class ErrorHandlerUtilTest {
         Mockito.when(vaadinService.getDeploymentConfiguration())
                 .thenReturn(config);
 
-        Mockito.when(config.isErrorRedirectEnabled()).thenReturn(true);
-
         Mockito.when(vaadinService.accessSession(
                 Mockito.any(VaadinSession.class), Mockito.any(Command.class)))
                 .thenCallRealMethod();
@@ -182,29 +180,9 @@ public class ErrorHandlerUtilTest {
     }
 
     @Test
-    public void featureNotEnabled_nullPointerException_doesNotExecuteErrorView() {
-        registry.setErrorNavigationTargets(
-                Collections.singleton(ErrorView.class));
-        Mockito.when(config.isErrorRedirectEnabled()).thenReturn(false);
-
-        Assert.assertEquals(0, ui.getElement().getChildren().count());
-
-        ui.access(() -> {
-        });
-
-        session.getPendingAccessQueue().forEach(futureAccess -> futureAccess
-                .handleError(new NullPointerException("NPE")));
-
-        Assert.assertFalse(ErrorView.initialized);
-        Assert.assertFalse(ErrorView.setError);
-        Assert.assertEquals(0, ui.getElement().getChildren().count());
-    }
-
-    @Test
     public void illegalArgumentException_doesNotExecuteErrorView() {
         registry.setErrorNavigationTargets(
                 Collections.singleton(ErrorView.class));
-        Mockito.when(config.isErrorRedirectEnabled()).thenReturn(false);
 
         Assert.assertEquals(0, ui.getElement().getChildren().count());
 


### PR DESCRIPTION
Based on DX feedback, the default for https://github.com/vaadin/flow/pull/17791 is swapped to true.