### PR TITLE
feat: show informative page during dev-bundle creation

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
@@ -83,13 +83,14 @@ public class VaadinServletService extends VaadinService {
         List<RequestHandler> handlers = super.createRequestHandlers();
         handlers.add(0, new FaviconHandler());
 
-        if (getDeploymentConfiguration()
-                .getMode() == Mode.DEVELOPMENT_FRONTEND_LIVERELOAD) {
+        Mode mode = getDeploymentConfiguration().getMode();
+        if (mode == Mode.DEVELOPMENT_FRONTEND_LIVERELOAD
+                || mode == Mode.DEVELOPMENT_BUNDLE) {
             Optional<DevModeHandler> handlerManager = DevModeHandlerManager
                     .getDevModeHandler(this);
             if (handlerManager.isPresent()) {
                 handlers.add(handlerManager.get());
-            } else {
+            } else if (mode == Mode.DEVELOPMENT_FRONTEND_LIVERELOAD) {
                 getLogger()
                         .warn("no DevModeHandlerManager implementation found "
                                 + "but dev server enabled. Include the "

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -455,7 +455,12 @@ public class FrontendUtils {
             if (config.isProductionMode()) {
                 // In production mode, this is on the class path
                 content = getFileFromClassPath(service, path);
-            } else if (devModeHandler.isPresent()) {
+            } else if (devModeHandler.filter(d -> d.getPort() >= 0)
+                    .isPresent()) {
+                // The DevModeHandler is serving contents only if the port is
+                // equal to or greater than zero. Otherwise, it is just a fake
+                // implementation use to present a waiting page during dev
+                // bundle creation
                 content = getFileFromDevModeHandler(devModeHandler.get(), path);
             } else {
                 // Get directly from the frontend folder in the project

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
@@ -636,6 +636,13 @@ public abstract class AbstractDevServerRunner implements DevModeHandler {
     @Override
     public boolean handleRequest(VaadinSession session, VaadinRequest request,
             VaadinResponse response) throws IOException {
+        return handleRequestInternal(request, response, devServerStartFuture,
+                isDevServerFailedToStart);
+    }
+
+    static boolean handleRequestInternal(VaadinRequest request,
+            VaadinResponse response, CompletableFuture<?> devServerStartFuture,
+            AtomicBoolean isDevServerFailedToStart) throws IOException {
         if (devServerStartFuture.isDone()) {
             // The server has started, check for any exceptions in the startup
             // process
@@ -778,7 +785,7 @@ public abstract class AbstractDevServerRunner implements DevModeHandler {
         return true;
     }
 
-    private RuntimeException getCause(Throwable exception) {
+    private static RuntimeException getCause(Throwable exception) {
         if (exception instanceof CompletionException) {
             return getCause(exception.getCause());
         } else if (exception instanceof RuntimeException) {

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevBundleBuildingHandler.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevBundleBuildingHandler.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.base.devserver;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.vaadin.flow.internal.DevModeHandler;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinResponse;
+import com.vaadin.flow.server.VaadinSession;
+
+/**
+ * A fake DevModeHandler whose only scope is to eagerly show a "build in
+ * progress" HTML page to the user, during the creation of the development
+ * bundle creation.
+ * <p>
+ * </p>
+ * The {@link #getPort()} method returns a fixed value of {@literal -1}, meaning
+ * that this handler will not start a server listening for incoming requests.
+ * <p>
+ * </p>
+ * Most of the other method should not be invoked, and they will throw an
+ * exception if called.
+ */
+public final class DevBundleBuildingHandler implements DevModeHandler {
+
+    private final transient CompletableFuture<Void> buildCompletedFuture;
+
+    public DevBundleBuildingHandler(
+            CompletableFuture<Void> buildCompletedFuture) {
+        this.buildCompletedFuture = buildCompletedFuture;
+    }
+
+    @Override
+    public String getFailedOutput() {
+        return null;
+    }
+
+    @Override
+    public HttpURLConnection prepareConnection(String path, String method) {
+        throw new UnsupportedOperationException("Must never be invoked");
+    }
+
+    @Override
+    public boolean serveDevModeRequest(HttpServletRequest request,
+            HttpServletResponse response) {
+        return false;
+    }
+
+    @Override
+    public void stop() {
+        // Nothing to do
+    }
+
+    @Override
+    public File getProjectRoot() {
+        throw new UnsupportedOperationException("Must never be invoked");
+    }
+
+    /**
+     * Gets always {@literal -1}, as this handler does not start a server.
+     *
+     * @return -1
+     */
+    @Override
+    public int getPort() {
+        return -1;
+    }
+
+    @Override
+    public boolean handleRequest(VaadinSession session, VaadinRequest request,
+            VaadinResponse response) throws IOException {
+        return AbstractDevServerRunner.handleRequestInternal(request, response,
+                buildCompletedFuture, new AtomicBoolean());
+    }
+}

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
@@ -50,6 +50,7 @@ import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.base.devserver.DevBundleBuildingHandler;
 import com.vaadin.base.devserver.ViteHandler;
 import com.vaadin.base.devserver.stats.DevModeUsageStatistics;
 import com.vaadin.base.devserver.stats.StatisticsSender;
@@ -315,8 +316,8 @@ public class DevModeInitializer implements Serializable {
         int port = Integer
                 .parseInt(config.getStringProperty("devServerPort", "0"));
         if (mode == Mode.DEVELOPMENT_BUNDLE) {
-            nodeTasksFuture.join();
-            return null;
+            // Shows a "build in progress" page during dev bundle creation
+            return new DevBundleBuildingHandler(nodeTasksFuture);
         } else {
             ViteHandler handler = new ViteHandler(devServerLookup, port,
                     options.getNpmFolder(), nodeTasksFuture);


### PR DESCRIPTION
## Description

When a new dev-bundle is required, the server startup is blocked until the bundle creation completes.
This change allows the server startup to complete, showing an informative page to the user until the bundle creation is completed.

Fixes #16607

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
