### PR TITLE
fix: prevent dev-tools connection to downgrade to streaming transport

### DIFF
--- a/vaadin-dev-server/frontend/websocket-connection.ts
+++ b/vaadin-dev-server/frontend/websocket-connection.ts
@@ -15,6 +15,7 @@ export class WebSocketConnection extends Connection {
 
     const config = {
       transport: 'websocket',
+      fallbackTransport: 'websocket',
       url,
       contentType: 'application/json; charset=UTF-8',
       reconnectInterval: 5000,


### PR DESCRIPTION
## Description

PushHandler expects that dev-tools connection to always use websocket transport. However, in case of client reconnection, atmosphere after a couple of attempts downgrades the transport to 'streaming', causing PushHandler to treat the connection as a Flow UI Push connection.
This change set 'websocket' also as atmospehere fallback transport, so all reconnection attempts will use the expected transport.

Fixes #18398

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
