### PR TITLE
fix: Pass a mutable copy of routes array into React function

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -150,7 +150,7 @@ function navigateEventHandler(event) {
         event.preventDefault();
     }
     // @ts-ignore
-    let matched = matchRoutes(routes, event.detail.pathname);
+    let matched = matchRoutes(Array.from(routes), event.detail.pathname);
     prevNavigation = lastNavigation;
 
     // if navigation event route targets a flow view do beforeEnter for the
@@ -261,7 +261,7 @@ export default function Flow() {
                 window.addEventListener('popstate', popstateListener.listener, popstateListener.useCapture);
             }
 
-            let matched = matchRoutes(routes, pathname);
+            let matched = matchRoutes(Array.from(routes), pathname);
 
             // if router force navigated using 'Link' we will need to remove
             // flow from the view


### PR DESCRIPTION
This should fix the TS compilation error in Hilla test module, saying

```
frontend/generated/flow/Flow.tsx(264,39): error TS2345: Argument of type 'readonly ViewRouteObject[]' is not assignable to parameter of type 'ViewRouteObject[]'. The type 'readonly ViewRouteObject[]' is 'readonly' and cannot be assigned to the mutable type 'ViewRouteObject[]'.
```

by converting an immutable routes array into mutable copy.

Related-to https://github.com/vaadin/hilla/pull/1990