### PR TITLE
Validation fixes

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -1347,8 +1347,7 @@ public class Binder<BEAN> implements Serializable {
             getBinder().getValidationStatusHandler()
                     .statusChange(new BinderValidationStatus<>(getBinder(),
                             Collections.singletonList(status),
-                            Collections.emptyList(), bindingValidationStatuses,
-                            beanStatuses));
+                            Collections.emptyList()));
 
             boolean binderHasErrors = bindingValidationStatuses.stream()
                     .anyMatch(BindingValidationStatus::isError)

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/BinderValidationStatus.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/BinderValidationStatus.java
@@ -54,6 +54,8 @@ public class BinderValidationStatus<BEAN> implements Serializable {
     private final Binder<BEAN> binder;
     private final List<BindingValidationStatus<?>> bindingStatuses;
     private final List<ValidationResult> binderStatuses;
+    private List<BindingValidationStatus<?>> bindingValidationStatuses;
+    private List<ValidationResult> beanStatuses;
 
     /**
      * Creates a new binder validation status for the given binder and
@@ -76,6 +78,31 @@ public class BinderValidationStatus<BEAN> implements Serializable {
         this.binder = source;
         this.bindingStatuses = Collections.unmodifiableList(bindingStatuses);
         this.binderStatuses = Collections.unmodifiableList(binderStatuses);
+    }
+
+    /**
+     * Creates a new binder validation status for the given binder and
+     * validation results. This constructor is called when the status is changed
+     * due to a change in the status of a single binding. In this case
+     * bindingStatuses will only contain status for that binding and
+     * binderStatuses will always be empty. The current validation status of the
+     * whole binder should be passed in as binderValidationStatus.
+     *
+     * @param source
+     *            the source binder
+     * @param bindingStatuses
+     *            the validation results for the fields
+     * @param binderStatuses
+     *            the validation results for binder level validation // TODO
+     */
+    public BinderValidationStatus(Binder<BEAN> source,
+            List<BindingValidationStatus<?>> bindingStatuses,
+            List<ValidationResult> binderStatuses,
+            List<BindingValidationStatus<?>> bindingValidationStatuses,
+            List<ValidationResult> beanStatuses) {
+        this(source, bindingStatuses, binderStatuses);
+        this.bindingValidationStatuses = bindingValidationStatuses;
+        this.beanStatuses = beanStatuses;
     }
 
     /**
@@ -212,5 +239,13 @@ public class BinderValidationStatus<BEAN> implements Serializable {
             SerializablePredicate<BindingValidationStatus<?>> filter) {
         bindingStatuses.stream().filter(filter).forEach(s -> s.getBinding()
                 .getValidationStatusHandler().statusChange(s));
+    }
+
+    public List<BindingValidationStatus<?>> getBindingValidationStatuses() {
+        return bindingValidationStatuses;
+    }
+
+    public List<ValidationResult> getBeanStatuses() {
+        return beanStatuses;
     }
 }

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/BinderValidationStatus.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/BinderValidationStatus.java
@@ -54,8 +54,6 @@ public class BinderValidationStatus<BEAN> implements Serializable {
     private final Binder<BEAN> binder;
     private final List<BindingValidationStatus<?>> bindingStatuses;
     private final List<ValidationResult> binderStatuses;
-    private List<BindingValidationStatus<?>> bindingValidationStatuses;
-    private List<ValidationResult> beanStatuses;
 
     /**
      * Creates a new binder validation status for the given binder and
@@ -78,31 +76,6 @@ public class BinderValidationStatus<BEAN> implements Serializable {
         this.binder = source;
         this.bindingStatuses = Collections.unmodifiableList(bindingStatuses);
         this.binderStatuses = Collections.unmodifiableList(binderStatuses);
-    }
-
-    /**
-     * Creates a new binder validation status for the given binder and
-     * validation results. This constructor is called when the status is changed
-     * due to a change in the status of a single binding. In this case
-     * bindingStatuses will only contain status for that binding and
-     * binderStatuses will always be empty. The current validation status of the
-     * whole binder should be passed in as binderValidationStatus.
-     *
-     * @param source
-     *            the source binder
-     * @param bindingStatuses
-     *            the validation results for the fields
-     * @param binderStatuses
-     *            the validation results for binder level validation // TODO
-     */
-    public BinderValidationStatus(Binder<BEAN> source,
-            List<BindingValidationStatus<?>> bindingStatuses,
-            List<ValidationResult> binderStatuses,
-            List<BindingValidationStatus<?>> bindingValidationStatuses,
-            List<ValidationResult> beanStatuses) {
-        this(source, bindingStatuses, binderStatuses);
-        this.bindingValidationStatuses = bindingValidationStatuses;
-        this.beanStatuses = beanStatuses;
     }
 
     /**
@@ -239,13 +212,5 @@ public class BinderValidationStatus<BEAN> implements Serializable {
             SerializablePredicate<BindingValidationStatus<?>> filter) {
         bindingStatuses.stream().filter(filter).forEach(s -> s.getBinding()
                 .getValidationStatusHandler().statusChange(s));
-    }
-
-    public List<BindingValidationStatus<?>> getBindingValidationStatuses() {
-        return bindingValidationStatuses;
-    }
-
-    public List<ValidationResult> getBeanStatuses() {
-        return beanStatuses;
     }
 }

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -1450,7 +1450,7 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
     }
 
     @Test
-    public void two_asRequired_fields_without_initial_values() {
+    public void two_asRequired_fields_without_initial_values_setBean() {
         binder.forField(nameField).asRequired("Empty name").bind(p -> "",
                 (p, s) -> {
                 });
@@ -1459,6 +1459,37 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
                 });
 
         binder.setBean(item);
+        assertThat("Initially there should be no errors",
+                nameField.getErrorMessage(), isEmptyString());
+        assertThat("Initially there should be no errors",
+                ageField.getErrorMessage(), isEmptyString());
+
+        nameField.setValue("Foo");
+        assertThat("Name with a value should not be an error",
+                nameField.getErrorMessage(), isEmptyString());
+
+        assertNotNull(
+                "Age field should now be in error, since setBean is used.",
+                ageField.getErrorMessage());
+
+        nameField.setValue("");
+        assertNotNull("Empty name should now be in error.",
+                nameField.getErrorMessage());
+
+        assertNotNull("Age field should still be in error.",
+                ageField.getErrorMessage());
+    }
+
+    @Test
+    public void two_asRequired_fields_without_initial_values_readBean() {
+        binder.forField(nameField).asRequired("Empty name").bind(p -> "",
+                (p, s) -> {
+                });
+        binder.forField(ageField).asRequired("Empty age").bind(p -> "",
+                (p, s) -> {
+                });
+
+        binder.readBean(item);
         assertThat("Initially there should be no errors",
                 nameField.getErrorMessage(), isEmptyString());
         assertThat("Initially there should be no errors",


### PR DESCRIPTION
Changes:

1. Adds an `isApplied` check and predicate for `Binding`. If false is returned, the binding will be ignored for validation and bean writing. This can be customized by the developer. Default is that bindings whose fields have `isVisible() == false` are ignored.
2. Once `Binder.handleFieldValueChange` runs for a binding when `readBean` was used, the whole binder will be silently validated also. `BinderValidationStatusHandler` is called like before (only contains status from changed binding), but `StatusChangeEvent` is now fired considering all bindings and if possible bean validators as well.
3. Once `Binder.handleFieldValueChange` runs for a binding when `setBean` was used, `doWriteIfValid` will validate all bindings, not only the changed ones. This prevents writing an invalid bean in cases where one or more of the initial values are in invalid state (but not marked as such since `setBean` resets validation status), but they have not been changed from their initial value(s).
4. Calling `setAsRequiredEnabled` with a changed value no longer triggers validation, since that validation is now handled elsewhere when needed as stated above.
5. Minor Javadoc fixes, trying to align Javadocs with code.

Fixes https://github.com/vaadin/flow/issues/18163
Fixes https://github.com/vaadin/flow/issues/4988
Fixes https://github.com/vaadin/flow/issues/17515

Probably fixes some other binder / validation issues as well.