### PR TITLE
fix: Spring Boot's deprecation warning

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/annotation/SpringComponent.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/annotation/SpringComponent.java
@@ -19,6 +19,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import org.springframework.core.annotation.AliasFor;
 import org.springframework.stereotype.Component;
 
 /**
@@ -40,5 +41,6 @@ public @interface SpringComponent {
      *
      * @return the suggested component name, if any
      */
+    @AliasFor(annotation = Component.class)
     String value() default "";
 }


### PR DESCRIPTION
## Description

Fixed Spring Boot's deprecation warning affecting SpringComponent. Relevant information about the motivation to deprecate convention-based naming: https://github.com/spring-projects/spring-framework/issues/31093

Fixes # ([18632](https://github.com/vaadin/flow/issues/18632))

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.