### PR TITLE
fix: consider theme variants from JAR in bundleImports

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleUtils.java
@@ -37,6 +37,7 @@ import com.vaadin.flow.server.Constants;
 import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
+
 import static com.vaadin.flow.server.Constants.DEV_BUNDLE_JAR_PATH;
 
 public final class BundleUtils {
@@ -64,6 +65,9 @@ public final class BundleUtils {
             bundledImports.add(jsImport);
             bundledImports.add(jsImport.replace("/theme/lumo/", "/src/"));
             bundledImports.add(jsImport.replace("/theme/material/", "/src/"));
+            bundledImports.add(jsImport.replaceFirst(
+                    "^Frontend/generated/jar-resources/theme/(lumo|material)/",
+                    "./src/"));
             bundledImports.add(jsImport
                     .replaceFirst("^Frontend/generated/jar-resources/", "./"));
             bundledImports.add(jsImport

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/BundleUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/BundleUtilsTest.java
@@ -23,6 +23,7 @@ import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
+
 import static com.vaadin.flow.server.Constants.DEV_BUNDLE_JAR_PATH;
 
 public class BundleUtilsTest {
@@ -80,6 +81,19 @@ public class BundleUtilsTest {
         Assert.assertTrue(
                 bundleImports.contains("@foo/bar/theme/lumo/file.js"));
         Assert.assertTrue(bundleImports.contains("@foo/bar/src/file.js"));
+    }
+
+    @Test
+    public void themeVariantsFromJarHandled() {
+        mockStatsJson("Frontend/generated/jar-resources/theme/lumo/file.js",
+                "Frontend/generated/jar-resources/theme/material/file.js");
+        Set<String> bundleImports = BundleUtils.loadBundleImports();
+
+        Assert.assertTrue(bundleImports.contains(
+                "Frontend/generated/jar-resources/theme/lumo/file.js"));
+        Assert.assertTrue(bundleImports.contains(
+                "Frontend/generated/jar-resources/theme/material/file.js"));
+        Assert.assertTrue(bundleImports.contains("./src/file.js"));
     }
 
     private void mockStatsJson(String... imports) {


### PR DESCRIPTION
## Description

BundleUtil computes import paths for component theme variants from npm packages, but it does not consider variants from JAR add-ons.
This change applies the same import rules for both variants from npm packages and JAR unpacked in the fronted generated folder.

Fixes #18245

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
