### PR TITLE
chore: install also react-plugin-swc

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "vite": "5.0.2",
     "@vitejs/plugin-react": "4.2.0",
+    "@vitejs/plugin-react-swc": "3.5.0",
     "@rollup/plugin-replace": "5.0.4",
     "@rollup/pluginutils": "5.0.5",
     "rollup-plugin-visualizer": "5.9.2",

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -130,6 +130,7 @@ public class NodeUpdaterTest {
         // Vite
         expectedDependencies.add("vite");
         expectedDependencies.add("@vitejs/plugin-react");
+        expectedDependencies.add("@vitejs/plugin-react-swc");
         expectedDependencies.add("rollup-plugin-brotli");
         expectedDependencies.add("@rollup/plugin-replace");
         expectedDependencies.add("@rollup/pluginutils");


### PR DESCRIPTION
It is faster and more correct.
Did not remove the old plugin as it is used in all existing projects and Flow would uninstall it if removed from here