### PR TITLE
test: wait for dev server start future completion

### DIFF
--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/AbstractDevServerRunnerTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/AbstractDevServerRunnerTest.java
@@ -100,6 +100,7 @@ public class AbstractDevServerRunnerTest extends AbstractDevModeTest {
     @Test
     public void shouldPassEncodedUrlToDevServer() throws Exception {
         handler = new DummyRunner();
+        waitForDevServer();
         DevModeHandler devServer = Mockito.spy(handler);
 
         HttpServletResponse response = Mockito.mock(HttpServletResponse.class);


### PR DESCRIPTION
AbstractDevServerRunner serves dev mode request only when the waitFor task completes. The asynchronous completion of the internal devServerStartFuture may result in the test proceeding before the future is fulfilled, potentially causing failure due to the false return of 'serveDevModeRequest.'

This change waits for the future to complete, before proceeding with the test.

Fixes #18159
