### PR TITLE
chore: provide default session lock strategy

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
@@ -322,9 +322,13 @@ public interface DeploymentConfiguration
      * Returns the strategy for Vaadin session lock checking in production mode.
      * Ignored in development mode.
      *
+     * By default, it returns {@link SessionLockCheckStrategy#ASSERT}.
+     *
      * @return the lock checking strategy, never null.
      */
-    SessionLockCheckStrategy getSessionLockCheckStrategy();
+    default SessionLockCheckStrategy getSessionLockCheckStrategy() {
+        return SessionLockCheckStrategy.ASSERT;
+    }
 
     /**
      * Check if the React Router is enabled for the project instead of Vaadin


### PR DESCRIPTION
This change makes getSessionLockCheckStrategy a default method, returning ASSERT as the default lock strategy.
It prevents potential compilation issues in internal modules implementing DeploymentConfiguration for testing purposes that may run against different versions of Flow (e.g. MPR)
