### PR TITLE
Adds skipDefaultValidator API

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -257,28 +257,28 @@ public class Binder<BEAN> implements Serializable {
 
         /**
          * Sets up this binding to either disable or enable the default field
-         * validators (e.g. min/max validators in DatePicker). This
+         * validator (e.g. min/max validators in DatePicker). This
          * binding-level setting will override the Binder-level setting for this
          * property.
          *
          * Defaults to {@literal false}.
          *
-         * @param defaultValidatorsDisabled
-         *            {@literal true} to disable default validators for this
-         *            binding, {@literal false} to enable them, {@literal null}
+         * @param defaultValidatorDisabled
+         *            {@literal true} to disable default validator for this
+         *            binding, {@literal false} to enable it, {@literal null}
          *            to reset (fallback to Binder-level setting)
          * @see Binder#setDefaultValidatorsDisabled(boolean) for faster way to
          *      disable default validators for all bound fields.
          */
-        void setDefaultValidatorsDisabled(boolean defaultValidatorsDisabled);
+        void setDefaultValidatorDisabled(boolean defaultValidatorDisabled);
 
         /**
-         * Returns if default validators of bound field are disabled..
+         * Returns if default validator of bound field is disabled.
          *
-         * @return {@literal true} if default validators are disabled for this
-         *         binding, {@literal false} if they are enabled
+         * @return {@literal true} if default validator is disabled for this
+         *         binding, {@literal false} if it is enabled
          */
-        boolean isDefaultValidatorsDisabled();
+        boolean isDefaultValidatorDisabled();
 
         /**
          * Define whether the value should be converted back to the presentation
@@ -851,22 +851,22 @@ public class Binder<BEAN> implements Serializable {
 
         /**
          * Sets up this binding to either disable or enable the default field
-         * validators (e.g. min/max validators in DatePicker). This
+         * validator (e.g. min/max validators in DatePicker). This
          * binding-level setting will override the Binder-level setting for this
          * property.
          *
          * Defaults to {@literal false}.
          *
-         * @param defaultValidatorsDisabled
-         *            {@literal true} to disable default validators for this
-         *            binding, {@literal false} to enable them, {@literal null}
+         * @param defaultValidatorDisabled
+         *            {@literal true} to disable default validator for this
+         *            binding, {@literal false} to enable it, {@literal null}
          *            to reset (fallback to Binder-level setting)
          * @return this binding, for chaining
          * @see Binder#setDefaultValidatorsDisabled(boolean) for faster way to
          *      disable default validators for all bound fields.
          */
-        BindingBuilder<BEAN, TARGET> setDefaultValidatorsDisabled(
-                boolean defaultValidatorsDisabled);
+        BindingBuilder<BEAN, TARGET> setDefaultValidatorDisabled(
+                boolean defaultValidatorDisabled);
 
         /**
          * Sets the field to be required. This means two things:
@@ -982,7 +982,7 @@ public class Binder<BEAN> implements Serializable {
 
         private boolean asRequiredSet;
 
-        private Boolean defaultValidatorsDisabled;
+        private Boolean defaultValidatorDisabled;
 
         /**
          * Creates a new binding builder associated with the given field.
@@ -1009,7 +1009,7 @@ public class Binder<BEAN> implements Serializable {
 
             if (field instanceof HasValidator hasValidator) {
                 withValidator(
-                        (val, ctx) -> binding.isDefaultValidatorsDisabled()
+                        (val, ctx) -> binding.isDefaultValidatorDisabled()
                                 ? ValidationResult.ok()
                                 : hasValidator.getDefaultValidator().apply(val,
                                         ctx));
@@ -1158,10 +1158,10 @@ public class Binder<BEAN> implements Serializable {
         }
 
         @Override
-        public BindingBuilder<BEAN, TARGET> setDefaultValidatorsDisabled(
-                boolean defaultValidatorsDisabled) {
+        public BindingBuilder<BEAN, TARGET> setDefaultValidatorDisabled(
+                boolean defaultValidatorDisabled) {
             checkUnbound();
-            this.defaultValidatorsDisabled = defaultValidatorsDisabled;
+            this.defaultValidatorDisabled = defaultValidatorDisabled;
             return this;
         }
 
@@ -1300,7 +1300,7 @@ public class Binder<BEAN> implements Serializable {
 
         private Registration onValidationStatusChange;
 
-        private Boolean defaultValidatorsDisabled;
+        private Boolean defaultValidatorDisabled;
 
         public BindingImpl(BindingBuilderImpl<BEAN, FIELDVALUE, TARGET> builder,
                 ValueProvider<BEAN, TARGET> getter,
@@ -1311,7 +1311,7 @@ public class Binder<BEAN> implements Serializable {
             this.asRequiredSet = builder.asRequiredSet;
             converterValidatorChain = ((Converter<FIELDVALUE, TARGET>) builder.converterValidatorChain);
 
-            defaultValidatorsDisabled = builder.defaultValidatorsDisabled;
+            defaultValidatorDisabled = builder.defaultValidatorDisabled;
 
             onValueChange = getField().addValueChangeListener(
                     event -> handleFieldValueChange(event));
@@ -1633,14 +1633,14 @@ public class Binder<BEAN> implements Serializable {
         }
 
         @Override
-        public void setDefaultValidatorsDisabled(
-                boolean defaultValidatorsDisabled) {
-            this.defaultValidatorsDisabled = defaultValidatorsDisabled;
+        public void setDefaultValidatorDisabled(
+                boolean defaultValidatorDisabled) {
+            this.defaultValidatorDisabled = defaultValidatorDisabled;
         }
 
         @Override
-        public boolean isDefaultValidatorsDisabled() {
-            return Optional.ofNullable(defaultValidatorsDisabled)
+        public boolean isDefaultValidatorDisabled() {
+            return Optional.ofNullable(defaultValidatorDisabled)
                     .orElse(getBinder().isDefaultValidatorsDisabled());
         }
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -257,16 +257,15 @@ public class Binder<BEAN> implements Serializable {
 
         /**
          * Sets up this binding to either disable or enable the default field
-         * validator (e.g. min/max validators in DatePicker). This
-         * binding-level setting will override the Binder-level setting for this
-         * property.
+         * validator (e.g. min/max validators in DatePicker). This binding-level
+         * setting will override the Binder-level setting for this property.
          *
          * Defaults to {@literal false}.
          *
          * @param defaultValidatorDisabled
          *            {@literal true} to disable default validator for this
-         *            binding, {@literal false} to enable it, {@literal null}
-         *            to reset (fallback to Binder-level setting)
+         *            binding, {@literal false} to enable it, {@literal null} to
+         *            reset (fallback to Binder-level setting)
          * @see Binder#setDefaultValidatorsDisabled(boolean) for faster way to
          *      disable default validators for all bound fields.
          */
@@ -851,16 +850,15 @@ public class Binder<BEAN> implements Serializable {
 
         /**
          * Sets up this binding to either disable or enable the default field
-         * validator (e.g. min/max validators in DatePicker). This
-         * binding-level setting will override the Binder-level setting for this
-         * property.
+         * validator (e.g. min/max validators in DatePicker). This binding-level
+         * setting will override the Binder-level setting for this property.
          *
          * Defaults to {@literal false}.
          *
          * @param defaultValidatorDisabled
          *            {@literal true} to disable default validator for this
-         *            binding, {@literal false} to enable it, {@literal null}
-         *            to reset (fallback to Binder-level setting)
+         *            binding, {@literal false} to enable it, {@literal null} to
+         *            reset (fallback to Binder-level setting)
          * @return this binding, for chaining
          * @see Binder#setDefaultValidatorsDisabled(boolean) for faster way to
          *      disable default validators for all bound fields.
@@ -1008,11 +1006,9 @@ public class Binder<BEAN> implements Serializable {
             this.statusHandler = statusHandler;
 
             if (field instanceof HasValidator hasValidator) {
-                withValidator(
-                        (val, ctx) -> binding.isDefaultValidatorDisabled()
-                                ? ValidationResult.ok()
-                                : hasValidator.getDefaultValidator().apply(val,
-                                        ctx));
+                withValidator((val, ctx) -> binding.isDefaultValidatorDisabled()
+                        ? ValidationResult.ok()
+                        : hasValidator.getDefaultValidator().apply(val, ctx));
             }
         }
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -260,7 +260,7 @@ public class Binder<BEAN> implements Serializable {
          *
          * @return A boolean value.
          */
-        boolean isSkipDefaultValidator();
+        boolean isDefaultValidatorSkipped();
 
         /**
          * Define whether the value should be converted back to the presentation
@@ -983,7 +983,7 @@ public class Binder<BEAN> implements Serializable {
             if (field instanceof HasValidator hasValidator) {
                 withValidator((val,
                         ctx) -> getBinder().skipDefaultValidators
-                                || binding.isSkipDefaultValidator()
+                                || binding.isDefaultValidatorSkipped()
                                         ? ValidationResult.ok()
                                         : hasValidator.getDefaultValidator()
                                                 .apply(val, ctx));
@@ -1606,7 +1606,7 @@ public class Binder<BEAN> implements Serializable {
         }
 
         @Override
-        public boolean isSkipDefaultValidator() {
+        public boolean isDefaultValidatorSkipped() {
             return skipDefaultValidator;
         }
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -267,7 +267,6 @@ public class Binder<BEAN> implements Serializable {
          *            {@literal true} to disable default validators for this
          *            binding, {@literal false} to enable them, {@literal null}
          *            to reset (fallback to Binder-level setting)
-         * @return this binding, for chaining
          * @see Binder#setDefaultValidatorsDisabled(boolean) for faster way to
          *      disable default validators for all bound fields.
          */

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -1615,11 +1615,8 @@ public class Binder<BEAN> implements Serializable {
 
         @Override
         public boolean isDefaultValidatorsSkipped() {
-            if (defaultValidatorsSkipped == null) {
-                return getBinder().isDefaultValidatorsSkipped();
-            } else {
-                return defaultValidatorsSkipped;
-            }
+            return Optional.ofNullable(defaultValidatorsSkipped)
+                    .orElse(getBinder().isDefaultValidatorsSkipped());
         }
 
         @Override

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -1578,7 +1578,7 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         binder.forField(field1).bind(Person::getFirstName,
                 Person::setFirstName);
         Binding<Person, String> binding = binder.forField(field2)
-                .setDefaultValidatorsDisabled(true)
+                .setDefaultValidatorDisabled(true)
                 .bind(Person::getLastName, Person::setLastName);
 
         // One binding has default validators disabled
@@ -1589,7 +1589,7 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
                 1, status.getValidationErrors().size());
 
         // Re-enable default validators of binding
-        binding.setDefaultValidatorsDisabled(false);
+        binding.setDefaultValidatorDisabled(false);
         status = binder.validate();
         assertEquals(
                 "Validation should have two errors. "
@@ -1612,7 +1612,7 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         binder.forField(field1).bind(Person::getFirstName,
                 Person::setFirstName);
         Binding<Person, String> binding = binder.forField(field2)
-                .setDefaultValidatorsDisabled(false)
+                .setDefaultValidatorDisabled(false)
                 .bind(Person::getLastName, Person::setLastName);
 
         // Initial case: binder disabled & binding overrides to enable
@@ -1629,7 +1629,7 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
 
         // Cross-toggle false <-> true
         binder.setDefaultValidatorsDisabled(false);
-        binding.setDefaultValidatorsDisabled(true);
+        binding.setDefaultValidatorDisabled(true);
         status = binder.validate();
         assertEquals(
                 "Validation should have one error. "

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/CleanFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/CleanFrontendMojo.java
@@ -54,30 +54,117 @@ public class CleanFrontendMojo extends FlowModeAbstractMojo {
     public static final String DEV_DEPENDENCIES = "devDependencies";
     public static final String OVERRIDES = "overrides";
 
+    public class Options {
+        private boolean cleanPackageJson = true;
+
+        private boolean removeDevBundle = true;
+        private boolean removeFrontendGeneratedFolder = true;
+        private boolean removeGeneratedTSFolder = true;
+        private boolean removeNodeModules = true;
+        private boolean removePackageLock = true;
+        private boolean removePnpmFile = true;
+
+        public Options withRemovePackageLock(boolean removePackageLock) {
+            this.removePackageLock = removePackageLock;
+            return this;
+        }
+
+        public Options withRemovePnpmFile(boolean removePnpmFile) {
+            this.removePnpmFile = removePnpmFile;
+            return this;
+        }
+
+        public Options withRemoveGeneratedTSFolder(
+                boolean removeGeneratedTSFolder) {
+            this.removeGeneratedTSFolder = removeGeneratedTSFolder;
+            return this;
+        }
+
+        public Options withRemoveFrontendGeneratedFolder(
+                boolean removeFrontendGeneratedFolder) {
+            this.removeFrontendGeneratedFolder = removeFrontendGeneratedFolder;
+            return this;
+        }
+
+        public Options withCleanPackageJson(boolean cleanPackageJson) {
+            this.cleanPackageJson = cleanPackageJson;
+            return this;
+        }
+
+        public Options withRemoveDevBundle(boolean removeDevBundle) {
+            this.removeDevBundle = removeDevBundle;
+            return this;
+        }
+
+        public Options withRemoveNodeModules(boolean removeNodeModules) {
+            this.removeNodeModules = removeNodeModules;
+            return this;
+        }
+
+        public boolean isRemovePackageLock() {
+            return removePackageLock;
+        }
+
+        public boolean isRemovePnpmFile() {
+            return removePnpmFile;
+        }
+
+        public boolean isRemoveGeneratedTSFolder() {
+            return removeGeneratedTSFolder;
+        }
+
+        public boolean isRemoveFrontendGeneratedFolder() {
+            return removeFrontendGeneratedFolder;
+        }
+
+        public boolean isCleanPackageJson() {
+            return cleanPackageJson;
+        }
+
+        public boolean isRemoveDevBundle() {
+            return removeDevBundle;
+        }
+
+        public boolean isRemoveNodeModules() {
+            return removeNodeModules;
+        }
+    }
+
     @Override
     public void execute() throws MojoFailureException {
-        removeNodeModules();
+        runCleaning(new Options());
+    }
 
-        // Cleanup (p)npm lock file.
-        File lockFile = new File(npmFolder(), Constants.PACKAGE_LOCK_YAML);
-        if (!lockFile.exists()) {
-            lockFile = new File(npmFolder(), Constants.PACKAGE_LOCK_BUN);
-        }
-        if (!lockFile.exists()) {
-            lockFile = new File(npmFolder(), Constants.PACKAGE_LOCK_JSON);
-        }
-        if (lockFile.exists()) {
-            lockFile.delete();
+    protected void runCleaning(Options options) throws MojoFailureException {
+        if (options.isRemoveNodeModules()) {
+            removeNodeModules();
         }
 
-        // clean up .pnpmfile.cjs
-        File pnpmfile = new File(npmFolder(), ".pnpmfile.cjs");
-        if (pnpmfile.exists()) {
-            pnpmfile.delete();
+        if (options.isRemovePackageLock()) {
+            // Cleanup (p)npm lock file.
+            File lockFile = new File(npmFolder(), Constants.PACKAGE_LOCK_YAML);
+            if (!lockFile.exists()) {
+                lockFile = new File(npmFolder(), Constants.PACKAGE_LOCK_BUN);
+            }
+            if (!lockFile.exists()) {
+                lockFile = new File(npmFolder(), Constants.PACKAGE_LOCK_JSON);
+            }
+            if (lockFile.exists()) {
+                lockFile.delete();
+            }
+        }
+
+        if (options.isRemovePnpmFile()) {
+            // clean up .pnpmfile.cjs
+            File pnpmfile = new File(npmFolder(), ".pnpmfile.cjs");
+            if (pnpmfile.exists()) {
+                pnpmfile.delete();
+            }
         }
 
         // clean up generated files from frontend
-        if (generatedTsFolder().exists()) {
+        if (generatedTsFolder().exists()
+                && options.isRemoveGeneratedTSFolder()) {
             try {
                 FileUtils.deleteDirectory(generatedTsFolder());
             } catch (IOException exception) {
@@ -94,7 +181,8 @@ public class CleanFrontendMojo extends FlowModeAbstractMojo {
         // ${frontendDirectory}/generated
         File frontendGeneratedFolder = new File(frontendDirectory(),
                 FrontendUtils.GENERATED);
-        if (frontendGeneratedFolder.exists()) {
+        if (frontendGeneratedFolder.exists()
+                && options.isRemoveFrontendGeneratedFolder()) {
             try {
                 FileUtils.deleteDirectory(frontendGeneratedFolder);
             } catch (IOException exception) {
@@ -107,7 +195,7 @@ public class CleanFrontendMojo extends FlowModeAbstractMojo {
         try {
             // Clean up package json framework managed versions.
             File packageJsonFile = new File(npmFolder(), "package.json");
-            if (packageJsonFile.exists()) {
+            if (packageJsonFile.exists() && options.isCleanPackageJson()) {
                 JsonObject packageJson = Json.parse(FileUtils.readFileToString(
                         packageJsonFile, StandardCharsets.UTF_8.name()));
 
@@ -122,7 +210,9 @@ public class CleanFrontendMojo extends FlowModeAbstractMojo {
                     "Failed to clean 'package.json' file", e);
         }
 
-        removeDevBundle();
+        if (options.removeDevBundle) {
+            removeDevBundle();
+        }
     }
 
     /**


### PR DESCRIPTION
Provides means to skip default validators of bound fields. Skipping can be done either for the Binder instance (skips all), or per-binding via BindingBuilder.

Fixes https://github.com/vaadin/flow/issues/17178