### PR TITLE
chore: update @vaadin/common-frontend

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/default/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/default/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@polymer/polymer": "3.5.1",
-    "@vaadin/common-frontend": "0.0.18",
+    "@vaadin/common-frontend": "0.0.19",
     "construct-style-sheets-polyfill": "3.1.0",
     "lit": "3.1.0"
   },


### PR DESCRIPTION
Update to v0.0.19, which supports Lit 3.