### PR TITLE
refactoring: make SessionLockCheckStrategy.LOG log stack trace as well

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/SessionLockCheckStrategy.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/SessionLockCheckStrategy.java
@@ -22,7 +22,8 @@ public enum SessionLockCheckStrategy {
         @Override
         public void checkHasLock(VaadinSession session, String message) {
             if (!session.hasLock()) {
-                session.getLogger().warn(message);
+                session.getLogger().warn(message,
+                        new IllegalStateException(message));
             }
         }
     },

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinSessionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinSessionTest.java
@@ -72,6 +72,7 @@ public class VaadinSessionTest {
 
         public VaadinSessionWithMockLogger(VaadinService service) {
             super(service);
+            mockLogger.includeStackTrace = true;
         }
 
         @Override
@@ -603,10 +604,13 @@ public class VaadinSessionTest {
         session.unlock();
         Assume.assumeFalse(session.hasLock());
 
-        // this should throw IllegalStateException
+        // this should log a warning message into the logger, including the
+        // stacktrace.
         session.checkHasLock();
-        Assert.assertEquals(
-                "[Warning] Cannot access state in VaadinSession or UI without locking the session.",
-                session.mockLogger.getLogs().trim());
+        Assert.assertTrue(session.mockLogger.getLogs().trim(),
+                session.mockLogger.getLogs().contains(
+                        "[Warning] Cannot access state in VaadinSession or UI without locking the session.\n"
+                                + "java.lang.IllegalStateException: Cannot access state in VaadinSession or UI without locking the session.\n"
+                                + "\tat com.vaadin.flow.server.SessionLockCheckStrategy$2.checkHasLock(SessionLockCheckStrategy.java:"));
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/MockLogger.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/MockLogger.java
@@ -16,14 +16,18 @@
 
 package com.vaadin.flow.server.frontend;
 
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.slf4j.Logger;
 import org.slf4j.Marker;
 
+import java.io.PrintWriter;
 import java.io.Serializable;
+import java.io.StringWriter;
 
 public class MockLogger implements Logger, Serializable {
 
     StringBuilder logs = new StringBuilder();
+    public boolean includeStackTrace = false;
 
     public static String TRACE = "[Trace] ";
     public static String DEBUG = "[Debug] ";
@@ -33,6 +37,13 @@ public class MockLogger implements Logger, Serializable {
 
     public String getLogs() {
         return logs.toString().replaceAll("\r", "");
+    }
+
+    private void append(Throwable throwable) {
+        if (throwable != null && includeStackTrace) {
+            throwable.printStackTrace(
+                    new PrintWriter(new StringBuilderWriter(logs)));
+        }
     }
 
     public void clearLogs() {
@@ -85,6 +96,7 @@ public class MockLogger implements Logger, Serializable {
     @Override
     public void trace(String s, Throwable throwable) {
         logs.append(TRACE).append(s).append("\n");
+        append(throwable);
     }
 
     @Override
@@ -156,6 +168,7 @@ public class MockLogger implements Logger, Serializable {
     @Override
     public void debug(String s, Throwable throwable) {
         logs.append(DEBUG).append(s).append("\n");
+        append(throwable);
     }
 
     @Override
@@ -227,6 +240,7 @@ public class MockLogger implements Logger, Serializable {
     @Override
     public void info(String s, Throwable throwable) {
         logs.append(INFO).append(s).append("\n");
+        append(throwable);
     }
 
     @Override
@@ -298,6 +312,7 @@ public class MockLogger implements Logger, Serializable {
     @Override
     public void warn(String s, Throwable throwable) {
         logs.append(WARN).append(s).append("\n");
+        append(throwable);
     }
 
     @Override
@@ -369,6 +384,7 @@ public class MockLogger implements Logger, Serializable {
     @Override
     public void error(String s, Throwable throwable) {
         logs.append(ERROR).append(s).append("\n");
+        append(throwable);
     }
 
     @Override


### PR DESCRIPTION
## Description

Building on the https://github.com/vaadin/flow/pull/18175 PR, to my horror I realized that the stack trace is not logged by the SessionLockCheckStrategy.LOG strategy, which was the whole purpose of the original PR. Sorry about that; this PR makes sure the stacktrace is logged properly.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
