### PR TITLE
fix: change SBOM maven goals lifecycle phase

### DIFF
--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/GenerateMavenBOMMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/GenerateMavenBOMMojo.java
@@ -33,7 +33,7 @@ import org.apache.maven.shared.invoker.MavenInvocationException;
 /**
  * Goal that generates a CycloneDX SBOM file focused on backend dependencies.
  */
-@Mojo(name = "generate-maven-sbom", requiresDependencyResolution = ResolutionScope.COMPILE, defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
+@Mojo(name = "generate-maven-sbom", requiresDependencyResolution = ResolutionScope.COMPILE, defaultPhase = LifecyclePhase.PROCESS_RESOURCES)
 public class GenerateMavenBOMMojo extends AbstractMojo {
 
     private static final String GROUP = "org.cyclonedx";

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/GenerateNpmBOMMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/GenerateNpmBOMMojo.java
@@ -34,7 +34,7 @@ import org.apache.maven.shared.invoker.MavenInvocationException;
 /**
  * Goal that generates a CycloneDX SBOM file focused on frontend dependencies.
  */
-@Mojo(name = "generate-npm-sbom", requiresDependencyResolution = ResolutionScope.COMPILE, defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
+@Mojo(name = "generate-npm-sbom", requiresDependencyResolution = ResolutionScope.COMPILE, defaultPhase = LifecyclePhase.PROCESS_RESOURCES)
 public class GenerateNpmBOMMojo extends AbstractMojo {
 
     private static final String GROUP = "org.codehaus.mojo";

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
@@ -238,7 +238,7 @@ public class PrepareFrontendMojoTest {
     }
 
     @Test
-    public void should_updateAndkeepDependencies_when_packageJsonExists()
+    public void should_updateAndKeepDependencies_when_packageJsonExists()
             throws Exception {
         JsonObject json = TestUtils.getInitialPackageJson();
         json.put("dependencies", Json.createObject());

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -150,8 +150,7 @@ public class BuildFrontendUtil {
                 .withBuildDirectory(adapter.buildFolder())
                 .withJarFrontendResourcesFolder(
                         getJarFrontendResourcesFolder(adapter))
-                .createMissingPackageJson(
-                        !new File(adapter.npmFolder(), PACKAGE_JSON).exists())
+                .createMissingPackageJson(true)
                 .enableImportsUpdate(false).enablePackagesUpdate(false)
                 .withRunNpmInstall(false)
                 .withFrontendGeneratedFolder(adapter.generatedTsFolder())

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -150,9 +150,8 @@ public class BuildFrontendUtil {
                 .withBuildDirectory(adapter.buildFolder())
                 .withJarFrontendResourcesFolder(
                         getJarFrontendResourcesFolder(adapter))
-                .createMissingPackageJson(true)
-                .enableImportsUpdate(false).enablePackagesUpdate(false)
-                .withRunNpmInstall(false)
+                .createMissingPackageJson(true).enableImportsUpdate(false)
+                .enablePackagesUpdate(false).withRunNpmInstall(false)
                 .withFrontendGeneratedFolder(adapter.generatedTsFolder())
                 .withNodeVersion(adapter.nodeVersion())
                 .withNodeDownloadRoot(nodeDownloadRootURI)

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -151,7 +151,7 @@ public class BuildFrontendUtil {
                 .withJarFrontendResourcesFolder(
                         getJarFrontendResourcesFolder(adapter))
                 .createMissingPackageJson(
-                        new File(adapter.npmFolder(), PACKAGE_JSON).exists())
+                        !new File(adapter.npmFolder(), PACKAGE_JSON).exists())
                 .enableImportsUpdate(false).enablePackagesUpdate(false)
                 .withRunNpmInstall(false)
                 .withFrontendGeneratedFolder(adapter.generatedTsFolder())


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

- Change the lifecycle phase of sbom generator maven goals from `generate-resources` to `prepare-resources` so that it matches the `prepare-frontend` maven goal.
- Flip a boolean expression so that the `package.json` file is created if it doesn't exist when running the `prepare-frontend` maven goal.