### PR TITLE
fix(React): install React components even when Hilla is absent

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -177,8 +177,7 @@ public abstract class NodeUpdater implements FallibleCommand {
             VersionsJsonConverter convert = new VersionsJsonConverter(
                     Json.parse(
                             IOUtils.toString(content, StandardCharsets.UTF_8)),
-                    options.isReactRouterEnabled()
-                            && EndpointRequestUtil.isHillaAvailable());
+                    options.isReactRouterEnabled());
             versionsJson = convert.getConvertedJson();
             versionsJson = new VersionsJsonFilter(getPackageJson(),
                     DEPENDENCIES)


### PR DESCRIPTION
Using basic React features should not require having Hilla on the class
path.