### PR TITLE
test: prevent test flakyness by waiting for element

### DIFF
--- a/flow-tests/test-frontend/vite-embedded-webcomponent-resync/pom.xml
+++ b/flow-tests/test-frontend/vite-embedded-webcomponent-resync/pom.xml
@@ -67,6 +67,11 @@
             <artifactId>jetty-ee10-servlet</artifactId>
             <version>${jetty.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+            <artifactId>jetty-ee10-websocket-jakarta-server</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
         <!-- This is probably needed here only because we run the tests with Jetty 11 (ee9) instead
         of 12 (ee10) and the websocket API is from EE10 -->
         <dependency>

--- a/flow-tests/test-frontend/vite-embedded-webcomponent-resync/src/test/java/com/vaadin/viteapp/BasicComponentIT.java
+++ b/flow-tests/test-frontend/vite-embedded-webcomponent-resync/src/test/java/com/vaadin/viteapp/BasicComponentIT.java
@@ -15,11 +15,15 @@
  */
 package com.vaadin.viteapp;
 
+import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpSessionEvent;
+import jakarta.servlet.http.HttpSessionListener;
+
 import java.io.File;
 
+import org.eclipse.jetty.ee10.webapp.WebAppContext;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.ee10.webapp.WebAppContext;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -29,10 +33,6 @@ import org.openqa.selenium.StaleElementReferenceException;
 
 import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.testutil.ChromeDeviceTest;
-
-import jakarta.servlet.http.HttpSession;
-import jakarta.servlet.http.HttpSessionEvent;
-import jakarta.servlet.http.HttpSessionListener;
 
 public class BasicComponentIT extends ChromeDeviceTest {
 
@@ -86,7 +86,7 @@ public class BasicComponentIT extends ChromeDeviceTest {
     }
 
     private void clickButton() {
-        $("login-form").first().$("button").first().click();
+        waitUntil(d -> $("login-form").first().$("button").first()).click();
     }
 
     private String getAuthenticationResult() {


### PR DESCRIPTION
If the button is not available on the page, the test immediately fails and stops the embedded server.
This change waits for the element to be available before clicking on it.
It also adds the websocket dependency to prevent PUSH initialization errors at startup