### PR TITLE
fix: Make web component UI not interfere with a main UI

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
@@ -65,8 +65,10 @@ public class ApplicationConnection {
 
         Element body = Browser.getDocument().getBody();
 
-        rootNode.setDomNode(body);
-        Binder.bind(rootNode, body);
+        if (applicationConfiguration.getExportedWebComponents() == null) {
+            rootNode.setDomNode(body);
+            Binder.bind(rootNode, body);
+        }
 
         Console.log("Starting application "
                 + applicationConfiguration.getApplicationId());

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -264,13 +264,16 @@ public class UI extends Component
 
         getInternals().setFullAppId(appId);
 
-        // Create flow reference for the client outlet element
-        wrapperElement = new Element(getInternals().getContainerTag());
+        if (isNavigationSupported()) {
 
-        // Connect server with client
-        getElement().getStateProvider().appendVirtualChild(
-                getElement().getNode(), wrapperElement,
-                NodeProperties.INJECT_BY_ID, appId);
+            // Create flow reference for the client outlet element
+            wrapperElement = new Element(getInternals().getContainerTag());
+
+            // Connect server with client
+            getElement().getStateProvider().appendVirtualChild(
+                    getElement().getNode(), wrapperElement,
+                    NodeProperties.INJECT_BY_ID, appId);
+        }
 
         // Add any dependencies from the UI class
         getInternals().addComponentDependencies(getClass());

--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentUI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentUI.java
@@ -46,6 +46,7 @@ import com.vaadin.flow.theme.Theme;
 import com.vaadin.flow.theme.ThemeDefinition;
 
 import elemental.json.JsonObject;
+import elemental.json.JsonValue;
 
 /**
  * Custom UI for use with WebComponents served from the server.
@@ -65,6 +66,17 @@ public class WebComponentUI extends UI {
         assignThemeVariant();
         getEventBus().addListener(WebComponentConnectEvent.class,
                 this::connectWebComponent);
+    }
+
+    @Override
+    public void connectClient(String flowRoutePath, String flowRouteQuery,
+            String appShellTitle, JsonValue historyState, String trigger) {
+        return;
+    }
+
+    @Override
+    public void leaveNavigation(String route, String query) {
+        return;
     }
 
     /**


### PR DESCRIPTION
No longer associates web component UIs with the document body

No longer creates a container element for web component UIs
