### PR TITLE
fix: ignore plugins registration when dev-tools are disabled

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
@@ -179,6 +179,18 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
             catchErrorsInDevMode(indexDocument);
 
             addLicenseChecker(indexDocument);
+        } else if (!config.isProductionMode()) {
+            // If a dev-tools plugin tries to register itself with disabled
+            // dev-tools, the application completely breaks with a JS error
+            addScript(indexDocument,
+                    """
+                            window.Vaadin = window.Vaadin || {};
+                            window.Vaadin.devToolsPlugins = {
+                                push: function(plugin) {
+                                    window.console.debug("Vaadin Dev Tools disabled. Plugin cannot be registered.", plugin);
+                                }
+                            };
+                            """);
         }
 
         // this invokes any custom listeners and should be run when the whole

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.server.communication;
 
+import jakarta.servlet.http.HttpServletRequest;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -29,7 +31,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import jakarta.servlet.http.HttpServletRequest;
 import org.jsoup.Jsoup;
 import org.jsoup.internal.StringUtil;
 import org.jsoup.nodes.Document;
@@ -725,6 +726,33 @@ public class IndexHtmlRequestHandlerTest {
     //
     // assertFalse(isTokenPresent(indexHtml));
     // }
+
+    @Test
+    public void devTools_disable_stubPushFunctionRegistered()
+            throws IOException {
+        File projectRootFolder = temporaryFolder.newFolder();
+        TestUtil.createIndexHtmlStub(projectRootFolder);
+        TestUtil.createStatsJsonStub(projectRootFolder);
+        deploymentConfiguration.setDevToolsEnabled(false);
+        deploymentConfiguration.setProductionMode(false);
+        deploymentConfiguration.setProjectFolder(projectRootFolder);
+
+        indexHtmlRequestHandler.synchronizedHandleRequest(session,
+                createVaadinRequest("/"), response);
+
+        String indexHtml = responseOutput.toString(StandardCharsets.UTF_8);
+        Document document = Jsoup.parse(indexHtml);
+
+        assertTrue(
+                "Expected devToolsPlugins.push function when dev-tools are disabled",
+                document.head().getElementsByTag("script").stream()
+                        .map(Element::html)
+                        .anyMatch(script -> script
+                                .contains("window.Vaadin.devToolsPlugins = {")
+                                && script
+                                        .contains("push: function(plugin) {")));
+
+    }
 
     @Test
     public void should_NOT_export_usage_statistics_in_production_mode()


### PR DESCRIPTION
## Description

Prevents JavaScript errors caused by dev-tools plug-ins attempting to register themselves when the development tools are disabled.

Fixes #18350

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
