### PR TITLE
chore: Upgrade @koa/cors

### DIFF
--- a/vaadin-dev-server/package.json
+++ b/vaadin-dev-server/package.json
@@ -9,7 +9,7 @@
     "prettier": "prettier --write frontend"
   },
   "devDependencies": {
-    "@koa/cors": "^4.0.0",
+    "@koa/cors": "^5.0.0",
     "@open-wc/dev-server-hmr": "^0.1.2-next.0",
     "@open-wc/testing": "^3.1.7",
     "@rollup/plugin-typescript": "^11.1.1",


### PR DESCRIPTION
Breaking change between 5.0 and 4.0
The default origin is set to *, if you want to keep the 4.0 behavior, you can set the origin handler like this:

app.use(cors({
  origin(ctx) {
    return ctx.get('Origin') || '*';
  },
}));
