### PR TITLE
feat: support DataProviderWrapper better in AbstractDataView

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataView.java
@@ -71,7 +71,7 @@ public abstract class AbstractDataView<T> implements DataView<T> {
          * the data provider.
          */
         if (isDataProviderInitialized(dataProviderType)) {
-            verifyDataProviderType(dataProviderType);
+            verifyDataProviderType(dataProviderSupplier.get());
         }
     }
 
@@ -112,6 +112,32 @@ public abstract class AbstractDataView<T> implements DataView<T> {
                     supportedDataProviderType.getSimpleName(),
                     dataProviderType.getSuperclass().getSimpleName());
             throw new IllegalStateException(message);
+        }
+    }
+
+    /**
+     * Verifies an obtained {@link DataProvider} type is appropriate for current
+     * Data View type. If the data provider is a wrapper, then the wrapped data
+     * provider is verified too.
+     *
+     * @param dataProvider
+     *            data provider to be verified
+     * @throws IllegalStateException
+     *             if data provider type is incompatible with data view type
+     */
+    protected final void verifyDataProviderType(
+            DataProvider<T, ?> dataProvider) {
+        try {
+            verifyDataProviderType(dataProvider.getClass());
+        } catch (IllegalStateException e) {
+            if (DataProviderWrapper.class
+                    .isAssignableFrom(dataProvider.getClass())) {
+                verifyDataProviderType(
+                        ((DataProviderWrapper<T, ?, ?>) dataProvider)
+                                .getWrappedDataProvider());
+            } else {
+                throw e;
+            }
         }
     }
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractLazyDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractLazyDataView.java
@@ -55,7 +55,7 @@ public abstract class AbstractLazyDataView<T> extends AbstractDataView<T>
      * @return the data communicator
      */
     protected DataCommunicator<T> getDataCommunicator() {
-        verifyDataProviderType(dataCommunicator.getDataProvider().getClass());
+        verifyDataProviderType(dataCommunicator.getDataProvider());
         return dataCommunicator;
     }
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractListDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractListDataView.java
@@ -203,7 +203,7 @@ public abstract class AbstractListDataView<T> extends AbstractDataView<T>
     protected ListDataProvider<T> getDataProvider() {
         final DataProvider<T, ?> dataProvider = dataProviderSupplier.get();
         Objects.requireNonNull(dataProvider, "DataProvider cannot be null");
-        verifyDataProviderType(dataProvider.getClass());
+        verifyDataProviderType(dataProvider);
         return (ListDataProvider<T>) dataProvider;
     }
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataProviderWrapper.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataProviderWrapper.java
@@ -54,6 +54,15 @@ public abstract class DataProviderWrapper<T, F, M>
                 "The wrapped data provider cannot be null.");
     }
 
+    /**
+     * Gets wrapped data provider.
+     *
+     * @return the wrapped data provider
+     */
+    public DataProvider<T, M> getWrappedDataProvider() {
+        return dataProvider;
+    }
+
     @Override
     public boolean isInMemory() {
         return dataProvider.isInMemory();

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataProviderWrapper.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataProviderWrapper.java
@@ -59,7 +59,7 @@ public abstract class DataProviderWrapper<T, F, M>
      *
      * @return the wrapped data provider
      */
-    public DataProvider<T, M> getWrappedDataProvider() {
+    DataProvider<T, M> getWrappedDataProvider() {
         return dataProvider;
     }
 

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractDataViewTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractDataViewTest.java
@@ -19,6 +19,7 @@ package com.vaadin.flow.data.provider;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
@@ -26,7 +27,9 @@ import java.util.stream.Stream;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.function.SerializableSupplier;
+import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.tests.data.bean.Item;
 import org.junit.Assert;
 import org.junit.Before;
@@ -37,6 +40,8 @@ public class AbstractDataViewTest {
     private Collection<Item> items;
 
     private ListDataProvider<Item> dataProvider;
+
+    private DataProvider<Item, ?> wrapperDataProvider;
 
     private AbstractDataView<Item> dataView;
 
@@ -98,6 +103,139 @@ public class AbstractDataViewTest {
         dataView.refreshAll();
         Assert.assertNotNull(refreshAllEvent.get());
         Assert.assertEquals(dataProvider, refreshAllEvent.get().getSource());
+    }
+
+    @Test
+    public void verifyDataProviderType_wrappedDataProviderIsSupported() {
+        // starting with EmptyDataProvider to bypass checking too early in
+        // the DataViewImpl constructor.
+        wrapperDataProvider = new DataCommunicator.EmptyDataProvider<>();
+        DataViewImpl dataView = new DataViewImpl(() -> wrapperDataProvider,
+                component) {
+            @Override
+            public Class<?> getSupportedDataProviderType() {
+                return InMemoryDataProvider.class;
+            }
+        };
+        wrapperDataProvider = getWrapperDataProvider();
+        dataView.verifyDataProviderType(wrapperDataProvider);
+    }
+
+    @Test
+    public void verifyDataProviderType_withConfigurableFilter_wrappedDataProviderIsSupported() {
+        wrapperDataProvider = new DataCommunicator.EmptyDataProvider<>();
+        DataViewImpl dataView = new DataViewImpl(() -> wrapperDataProvider,
+                component) {
+            @Override
+            public Class<?> getSupportedDataProviderType() {
+                return InMemoryDataProvider.class;
+            }
+        };
+        wrapperDataProvider = dataProvider.withConfigurableFilter();
+        dataView.verifyDataProviderType(wrapperDataProvider);
+    }
+
+    @Test
+    public void verifyDataProviderType_wrappedDataProviderIsNotSupported() {
+        wrapperDataProvider = new DataCommunicator.EmptyDataProvider<>();
+        DataViewImpl dataView = new DataViewImpl(() -> wrapperDataProvider,
+                component) {
+            @Override
+            public Class<?> getSupportedDataProviderType() {
+                return BackEndDataProvider.class;
+            }
+        };
+        wrapperDataProvider = getWrapperDataProvider();
+        Assert.assertThrows(IllegalStateException.class,
+                () -> dataView.verifyDataProviderType(wrapperDataProvider));
+    }
+
+    @Test
+    public void verifyDataProviderType_withConfigurableFilter_wrappedDataProviderIsNotSupported() {
+        wrapperDataProvider = new DataCommunicator.EmptyDataProvider<>();
+        DataViewImpl dataView = new DataViewImpl(() -> wrapperDataProvider,
+                component) {
+            @Override
+            public Class<?> getSupportedDataProviderType() {
+                return BackEndDataProvider.class;
+            }
+        };
+        wrapperDataProvider = dataProvider.withConfigurableFilter();
+        Assert.assertThrows(IllegalStateException.class,
+                () -> dataView.verifyDataProviderType(wrapperDataProvider));
+    }
+
+    @Test
+    public void verifyDataProviderType_wrapperIsBackEndDataProvider_wrapperDataProviderIsSupported() {
+        wrapperDataProvider = new DataCommunicator.EmptyDataProvider<>();
+        DataViewImpl dataView = new DataViewImpl(() -> wrapperDataProvider,
+                component) {
+            @Override
+            public Class<?> getSupportedDataProviderType() {
+                return BackEndDataProvider.class;
+            }
+        };
+        wrapperDataProvider = new BackEndDataProviderWrapper(dataProvider);
+        dataView.verifyDataProviderType(wrapperDataProvider);
+    }
+
+    private DataProvider<Item, Object> getWrapperDataProvider() {
+        return new DataProviderWrapper<Item, Object, SerializablePredicate<Item>>(
+                dataProvider) {
+            @Override
+            protected SerializablePredicate<Item> getFilter(Query query) {
+                return null;
+            }
+
+            @Override
+            public Stream fetch(Query query) {
+                return null;
+            }
+        };
+    }
+
+    // BackEndDataProvider that is also a DataProviderWrapper
+    private static class BackEndDataProviderWrapper extends
+            DataProviderWrapper<Item, Object, SerializablePredicate<Item>>
+            implements BackEndDataProvider<Item, Object> {
+        protected BackEndDataProviderWrapper(
+                DataProvider<Item, SerializablePredicate<Item>> dataProvider) {
+            super(dataProvider);
+        }
+
+        @Override
+        public Stream fetch(Query query) {
+            return null;
+        }
+
+        @Override
+        public void setSortOrders(List<QuerySortOrder> sortOrders) {
+        }
+
+        @Override
+        public int size(Query<Item, Object> query) {
+            return 0;
+        }
+
+        @Override
+        protected SerializablePredicate<Item> getFilter(
+                Query<Item, Object> query) {
+            return null;
+        }
+
+        @Override
+        public void refreshItem(Item item) {
+        }
+
+        @Override
+        public void refreshAll() {
+        }
+
+        @Override
+        public Registration addDataProviderListener(
+                DataProviderListener<Item> listener) {
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
Adds in `AbstractDataView` a better support for wrapper data providers that implements `DataProviderWrapper`. `AbstractDataView` won't throw exception anymore if wrapped data container is supported by the data view implementation. Adds public `getWrappedDataProvider` method in `DataProviderWrapper`.

Related-to: #18088
