### PR TITLE
feat: Pass theme definition to bootstrap modifiers

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrap.java
@@ -82,7 +82,8 @@ public class TaskGenerateBootstrap extends AbstractTaskClientGenerator {
         lines.addAll(getThemeLines());
 
         for (TypeScriptBootstrapModifier modifier : modifiers) {
-            modifier.modify(lines, options.isProductionMode());
+            modifier.modify(lines, options.isProductionMode(),
+                    frontDeps.getThemeDefinition());
         }
         return String.join(System.lineSeparator(), lines);
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TypeScriptBootstrapModifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TypeScriptBootstrapModifier.java
@@ -33,7 +33,9 @@ public interface TypeScriptBootstrapModifier extends Serializable {
      * @param themeDefinition
      *            the theme used by the application
      */
-    void modify(List<String> bootstrapTypeScript, boolean productionMode,
-            ThemeDefinition themeDefinition);
+    default void modify(List<String> bootstrapTypeScript,
+            boolean productionMode, ThemeDefinition themeDefinition) {
+        modify(bootstrapTypeScript, productionMode);
+    }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TypeScriptBootstrapModifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TypeScriptBootstrapModifier.java
@@ -21,7 +21,10 @@ public interface TypeScriptBootstrapModifier extends Serializable {
      * @deprecated use {@link #modify(List, boolean, ThemeDefinition)} instead
      */
     @Deprecated
-    void modify(List<String> bootstrapTypeScript, boolean productionMode);
+    default void modify(List<String> bootstrapTypeScript,
+            boolean productionMode) {
+
+    }
 
     /**
      * Modifies the bootstrap typescript by mutating the parameter.

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TypeScriptBootstrapModifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TypeScriptBootstrapModifier.java
@@ -3,6 +3,9 @@ package com.vaadin.flow.server.frontend;
 import java.io.Serializable;
 import java.util.List;
 
+import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
+import com.vaadin.flow.theme.ThemeDefinition;
+
 /**
  * Implemented by classes that want to modify the bootstrap typescript.
  */
@@ -15,7 +18,22 @@ public interface TypeScriptBootstrapModifier extends Serializable {
      *            the input typescript split into lines
      * @param productionMode
      *            true if building for production, false otherwise
+     * @deprecated use {@link #modify(List, boolean, ThemeDefinition)} instead
      */
+    @Deprecated
     void modify(List<String> bootstrapTypeScript, boolean productionMode);
+
+    /**
+     * Modifies the bootstrap typescript by mutating the parameter.
+     *
+     * @param bootstrapTypeScript
+     *            the input typescript split into lines
+     * @param productionMode
+     *            true if building for production, false otherwise
+     * @param themeDefinition
+     *            the theme used by the application
+     */
+    void modify(List<String> bootstrapTypeScript, boolean productionMode,
+            ThemeDefinition themeDefinition);
 
 }


### PR DESCRIPTION
This is needed to be able to import the correct version of components in an addon, e.g. if the application uses Material you will break the app if you import the Lumo version of vaadin-button
