### PR TITLE
On resync close the UI and do not fire attach listeners twice

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
@@ -450,7 +450,6 @@ public class StateNode implements Serializable {
             stateNode.hasBeenAttached = false;
             stateNode.hasBeenDetached = false;
         });
-        visitNodeTreeBottomUp(sn -> sn.fireAttachListeners(true));
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
@@ -331,6 +331,8 @@ public class ServerRpcHandler implements Serializable {
                     + " the network infrastructure (load balancer, proxy) terminating a push (websocket or long-polling) connection."
                     + " If you are using push with a proxy, make sure the push timeout is set to be smaller than the proxy connection timeout");
 
+            ui.close();
+
             // Run detach listeners and re-attach all nodes again to the
             // state tree, in order to send changes for a full re-build of
             // the client-side state tree in the response

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
@@ -331,8 +331,6 @@ public class ServerRpcHandler implements Serializable {
                     + " the network infrastructure (load balancer, proxy) terminating a push (websocket or long-polling) connection."
                     + " If you are using push with a proxy, make sure the push timeout is set to be smaller than the proxy connection timeout");
 
-            ui.close();
-
             // Run detach listeners and re-attach all nodes again to the
             // state tree, in order to send changes for a full re-build of
             // the client-side state tree in the response


### PR DESCRIPTION
Removes attach listener call from `prepareForResync` -method, since currently there's double attach happening on resync: once for the old closing UI and once for the new "after resync" UI.

Fixes https://github.com/vaadin/flow/issues/18526