### PR TITLE
feat: More eager cleanup for UIs using Beacon API (#16657)

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
@@ -133,6 +133,21 @@ public class ApplicationConnection {
             registry.getRequestResponseTracker().startRequest();
             registry.getMessageHandler().handleMessage(initialUidl);
         }
+
+        Browser.getWindow().addEventListener("pagehide", e -> {
+            registry.getMessageSender().sendUnloadBeacon();
+        });
+
+        Browser.getWindow().addEventListener("pageshow", e -> {
+            // Currently only Safari gets here, sometimes when going back/foward
+            // with browser buttons
+            // Chrome discards our state as beforeunload is used
+            // As state is most likely cleared on the server already (especially
+            // now with Beacon API request, it is probably
+            // better resyncronize the state (would happen on first server
+            // visit)
+            Browser.getWindow().getLocation().reload();
+        });
     }
 
     /**

--- a/flow-client/src/main/java/com/vaadin/client/communication/MessageSender.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/MessageSender.java
@@ -30,6 +30,18 @@ import elemental.json.JsonValue;
  */
 public class MessageSender {
 
+    public void sendUnloadBeacon() {
+        JsonArray dummyEmptyJson = Json.createArray();
+        JsonObject extraJson = Json.createObject();
+        extraJson.put(ApplicationConstants.UNLOAD_BEACON, true);
+        JsonObject payload = preparePayload(dummyEmptyJson, extraJson);
+        sendBeacon(registry.getXhrConnection().getUri(), payload.toJson());
+    }
+
+    public static native void sendBeacon(String url, String payload) /*-{
+        $wnd.navigator.sendBeacon(url, payload);
+    }-*/;
+
     public enum ResynchronizationState {
         NOT_ACTIVE, SEND_TO_SERVER, WAITING_FOR_RESPONSE
     }
@@ -128,7 +140,12 @@ public class MessageSender {
     protected void send(final JsonArray reqInvocations,
             final JsonObject extraJson) {
         registry.getRequestResponseTracker().startRequest();
+        send(preparePayload(reqInvocations, extraJson));
 
+    }
+
+    private JsonObject preparePayload(final JsonArray reqInvocations,
+            final JsonObject extraJson) {
         JsonObject payload = Json.createObject();
         String csrfToken = registry.getMessageHandler().getCsrfToken();
         if (!csrfToken.equals(ApplicationConstants.CSRF_TOKEN_DEFAULT_VALUE)) {
@@ -139,16 +156,13 @@ public class MessageSender {
                 registry.getMessageHandler().getLastSeenServerSyncId());
         payload.put(ApplicationConstants.CLIENT_TO_SERVER_ID,
                 clientToServerMessageId++);
-
         if (extraJson != null) {
             for (String key : extraJson.keys()) {
                 JsonValue value = extraJson.get(key);
                 payload.put(key, value);
             }
         }
-
-        send(payload);
-
+        return payload;
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/AtmospherePushConnection.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/AtmospherePushConnection.java
@@ -343,9 +343,14 @@ public class AtmospherePushConnection implements PushConnection {
                     try {
                         outgoingMessage.get(1000, TimeUnit.MILLISECONDS);
                     } catch (TimeoutException e) {
-                        getLogger().info(
-                                "Timeout waiting for messages to be sent to client before disconnect",
-                                e);
+                        if (ui.isClosing()) {
+                            getLogger().debug(
+                                    "Something was not sent to client on an UI that was already closed by beacon request or similar. This seems to happen with Safari occassionally when navigating away from a UI.");
+                        } else {
+                            getLogger().info(
+                                    "Timeout waiting for messages to be sent to client before disconnect",
+                                    e);
+                        }
                     } catch (Exception e) {
                         getLogger().info(
                                 "Error waiting for messages to be sent to client before disconnect",

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.internal.MessageDigestUtil;
+import com.vaadin.flow.router.PreserveOnRefresh;
 import com.vaadin.flow.server.ErrorEvent;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinService;
@@ -181,6 +182,10 @@ public class ServerRpcHandler implements Serializable {
             return json;
         }
 
+        private boolean isUnloadBeaconRequest() {
+            return json.hasKey(ApplicationConstants.UNLOAD_BEACON);
+        }
+
     }
 
     private static final int MAX_BUFFER_SIZE = 64 * 1024;
@@ -272,7 +277,6 @@ public class ServerRpcHandler implements Serializable {
             // did not reach the client. When the client re-sends the message,
             // it would only get an empty response (because the dirty flags have
             // been cleared on the server) and would be out of sync
-
             if (requestId == expectedId - 1 && Arrays.equals(messageHash,
                     ui.getInternals().getLastProcessedMessageHash())) {
                 /*
@@ -332,6 +336,24 @@ public class ServerRpcHandler implements Serializable {
             // signature for source and binary compatibility
             throw new ResynchronizationRequiredException();
         }
+        if (rpcRequest.isUnloadBeaconRequest()) {
+            if (isPreserveOnRefreshTarget(ui)) {
+                getLogger().debug(
+                        "Eager UI close ignored for @PreserveOnRefresh view");
+            } else {
+                ui.close();
+                getLogger().debug("UI closed with a beacon request");
+            }
+        }
+
+    }
+
+    // Kind of same as in AbstractNavigationStateRenderer, but gets
+    // "routeLayoutTypes" & class from UI instance.
+    private static boolean isPreserveOnRefreshTarget(UI ui) {
+        return ui.getInternals().getActiveRouterTargetsChain().stream()
+                .anyMatch(rt -> rt.getClass()
+                        .isAnnotationPresent(PreserveOnRefresh.class));
     }
 
     private String getMessageDetails(RpcRequest rpcRequest) {
@@ -466,6 +488,7 @@ public class ServerRpcHandler implements Serializable {
     }
 
     private static class LazyInvocationHandlers {
+
         private static final Map<String, RpcInvocationHandler> HANDLERS = loadHandlers()
                 .stream()
                 .collect(Collectors.toMap(RpcInvocationHandler::getRpcType,

--- a/flow-server/src/main/java/com/vaadin/flow/shared/ApplicationConstants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/ApplicationConstants.java
@@ -209,4 +209,10 @@ public class ApplicationConstants implements Serializable {
      */
     public static final String DEVMODE_GIZMO_ENABLED = "devmodeGizmoEnabled";
 
+    /**
+     * The name of the parameter used for notifying the server that user closed
+     * the tab/window or navigated away.
+     */
+    public static final String UNLOAD_BEACON = "UNLOAD";
+
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/UIsCollectedWithBeaconAPIView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/UIsCollectedWithBeaconAPIView.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.DetachEvent;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "com.vaadin.flow.uitest.ui.UIsCollectedWithBeaconAPIView")
+public class UIsCollectedWithBeaconAPIView extends Div {
+
+    static int viewcount = 0;
+
+    Div count = new Div();
+
+    public UIsCollectedWithBeaconAPIView() {
+        viewcount++;
+        add(count);
+        count.setId("uis");
+        NativeButton showUisNumber = new NativeButton("Update",
+                event -> updateCount());
+        add(showUisNumber);
+        updateCount();
+    }
+
+    private void updateCount() {
+        count.setText("" + viewcount);
+    }
+
+    @Override
+    protected void onDetach(DetachEvent detachEvent) {
+        super.onDetach(detachEvent);
+        viewcount--;
+    }
+
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/LocaleChangeIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/LocaleChangeIT.java
@@ -8,6 +8,7 @@
  */
 package com.vaadin.flow.uitest.ui;
 
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.junit.Assert;
@@ -20,7 +21,6 @@ import com.vaadin.flow.testutil.ChromeBrowserTest;
 import static com.vaadin.flow.uitest.ui.LocaleChangeView.CHANGE_LOCALE_BUTTON_ID;
 import static com.vaadin.flow.uitest.ui.LocaleChangeView.SAME_UI_RESULT_ID;
 import static com.vaadin.flow.uitest.ui.LocaleChangeView.SHOW_RESULTS_BUTTON_ID;
-import org.openqa.selenium.WindowType;
 
 public class LocaleChangeIT extends ChromeBrowserTest {
 
@@ -29,8 +29,10 @@ public class LocaleChangeIT extends ChromeBrowserTest {
         final int openedUI = 3;
 
         IntStream.range(0, openedUI).forEach(i -> {
-            driver.switchTo().newWindow(WindowType.TAB);
-            open();
+            executeScript("window.open('" + getTestURL() + "')");
+            waitForDevServer();
+            driver.switchTo().window(driver.getWindowHandles().stream()
+                    .collect(Collectors.toList()).get(i));
         });
 
         waitForElementPresent(By.id(CHANGE_LOCALE_BUTTON_ID));

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/LocaleChangeIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/LocaleChangeIT.java
@@ -20,6 +20,7 @@ import com.vaadin.flow.testutil.ChromeBrowserTest;
 import static com.vaadin.flow.uitest.ui.LocaleChangeView.CHANGE_LOCALE_BUTTON_ID;
 import static com.vaadin.flow.uitest.ui.LocaleChangeView.SAME_UI_RESULT_ID;
 import static com.vaadin.flow.uitest.ui.LocaleChangeView.SHOW_RESULTS_BUTTON_ID;
+import org.openqa.selenium.WindowType;
 
 public class LocaleChangeIT extends ChromeBrowserTest {
 
@@ -27,7 +28,10 @@ public class LocaleChangeIT extends ChromeBrowserTest {
     public void setSessionLocale_currentUIInstanceUpdatedUponEachLocaleUpdate() {
         final int openedUI = 3;
 
-        IntStream.range(0, openedUI).forEach(i -> open());
+        IntStream.range(0, openedUI).forEach(i -> {
+            driver.switchTo().newWindow(WindowType.TAB);
+            open();
+        });
 
         waitForElementPresent(By.id(CHANGE_LOCALE_BUTTON_ID));
         findElement(By.id(CHANGE_LOCALE_BUTTON_ID)).click();

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/LocaleChangeIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/LocaleChangeIT.java
@@ -8,6 +8,7 @@
  */
 package com.vaadin.flow.uitest.ui;
 
+import java.util.ArrayList;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -31,8 +32,8 @@ public class LocaleChangeIT extends ChromeBrowserTest {
         IntStream.range(0, openedUI).forEach(i -> {
             executeScript("window.open('" + getTestURL() + "')");
             waitForDevServer();
-            driver.switchTo().window(driver.getWindowHandles().stream()
-                    .collect(Collectors.toList()).get(i));
+            driver.switchTo()
+                    .window(new ArrayList<>(driver.getWindowHandles()).get(i));
         });
 
         waitForElementPresent(By.id(CHANGE_LOCALE_BUTTON_ID));

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/LocaleChangeIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/LocaleChangeIT.java
@@ -9,7 +9,6 @@
 package com.vaadin.flow.uitest.ui;
 
 import java.util.ArrayList;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.junit.Assert;
@@ -32,8 +31,8 @@ public class LocaleChangeIT extends ChromeBrowserTest {
         IntStream.range(0, openedUI).forEach(i -> {
             executeScript("window.open('" + getTestURL() + "')");
             waitForDevServer();
-            driver.switchTo()
-                    .window(new ArrayList<>(driver.getWindowHandles()).get(i));
+            driver.switchTo().window(
+                    new ArrayList<>(driver.getWindowHandles()).get(i + 1));
         });
 
         waitForElementPresent(By.id(CHANGE_LOCALE_BUTTON_ID));

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/UIsCollectedWithBeaconAPIIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/UIsCollectedWithBeaconAPIIT.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class UIsCollectedWithBeaconAPIIT extends ChromeBrowserTest {
+
+    @Test
+    public void beaconHandling_navigateAwayFromApplication_uiClosedEarly() {
+        openUiAndExpect1();
+        goToGoogle();
+        // If previous UI is not properly detached, following will fail
+        openUiAndExpect1();
+    }
+
+    private void openUiAndExpect1() throws NumberFormatException {
+        open();
+        WebElement uisCount = findElement(By.id("uis"));
+        int count = Integer.parseInt(uisCount.getText());
+        Assert.assertEquals(1, count);
+    }
+
+    private void goToGoogle() {
+        getDriver().get("https://google.com/");
+        Assert.assertTrue(getDriver().getPageSource().contains("Google"));
+    }
+
+}

--- a/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/routescope/PreserveOnRefreshIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/routescope/PreserveOnRefreshIT.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2000-2023 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.spring.test.routescope;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.spring.test.AbstractSpringTest;
+
+public class PreserveOnRefreshIT extends AbstractSpringTest {
+
+    @Override
+    protected String getTestPath() {
+        return "/preserve-on-refresh";
+    }
+
+    @Test
+    public void routeScopedBeanIsPreservedAfterViewRefresh() {
+        open();
+
+        String beanCall = findElement(By.id("preserve-on-refresh")).getText();
+
+        // refresh
+        getDriver().navigate().refresh();
+
+        Assert.assertEquals("Bean is not preserved after refresh", beanCall,
+                findElement(By.id("preserve-on-refresh")).getText());
+    }
+}


### PR DESCRIPTION
Notifies server about closed UIs using a beacon request on pagehide event.

At the same time unifies behaviour in certain edge cases, where Safari maintained the state when brought back from page cache. Previously Safari in some situations kept the state.

Tested manually with Safari, Chrome, Firefox and validated results using VisualVM.

Back ported from 24 to 23.4.

Closes #6293
