### PR TITLE
Revert "fix: postpone commands scheduled with runWhenAttached for detached nodes (#18078)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
@@ -956,9 +956,8 @@ public class StateNode implements Serializable {
      *            the command to run immediately or when the node is attached
      */
     public void runWhenAttached(SerializableConsumer<UI> command) {
-        // Execute immediately only if the node han not been detached
-        // during current roundtrip
-        if (isAttached() && (!wasAttached || !hasBeenDetached)) {
+
+        if (isAttached()) {
             command.accept(getUI());
         } else {
             addAttachListener(new Command() {

--- a/flow-server/src/test/java/com/vaadin/flow/internal/StateNodeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/StateNodeTest.java
@@ -569,29 +569,6 @@ public class StateNodeTest {
     }
 
     @Test
-    public void runWhenAttachedNodeDetachedInSameRoundTrip() {
-        StateTree tree = createStateTree();
-        AtomicInteger commandRun = new AtomicInteger(0);
-        StateNode node = createEmptyNode();
-        setParent(node, tree.getRootNode());
-        node.removeFromTree();
-
-        node.runWhenAttached(ui -> {
-            Assert.assertEquals(tree.getUI(), ui);
-            commandRun.incrementAndGet();
-        });
-
-        Assert.assertEquals(0, commandRun.get());
-
-        setParent(node, tree.getRootNode());
-        Assert.assertEquals(1, commandRun.get());
-
-        setParent(node, null);
-        setParent(node, tree.getRootNode());
-        Assert.assertEquals(1, commandRun.get());
-    }
-
-    @Test
     public void requiredFeatures() {
         StateNode stateNode = new StateNode(
                 Arrays.asList(ElementClassList.class, ElementPropertyMap.class),


### PR DESCRIPTION
This reverts commit c73bbacd3b77eaa19b924ca113186877c2784352.

Reverted, because it leads to various regressions in components, e.g. for cases when `ComboBox` gets detached and re-attached and then contains no items (see `DataProviderIT::loadData_toggleAttached_correctItemsDisplayed` in flow components).


