### PR TITLE
fix: remove Lazy annotation from Flow security beans

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringSecurityAutoConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringSecurityAutoConfiguration.java
@@ -119,7 +119,7 @@ public class SpringSecurityAutoConfiguration {
      */
     @Bean
     public AnnotatedViewAccessChecker annotatedViewAccessChecker(
-            @Lazy AccessAnnotationChecker accessAnnotationChecker) {
+            AccessAnnotationChecker accessAnnotationChecker) {
         return new AnnotatedViewAccessChecker(accessAnnotationChecker);
     }
 
@@ -133,7 +133,7 @@ public class SpringSecurityAutoConfiguration {
      */
     @Bean
     public RoutePathAccessChecker routePathAccessChecker(
-            @Lazy AccessPathChecker accessPathChecker) {
+            AccessPathChecker accessPathChecker) {
         return new RoutePathAccessChecker(accessPathChecker);
     }
 

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringSecurityAutoConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringSecurityAutoConfiguration.java
@@ -48,7 +48,7 @@ import com.vaadin.flow.spring.security.VaadinRolePrefixHolder;
  * @author Vaadin Ltd
  *
  */
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(WebSecurityCustomizer.class)
 @EnableConfigurationProperties(VaadinConfigurationProperties.class)
 public class SpringSecurityAutoConfiguration {

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.spring.security;
 
+import jakarta.annotation.PostConstruct;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -31,6 +32,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
@@ -120,7 +122,14 @@ public abstract class VaadinWebSecurity {
     private String servletContextPath;
 
     @Autowired
+    private ObjectProvider<NavigationAccessControl> accessControlProvider;
+
     private NavigationAccessControl accessControl;
+
+    @PostConstruct
+    void afterPropertiesSet() {
+        accessControl = accessControlProvider.getIfAvailable();
+    }
 
     private final AuthenticationContext authenticationContext = new AuthenticationContext();
 

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringSecurityAutoConfigurationTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringSecurityAutoConfigurationTest.java
@@ -184,15 +184,17 @@ class SpringSecurityAutoConfigurationTest {
     private <T> void assertObjectIsSerializable(T instance) {
         Object deserialized = Assertions.assertDoesNotThrow(() -> {
             ByteArrayOutputStream bs = new ByteArrayOutputStream();
-            ObjectOutputStream out = new ObjectOutputStream(bs);
-            out.writeObject(instance);
+            try (ObjectOutputStream out = new ObjectOutputStream(bs)) {
+                out.writeObject(instance);
+            }
             byte[] data = bs.toByteArray();
-            ObjectInputStream in = new ObjectInputStream(
-                    new ByteArrayInputStream(data));
+            try (ObjectInputStream in = new ObjectInputStream(
+                    new ByteArrayInputStream(data))) {
 
-            @SuppressWarnings("unchecked")
-            T readObject = (T) in.readObject();
-            return readObject;
+                @SuppressWarnings("unchecked")
+                T readObject = (T) in.readObject();
+                return readObject;
+            }
         });
         Assertions.assertNotNull(deserialized, "Deserialized object is null");
     }

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringSecurityAutoConfigurationTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringSecurityAutoConfigurationTest.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.spring;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.lang.reflect.Method;

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringSecurityAutoConfigurationTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringSecurityAutoConfigurationTest.java
@@ -16,10 +16,16 @@
 
 package com.vaadin.flow.spring;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.lang.reflect.Method;
 import java.security.Principal;
 import java.util.function.Function;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
@@ -36,9 +42,11 @@ import com.vaadin.flow.server.auth.AccessAnnotationChecker;
 import com.vaadin.flow.server.auth.AccessCheckDecision;
 import com.vaadin.flow.server.auth.AccessCheckResult;
 import com.vaadin.flow.server.auth.AccessPathChecker;
+import com.vaadin.flow.server.auth.AnnotatedViewAccessChecker;
 import com.vaadin.flow.server.auth.NavigationAccessChecker;
 import com.vaadin.flow.server.auth.NavigationAccessControl;
 import com.vaadin.flow.server.auth.NavigationContext;
+import com.vaadin.flow.server.auth.RoutePathAccessChecker;
 import com.vaadin.flow.spring.security.NavigationAccessControlConfigurer;
 import com.vaadin.flow.spring.security.SpringAccessPathChecker;
 import com.vaadin.flow.spring.security.SpringNavigationAccessControl;
@@ -124,6 +132,29 @@ class SpringSecurityAutoConfigurationTest {
                 .run(SpringSecurityAutoConfigurationTest::assertThatCustomNavigationAccessCheckerIsUsed);
     }
 
+    @Test
+    void securityBeansAreSerializable() {
+        this.contextRunner.run((context) -> {
+
+            // view access checker
+            assertThat(context).getBean(AccessAnnotationChecker.class)
+                    .satisfies(this::assertObjectIsSerializable);
+
+            assertThat(context).getBean(AnnotatedViewAccessChecker.class)
+                    .satisfies(this::assertObjectIsSerializable);
+
+            assertThat(context).getBean(AccessPathChecker.class)
+                    .satisfies(this::assertObjectIsSerializable);
+
+            assertThat(context).getBean(RoutePathAccessChecker.class)
+                    .satisfies(this::assertObjectIsSerializable);
+
+            assertThat(context).getBean(NavigationAccessControl.class)
+                    .satisfies(this::assertObjectIsSerializable);
+        });
+
+    }
+
     private static void assertThatCustomNavigationAccessCheckerIsUsed(
             AssertableWebApplicationContext context) {
         assertThat(context).hasSingleBean(NavigationAccessControl.class);
@@ -151,11 +182,27 @@ class SpringSecurityAutoConfigurationTest {
         Mockito.verify(navigationContext, Mockito.never()).neutral();
     }
 
+    private <T> void assertObjectIsSerializable(T instance) {
+        Object deserialized = Assertions.assertDoesNotThrow(() -> {
+            ByteArrayOutputStream bs = new ByteArrayOutputStream();
+            ObjectOutputStream out = new ObjectOutputStream(bs);
+            out.writeObject(instance);
+            byte[] data = bs.toByteArray();
+            ObjectInputStream in = new ObjectInputStream(
+                    new ByteArrayInputStream(data));
+
+            @SuppressWarnings("unchecked")
+            T readObject = (T) in.readObject();
+            return readObject;
+        });
+        Assertions.assertNotNull(deserialized, "Deserialized object is null");
+    }
+
     @TestConfiguration(proxyBeanMethods = false)
     static class CustomAccessPathChecker extends VaadinWebSecurity {
 
         @Bean
-        AccessPathChecker customAccessPathChecker() {
+        static AccessPathChecker customAccessPathChecker() {
             return DISABLED_PATH_CHECKER;
         }
     }
@@ -164,7 +211,7 @@ class SpringSecurityAutoConfigurationTest {
     static class CustomAccessAnnotationChecker extends VaadinWebSecurity {
 
         @Bean
-        AccessAnnotationChecker accessAnnotationChecker() {
+        static AccessAnnotationChecker accessAnnotationChecker() {
             return DISABLED_ANNOTATION_CHECKER;
         }
     }


### PR DESCRIPTION
## Description

For parameters with Lazy annotation, Spring generates a not-serializable proxy. Since some security beans are used inside Flow listeners, they should be fully serializable (or defined transient, if possible).
This change removes the unnecessary Lazy annotaions, moving the lazy evaluation to VaadinWebSecurity.

Fixes #18458

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
