### PR TITLE
feat: add utility to auto-detect Hilla views usage

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -36,6 +36,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
@@ -50,6 +52,7 @@ import com.vaadin.flow.internal.DevModeHandler;
 import com.vaadin.flow.internal.DevModeHandlerManager;
 import com.vaadin.flow.internal.Pair;
 import com.vaadin.flow.internal.StringUtil;
+import com.vaadin.flow.internal.hilla.EndpointRequestUtil;
 import com.vaadin.flow.server.AbstractConfiguration;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.VaadinService;
@@ -220,6 +223,10 @@ public class FrontendUtils {
      */
     public static final String VITE_DEVMODE_TS = "vite-devmode.ts";
 
+    public static final String ROUTES_TS = "routes.ts";
+
+    public static final String ROUTES_TSX = "routes.tsx";
+
     /**
      * Default generated path for generated frontend files.
      */
@@ -307,6 +314,16 @@ public class FrontendUtils {
     public static final String GREEN = "\u001b[38;5;35m%s\u001b[0m";
 
     public static final String BRIGHT_BLUE = "\u001b[94m%s\u001b[0m";
+
+    // Regex pattern matches "...serverSideRoutes"
+    private static final Pattern SERVER_SIDE_ROUTES_PATTERN = Pattern.compile(
+            "(?<=\\s|^)\\.{3}serverSideRoutes(?=\\s|$)", Pattern.MULTILINE);
+
+    // Regex pattern matches everything between "const|let|var routes = [" (or
+    // "const routes: RouteObject[] = [") and "...serverSideRoutes"
+    private static final Pattern CLIENT_SIDE_ROUTES_PATTERN = Pattern.compile(
+            "(?<=(?:const|let|var) routes(:\\s?RouteObject\\[\\s?])?\\s?=\\s?\\[)([\\s\\S]*?)(?=\\.{3}serverSideRoutes)",
+            Pattern.MULTILINE);
 
     /**
      * Only static stuff here.
@@ -1209,4 +1226,82 @@ public class FrontendUtils {
         }
         return result;
     }
+
+    /**
+     * Auto-detects if hilla views are used in the project based on what is in
+     * routes.ts or routes.tsx file.
+     * {@link FrontendUtils#getProjectFrontendDir(AbstractConfiguration)} can be
+     * used to get the frontend directory.
+     *
+     * @param frontendDirectory
+     *            Target frontend directory.
+     * @return {@code true} if hilla views are used, {@code false} otherwise.
+     */
+    public static boolean isHillaViewsUsed(File frontendDirectory) {
+        Objects.requireNonNull(frontendDirectory);
+        var files = List.of(FrontendUtils.ROUTES_TS, FrontendUtils.ROUTES_TSX);
+        for (String fileName : files) {
+            File routesFile = new File(frontendDirectory, fileName);
+            if (routesFile.exists()) {
+                try {
+                    String routesTsContent = IOUtils
+                            .toString(routesFile.toURI(), UTF_8);
+                    return isRoutesContentUsingHillaViews(routesTsContent);
+                } catch (IOException e) {
+                    getLogger().error(
+                            "Couldn't read {} for hilla views auto-detection",
+                            routesFile.getName(), e);
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks if Hilla is available and Hilla views are used in the project
+     * based on what is in routes.ts or routes.tsx file.
+     * {@link FrontendUtils#getProjectFrontendDir(AbstractConfiguration)} can be
+     * used to get the frontend directory.
+     *
+     * @return {@code true} if Hilla is available and Hilla views are used,
+     *         {@code false} otherwise
+     */
+    public static boolean isHillaUsed(File frontendDirectory) {
+        return EndpointRequestUtil.isHillaAvailable()
+                && isHillaViewsUsed(frontendDirectory);
+    }
+
+    private static boolean isRoutesContentUsingHillaViews(
+            String routesContent) {
+        routesContent = StringUtil.removeComments(routesContent);
+        if (missingServerSideRoutes(routesContent)) {
+            return true;
+        }
+        return mayHaveClientSideRoutes(routesContent);
+    }
+
+    private static boolean missingServerSideRoutes(String routesContent) {
+        return !SERVER_SIDE_ROUTES_PATTERN.matcher(routesContent).find();
+    }
+
+    private static boolean mayHaveClientSideRoutes(String routesContent) {
+        Matcher matcher = CLIENT_SIDE_ROUTES_PATTERN.matcher(routesContent);
+        while (matcher.find()) {
+            for (int index = 0; index <= matcher.groupCount(); index++) {
+                String group = matcher.group(index);
+                if (group != null && !group.isBlank()
+                        && group.startsWith(":")) {
+                    continue;
+                }
+                if (group != null && !group.isBlank()) {
+                    group = group.trim();
+                    // Not checking actual routes here. It's enough to know that
+                    // array contains more than just "...serverSideRoutes".
+                    return group.contains(",");
+                }
+            }
+        }
+        return false;
+    }
+
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -60,6 +60,123 @@ public class FrontendUtilsTest {
     @Rule
     public final TemporaryFolder tmpDir = new TemporaryFolder();
 
+    private static final String ROUTES_CONTENT_WITH_ONLY_SERVERSIDE_ROUTES = """
+                import {serverSideRoutes} from "Frontend/generated/flow/Flow";
+
+                export const routes = [
+                  ...serverSideRoutes
+                ]
+            """;
+
+    private static final String ROUTES_CONTENT_WITH_ONLY_CLIENTSIDE_ROUTES = """
+                import {serverSideRoutes} from "Frontend/generated/flow/Flow";
+
+                export const routes = [
+                  {
+                    path: 'hello',
+                    component: 'hello-world-view',
+                    title: 'Hello World',
+                  },
+                  {
+                    path: '',
+                    component: 'about-view',
+                    title: 'About',
+                  }
+                ]
+            """;
+
+    private static final String ROUTES_CONTENT_WITH_CLIENT_AND_SERVER_SIDE_ROUTES_1 = """
+                import {serverSideRoutes} from "Frontend/generated/flow/Flow";
+
+                let routes = [
+                  {
+                    path: 'hello',
+                    component: 'hello-world-view',
+                    title: 'Hello World',
+                  },
+                  ...serverSideRoutes
+                ];
+
+                let unknownRoutes = [
+                  ...serverSideRoutes
+                ];
+            """;
+
+    private static final String ROUTES_CONTENT_WITH_CLIENT_AND_SERVER_SIDE_ROUTES_2 = """
+                import {serverSideRoutes} from "Frontend/generated/flow/Flow";
+
+                export const routes: RouteObject[] = [
+                  {
+                    path: 'hello',
+                    component: 'hello-world-view',
+                    title: 'Hello World',
+                  },
+                  ...serverSideRoutes
+                ]
+            """;
+
+    private static final String ROUTES_CONTENT_WITH_CLIENT_AND_SERVER_SIDE_ROUTES_3 = """
+                import {serverSideRoutes} from "Frontend/generated/flow/Flow";
+
+                var myFunc = function() {
+                     // this is checked too
+                     export const routes = [
+                      ...serverSideRoutes
+                    ];
+                }
+
+                let unknownRoutes = [
+                  ...serverSideRoutes
+                ];
+
+                const routes = [
+                  {
+                    path: 'hello',
+                    component: 'hello-world-view',
+                    title: 'Hello World',
+                  },
+                  ...serverSideRoutes
+                ];
+            """;
+
+    private static final String ROUTES_CONTENT_WITH_CLIENT_AND_SERVER_SIDE_ROUTES_MAINLAYOUT_TSX = """
+                import { serverSideRoutes } from "Frontend/generated/flow/Flow";
+                import MainLayout from 'Frontend/views/MainLayout';
+                import ContactsView from 'Frontend/views/ContactsView';
+                import AboutView from 'Frontend/views/AboutView';
+                import { RouteObject } from 'react-router-dom';
+
+                export const routes: RouteObject[] = [
+                      {
+                          element: <MainLayout />,
+                          handle: { title: 'Hilla CRM' },
+                          children: [
+                              { path: '/', element: <ContactsView />, handle: { title: 'Contacts' } },
+                              { path: '/about', element: <AboutView />, handle: { title: 'About' } },
+                              ...serverSideRoutes
+                          ],
+                      },
+                  ];
+            """;
+
+    private static final String ROUTES_CONTENT_WITH_SERVER_SIDE_ROUTES_MAINLAYOUT_TSX = """
+                import { serverSideRoutes } from "Frontend/generated/flow/Flow";
+                import MainLayout from 'Frontend/views/MainLayout';
+                import ContactsView from 'Frontend/views/ContactsView';
+                import AboutView from 'Frontend/views/AboutView';
+                import { RouteObject } from 'react-router-dom';
+
+                export const routes: RouteObject[] = [
+                      {
+                          element: <MainLayout />,
+                          handle: { title: 'Hilla CRM' },
+                          children: [
+                              ...serverSideRoutes
+                          ],
+                      },
+                  ];
+            """;
+
     @Test
     public void parseValidVersions() {
         FrontendVersion sixPointO = new FrontendVersion(6, 0);
@@ -347,18 +464,14 @@ public class FrontendUtilsTest {
     @Test
     public void isReactRouterRequired_importsVaadinRouter_false()
             throws IOException {
-        File frontend = tmpDir.newFolder("frontend");
-        File indexTs = new File(frontend, FrontendUtils.INDEX_TS);
+        File frontend = prepareFrontendForRoutesFile(FrontendUtils.INDEX_TS,
+                """
+                            import { Router } from '@vaadin/router';
+                            import { routes } from './routes';
 
-        String content = """
-                    import { Router } from '@vaadin/router';
-                    import { routes } from './routes';
-
-                    export const router = new Router(document.querySelector('#outlet'));
-                    router.setRoutes(routes);
-                """;
-
-        FileUtils.write(indexTs, content, StandardCharsets.UTF_8);
+                            export const router = new Router(document.querySelector('#outlet'));
+                            router.setRoutes(routes);
+                        """);
         Assert.assertFalse("vaadin-router expected when it imported",
                 FrontendUtils.isReactRouterRequired(frontend));
     }
@@ -366,18 +479,14 @@ public class FrontendUtilsTest {
     @Test
     public void isReactRouterRequired_doesntImportVaadinRouter_true()
             throws IOException {
-        File frontend = tmpDir.newFolder("frontend");
-        File indexTs = new File(frontend, FrontendUtils.INDEX_TS);
+        File frontend = prepareFrontendForRoutesFile(FrontendUtils.INDEX_TS,
+                """
+                            import { createElement } from "react";
+                            import { createRoot } from "react-dom/client";
+                            import App from "./App.js";
 
-        String content = """
-                    import { createElement } from "react";
-                    import { createRoot } from "react-dom/client";
-                    import App from "./App.js";
-
-                    createRoot(document.getElementById("outlet")!).render(createElement(App));
-                """;
-
-        FileUtils.write(indexTs, content, StandardCharsets.UTF_8);
+                            createRoot(document.getElementById("outlet")!).render(createElement(App));
+                        """);
         Assert.assertTrue(
                 "react-router expected when no vaadin-router imported",
                 FrontendUtils.isReactRouterRequired(frontend));
@@ -388,6 +497,122 @@ public class FrontendUtilsTest {
         File frontend = tmpDir.newFolder("frontend");
         Assert.assertTrue("react-router expected when index.ts isn't there",
                 FrontendUtils.isReactRouterRequired(frontend));
+    }
+
+    @Test
+    public void isHillaViewsUsed_onlyServerSideRoutesTs_false()
+            throws IOException {
+        File frontend = prepareFrontendForRoutesFile(FrontendUtils.ROUTES_TS,
+                ROUTES_CONTENT_WITH_ONLY_SERVERSIDE_ROUTES);
+        Assert.assertFalse("hilla-views are not expected",
+                FrontendUtils.isHillaViewsUsed(frontend));
+    }
+
+    @Test
+    public void isHillaViewsUsed_onlyServerSideRoutesTsx_false()
+            throws IOException {
+        File frontend = prepareFrontendForRoutesFile(FrontendUtils.ROUTES_TSX,
+                ROUTES_CONTENT_WITH_ONLY_SERVERSIDE_ROUTES);
+        Assert.assertFalse("hilla-views are not expected",
+                FrontendUtils.isHillaViewsUsed(frontend));
+    }
+
+    @Test
+    public void isHillaViewsUsed_onlyClientSideRoutesTs_true()
+            throws IOException {
+        File frontend = prepareFrontendForRoutesFile(FrontendUtils.ROUTES_TS,
+                ROUTES_CONTENT_WITH_ONLY_CLIENTSIDE_ROUTES);
+        Assert.assertTrue("hilla-views are expected",
+                FrontendUtils.isHillaViewsUsed(frontend));
+    }
+
+    @Test
+    public void isHillaViewsUsed_onlyClientSideRoutesTsx_true()
+            throws IOException {
+        File frontend = prepareFrontendForRoutesFile(FrontendUtils.ROUTES_TSX,
+                ROUTES_CONTENT_WITH_ONLY_CLIENTSIDE_ROUTES);
+        Assert.assertTrue("hilla-views are expected",
+                FrontendUtils.isHillaViewsUsed(frontend));
+    }
+
+    @Test
+    public void isHillaViewsUsed_clientAndServerSideRoutesTs1_true()
+            throws IOException {
+        File frontend = prepareFrontendForRoutesFile(FrontendUtils.ROUTES_TS,
+                ROUTES_CONTENT_WITH_CLIENT_AND_SERVER_SIDE_ROUTES_1);
+        Assert.assertTrue("hilla-views are expected",
+                FrontendUtils.isHillaViewsUsed(frontend));
+    }
+
+    @Test
+    public void isHillaViewsUsed_clientAndServerSideRoutesTsx1_true()
+            throws IOException {
+        File frontend = prepareFrontendForRoutesFile(FrontendUtils.ROUTES_TSX,
+                ROUTES_CONTENT_WITH_CLIENT_AND_SERVER_SIDE_ROUTES_1);
+        Assert.assertTrue("hilla-views are expected",
+                FrontendUtils.isHillaViewsUsed(frontend));
+    }
+
+    @Test
+    public void isHillaViewsUsed_clientAndServerSideRoutesTs2_true()
+            throws IOException {
+        File frontend = prepareFrontendForRoutesFile(FrontendUtils.ROUTES_TS,
+                ROUTES_CONTENT_WITH_CLIENT_AND_SERVER_SIDE_ROUTES_2);
+        Assert.assertTrue("hilla-views are expected",
+                FrontendUtils.isHillaViewsUsed(frontend));
+    }
+
+    @Test
+    public void isHillaViewsUsed_clientAndServerSideRoutesTsx2_true()
+            throws IOException {
+        File frontend = prepareFrontendForRoutesFile(FrontendUtils.ROUTES_TSX,
+                ROUTES_CONTENT_WITH_CLIENT_AND_SERVER_SIDE_ROUTES_2);
+        Assert.assertTrue("hilla-views are expected",
+                FrontendUtils.isHillaViewsUsed(frontend));
+    }
+
+    @Test
+    public void isHillaViewsUsed_clientAndServerSideRoutesTs3_true()
+            throws IOException {
+        File frontend = prepareFrontendForRoutesFile(FrontendUtils.ROUTES_TS,
+                ROUTES_CONTENT_WITH_CLIENT_AND_SERVER_SIDE_ROUTES_3);
+        Assert.assertTrue("hilla-views are expected",
+                FrontendUtils.isHillaViewsUsed(frontend));
+    }
+
+    @Test
+    public void isHillaViewsUsed_clientAndServerSideRoutesTsx3_true()
+            throws IOException {
+        File frontend = prepareFrontendForRoutesFile(FrontendUtils.ROUTES_TSX,
+                ROUTES_CONTENT_WITH_CLIENT_AND_SERVER_SIDE_ROUTES_3);
+        Assert.assertTrue("hilla-views are expected",
+                FrontendUtils.isHillaViewsUsed(frontend));
+    }
+
+    @Test
+    public void isHillaViewsUsed_clientAndServerSideRoutesMainLayoutTsx_true()
+            throws IOException {
+        File frontend = prepareFrontendForRoutesFile(FrontendUtils.ROUTES_TSX,
+                ROUTES_CONTENT_WITH_CLIENT_AND_SERVER_SIDE_ROUTES_MAINLAYOUT_TSX);
+        Assert.assertTrue("hilla-views are expected",
+                FrontendUtils.isHillaViewsUsed(frontend));
+    }
+
+    @Test
+    public void isHillaViewsUsed_serverSideRoutesMainLayoutTsx_true()
+            throws IOException {
+        File frontend = prepareFrontendForRoutesFile(FrontendUtils.ROUTES_TSX,
+                ROUTES_CONTENT_WITH_SERVER_SIDE_ROUTES_MAINLAYOUT_TSX);
+        Assert.assertTrue("hilla-views are expected",
+                FrontendUtils.isHillaViewsUsed(frontend));
+    }
+
+    private File prepareFrontendForRoutesFile(String fileName, String content)
+            throws IOException {
+        File frontend = tmpDir.newFolder("frontend");
+        FileUtils.write(new File(frontend, fileName), content,
+                StandardCharsets.UTF_8);
+        return frontend;
     }
 
     private Pair<String, String> executeExternalProcess(String... args)


### PR DESCRIPTION
Adds `FrontendUtils.isHillaViewsUsed(File frontendDir)` to check if Hilla views are used in routes.ts or routes.tsx file. This does the check based on these two files only and the `routes` array variable content without doing any validation.

Hilla views are in use in following cases based on the `routes` array:
- If file does not contain `...serversideRoutes`
- If `routes` contains anything else in addition to `...serversideRoutes`
- If tsx has `...serversideRoutes` in MainLayout's `children` array Hilla views are not used in following case:
- If `...serversideRoutes` is the only item

Related-to: #18577
