### PR TITLE
fix: Support fragmented messages in debug window

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReload.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReload.java
@@ -17,6 +17,8 @@ package com.vaadin.flow.internal;
 
 import org.atmosphere.cpr.AtmosphereResource;
 
+import com.vaadin.flow.server.communication.FragmentedMessageHolder;
+
 /**
  * Provides a way to reload browser tabs via web socket connection passed as a
  * {@link AtmosphereResource}.
@@ -26,7 +28,7 @@ import org.atmosphere.cpr.AtmosphereResource;
  * @author Vaadin Ltd
  *
  */
-public interface BrowserLiveReload {
+public interface BrowserLiveReload extends FragmentedMessageHolder {
 
     /**
      * Live reload enabling technology detected.

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/AtmospherePushConnection.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/AtmospherePushConnection.java
@@ -63,7 +63,7 @@ public class AtmospherePushConnection
      */
     public static class FragmentedMessage implements Serializable {
         private final StringBuilder message = new StringBuilder();
-        private final int messageLength;
+        private int messageLength;
 
         /**
          * Creates a message by reading from the given reader.
@@ -78,6 +78,10 @@ public class AtmospherePushConnection
          *             if unexpected data was read
          */
         public FragmentedMessage(Reader reader) throws IOException {
+            readMessageLength(reader);
+        }
+
+        private void readMessageLength(Reader reader) throws IOException {
             // Messages are prefixed by the total message length plus a
             // delimiter
             String length = "";

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/AtmospherePushConnection.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/AtmospherePushConnection.java
@@ -25,7 +25,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.atmosphere.cpr.AtmosphereRequest;
 import org.atmosphere.cpr.AtmosphereResource;
 import org.atmosphere.cpr.AtmosphereResource.TRANSPORT;
 import org.atmosphere.cpr.BroadcastFilterAdapter;
@@ -235,8 +234,8 @@ public class AtmospherePushConnection
      * received message, returns a {@link Reader} yielding the complete message.
      * Otherwise, returns null.
      *
-     * @param request
-     *            The atmosphere request with data
+     * @param resource
+     *            The atmosphere resource with data
      * @param reader
      *            The request body reader
      * @param holder
@@ -248,19 +247,18 @@ public class AtmospherePushConnection
      * @return a Reader yielding the complete message, or {@code null} if the
      *         received message was a partial message
      */
-    protected static Reader receiveMessage(AtmosphereRequest request,
+    protected static Reader receiveMessage(AtmosphereResource resource,
             Reader reader, FragmentedMessageHolder holder) throws IOException {
 
-        AtmosphereResource resource = request.resource();
         if (resource == null || resource.transport() != TRANSPORT.WEBSOCKET) {
             return reader;
         }
 
-        FragmentedMessage msg = holder.getOrCreateFragmentedMessage(request,
+        FragmentedMessage msg = holder.getOrCreateFragmentedMessage(resource,
                 reader);
         if (msg.append(reader)) {
             Reader messageReader = msg.getReader();
-            holder.clearFragmentedMessage(request);
+            holder.clearFragmentedMessage(resource);
             return messageReader;
         } else {
             // Only received a partial message
@@ -399,7 +397,7 @@ public class AtmospherePushConnection
 
     @Override
     public FragmentedMessage getOrCreateFragmentedMessage(
-            AtmosphereRequest request, Reader reader) throws IOException {
+            AtmosphereResource resource, Reader reader) throws IOException {
         if (incomingMessage == null) {
             incomingMessage = new FragmentedMessage(reader);
         }
@@ -407,7 +405,7 @@ public class AtmospherePushConnection
     }
 
     @Override
-    public void clearFragmentedMessage(AtmosphereRequest request) {
+    public void clearFragmentedMessage(AtmosphereResource resource) {
         incomingMessage = null;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/FragmentedMessageHolder.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/FragmentedMessageHolder.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.Serializable;
 
-import org.atmosphere.cpr.AtmosphereRequest;
+import org.atmosphere.cpr.AtmosphereResource;
 
 import com.vaadin.flow.server.communication.AtmospherePushConnection.FragmentedMessage;
 
@@ -13,21 +13,21 @@ public interface FragmentedMessageHolder extends Serializable {
     /**
      * Gets the partial message that is currently being received, if any.
      *
-     * @param request
-     *            the request to get the partial message for
+     * @param resource
+     *            the resource to get the partial message for
      * @param reader
      *            the request body reader
      * @return the partial message or null
      */
     public FragmentedMessage getOrCreateFragmentedMessage(
-            AtmosphereRequest request, Reader reader) throws IOException;
+            AtmosphereResource resource, Reader reader) throws IOException;
 
     /**
      * Clears the partial message that is currently being received. Should be
      * called when the whole message has been received.
      *
-     * @param request
-     *            the related request
+     * @param resource
+     *            the related resource
      */
-    public void clearFragmentedMessage(AtmosphereRequest request);
+    public void clearFragmentedMessage(AtmosphereResource resource);
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/FragmentedMessageHolder.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/FragmentedMessageHolder.java
@@ -17,7 +17,7 @@ public interface FragmentedMessageHolder extends Serializable {
      *            the resource to get the partial message for
      * @param reader
      *            the request body reader
-     * @return the partial message or null
+     * @return the fragmented message being received or a new empty instance
      */
     public FragmentedMessage getOrCreateFragmentedMessage(
             AtmosphereResource resource, Reader reader) throws IOException;

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/FragmentedMessageHolder.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/FragmentedMessageHolder.java
@@ -12,7 +12,7 @@ public interface FragmentedMessageHolder extends Serializable {
      * Gets the partial message that is currently being received, if any.
      *
      * @param resource
-     *            the resource to get the partial message forder
+     *            the resource to get the partial message from
      * @return the fragmented message being received or a new empty instance
      */
     public FragmentedMessage getOrCreateFragmentedMessage(

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/FragmentedMessageHolder.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/FragmentedMessageHolder.java
@@ -1,0 +1,33 @@
+package com.vaadin.flow.server.communication;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Serializable;
+
+import org.atmosphere.cpr.AtmosphereRequest;
+
+import com.vaadin.flow.server.communication.AtmospherePushConnection.FragmentedMessage;
+
+public interface FragmentedMessageHolder extends Serializable {
+
+    /**
+     * Gets the partial message that is currently being received, if any.
+     *
+     * @param request
+     *            the request to get the partial message for
+     * @param reader
+     *            the request body reader
+     * @return the partial message or null
+     */
+    public FragmentedMessage getOrCreateFragmentedMessage(
+            AtmosphereRequest request, Reader reader) throws IOException;
+
+    /**
+     * Clears the partial message that is currently being received. Should be
+     * called when the whole message has been received.
+     *
+     * @param request
+     *            the related request
+     */
+    public void clearFragmentedMessage(AtmosphereRequest request);
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/FragmentedMessageHolder.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/FragmentedMessageHolder.java
@@ -1,7 +1,5 @@
 package com.vaadin.flow.server.communication;
 
-import java.io.IOException;
-import java.io.Reader;
 import java.io.Serializable;
 
 import org.atmosphere.cpr.AtmosphereResource;
@@ -14,13 +12,11 @@ public interface FragmentedMessageHolder extends Serializable {
      * Gets the partial message that is currently being received, if any.
      *
      * @param resource
-     *            the resource to get the partial message for
-     * @param reader
-     *            the request body reader
+     *            the resource to get the partial message forder
      * @return the fragmented message being received or a new empty instance
      */
     public FragmentedMessage getOrCreateFragmentedMessage(
-            AtmosphereResource resource, Reader reader) throws IOException;
+            AtmosphereResource resource);
 
     /**
      * Clears the partial message that is currently being received. Should be

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PushHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PushHandler.java
@@ -150,7 +150,7 @@ public class PushHandler {
                 + "connection is kept open or if the UI has a "
                 + "connection of unexpected type.";
 
-        Reader reader = AtmospherePushConnection.receiveMessage(req,
+        Reader reader = AtmospherePushConnection.receiveMessage(resource,
                 req.getReader(), connection);
         if (reader == null) {
             // The whole message was not yet received
@@ -632,7 +632,8 @@ public class PushHandler {
                         "Received message for debug window but there is no debug window connection available");
                 return;
             }
-            Reader reader = AtmospherePushConnection.receiveMessage(request,
+            AtmosphereResource resource = request.resource();
+            Reader reader = AtmospherePushConnection.receiveMessage(resource,
                     request.getReader(), liveReload.get());
             if (reader == null) {
                 // The whole message was not yet received
@@ -640,7 +641,7 @@ public class PushHandler {
             }
 
             String msg = IOUtils.toString(reader);
-            liveReload.get().onMessage(request.resource(), msg);
+            liveReload.get().onMessage(resource, msg);
         } catch (IOException e) {
             getLogger().error(
                     "Unable to read contents of debug connection message", e);

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PushHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PushHandler.java
@@ -150,7 +150,8 @@ public class PushHandler {
                 + "connection is kept open or if the UI has a "
                 + "connection of unexpected type.";
 
-        Reader reader = connection.receiveMessage(req.getReader());
+        Reader reader = AtmospherePushConnection.receiveMessage(req,
+                req.getReader(), connection);
         if (reader == null) {
             // The whole message was not yet received
             return;
@@ -624,15 +625,22 @@ public class PushHandler {
 
     private void handleDebugWindowMessage(AtmosphereRequest request) {
         try {
-            String msg = IOUtils.toString(request.getReader());
             Optional<BrowserLiveReload> liveReload = BrowserLiveReloadAccessor
                     .getLiveReloadFromService(service);
-            if (liveReload.isPresent()) {
-                liveReload.get().onMessage(request.resource(), msg);
-            } else {
+            if (!liveReload.isPresent()) {
                 getLogger().error(
                         "Received message for debug window but there is no debug window connection available");
+                return;
             }
+            Reader reader = AtmospherePushConnection.receiveMessage(request,
+                    request.getReader(), liveReload.get());
+            if (reader == null) {
+                // The whole message was not yet received
+                return;
+            }
+
+            String msg = IOUtils.toString(reader);
+            liveReload.get().onMessage(request.resource(), msg);
         } catch (IOException e) {
             getLogger().error(
                     "Unable to read contents of debug connection message", e);

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/FragmentedMessageTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/FragmentedMessageTest.java
@@ -1,0 +1,62 @@
+package com.vaadin.flow.server.communication;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.server.communication.AtmospherePushConnection.FragmentedMessage;
+import com.vaadin.flow.shared.communication.PushConstants;
+
+public class FragmentedMessageTest {
+
+    @Test
+    public void shortMessageCompleteImmediately() throws IOException {
+        FragmentedMessage msg = new FragmentedMessage();
+        Assert.assertTrue(
+                msg.append(new StringReader("Hello".length() + "|" + "Hello")));
+        Assert.assertEquals("Hello", IOUtils.toString(msg.getReader()));
+    }
+
+    @Test
+    public void longMessageConcatenated() throws IOException {
+        FragmentedMessage msg = new FragmentedMessage();
+        String text = "HelloWorld".repeat(1700);
+        String textWithLength = text.length() + "|" + text;
+        String part1 = textWithLength.substring(0,
+                PushConstants.WEBSOCKET_BUFFER_SIZE);
+        String part2 = textWithLength
+                .substring(PushConstants.WEBSOCKET_BUFFER_SIZE);
+
+        Assert.assertEquals(PushConstants.WEBSOCKET_BUFFER_SIZE,
+                part1.length());
+        Assert.assertEquals(
+                textWithLength.length() - PushConstants.WEBSOCKET_BUFFER_SIZE,
+                part2.length());
+
+        StringReader messageReader = new StringReader(part1);
+        Assert.assertFalse(msg.append(messageReader));
+        StringReader messageReader2 = new StringReader(part2);
+        Assert.assertTrue(msg.append(messageReader2));
+        Assert.assertEquals(text, IOUtils.toString(msg.getReader()));
+    }
+
+    @Test
+    public void lengthEqualsLimitHandledCorrectly() throws IOException {
+        FragmentedMessage msg = new FragmentedMessage();
+        int length = (PushConstants.WEBSOCKET_BUFFER_SIZE
+                - String.valueOf(PushConstants.WEBSOCKET_BUFFER_SIZE).length()
+                - 1);
+        String text = "A".repeat(length);
+        String textWithLength = length + "|" + text;
+
+        Assert.assertEquals(PushConstants.WEBSOCKET_BUFFER_SIZE,
+                textWithLength.length());
+
+        StringReader messageReader = new StringReader(textWithLength);
+        Assert.assertTrue(msg.append(messageReader));
+        Assert.assertEquals(text, IOUtils.toString(msg.getReader()));
+    }
+}

--- a/vaadin-dev-server/frontend/websocket-connection.ts
+++ b/vaadin-dev-server/frontend/websocket-connection.ts
@@ -1,5 +1,7 @@
 import { Connection, ConnectionStatus } from './connection';
 
+const WEBSOCKET_FRAGMENT_SIZE = 16384; // This is PushConstants.WEBSOCKET_FRAGMENT_SIZE
+
 export class WebSocketConnection extends Connection {
   static HEARTBEAT_INTERVAL = 180000;
 
@@ -8,7 +10,7 @@ export class WebSocketConnection extends Connection {
   constructor(url: string) {
     super();
     if (!url) {
-        return;
+      return;
     }
 
     const config = {
@@ -89,7 +91,13 @@ export class WebSocketConnection extends Connection {
     }
 
     const message = JSON.stringify({ command, data });
-    this.socket.push(message);
+    const payload = message.length + '|' + message;
+
+    let remaining = payload;
+    while (remaining.length) {
+      this.socket.push(remaining.substring(0, WEBSOCKET_FRAGMENT_SIZE));
+      remaining = remaining.substring(WEBSOCKET_FRAGMENT_SIZE);
+    }
   }
 }
 

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DebugWindowConnection.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DebugWindowConnection.java
@@ -32,7 +32,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.atmosphere.cpr.AtmosphereRequest;
 import org.atmosphere.cpr.AtmosphereResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -385,8 +384,8 @@ public class DebugWindowConnection implements BrowserLiveReload {
 
     @Override
     public FragmentedMessage getOrCreateFragmentedMessage(
-            AtmosphereRequest request, Reader reader) throws IOException {
-        return fragmentedMessages.computeIfAbsent(request.resource(), res -> {
+            AtmosphereResource resource, Reader reader) throws IOException {
+        return fragmentedMessages.computeIfAbsent(resource, res -> {
             try {
                 return new FragmentedMessage(reader);
             } catch (IOException e) {
@@ -397,8 +396,8 @@ public class DebugWindowConnection implements BrowserLiveReload {
     }
 
     @Override
-    public void clearFragmentedMessage(AtmosphereRequest request) {
-        fragmentedMessages.remove(request.resource());
+    public void clearFragmentedMessage(AtmosphereResource resource) {
+        fragmentedMessages.remove(resource);
     }
 
 }

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DebugWindowConnection.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DebugWindowConnection.java
@@ -255,7 +255,7 @@ public class DebugWindowConnection implements BrowserLiveReload {
             plugin.handleDisconnect(getDevToolsInterface(resource));
         }
         if (!resources.keySet()
-                .removeIf(resourceRef -> resourceRef.refersTo(resource))) {
+                .removeIf(resourceRef -> resource.equals(resourceRef.get()))) {
             String uuid = resource.uuid();
             getLogger().warn(
                     "Push connection {} is not a live-reload connection or already closed",
@@ -391,7 +391,7 @@ public class DebugWindowConnection implements BrowserLiveReload {
     private WeakReference<AtmosphereResource> getRef(
             AtmosphereResource resource) {
         return resources.keySet().stream()
-                .filter(resourceRef -> resourceRef.refersTo(resource))
+                .filter(resourceRef -> resource.equals(resourceRef.get())))
                 .findFirst().orElse(null);
     }
 

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DebugWindowConnection.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DebugWindowConnection.java
@@ -16,7 +16,6 @@
 package com.vaadin.base.devserver;
 
 import java.io.IOException;
-import java.io.Reader;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,7 +28,6 @@ import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -385,22 +383,9 @@ public class DebugWindowConnection implements BrowserLiveReload {
 
     @Override
     public FragmentedMessage getOrCreateFragmentedMessage(
-            AtmosphereResource resource, Reader reader) throws IOException {
-        AtomicReference<IOException> exceptionHolder = new AtomicReference<>();
-
-        FragmentedMessage message = fragmentedMessages.computeIfAbsent(resource,
-                res -> {
-                    try {
-                        return new FragmentedMessage(reader);
-                    } catch (IOException e) {
-                        exceptionHolder.set(e);
-                        return null;
-                    }
-                });
-        if (message == null) {
-            throw exceptionHolder.get();
-        }
-        return message;
+            AtmosphereResource resource) {
+        return fragmentedMessages.computeIfAbsent(resource,
+                res -> new FragmentedMessage());
     }
 
     @Override

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DebugWindowConnection.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DebugWindowConnection.java
@@ -255,7 +255,7 @@ public class DebugWindowConnection implements BrowserLiveReload {
             plugin.handleDisconnect(getDevToolsInterface(resource));
         }
         if (!resources.keySet()
-                .removeIf(resourceRef -> resource.equals(resourceRef.get()))) {
+                .removeIf(resourceRef -> resourceRef.refersTo(resource))) {
             String uuid = resource.uuid();
             getLogger().warn(
                     "Push connection {} is not a live-reload connection or already closed",

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DebugWindowConnection.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DebugWindowConnection.java
@@ -391,7 +391,7 @@ public class DebugWindowConnection implements BrowserLiveReload {
     private WeakReference<AtmosphereResource> getRef(
             AtmosphereResource resource) {
         return resources.keySet().stream()
-                .filter(resourceRef -> resource.equals(resourceRef.get())))
+                .filter(resourceRef -> resource.equals(resourceRef.get()))
                 .findFirst().orElse(null);
     }
 


### PR DESCRIPTION
Without this, a message larger than 16KB will cause the connection to close instead of the message being delivered