### PR TITLE
test: Ignore leftover lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,8 @@ flow-tests/test-express-build/test-parent-theme-express-build/src/main/bundles
 flow-tests/test-express-build/test-embedding-express-build/src/main/bundles
 flow-tests/test-express-build/test-prod-bundle/src/main/bundles
 
+.flow-node-tasks.lock
+
 # Exclude generated vaadin dev tools frontend
 vaadin-dev-server/src/main/resources/META-INF/frontend
 vaadin-dev-server/src/main/resources/META-INF/metadata


### PR DESCRIPTION
Not sure if something is wrong with the tests they leave these I have at least
	flow-tests/test-eager-bootstrap/.flow-node-tasks.lock
	flow-tests/test-live-reload-multimodule/ui/.flow-node-tasks.lock
	flow-tests/test-npm-only-features/test-npm-performance-regression/.flow-node-tasks.lock
	flow-tests/test-redeployment-no-cache/.flow-node-tasks.lock
	flow-tests/test-redeployment/.flow-node-tasks.lock
	flow-tests/test-router-custom-context/.flow-node-tasks.lock
	flow-tests/test-servlet/.flow-node-tasks.lock
	flow-tests/test-themes/.flow-node-tasks.lock
