### PR TITLE
feat: add react components to package.json

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -38,6 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.experimental.FeatureFlags;
+import com.vaadin.flow.internal.hilla.EndpointRequestUtil;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
@@ -176,7 +177,8 @@ public abstract class NodeUpdater implements FallibleCommand {
             VersionsJsonConverter convert = new VersionsJsonConverter(
                     Json.parse(
                             IOUtils.toString(content, StandardCharsets.UTF_8)),
-                    options.isReactRouterEnabled());
+                    options.isReactRouterEnabled()
+                            && EndpointRequestUtil.isHillaAvailable());
             versionsJson = convert.getConvertedJson();
             versionsJson = new VersionsJsonFilter(getPackageJson(),
                     DEPENDENCIES)

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -173,8 +173,10 @@ public abstract class NodeUpdater implements FallibleCommand {
             String versionsOrigin) throws IOException {
         JsonObject versionsJson;
         try (InputStream content = versionsResource.openStream()) {
-            VersionsJsonConverter convert = new VersionsJsonConverter(Json
-                    .parse(IOUtils.toString(content, StandardCharsets.UTF_8)));
+            VersionsJsonConverter convert = new VersionsJsonConverter(
+                    Json.parse(
+                            IOUtils.toString(content, StandardCharsets.UTF_8)),
+                    options.isReactRouterEnabled());
             versionsJson = convert.getConvertedJson();
             versionsJson = new VersionsJsonFilter(getPackageJson(),
                     DEPENDENCIES)

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonConverter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonConverter.java
@@ -42,8 +42,9 @@ class VersionsJsonConverter {
 
     private boolean reactEnabled;
 
-    VersionsJsonConverter(JsonObject platformVersions, boolean reactEnabled) {
-        this.reactEnabled = reactEnabled;
+    VersionsJsonConverter(JsonObject platformVersions,
+            boolean collectReactComponents) {
+        this.reactEnabled = collectReactComponents;
         convertedObject = Json.createObject();
 
         collectDependencies(platformVersions);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonConverter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonConverter.java
@@ -40,7 +40,10 @@ class VersionsJsonConverter {
     private static final String NPM_VERSION = "npmVersion";
     private final JsonObject convertedObject;
 
-    VersionsJsonConverter(JsonObject platformVersions) {
+    private boolean reactEnabled;
+
+    VersionsJsonConverter(JsonObject platformVersions, boolean reactEnabled) {
+        this.reactEnabled = reactEnabled;
         convertedObject = Json.createObject();
 
         collectDependencies(platformVersions);
@@ -59,7 +62,8 @@ class VersionsJsonConverter {
     private void collectDependencies(JsonObject obj) {
         for (String key : obj.keys()) {
             JsonValue value = obj.get(key);
-            if (!(value instanceof JsonObject)) {
+            if (!(value instanceof JsonObject)
+                    || (!reactEnabled && isReactObject(key))) {
                 continue;
             }
             JsonObject json = (JsonObject) value;
@@ -69,6 +73,10 @@ class VersionsJsonConverter {
                 collectDependencies(json);
             }
         }
+    }
+
+    private boolean isReactObject(String key) {
+        return key.equals("react") || key.equals("react-pro");
     }
 
     private void addDependency(JsonObject obj) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/VersionsJsonConverterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/VersionsJsonConverterTest.java
@@ -63,7 +63,7 @@ public class VersionsJsonConverterTest {
         // @formatter:on
 
         VersionsJsonConverter convert = new VersionsJsonConverter(
-                Json.parse(json));
+                Json.parse(json), true);
         JsonObject convertedJson = convert.getConvertedJson();
         Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-progress-bar"));
         Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-upload"));
@@ -73,6 +73,149 @@ public class VersionsJsonConverterTest {
         Assert.assertFalse(convertedJson.hasKey("core"));
         Assert.assertFalse(convertedJson.hasKey(VAADIN_CORE_NPM_PACKAGE));
         Assert.assertFalse(convertedJson.hasKey("platform"));
+
+        Assert.assertEquals("1.1.2",
+                convertedJson.getString("@vaadin/vaadin-progress-bar"));
+        Assert.assertEquals("4.2.2",
+                convertedJson.getString("@vaadin/vaadin-upload"));
+        Assert.assertEquals("3.0.2",
+                convertedJson.getString("@polymer/iron-list"));
+    }
+
+    @Test
+    public void reactRouterInUse_reactComponentsAreAdded() {
+        String json = """
+                {
+                  "core": {
+                    "flow": {
+                      "javaVersion": "3.0.0.alpha17"
+                    },
+                    "vaadin-progress-bar": {
+                      "npmName": "@vaadin/vaadin-progress-bar",
+                      "jsVersion": "1.1.2"
+                    },
+                  },
+                  "vaadin-upload": {
+                    "npmName": "@vaadin/vaadin-upload",
+                    "jsVersion": "4.2.2"
+                  },
+                  "iron-list": {
+                    "npmName": "@polymer/iron-list",
+                    "npmVersion": "3.0.2",
+                    "javaVersion": "3.0.0.beta1",
+                    "jsVersion": "2.0.19"
+                  },
+                  "vaadin-core": {
+                      "jsVersion": "21.0.0.alpha1",
+                      "npmName": "%s"
+                  },
+                  "react": {
+                    "react-components": {
+                      "jsVersion": "24.4.0-alpha7",
+                      "npmName": "@vaadin/react-components"
+                    }
+                  },
+                  "react-pro": {
+                    "react-components-pro": {
+                      "jsVersion": "24.4.0-alpha7",
+                      "npmName": "@vaadin/react-components-pro"
+                    }
+                  },
+                  "platform": "foo"
+                }
+                """.formatted(VAADIN_CORE_NPM_PACKAGE);
+
+        VersionsJsonConverter convert = new VersionsJsonConverter(
+                Json.parse(json), true);
+        JsonObject convertedJson = convert.getConvertedJson();
+        Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-progress-bar"));
+        Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-upload"));
+        Assert.assertTrue(convertedJson.hasKey("@polymer/iron-list"));
+        Assert.assertTrue(convertedJson.hasKey("@vaadin/react-components-pro"));
+        Assert.assertTrue(convertedJson.hasKey("@vaadin/react-components"));
+
+        Assert.assertFalse(convertedJson.hasKey("flow"));
+        Assert.assertFalse(convertedJson.hasKey("core"));
+        Assert.assertFalse(convertedJson.hasKey(VAADIN_CORE_NPM_PACKAGE));
+        Assert.assertFalse(convertedJson.hasKey("platform"));
+        Assert.assertFalse(convertedJson.hasKey("react"));
+        Assert.assertFalse(convertedJson.hasKey("react-pro"));
+        Assert.assertFalse(convertedJson.hasKey("react-components"));
+        Assert.assertFalse(convertedJson.hasKey("react-components-pro"));
+
+        Assert.assertEquals("1.1.2",
+                convertedJson.getString("@vaadin/vaadin-progress-bar"));
+        Assert.assertEquals("4.2.2",
+                convertedJson.getString("@vaadin/vaadin-upload"));
+        Assert.assertEquals("3.0.2",
+                convertedJson.getString("@polymer/iron-list"));
+        Assert.assertEquals("24.4.0-alpha7",
+                convertedJson.getString("@vaadin/react-components"));
+        Assert.assertEquals("24.4.0-alpha7",
+                convertedJson.getString("@vaadin/react-components-pro"));
+    }
+
+    @Test
+    public void reactRouterNotUsed_reactComponentsIgnored() {
+        String json = """
+                {
+                  "core": {
+                    "flow": {
+                      "javaVersion": "3.0.0.alpha17"
+                    },
+                    "vaadin-progress-bar": {
+                      "npmName": "@vaadin/vaadin-progress-bar",
+                      "jsVersion": "1.1.2"
+                    },
+                  },
+                  "vaadin-upload": {
+                    "npmName": "@vaadin/vaadin-upload",
+                    "jsVersion": "4.2.2"
+                  },
+                  "iron-list": {
+                    "npmName": "@polymer/iron-list",
+                    "npmVersion": "3.0.2",
+                    "javaVersion": "3.0.0.beta1",
+                    "jsVersion": "2.0.19"
+                  },
+                  "vaadin-core": {
+                      "jsVersion": "21.0.0.alpha1",
+                      "npmName": "%s"
+                  },
+                  "react": {
+                    "react-components": {
+                      "jsVersion": "24.4.0-alpha7",
+                      "npmName": "@vaadin/react-components"
+                    }
+                  },
+                  "react-pro": {
+                    "react-components-pro": {
+                      "jsVersion": "24.4.0-alpha7",
+                      "npmName": "@vaadin/react-components-pro"
+                    }
+                  },
+                  "platform": "foo"
+                }
+                """.formatted(VAADIN_CORE_NPM_PACKAGE);
+
+        VersionsJsonConverter convert = new VersionsJsonConverter(
+                Json.parse(json), false);
+        JsonObject convertedJson = convert.getConvertedJson();
+        Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-progress-bar"));
+        Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-upload"));
+        Assert.assertTrue(convertedJson.hasKey("@polymer/iron-list"));
+
+        Assert.assertFalse(convertedJson.hasKey("flow"));
+        Assert.assertFalse(convertedJson.hasKey("core"));
+        Assert.assertFalse(convertedJson.hasKey(VAADIN_CORE_NPM_PACKAGE));
+        Assert.assertFalse(convertedJson.hasKey("platform"));
+        Assert.assertFalse(
+                convertedJson.hasKey("@vaadin/react-components-pro"));
+        Assert.assertFalse(convertedJson.hasKey("@vaadin/react-components"));
+        Assert.assertFalse(convertedJson.hasKey("react"));
+        Assert.assertFalse(convertedJson.hasKey("react-pro"));
+        Assert.assertFalse(convertedJson.hasKey("react-components"));
+        Assert.assertFalse(convertedJson.hasKey("react-components-pro"));
 
         Assert.assertEquals("1.1.2",
                 convertedJson.getString("@vaadin/vaadin-progress-bar"));


### PR DESCRIPTION
If react is enabled for
add react-components to
package.json from
vaadin-versions.json and
vaadin-core-versions.json
else skip adding react npm packages.

Fixes #18506
