### PR TITLE
docs: fix broken contributing link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 *There are many ways to participate in the Vaadin Flow project. You can ask questions and participate to discussion in [Discord](https://discord.com/channels/732335336448852018/1009201939092865084), [Stack Overflow](https://stackoverflow.com/questions/tagged/vaadin), [fill bug reports](https://github.com/vaadin/flow/issues) and enhancement suggestions and contribute code. These instructions are for contributing code to Flow project itself.*
 
-The contributing docs have moved to: https://vaadin.com/docs/latest/contributing/overview
+The contributing docs have moved to: https://vaadin.com/docs/latest/contributing/pr


### PR DESCRIPTION
Minor fix to docs to correct broken link
