### PR TITLE
chore: Use type Import in types.d.ts

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/types.d.ts
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/types.d.ts
@@ -4,7 +4,7 @@
 // It is recommended to commit this file to the VCS.
 // You might want to change the configurations to fit your preferences
 declare module '*.css?inline' {
-  import { CSSResultGroup } from 'lit';
+  import type { CSSResultGroup } from 'lit';
   const content: CSSResultGroup;
   export default content;
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateTsDefinitionsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateTsDefinitionsTest.java
@@ -193,7 +193,7 @@ public class TaskGenerateTsDefinitionsTest {
                             [Ref in string]?: SchemaObject;
                         };
                         declare module '*.css?inline' {
-                          import { CSSResultGroup } from 'lit';
+                          import type { CSSResultGroup } from 'lit';
                           const content: CSSResultGroup;
                           export default content;
                         }
@@ -220,7 +220,7 @@ public class TaskGenerateTsDefinitionsTest {
                             [Ref in string]?: SchemaObject;
                         };
                         declare module '*.css?inline' {
-                          import { CSSResultGroup } from 'lit';
+                          import type { CSSResultGroup } from 'lit';
                           const content: CSSResultGroup;
                           export default content;
                         }
@@ -249,7 +249,7 @@ public class TaskGenerateTsDefinitionsTest {
                         };
                         declare module '*.css?inline' {
 
-                          import { CSSResultGroup } from 'lit';
+                          import type { CSSResultGroup } from 'lit';
 
                           const content: CSSResultGroup;
 


### PR DESCRIPTION
Without this, it seems some linters/formatters will go and change types.d.ts to `import type` and then Flow will refuse to start
