### PR TITLE
fix: fix css module definition in typescript declaration file

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsDefinitions.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsDefinitions.java
@@ -59,11 +59,11 @@ public class TaskGenerateTsDefinitions extends AbstractTaskClientGenerator {
 
             ************************************************************************
             *  TypeScript type declaration file 'types.d.ts' have been customized  *
-            *  customized, but is seems to contain the configuration required by   *
-            *  Vaadin. Please make sure the following configuration is present     *
-            *  in the 'types.d.ts' file exactly as show below. As an alternative   *
-            *  you can rename the 'types.d.ts', make Vaadin re-generate it, and    *
-            *  then update it with your custom contents.                           *
+            *  but is seems to contain the configuration required by Vaadin.       *
+            *  Please make sure the following configuration is present in the      *
+            *  'types.d.ts' file exactly as show below. As an alternative you can  *
+            *  rename the 'types.d.ts', make Vaadin re-generate it, and then       *
+            *  update it with your custom contents.                                *
             *  ------------------------------------------------------------------  *
             %s
             *  ------------------------------------------------------------------  *

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsDefinitions.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsDefinitions.java
@@ -18,8 +18,14 @@ package com.vaadin.flow.server.frontend;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.regex.Pattern;
 
 import org.apache.commons.io.IOUtils;
+
+import com.vaadin.flow.server.ExecutionFailedException;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -33,8 +39,42 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  */
 public class TaskGenerateTsDefinitions extends AbstractTaskClientGenerator {
 
+    private static final String DECLARE_CSS_MODULE = "declare module '*.css?inline' {";
+    static final String UPDATE_MESSAGE = """
+
+
+            ***************************************************************************
+            *  TypeScript type declaration file 'types.d.ts' has been updated to the  *
+            *  latest version by Vaadin. Previous content has been backed up on       *
+            *  'types.d.ts.flowBackup' file. Please verify that the updated           *
+            *  'types.d.ts' file contains configuration needed for your project, and  *
+            *  then delete the backup file.                                           *
+            ***************************************************************************
+
+
+            """;
+
+    static final String CHECK_CONTENT_MESSAGE = """
+
+
+            ************************************************************************
+            *  TypeScript type declaration file 'types.d.ts' have been customized  *
+            *  customized, but is seems to contain the configuration required by   *
+            *  Vaadin. Please make sure the following configuration is present     *
+            *  in the 'types.d.ts' file exactly as show below. As an alternative   *
+            *  you can rename the 'types.d.ts', make Vaadin re-generate it, and    *
+            *  then update it with your custom contents.                           *
+            *  ------------------------------------------------------------------  *
+            %s
+            *  ------------------------------------------------------------------  *
+            ************************************************************************"
+
+
+            """;
+
     static final String TS_DEFINITIONS = "types.d.ts";
-    private Options options;
+    static final Pattern COMMENT_LINE = Pattern.compile("(?m)//.*\\R");
+    private final Options options;
 
     /**
      * Create a task to generate <code>types.d.ts</code> file.
@@ -47,11 +87,17 @@ public class TaskGenerateTsDefinitions extends AbstractTaskClientGenerator {
     }
 
     @Override
-    protected String getFileContent() throws IOException {
-        try (InputStream tsDefinitionStream = getClass()
-                .getResourceAsStream(TS_DEFINITIONS)) {
-            return IOUtils.toString(tsDefinitionStream, UTF_8);
+    public void execute() throws ExecutionFailedException {
+        if (shouldGenerate()) {
+            super.execute();
+        } else {
+            updateIfContentMissing();
         }
+    }
+
+    @Override
+    protected String getFileContent() throws IOException {
+        return getTemplateContent("");
     }
 
     @Override
@@ -65,4 +111,93 @@ public class TaskGenerateTsDefinitions extends AbstractTaskClientGenerator {
         return !tsDefinitionsFile.exists() && new File(options.getNpmFolder(),
                 TaskGenerateTsConfig.TSCONFIG_JSON).exists();
     }
+
+    private void updateIfContentMissing() throws ExecutionFailedException {
+        File tsDefinitions = getGeneratedFile();
+        if (tsDefinitions.exists()) {
+            String defaultContent;
+            try {
+                defaultContent = getFileContent();
+            } catch (IOException ex) {
+                throw new ExecutionFailedException(
+                        "Cannot read default " + TS_DEFINITIONS + " contents",
+                        ex);
+            }
+
+            String content;
+            try {
+                content = Files.readString(tsDefinitions.toPath());
+            } catch (IOException ex) {
+                throw new ExecutionFailedException(
+                        "Cannot read " + TS_DEFINITIONS + " contents", ex);
+            }
+
+            String uncommentedDefaultContent = COMMENT_LINE
+                    .matcher(defaultContent).replaceAll("");
+            if (content.equals(defaultContent)
+                    || content.contains(uncommentedDefaultContent)) {
+                log().debug("{} is up-to-date", TS_DEFINITIONS);
+            } else if (content.contains(DECLARE_CSS_MODULE)) {
+                log().debug(
+                        "Custom {} not updated because it contains '*.css?inline' module declaration",
+                        TS_DEFINITIONS);
+                throw new ExecutionFailedException(String.format(
+                        CHECK_CONTENT_MESSAGE, uncommentedDefaultContent));
+            } else {
+                log().debug(
+                        "Updating custom {} to add '*.css?inline' module declaration",
+                        TS_DEFINITIONS);
+                boolean customContent = hasCustomContent(content);
+                if (customContent) {
+                    try {
+                        Path backupFile = tsDefinitions.toPath().getParent()
+                                .resolve(TS_DEFINITIONS + ".flowBackup");
+                        Files.copy(tsDefinitions.toPath(), backupFile);
+                        log().debug("Created {} backup copy on {}",
+                                TS_DEFINITIONS, backupFile);
+                    } catch (IOException ex) {
+                        throw new ExecutionFailedException(
+                                "Cannot create backup copy of " + TS_DEFINITIONS
+                                        + " file",
+                                ex);
+                    }
+                }
+                try {
+                    if (customContent) {
+                        Files.writeString(tsDefinitions.toPath(),
+                                uncommentedDefaultContent,
+                                StandardOpenOption.APPEND);
+                        throw new ExecutionFailedException(UPDATE_MESSAGE);
+                    } else {
+                        Files.writeString(tsDefinitions.toPath(),
+                                defaultContent,
+                                StandardOpenOption.TRUNCATE_EXISTING);
+                    }
+                } catch (IOException ex) {
+                    throw new ExecutionFailedException(
+                            "Error updating custom " + TS_DEFINITIONS + " file",
+                            ex);
+                }
+            }
+        }
+    }
+
+    private boolean hasCustomContent(String content)
+            throws ExecutionFailedException {
+        try {
+            return !content.equals(getTemplateContent(".v1"));
+        } catch (IOException ex) {
+            throw new ExecutionFailedException(
+                    "Cannot read default " + TS_DEFINITIONS + ".v1 contents",
+                    ex);
+        }
+    }
+
+    private String getTemplateContent(String suffix) throws IOException {
+        try (InputStream tsDefinitionStream = getClass()
+                .getResourceAsStream(TS_DEFINITIONS + suffix)) {
+            return IOUtils.toString(tsDefinitionStream, UTF_8);
+        }
+    }
+
 }

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/types.d.ts.v1
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/types.d.ts.v1
@@ -3,7 +3,7 @@
 // This is needed for TypeScript compiler to declare and export as a TypeScript module.
 // It is recommended to commit this file to the VCS.
 // You might want to change the configurations to fit your preferences
-declare module '*.css?inline' {
+declare module '*.css' {
   import { CSSResultGroup } from 'lit';
   const content: CSSResultGroup;
   export default content;

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateTsDefinitionsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateTsDefinitionsTest.java
@@ -195,6 +195,34 @@ public class TaskGenerateTsDefinitionsTest {
     }
 
     @Test
+    public void customTsDefinition_windowsEOL_flowContents_tsDefinitionNotUpdated()
+            throws Exception {
+        Path typesTSfile = new File(outputFolder, "types.d.ts").toPath();
+        Files.writeString(typesTSfile,
+                """
+                        import type { SchemaObject } from "../../types";
+                        export type SchemaObjectMap = {
+                            [Ref in string]?: SchemaObject;
+                        };
+                        declare module '*.css?inline' {
+                          import { CSSResultGroup } from 'lit';
+                          const content: CSSResultGroup;
+                          export default content;
+                        }
+                        export declare const jtdForms: readonly ["elements", "values", "discriminator", "properties", "optionalProperties", "enum", "type", "ref"];
+                        export type JTDForm = typeof jtdForms[number];
+                        }"""
+                        .replace("\n", "\r\n"));
+        FileTime lastModifiedTime = Files.getLastModifiedTime(typesTSfile);
+        taskGenerateTsDefinitions.execute();
+        Assert.assertFalse(
+                "Should not generate types.d.ts when already existing",
+                taskGenerateTsDefinitions.shouldGenerate());
+        Assert.assertEquals("types.d.ts should not have been updated",
+                lastModifiedTime, Files.getLastModifiedTime(typesTSfile));
+    }
+
+    @Test
     public void customTsDefinition_flowContentsNotMatching_tsDefinitionNotUpdated()
             throws Exception {
         Path typesTSfile = new File(outputFolder, "types.d.ts").toPath();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateTsDefinitionsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateTsDefinitionsTest.java
@@ -19,8 +19,12 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
 
 import org.apache.commons.io.IOUtils;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -29,6 +33,10 @@ import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.server.ExecutionFailedException;
+
+import static com.vaadin.flow.server.frontend.TaskGenerateTsDefinitions.TS_DEFINITIONS;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class TaskGenerateTsDefinitionsTest {
     @Rule
@@ -68,14 +76,209 @@ public class TaskGenerateTsDefinitionsTest {
     @Test
     public void should_notGenerateTsDefinitions_TsConfigNotExist()
             throws Exception {
-        Files.createFile(new File(outputFolder, "types.d.ts").toPath());
         taskGenerateTsDefinitions.execute();
         Assert.assertFalse(
                 "Should not generate types.d.ts when tsconfig.json "
                         + "doesn't exist",
                 taskGenerateTsDefinitions.shouldGenerate());
-        Assert.assertTrue("The types.d.ts should already exist",
+        Assert.assertFalse("The types.d.ts should not exist",
                 taskGenerateTsDefinitions.getGeneratedFile().exists());
+    }
+
+    @Test
+    public void tsDefinition_upToDate_tsDefinitionNotUpdated()
+            throws Exception {
+        Path typesTSfile = new File(outputFolder, "types.d.ts").toPath();
+        String expectedContent = readExpectedContent(false);
+        Files.writeString(typesTSfile, expectedContent);
+        FileTime lastModifiedTime = Files.getLastModifiedTime(typesTSfile);
+        taskGenerateTsDefinitions.execute();
+        Assert.assertFalse(
+                "Should not generate types.d.ts when already existing",
+                taskGenerateTsDefinitions.shouldGenerate());
+        String updatedContent = Files.readString(typesTSfile);
+        Assert.assertEquals("types.d.ts should not have been updated",
+                lastModifiedTime, Files.getLastModifiedTime(typesTSfile));
+        Assert.assertEquals("types.d.ts should have been replaced",
+                updatedContent, expectedContent);
+    }
+
+    @Test
+    public void tsDefinition_oldFlowContents_tsDefinitionUpdated()
+            throws Exception {
+        Path typesTSfile = new File(outputFolder, "types.d.ts").toPath();
+        Files.writeString(typesTSfile, readPreviousContent());
+        taskGenerateTsDefinitions.execute();
+        Assert.assertFalse(
+                "Should not generate types.d.ts when already existing",
+                taskGenerateTsDefinitions.shouldGenerate());
+        String updatedContent = Files.readString(typesTSfile);
+        Assert.assertEquals("types.d.ts should have been replaced",
+                updatedContent, readExpectedContent(false));
+    }
+
+    @Test
+    public void customTsDefinition_missingFlowContents_tsDefinitionUpdatedAndExceptionThrown()
+            throws Exception {
+        Path typesTSfile = new File(outputFolder, "types.d.ts").toPath();
+        String originalContent = """
+                import type { SchemaObject } from "../../types";
+                export type SchemaObjectMap = {
+                    [Ref in string]?: SchemaObject;
+                };
+                export declare const jtdForms: readonly ["elements", "values", "discriminator", "properties", "optionalProperties", "enum", "type", "ref"];
+                export type JTDForm = typeof jtdForms[number];
+                """;
+        Files.writeString(typesTSfile, originalContent);
+        ExecutionFailedException exception = Assert.assertThrows(
+                ExecutionFailedException.class,
+                taskGenerateTsDefinitions::execute);
+        MatcherAssert.assertThat(exception.getMessage(), CoreMatchers
+                .containsString(TaskGenerateTsDefinitions.UPDATE_MESSAGE));
+        Assert.assertFalse(
+                "Should not generate types.d.ts when already existing",
+                taskGenerateTsDefinitions.shouldGenerate());
+        String updatedContent = Files.readString(typesTSfile);
+        MatcherAssert.assertThat("types.d.ts should have been updated",
+                updatedContent,
+                CoreMatchers.containsString(readExpectedContent(true)));
+        assertBackupFileCreated(originalContent);
+    }
+
+    @Test
+    public void customTsDefinition_oldFlowContents_tsDefinitionUpdatedAndExceptionThrown()
+            throws Exception {
+        Path typesTSfile = new File(outputFolder, "types.d.ts").toPath();
+        String originalContent = "import type { SchemaObject } from \"../../types\";"
+                + System.lineSeparator() + readPreviousContent();
+        Files.writeString(typesTSfile, originalContent);
+        ExecutionFailedException exception = Assert.assertThrows(
+                ExecutionFailedException.class,
+                taskGenerateTsDefinitions::execute);
+        MatcherAssert.assertThat(exception.getMessage(), CoreMatchers
+                .containsString(TaskGenerateTsDefinitions.UPDATE_MESSAGE));
+        Assert.assertFalse(
+                "Should not generate types.d.ts when already existing",
+                taskGenerateTsDefinitions.shouldGenerate());
+        String updatedContent = Files.readString(typesTSfile);
+        MatcherAssert.assertThat("types.d.ts should have been updated",
+                updatedContent,
+                CoreMatchers.containsString(readExpectedContent(true)));
+        assertBackupFileCreated(originalContent);
+    }
+
+    @Test
+    public void customTsDefinition_flowContents_tsDefinitionNotUpdated()
+            throws Exception {
+        Path typesTSfile = new File(outputFolder, "types.d.ts").toPath();
+        Files.writeString(typesTSfile,
+                """
+                        import type { SchemaObject } from "../../types";
+                        export type SchemaObjectMap = {
+                            [Ref in string]?: SchemaObject;
+                        };
+                        declare module '*.css?inline' {
+                          import { CSSResultGroup } from 'lit';
+                          const content: CSSResultGroup;
+                          export default content;
+                        }
+                        export declare const jtdForms: readonly ["elements", "values", "discriminator", "properties", "optionalProperties", "enum", "type", "ref"];
+                        export type JTDForm = typeof jtdForms[number];
+                        }""");
+        FileTime lastModifiedTime = Files.getLastModifiedTime(typesTSfile);
+        taskGenerateTsDefinitions.execute();
+        Assert.assertFalse(
+                "Should not generate types.d.ts when already existing",
+                taskGenerateTsDefinitions.shouldGenerate());
+        Assert.assertEquals("types.d.ts should not have been updated",
+                lastModifiedTime, Files.getLastModifiedTime(typesTSfile));
+    }
+
+    @Test
+    public void customTsDefinition_flowContentsNotMatching_tsDefinitionNotUpdated()
+            throws Exception {
+        Path typesTSfile = new File(outputFolder, "types.d.ts").toPath();
+        Files.writeString(typesTSfile,
+                """
+                        import type { SchemaObject } from "../../types";
+                        export type SchemaObjectMap = {
+                            [Ref in string]?: SchemaObject;
+                        };
+                        declare module '*.css?inline' {
+
+                          import { CSSResultGroup } from 'lit';
+
+                          const content: CSSResultGroup;
+
+                          export default content;
+                        }
+                        export declare const jtdForms: readonly ["elements", "values", "discriminator", "properties", "optionalProperties", "enum", "type", "ref"];
+                        export type JTDForm = typeof jtdForms[number];
+                        }""");
+        FileTime lastModifiedTime = Files.getLastModifiedTime(typesTSfile);
+        ExecutionFailedException exception = Assert.assertThrows(
+                ExecutionFailedException.class,
+                taskGenerateTsDefinitions::execute);
+        MatcherAssert.assertThat(exception.getMessage(), CoreMatchers
+                .containsString(TaskGenerateTsDefinitions.CHECK_CONTENT_MESSAGE
+                        .substring(0,
+                                TaskGenerateTsDefinitions.CHECK_CONTENT_MESSAGE
+                                        .indexOf("%s"))));
+        Assert.assertFalse(
+                "Should not generate types.d.ts when already existing",
+                taskGenerateTsDefinitions.shouldGenerate());
+        Assert.assertEquals("types.d.ts should not have been updated",
+                lastModifiedTime, Files.getLastModifiedTime(typesTSfile));
+    }
+
+    @Test
+    public void customTsDefinition_differentCSSModuleDefinition_tsDefinitionNotUpdated()
+            throws Exception {
+        Path typesTSfile = new File(outputFolder, "types.d.ts").toPath();
+        Files.writeString(typesTSfile, """
+                declare module '*.css?inline' {
+                    custom configuration
+                }""");
+        FileTime lastModifiedTime = Files.getLastModifiedTime(typesTSfile);
+        ExecutionFailedException exception = Assert.assertThrows(
+                ExecutionFailedException.class,
+                taskGenerateTsDefinitions::execute);
+        MatcherAssert.assertThat(exception.getMessage(), CoreMatchers
+                .containsString(TaskGenerateTsDefinitions.CHECK_CONTENT_MESSAGE
+                        .substring(0,
+                                TaskGenerateTsDefinitions.CHECK_CONTENT_MESSAGE
+                                        .indexOf("%s"))));
+        Assert.assertFalse(
+                "Should not generate types.d.ts when already existing",
+                taskGenerateTsDefinitions.shouldGenerate());
+        Assert.assertEquals("types.d.ts should not have been updated",
+                lastModifiedTime, Files.getLastModifiedTime(typesTSfile));
+    }
+
+    private void assertBackupFileCreated(String originalContent)
+            throws IOException {
+        File backupFile = new File(
+                taskGenerateTsDefinitions.getGeneratedFile().getParent(),
+                TS_DEFINITIONS + ".flowBackup");
+        Assert.assertTrue("Original types.d.ts backup should exist",
+                backupFile.exists());
+        Assert.assertEquals(originalContent,
+                Files.readString(backupFile.toPath()));
+    }
+
+    private String readExpectedContent(boolean stripComments)
+            throws IOException {
+        String fileContent = taskGenerateTsDefinitions.getFileContent();
+        if (stripComments) {
+            fileContent = TaskGenerateTsDefinitions.COMMENT_LINE
+                    .matcher(fileContent).replaceAll("");
+        }
+        return fileContent;
+    }
+
+    private String readPreviousContent() throws IOException {
+        return IOUtils.toString(
+                getClass().getResourceAsStream(TS_DEFINITIONS + ".v1"), UTF_8);
     }
 
 }

--- a/flow-tests/test-ccdm/frontend/css-importing-test.ts
+++ b/flow-tests/test-ccdm/frontend/css-importing-test.ts
@@ -1,7 +1,6 @@
 import { LitElement } from 'lit';
 
 import '@vaadin/vaadin-login/vaadin-login-overlay';
-// @ts-ignore
 import styles from './test-styles.css?inline';
 
 // Regression test for flow#9167 (`styles` assignment will cause a type

--- a/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/side-src/main/frontend/typescript/hello-world-view.ts
+++ b/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/side-src/main/frontend/typescript/hello-world-view.ts
@@ -1,7 +1,6 @@
 import '@vaadin/text-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-// @ts-ignore
 import styles from './hello-world-view.css?inline';
 
 

--- a/flow-tests/test-themes/frontend/typescript/hello-world-view.ts
+++ b/flow-tests/test-themes/frontend/typescript/hello-world-view.ts
@@ -1,7 +1,6 @@
 import '@vaadin/text-field';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-// @ts-ignore
 import styles from './hello-world-view.css?inline';
 
 @customElement('hello-world-view')


### PR DESCRIPTION
## Description

When importing styles in typescript sources, the import should contains the inline parameter (e.g. import styles from './some.css?inline'). The current module definition in types.d.ts does not handle the parameter, so TypeScript errors happen during build.
This change updates the definition in Flow default types.d.ts file and handles upgrade of existing files.

Fixes #18330

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
