### PR TITLE
chore: upgrade to Vite 4.5.2 (24.2)

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "dependencies": {},
   "devDependencies": {
-    "vite": "4.5.1",
+    "vite": "4.5.2",
     "@vitejs/plugin-react": "4.0.4",
     "@rollup/plugin-replace": "5.0.2",
     "@rollup/pluginutils": "5.0.2",


### PR DESCRIPTION
https://github.com/advisories/GHSA-c24v-8rfc-w8vw