### PR TITLE
chore: Easier copy-paste for no import message

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
@@ -65,9 +65,8 @@ public class TaskGenerateReactFiles implements FallibleCommand {
             The server route definition is missing from the '%1$s' file
 
             To have working Flow routes add the following to the '%1$s' file:
-            - import line 'import {serverSideRoutes} from 'Frontend/generated/flow/Flow';'
-            - route '...serverSideRoutes' into the routes definition
-            Hybrid example with client main layout wrapper:
+            - import { serverSideRoutes } from "Frontend/generated/flow/Flow";
+            - route '...serverSideRoutes' into the routes definition as shown below:
 
                 export const routes = [
                   {

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/routes.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/routes.tsx
@@ -1,5 +1,5 @@
 import { createBrowserRouter, RouteObject } from 'react-router-dom';
-import {serverSideRoutes} from "Frontend/generated/flow/Flow";
+import { serverSideRoutes } from "Frontend/generated/flow/Flow";
 
 export const routes = [
   ...serverSideRoutes


### PR DESCRIPTION
First line with import can be copy-pasted as is.
Feedback from DX test.