### PR TITLE
fix: replace 'blacklist' and 'whitelist' with 'blocked' and 'allowed' (#18405) (CP: 23.4)

### DIFF
--- a/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/internal/LitTemplateParserImpl.java
+++ b/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/internal/LitTemplateParserImpl.java
@@ -134,7 +134,7 @@ public class LitTemplateParserImpl implements LitTemplateParser {
                 + "definition of the element with tag '{}' "
                 + "in any lit template file declared using '@{}' annotations. "
                 + "In a Spring Boot project, please ensure that the template's "
-                + "groupId is added to the vaadin.whitelisted-packages "
+                + "groupId is added to the vaadin.allowed-packages "
                 + "property. Otherwise, please Check the availability of the "
                 + "template files in your WAR file or provide alternative "
                 + "implementation of the method "

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/NpmTemplateParser.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/NpmTemplateParser.java
@@ -140,7 +140,7 @@ public class NpmTemplateParser implements TemplateParser {
                 + "definition of the element with tag '%s' "
                 + "in any template file declared using '@%s' annotations. "
                 + "In a Spring Boot project, please ensure that the template's "
-                + "groupId is added to the vaadin.whitelisted-packages "
+                + "groupId is added to the vaadin.allowed-packages "
                 + "property. Otherwise, please Check the availability of the "
                 + "template files in your WAR file or provide alternative "
                 + "implementation of the method getTemplateContent() which "

--- a/flow-tests/vaadin-spring-tests/test-mvc-without-endpoints/src/main/resources/application.properties
+++ b/flow-tests/vaadin-spring-tests/test-mvc-without-endpoints/src/main/resources/application.properties
@@ -5,4 +5,4 @@ vaadin.devmode.liveReload.enabled=false
 
 # To improve the performance during development. 
 # For more information https://vaadin.com/docs/flow/spring/tutorial-spring-configuration.html#special-configuration-parameters
-# vaadin.whitelisted-packages= org/vaadin/example
+# vaadin.allowed-packages= org/vaadin/example

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-only-prepare/src/main/resources/application.properties
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-only-prepare/src/main/resources/application.properties
@@ -1,3 +1,3 @@
 server.port=8888
-vaadin.blacklisted-packages=vaadin-spring/target/test-classes
+vaadin.blocked-packages=vaadin-spring/target/test-classes
 vaadin.excludeUrls=/swagger-ui/**

--- a/flow-tests/vaadin-spring-tests/test-spring-white-list/src/main/resources/application.properties
+++ b/flow-tests/vaadin-spring-tests/test-spring-white-list/src/main/resources/application.properties
@@ -1,2 +1,2 @@
 server.port=8888
-vaadin.whitelisted-packages=com/vaadin/flow/spring/test/whitelist
+vaadin.allowed-packages=com/vaadin/flow/spring/test/whitelist

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinConfigurationProperties.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinConfigurationProperties.java
@@ -86,14 +86,14 @@ public class VaadinConfigurationProperties {
     private Pnpm pnpm = new Pnpm();
 
     /**
-     * Custom package blacklist that should be skipped in scanning.
+     * List of blocked packages that shouldn't be scanned.
      */
-    private List<String> blacklistedPackages = new ArrayList<>();
+    private List<String> blockedPackages = new ArrayList<>();
 
     /**
-     * Custom package whitelist that should be scanned.
+     * List of allowed packages that should be scanned.
      */
-    private List<String> whitelistedPackages = new ArrayList<>();
+    private List<String> allowedPackages = new ArrayList<>();
 
     /**
      * Whether a browser should be launched on startup when in development mode.
@@ -246,42 +246,89 @@ public class VaadinConfigurationProperties {
     }
 
     /**
-     * Get a list of packages that are blacklisted for class scanning.
+     * Get a list of packages that are blocked for class scanning.
      *
-     * @return package blacklist
+     * @return blocked packages
      */
-    public List<String> getBlacklistedPackages() {
-        return Collections.unmodifiableList(blacklistedPackages);
+    public List<String> getBlockedPackages() {
+        return Collections.unmodifiableList(blockedPackages);
     }
 
     /**
      * Set list of packages to ignore for class scanning.
      *
-     * @param blacklistedPackages
+     * @param blockedPackages
      *            list of packages to ignore
      */
-    public void setBlacklistedPackages(List<String> blacklistedPackages) {
-        this.blacklistedPackages = new ArrayList<>(blacklistedPackages);
+    public void setBlockedPackages(List<String> blockedPackages) {
+        this.blockedPackages = blockedPackages;
     }
 
     /**
-     * Get a list of packages that are white-listed for class scanning.
+     * Get a list of packages that are blocked for class scanning.
      *
-     * @return package white-list
+     * @return blocked packages
+     * @deprecated use {@link #getBlockedPackages()}
      */
-    public List<String> getWhitelistedPackages() {
-        return Collections.unmodifiableList(whitelistedPackages);
+    @Deprecated(forRemoval = true)
+    public List<String> getBlacklistedPackages() {
+        return Collections.unmodifiableList(blockedPackages);
     }
 
     /**
-     * Set list of packages to be scanned. If <code>whitelistedPackages</code>
-     * is set then <code>blacklistedPackages</code> is ignored.
+     * Set list of packages to ignore for class scanning.
      *
-     * @param whitelistedPackages
+     * @param blockedPackages
+     *            list of packages to ignore
+     * @deprecated use {@link #setBlockedPackages(List)}
+     */
+    @Deprecated(forRemoval = true)
+    public void setBlacklistedPackages(List<String> blockedPackages) {
+        this.blockedPackages = new ArrayList<>(blockedPackages);
+    }
+
+    /**
+     * Get a list of packages that are allowed for class scanning.
+     *
+     * @return allowed packages
+     */
+    public List<String> getAllowedPackages() {
+        return allowedPackages;
+    }
+
+    /**
+     * Set list of packages to be scanned. If <code>allowedPackages</code> is
+     * set then <code>blockedPackages</code> is ignored.
+     *
+     * @param allowedPackages
      *            list of packages to be scanned
      */
-    public void setWhitelistedPackages(List<String> whitelistedPackages) {
-        this.whitelistedPackages = new ArrayList<>(whitelistedPackages);
+    public void setAllowedPackages(List<String> allowedPackages) {
+        this.allowedPackages = allowedPackages;
+    }
+
+    /**
+     * Get a list of packages that are allowed for class scanning.
+     *
+     * @return allowed packages
+     * @deprecated use {@link #getAllowedPackages()}
+     */
+    @Deprecated(forRemoval = true)
+    public List<String> getWhitelistedPackages() {
+        return Collections.unmodifiableList(allowedPackages);
+    }
+
+    /**
+     * Set list of packages to be scanned. If <code>allowedPackages</code> is
+     * set then <code>blockedPackages</code> is ignored.
+     *
+     * @param allowedPackages
+     *            list of packages to be scanned
+     * @deprecated use {@link #setAllowedPackages(List)}
+     */
+    @Deprecated(forRemoval = true)
+    public void setWhitelistedPackages(List<String> allowedPackages) {
+        this.allowedPackages = new ArrayList<>(allowedPackages);
     }
 
     /**

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -464,11 +464,15 @@ public class VaadinServletContextInitializer
                     "Search for subclasses and classes with annotations took {} ms",
                     ms);
 
-            if (ms > 10000 && appContext.getEnvironment()
-                    .getProperty("vaadin.whitelisted-packages") == null) {
+            Environment environment = appContext.getEnvironment();
+            if (ms > 10000
+                    && environment
+                            .getProperty("vaadin.allowed-packages") == null
+                    && environment.getProperty(
+                            "vaadin.whitelisted-packages") == null) {
                 getLogger().info(
-                        "Due to slow search it is recommended to use the whitelisted-packages feature to make scanning faster.\n\n"
-                                + "See the whitelisted-packages section in the docs at https://vaadin.com/docs/latest/flow/integrations/spring/configuration#special-configuration-parameters");
+                        "Due to slow search it is recommended to use the allowed-packages feature to make scanning faster.\n\n"
+                                + "See the allowed-packages section in the docs at https://vaadin.com/docs/latest/flow/integrations/spring/configuration#special-configuration-parameters");
             }
 
             try {
@@ -568,7 +572,15 @@ public class VaadinServletContextInitializer
     public VaadinServletContextInitializer(ApplicationContext context) {
         appContext = context;
         String neverScanProperty = appContext.getEnvironment()
-                .getProperty("vaadin.blacklisted-packages");
+                .getProperty("vaadin.blocked-packages");
+        if (neverScanProperty == null) {
+            neverScanProperty = appContext.getEnvironment()
+                    .getProperty("vaadin.blacklisted-packages");
+            if (neverScanProperty != null) {
+                getLogger().warn(
+                        "vaadin.blacklisted-packages is deprecated and may not be supported in the future. Use vaadin.blocked-packages instead.");
+            }
+        }
         List<String> neverScan;
         if (neverScanProperty == null) {
             neverScan = Collections.emptyList();
@@ -579,7 +591,15 @@ public class VaadinServletContextInitializer
         }
 
         String onlyScanProperty = appContext.getEnvironment()
-                .getProperty("vaadin.whitelisted-packages");
+                .getProperty("vaadin.allowed-packages");
+        if (onlyScanProperty == null) {
+            onlyScanProperty = appContext.getEnvironment()
+                    .getProperty("vaadin.whitelisted-packages");
+            if (onlyScanProperty != null) {
+                getLogger().warn(
+                        "vaadin.whitelisted-packages is deprecated and may not be supported in the future. Use vaadin.allowed-packages instead.");
+            }
+        }
         if (onlyScanProperty == null) {
             customScanOnly = Collections.emptyList();
             customLoader = new CustomResourceLoader(appContext, neverScan);
@@ -593,7 +613,7 @@ public class VaadinServletContextInitializer
 
         if (!customScanOnly.isEmpty() && !neverScan.isEmpty()) {
             getLogger().warn(
-                    "vaadin.blacklisted-packages is ignored because both vaadin.whitelisted-packages and vaadin.blacklisted-packages have been set.");
+                    "vaadin.blocked-packages is ignored because both vaadin.allowed-packages and vaadin.blocked-packages have been set.");
         }
     }
 


### PR DESCRIPTION
Mark the existing methods as deprecated and introduce methods with new names. Fall back to the old configuration properties if the new ones aren't used.

Fixes vaadin/spring#645