### PR TITLE
fix: limit the requested items to a given threshold (#18417)

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -164,6 +164,20 @@ public class DataCommunicator<T> implements Serializable {
      * @param length the end of the requested range
      */
     public void setRequestedRange(int start, int length) {
+        requestedRange = computeRequestedRange(start, length);
+        requestFlush();
+    }
+
+    /**
+     * Computes the requested range, limiting the number of requested items to a
+     * given threshold of ten pages.
+     *
+     * @param start
+     *            the start of the requested range
+     * @param length
+     *            the end of the requested range
+     */
+    protected final Range computeRequestedRange(int start, int length) {
         if (length > MAXIMUM_ALLOWED_ITEMS) {
             getLogger().warn(
                     "Attempted to fetch more items from server than allowed "
@@ -171,10 +185,7 @@ public class DataCommunicator<T> implements Serializable {
                             + "items allowed '{}'.",
                     length, MAXIMUM_ALLOWED_ITEMS);
         }
-        requestedRange = Range.withLength(start,
-                Math.min(length, MAXIMUM_ALLOWED_ITEMS));
-
-        requestFlush();
+        return Range.withLength(start, Math.min(length, MAXIMUM_ALLOWED_ITEMS));
     }
 
     /**

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicatorDataTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicatorDataTest.java
@@ -20,7 +20,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.IntStream;
 
-import com.vaadin.flow.function.SerializablePredicate;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,6 +31,7 @@ import com.vaadin.flow.data.provider.CompositeDataGenerator;
 import com.vaadin.flow.data.provider.DataCommunicatorTest;
 import com.vaadin.flow.data.provider.hierarchy.HierarchicalArrayUpdater.HierarchicalUpdate;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinService;
@@ -204,8 +204,9 @@ public class HierarchicalCommunicatorDataTest {
         fakeClientCommunication();
 
         Arrays.asList("ROOT", "FOLDER", "LEAF")
-                .forEach(key -> Assert.assertNotNull("Expected key '" + key
-                        + "' to be generated when unique key provider used",
+                .forEach(key -> Assert.assertNotNull(
+                        "Expected key '" + key
+                                + "' to be generated when unique key provider used",
                         communicator.getKeyMapper().get(key)));
     }
 
@@ -225,8 +226,9 @@ public class HierarchicalCommunicatorDataTest {
 
         // key mapper should generate keys 1,2,3
         IntStream.range(1, 4).mapToObj(String::valueOf)
-                .forEach(i -> Assert.assertNotNull("Expected key '" + i
-                        + "' to be generated when unique key provider is not set",
+                .forEach(i -> Assert.assertNotNull(
+                        "Expected key '" + i
+                                + "' to be generated when unique key provider is not set",
                         communicator.getKeyMapper().get(i)));
     }
 
@@ -285,6 +287,38 @@ public class HierarchicalCommunicatorDataTest {
         assertKeyItemPairIsPresentInKeyMapper(initialKey, itemToTest);
 
         communicator.reset();
+    }
+
+    @Test
+    public void expandItem_tooMuchItemsRequested_maxItemsAllowedRequested() {
+        int startingChildId = 10000;
+        int children = 1000;
+        int maxAllowedItems = 500;
+        treeData.clear();
+        treeData.addItems(null, ROOT);
+        treeData.addItems(ROOT, IntStream.range(0, children).mapToObj(
+                i -> new Item(startingChildId + i, "ROOT CHILD " + i)));
+
+        communicator.expand(ROOT);
+        fakeClientCommunication();
+
+        communicator.setParentRequestedRange(0, children, ROOT);
+        fakeClientCommunication();
+
+        IntStream.range(0, children).forEach(i -> {
+            String treeItemId = Integer.toString(startingChildId + i);
+            if (i < maxAllowedItems) {
+                Assert.assertNotNull(
+                        "Expecting item " + treeItemId
+                                + " to be fetched, but was not",
+                        communicator.getKeyMapper().get(treeItemId));
+            } else {
+                Assert.assertNull(
+                        "Expecting item " + treeItemId
+                                + " not to be fetched because of max allowed items rule, but it was fetched",
+                        communicator.getKeyMapper().get(treeItemId));
+            }
+        });
     }
 
     private void assertKeyItemPairIsPresentInKeyMapper(String key, Item item) {

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicatorDataTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicatorDataTest.java
@@ -292,8 +292,8 @@ public class HierarchicalCommunicatorDataTest {
     @Test
     public void expandItem_tooMuchItemsRequested_maxItemsAllowedRequested() {
         int startingChildId = 10000;
-        int children = 1000;
-        int maxAllowedItems = 500;
+        int children = 3000;
+        int maxAllowedItems = 1000;
         treeData.clear();
         treeData.addItems(null, ROOT);
         treeData.addItems(ROOT, IntStream.range(0, children).mapToObj(


### PR DESCRIPTION
Limits the number of requested items from backend to a given threshold of ten pages. Exactly the same as #12003, but applied to HierarchicalDataCommunicator.

Fixes #18403