### PR TITLE
Remove generate package.json setting

### DIFF
--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -150,8 +150,6 @@ public class BuildFrontendUtil {
                 .withBuildDirectory(adapter.buildFolder())
                 .withJarFrontendResourcesFolder(
                         getJarFrontendResourcesFolder(adapter))
-                .createMissingPackageJson(
-                        new File(adapter.npmFolder(), PACKAGE_JSON).exists())
                 .enableImportsUpdate(false).enablePackagesUpdate(false)
                 .withRunNpmInstall(false)
                 .withFrontendGeneratedFolder(adapter.generatedTsFolder())

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -215,11 +215,7 @@ public class NodeTasks implements FallibleCommand {
 
         }
 
-        if (options.isCreateMissingPackageJson()) {
-            TaskGeneratePackageJson packageCreator = new TaskGeneratePackageJson(
-                    options);
-            commands.add(packageCreator);
-        }
+        commands.add(new TaskGeneratePackageJson(options));
 
         if (frontendDependencies != null) {
             addGenerateServiceWorkerTask(options,

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/Options.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/Options.java
@@ -34,8 +34,6 @@ public class Options implements Serializable {
 
     private boolean enablePackagesUpdate = false;
 
-    private boolean createMissingPackageJson = false;
-
     private boolean enableImportsUpdate = false;
 
     private boolean enableWebpackConfigUpdate = false;
@@ -227,8 +225,6 @@ public class Options implements Serializable {
      */
     public Options enableImportsUpdate(boolean enableImportsUpdate) {
         this.enableImportsUpdate = enableImportsUpdate;
-        this.createMissingPackageJson = enableImportsUpdate
-                || createMissingPackageJson;
         return this;
     }
 
@@ -300,18 +296,6 @@ public class Options implements Serializable {
     public Options withEmbeddableWebComponents(
             boolean generateEmbeddableWebComponents) {
         this.generateEmbeddableWebComponents = generateEmbeddableWebComponents;
-        return this;
-    }
-
-    /**
-     * Sets whether to create the package file if missing.
-     *
-     * @param create
-     *            create the package
-     * @return the builder
-     */
-    public Options createMissingPackageJson(boolean create) {
-        this.createMissingPackageJson = create;
         return this;
     }
 
@@ -698,10 +682,6 @@ public class Options implements Serializable {
 
     public boolean isEnablePackagesUpdate() {
         return enablePackagesUpdate;
-    }
-
-    public boolean isCreateMissingPackageJson() {
-        return createMissingPackageJson;
     }
 
     public boolean isEnableImportsUpdate() {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGeneratePackageJson.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGeneratePackageJson.java
@@ -30,14 +30,10 @@ import elemental.json.JsonObject;
 public class TaskGeneratePackageJson extends NodeUpdater {
 
     /**
-     * Create an instance of the updater given all configurable parameters.
+     * Create an instance of the updater
      *
-     * @param npmFolder
-     *            folder with the `package.json` file.
-     * @param generatedPath
-     *            folder where flow generated files will be placed.
-     * @param buildDir
-     *            the used build directory
+     * @param options
+     *            task execution options
      */
     TaskGeneratePackageJson(Options options) {
         super(null, null, options);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendResourcesAreCopiedAfterCleaningTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendResourcesAreCopiedAfterCleaningTest.java
@@ -93,9 +93,8 @@ public class FrontendResourcesAreCopiedAfterCleaningTest {
                 .withBuildDirectory(TARGET);
 
         new NodeTasks(options.withEmbeddableWebComponents(false)
-                .enableImportsUpdate(false).createMissingPackageJson(true)
-                .enableImportsUpdate(true).withRunNpmInstall(false)
-                .enablePackagesUpdate(true)
+                .enableImportsUpdate(false).enableImportsUpdate(true)
+                .withRunNpmInstall(false).enablePackagesUpdate(true)
                 .withJarFrontendResourcesFolder(getJarFrontendResourcesFolder())
                 .copyResources(Collections.singleton(testJar))).execute();
     }
@@ -109,9 +108,8 @@ public class FrontendResourcesAreCopiedAfterCleaningTest {
                 .lookup(ClassFinder.class);
         Options options = new Options(mockLookup, npmFolder)
                 .withBuildDirectory(TARGET).withEmbeddableWebComponents(false)
-                .enableImportsUpdate(false).createMissingPackageJson(true)
-                .enableImportsUpdate(true).withRunNpmInstall(false)
-                .enableNpmFileCleaning(true)
+                .enableImportsUpdate(false).enableImportsUpdate(true)
+                .withRunNpmInstall(false).enableNpmFileCleaning(true)
                 .withJarFrontendResourcesFolder(getJarFrontendResourcesFolder())
                 .copyResources(Collections.emptySet())
                 .enablePackagesUpdate(true);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksExecutionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksExecutionTest.java
@@ -1,5 +1,6 @@
 package com.vaadin.flow.server.frontend;
 
+import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
@@ -59,8 +60,10 @@ public class NodeTasksExecutionTest {
         ClassFinder.DefaultClassFinder finder = new ClassFinder.DefaultClassFinder(
                 Collections.singleton(this.getClass()));
         Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(finder);
-        options = new Options(lookup, null).withBuildDirectory(TARGET);
-        options.withProductionMode(false);
+        options = new Options(lookup, new File(TARGET))
+                .withBuildDirectory(TARGET)
+                .withJarFrontendResourcesFolder(new File(TARGET))
+                .withProductionMode(false);
 
         nodeTasks = new NodeTasks(options);
         commandsOrder = getCommandOrder(nodeTasks);

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
@@ -232,12 +232,6 @@ public class DevModeInitializer implements Serializable {
                 Paths.get(target.getPath(), "classes", VAADIN_SERVLET_RESOURCES)
                         .toFile());
 
-        // If we are missing either the base or generated package json
-        // files generate those
-        if (!new File(options.getNpmFolder(), PACKAGE_JSON).exists()) {
-            options.createMissingPackageJson(true);
-        }
-
         Set<File> frontendLocations = getFrontendLocationsFromClassloader(
                 DevModeStartupListener.class.getClassLoader());
 


### PR DESCRIPTION
Seems that the `createMissingPackageJson` setting is not really needed anymore. This PR tests removing that setting.