### PR TITLE
chore: improve session lock strategy

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
@@ -324,5 +324,5 @@ public interface DeploymentConfiguration
      *
      * @return the lock checking strategy, never null.
      */
-    SessionLockCheckStrategy getProductionSessionLockCheckStrategy();
+    SessionLockCheckStrategy getSessionLockCheckStrategy();
 }

--- a/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 import com.vaadin.flow.server.AbstractConfiguration;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.InitParameters;
-import com.vaadin.flow.server.LockCheckStrategy;
+import com.vaadin.flow.server.SessionLockCheckStrategy;
 import com.vaadin.flow.server.WrappedSession;
 import com.vaadin.flow.shared.communication.PushMode;
 
@@ -324,5 +324,5 @@ public interface DeploymentConfiguration
      *
      * @return the lock checking strategy, never null.
      */
-    LockCheckStrategy getLockCheckStrategy();
+    SessionLockCheckStrategy getProductionSessionLockCheckStrategy();
 }

--- a/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
@@ -319,7 +319,7 @@ public interface DeploymentConfiguration
     boolean isDevToolsEnabled();
 
     /**
-     * Returns the strategy for session lock checking in production mode.
+     * Returns the strategy for Vaadin session lock checking in production mode.
      * Ignored in development mode.
      *
      * @return the lock checking strategy, never null.

--- a/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
@@ -56,7 +56,9 @@ public class DefaultDeploymentConfiguration
             + "The permitted values are \"disabled\", \"manual\",\n"
             + "and \"automatic\". The default of \"disabled\" will be used.";
 
-    public static final String WARNING_SESSION_LOCK_CHECK_STRATEGY_NOT_RECOGNIZED = "WARNING: lockCheckStrategy has been set to an unrecognized value.\n"
+    public static final String WARNING_SESSION_LOCK_CHECK_STRATEGY_NOT_RECOGNIZED = "WARNING: "
+            + InitParameters.SERVLET_PARAMETER_PRODUCTION_SESSION_LOCK_CHECK_STRATEGY
+            + " has been set to an unrecognized value.\n"
             + "The permitted values are "
             + Arrays.stream(SessionLockCheckStrategy.values())
                     .map(it -> "\"" + it.name().toLowerCase() + "\"")

--- a/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
@@ -57,7 +57,7 @@ public class DefaultDeploymentConfiguration
             + "and \"automatic\". The default of \"disabled\" will be used.";
 
     public static final String WARNING_SESSION_LOCK_CHECK_STRATEGY_NOT_RECOGNIZED = "WARNING: "
-            + InitParameters.SERVLET_PARAMETER_PRODUCTION_SESSION_LOCK_CHECK_STRATEGY
+            + InitParameters.SERVLET_PARAMETER_SESSION_LOCK_CHECK_STRATEGY
             + " has been set to an unrecognized value.\n"
             + "The permitted values are "
             + Arrays.stream(SessionLockCheckStrategy.values())
@@ -106,7 +106,7 @@ public class DefaultDeploymentConfiguration
     private boolean sendUrlsAsParameters;
     private boolean requestTiming;
     private boolean frontendHotdeploy;
-    private SessionLockCheckStrategy productionSessionLockCheckStrategy;
+    private SessionLockCheckStrategy sessionLockCheckStrategy;
 
     private static AtomicBoolean logging = new AtomicBoolean(true);
     private List<String> warnings = new ArrayList<>();
@@ -143,7 +143,7 @@ public class DefaultDeploymentConfiguration
         checkSyncIdCheck();
         checkSendUrlsAsParameters();
         checkFrontendHotdeploy();
-        checkProductionSessionLockCheckStrategy();
+        checkSessionLockCheckStrategy();
 
         if (log) {
             logMessages();
@@ -277,8 +277,8 @@ public class DefaultDeploymentConfiguration
     }
 
     @Override
-    public SessionLockCheckStrategy getProductionSessionLockCheckStrategy() {
-        return productionSessionLockCheckStrategy;
+    public SessionLockCheckStrategy getSessionLockCheckStrategy() {
+        return sessionLockCheckStrategy;
     }
 
     /**
@@ -400,17 +400,17 @@ public class DefaultDeploymentConfiguration
         }
     }
 
-    private void checkProductionSessionLockCheckStrategy() {
+    private void checkSessionLockCheckStrategy() {
         try {
-            productionSessionLockCheckStrategy = getApplicationOrSystemProperty(
-                    InitParameters.SERVLET_PARAMETER_PRODUCTION_SESSION_LOCK_CHECK_STRATEGY,
+            sessionLockCheckStrategy = getApplicationOrSystemProperty(
+                    InitParameters.SERVLET_PARAMETER_SESSION_LOCK_CHECK_STRATEGY,
                     SessionLockCheckStrategy.ASSERT,
                     stringStrategy -> Enum.valueOf(
                             SessionLockCheckStrategy.class,
                             stringStrategy.toUpperCase()));
         } catch (IllegalArgumentException e) {
             warnings.add(WARNING_SESSION_LOCK_CHECK_STRATEGY_NOT_RECOGNIZED);
-            productionSessionLockCheckStrategy = SessionLockCheckStrategy.ASSERT;
+            sessionLockCheckStrategy = SessionLockCheckStrategy.ASSERT;
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
@@ -17,6 +17,7 @@
 package com.vaadin.flow.server;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -55,9 +56,14 @@ public class DefaultDeploymentConfiguration
             + "The permitted values are \"disabled\", \"manual\",\n"
             + "and \"automatic\". The default of \"disabled\" will be used.";
 
-    public static final String WARNING_LOCK_CHECK_STRATEGY_NOT_RECOGNIZED = "WARNING: lockCheckStrategy has been set to an unrecognized value.\n"
-            + "The permitted values are \"assert\", \"log\",\n"
-            + "and \"throw\". The default of \"assert\" will be used.";
+    public static final String WARNING_SESSION_LOCK_CHECK_STRATEGY_NOT_RECOGNIZED = "WARNING: lockCheckStrategy has been set to an unrecognized value.\n"
+            + "The permitted values are "
+            + Arrays.stream(SessionLockCheckStrategy.values())
+                    .map(it -> "\"" + it.name().toLowerCase() + "\"")
+                    .collect(Collectors.joining(", "))
+            + ".\nThe default of \""
+            + SessionLockCheckStrategy.ASSERT.name().toLowerCase()
+            + "\" will be used.";
 
     /**
      * Default value for {@link #getHeartbeatInterval()} = {@value} .
@@ -98,7 +104,7 @@ public class DefaultDeploymentConfiguration
     private boolean sendUrlsAsParameters;
     private boolean requestTiming;
     private boolean frontendHotdeploy;
-    private LockCheckStrategy lockCheckStrategy;
+    private SessionLockCheckStrategy productionSessionLockCheckStrategy;
 
     private static AtomicBoolean logging = new AtomicBoolean(true);
     private List<String> warnings = new ArrayList<>();
@@ -135,7 +141,7 @@ public class DefaultDeploymentConfiguration
         checkSyncIdCheck();
         checkSendUrlsAsParameters();
         checkFrontendHotdeploy();
-        checkLockCheckStrategy();
+        checkProductionSessionLockCheckStrategy();
 
         if (log) {
             logMessages();
@@ -269,8 +275,8 @@ public class DefaultDeploymentConfiguration
     }
 
     @Override
-    public LockCheckStrategy getLockCheckStrategy() {
-        return lockCheckStrategy;
+    public SessionLockCheckStrategy getProductionSessionLockCheckStrategy() {
+        return productionSessionLockCheckStrategy;
     }
 
     /**
@@ -392,16 +398,17 @@ public class DefaultDeploymentConfiguration
         }
     }
 
-    private void checkLockCheckStrategy() {
+    private void checkProductionSessionLockCheckStrategy() {
         try {
-            lockCheckStrategy = getApplicationOrSystemProperty(
-                    InitParameters.SERVLET_PARAMETER_LOCK_CHECK_STRATEGY,
-                    LockCheckStrategy.ASSERT,
-                    stringStrategy -> Enum.valueOf(LockCheckStrategy.class,
+            productionSessionLockCheckStrategy = getApplicationOrSystemProperty(
+                    InitParameters.SERVLET_PARAMETER_PRODUCTION_SESSION_LOCK_CHECK_STRATEGY,
+                    SessionLockCheckStrategy.ASSERT,
+                    stringStrategy -> Enum.valueOf(
+                            SessionLockCheckStrategy.class,
                             stringStrategy.toUpperCase()));
         } catch (IllegalArgumentException e) {
-            warnings.add(WARNING_LOCK_CHECK_STRATEGY_NOT_RECOGNIZED);
-            lockCheckStrategy = LockCheckStrategy.ASSERT;
+            warnings.add(WARNING_SESSION_LOCK_CHECK_STRATEGY_NOT_RECOGNIZED);
+            productionSessionLockCheckStrategy = SessionLockCheckStrategy.ASSERT;
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
@@ -396,12 +396,12 @@ public class DefaultDeploymentConfiguration
         try {
             lockCheckStrategy = getApplicationOrSystemProperty(
                     InitParameters.SERVLET_PARAMETER_LOCK_CHECK_STRATEGY,
-                    LockCheckStrategy.DEFAULT,
+                    LockCheckStrategy.ASSERT,
                     stringStrategy -> Enum.valueOf(LockCheckStrategy.class,
                             stringStrategy.toUpperCase()));
         } catch (IllegalArgumentException e) {
             warnings.add(WARNING_LOCK_CHECK_STRATEGY_NOT_RECOGNIZED);
-            lockCheckStrategy = LockCheckStrategy.DEFAULT;
+            lockCheckStrategy = LockCheckStrategy.ASSERT;
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -55,7 +55,7 @@ public class InitParameters implements Serializable {
     public static final String SERVLET_PARAMETER_WEB_COMPONENT_DISCONNECT = "webComponentDisconnect";
     public static final String SERVLET_PARAMETER_CLOSE_IDLE_SESSIONS = "closeIdleSessions";
     public static final String SERVLET_PARAMETER_PUSH_MODE = "pushMode";
-    public static final String SERVLET_PARAMETER_PRODUCTION_SESSION_LOCK_CHECK_STRATEGY = "productionSessionLockCheckStrategy";
+    public static final String SERVLET_PARAMETER_SESSION_LOCK_CHECK_STRATEGY = "sessionLockCheckStrategy";
     public static final String SERVLET_PARAMETER_PUSH_SERVLET_MAPPING = "pushServletMapping";
     public static final String SERVLET_PARAMETER_SYNC_ID_CHECK = "syncIdCheck";
     public static final String SERVLET_PARAMETER_SEND_URLS_AS_PARAMETERS = "sendUrlsAsParameters";

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -55,7 +55,7 @@ public class InitParameters implements Serializable {
     public static final String SERVLET_PARAMETER_WEB_COMPONENT_DISCONNECT = "webComponentDisconnect";
     public static final String SERVLET_PARAMETER_CLOSE_IDLE_SESSIONS = "closeIdleSessions";
     public static final String SERVLET_PARAMETER_PUSH_MODE = "pushMode";
-    public static final String SERVLET_PARAMETER_LOCK_CHECK_STRATEGY = "lockCheckStrategy";
+    public static final String SERVLET_PARAMETER_PRODUCTION_SESSION_LOCK_CHECK_STRATEGY = "productionSessionLockCheckStrategy";
     public static final String SERVLET_PARAMETER_PUSH_SERVLET_MAPPING = "pushServletMapping";
     public static final String SERVLET_PARAMETER_SYNC_ID_CHECK = "syncIdCheck";
     public static final String SERVLET_PARAMETER_SEND_URLS_AS_PARAMETERS = "sendUrlsAsParameters";

--- a/flow-server/src/main/java/com/vaadin/flow/server/LockCheckStrategy.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/LockCheckStrategy.java
@@ -39,8 +39,6 @@ public enum LockCheckStrategy {
         }
     };
 
-    public static final LockCheckStrategy DEFAULT = ASSERT;
-
     /**
      * Potentially checks whether this session is currently locked by the
      * current thread

--- a/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
@@ -281,7 +281,7 @@ public class PropertyDeploymentConfiguration
     }
 
     @Override
-    public SessionLockCheckStrategy getProductionSessionLockCheckStrategy() {
+    public SessionLockCheckStrategy getSessionLockCheckStrategy() {
         return SessionLockCheckStrategy.ASSERT;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
@@ -282,7 +282,7 @@ public class PropertyDeploymentConfiguration
 
     @Override
     public LockCheckStrategy getLockCheckStrategy() {
-        return LockCheckStrategy.DEFAULT;
+        return LockCheckStrategy.ASSERT;
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
@@ -281,8 +281,8 @@ public class PropertyDeploymentConfiguration
     }
 
     @Override
-    public LockCheckStrategy getLockCheckStrategy() {
-        return LockCheckStrategy.ASSERT;
+    public SessionLockCheckStrategy getProductionSessionLockCheckStrategy() {
+        return SessionLockCheckStrategy.ASSERT;
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/SessionLockCheckStrategy.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/SessionLockCheckStrategy.java
@@ -1,9 +1,9 @@
 package com.vaadin.flow.server;
 
 /**
- * The strategy for session lock checking in production mode.
+ * Available strategies for session lock checking.
  */
-public enum LockCheckStrategy {
+public enum SessionLockCheckStrategy {
     /**
      * The default strategy, runs Java `assert` statement. Does nothing when
      * assertions are disabled (the default for JVM).

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
@@ -570,9 +570,9 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * current thread, and fails with the given message if not.
      * <p>
      * When production mode is enabled, the check is done according to the
-     * {@link InitParameters#SERVLET_PARAMETER_SESSION_LOCK_CHECK_STRATEGY
-     * lock check strategy}. By default, the check is only done if assertions
-     * are also enabled: this is done to avoid the small performance impact of
+     * {@link InitParameters#SERVLET_PARAMETER_SESSION_LOCK_CHECK_STRATEGY lock
+     * check strategy}. By default, the check is only done if assertions are
+     * also enabled: this is done to avoid the small performance impact of
      * continuously checking the lock status.
      * <p>
      * The check is always done when production mode is not enabled, using the
@@ -591,9 +591,9 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * current thread, and fails with a standard error message if not.
      * <p>
      * When production mode is enabled, the check is done according to the
-     * {@link InitParameters#SERVLET_PARAMETER_SESSION_LOCK_CHECK_STRATEGY
-     * lock check strategy}. By default, the check is only done if assertions
-     * are also enabled: this is done to avoid the small performance impact of
+     * {@link InitParameters#SERVLET_PARAMETER_SESSION_LOCK_CHECK_STRATEGY lock
+     * check strategy}. By default, the check is only done if assertions are
+     * also enabled: this is done to avoid the small performance impact of
      * continuously checking the lock status.
      * <p>
      * The check is always done when production mode is not enabled, using the

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
@@ -114,7 +114,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
 
     private transient Lock lock;
 
-    private LockCheckStrategy lockCheckStrategy = LockCheckStrategy.ASSERT;
+    private SessionLockCheckStrategy sessionLockCheckStrategy = SessionLockCheckStrategy.ASSERT;
 
     /*
      * Pending tasks can't be serialized and the queue should be empty when the
@@ -352,10 +352,10 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
         checkSetConfiguration();
         this.configuration = configuration;
 
-        lockCheckStrategy = configuration.isProductionMode()
-                ? configuration.getLockCheckStrategy()
-                : LockCheckStrategy.THROW;
-        assert lockCheckStrategy != null;
+        sessionLockCheckStrategy = configuration.isProductionMode()
+                ? configuration.getProductionSessionLockCheckStrategy()
+                : SessionLockCheckStrategy.THROW;
+        assert sessionLockCheckStrategy != null;
     }
 
     protected void checkSetConfiguration() {
@@ -570,9 +570,9 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * current thread, and fails with the given message if not.
      * <p>
      * When production mode is enabled, the check is done according to the
-     * {@link InitParameters#SERVLET_PARAMETER_LOCK_CHECK_STRATEGY lock check
-     * strategy}. By default, the check is only done if assertions are also
-     * enabled: this is done to avoid the small performance impact of
+     * {@link InitParameters#SERVLET_PARAMETER_PRODUCTION_SESSION_LOCK_CHECK_STRATEGY
+     * lock check strategy}. By default, the check is only done if assertions
+     * are also enabled: this is done to avoid the small performance impact of
      * continuously checking the lock status. The check is always done when
      * production mode is not enabled.
      *
@@ -581,7 +581,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      *            and the session is not locked
      */
     public void checkHasLock(String message) {
-        lockCheckStrategy.checkHasLock(this, message);
+        sessionLockCheckStrategy.checkHasLock(this, message);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
@@ -114,7 +114,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
 
     private transient Lock lock;
 
-    private LockCheckStrategy lockCheckStrategy = LockCheckStrategy.DEFAULT;
+    private LockCheckStrategy lockCheckStrategy = LockCheckStrategy.ASSERT;
 
     /*
      * Pending tasks can't be serialized and the queue should be empty when the

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
@@ -353,7 +353,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
         this.configuration = configuration;
 
         sessionLockCheckStrategy = configuration.isProductionMode()
-                ? configuration.getProductionSessionLockCheckStrategy()
+                ? configuration.getSessionLockCheckStrategy()
                 : SessionLockCheckStrategy.THROW;
         assert sessionLockCheckStrategy != null;
     }
@@ -570,7 +570,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * current thread, and fails with the given message if not.
      * <p>
      * When production mode is enabled, the check is done according to the
-     * {@link InitParameters#SERVLET_PARAMETER_PRODUCTION_SESSION_LOCK_CHECK_STRATEGY
+     * {@link InitParameters#SERVLET_PARAMETER_SESSION_LOCK_CHECK_STRATEGY
      * lock check strategy}. By default, the check is only done if assertions
      * are also enabled: this is done to avoid the small performance impact of
      * continuously checking the lock status.
@@ -591,7 +591,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * current thread, and fails with a standard error message if not.
      * <p>
      * When production mode is enabled, the check is done according to the
-     * {@link InitParameters#SERVLET_PARAMETER_PRODUCTION_SESSION_LOCK_CHECK_STRATEGY
+     * {@link InitParameters#SERVLET_PARAMETER_SESSION_LOCK_CHECK_STRATEGY
      * lock check strategy}. By default, the check is only done if assertions
      * are also enabled: this is done to avoid the small performance impact of
      * continuously checking the lock status.

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
@@ -573,8 +573,10 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * {@link InitParameters#SERVLET_PARAMETER_PRODUCTION_SESSION_LOCK_CHECK_STRATEGY
      * lock check strategy}. By default, the check is only done if assertions
      * are also enabled: this is done to avoid the small performance impact of
-     * continuously checking the lock status. The check is always done when
-     * production mode is not enabled.
+     * continuously checking the lock status.
+     * <p>
+     * The check is always done when production mode is not enabled, using the
+     * {@link SessionLockCheckStrategy#THROW} strategy.
      *
      * @param message
      *            the error message to include when failing if the check is done
@@ -588,10 +590,14 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * Potentially checks whether this session is currently locked by the
      * current thread, and fails with a standard error message if not.
      * <p>
-     * When production mode is enabled, the check is only done if assertions are
-     * also enabled. This is done to avoid the small performance impact of
-     * continuously checking the lock status. The check is always done when
-     * production mode is not enabled.
+     * When production mode is enabled, the check is done according to the
+     * {@link InitParameters#SERVLET_PARAMETER_PRODUCTION_SESSION_LOCK_CHECK_STRATEGY
+     * lock check strategy}. By default, the check is only done if assertions
+     * are also enabled: this is done to avoid the small performance impact of
+     * continuously checking the lock status.
+     * <p>
+     * The check is always done when production mode is not enabled, using the
+     * {@link SessionLockCheckStrategy#THROW} strategy.
      */
     public void checkHasLock() {
         checkHasLock(SESSION_NOT_LOCKED_MESSAGE);

--- a/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
@@ -143,7 +143,7 @@ public class AbstractDeploymentConfigurationTest {
         }
 
         @Override
-        public SessionLockCheckStrategy getProductionSessionLockCheckStrategy() {
+        public SessionLockCheckStrategy getSessionLockCheckStrategy() {
             return SessionLockCheckStrategy.ASSERT;
         }
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
@@ -143,8 +143,8 @@ public class AbstractDeploymentConfigurationTest {
         }
 
         @Override
-        public LockCheckStrategy getLockCheckStrategy() {
-            return LockCheckStrategy.ASSERT;
+        public SessionLockCheckStrategy getProductionSessionLockCheckStrategy() {
+            return SessionLockCheckStrategy.ASSERT;
         }
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
@@ -144,7 +144,7 @@ public class AbstractDeploymentConfigurationTest {
 
         @Override
         public LockCheckStrategy getLockCheckStrategy() {
-            return LockCheckStrategy.DEFAULT;
+            return LockCheckStrategy.ASSERT;
         }
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/DefaultDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DefaultDeploymentConfigurationTest.java
@@ -266,8 +266,7 @@ public class DefaultDeploymentConfigurationTest {
     @Test
     public void checkLockStrategy_configurableViaPropertyParameter() {
         Properties init = new Properties();
-        init.put(
-                InitParameters.SERVLET_PARAMETER_SESSION_LOCK_CHECK_STRATEGY,
+        init.put(InitParameters.SERVLET_PARAMETER_SESSION_LOCK_CHECK_STRATEGY,
                 "throw");
         DefaultDeploymentConfiguration config = createDeploymentConfig(init);
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/DefaultDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DefaultDeploymentConfigurationTest.java
@@ -260,19 +260,19 @@ public class DefaultDeploymentConfigurationTest {
         DefaultDeploymentConfiguration config = createDeploymentConfig(init);
 
         Assert.assertEquals(SessionLockCheckStrategy.ASSERT,
-                config.getProductionSessionLockCheckStrategy());
+                config.getSessionLockCheckStrategy());
     }
 
     @Test
     public void checkLockStrategy_configurableViaPropertyParameter() {
         Properties init = new Properties();
         init.put(
-                InitParameters.SERVLET_PARAMETER_PRODUCTION_SESSION_LOCK_CHECK_STRATEGY,
+                InitParameters.SERVLET_PARAMETER_SESSION_LOCK_CHECK_STRATEGY,
                 "throw");
         DefaultDeploymentConfiguration config = createDeploymentConfig(init);
 
         Assert.assertEquals(SessionLockCheckStrategy.THROW,
-                config.getProductionSessionLockCheckStrategy());
+                config.getSessionLockCheckStrategy());
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/DefaultDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DefaultDeploymentConfigurationTest.java
@@ -259,18 +259,20 @@ public class DefaultDeploymentConfigurationTest {
         Properties init = new Properties();
         DefaultDeploymentConfiguration config = createDeploymentConfig(init);
 
-        Assert.assertEquals(LockCheckStrategy.ASSERT,
-                config.getLockCheckStrategy());
+        Assert.assertEquals(SessionLockCheckStrategy.ASSERT,
+                config.getProductionSessionLockCheckStrategy());
     }
 
     @Test
     public void checkLockStrategy_configurableViaPropertyParameter() {
         Properties init = new Properties();
-        init.put(InitParameters.SERVLET_PARAMETER_LOCK_CHECK_STRATEGY, "throw");
+        init.put(
+                InitParameters.SERVLET_PARAMETER_PRODUCTION_SESSION_LOCK_CHECK_STRATEGY,
+                "throw");
         DefaultDeploymentConfiguration config = createDeploymentConfig(init);
 
-        Assert.assertEquals(LockCheckStrategy.THROW,
-                config.getLockCheckStrategy());
+        Assert.assertEquals(SessionLockCheckStrategy.THROW,
+                config.getProductionSessionLockCheckStrategy());
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinSessionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinSessionTest.java
@@ -536,20 +536,20 @@ public class VaadinSessionTest {
     public void checkHasLock_noCheckInDevMode() {
         Assume.assumeTrue(session.hasLock());
         Assume.assumeFalse(session.getConfiguration().isProductionMode());
-        Assert.assertEquals(LockCheckStrategy.ASSERT,
-                session.getConfiguration().getLockCheckStrategy());
+        Assert.assertEquals(SessionLockCheckStrategy.ASSERT, session
+                .getConfiguration().getProductionSessionLockCheckStrategy());
         final MockDeploymentConfiguration configuration = (MockDeploymentConfiguration) session
                 .getConfiguration();
 
         session.checkHasLock();
 
-        configuration.setLockCheckStrategy(LockCheckStrategy.LOG);
+        configuration.setLockCheckStrategy(SessionLockCheckStrategy.LOG);
         session.setConfiguration(configuration);
         session.mockLogger.clearLogs();
         session.checkHasLock();
         Assert.assertEquals("", session.mockLogger.getLogs());
 
-        configuration.setLockCheckStrategy(LockCheckStrategy.ASSERT);
+        configuration.setLockCheckStrategy(SessionLockCheckStrategy.ASSERT);
         session.setConfiguration(configuration);
         session.checkHasLock();
     }
@@ -579,7 +579,7 @@ public class VaadinSessionTest {
         final MockDeploymentConfiguration configuration = (MockDeploymentConfiguration) session
                 .getConfiguration();
         configuration.setProductionMode(true);
-        configuration.setLockCheckStrategy(LockCheckStrategy.THROW);
+        configuration.setLockCheckStrategy(SessionLockCheckStrategy.THROW);
         session.setConfiguration(configuration);
         session.unlock();
         Assume.assumeFalse(session.hasLock());
@@ -598,7 +598,7 @@ public class VaadinSessionTest {
         final MockDeploymentConfiguration configuration = (MockDeploymentConfiguration) session
                 .getConfiguration();
         configuration.setProductionMode(true);
-        configuration.setLockCheckStrategy(LockCheckStrategy.LOG);
+        configuration.setLockCheckStrategy(SessionLockCheckStrategy.LOG);
         session.setConfiguration(configuration);
         session.unlock();
         Assume.assumeFalse(session.hasLock());

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinSessionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinSessionTest.java
@@ -537,7 +537,7 @@ public class VaadinSessionTest {
         Assume.assumeTrue(session.hasLock());
         Assume.assumeFalse(session.getConfiguration().isProductionMode());
         Assert.assertEquals(SessionLockCheckStrategy.ASSERT, session
-                .getConfiguration().getProductionSessionLockCheckStrategy());
+                .getConfiguration().getSessionLockCheckStrategy());
         final MockDeploymentConfiguration configuration = (MockDeploymentConfiguration) session
                 .getConfiguration();
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinSessionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinSessionTest.java
@@ -536,8 +536,8 @@ public class VaadinSessionTest {
     public void checkHasLock_noCheckInDevMode() {
         Assume.assumeTrue(session.hasLock());
         Assume.assumeFalse(session.getConfiguration().isProductionMode());
-        Assert.assertEquals(SessionLockCheckStrategy.ASSERT, session
-                .getConfiguration().getSessionLockCheckStrategy());
+        Assert.assertEquals(SessionLockCheckStrategy.ASSERT,
+                session.getConfiguration().getSessionLockCheckStrategy());
         final MockDeploymentConfiguration configuration = (MockDeploymentConfiguration) session
                 .getConfiguration();
 

--- a/flow-server/src/test/java/com/vaadin/tests/util/MockDeploymentConfiguration.java
+++ b/flow-server/src/test/java/com/vaadin/tests/util/MockDeploymentConfiguration.java
@@ -32,7 +32,7 @@ public class MockDeploymentConfiguration
     private boolean eagerServerLoad = false;
     private boolean devModeLiveReloadEnabled = false;
     private boolean devToolsEnabled = true;
-    private LockCheckStrategy lockCheckStrategy = LockCheckStrategy.DEFAULT;
+    private LockCheckStrategy lockCheckStrategy = LockCheckStrategy.ASSERT;
 
     private File projectFolder = null;
 

--- a/flow-server/src/test/java/com/vaadin/tests/util/MockDeploymentConfiguration.java
+++ b/flow-server/src/test/java/com/vaadin/tests/util/MockDeploymentConfiguration.java
@@ -8,7 +8,7 @@ import java.util.Properties;
 import java.util.function.Function;
 
 import com.vaadin.flow.server.AbstractDeploymentConfiguration;
-import com.vaadin.flow.server.LockCheckStrategy;
+import com.vaadin.flow.server.SessionLockCheckStrategy;
 import com.vaadin.flow.shared.communication.PushMode;
 
 public class MockDeploymentConfiguration
@@ -32,7 +32,7 @@ public class MockDeploymentConfiguration
     private boolean eagerServerLoad = false;
     private boolean devModeLiveReloadEnabled = false;
     private boolean devToolsEnabled = true;
-    private LockCheckStrategy lockCheckStrategy = LockCheckStrategy.ASSERT;
+    private SessionLockCheckStrategy sessionLockCheckStrategy = SessionLockCheckStrategy.ASSERT;
 
     private File projectFolder = null;
 
@@ -211,11 +211,12 @@ public class MockDeploymentConfiguration
     }
 
     @Override
-    public LockCheckStrategy getLockCheckStrategy() {
-        return lockCheckStrategy;
+    public SessionLockCheckStrategy getProductionSessionLockCheckStrategy() {
+        return sessionLockCheckStrategy;
     }
 
-    public void setLockCheckStrategy(LockCheckStrategy lockCheckStrategy) {
-        this.lockCheckStrategy = lockCheckStrategy;
+    public void setLockCheckStrategy(
+            SessionLockCheckStrategy sessionLockCheckStrategy) {
+        this.sessionLockCheckStrategy = sessionLockCheckStrategy;
     }
 }

--- a/flow-server/src/test/java/com/vaadin/tests/util/MockDeploymentConfiguration.java
+++ b/flow-server/src/test/java/com/vaadin/tests/util/MockDeploymentConfiguration.java
@@ -211,7 +211,7 @@ public class MockDeploymentConfiguration
     }
 
     @Override
-    public SessionLockCheckStrategy getProductionSessionLockCheckStrategy() {
+    public SessionLockCheckStrategy getSessionLockCheckStrategy() {
         return sessionLockCheckStrategy;
     }
 

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/MockDeploymentConfiguration.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/MockDeploymentConfiguration.java
@@ -7,7 +7,7 @@ import java.util.Properties;
 import java.util.function.Function;
 
 import com.vaadin.flow.server.AbstractDeploymentConfiguration;
-import com.vaadin.flow.server.LockCheckStrategy;
+import com.vaadin.flow.server.SessionLockCheckStrategy;
 import com.vaadin.flow.shared.communication.PushMode;
 
 public class MockDeploymentConfiguration
@@ -31,7 +31,7 @@ public class MockDeploymentConfiguration
     private boolean eagerServerLoad = false;
     private boolean devModeLiveReloadEnabled = false;
     private boolean devToolsEnabled = true;
-    private LockCheckStrategy lockCheckStrategy = LockCheckStrategy.ASSERT;
+    private SessionLockCheckStrategy sessionLockCheckStrategy = SessionLockCheckStrategy.ASSERT;
 
     public MockDeploymentConfiguration() {
         super(Collections.emptyMap());
@@ -199,11 +199,12 @@ public class MockDeploymentConfiguration
     }
 
     @Override
-    public LockCheckStrategy getLockCheckStrategy() {
-        return lockCheckStrategy;
+    public SessionLockCheckStrategy getProductionSessionLockCheckStrategy() {
+        return sessionLockCheckStrategy;
     }
 
-    public void setLockCheckStrategy(LockCheckStrategy lockCheckStrategy) {
-        this.lockCheckStrategy = lockCheckStrategy;
+    public void setLockCheckStrategy(
+            SessionLockCheckStrategy sessionLockCheckStrategy) {
+        this.sessionLockCheckStrategy = sessionLockCheckStrategy;
     }
 }

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/MockDeploymentConfiguration.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/MockDeploymentConfiguration.java
@@ -199,7 +199,7 @@ public class MockDeploymentConfiguration
     }
 
     @Override
-    public SessionLockCheckStrategy getProductionSessionLockCheckStrategy() {
+    public SessionLockCheckStrategy getSessionLockCheckStrategy() {
         return sessionLockCheckStrategy;
     }
 

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/MockDeploymentConfiguration.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/MockDeploymentConfiguration.java
@@ -31,7 +31,7 @@ public class MockDeploymentConfiguration
     private boolean eagerServerLoad = false;
     private boolean devModeLiveReloadEnabled = false;
     private boolean devToolsEnabled = true;
-    private LockCheckStrategy lockCheckStrategy = LockCheckStrategy.DEFAULT;
+    private LockCheckStrategy lockCheckStrategy = LockCheckStrategy.ASSERT;
 
     public MockDeploymentConfiguration() {
         super(Collections.emptyMap());


### PR DESCRIPTION
## Description

Fixes for https://github.com/vaadin/flow/pull/18129 that was unfortunately merged too hastily.

Couple of changes:

* The LockCheckStrategy.DEFAULT was misleading since there are two defaults, one for production mode (assert), the other for development mode (throw).
* Renamed LockCheckStrategy to SessionLockCheckStrategy, to explicitly scope the lock to VaadinSession
* The init parameter got renamed to "productionSessionLockCheckStrategy", to explicitly mention that this is meant for a session lock which is only taken into account in production mode. However, this is a bit mouthful, perhaps sessionLockCheckStrategy would suffice? @mcollovati 
