### PR TITLE
Validation fixes

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -2341,11 +2341,10 @@ public class Binder<BEAN> implements Serializable {
         Objects.requireNonNull(bean, "bean cannot be null");
         List<ValidationResult> binderResults = Collections.emptyList();
 
-        // Make a copy of the incoming bindings to avoid their modifications
-        // during validation. Also filter out bindings which should not be
-        // applied.
-        Collection<Binding<BEAN, ?>> currentBindings = bindings.stream()
-                .collect(Collectors.toList());
+        // make a copy of the incoming bindings to avoid their modifications
+        // during validation
+        Collection<Binding<BEAN, ?>> currentBindings = new ArrayList<>(
+                bindings);
 
         // First run fields level validation, if no validation errors then
         // update bean. Note that this will validate all bindings.
@@ -2412,15 +2411,13 @@ public class Binder<BEAN> implements Serializable {
         Objects.requireNonNull(bean, "bean cannot be null");
 
         if (!forced) {
-            bindings.stream()
-                    .forEach(binding -> ((BindingImpl<BEAN, ?, ?>) binding)
-                            .writeFieldValue(bean));
+            bindings.forEach(binding -> ((BindingImpl<BEAN, ?, ?>) binding)
+                    .writeFieldValue(bean));
         } else {
             boolean isDisabled = isValidatorsDisabled();
             setValidatorsDisabled(true);
-            bindings.stream()
-                    .forEach(binding -> ((BindingImpl<BEAN, ?, ?>) binding)
-                            .writeFieldValue(bean));
+            bindings.forEach(binding -> ((BindingImpl<BEAN, ?, ?>) binding)
+                    .writeFieldValue(bean));
             setValidatorsDisabled(isDisabled);
         }
     }

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -1468,6 +1468,37 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         assertThat("Name with a value should not be an error",
                 nameField.getErrorMessage(), isEmptyString());
 
+        assertNotNull(
+                "Age field should now be in error, since setBean is used.",
+                ageField.getErrorMessage());
+
+        nameField.setValue("");
+        assertNotNull("Empty name should now be in error.",
+                nameField.getErrorMessage());
+
+        assertNotNull("Age field should still be in error.",
+                ageField.getErrorMessage());
+    }
+
+    @Test
+    public void two_asRequired_fields_without_initial_values_readBean() {
+        binder.forField(nameField).asRequired("Empty name").bind(p -> "",
+                (p, s) -> {
+                });
+        binder.forField(ageField).asRequired("Empty age").bind(p -> "",
+                (p, s) -> {
+                });
+
+        binder.readBean(item);
+        assertThat("Initially there should be no errors",
+                nameField.getErrorMessage(), isEmptyString());
+        assertThat("Initially there should be no errors",
+                ageField.getErrorMessage(), isEmptyString());
+
+        nameField.setValue("Foo");
+        assertThat("Name with a value should not be an error",
+                nameField.getErrorMessage(), isEmptyString());
+
         assertThat(
                 "Age field should not be in error, since it has not been modified.",
                 ageField.getErrorMessage(), isEmptyString());

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -968,6 +968,7 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         Assert.assertEquals("Name field should not be in error.", "",
                 nameField.getErrorMessage());
     }
+
     @Test
     public void validationStatusHandler_onlyRunForChangedField() {
         TestTextField firstNameField = new TestTextField();

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -51,6 +51,7 @@ import com.vaadin.flow.data.converter.StringToIntegerConverter;
 import com.vaadin.flow.data.validator.IntegerRangeValidator;
 import com.vaadin.flow.data.validator.NotEmptyValidator;
 import com.vaadin.flow.data.validator.StringLengthValidator;
+import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.internal.CurrentInstance;
 import com.vaadin.flow.tests.data.bean.Person;
 import com.vaadin.flow.tests.data.bean.Sex;
@@ -938,6 +939,35 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         assertTrue(textField.isRequiredIndicatorVisible());
     }
 
+    @Test
+    public void setRequiredAsEnabled_shouldNotTriggerValidation() {
+        AtomicBoolean hasErrors = new AtomicBoolean();
+        // Binding is required but has setAsRequiredEnabled set to false
+        Binding<Person, String> nameBinding = binder.forField(nameField)
+                .asRequired("Name is required")
+                .bind(Person::getFirstName, Person::setFirstName);
+
+        binder.addStatusChangeListener(
+                status -> hasErrors.getAndSet(status.hasValidationErrors()));
+        binder.setBean(new Person());
+
+        // Base state -> valid
+        Assert.assertFalse("binder should not have errors", hasErrors.get());
+        Assert.assertEquals("Name field should not be in error.", "",
+                nameField.getErrorMessage());
+
+        // Set setAsRequiredEnabled false -> should still be valid
+        nameBinding.setAsRequiredEnabled(false);
+        Assert.assertFalse("binder should not have errors", hasErrors.get());
+        Assert.assertEquals("Name field should not be in error.", "",
+                nameField.getErrorMessage());
+
+        // Set setAsRequiredEnabled true -> should still be valid
+        nameBinding.setAsRequiredEnabled(true);
+        Assert.assertFalse("binder should not have errors", hasErrors.get());
+        Assert.assertEquals("Name field should not be in error.", "",
+                nameField.getErrorMessage());
+    }
     @Test
     public void validationStatusHandler_onlyRunForChangedField() {
         TestTextField firstNameField = new TestTextField();


### PR DESCRIPTION
Changes:

1. Once `Binder.handleFieldValueChange` runs for a binding when `readBean` was used, the whole binder will be silently validated also. `BinderValidationStatusHandler` is called like before (only contains status from changed binding), but `StatusChangeEvent` is now fired considering all bindings and if possible bean validators as well.
2. Once `Binder.handleFieldValueChange` runs for a binding when `setBean` was used, `doWriteIfValid` will validate all bindings, not only the changed ones. This prevents writing an invalid bean in cases where one or more of the initial values are in invalid state (but not marked as such since `setBean` resets validation status), but they have not been changed from their initial value(s).
3. Calling `setAsRequiredEnabled` with a changed value no longer triggers validation, since that validation is now handled elsewhere when needed as stated above.
4. Minor Javadoc fixes, trying to align Javadocs with code.

Fixes https://github.com/vaadin/flow/issues/18163
Fixes https://github.com/vaadin/flow/issues/4988
Fixes https://github.com/vaadin/flow/issues/17515

Probably fixes some other binder / validation issues as well.