### PR TITLE
fix: fix static resource retrieval with Jetty 12

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/PwaRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PwaRegistry.java
@@ -29,9 +29,12 @@ import java.io.InputStreamReader;
 import java.io.Serializable;
 import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -161,7 +164,7 @@ public class PwaRegistry implements Serializable {
 
     private URL getResourceUrl(ServletContext context, String path)
             throws MalformedURLException {
-        URL resourceUrl = context.getResource(path);
+        URL resourceUrl = VaadinServletService.getStaticResource(context, path);
         if (resourceUrl == null) {
             // this is a workaround specific for Spring default static resources
             // location: see #8705

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
@@ -243,8 +243,7 @@ public class VaadinServletService extends VaadinService {
     @Override
     public URL getStaticResource(String path) {
         try {
-            return VaadinServletService
-                    .getStaticResource(getServlet().getServletContext(), path);
+            return getStaticResource(getServlet().getServletContext(), path);
         } catch (MalformedURLException e) {
             getLogger().warn("Error finding resource for '{}'", path, e);
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
@@ -22,7 +22,10 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import java.io.InputStream;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -240,7 +243,8 @@ public class VaadinServletService extends VaadinService {
     @Override
     public URL getStaticResource(String path) {
         try {
-            return getServlet().getServletContext().getResource(path);
+            return VaadinServletService
+                    .getStaticResource(getServlet().getServletContext(), path);
         } catch (MalformedURLException e) {
             getLogger().warn("Error finding resource for '{}'", path, e);
         }
@@ -315,5 +319,23 @@ public class VaadinServletService extends VaadinService {
     @Override
     protected void setDefaultClassLoader() {
         setClassLoader(getServlet().getServletContext().getClassLoader());
+    }
+
+    static URL getStaticResource(ServletContext servletContext, String path)
+            throws MalformedURLException {
+        URL url = servletContext.getResource(path);
+        if (url != null && Optional.ofNullable(servletContext.getServerInfo())
+                .orElse("").contains("jetty/12.")) {
+            // Making sure that resource exists before returning it. Jetty
+            // 12 may return URL for non-existing resource.
+            try {
+                if (!Files.exists(Path.of(url.toURI()))) {
+                    url = null;
+                }
+            } catch (URISyntaxException e) {
+                url = null;
+            }
+        }
+        return url;
     }
 }


### PR DESCRIPTION
With Jetty 12, static resources retrieved via servlet context's `getResource(String)` may return non-null URL for non-existing resource. Jetty 11 returns null for non-existing resource. This change adds a double check for the static resource retrieved with the `getResource`, and returns null if it doesn't exist, to keep other parts work the same way as with Jetty 11.

This PR is tested manually. IT for executable JAR will be created in another task/PR.

Fixes: #18410