### PR TITLE
fix: no serverSideRoutes check if no Routes

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.internal.UsageStatistics;
+import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.Version;
@@ -60,6 +61,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class TaskGenerateReactFiles implements FallibleCommand {
 
     private final File frontendDirectory;
+    private Options options;
     protected static String NO_IMPORT = """
             Faulty configuration of serverSideRoutes.
             The server route definition is missing from the '%1$s' file
@@ -93,6 +95,7 @@ public class TaskGenerateReactFiles implements FallibleCommand {
      *            the task options
      */
     TaskGenerateReactFiles(Options options) {
+        this.options = options;
         this.frontendDirectory = options.getFrontendDirectory();
     }
 
@@ -116,7 +119,9 @@ public class TaskGenerateReactFiles implements FallibleCommand {
                         UTF_8);
                 Pattern serverImport = Pattern.compile(
                         "import[\\s\\S]?\\{[\\s\\S]?serverSideRoutes[\\s\\S]?\\}[\\s\\S]?from[\\s\\S]?(\"|'|`)Frontend\\/generated\\/flow\\/Flow\\1;");
-                if (!serverImport.matcher(routesContent).find()) {
+                if (!serverImport.matcher(routesContent).find()
+                        && !options.getClassFinder()
+                                .getAnnotatedClasses(Route.class).isEmpty()) {
                     throw new ExecutionFailedException(
                             String.format(NO_IMPORT, routesTsx.getPath()));
                 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateReactFilesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateReactFilesTest.java
@@ -19,6 +19,7 @@ package com.vaadin.flow.server.frontend;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
@@ -29,7 +30,9 @@ import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.ExecutionFailedException;
+import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 
 public class TaskGenerateReactFilesTest {
 
@@ -38,11 +41,15 @@ public class TaskGenerateReactFilesTest {
 
     Options options;
     File routesTsx, frontend;
+    ClassFinder classFinder;
 
     @Before
     public void setup() throws IOException {
-        options = new Options(Mockito.mock(Lookup.class),
-                temporaryFolder.getRoot()).withBuildDirectory("target");
+        classFinder = Mockito.mock(ClassFinder.class);
+        Lookup lookup = Mockito.mock(Lookup.class);
+        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(classFinder);
+        options = new Options(lookup, temporaryFolder.getRoot())
+                .withBuildDirectory("target");
         frontend = temporaryFolder.newFolder("frontend");
         options.withFrontendDirectory(frontend);
         routesTsx = new File(frontend, "routes.tsx");
@@ -130,6 +137,9 @@ public class TaskGenerateReactFilesTest {
                 """;
 
         FileUtils.write(routesTsx, content, StandardCharsets.UTF_8);
+
+        Mockito.when(classFinder.getAnnotatedClasses(Route.class)).thenReturn(
+                Collections.singleton(TaskGenerateReactFilesTest.class));
 
         TaskGenerateReactFiles task = new TaskGenerateReactFiles(options);
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateReactFilesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateReactFilesTest.java
@@ -29,6 +29,8 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.ExecutionFailedException;
@@ -48,6 +50,10 @@ public class TaskGenerateReactFilesTest {
         classFinder = Mockito.mock(ClassFinder.class);
         Lookup lookup = Mockito.mock(Lookup.class);
         Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(classFinder);
+
+        Mockito.when(classFinder.getAnnotatedClasses(Route.class))
+                .thenReturn(Collections.singleton(TestRoute.class));
+
         options = new Options(lookup, temporaryFolder.getRoot())
                 .withBuildDirectory("target");
         frontend = temporaryFolder.newFolder("frontend");
@@ -138,9 +144,6 @@ public class TaskGenerateReactFilesTest {
 
         FileUtils.write(routesTsx, content, StandardCharsets.UTF_8);
 
-        Mockito.when(classFinder.getAnnotatedClasses(Route.class)).thenReturn(
-                Collections.singleton(TaskGenerateReactFilesTest.class));
-
         TaskGenerateReactFiles task = new TaskGenerateReactFiles(options);
 
         Exception exception = Assert.assertThrows(
@@ -187,6 +190,44 @@ public class TaskGenerateReactFilesTest {
     }
 
     @Test
+    public void missingImport_noServerRoutesDefined_noExpectionThrown()
+            throws IOException, ExecutionFailedException {
+        String content = """
+                        import HelloWorldView from 'Frontend/views/helloworld/HelloWorldView.js';
+                        import MainLayout from 'Frontend/views/MainLayout.js';
+                        import { lazy } from 'react';
+                        import { createBrowserRouter, RouteObject } from 'react-router-dom';
+                        import {protectRoutes} from "@hilla/react-auth";
+                        import LoginView from "Frontend/views/LoginView";
+
+                        const AboutView = lazy(async () => import('Frontend/views/about/AboutView.js'));
+
+                                export const routes: RouteObject[] = protectRoutes([
+                                        {
+                                                element: <MainLayout />,
+                                        handle: { title: 'Main' },
+                                children: [
+                                { path: '/', element: <HelloWorldView />, handle: { title: 'Hello World', rolesAllowed: ['USER'] } },
+                                { path: '/about', element: <AboutView />, handle: { title: 'About' } }
+                            ],
+                          },
+                                { path: '/login', element: <LoginView />},
+                        ]);
+
+                        export default createBrowserRouter(routes);
+                """;
+
+        FileUtils.write(routesTsx, content, StandardCharsets.UTF_8);
+
+        Mockito.when(classFinder.getAnnotatedClasses(Route.class))
+                .thenReturn(Collections.emptySet());
+
+        TaskGenerateReactFiles task = new TaskGenerateReactFiles(options);
+
+        task.execute();
+    }
+
+    @Test
     public void routesexportMissing_expectionThrown() throws IOException {
         String content = """
                         import HelloWorldView from 'Frontend/views/helloworld/HelloWorldView.js';
@@ -223,5 +264,10 @@ public class TaskGenerateReactFilesTest {
                 ExecutionFailedException.class, () -> task.execute());
         Assert.assertEquals(TaskGenerateReactFiles.MISSING_ROUTES_EXPORT,
                 exception.getMessage());
+    }
+
+    @Tag("div")
+    @Route("test")
+    private class TestRoute extends Component {
     }
 }


### PR DESCRIPTION
Do not check for the
serverSideRoutes in
routes.tsx in react mode
if no `@Route` annotated
Flow routes found.

Fixes #18539
