### PR TITLE
feat: reset focus on active element in ShortcutRegistration

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
@@ -97,6 +97,7 @@ public interface ClickNotifier<T extends Component> extends Serializable {
                 () -> new Component[] { thisComponent.getUI().get() },
                 event -> ComponentUtil.fireEvent(thisComponent,
                         new ClickEvent<>(thisComponent)),
-                key).withModifiers(keyModifiers).allowBrowserDefault();
+                key).withModifiers(keyModifiers).allowBrowserDefault()
+                .resetFocusOnActiveElement();
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
@@ -97,7 +97,6 @@ public interface ClickNotifier<T extends Component> extends Serializable {
                 () -> new Component[] { thisComponent.getUI().get() },
                 event -> ComponentUtil.fireEvent(thisComponent,
                         new ClickEvent<>(thisComponent)),
-                key).withModifiers(keyModifiers).allowBrowserDefault()
-                .resetFocusOnActiveElement();
+                key).withModifiers(keyModifiers).allowBrowserDefault();
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -63,12 +63,6 @@ public class ShortcutRegistration implements Registration, Serializable {
                     + "} else {"
                     + "throw \"Shortcut listenOn element not found with JS locator string '%1$s'\""
                     + "}";//@formatter:on
-    static final String FOCUS_ACTIVE_ELEMENT_JS = //@formatter:off
-        "function(){" +
-                "let ae=document.activeElement;" +
-                "while(ae&&ae.shadowRoot) ae = ae.shadowRoot.activeElement;" +
-                "return !ae || ae.blur() || ae.focus() || true;" +
-                "}()";//@formatter:on
 
     private boolean allowDefaultBehavior = false;
     private boolean allowEventPropagation = false;
@@ -683,7 +677,7 @@ public class ShortcutRegistration implements Registration, Serializable {
                     filterText += " && (event.stopPropagation() || true)";
                 }
                 if (resetFocusOnActiveElement) {
-                    filterText += " && (" + FOCUS_ACTIVE_ELEMENT_JS + ")";
+                    filterText += " && window.Vaadin.Flow.resetFocus()";
                 }
                 listenerRegistration.setFilter(filterText);
                 shortcutActive = true;
@@ -871,7 +865,7 @@ public class ShortcutRegistration implements Registration, Serializable {
             // typing or existing shortcuts
             final String filterText = filterText();
             final String focusJs = resetFocusOnActiveElement
-                    ? FOCUS_ACTIVE_ELEMENT_JS + ";"
+                    ? "window.Vaadin.Flow.resetFocus();"
                     : "";
             // enable default actions if desired
             final String preventDefault = allowDefaultBehavior ? ""

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -66,7 +66,7 @@ public class ShortcutRegistration implements Registration, Serializable {
     static final String FOCUS_ACTIVE_ELEMENT_JS = //@formatter:off
         "function(){" +
                 "let ae=document.activeElement;" +
-                "while(ae.shadowRoot) ae = ae.shadowRoot.activeElement;" +
+                "while(ae&&ae.shadowRoot) ae = ae.shadowRoot.activeElement;" +
                 "return !ae || ae.blur() || ae.focus() || true;" +
                 "}()";//@formatter:on
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -80,6 +80,10 @@ abstract class AbstractUpdateImports implements Runnable {
     private static final String THEMABLE_MIXIN_IMPORT = "import { css, unsafeCSS, registerStyles } from '@vaadin/vaadin-themable-mixin';";
     private static final String REGISTER_STYLES_FOR_TEMPLATE = CSS_IMPORT + "%n"
             + "registerStyles('%s', $css_%1$d%s);";
+    static final String RESET_FOCUS_JS = "() => {\n"
+            + " let ae=document.activeElement;\n"
+            + " while(ae&&ae.shadowRoot) ae = ae.shadowRoot.activeElement;\n"
+            + " return !ae || ae.blur() || ae.focus() || true;\n" + "}";
 
     private static final String IMPORT_TEMPLATE = "import '%s';";
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -80,10 +80,10 @@ abstract class AbstractUpdateImports implements Runnable {
     private static final String THEMABLE_MIXIN_IMPORT = "import { css, unsafeCSS, registerStyles } from '@vaadin/vaadin-themable-mixin';";
     private static final String REGISTER_STYLES_FOR_TEMPLATE = CSS_IMPORT + "%n"
             + "registerStyles('%s', $css_%1$d%s);";
-    static final String RESET_FOCUS_JS = "() => {\n"
-            + " let ae=document.activeElement;\n"
-            + " while(ae&&ae.shadowRoot) ae = ae.shadowRoot.activeElement;\n"
-            + " return !ae || ae.blur() || ae.focus() || true;\n" + "}";
+    static final String RESET_FOCUS_JS = "() => {"
+            + " let ae=document.activeElement;"
+            + " while(ae&&ae.shadowRoot) ae = ae.shadowRoot.activeElement;"
+            + " return !ae || ae.blur() || ae.focus() || true;" + "}";
 
     private static final String IMPORT_TEMPLATE = "import '%s';";
 
@@ -125,6 +125,9 @@ abstract class AbstractUpdateImports implements Runnable {
         lines.addAll(getExportLines());
         lines.addAll(getThemeLines());
         lines.addAll(getCssLines());
+        lines.add("window.Vaadin = window.Vaadin || {};");
+        lines.add("window.Vaadin.Flow = window.Vaadin.Flow || {};");
+        lines.add("window.Vaadin.Flow.resetFocus = " + RESET_FOCUS_JS);
         if (!productionMode && useLegacyV14Bootstrap) {
             // This is only needed for v14bootstrap mode
             lines.add(TaskGenerateBootstrap.DEV_TOOLS_IMPORT);

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
@@ -149,6 +149,17 @@ public class ShortcutRegistrationTest {
     }
 
     @Test
+    public void resetFocusOnActiveElementValuesDefaultToTrue() {
+        ShortcutRegistration registration = new ShortcutRegistration(
+                lifecycleOwner, () -> listenOn, event -> {
+                }, Key.KEY_A);
+
+        assertFalse(registration.isResetFocusOnActiveElement());
+        registration.resetFocusOnActiveElement();
+        assertTrue(registration.isResetFocusOnActiveElement());
+    }
+
+    @Test
     public void bindLifecycleToChangesLifecycleOwner() {
         Component newOwner = mock(Component.class);
 
@@ -174,6 +185,7 @@ public class ShortcutRegistrationTest {
 
         registration.setBrowserDefaultAllowed(true);
         registration.setEventPropagationAllowed(true);
+        registration.setResetFocusOnActiveElement(true);
 
         clientResponse();
 
@@ -181,9 +193,12 @@ public class ShortcutRegistrationTest {
                 registration.isBrowserDefaultAllowed());
         assertTrue("Allow propagation was not set to true",
                 registration.isBrowserDefaultAllowed());
+        assertTrue("Reset focus on active element was not set to true",
+                registration.isResetFocusOnActiveElement());
 
         registration.setBrowserDefaultAllowed(false);
         registration.setEventPropagationAllowed(false);
+        registration.setResetFocusOnActiveElement(false);
 
         clientResponse();
 
@@ -191,6 +206,8 @@ public class ShortcutRegistrationTest {
                 registration.isBrowserDefaultAllowed());
         assertFalse("Allow propagation was not set to false",
                 registration.isEventPropagationAllowed());
+        assertFalse("Reset focus on active element was not set to false",
+                registration.isResetFocusOnActiveElement());
     }
 
     @Test
@@ -316,6 +333,9 @@ public class ShortcutRegistrationTest {
 
         assertFalse("Allows propagation was not false",
                 registration.isEventPropagationAllowed());
+
+        assertFalse("Reset focus on active element was not set to false",
+                registration.isResetFocusOnActiveElement());
     }
 
     @Test
@@ -330,6 +350,9 @@ public class ShortcutRegistrationTest {
 
         assertFalse("Allows propagation was not false",
                 registration.isEventPropagationAllowed());
+
+        assertFalse("Reset focus on active element was not set to false",
+                registration.isResetFocusOnActiveElement());
     }
 
     @Test
@@ -399,6 +422,11 @@ public class ShortcutRegistrationTest {
                 expression.contains("event.stopPropagation();"));
         Assert.assertTrue("JS execution string missing the key" + key,
                 expression.contains(key.getKeys().get(0)));
+        Assert.assertFalse(
+                "JS execution string should not have blur() and focus() on active element in it"
+                        + expression,
+                expression.contains(
+                        ShortcutRegistration.FOCUS_ACTIVE_ELEMENT_JS));
 
         fixture.registration.remove();
 
@@ -424,6 +452,25 @@ public class ShortcutRegistrationTest {
                 "JS execution string should NOT have event.preventDefault() in it"
                         + expression,
                 expression.contains("event.preventDefault();"));
+    }
+
+    @Test
+    public void listenOnComponentHasElementLocatorJs_resetFocusOnActiveElement_JsExecutionResetFocusOnActiveElement() {
+        final ElementLocatorTestFixture fixture = new ElementLocatorTestFixture();
+        final Key key = Key.KEY_A;
+        fixture.createNewShortcut(key).resetFocusOnActiveElement();
+
+        List<PendingJavaScriptInvocation> pendingJavaScriptInvocations = fixture
+                .writeResponse();
+
+        final PendingJavaScriptInvocation js = pendingJavaScriptInvocations
+                .get(0);
+        final String expression = js.getInvocation().getExpression();
+        Assert.assertTrue(
+                "JS execution string should have blur() and focus() on active element in it"
+                        + expression,
+                expression.contains(
+                        ShortcutRegistration.FOCUS_ACTIVE_ELEMENT_JS));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
@@ -425,8 +425,7 @@ public class ShortcutRegistrationTest {
         Assert.assertFalse(
                 "JS execution string should not have blur() and focus() on active element in it"
                         + expression,
-                expression.contains(
-                        ShortcutRegistration.FOCUS_ACTIVE_ELEMENT_JS));
+                expression.contains("window.Vaadin.Flow.resetFocus()"));
 
         fixture.registration.remove();
 
@@ -469,8 +468,7 @@ public class ShortcutRegistrationTest {
         Assert.assertTrue(
                 "JS execution string should have blur() and focus() on active element in it"
                         + expression,
-                expression.contains(
-                        ShortcutRegistration.FOCUS_ACTIVE_ELEMENT_JS));
+                expression.contains("window.Vaadin.Flow.resetFocus()"));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
@@ -334,7 +334,7 @@ public class ShortcutRegistrationTest {
         assertFalse("Allows propagation was not false",
                 registration.isEventPropagationAllowed());
 
-        assertTrue("Reset focus on active element was not set to true",
+        assertFalse("Reset focus on active element was not set to false",
                 registration.isResetFocusOnActiveElement());
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
@@ -334,7 +334,7 @@ public class ShortcutRegistrationTest {
         assertFalse("Allows propagation was not false",
                 registration.isEventPropagationAllowed());
 
-        assertFalse("Reset focus on active element was not set to false",
+        assertTrue("Reset focus on active element was not set to true",
                 registration.isResetFocusOnActiveElement());
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
@@ -499,7 +499,8 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
         expectedImports.addAll(updater.getThemeLines());
         expectedImports.add("window.Vaadin = window.Vaadin || {};");
         expectedImports.add("window.Vaadin.Flow = window.Vaadin.Flow || {};");
-        expectedImports.add("window.Vaadin.Flow.resetFocus = " + AbstractUpdateImports.RESET_FOCUS_JS);
+        expectedImports.add("window.Vaadin.Flow.resetFocus = "
+                + AbstractUpdateImports.RESET_FOCUS_JS);
 
         getAnntotationsAsStream(JsModule.class, testClasses)
                 .map(JsModule::value).map(this::updateToImport).sorted()

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
@@ -497,6 +497,9 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
         List<String> expectedImports = new ArrayList<>();
         expectedImports.addAll(updater.getExportLines());
         expectedImports.addAll(updater.getThemeLines());
+        expectedImports.add("window.Vaadin = window.Vaadin || {};");
+        expectedImports.add("window.Vaadin.Flow = window.Vaadin.Flow || {};");
+        expectedImports.add("window.Vaadin.Flow.resetFocus = " + AbstractUpdateImports.RESET_FOCUS_JS);
 
         getAnntotationsAsStream(JsModule.class, testClasses)
                 .map(JsModule::value).map(this::updateToImport).sorted()

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShadowRootShortcutsWithValueChangeModeView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShadowRootShortcutsWithValueChangeModeView.java
@@ -62,7 +62,7 @@ public class ShadowRootShortcutsWithValueChangeModeView extends Div
 
         // clickShortcutWorks
         button.setText(
-                "Button triggered by CTRL + ALT + S and CTRL + ENTER (with auto-focus)");
+                "Button triggered by CTRL + ALT + S and CTRL + ENTER (with reset focus)");
         button.addClickShortcut(Key.KEY_S, KeyModifier.CONTROL, KeyModifier.ALT)
                 .setResetFocusOnActiveElement(false);
         button.addClickShortcut(Key.ENTER, KeyModifier.CONTROL);

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShadowRootShortcutsWithValueChangeModeView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShadowRootShortcutsWithValueChangeModeView.java
@@ -63,9 +63,10 @@ public class ShadowRootShortcutsWithValueChangeModeView extends Div
         // clickShortcutWorks
         button.setText(
                 "Button triggered by CTRL + ALT + S and CTRL + ENTER (with reset focus)");
-        button.addClickShortcut(Key.KEY_S, KeyModifier.CONTROL, KeyModifier.ALT)
-                .setResetFocusOnActiveElement(false);
-        button.addClickShortcut(Key.ENTER, KeyModifier.CONTROL);
+        button.addClickShortcut(Key.KEY_S, KeyModifier.CONTROL,
+                KeyModifier.ALT);
+        button.addClickShortcut(Key.ENTER, KeyModifier.CONTROL)
+                .setResetFocusOnActiveElement(true);
         button.addClickListener(e -> value.setText(input.getValue()));
 
         shadowRoot.appendChild(shadowDiv);

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShadowRootShortcutsWithValueChangeModeView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShadowRootShortcutsWithValueChangeModeView.java
@@ -63,10 +63,9 @@ public class ShadowRootShortcutsWithValueChangeModeView extends Div
         // clickShortcutWorks
         button.setText(
                 "Button triggered by CTRL + ALT + S and CTRL + ENTER (with auto-focus)");
-        button.addClickShortcut(Key.KEY_S, KeyModifier.CONTROL,
-                KeyModifier.ALT);
-        button.addClickShortcut(Key.ENTER, KeyModifier.CONTROL)
-                .resetFocusOnActiveElement();// .listenOn(button);
+        button.addClickShortcut(Key.KEY_S, KeyModifier.CONTROL, KeyModifier.ALT)
+                .setResetFocusOnActiveElement(false);
+        button.addClickShortcut(Key.ENTER, KeyModifier.CONTROL);
         button.addClickListener(e -> value.setText(input.getValue()));
 
         shadowRoot.appendChild(shadowDiv);

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShadowRootShortcutsWithValueChangeModeView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShadowRootShortcutsWithValueChangeModeView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2022 Vaadin Ltd.
+ * Copyright 2000-2023 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -23,21 +23,31 @@ import com.vaadin.flow.component.html.Input;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.data.value.ValueChangeMode;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.ElementFactory;
+import com.vaadin.flow.dom.ShadowRoot;
 import com.vaadin.flow.router.AfterNavigationEvent;
 import com.vaadin.flow.router.AfterNavigationObserver;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 
-@Route(value = "com.vaadin.flow.uitest.ui.ShortcutsWithValueChangeModeView", layout = ViewTestLayout.class)
-public class ShortcutsWithValueChangeModeView extends Div
+@Route(value = "com.vaadin.flow.uitest.ui.ShadowRootShortcutsWithValueChangeModeView", layout = ViewTestLayout.class)
+public class ShadowRootShortcutsWithValueChangeModeView extends Div
         implements AfterNavigationObserver {
 
     private final Input input;
 
-    public ShortcutsWithValueChangeModeView() {
+    public ShadowRootShortcutsWithValueChangeModeView() {
+        setId("test-element");
+
+        ShadowRoot shadowRoot = getElement().attachShadow();
+        Element shadowDiv = ElementFactory.createDiv();
+        shadowDiv.setText("Div inside shadow DOM");
+        shadowDiv.setAttribute("id", "shadow-div");
 
         input = new Input();
         input.setId("input");
+        shadowDiv.appendChild(input.getElement());
 
         NativeButton button = new NativeButton("Report value");
         button.setId("button");
@@ -56,10 +66,12 @@ public class ShortcutsWithValueChangeModeView extends Div
         button.addClickShortcut(Key.KEY_S, KeyModifier.CONTROL,
                 KeyModifier.ALT);
         button.addClickShortcut(Key.ENTER, KeyModifier.CONTROL)
-                .resetFocusOnActiveElement();
+                .resetFocusOnActiveElement();// .listenOn(button);
         button.addClickListener(e -> value.setText(input.getValue()));
 
-        add(input, button, value);
+        shadowRoot.appendChild(shadowDiv);
+        shadowRoot.appendChild(button.getElement());
+        shadowRoot.appendChild(value.getElement());
     }
 
     @Override

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsView.java
@@ -178,9 +178,6 @@ public class ShortcutsView extends Div {
         // this matches the default of other shortcuts but changes
         // the default of the click shortcut
         reg.setBrowserDefaultAllowed(false);
-        // setting setResetFocusOnActiveElement(false) to test browser default
-        // allowed feature alone.
-        reg.setResetFocusOnActiveElement(false);
 
         wrapper1.add(clickInput1, clickButton1);
         wrapper2.add(clickInput2, clickButton2);
@@ -223,11 +220,11 @@ public class ShortcutsView extends Div {
                         + "," + clickInput6.getValue()));
         clickButton4.addClickShortcut(Key.ENTER)
                 .listenOn(clickInput5, clickInput6)
-                // by default addClickShortcut sets setResetFocusOnActiveElement
+                // sets setResetFocusOnActiveElement
                 // to true and this will cause input value change being
                 // triggered no matter what
                 // setBrowserDefaultAllowed is.
-                .setBrowserDefaultAllowed(false);
+                .resetFocusOnActiveElement().setBrowserDefaultAllowed(false);
 
         NativeButton clickButton5 = new NativeButton("CB5",
                 event -> actual.setValue("click5: " + clickInput7.getValue()));
@@ -235,7 +232,6 @@ public class ShortcutsView extends Div {
         // this matches the default of other shortcuts but changes
         // the default of the click shortcut
         reg.setBrowserDefaultAllowed(false);
-        reg.setResetFocusOnActiveElement(false);
 
         wrapper4.add(clickInput5, clickInput6, clickInput7, clickButton4,
                 clickButton5);

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsView.java
@@ -173,10 +173,14 @@ public class ShortcutsView extends Div {
 
         NativeButton clickButton2 = new NativeButton("CB2",
                 event -> actual.setValue("click: " + clickInput2.getValue()));
-        clickButton2.addClickShortcut(Key.ENTER).listenOn(wrapper2)
-                // this matches the default of other shortcuts but changes
-                // the default of the click shortcut
-                .setBrowserDefaultAllowed(false);
+        ShortcutRegistration reg = clickButton2.addClickShortcut(Key.ENTER)
+                .listenOn(wrapper2);
+        // this matches the default of other shortcuts but changes
+        // the default of the click shortcut
+        reg.setBrowserDefaultAllowed(false);
+        // setting setResetFocusOnActiveElement(false) to test browser default
+        // allowed feature alone.
+        reg.setResetFocusOnActiveElement(false);
 
         wrapper1.add(clickInput1, clickButton1);
         wrapper2.add(clickInput2, clickButton2);
@@ -210,16 +214,31 @@ public class ShortcutsView extends Div {
         clickInput6.setType("text");
         clickInput6.setId("click-input-6");
 
+        final Input clickInput7 = new Input();
+        clickInput7.setType("text");
+        clickInput7.setId("click-input-7");
+
         NativeButton clickButton4 = new NativeButton("CB4",
                 event -> actual.setValue("click4: " + clickInput5.getValue()
                         + "," + clickInput6.getValue()));
         clickButton4.addClickShortcut(Key.ENTER)
                 .listenOn(clickInput5, clickInput6)
-                // this matches the default of other shortcuts but changes
-                // the default of the click shortcut
+                // by default addClickShortcut sets setResetFocusOnActiveElement
+                // to true and this will cause input value change being
+                // triggered no matter what
+                // setBrowserDefaultAllowed is.
                 .setBrowserDefaultAllowed(false);
 
-        wrapper4.add(clickInput5, clickInput6, clickButton4);
+        NativeButton clickButton5 = new NativeButton("CB5",
+                event -> actual.setValue("click5: " + clickInput7.getValue()));
+        reg = clickButton5.addClickShortcut(Key.ENTER).listenOn(clickInput7);
+        // this matches the default of other shortcuts but changes
+        // the default of the click shortcut
+        reg.setBrowserDefaultAllowed(false);
+        reg.setResetFocusOnActiveElement(false);
+
+        wrapper4.add(clickInput5, clickInput6, clickInput7, clickButton4,
+                clickButton5);
         add(wrapper4);
 
         // removingShortcutCleansJavascriptEventSettingsItUsed

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsWithValueChangeModeView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsWithValueChangeModeView.java
@@ -52,7 +52,7 @@ public class ShortcutsWithValueChangeModeView extends Div
 
         // clickShortcutWorks
         button.setText(
-                "Button triggered by CTRL + ALT + S and CTRL + ENTER (with auto-focus)");
+                "Button triggered by CTRL + ALT + S and CTRL + ENTER (with reset focus)");
         button.addClickShortcut(Key.KEY_S, KeyModifier.CONTROL, KeyModifier.ALT)
                 .setResetFocusOnActiveElement(false);
         button.addClickShortcut(Key.ENTER, KeyModifier.CONTROL);

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsWithValueChangeModeView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsWithValueChangeModeView.java
@@ -53,9 +53,10 @@ public class ShortcutsWithValueChangeModeView extends Div
         // clickShortcutWorks
         button.setText(
                 "Button triggered by CTRL + ALT + S and CTRL + ENTER (with reset focus)");
-        button.addClickShortcut(Key.KEY_S, KeyModifier.CONTROL, KeyModifier.ALT)
-                .setResetFocusOnActiveElement(false);
-        button.addClickShortcut(Key.ENTER, KeyModifier.CONTROL);
+        button.addClickShortcut(Key.KEY_S, KeyModifier.CONTROL,
+                KeyModifier.ALT);
+        button.addClickShortcut(Key.ENTER, KeyModifier.CONTROL)
+                .setResetFocusOnActiveElement(true);
         button.addClickListener(e -> value.setText(input.getValue()));
 
         add(input, button, value);

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsWithValueChangeModeView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsWithValueChangeModeView.java
@@ -53,10 +53,9 @@ public class ShortcutsWithValueChangeModeView extends Div
         // clickShortcutWorks
         button.setText(
                 "Button triggered by CTRL + ALT + S and CTRL + ENTER (with auto-focus)");
-        button.addClickShortcut(Key.KEY_S, KeyModifier.CONTROL,
-                KeyModifier.ALT);
-        button.addClickShortcut(Key.ENTER, KeyModifier.CONTROL)
-                .resetFocusOnActiveElement();
+        button.addClickShortcut(Key.KEY_S, KeyModifier.CONTROL, KeyModifier.ALT)
+                .setResetFocusOnActiveElement(false);
+        button.addClickShortcut(Key.ENTER, KeyModifier.CONTROL);
         button.addClickListener(e -> value.setText(input.getValue()));
 
         add(input, button, value);

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ShadowRootShortcutsWithValueChangeModeIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ShadowRootShortcutsWithValueChangeModeIT.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.Keys;
+
+import com.vaadin.flow.component.html.testbench.DivElement;
+import com.vaadin.flow.component.html.testbench.InputTextElement;
+import com.vaadin.flow.component.html.testbench.ParagraphElement;
+import com.vaadin.flow.data.value.ValueChangeMode;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class ShadowRootShortcutsWithValueChangeModeIT
+        extends ChromeBrowserTest {
+
+    private String text = "Some text";
+
+    @Test
+    public void onChangeValueChange_shortcutExecution_valueNotSentToServer() {
+        assertValueCommittedOnShortcutExecution(ValueChangeMode.ON_CHANGE,
+                false);
+        DivElement div = $(DivElement.class).id("test-element");
+
+        // trigger change event and check value
+        InputTextElement input = div.$(InputTextElement.class).id("input");
+        input.sendKeys(Keys.ENTER);
+        triggerShortcut(true);
+    }
+
+    @Test
+    public void onChangeValueChange_shortcutExecution_resetFocusOnActiveElement_valueSentToServer() {
+        open(ValueChangeMode.ON_CHANGE.name());
+
+        DivElement div = $(DivElement.class).id("test-element");
+        InputTextElement input = div.$(InputTextElement.class).id("input");
+        input.focus();
+        input.sendKeys(text);
+
+        doTriggerShortcut(true, Keys.CONTROL, Keys.ENTER);
+    }
+
+    private void assertValueCommittedOnShortcutExecution(ValueChangeMode mode,
+            boolean expectValue) {
+        open(mode.name());
+
+        DivElement div = $(DivElement.class).id("test-element");
+        InputTextElement input = div.$(InputTextElement.class).id("input");
+        input.focus();
+        input.sendKeys(text);
+
+        triggerShortcut(expectValue);
+    }
+
+    private void triggerShortcut(boolean expectValue) {
+        doTriggerShortcut(expectValue, Keys.CONTROL, Keys.ALT, "s");
+    }
+
+    private void doTriggerShortcut(boolean expectValue, CharSequence... keys) {
+        ShortcutsWithValueChangeModeIT.sendKeys(driver, keys);
+
+        DivElement div = $(DivElement.class).id("test-element");
+        String paragraphText = div.$(ParagraphElement.class).id("value")
+                .getText();
+
+        if (expectValue) {
+            Assert.assertEquals(
+                    "Expecting input value to be in sync with server value",
+                    text, paragraphText);
+        } else {
+            Assert.assertEquals(
+                    "Expecting input value not to be synced with server", "",
+                    paragraphText);
+        }
+    }
+
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ShortcutsIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ShortcutsIT.java
@@ -187,6 +187,7 @@ public class ShortcutsIT extends ChromeBrowserTest {
         WebElement textField4 = findElement(By.id("click-input-4"));
         WebElement textField5 = findElement(By.id("click-input-5"));
         WebElement textField6 = findElement(By.id("click-input-6"));
+        WebElement textField7 = findElement(By.id("click-input-7"));
 
         // ClickButton3: allows browser's default behavior
         textField3.sendKeys("value 3");
@@ -206,12 +207,17 @@ public class ShortcutsIT extends ChromeBrowserTest {
         textField5.sendKeys("value 5");
         sendKeys(Keys.ENTER);
 
-        assertActualEquals("click4: ,");
+        assertActualEquals("click4: value 5,");
 
         textField6.sendKeys("value 6");
         sendKeys(Keys.ENTER);
 
-        assertActualEquals("click4: value 5,");
+        assertActualEquals("click4: value 5,value 6");
+
+        textField7.sendKeys("value 7");
+        sendKeys(Keys.ENTER);
+
+        assertActualEquals("click5: ");
     }
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ShortcutsWithValueChangeModeIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ShortcutsWithValueChangeModeIT.java
@@ -23,6 +23,7 @@ import java.util.stream.Stream;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.interactions.Actions;
 
 import com.vaadin.flow.component.html.testbench.InputTextElement;
@@ -65,6 +66,17 @@ public class ShortcutsWithValueChangeModeIT extends ChromeBrowserTest {
     }
 
     @Test
+    public void onChangeValueChange_shortcutExecution_resetFocusOnActiveElement_valueSentToServer() {
+        open(ValueChangeMode.ON_CHANGE.name());
+
+        InputTextElement input = $(InputTextElement.class).id("input");
+        input.focus();
+        input.sendKeys(text);
+
+        doTriggerShortcut(true, Keys.CONTROL, Keys.ENTER);
+    }
+
+    @Test
     public void onBlurValueChange_shortcutExecution_valueNotSentToServer() {
         assertValueCommittedOnShortcutExecution(ValueChangeMode.ON_BLUR, false);
         // trigger blur event and check value
@@ -85,7 +97,11 @@ public class ShortcutsWithValueChangeModeIT extends ChromeBrowserTest {
     }
 
     private void triggerShortcut(boolean expectValue) {
-        sendKeys(Keys.CONTROL, Keys.ALT, "s");
+        doTriggerShortcut(expectValue, Keys.CONTROL, Keys.ALT, "s");
+    }
+
+    private void doTriggerShortcut(boolean expectValue, CharSequence... keys) {
+        sendKeys(driver, keys);
 
         String paragraphText = $(ParagraphElement.class).id("value").getText();
 
@@ -100,7 +116,7 @@ public class ShortcutsWithValueChangeModeIT extends ChromeBrowserTest {
         }
     }
 
-    private void sendKeys(CharSequence... keys) {
+    public static void sendKeys(WebDriver driver, CharSequence... keys) {
         Actions actions = new Actions(driver);
         for (CharSequence keySeq : keys) {
             if (modifiers.contains(keySeq)) {
@@ -113,10 +129,10 @@ public class ShortcutsWithValueChangeModeIT extends ChromeBrowserTest {
         // Implementation that worked for driver < 75.beta:
         // new Actions(driver).sendKeys(keys).build().perform();
         // if keys are not reset, alt will remain down and start flip-flopping
-        resetKeys();
+        resetKeys(driver);
     }
 
-    private void resetKeys() {
+    public static void resetKeys(WebDriver driver) {
         Actions actions = new Actions(driver);
         modifiers.forEach(actions::keyUp);
         actions.build().perform();


### PR DESCRIPTION
Adds `setResetFocusOnActiveElement`, `resetFocusOnActiveElement` and `isResetFocusOnActiveElement` to `ShortcutRegistration` class to optionally reset focus on active element (focused element in browser). Resetting means calling `blur()` and `focus()` on the active element to ensure that input fields with `ValueChangeMode` `ON_CHANGE` will fire value change event before shortcut handler is run.

Back ported from Flow 24 for 23.4.

Fixes: https://github.com/vaadin/flow/issues/5959