### PR TITLE
test: prevent write theme resource if content is not changed

### DIFF
--- a/flow-tests/test-live-reload-multimodule/ui/src/test/java/com/vaadin/flow/uitest/multimodule/ui/FrontendLiveReloadIT.java
+++ b/flow-tests/test-live-reload-multimodule/ui/src/test/java/com/vaadin/flow/uitest/multimodule/ui/FrontendLiveReloadIT.java
@@ -23,6 +23,7 @@ import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -170,11 +171,13 @@ public class FrontendLiveReloadIT extends ChromeBrowserTest {
             String content = FileUtils.readFileToString(file,
                     StandardCharsets.UTF_8);
             String newContent = content.replace(from, to);
+            boolean isSameContent = Objects.equals(content, newContent);
             if (failIfNotModified) {
-                Assert.assertNotEquals("Failed to update content", content,
-                        newContent);
+                Assert.assertFalse("Failed to update content", isSameContent);
             }
-            FileUtils.write(file, newContent, StandardCharsets.UTF_8);
+            if (!isSameContent) {
+                FileUtils.write(file, newContent, StandardCharsets.UTF_8);
+            }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }


### PR DESCRIPTION
## Description

FrontendLiveReloadIT.modifyThemeFile test updates a theme resource as a preliminary operation to have the expected initial setup. It then updates the same resource for testing purpose; however, if the two updates happens too fast, only one event is triggers by Vite reload, thus failing the test.
This change performs the initial write only if the actual content is not the expected one (may happen only on local tests, not on CI where there's ailway a fresh project clone).

Fixes #18053

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
