### PR TITLE
chore: allow all hosts for devmode performance tests

### DIFF
--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/main/resources/application.properties
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/main/resources/application.properties
@@ -3,6 +3,7 @@ server.port=8888
 vaadin.frontend.hotdeploy=true
 spring.devtools.restart.poll-interval=100ms
 spring.devtools.restart.quiet-period=50ms
+vaadin.devmode.hostsAllowed=*
 
 # To improve the performance during development. 
 # For more information https://vaadin.com/docs/flow/spring/tutorial-spring-configuration.html#special-configuration-parameters

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-reload-time/src/main/resources/application.properties
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-reload-time/src/main/resources/application.properties
@@ -3,6 +3,7 @@ server.port=8888
 vaadin.frontend.hotdeploy=true
 spring.devtools.restart.poll-interval=100ms
 spring.devtools.restart.quiet-period=50ms
+vaadin.devmode.hostsAllowed=*
 
 # To improve the performance during development. 
 # For more information https://vaadin.com/docs/flow/spring/tutorial-spring-configuration.html#special-configuration-parameters


### PR DESCRIPTION
Fixes slower reload times when run in CI due to connection errors with blocked host.

Related-To: vaadin/flow/pull/18079