### PR TITLE
Highlight previous selected component when ESC is pressed

### DIFF
--- a/vaadin-dev-server/frontend/component-picker.ts
+++ b/vaadin-dev-server/frontend/component-picker.ts
@@ -110,9 +110,9 @@ export class ComponentPicker extends LitElement {
     this.dispatchEvent(new CustomEvent('component-picker-opened', {}));
   }
 
-  close() {
+  close(component?: ComponentReference) {
     this.active = false;
-    this.dispatchEvent(new CustomEvent('component-picker-closed', {}));
+    this.dispatchEvent(new CustomEvent('component-picker-closed',  {detail:{selectedComponent: component}}));
   }
 
   update(changedProperties: PropertyValues): void {
@@ -194,7 +194,7 @@ export class ComponentPicker extends LitElement {
         console.error('Pick callback failed', error);
       }
     }
-    this.close();
+    this.close(component);
   }
 
   highlight(componentRef: ComponentReference | undefined) {

--- a/vaadin-dev-server/frontend/theme-editor/components/component-overlay-manager.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/components/component-overlay-manager.test.ts
@@ -153,13 +153,13 @@ describe('component overlay manager', () => {
     it(`Expanding editor must show/hide the overlay for the ${componentDefinition.name}`, async () => {
       const component = await createComponent(componentDefinition.name);
       await pickComponent(component!);
-      editor.expanded = false;
+      editor.removeCurrentSelectedElementHighlight()
       await elementUpdated(editor);
       const overlay = document.getElementsByTagName(componentDefinition.overlayTagName).item(0);
       //waiting overlay to be hidden.
       const openedAttribute = overlay!.hasAttribute('opened');
       expect(openedAttribute).to.be.false;
-      editor.expanded = true;
+      editor.highlightCurrentSelectedElement()
       await elementUpdated(editor);
       await aTimeout(100);
       expect(overlay!.hasAttribute('opened')).to.be.true;

--- a/vaadin-dev-server/frontend/theme-editor/editor.test.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.test.ts
@@ -50,7 +50,6 @@ describe('theme-editor', () => {
     };
     const pickerProvider: PickerProvider = () => pickerMock as any;
     const editor = (await fixture(html` <vaadin-dev-tools-theme-editor
-      .expanded=${true}
       .pickerProvider=${pickerProvider}
       .connection=${connectionMock}
     ></vaadin-dev-tools-theme-editor>`)) as ThemeEditor;
@@ -621,7 +620,8 @@ describe('theme-editor', () => {
     it('should remove highlight when editor is closed', async () => {
       await pickComponent();
 
-      editor.expanded = false;
+      expect(testElement.classList.contains('vaadin-theme-editor-highlight')).to.be.true;
+      editor.removeCurrentSelectedElementHighlight();
       await elementUpdated(editor);
       expect(testElement.classList.contains('vaadin-theme-editor-highlight')).to.be.false;
     });
@@ -629,9 +629,11 @@ describe('theme-editor', () => {
     it('should restore highlight when editor is opened again', async () => {
       await pickComponent();
 
-      editor.expanded = false;
+      expect(testElement.classList.contains('vaadin-theme-editor-highlight')).to.be.true;
+      editor.removeCurrentSelectedElementHighlight();
       await elementUpdated(editor);
-      editor.expanded = true;
+      expect(testElement.classList.contains('vaadin-theme-editor-highlight')).to.be.false;
+      editor.highlightCurrentSelectedElement();
       await elementUpdated(editor);
       expect(testElement.classList.contains('vaadin-theme-editor-highlight')).to.be.true;
     });

--- a/vaadin-dev-server/frontend/theme-editor/editor.ts
+++ b/vaadin-dev-server/frontend/theme-editor/editor.ts
@@ -41,8 +41,6 @@ injectGlobalCss(css`
 @customElement('vaadin-dev-tools-theme-editor')
 export class ThemeEditor extends LitElement {
   @property({})
-  public expanded: boolean = false;
-  @property({})
   public themeEditorState: ThemeEditorState = ThemeEditorState.enabled;
   @property({})
   public pickerProvider!: PickerProvider;
@@ -245,17 +243,16 @@ export class ThemeEditor extends LitElement {
 
   protected update(changedProperties: PropertyValues) {
     super.update(changedProperties);
+  }
 
-    // Remove or restore selected element highlight when expanded state changes
-    if (changedProperties.has('expanded')) {
-      if (this.expanded) {
-        this.highlightElement(this.context?.component.element);
-        componentOverlayManager.showOverlay();
-      } else {
-        componentOverlayManager.hideOverlay();
-        this.removeElementHighlight(this.context?.component.element);
-      }
-    }
+  highlightCurrentSelectedElement() {
+    this.highlightElement(this.context?.component.element);
+    componentOverlayManager.showOverlay();
+  }
+
+  removeCurrentSelectedElementHighlight() {
+    componentOverlayManager.hideOverlay();
+    this.removeElementHighlight(this.context?.component.element);
   }
 
   disconnectedCallback() {

--- a/vaadin-dev-server/frontend/vaadin-dev-tools.ts
+++ b/vaadin-dev-server/frontend/vaadin-dev-tools.ts
@@ -10,6 +10,7 @@ import { ConnectionStatus } from './connection';
 import { LiveReloadConnection } from './live-reload-connection';
 import { popupStyles } from './styles';
 import './theme-editor/editor';
+import { ThemeEditor } from './theme-editor/editor';
 import { ThemeEditorState } from './theme-editor/model';
 import './vaadin-dev-tools-info';
 import './vaadin-dev-tools-log';
@@ -861,6 +862,9 @@ export class VaadinDevTools extends LitElement {
   @query('.window')
   private root!: HTMLElement;
 
+  @query('vaadin-dev-tools-theme-editor')
+  private themeEditor!: ThemeEditor;
+
   @query('vaadin-dev-tools-component-picker')
   private componentPicker!: ComponentPicker;
 
@@ -1148,7 +1152,11 @@ export class VaadinDevTools extends LitElement {
     this.notifications.slice().forEach((notification) => this.dismissNotification(notification.id));
     this.expanded = !this.expanded;
     if (this.expanded) {
+      this.themeEditor.highlightCurrentSelectedElement();
       this.root.focus();
+    }
+    else {
+      this.themeEditor.removeCurrentSelectedElementHighlight();
     }
   }
 
@@ -1417,7 +1425,10 @@ export class VaadinDevTools extends LitElement {
         @component-picker-opened=${() => {
           this.componentPickActive = true;
         }}
-        @component-picker-closed=${() => {
+        @component-picker-closed=${(e: CustomEvent) => {
+          if (!e.detail.selectedComponent) {
+            this.themeEditor.highlightCurrentSelectedElement();
+          }
           this.componentPickActive = false;
         }}
       ></vaadin-dev-tools-component-picker>
@@ -1612,7 +1623,6 @@ export class VaadinDevTools extends LitElement {
 
   renderThemeEditor() {
     return html` <vaadin-dev-tools-theme-editor
-      .expanded=${this.expanded}
       .themeEditorState=${this.themeEditorState}
       .pickerProvider=${() => this.componentPicker}
       .connection=${this.frontendConnection}


### PR DESCRIPTION
## Description

In Theme Editor, when a user selects a component, starts component picker and then presses ESC, the theme editor will be re-opened and the previous selected component will be highlighted. The behavior is similar to what happens when the user closes the dev tools and then re-open it.

Instead of relying on the highlighting behavior to be triggered indirectly when the ThemeEditor.expand property is updated, I exposed methods that must be called to control when the previously selected component must be highlighted. This makes it easier to understand what is happening.

One thing that was not done in this PR, but might be useful, is to remove the highlighting when the dev tools is expanded, but theme editor is not visible.

## Type of change

- [ X ] Bugfix
- [ ] Feature

## Checklist

- [ X ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ X ] I have added a description following the guideline.
- [ X ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ X ] New and existing tests are passing locally with my change.
- [ X ] I have performed self-review and corrected misspellings.
