### PR TITLE
test: re-enable gradle MPR test

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
@@ -27,19 +27,22 @@ class MiscSingleModuleTest : AbstractGradleTest() {
     /**
      * Tests https://github.com/vaadin/vaadin-gradle-plugin/issues/26
      */
-    @Ignore("The devsoap plugin does not work with Gradle 7")
     @Test
     fun testVaadin8VaadinPlatformMPRProject() {
         testProject.buildFile.writeText(
                 """
             plugins {
-                id "com.devsoap.plugin.vaadin" version "1.4.1"
+                id "com.devsoap.plugin.vaadin" version "2.0.0.beta2"
                 id 'com.vaadin'
             }
             repositories {
                 mavenLocal()
                 mavenCentral()
                 maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
+            }
+            configurations {
+                compile
+                compile.extendsFrom(implementation)
             }
             // test that we can configure both plugins
             vaadin {


### PR DESCRIPTION
Test was failing because the devsoap plugin was not compatible with Gradle 7.6. Bump it to latest beta and adding a configuration workaround makes the test pass.

Fixes vaadin/multiplatform-runtime#117
