### PR TITLE
feat!: reject AppShell classes which extend Component

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/page/AppShellConfigurator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/AppShellConfigurator.java
@@ -43,7 +43,9 @@ import com.vaadin.flow.server.AppShellSettings;
  * <p>
  * There is a single application shell for the entire Vaadin application, and
  * there can only be one class implementing {@link AppShellConfigurator} per
- * Application.
+ * Application. Also, app shell class is not allowed to extend Vaadin Component,
+ * since app shells are only intended for page configuration and are
+ * instantiated before the UI is created.
  * </p>
  *
  * <p>

--- a/flow-server/src/main/java/com/vaadin/flow/server/AppShellRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AppShellRegistry.java
@@ -64,7 +64,7 @@ public class AppShellRegistry implements Serializable {
     private static final String ERROR_MULTIPLE_ANNOTATION = "%n%s is not a repeatable annotation type.%n";
 
     private static final String ERROR_EXTENDS_COMPONENT = "%nApp shell class is not allowed to extend Vaadin Component: %s. "
-            + "App shells are intended for page configuration and are instantiated before the UI is created.%n";
+            + "App shells are only intended for page configuration and are instantiated before the UI is created.%n";
 
     // There must be no more than one of the following elements per document
     private static final String[] UNIQUE_ELEMENTS = { "meta[name=viewport]",

--- a/flow-server/src/main/java/com/vaadin/flow/server/AppShellRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AppShellRegistry.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
+import com.vaadin.flow.component.Component;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 
@@ -61,6 +62,9 @@ public class AppShellRegistry implements Serializable {
             + "%nRemove \"implements AppShellConfigurator\" from all but one of the following classes:%n  %s%n  %s%n";
 
     private static final String ERROR_MULTIPLE_ANNOTATION = "%n%s is not a repeatable annotation type.%n";
+
+    private static final String ERROR_EXTENDS_COMPONENT = "%nApp shell class is not allowed to extend Vaadin Component: %s. "
+            + "App shells are intended for page configuration and are instantiated before the UI is created.%n";
 
     // There must be no more than one of the following elements per document
     private static final String[] UNIQUE_ELEMENTS = { "meta[name=viewport]",
@@ -133,6 +137,10 @@ public class AppShellRegistry implements Serializable {
             throw new InvalidApplicationConfigurationException(
                     String.format(AppShellRegistry.ERROR_MULTIPLE_SHELL,
                             this.appShellClass.getName(), shell.getName()));
+        }
+        if (shell != null && Component.class.isAssignableFrom(shell)) {
+            throw new InvalidApplicationConfigurationException(
+                    String.format(ERROR_EXTENDS_COMPONENT, shell.getName()));
         }
         this.appShellClass = shell;
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/VaadinAppShellInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/VaadinAppShellInitializerTest.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 
+import com.vaadin.flow.component.Tag;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.junit.After;
@@ -172,6 +173,11 @@ public class VaadinAppShellInitializerTest {
     @Viewport("my-viewport")
     @BodySize(height = "my-height", width = "my-width")
     public static class AppShellWithPWA implements AppShellConfigurator {
+    }
+
+    @Tag("div")
+    public static class AppShellExtendingComponent extends Component
+            implements AppShellConfigurator {
     }
 
     @Rule
@@ -437,6 +443,13 @@ public class VaadinAppShellInitializerTest {
         assertFalse(arg.getValue()
                 .contains("We changed the way you configure PWAs"));
         assertTrue(arg.getValue().contains("@Viewport"));
+    }
+
+    @Test(expected = InvalidApplicationConfigurationException.class)
+    public void should_throwException_when_appShellExtendsComponent()
+            throws Exception {
+        classes.add(AppShellExtendingComponent.class);
+        initializer.process(classes, servletContext);
     }
 
     private VaadinServletRequest createVaadinRequest(String pathInfo) {

--- a/flow-tests/test-frontend/vite-pwa-custom-offline-path/src/main/java/com/vaadin/viteapp/AppShell.java
+++ b/flow-tests/test-frontend/vite-pwa-custom-offline-path/src/main/java/com/vaadin/viteapp/AppShell.java
@@ -15,14 +15,11 @@
  */
 package com.vaadin.viteapp;
 
-import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.page.AppShellConfigurator;
-import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.server.PWA;
 
 @PWA(name = "My PWA app", shortName = "app", offlinePath = "offline.html")
-public class AppShell extends Div
-        implements RouterLayout, AppShellConfigurator {
+public class AppShell implements AppShellConfigurator {
     public AppShell() {
     }
 }

--- a/flow-tests/test-frontend/vite-pwa-custom-offline-path/src/main/java/com/vaadin/viteapp/AppShell.java
+++ b/flow-tests/test-frontend/vite-pwa-custom-offline-path/src/main/java/com/vaadin/viteapp/AppShell.java
@@ -20,6 +20,4 @@ import com.vaadin.flow.server.PWA;
 
 @PWA(name = "My PWA app", shortName = "app", offlinePath = "offline.html")
 public class AppShell implements AppShellConfigurator {
-    public AppShell() {
-    }
 }

--- a/flow-tests/test-frontend/vite-pwa-custom-offline-path/src/main/java/com/vaadin/viteapp/MainView.java
+++ b/flow-tests/test-frontend/vite-pwa-custom-offline-path/src/main/java/com/vaadin/viteapp/MainView.java
@@ -18,6 +18,6 @@ package com.vaadin.viteapp;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
 
-@Route(value = "", layout = AppShell.class)
+@Route(value = "")
 public class MainView extends Div {
 }

--- a/flow-tests/test-frontend/vite-pwa-disabled-offline/src/main/java/com/vaadin/viteapp/AppShell.java
+++ b/flow-tests/test-frontend/vite-pwa-disabled-offline/src/main/java/com/vaadin/viteapp/AppShell.java
@@ -15,13 +15,9 @@
  */
 package com.vaadin.viteapp;
 
-import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.page.AppShellConfigurator;
-import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.server.PWA;
 
 @PWA(name = "PWA app", shortName = "app", offline = false)
 public class AppShell implements AppShellConfigurator {
-    public AppShell() {
-    }
 }

--- a/flow-tests/test-frontend/vite-pwa-disabled-offline/src/main/java/com/vaadin/viteapp/AppShell.java
+++ b/flow-tests/test-frontend/vite-pwa-disabled-offline/src/main/java/com/vaadin/viteapp/AppShell.java
@@ -21,8 +21,7 @@ import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.server.PWA;
 
 @PWA(name = "PWA app", shortName = "app", offline = false)
-public class AppShell extends Div
-        implements RouterLayout, AppShellConfigurator {
+public class AppShell implements AppShellConfigurator {
     public AppShell() {
     }
 }

--- a/flow-tests/test-frontend/vite-pwa-disabled-offline/src/main/java/com/vaadin/viteapp/MainView.java
+++ b/flow-tests/test-frontend/vite-pwa-disabled-offline/src/main/java/com/vaadin/viteapp/MainView.java
@@ -18,6 +18,6 @@ package com.vaadin.viteapp;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
 
-@Route(value = "", layout = AppShell.class)
+@Route(value = "")
 public class MainView extends Div {
 }

--- a/flow-tests/test-frontend/vite-pwa-production/src/main/java/com/vaadin/viteapp/AppShell.java
+++ b/flow-tests/test-frontend/vite-pwa-production/src/main/java/com/vaadin/viteapp/AppShell.java
@@ -15,15 +15,11 @@
  */
 package com.vaadin.viteapp;
 
-import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.page.AppShellConfigurator;
-import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.server.PWA;
 import com.vaadin.flow.theme.Theme;
 
 @Theme("my-theme")
 @PWA(name = "My PWA app", shortName = "app")
 public class AppShell implements AppShellConfigurator {
-    public AppShell() {
-    }
 }

--- a/flow-tests/test-frontend/vite-pwa-production/src/main/java/com/vaadin/viteapp/AppShell.java
+++ b/flow-tests/test-frontend/vite-pwa-production/src/main/java/com/vaadin/viteapp/AppShell.java
@@ -23,8 +23,7 @@ import com.vaadin.flow.theme.Theme;
 
 @Theme("my-theme")
 @PWA(name = "My PWA app", shortName = "app")
-public class AppShell extends Div
-        implements RouterLayout, AppShellConfigurator {
+public class AppShell implements AppShellConfigurator {
     public AppShell() {
     }
 }

--- a/flow-tests/test-frontend/vite-pwa-production/src/main/java/com/vaadin/viteapp/MainView.java
+++ b/flow-tests/test-frontend/vite-pwa-production/src/main/java/com/vaadin/viteapp/MainView.java
@@ -18,6 +18,6 @@ package com.vaadin.viteapp;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
 
-@Route(value = "", layout = AppShell.class)
+@Route(value = "")
 public class MainView extends Div {
 }

--- a/flow-tests/test-frontend/vite-pwa/src/main/java/com/vaadin/viteapp/AppShell.java
+++ b/flow-tests/test-frontend/vite-pwa/src/main/java/com/vaadin/viteapp/AppShell.java
@@ -15,15 +15,11 @@
  */
 package com.vaadin.viteapp;
 
-import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.page.AppShellConfigurator;
-import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.server.PWA;
 import com.vaadin.flow.theme.Theme;
 
 @Theme("my-theme")
 @PWA(name = "My PWA app", shortName = "app")
 public class AppShell implements AppShellConfigurator {
-    public AppShell() {
-    }
 }

--- a/flow-tests/test-frontend/vite-pwa/src/main/java/com/vaadin/viteapp/AppShell.java
+++ b/flow-tests/test-frontend/vite-pwa/src/main/java/com/vaadin/viteapp/AppShell.java
@@ -23,8 +23,7 @@ import com.vaadin.flow.theme.Theme;
 
 @Theme("my-theme")
 @PWA(name = "My PWA app", shortName = "app")
-public class AppShell extends Div
-        implements RouterLayout, AppShellConfigurator {
+public class AppShell implements AppShellConfigurator {
     public AppShell() {
     }
 }

--- a/flow-tests/test-frontend/vite-pwa/src/main/java/com/vaadin/viteapp/MainView.java
+++ b/flow-tests/test-frontend/vite-pwa/src/main/java/com/vaadin/viteapp/MainView.java
@@ -18,6 +18,6 @@ package com.vaadin.viteapp;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
 
-@Route(value = "", layout = AppShell.class)
+@Route(value = "")
 public class MainView extends Div {
 }

--- a/flow-tests/test-live-reload/src/main/java/com/vaadin/flow/uitest/ui/AppShell.java
+++ b/flow-tests/test-live-reload/src/main/java/com/vaadin/flow/uitest/ui/AppShell.java
@@ -1,0 +1,10 @@
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.page.AppShellConfigurator;
+import com.vaadin.flow.server.PWA;
+import com.vaadin.flow.theme.Theme;
+
+@PWA(name = "Live Reload View", shortName = "live-reload-view")
+@Theme("mytheme")
+public class AppShell implements AppShellConfigurator {
+}

--- a/flow-tests/test-live-reload/src/main/java/com/vaadin/flow/uitest/ui/FrontendLiveReloadView.java
+++ b/flow-tests/test-live-reload/src/main/java/com/vaadin/flow/uitest/ui/FrontendLiveReloadView.java
@@ -35,11 +35,8 @@ import com.vaadin.flow.server.frontend.FrontendUtils;
 import com.vaadin.flow.theme.Theme;
 import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 
-@PWA(name = "Live Reload View", shortName = "live-reload-view")
 @Route(value = "com.vaadin.flow.uitest.ui.FrontendLiveReloadView", layout = ViewTestLayout.class)
-@Theme("mytheme")
-public class FrontendLiveReloadView extends AbstractLiveReloadView
-        implements AppShellConfigurator {
+public class FrontendLiveReloadView extends AbstractLiveReloadView {
     public static final String FRONTEND_CODE_TEXT = "frontend-code-text";
     public static final String FRONTEND_CODE_UPDATE_BUTTON = "frontend-code-update-button";
     public static final String FRONTEND_CODE_RESET_BUTTON = "frontend-code-reset-button";

--- a/flow-tests/test-pwa-disabled-offline/src/main/java/com/vaadin/flow/pwatest/AppShell.java
+++ b/flow-tests/test-pwa-disabled-offline/src/main/java/com/vaadin/flow/pwatest/AppShell.java
@@ -21,8 +21,7 @@ import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.server.PWA;
 
 @PWA(name = "PWA app", shortName = "app", offline = false)
-public class AppShell extends Div
-        implements RouterLayout, AppShellConfigurator {
+public class AppShell implements AppShellConfigurator {
     public AppShell() {
     }
 }

--- a/flow-tests/test-pwa-disabled-offline/src/main/java/com/vaadin/flow/pwatest/MainView.java
+++ b/flow-tests/test-pwa-disabled-offline/src/main/java/com/vaadin/flow/pwatest/MainView.java
@@ -18,6 +18,6 @@ package com.vaadin.flow.pwatest;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
 
-@Route(value = "", layout = AppShell.class)
+@Route(value = "")
 public class MainView extends Div {
 }

--- a/flow-tests/test-pwa/src/main/java/com/vaadin/flow/pwatest/ui/AppShell.java
+++ b/flow-tests/test-pwa/src/main/java/com/vaadin/flow/pwatest/ui/AppShell.java
@@ -15,19 +15,17 @@
  */
 package com.vaadin.flow.pwatest.ui;
 
-import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.page.AppShellConfigurator;
-import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.server.PWA;
 
-@PWA(name = ParentLayout.PWA_NAME, shortName = ParentLayout.PWA_SHORT_NAME, themeColor = ParentLayout.THEME_COLOR, backgroundColor = ParentLayout.BG_COLOR, offlinePath = "offline.html", offlineResources = {
+@PWA(name = AppShell.PWA_NAME, shortName = AppShell.PWA_SHORT_NAME, themeColor = AppShell.THEME_COLOR, backgroundColor = AppShell.BG_COLOR, offlinePath = "offline.html", offlineResources = {
         "yes.png" })
-public class ParentLayout implements AppShellConfigurator {
+public class AppShell implements AppShellConfigurator {
     static final String THEME_COLOR = "#1f1f1f";
     static final String BG_COLOR = "#ffffff";
     static final String PWA_NAME = "PWA test name";
     static final String PWA_SHORT_NAME = "PWA";
 
-    public ParentLayout() {
+    public AppShell() {
     }
 }

--- a/flow-tests/test-pwa/src/main/java/com/vaadin/flow/pwatest/ui/ParentLayout.java
+++ b/flow-tests/test-pwa/src/main/java/com/vaadin/flow/pwatest/ui/ParentLayout.java
@@ -22,8 +22,7 @@ import com.vaadin.flow.server.PWA;
 
 @PWA(name = ParentLayout.PWA_NAME, shortName = ParentLayout.PWA_SHORT_NAME, themeColor = ParentLayout.THEME_COLOR, backgroundColor = ParentLayout.BG_COLOR, offlinePath = "offline.html", offlineResources = {
         "yes.png" })
-public class ParentLayout extends Div
-        implements RouterLayout, AppShellConfigurator {
+public class ParentLayout implements AppShellConfigurator {
     static final String THEME_COLOR = "#1f1f1f";
     static final String BG_COLOR = "#ffffff";
     static final String PWA_NAME = "PWA test name";

--- a/flow-tests/test-pwa/src/main/java/com/vaadin/flow/pwatest/ui/PwaTestView.java
+++ b/flow-tests/test-pwa/src/main/java/com/vaadin/flow/pwatest/ui/PwaTestView.java
@@ -18,6 +18,6 @@ package com.vaadin.flow.pwatest.ui;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
 
-@Route(value = "", layout = ParentLayout.class)
+@Route(value = "")
 public class PwaTestView extends Div {
 }

--- a/flow-tests/test-pwa/src/test/java/com/vaadin/flow/pwatest/ui/PwaTestIT.java
+++ b/flow-tests/test-pwa/src/test/java/com/vaadin/flow/pwatest/ui/PwaTestIT.java
@@ -57,17 +57,17 @@ public class PwaTestIT extends ChromeDeviceTest {
                 .findElements(By.name("apple-mobile-web-app-capable")).size());
 
         // test theme color
-        Assert.assertEquals(
-                1, head
-                        .findElements(By
-                                .xpath("//meta[@name='theme-color'][@content='"
-                                        + ParentLayout.THEME_COLOR + "']"))
+        Assert.assertEquals(1,
+                head.findElements(
+                        By.xpath("//meta[@name='theme-color'][@content='"
+                                + AppShell.THEME_COLOR + "']"))
                         .size());
 
         // test theme color for apple mobile
-        Assert.assertEquals(1, head.findElements(
-                By.xpath("//meta[@name='apple-mobile-web-app-status-bar-style']"
-                        + "[@content='" + ParentLayout.THEME_COLOR + "']"))
+        Assert.assertEquals(1, head
+                .findElements(By.xpath(
+                        "//meta[@name='apple-mobile-web-app-status-bar-style']"
+                                + "[@content='" + AppShell.THEME_COLOR + "']"))
                 .size());
         // icons test
         checkIcons(head.findElements(By.xpath("//link[@rel='shortcut icon']")),
@@ -94,12 +94,12 @@ public class PwaTestIT extends ChromeDeviceTest {
             href = getRootURL() + '/' + href;
         }
         JsonObject manifest = readJsonFromUrl(href);
-        Assert.assertEquals(ParentLayout.PWA_NAME, manifest.getString("name"));
-        Assert.assertEquals(ParentLayout.PWA_SHORT_NAME,
+        Assert.assertEquals(AppShell.PWA_NAME, manifest.getString("name"));
+        Assert.assertEquals(AppShell.PWA_SHORT_NAME,
                 manifest.getString("short_name"));
-        Assert.assertEquals(ParentLayout.BG_COLOR,
+        Assert.assertEquals(AppShell.BG_COLOR,
                 manifest.getString("background_color"));
-        Assert.assertEquals(ParentLayout.THEME_COLOR,
+        Assert.assertEquals(AppShell.THEME_COLOR,
                 manifest.getString("theme_color"));
 
         // test service worker initialization
@@ -200,9 +200,9 @@ public class PwaTestIT extends ChromeDeviceTest {
             WebElement head = findElement(By.tagName("head"));
             waitForElementPresent(By.tagName("title"));
             WebElement title = head.findElement(By.tagName("title"));
-            Assert.assertEquals(ParentLayout.PWA_NAME,
+            Assert.assertEquals(AppShell.PWA_NAME,
                     executeScript("return arguments[0].textContent", title));
-            Assert.assertEquals(ParentLayout.PWA_NAME,
+            Assert.assertEquals(AppShell.PWA_NAME,
                     executeScript("return document.title;"));
 
             // Assert default offline.html page contents
@@ -211,7 +211,7 @@ public class PwaTestIT extends ChromeDeviceTest {
                     body.findElements(By.id("outlet")).isEmpty());
 
             WebElement offline = body.findElement(By.id("offline"));
-            Assert.assertEquals(ParentLayout.PWA_NAME,
+            Assert.assertEquals(AppShell.PWA_NAME,
                     offline.findElement(By.tagName("h1")).getText());
             WebElement message = offline.findElement(By.className("message"));
             Assert.assertTrue("Should have “offline” in message",


### PR DESCRIPTION
## Description

AppShellRegistry now rejects app shell class which extends Component.

Fixes #18012 

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
