### PR TITLE
fix: limit the requested items to a given threshold

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -332,6 +332,21 @@ public class DataCommunicator<T> implements Serializable {
      *            the end of the requested range
      */
     public void setRequestedRange(int start, int length) {
+        requestedRange = computeRequestedRange(start, length);
+        requestFlush();
+    }
+
+    /**
+     * Computes the requested range, limiting the number of requested items to a
+     * given threshold of ten pages.
+     *
+     * @param start
+     *            the start of the requested range
+     * @param length
+     *            the end of the requested range
+     * @return
+     */
+    protected final Range computeRequestedRange(int start, int length) {
         final int maximumAllowedItems = getMaximumAllowedItems();
         if (length > maximumAllowedItems) {
             getLogger().warn(String.format(
@@ -340,10 +355,7 @@ public class DataCommunicator<T> implements Serializable {
                             + "items allowed '%d'.",
                     length, maximumAllowedItems));
         }
-        requestedRange = Range.withLength(start,
-                Math.min(length, maximumAllowedItems));
-
-        requestFlush();
+        return Range.withLength(start, Math.min(length, maximumAllowedItems));
     }
 
     /**

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
@@ -187,7 +187,6 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
 
     public void setParentRequestedRange(int start, int length, T parentItem) {
         String parentKey = getKeyMapper().key(parentItem);
-
         HierarchicalCommunicationController<T> controller = dataControllers
                 .computeIfAbsent(parentKey,
                         key -> new HierarchicalCommunicationController<>(
@@ -198,7 +197,8 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
                                 (pkey, range) -> mapper.fetchChildItems(
                                         getKeyMapper().get(pkey), range)));
 
-        controller.setRequestRange(start, length);
+        Range range = computeRequestedRange(start, length);
+        controller.setRequestRange(range.getStart(), range.length());
         requestFlush(controller);
     }
 

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicatorDataTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicatorDataTest.java
@@ -20,7 +20,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.IntStream;
 
-import com.vaadin.flow.function.SerializablePredicate;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,6 +31,7 @@ import com.vaadin.flow.data.provider.CompositeDataGenerator;
 import com.vaadin.flow.data.provider.DataCommunicatorTest;
 import com.vaadin.flow.data.provider.hierarchy.HierarchicalArrayUpdater.HierarchicalUpdate;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinService;
@@ -276,6 +276,37 @@ public class HierarchicalCommunicatorDataTest {
         assertKeyItemPairIsPresentInKeyMapper(initialKey, itemToTest);
 
         communicator.reset();
+    }
+
+    @Test
+    public void expandItem_tooMuchItemsRequested_maxItemsAllowedRequested() {
+        int startingChildId = 10000;
+        int children = 1000;
+        int maxAllowedItems = 500;
+        treeData.clear();
+        treeData.addItems(null, ROOT);
+        treeData.addItems(ROOT, IntStream.range(0, children).mapToObj(
+                i -> new Item(startingChildId + i, "ROOT CHILD " + i)));
+
+        communicator.expand(ROOT);
+        fakeClientCommunication();
+
+        communicator.setParentRequestedRange(0, children, ROOT);
+        fakeClientCommunication();
+
+        IntStream.range(0, children).forEach(i -> {
+            String treeItemId = Integer.toString(startingChildId + i);
+            if (i < maxAllowedItems) {
+                Assert.assertNotNull(
+                        "Expecting item " + treeItemId
+                                + " to be fetched, but was not",
+                        communicator.getKeyMapper().get(treeItemId));
+            } else {
+                Assert.assertNull("Expecting item " + treeItemId
+                        + " not to be fetched because of max allowed items rule, but it was fetched",
+                        communicator.getKeyMapper().get(treeItemId));
+            }
+        });
     }
 
     private void assertKeyItemPairIsPresentInKeyMapper(String key, Item item) {


### PR DESCRIPTION
## Description

Limits the number of requested items from backend to a given threshold of ten pages. Exactly the same as #12003, but applied to HierarchicalDataCommunicator.

Fixes #18403

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
