### PR TITLE
chore: update @vaadin/common-frontend (#18273)(CP: 24.3)

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/default/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/default/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@polymer/polymer": "3.5.1",
-    "@vaadin/common-frontend": "0.0.18",
+    "@vaadin/common-frontend": "0.0.19",
     "construct-style-sheets-polyfill": "3.1.0",
     "lit": "3.1.0"
   },


### PR DESCRIPTION
Update to v0.0.19, which supports Lit 3.

Co-authored-by: Zhe Sun <31067185+ZheSun88@users.noreply.github.com>
(cherry picked from commit 505b7973b766ed1ba57cac9d4cdd9b9d0b0d59d1)
