### PR TITLE
Validation fixes

### DIFF
--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -1450,7 +1450,7 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
     }
 
     @Test
-    public void two_asRequired_fields_without_initial_values() {
+    public void two_asRequired_fields_without_initial_values_setBean() {
         binder.forField(nameField).asRequired("Empty name").bind(p -> "",
                 (p, s) -> {
                 });
@@ -1459,6 +1459,37 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
                 });
 
         binder.setBean(item);
+        assertThat("Initially there should be no errors",
+                nameField.getErrorMessage(), isEmptyString());
+        assertThat("Initially there should be no errors",
+                ageField.getErrorMessage(), isEmptyString());
+
+        nameField.setValue("Foo");
+        assertThat("Name with a value should not be an error",
+                nameField.getErrorMessage(), isEmptyString());
+
+        assertNotNull(
+                "Age field should now be in error, since setBean is used.",
+                ageField.getErrorMessage());
+
+        nameField.setValue("");
+        assertNotNull("Empty name should now be in error.",
+                nameField.getErrorMessage());
+
+        assertNotNull("Age field should still be in error.",
+                ageField.getErrorMessage());
+    }
+
+    @Test
+    public void two_asRequired_fields_without_initial_values_readBean() {
+        binder.forField(nameField).asRequired("Empty name").bind(p -> "",
+                (p, s) -> {
+                });
+        binder.forField(ageField).asRequired("Empty age").bind(p -> "",
+                (p, s) -> {
+                });
+
+        binder.readBean(item);
         assertThat("Initially there should be no errors",
                 nameField.getErrorMessage(), isEmptyString());
         assertThat("Initially there should be no errors",


### PR DESCRIPTION
Changes:

1. Adds an `isApplied` check and predicate for `Binding`. If false is returned, the binding will be ignored for validation and bean writing. This can be customized by the developer. Default is that bindings whose fields have `isVisible() == false` are ignored.
2. Once `Binder.handleFieldValueChange` runs for a binding when `readBean` was used, the whole binder will be silently validated also. `BinderValidationStatusHandler` is called like before (only contains status from changed binding), but `StatusChangeEvent` is now fired considering all bindings and if possible bean validators as well.
3. Once `Binder.handleFieldValueChange` runs for a binding when `setBean` was used, `doWriteIfValid` will validate all bindings, not only the changed ones. This prevents writing an invalid bean in cases where one or more of the initial values are in invalid state (but not marked as such since `setBean` resets validation status), but they have not been changed from their initial value(s).
4. Calling `setAsRequiredEnabled` with a changed value no longer triggers validation, since that validation is now handled elsewhere when needed as stated above.
5. Minor Javadoc fixes, trying to align Javadocs with code.

Fixes https://github.com/vaadin/flow/issues/18163
Fixes https://github.com/vaadin/flow/issues/4988
Fixes https://github.com/vaadin/flow/issues/17515

Probably fixes some other binder / validation issues as well.