### PR TITLE
fix: Catch exceptions when package.json template doesn't exist

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -337,8 +337,8 @@ public abstract class NodeUpdater implements FallibleCommand {
         try (InputStream packageJson = NodeUpdater.class
                 .getResourceAsStream("dependencies/" + id + "/package.json")) {
             if (packageJson == null) {
-                LoggerFactory.getLogger(NodeUpdater.class).error(
-                        "Unable to find package.json from '" + id + "'");
+                LoggerFactory.getLogger(NodeUpdater.class)
+                        .error("Unable to find package.json from '" + id + "'");
                 return Json.createObject();
             }
             JsonObject content = Json.parse(

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -313,6 +313,12 @@ public abstract class NodeUpdater implements FallibleCommand {
             Map<String, String> map = new HashMap<>();
             JsonObject dependencies = readPackageJson(id)
                     .getObject(packageJsonKey);
+            if (dependencies == null) {
+                LoggerFactory.getLogger(NodeUpdater.class)
+                        .error("Unable to find " + packageJsonKey + " from '"
+                                + id + "'");
+                return new HashMap<>();
+            }
             for (String key : dependencies.keys()) {
                 map.put(key, dependencies.getString(key));
             }
@@ -327,9 +333,14 @@ public abstract class NodeUpdater implements FallibleCommand {
 
     }
 
-    private static JsonObject readPackageJson(String id) throws IOException {
+    static JsonObject readPackageJson(String id) throws IOException {
         try (InputStream packageJson = NodeUpdater.class
                 .getResourceAsStream("dependencies/" + id + "/package.json")) {
+            if (packageJson == null) {
+                LoggerFactory.getLogger(NodeUpdater.class).error(
+                        "Unable to find package.json from '" + id + "'");
+                return Json.createObject();
+            }
             JsonObject content = Json.parse(
                     IOUtils.toString(packageJson, StandardCharsets.UTF_8));
             return content;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -175,8 +175,7 @@ public abstract class NodeUpdater implements FallibleCommand {
             VersionsJsonConverter convert = new VersionsJsonConverter(
                     Json.parse(
                             IOUtils.toString(content, StandardCharsets.UTF_8)),
-                    options.isReactRouterEnabled() && FrontendUtils
-                            .isHillaUsed(options.getFrontendDirectory()));
+                    options.isReactRouterEnabled());
             versionsJson = convert.getConvertedJson();
             versionsJson = new VersionsJsonFilter(getPackageJson(),
                     DEPENDENCIES)

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -554,6 +554,18 @@ public class NodeUpdaterTest {
                 defaultDevDeps.containsKey("lit-dev-dependency"));
     }
 
+    @Test
+    public void readPackageJson_nonExistingFile_doesNotThrow()
+            throws IOException {
+        NodeUpdater.readPackageJson("non-existing-folder");
+    }
+
+    @Test
+    public void readDependencies_doesntHaveDependencies_doesNotThrow() {
+        NodeUpdater.readDependencies("no-deps", "dependencies");
+        NodeUpdater.readDependencies("no-deps", "devDependencies");
+    }
+
     private String getPolymerVersion(JsonObject object) {
         JsonObject deps = object.get("dependencies");
         String version = deps.getString("@polymer/polymer");

--- a/flow-server/src/test/resources/com/vaadin/flow/server/frontend/dependencies/hilla/components/no-deps/package.json
+++ b/flow-server/src/test/resources/com/vaadin/flow/server/frontend/dependencies/hilla/components/no-deps/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "hilla-components-dependencies",
+  "version": "1.0.0",
+  "description": "A list of Hilla React components that are added by Flow automatically to package.json",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "Apache-2.0"
+}


### PR DESCRIPTION
If a package.json template cannot be found for any reason, Flow catches it and logs an error message.