### PR TITLE
fix: Single request navigation

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -1868,24 +1868,8 @@ public class UI extends Component
         } catch (Exception exception) {
             handleExceptionNavigation(location, exception);
         } finally {
-            FeatureFlags featureFlags;
-            try {
-                featureFlags = FeatureFlags.get(
-                        getInternals().getSession().getService().getContext());
-            } catch (NullPointerException npe) {
-                featureFlags = new FeatureFlags(null) {
-                    @Override
-                    public boolean isEnabled(Feature feature) {
-                        return false;
-                    }
-
-                    @Override
-                    public void loadProperties() {
-                        // NO-OP
-                    }
-                };
-            }
-            if (featureFlags.isEnabled(FeatureFlags.REACT_ROUTER)
+            if (getInternals().getSession().getConfiguration()
+                    .isReactRouterEnabled()
                     && getInternals().getContinueNavigationAction() != null) {
                 getInternals().clearLastHandledNavigation();
             } else {

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -1867,11 +1867,13 @@ public class UI extends Component
         } catch (Exception exception) {
             handleExceptionNavigation(location, exception);
         } finally {
-            if (!FeatureFlags
-                    .get(getInternals().getSession().getService().getContext())
-                    .isEnabled(FeatureFlags.REACT_ROUTER)) {
+            // if (!FeatureFlags
+            // .get(getInternals().getSession().getService().getContext())
+            // .isEnabled(FeatureFlags.REACT_ROUTER)) {
+            if(getInternals().getContinueNavigationAction() != null) {
                 getInternals().clearLastHandledNavigation();
             }
+            // }
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -30,6 +30,7 @@ import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.experimental.Feature;
 import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.internal.AllowInert;
@@ -1867,13 +1868,30 @@ public class UI extends Component
         } catch (Exception exception) {
             handleExceptionNavigation(location, exception);
         } finally {
-            // if (!FeatureFlags
-            // .get(getInternals().getSession().getService().getContext())
-            // .isEnabled(FeatureFlags.REACT_ROUTER)) {
-            if(getInternals().getContinueNavigationAction() != null) {
+            FeatureFlags featureFlags;
+            try {
+                featureFlags = FeatureFlags.get(
+                        getInternals().getSession().getService().getContext());
+            } catch (NullPointerException npe) {
+                featureFlags = new FeatureFlags(null) {
+                    @Override
+                    public boolean isEnabled(Feature feature) {
+                        return false;
+                    }
+
+                    @Override
+                    public void loadProperties() {
+                        // NO-OP
+                    }
+                };
+            }
+            if (featureFlags.isEnabled(FeatureFlags.REACT_ROUTER)
+                    && getInternals().getContinueNavigationAction() != null) {
+                getInternals().clearLastHandledNavigation();
+            } else {
                 getInternals().clearLastHandledNavigation();
             }
-            // }
+
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -30,6 +30,7 @@ import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.internal.AllowInert;
 import com.vaadin.flow.component.internal.JavaScriptNavigationStateRenderer;
@@ -1866,7 +1867,11 @@ public class UI extends Component
         } catch (Exception exception) {
             handleExceptionNavigation(location, exception);
         } finally {
-            getInternals().clearLastHandledNavigation();
+            if (!FeatureFlags
+                    .get(getInternals().getSession().getService().getContext())
+                    .isEnabled(FeatureFlags.REACT_ROUTER)) {
+                getInternals().clearLastHandledNavigation();
+            }
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptNavigationStateRenderer.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.router.BeforeEvent;
 import com.vaadin.flow.router.BeforeLeaveEvent;
@@ -105,7 +106,12 @@ public class JavaScriptNavigationStateRenderer extends NavigationStateRenderer {
                 || NavigationTrigger.ROUTER_LINK.equals(event.getTrigger())) {
             return true;
         } else {
-            return super.shouldPushHistoryState(event);
+            return super.shouldPushHistoryState(event) || (FeatureFlags
+                    .get(event.getUI().getInternals().getSession().getService()
+                            .getContext())
+                    .isEnabled(FeatureFlags.REACT_ROUTER)
+                    && NavigationTrigger.CLIENT_SIDE
+                            .equals(event.getTrigger()));
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptNavigationStateRenderer.java
@@ -106,12 +106,11 @@ public class JavaScriptNavigationStateRenderer extends NavigationStateRenderer {
                 || NavigationTrigger.ROUTER_LINK.equals(event.getTrigger())) {
             return true;
         } else {
-            return super.shouldPushHistoryState(event) || (FeatureFlags
-                    .get(event.getUI().getInternals().getSession().getService()
-                            .getContext())
-                    .isEnabled(FeatureFlags.REACT_ROUTER)
-                    && NavigationTrigger.CLIENT_SIDE
-                            .equals(event.getTrigger()));
+            return super.shouldPushHistoryState(event)
+                    || (event.getUI().getInternals().getSession()
+                            .getConfiguration().isReactRouterEnabled()
+                            && NavigationTrigger.CLIENT_SIDE
+                                    .equals(event.getTrigger()));
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptNavigationStateRenderer.java
@@ -106,6 +106,9 @@ public class JavaScriptNavigationStateRenderer extends NavigationStateRenderer {
                 || NavigationTrigger.ROUTER_LINK.equals(event.getTrigger())) {
             return true;
         } else {
+            // For react router the server should push history state for
+            // server rendering even when client previously updated url with
+            // vaadin-router.
             return super.shouldPushHistoryState(event)
                     || (event.getUI().getInternals().getSession()
                             .getConfiguration().isReactRouterEnabled()

--- a/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
@@ -325,4 +325,15 @@ public interface DeploymentConfiguration
      * @return the lock checking strategy, never null.
      */
     SessionLockCheckStrategy getSessionLockCheckStrategy();
+
+    /**
+     * Check if the React Router is enabled for the project instead of Vaadin
+     * router.
+     *
+     * @return {@code true} if React Router is used
+     */
+    default boolean isReactRouterEnabled() {
+        return getBooleanProperty(InitParameters.SERVLET_PARAMETER_INITIAL_UIDL,
+                false);
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
@@ -333,7 +333,6 @@ public interface DeploymentConfiguration
      * @return {@code true} if React Router is used
      */
     default boolean isReactRouterEnabled() {
-        return getBooleanProperty(InitParameters.SERVLET_PARAMETER_INITIAL_UIDL,
-                false);
+        return getBooleanProperty(InitParameters.REACT_ROUTER_ENABLED, false);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -272,35 +272,12 @@ public abstract class AbstractNavigationStateRenderer
             }
 
             ui.getInternals().setLastHandledNavigation(event.getLocation());
-        } else if (getFeatureFlags(event)
-                .isEnabled(FeatureFlags.REACT_ROUTER)) {
-
+        } else if (ui.getInternals().getSession().getConfiguration()
+                .isReactRouterEnabled()) {
             if (shouldPushHistoryState(event)) {
                 pushHistoryState(event);
             }
         }
-    }
-
-    private FeatureFlags getFeatureFlags(NavigationEvent event) {
-
-        FeatureFlags featureFlags;
-        try {
-            featureFlags = FeatureFlags.get(event.getUI().getInternals()
-                    .getSession().getService().getContext());
-        } catch (NullPointerException npe) {
-            featureFlags = new FeatureFlags(null) {
-                @Override
-                public boolean isEnabled(Feature feature) {
-                    return false;
-                }
-
-                @Override
-                public void loadProperties() {
-                    // NO-OP
-                }
-            };
-        }
-        return featureFlags;
     }
 
     protected void pushHistoryState(NavigationEvent event) {

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import com.vaadin.experimental.Feature;
 import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
@@ -271,14 +272,35 @@ public abstract class AbstractNavigationStateRenderer
             }
 
             ui.getInternals().setLastHandledNavigation(event.getLocation());
-        } else if (FeatureFlags.get(event.getUI().getInternals().getSession()
-                .getService().getContext())
+        } else if (getFeatureFlags(event)
                 .isEnabled(FeatureFlags.REACT_ROUTER)) {
 
             if (shouldPushHistoryState(event)) {
                 pushHistoryState(event);
             }
         }
+    }
+
+    private FeatureFlags getFeatureFlags(NavigationEvent event) {
+
+        FeatureFlags featureFlags;
+        try {
+            featureFlags = FeatureFlags.get(event.getUI().getInternals()
+                    .getSession().getService().getContext());
+        } catch (NullPointerException npe) {
+            featureFlags = new FeatureFlags(null) {
+                @Override
+                public boolean isEnabled(Feature feature) {
+                    return false;
+                }
+
+                @Override
+                public void loadProperties() {
+                    // NO-OP
+                }
+            };
+        }
+        return featureFlags;
     }
 
     protected void pushHistoryState(NavigationEvent event) {

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -288,13 +288,7 @@ public abstract class AbstractNavigationStateRenderer
     }
 
     protected boolean shouldPushHistoryState(NavigationEvent event) {
-        return NavigationTrigger.UI_NAVIGATE.equals(event.getTrigger())
-                || (FeatureFlags
-                        .get(event.getUI().getInternals().getSession()
-                                .getService().getContext())
-                        .isEnabled(FeatureFlags.REACT_ROUTER)
-                        && NavigationTrigger.CLIENT_SIDE
-                                .equals(event.getTrigger()));
+        return NavigationTrigger.UI_NAVIGATE.equals(event.getTrigger());
     }
 
     private boolean isRouterLinkNotFoundNavigationError(

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.UI;
@@ -270,6 +271,13 @@ public abstract class AbstractNavigationStateRenderer
             }
 
             ui.getInternals().setLastHandledNavigation(event.getLocation());
+        } else if (FeatureFlags.get(event.getUI().getInternals().getSession()
+                .getService().getContext())
+                .isEnabled(FeatureFlags.REACT_ROUTER)) {
+
+            if (shouldPushHistoryState(event)) {
+                pushHistoryState(event);
+            }
         }
     }
 
@@ -280,7 +288,13 @@ public abstract class AbstractNavigationStateRenderer
     }
 
     protected boolean shouldPushHistoryState(NavigationEvent event) {
-        return NavigationTrigger.UI_NAVIGATE.equals(event.getTrigger());
+        return NavigationTrigger.UI_NAVIGATE.equals(event.getTrigger())
+                || (FeatureFlags
+                        .get(event.getUI().getInternals().getSession()
+                                .getService().getContext())
+                        .isEnabled(FeatureFlags.REACT_ROUTER)
+                        && NavigationTrigger.CLIENT_SIDE
+                                .equals(event.getTrigger()));
     }
 
     private boolean isRouterLinkNotFoundNavigationError(

--- a/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
@@ -21,13 +21,16 @@ import java.util.Enumeration;
 import java.util.Map;
 import java.util.Properties;
 
+import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.server.startup.AbstractConfigurationFactory;
 import com.vaadin.flow.server.startup.ApplicationConfiguration;
 
 import elemental.json.JsonObject;
 import elemental.json.impl.JsonUtil;
+import static com.vaadin.flow.server.InitParameters.REACT_ROUTER_ENABLED;
 
 /**
  * Creates {@link DeploymentConfiguration} filled with all parameters specified
@@ -105,7 +108,6 @@ public class DeploymentConfigurationFactory extends AbstractConfigurationFactory
     private void readBuildInfo(Properties initParameters,
             VaadinContext context) {
         String json = getTokenFileContent(initParameters::getProperty);
-
         // Read the json and set the appropriate system properties if not
         // already set.
         if (json != null) {
@@ -118,6 +120,18 @@ public class DeploymentConfigurationFactory extends AbstractConfigurationFactory
                     initParameters.put(entry.getKey(), entry.getValue());
                 }
             }
+        }
+
+        if (!initParameters.containsKey(REACT_ROUTER_ENABLED)) {
+            // TODO: When not a feature flag remember to synchronize with
+            // NodeTasks!!
+            // This is set immediately, but a marking in the token file may
+            // override this.
+            // But mainly this is now dictated by the feature flag setting.
+            initParameters.put(REACT_ROUTER_ENABLED,
+                    String.valueOf(
+                            new FeatureFlags(context.getAttribute(Lookup.class))
+                                    .isEnabled(FeatureFlags.REACT_ROUTER)));
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
@@ -16,7 +16,6 @@
 
 package com.vaadin.flow.server;
 
-import java.io.File;
 import java.io.Serializable;
 import java.util.Enumeration;
 import java.util.Map;
@@ -129,8 +128,10 @@ public class DeploymentConfigurationFactory extends AbstractConfigurationFactory
             // This is set immediately, but a marking in the token file may
             // override this.
             // But mainly this is now dictated by the feature flag setting.
-            initParameters.put(REACT_ROUTER_ENABLED, String.valueOf(FeatureFlags
-                    .get(context).isEnabled(FeatureFlags.REACT_ROUTER)));
+            initParameters.put(REACT_ROUTER_ENABLED,
+                    String.valueOf(
+                            new FeatureFlags(context.getAttribute(Lookup.class))
+                                    .isEnabled(FeatureFlags.REACT_ROUTER)));
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
@@ -16,6 +16,7 @@
 
 package com.vaadin.flow.server;
 
+import java.io.File;
 import java.io.Serializable;
 import java.util.Enumeration;
 import java.util.Map;
@@ -128,10 +129,8 @@ public class DeploymentConfigurationFactory extends AbstractConfigurationFactory
             // This is set immediately, but a marking in the token file may
             // override this.
             // But mainly this is now dictated by the feature flag setting.
-            initParameters.put(REACT_ROUTER_ENABLED,
-                    String.valueOf(
-                            new FeatureFlags(context.getAttribute(Lookup.class))
-                                    .isEnabled(FeatureFlags.REACT_ROUTER)));
+            initParameters.put(REACT_ROUTER_ENABLED, String.valueOf(FeatureFlags
+                    .get(context).isEnabled(FeatureFlags.REACT_ROUTER)));
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -65,6 +65,7 @@ public class InitParameters implements Serializable {
     public static final String SERVLET_PARAMETER_POLYFILLS = "module.polyfills";
     public static final String NODE_VERSION = "node.version";
     public static final String NODE_DOWNLOAD_ROOT = "node.download.root";
+    public static final String REACT_ROUTER_ENABLED = "enable.react.router";
 
     /**
      * Configuration name for the parameter that determines whether Brotli

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
@@ -80,6 +80,12 @@ public class TaskGenerateReactFiles implements FallibleCommand {
                   },
                 ] as RouteObject[];
             """;
+    protected static String MISSING_ROUTES_EXPORT = """
+            Routes need to be exported as 'routes' for server navigation handling.
+            routes.tsx should at least contain
+            'export const routes = [...serverSideRoutes] as RouteObject[];'
+            but can have react routes also defined.
+            """;
 
     /**
      * Create a task to generate <code>index.js</code> if necessary.
@@ -114,6 +120,9 @@ public class TaskGenerateReactFiles implements FallibleCommand {
                 if (!serverImport.matcher(routesContent).find()) {
                     throw new ExecutionFailedException(
                             String.format(NO_IMPORT, routesTsx.getPath()));
+                }
+                if (!routesContent.contains("export const routes")) {
+                    throw new ExecutionFailedException(MISSING_ROUTES_EXPORT);
                 }
             }
         } catch (IOException e) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractConfigurationFactory.java
@@ -49,6 +49,7 @@ import static com.vaadin.flow.server.InitParameters.BUILD_FOLDER;
 import static com.vaadin.flow.server.InitParameters.FRONTEND_HOTDEPLOY;
 import static com.vaadin.flow.server.InitParameters.NODE_DOWNLOAD_ROOT;
 import static com.vaadin.flow.server.InitParameters.NODE_VERSION;
+import static com.vaadin.flow.server.InitParameters.REACT_ROUTER_ENABLED;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_ENABLE_DEV_SERVER;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_INITIAL_UIDL;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE;
@@ -165,6 +166,10 @@ public class AbstractConfigurationFactory implements Serializable {
         if (buildInfo.hasKey(DISABLE_PREPARE_FRONTEND_CACHE)) {
             UsageStatistics.markAsUsed("flow/always-execute-prepare-frontend",
                     null);
+        }
+        if (buildInfo.hasKey(REACT_ROUTER_ENABLED)) {
+            params.put(REACT_ROUTER_ENABLED,
+                    String.valueOf(buildInfo.getBoolean(REACT_ROUTER_ENABLED)));
         }
 
         setDevModePropertiesUsingTokenData(params, buildInfo);

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -145,6 +145,8 @@ function navigateEventHandler(event) {
     // @ts-ignore
     let matched = matchRoutes(routes, event.detail.pathname);
 
+    // if navigation event route targets a flow view do beforeEnter for the
+    // target path. Server will then handle updates and postpone as needed.
     if(matched?.length == 1 && matched[0].route.path === "/*") {
         if (mountedContainer?.onBeforeEnter) {
             mountedContainer.onBeforeEnter(
@@ -157,7 +159,6 @@ function navigateEventHandler(event) {
                     },
                     // @ts-ignore
                     redirect: (path) => {
-                        // window.history.pushState({}, "", path);
                         navigation(path, {replace: false});
                     }
                 },
@@ -165,11 +166,14 @@ function navigateEventHandler(event) {
             );
         }
     } else {
+        // Navigating to a non flow view. If beforeLeave set call that before
+        // navigation. If not postponed clear + navigate will be executed.
         if (mountedContainer?.onBeforeLeave) {
             mountedContainer?.onBeforeLeave({pathname: event.detail.pathname, search: event.detail.search}, {
                 prevent() {},
             }, router);
         } else {
+            // Navigate to a non flow view. Clean nodes and undefine container.
             mountedContainer?.parentNode?.removeChild(mountedContainer);
             mountedContainer = undefined;
             navigation(event.detail.pathname, {replace: false});

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -15,7 +15,8 @@
  */
 import { Flow as _Flow } from "Frontend/generated/jar-resources/Flow.js";
 import { useEffect, useRef } from "react";
-import { NavigateFunction, useLocation, useNavigate } from "react-router-dom";
+import { matchPath, matchRoutes, NavigateFunction, useLocation, useNavigate } from "react-router-dom";
+import { routes } from "Frontend/routes.js";
 
 const flow = new _Flow({
     imports: () => import("Frontend/generated/flow/generated-flow-imports.js")
@@ -138,13 +139,41 @@ function navigateEventHandler(event) {
     if (event && event.preventDefault) {
         event.preventDefault();
     }
+    if(matchPath(event.detail.pathname, window.location.pathname)) {
+        return;
+    }
+    // @ts-ignore
+    let matched = matchRoutes(routes, event.detail.pathname);
 
-    if (mountedContainer?.onBeforeLeave) {
-        mountedContainer?.onBeforeLeave({pathname: event.detail.pathname, search: event.detail.search}, {
-            prevent() {},
-        }, router);
+    if(matched?.length == 1 && matched[0].route.path === "/*") {
+        if (mountedContainer?.onBeforeEnter) {
+            mountedContainer.onBeforeEnter(
+                {
+                    pathname: event.detail.pathname,
+                    search: event.detail.search
+                },
+                {
+                    prevent() {
+                    },
+                    // @ts-ignore
+                    redirect: (path) => {
+                        // window.history.pushState({}, "", path);
+                        navigation(path, {replace: false});
+                    }
+                },
+                router,
+            );
+        }
     } else {
-        navigation(event.detail.pathname, {replace: false})
+        if (mountedContainer?.onBeforeLeave) {
+            mountedContainer?.onBeforeLeave({pathname: event.detail.pathname, search: event.detail.search}, {
+                prevent() {},
+            }, router);
+        } else {
+            mountedContainer?.parentNode?.removeChild(mountedContainer);
+            mountedContainer = undefined;
+            navigation(event.detail.pathname, {replace: false});
+        }
     }
 }
 
@@ -174,13 +203,6 @@ export default function Flow() {
             }
         });
         return () => {
-            if (mountedContainer?.onBeforeLeave) {
-                mountedContainer?.onBeforeLeave({pathname, search}, {
-                    prevent() {},
-                }, router);
-            }
-            mountedContainer?.parentNode?.removeChild(mountedContainer);
-            mountedContainer = undefined;
             window.document.removeEventListener('click', vaadinRouterGlobalClickHandler);
             window.removeEventListener('vaadin-router-go', navigateEventHandler);
         };

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
@@ -26,6 +26,7 @@ import com.vaadin.flow.component.page.History;
 import com.vaadin.flow.component.page.Page;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.impl.BasicElementStateProvider;
+import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.CurrentInstance;
 import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.internal.StateTree;
@@ -391,6 +392,13 @@ public class JavaScriptBootstrapUITest {
         Page page = mockPage();
 
         UIInternals internals = mockUIInternals();
+
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        DeploymentConfiguration configuration = Mockito
+                .mock(DeploymentConfiguration.class);
+        Mockito.when(internals.getSession()).thenReturn(session);
+        Mockito.when(session.getConfiguration()).thenReturn(configuration);
+        Mockito.when(configuration.isReactRouterEnabled()).thenReturn(false);
 
         Mockito.when(internals.hasLastHandledLocation()).thenReturn(true);
         Location lastLocation = new Location("clean");

--- a/flow-server/src/test/java/com/vaadin/flow/server/DeploymentConfigurationFactoryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DeploymentConfigurationFactoryTest.java
@@ -278,14 +278,15 @@ public class DeploymentConfigurationFactoryTest {
     }
 
     @Test
-    public void createInitParameters_valuesFromContextAreIgnored_valuesAreTakenFromservletConfig()
-            throws Exception {
+    public void createInitParameters_valuesFromContextAreIgnored_valuesAreTakenFromservletConfig() {
         DeploymentConfigurationFactory factory = new DeploymentConfigurationFactory();
 
         VaadinContext context = Mockito.mock(VaadinContext.class);
         VaadinConfig config = Mockito.mock(VaadinConfig.class);
 
         Mockito.when(config.getVaadinContext()).thenReturn(context);
+        Mockito.when(context.getAttribute(Lookup.class))
+                .thenReturn(Mockito.mock(Lookup.class));
 
         ApplicationConfiguration appConfig = Mockito
                 .mock(ApplicationConfiguration.class);
@@ -339,6 +340,12 @@ public class DeploymentConfigurationFactoryTest {
                 .equals(InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE));
         Mockito.when(config.getConfigParameterNames())
                 .thenReturn(Collections.enumeration(allParamsList));
+
+        VaadinContext context = Mockito.mock(VaadinContext.class);
+
+        Mockito.when(config.getVaadinContext()).thenReturn(context);
+        Mockito.when(context.getAttribute(Lookup.class))
+                .thenReturn(Mockito.mock(Lookup.class));
 
         Properties parameters = factory.createInitParameters(Object.class,
                 config);
@@ -422,6 +429,12 @@ public class DeploymentConfigurationFactoryTest {
         VaadinConfig config = mockTokenFileViaContextParam(
                 "{ 'externalStatsUrl': 'http://my.server/static/stats.json'}");
 
+        VaadinContext context = Mockito.mock(VaadinContext.class);
+
+        Mockito.when(config.getVaadinContext()).thenReturn(context);
+        Mockito.when(context.getAttribute(Lookup.class))
+                .thenReturn(Mockito.mock(Lookup.class));
+
         Properties parameters = factory.createInitParameters(Object.class,
                 config);
 
@@ -439,6 +452,12 @@ public class DeploymentConfigurationFactoryTest {
         VaadinConfig config = mockTokenFileViaContextParam(
                 "{ 'externalStatsFile': true}");
 
+        VaadinContext context = Mockito.mock(VaadinContext.class);
+
+        Mockito.when(config.getVaadinContext()).thenReturn(context);
+        Mockito.when(context.getAttribute(Lookup.class))
+                .thenReturn(Mockito.mock(Lookup.class));
+
         Properties parameters = factory.createInitParameters(Object.class,
                 config);
 
@@ -453,6 +472,12 @@ public class DeploymentConfigurationFactoryTest {
 
         VaadinConfig config = mockTokenFileViaContextParam(
                 "{ '" + SERVLET_PARAMETER_PRODUCTION_MODE + "': true}");
+
+        VaadinContext context = Mockito.mock(VaadinContext.class);
+
+        Mockito.when(config.getVaadinContext()).thenReturn(context);
+        Mockito.when(context.getAttribute(Lookup.class))
+                .thenReturn(Mockito.mock(Lookup.class));
 
         Properties parameters = factory.createInitParameters(Object.class,
                 config);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateReactFilesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateReactFilesTest.java
@@ -138,4 +138,80 @@ public class TaskGenerateReactFilesTest {
         Assert.assertEquals(String.format(TaskGenerateReactFiles.NO_IMPORT,
                 routesTsx.getPath()), exception.getMessage());
     }
+
+    @Test
+    public void routesContainsRoutesExport_noExpectionThrown()
+            throws IOException, ExecutionFailedException {
+        String content = """
+                        import HelloWorldView from 'Frontend/views/helloworld/HelloWorldView.js';
+                        import MainLayout from 'Frontend/views/MainLayout.js';
+                        import { lazy } from 'react';
+                        import { createBrowserRouter, RouteObject } from 'react-router-dom';
+                        import {serverSideRoutes} from "Frontend/generated/flow/Flow";
+                        import {protectRoutes} from "@hilla/react-auth";
+                        import LoginView from "Frontend/views/LoginView";
+
+                        const AboutView = lazy(async () => import('Frontend/views/about/AboutView.js'));
+
+                                export const routes: RouteObject[] = protectRoutes([
+                                        {
+                                                element: <MainLayout />,
+                                        handle: { title: 'Main' },
+                                children: [
+                                { path: '/', element: <HelloWorldView />, handle: { title: 'Hello World', rolesAllowed: ['USER'] } },
+                                { path: '/about', element: <AboutView />, handle: { title: 'About' } },
+                              ...serverSideRoutes
+                            ],
+                          },
+                                { path: '/login', element: <LoginView />},
+                        ]);
+
+                        export default createBrowserRouter(routes);
+                """;
+
+        FileUtils.write(routesTsx, content, StandardCharsets.UTF_8);
+
+        TaskGenerateReactFiles task = new TaskGenerateReactFiles(options);
+
+        task.execute();
+    }
+
+    @Test
+    public void routesexportMissing_expectionThrown() throws IOException {
+        String content = """
+                        import HelloWorldView from 'Frontend/views/helloworld/HelloWorldView.js';
+                        import MainLayout from 'Frontend/views/MainLayout.js';
+                        import { lazy } from 'react';
+                        import { createBrowserRouter, RouteObject } from 'react-router-dom';
+                        import {serverSideRoutes} from "Frontend/generated/flow/Flow";
+                        import {protectRoutes} from "@hilla/react-auth";
+                        import LoginView from "Frontend/views/LoginView";
+
+                        const AboutView = lazy(async () => import('Frontend/views/about/AboutView.js'));
+
+                                const routes: RouteObject[] = protectRoutes([
+                                        {
+                                                element: <MainLayout />,
+                                        handle: { title: 'Main' },
+                                children: [
+                                { path: '/', element: <HelloWorldView />, handle: { title: 'Hello World', rolesAllowed: ['USER'] } },
+                                { path: '/about', element: <AboutView />, handle: { title: 'About' } },
+                              ...serverSideRoutes
+                            ],
+                          },
+                                { path: '/login', element: <LoginView />},
+                        ]);
+
+                        export default createBrowserRouter(routes);
+                """;
+
+        FileUtils.write(routesTsx, content, StandardCharsets.UTF_8);
+
+        TaskGenerateReactFiles task = new TaskGenerateReactFiles(options);
+
+        Exception exception = Assert.assertThrows(
+                ExecutionFailedException.class, () -> task.execute());
+        Assert.assertEquals(TaskGenerateReactFiles.MISSING_ROUTES_EXPORT,
+                exception.getMessage());
+    }
 }

--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -332,6 +332,7 @@
                 <module>test-custom-frontend-directory</module>
 
                 <module>vaadin-spring-tests</module>
+                <module>test-react-router</module>
             </modules>
         </profile>
         <profile>

--- a/flow-tests/test-react-router/pom.xml
+++ b/flow-tests/test-react-router/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>flow-tests</artifactId>
+        <groupId>com.vaadin</groupId>
+        <version>24.4-SNAPSHOT</version>
+    </parent>
+    <artifactId>flow-test-react-router</artifactId>
+    <name>Flow tests for routing using react-router</name>
+
+    <packaging>war</packaging>
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-test-resources</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-dev-server</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-html-components-testbench</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-test-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>flow-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-frontend</goal>
+                        </goals>
+                        <phase>compile</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- This module is mapped to default web context -->
+            <plugin>
+                <groupId>org.eclipse.jetty.ee10</groupId>
+                <artifactId>jetty-ee10-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/flow-tests/test-react-router/src/main/java/com/vaadin/flow/StateView.java
+++ b/flow-tests/test-react-router/src/main/java/com/vaadin/flow/StateView.java
@@ -1,0 +1,44 @@
+package com.vaadin.flow;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.FileUtils;
+
+import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.Route;
+
+@Route("com.vaadin.flow.StateView")
+public class StateView extends Div {
+    protected static String ENABLED_SPAN = "enabled";
+    protected static String REACT_SPAN = "react_added";
+
+    public void StateView()  {
+    }
+
+    @Override
+    protected void onAttach(AttachEvent attachEvent)  {
+        Span enabled = new Span("React enabled: " +
+                getUI().get().getSession().getConfiguration()
+                        .isReactRouterEnabled());
+        enabled.setId(ENABLED_SPAN);
+
+        File baseDir = new File(System.getProperty("user.dir", "."));
+        String packageJson = null;
+        try {
+            packageJson = FileUtils.readFileToString(
+                    new File(baseDir, "package.json"), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            packageJson = "";
+        }
+
+        Span react = new Span("React found: " + packageJson.contains("react"));
+        react.setId(REACT_SPAN);
+
+        add(enabled, new Div(), react);
+    }
+
+}

--- a/flow-tests/test-react-router/src/main/java/com/vaadin/flow/StateView.java
+++ b/flow-tests/test-react-router/src/main/java/com/vaadin/flow/StateView.java
@@ -5,6 +5,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.html.Div;
@@ -13,6 +15,7 @@ import com.vaadin.flow.router.Route;
 
 @Route("com.vaadin.flow.StateView")
 public class StateView extends Div {
+    private static final Logger log = LoggerFactory.getLogger(StateView.class);
     protected static String ENABLED_SPAN = "enabled";
     protected static String REACT_SPAN = "react_added";
 
@@ -30,7 +33,9 @@ public class StateView extends Div {
         try {
             packageJson = FileUtils.readFileToString(
                     new File(baseDir, "package.json"), StandardCharsets.UTF_8);
+            log.info("Read package.json from {}", baseDir.getPath());
         } catch (IOException e) {
+            log.error("Could not read package.json", e);
             packageJson = "";
         }
 

--- a/flow-tests/test-react-router/src/main/java/com/vaadin/flow/StateView.java
+++ b/flow-tests/test-react-router/src/main/java/com/vaadin/flow/StateView.java
@@ -16,14 +16,13 @@ public class StateView extends Div {
     protected static String ENABLED_SPAN = "enabled";
     protected static String REACT_SPAN = "react_added";
 
-    public void StateView()  {
+    public void StateView() {
     }
 
     @Override
-    protected void onAttach(AttachEvent attachEvent)  {
-        Span enabled = new Span("React enabled: " +
-                getUI().get().getSession().getConfiguration()
-                        .isReactRouterEnabled());
+    protected void onAttach(AttachEvent attachEvent) {
+        Span enabled = new Span("React enabled: " + getUI().get().getSession()
+                .getConfiguration().isReactRouterEnabled());
         enabled.setId(ENABLED_SPAN);
 
         File baseDir = new File(System.getProperty("user.dir", "."));

--- a/flow-tests/test-react-router/src/main/java/com/vaadin/flow/StateView.java
+++ b/flow-tests/test-react-router/src/main/java/com/vaadin/flow/StateView.java
@@ -28,7 +28,8 @@ public class StateView extends Div {
                 .getConfiguration().isReactRouterEnabled());
         enabled.setId(ENABLED_SPAN);
 
-        File baseDir = new File(System.getProperty("user.dir", "."));
+        File baseDir = attachEvent.getSession().getConfiguration()
+                .getProjectFolder();
         String packageJson = null;
         try {
             packageJson = FileUtils.readFileToString(

--- a/flow-tests/test-react-router/src/main/resources/vaadin-featureflags.properties
+++ b/flow-tests/test-react-router/src/main/resources/vaadin-featureflags.properties
@@ -1,0 +1,2 @@
+# React router support
+com.vaadin.experimental.reactRouter=true

--- a/flow-tests/test-react-router/src/test/java/com/vaadin/flow/StateIT.java
+++ b/flow-tests/test-react-router/src/test/java/com/vaadin/flow/StateIT.java
@@ -14,12 +14,16 @@ public class StateIT extends ChromeBrowserTest {
 
         waitForDevServer();
 
-        SpanElement reactEnabled = $(SpanElement.class).id(StateView.ENABLED_SPAN);
-        Assert.assertEquals("React not enabled", "React enabled: true", reactEnabled.getText());
+        SpanElement reactEnabled = $(SpanElement.class)
+                .id(StateView.ENABLED_SPAN);
+        Assert.assertEquals("React not enabled", "React enabled: true",
+                reactEnabled.getText());
 
-        SpanElement reactInPackage = $(SpanElement.class).id(StateView.REACT_SPAN);
+        SpanElement reactInPackage = $(SpanElement.class)
+                .id(StateView.REACT_SPAN);
 
-        Assert.assertEquals("No react found in package.json", "React found: true", reactInPackage.getText());
+        Assert.assertEquals("No react found in package.json",
+                "React found: true", reactInPackage.getText());
     }
 
 }

--- a/flow-tests/test-react-router/src/test/java/com/vaadin/flow/StateIT.java
+++ b/flow-tests/test-react-router/src/test/java/com/vaadin/flow/StateIT.java
@@ -1,0 +1,25 @@
+package com.vaadin.flow;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.html.testbench.SpanElement;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class StateIT extends ChromeBrowserTest {
+
+    @Test
+    public void validateReactInUse() {
+        open();
+
+        waitForDevServer();
+
+        SpanElement reactEnabled = $(SpanElement.class).id(StateView.ENABLED_SPAN);
+        Assert.assertEquals("React not enabled", "React enabled: true", reactEnabled.getText());
+
+        SpanElement reactInPackage = $(SpanElement.class).id(StateView.REACT_SPAN);
+
+        Assert.assertEquals("No react found in package.json", "React found: true", reactInPackage.getText());
+    }
+
+}


### PR DESCRIPTION
Only one request sent to the
server for flow navigation
so that the request contains
removals and adds in the same
query.
