### PR TITLE
revert: Revert "chore(deps): bump jackson.version from 2.16.0 to 2.16.1 (#18360)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <slf4j.version>2.0.9</slf4j.version>
         <polymer.version>2.6.1</polymer.version>
         <jackson.version>2.16.0</jackson.version>
-        <jackson.databind.version>2.16.0</jackson.databind.version>
+        <jackson.databind.version>${jackson.version}</jackson.databind.version>
         <jakarta.validation.version>3.0.2</jakarta.validation.version>
         <jakarta.annotation.api.version>2.1.1</jakarta.annotation.api.version>
         <jaxb.version>4.0.4</jaxb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -89,8 +89,8 @@
         <hibernate.validator.version>8.0.1.Final</hibernate.validator.version>
         <slf4j.version>2.0.9</slf4j.version>
         <polymer.version>2.6.1</polymer.version>
-        <jackson.version>2.16.1</jackson.version>
-        <jackson.databind.version>${jackson.version}</jackson.databind.version>
+        <jackson.version>2.16.0</jackson.version>
+        <jackson.databind.version>2.16.0</jackson.databind.version>
         <jakarta.validation.version>3.0.2</jakarta.validation.version>
         <jakarta.annotation.api.version>2.1.1</jakarta.annotation.api.version>
         <jaxb.version>4.0.4</jaxb.version>


### PR DESCRIPTION
This reverts commit 4d1b6f6b9655970392e7d79a155eb81fb2623ed0.

jackson-core 2.16.1 is a multiversion JAR with classes for Java 21. Unfortunately, this breaks builds with gradle less than 8.4, and the Flow declared minimum supported version for gradle is 7.6.
