### PR TITLE
fix: delay web-component bootstrap during dev-bundle creation

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -333,8 +333,8 @@ public abstract class VaadinService implements Serializable {
         handlers.add(new StreamRequestHandler());
         handlers.add(new PwaHandler(() -> getPwaRegistry()));
 
-        handlers.add(new WebComponentProvider());
         handlers.add(new WebComponentBootstrapHandler());
+        handlers.add(new WebComponentProvider());
 
         return handlers;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
@@ -36,6 +36,7 @@ import com.vaadin.flow.internal.DevModeHandlerManager;
 import com.vaadin.flow.server.communication.FaviconHandler;
 import com.vaadin.flow.server.communication.IndexHtmlRequestHandler;
 import com.vaadin.flow.server.communication.PushRequestHandler;
+import com.vaadin.flow.server.communication.WebComponentProvider;
 import com.vaadin.flow.server.startup.ApplicationRouteRegistry;
 import com.vaadin.flow.shared.ApplicationConstants;
 
@@ -89,7 +90,15 @@ public class VaadinServletService extends VaadinService {
             Optional<DevModeHandler> handlerManager = DevModeHandlerManager
                     .getDevModeHandler(this);
             if (handlerManager.isPresent()) {
-                handlers.add(handlerManager.get());
+                DevModeHandler devModeHandler = handlerManager.get();
+                // WebComponentProvider handler should run before DevModeHandler
+                // to avoid responding with html contents when dev bundle is
+                // not ready (e.g. dev-mode-not-ready.html)
+                handlers.stream().filter(WebComponentProvider.class::isInstance)
+                        .findFirst().map(handlers::indexOf)
+                        .ifPresentOrElse(idx -> {
+                            handlers.add(idx, devModeHandler);
+                        }, () -> handlers.add(devModeHandler));
             } else if (mode == Mode.DEVELOPMENT_FRONTEND_LIVERELOAD) {
                 getLogger()
                         .warn("no DevModeHandlerManager implementation found "

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
@@ -15,10 +15,6 @@
  */
 package com.vaadin.flow.server.communication;
 
-import static com.vaadin.flow.server.frontend.FrontendUtils.EXPORT_CHUNK;
-import static com.vaadin.flow.shared.ApplicationConstants.CONTENT_TYPE_TEXT_JAVASCRIPT_UTF_8;
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
@@ -28,7 +24,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.regex.Pattern;
@@ -59,8 +55,6 @@ import com.vaadin.flow.server.VaadinResponse;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.server.VaadinSession;
-import com.vaadin.flow.server.frontend.BundleUtils;
-import com.vaadin.flow.server.frontend.DevBundleUtils;
 import com.vaadin.flow.server.frontend.FrontendUtils;
 import com.vaadin.flow.server.webcomponent.WebComponentConfigurationRegistry;
 import com.vaadin.flow.shared.ApplicationConstants;
@@ -70,6 +64,10 @@ import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 import elemental.json.impl.JsonUtil;
+
+import static com.vaadin.flow.server.frontend.FrontendUtils.EXPORT_CHUNK;
+import static com.vaadin.flow.shared.ApplicationConstants.CONTENT_TYPE_TEXT_JAVASCRIPT_UTF_8;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Bootstrap handler for WebComponent requests.
@@ -82,7 +80,7 @@ import elemental.json.impl.JsonUtil;
 public class WebComponentBootstrapHandler extends BootstrapHandler {
     private static final String REQ_PARAM_URL = "url";
     private static final String PATH_PREFIX = "/web-component/web-component";
-    private static final Pattern PATH_PATTERN = Pattern
+    static final Pattern PATH_PATTERN = Pattern
             .compile(".*" + PATH_PREFIX + "-(ui|bootstrap)\\.(js|html)$");
 
     private static class WebComponentBootstrapContext extends BootstrapContext {
@@ -295,6 +293,11 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
     @Override
     public boolean synchronizedHandleRequest(VaadinSession session,
             VaadinRequest request, VaadinResponse response) throws IOException {
+        if ("HEAD".equals(request.getMethod().toUpperCase(Locale.ROOT))) {
+            // Poll request to check if the dev-bundle is ready
+            // Prevent the creation of a UI
+            return true;
+        }
         // Find UI class
         Class<? extends UI> uiClass = getUIClass(request);
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandlerViteTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandlerViteTest.java
@@ -208,6 +208,7 @@ public class WebComponentBootstrapHandlerViteTest {
         VaadinServletRequest request = Mockito.mock(VaadinServletRequest.class);
         Mockito.when(request.getService()).thenReturn(service);
         Mockito.when(request.getServletPath()).thenReturn("/");
+        Mockito.when(request.getMethod()).thenReturn("GET");
         VaadinResponse response = getMockResponse(null);
 
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
@@ -242,6 +243,7 @@ public class WebComponentBootstrapHandlerViteTest {
         VaadinServletRequest request = Mockito.mock(VaadinServletRequest.class);
         Mockito.when(request.getService()).thenReturn(service);
         Mockito.when(request.getServletPath()).thenReturn("/");
+        Mockito.when(request.getMethod()).thenReturn("GET");
         VaadinResponse response = getMockResponse(null);
 
         ByteArrayOutputStream stream = new ByteArrayOutputStream();

--- a/flow-test-util/src/main/java/com/vaadin/flow/testutil/AbstractTestBenchTest.java
+++ b/flow-test-util/src/main/java/com/vaadin/flow/testutil/AbstractTestBenchTest.java
@@ -178,6 +178,13 @@ public abstract class AbstractTestBenchTest extends TestBenchHelpers {
         }
     }
 
+    protected void waitForWebComponentsBootstrap() {
+        waitUntil(driver -> driver.findElement(By.cssSelector(
+                "script[src*='web-component/web-component-bootstrap.js']")),
+                // longer timeout to prevent failures during dev-bundle creation
+                60);
+    }
+
     /**
      * Returns the URL to be used for the test.
      *

--- a/flow-tests/test-express-build/test-embedding-express-build/src/test/java/com/vaadin/flow/webcomponent/ApplicationThemeComponentIT.java
+++ b/flow-tests/test-express-build/test-embedding-express-build/src/test/java/com/vaadin/flow/webcomponent/ApplicationThemeComponentIT.java
@@ -124,7 +124,6 @@ public class ApplicationThemeComponentIT extends ChromeBrowserTest {
     private void validateEmbeddedComponent(TestBenchElement themedComponent,
             String target) {
         String imageUrl = themedComponent.getCssValue("background-image");
-        System.out.println("================================= " + imageUrl);
 
         Assert.assertTrue(target + " didn't contain the background image",
                 imageUrl.contains("VAADIN/themes/embedded-theme/img/bg.jpg"));

--- a/flow-tests/test-express-build/test-embedding-express-build/src/test/java/com/vaadin/flow/webcomponent/ApplicationThemeComponentIT.java
+++ b/flow-tests/test-express-build/test-embedding-express-build/src/test/java/com/vaadin/flow/webcomponent/ApplicationThemeComponentIT.java
@@ -59,6 +59,7 @@ public class ApplicationThemeComponentIT extends ChromeBrowserTest {
     @Test
     public void embeddedComponent_expressBuild_componentRendered() {
         open();
+        waitForWebComponentsBootstrap();
 
         TestBenchElement themedComponent = $("themed-component").waitForFirst();
 
@@ -90,6 +91,7 @@ public class ApplicationThemeComponentIT extends ChromeBrowserTest {
     @Test
     public void applicationTheme_GlobalCss_isUsedOnlyInEmbeddedComponent() {
         open();
+        waitForWebComponentsBootstrap();
         checkLogsForErrors();
 
         validateEmbeddedComponent($("themed-component").id("first"), "first");
@@ -122,6 +124,8 @@ public class ApplicationThemeComponentIT extends ChromeBrowserTest {
     private void validateEmbeddedComponent(TestBenchElement themedComponent,
             String target) {
         String imageUrl = themedComponent.getCssValue("background-image");
+        System.out.println("================================= " + imageUrl);
+
         Assert.assertTrue(target + " didn't contain the background image",
                 imageUrl.contains("VAADIN/themes/embedded-theme/img/bg.jpg"));
 
@@ -144,6 +148,7 @@ public class ApplicationThemeComponentIT extends ChromeBrowserTest {
     @Test
     public void componentThemeIsApplied() {
         open();
+        waitForWebComponentsBootstrap();
 
         final TestBenchElement themedComponent = $("themed-component").first();
         final TestBenchElement embeddedComponent = themedComponent
@@ -160,6 +165,7 @@ public class ApplicationThemeComponentIT extends ChromeBrowserTest {
     @Test
     public void documentCssFonts_fontsAreAppliedAndAvailable() {
         open();
+        waitForWebComponentsBootstrap();
         checkLogsForErrors();
         final TestBenchElement themedComponent = $("themed-component").first();
         final TestBenchElement embeddedComponent = themedComponent
@@ -182,6 +188,7 @@ public class ApplicationThemeComponentIT extends ChromeBrowserTest {
 
     public void documentCssFonts_fromLocalCssFile_fontAppliedToDocumentRoot() {
         open();
+        waitForWebComponentsBootstrap();
 
         Object ostrichFontStylesFound = getCommandExecutor().executeScript(
                 "let target = document;" + FIND_FONT_FACE_RULE_SCRIPT);
@@ -194,6 +201,7 @@ public class ApplicationThemeComponentIT extends ChromeBrowserTest {
     @Test
     public void documentCssFonts_fromLocalCssFile_fontNotAppliedToEmbeddedComponent() {
         open();
+        waitForWebComponentsBootstrap();
 
         Object ostrichFontStylesFoundForEmbedded = getCommandExecutor()
                 .executeScript("let target = document.getElementsByTagName"
@@ -208,6 +216,7 @@ public class ApplicationThemeComponentIT extends ChromeBrowserTest {
     @Test
     public void documentCssLinkAddedToHead() {
         open();
+        waitForWebComponentsBootstrap();
 
         final WebElement documentHead = getDriver()
                 .findElement(By.xpath("/html/head"));

--- a/flow-tests/test-frontend/vite-embedded-webcomponent-resync/src/test/java/com/vaadin/viteapp/BasicComponentIT.java
+++ b/flow-tests/test-frontend/vite-embedded-webcomponent-resync/src/test/java/com/vaadin/viteapp/BasicComponentIT.java
@@ -65,6 +65,7 @@ public class BasicComponentIT extends ChromeDeviceTest {
 
         // simulate expired session by invalidating current session
         session.invalidate();
+        waitForWebComponentsBootstrap();
 
         // init request to resynchronize expired session and recreate components
         clickButton();

--- a/flow-tests/test-frontend/vite-embedded-webcomponent-resync/src/test/java/com/vaadin/viteapp/BasicComponentIT.java
+++ b/flow-tests/test-frontend/vite-embedded-webcomponent-resync/src/test/java/com/vaadin/viteapp/BasicComponentIT.java
@@ -57,7 +57,7 @@ public class BasicComponentIT extends ChromeDeviceTest {
 
     @Test
     public void session_resynced_webcomponent_is_active() throws Exception {
-
+        waitForWebComponentsBootstrap();
         // check if web component works
         clickButton();
         Assert.assertEquals("Authentication failure",

--- a/flow-tests/test-multi-war/deployment/src/test/java/com/vaadin/flow/multiwar/deployment/TwoAppsIT.java
+++ b/flow-tests/test-multi-war/deployment/src/test/java/com/vaadin/flow/multiwar/deployment/TwoAppsIT.java
@@ -40,6 +40,7 @@ public class TwoAppsIT extends ChromeBrowserTest {
     @Test
     public void bothWebComponentsEmbedded() {
         open();
+        waitForWebComponentsBootstrap();
         WebElement hello1 = findElement(By.id("hello1"));
         WebElement hello2 = findElement(By.id("hello2"));
 


### PR DESCRIPTION
## Description

When a Flow component is embedded as a web-component, the bootstrap process may fail if the dev-bundle is still under creation, because an HTML page is returned instead of the javascript initialization code. This change waits for dev-bundle to be ready before loading the web-components bootstrap script.

Fixes #18283

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
