### PR TITLE
Feat: add loadComponentScript method

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -353,3 +353,21 @@ export const serverSideRoutes = [
         }
     });
 })();
+
+
+/**
+ * Load the script for an exported WebComponent with the given tag
+ *
+ * @param tag name of the exported web-component to load
+ */
+export const loadComponentScript = (tag: String) => {
+    useEffect(() => {
+        const script = document.createElement('script');
+        script.src = `/web-component/${tag}.js`;
+        document.head.appendChild(script);
+
+        return () => {
+            document.head.removeChild(script);
+        }
+    }, []);
+};


### PR DESCRIPTION
Add the loadComponentScript method
to Flow.tsx to be used when
WebComponents are loaded for
Hilla views.

part of #18401 