### PR TITLE
Fix regression NPE in binder

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -1024,6 +1024,12 @@ public class Binder<BEAN> implements Serializable {
 
             BindingImpl<BEAN, FIELDVALUE, TARGET> binding = new BindingImpl<>(
                     this, getter, setter);
+            // Setting the binding field value has been moved up here to fix a
+            // regression NPE https://github.com/vaadin/flow/issues/18608 which
+            // breaks tests of Grid component: UpdateEditorComponentIT,
+            // DynamicEditorKBNavigationIT and
+            // GridViewEditorIT.dynamicNotBufferedEditor*
+            this.binding = binding;
 
             // Remove existing binding for same field to avoid potential
             // multiple application of converter
@@ -1042,7 +1048,6 @@ public class Binder<BEAN> implements Serializable {
             if (getBinder().incompleteBindings != null) {
                 getBinder().incompleteBindings.remove(getField());
             }
-            this.binding = binding;
 
             return binding;
         }

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -1006,9 +1006,12 @@ public class Binder<BEAN> implements Serializable {
             this.statusHandler = statusHandler;
 
             if (field instanceof HasValidator hasValidator) {
-                withValidator((val, ctx) -> binding.isDefaultValidatorDisabled()
-                        ? ValidationResult.ok()
-                        : hasValidator.getDefaultValidator().apply(val, ctx));
+                withValidator((val,
+                        ctx) -> binding != null
+                                && binding.isDefaultValidatorDisabled()
+                                        ? ValidationResult.ok()
+                                        : hasValidator.getDefaultValidator()
+                                                .apply(val, ctx));
             }
         }
 


### PR DESCRIPTION
This patch fixes a regression in Binder introduced by adding skipDefaultValidator API (https://github.com/vaadin/flow/pull/18549). This issue was missed since it seems to be impossible/difficult to trigger via unit testing using the mock field components in Flow project.

Affected flow-components tests:
[UpdateEditorComponentIT](https://github.com/vaadin/flow-components/blob/main/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/UpdateEditorComponentIT.java#L34)
[DynamicEditorKBNavigationIT](https://github.com/vaadin/flow-components/blob/main/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/DynamicEditorKBNavigationIT.java#L37)
[GridViewEditorIT.dynamicNotBufferedEditor_closeEditorUsingKeyboard](https://github.com/vaadin/flow-components/blob/main/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewEditorIT.java#L96)
[GridViewEditorIT.dynamicNotBufferedEditor](https://github.com/vaadin/flow-components/blob/main/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewEditorIT.java#L404)
[GridViewEditorIT.dynamicNotBufferedEditor_navigateUsingKeyboard](https://github.com/vaadin/flow-components/blob/main/vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests/src/test/java/com/vaadin/flow/component/grid/it/GridViewEditorIT.java#L466)

Fixes https://github.com/vaadin/flow/issues/18608

