### PR TITLE
chore: replace deprecated Vite config options

### DIFF
--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -748,8 +748,8 @@ export const vaadinConfig: UserConfigFn = (env) => {
       {
         name: 'vaadin:force-remove-html-middleware',
         transformIndexHtml: {
-          enforce: 'pre',
-          transform(_html, { server }) {
+          order: 'pre',
+          handler(_html, { server }) {
             if (server && !spaMiddlewareForceRemoved) {
               server.middlewares.stack = server.middlewares.stack.filter((mw) => {
                 const handleName = '' + mw.handle;
@@ -763,8 +763,8 @@ export const vaadinConfig: UserConfigFn = (env) => {
       hasExportedWebComponents && {
         name: 'vaadin:inject-entrypoints-to-web-component-html',
         transformIndexHtml: {
-          enforce: 'pre',
-          transform(_html, { path, server }) {
+          order: 'pre',
+          handler(_html, { path, server }) {
             if (path !== '/web-component.html') {
               return;
             }
@@ -782,8 +782,8 @@ export const vaadinConfig: UserConfigFn = (env) => {
       {
         name: 'vaadin:inject-entrypoints-to-index-html',
         transformIndexHtml: {
-          enforce: 'pre',
-          transform(_html, { path, server }) {
+          order: 'pre',
+          handler(_html, { path, server }) {
             if (path !== '/index.html') {
               return;
             }


### PR DESCRIPTION
Running Vite currently results in the following warnings being logged:
```
2023-12-13T15:07:59.034+01:00  INFO 69460 --- [onPool-worker-3] c.v.b.devserver.AbstractDevServerRunner  : Running Vite to compile frontend resources. This may take a moment, please stand by...
2023-12-13T15:07:59.837+01:00  INFO 69460 --- [v-server-output] c.v.b.devserver.DevServerOutputTracker   : plugin 'vaadin:force-remove-html-middleware' uses deprecated 'enforce' option. Use 'order' option instead.
2023-12-13T15:07:59.837+01:00  INFO 69460 --- [v-server-output] c.v.b.devserver.DevServerOutputTracker   : plugin 'vaadin:force-remove-html-middleware' uses deprecated 'transform' option. Use 'handler' option instead.
2023-12-13T15:07:59.837+01:00  INFO 69460 --- [v-server-output] c.v.b.devserver.DevServerOutputTracker   : plugin 'vaadin:inject-entrypoints-to-index-html' uses deprecated 'enforce' option. Use 'order' option instead.
2023-12-13T15:07:59.837+01:00  INFO 69460 --- [v-server-output] c.v.b.devserver.DevServerOutputTracker   : plugin 'vaadin:inject-entrypoints-to-index-html' uses deprecated 'transform' option. Use 'handler' option instead.
```

This updates the Vite config template and replaces the deprecated options with their newer replacements. Used this for reference: https://vitejs.dev/guide/api-plugin.html#transformindexhtml

Fixes https://github.com/vaadin/flow/issues/18098