### PR TITLE
fix: propagate all request parameter to location in eagerServerLoad mode

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.server.communication;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -107,11 +108,11 @@ public class JavaScriptBootstrapHandler extends BootstrapHandler {
             }
 
             // Case 2, use the request
-            if (request instanceof VaadinServletRequest) {
+            Map<String, String[]> parameterMap = request.getParameterMap();
+            if (parameterMap != null && !parameterMap.isEmpty()) {
                 return new Location(request.getPathInfo(),
-                        QueryParameters
-                                .fromString(((VaadinServletRequest) request)
-                                        .getQueryString()));
+                        QueryParameters.full(parameterMap));
+
             } else {
                 return new Location(request.getPathInfo(),
                         QueryParameters.empty());

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
@@ -24,6 +24,7 @@ import java.io.UncheckedIOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -50,6 +51,8 @@ import com.vaadin.flow.component.page.AppShellConfigurator;
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.di.ResourceProvider;
 import com.vaadin.flow.internal.UsageStatistics;
+import com.vaadin.flow.router.Location;
+import com.vaadin.flow.router.QueryParameters;
 import com.vaadin.flow.server.AppShellRegistry;
 import com.vaadin.flow.server.BootstrapHandler;
 import com.vaadin.flow.server.MockServletServiceSessionSetup;
@@ -432,6 +435,36 @@ public class IndexHtmlRequestHandlerTest {
         verify(request.getService()).modifyIndexHtmlResponse(captor.capture());
 
         Assert.assertNotNull(captor.getValue().getUI());
+    }
+
+    @Test
+    public void eagerServerLoad_requestParameters_forwardedToLocationObject()
+            throws IOException {
+        deploymentConfiguration.setEagerServerLoad(true);
+
+        Map<String, String[]> requestParams = new HashMap<>();
+        requestParams.put("param1", new String[] { "a", "b" });
+        requestParams.put("param2", new String[] { "2" });
+        VaadinServletRequest request = createVaadinRequest("/view");
+        Mockito.when(request.getHttpServletRequest().getParameterMap())
+                .thenReturn(requestParams);
+
+        indexHtmlRequestHandler.synchronizedHandleRequest(session, request,
+                response);
+
+        ArgumentCaptor<IndexHtmlResponse> captor = ArgumentCaptor
+                .forClass(IndexHtmlResponse.class);
+
+        verify(request.getService()).modifyIndexHtmlResponse(captor.capture());
+
+        Optional<UI> maybeUI = captor.getValue().getUI();
+        Assert.assertNotNull(maybeUI);
+        QueryParameters locationParams = maybeUI.get().getActiveViewLocation()
+                .getQueryParameters();
+        Assert.assertEquals(List.of("a", "b"),
+                locationParams.getParameters("param1"));
+        Assert.assertEquals(List.of("2"),
+                locationParams.getParameters("param2"));
     }
 
     @Test


### PR DESCRIPTION
## Description

Currently, when eagerServerLoad is active only parameters from query string are propagated to the route Location. If the Flow view is accessed through a multipart form POST request thg form values are suppressed.
With this change all request parameters are propagated to the view location object.

Fixes #17972
## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
