### PR TITLE
fix!: rename default validator api

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -1009,10 +1009,10 @@ public class Binder<BEAN> implements Serializable {
             if (field instanceof HasValidator hasValidator) {
                 withValidator((val,
                         ctx) -> binding != null
-                                && binding.isDefaultValidatorEnabled()
-                                        ? hasValidator.getDefaultValidator()
-                                                .apply(val, ctx)
-                                        : ValidationResult.ok());
+                                && !binding.isDefaultValidatorEnabled()
+                                        ? ValidationResult.ok()
+                                        : hasValidator.getDefaultValidator()
+                                                .apply(val, ctx));
             }
         }
 

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -1560,7 +1560,7 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
                 2, status.getValidationErrors().size());
 
         // Toggle default validators to disabled
-        binder.setDefaultValidatorsDisabled(true);
+        binder.setDefaultValidatorsEnabled(false);
         status = binder.validate();
         Assert.assertTrue(
                 "Validation should not have errors. "
@@ -1578,7 +1578,7 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         binder.forField(field1).bind(Person::getFirstName,
                 Person::setFirstName);
         Binding<Person, String> binding = binder.forField(field2)
-                .setDefaultValidatorDisabled(true)
+                .withDefaultValidator(false)
                 .bind(Person::getLastName, Person::setLastName);
 
         // One binding has default validators disabled
@@ -1589,7 +1589,7 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
                 1, status.getValidationErrors().size());
 
         // Re-enable default validators of binding
-        binding.setDefaultValidatorDisabled(false);
+        binding.setDefaultValidatorEnabled(true);
         status = binder.validate();
         assertEquals(
                 "Validation should have two errors. "
@@ -1612,11 +1612,11 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         binder.forField(field1).bind(Person::getFirstName,
                 Person::setFirstName);
         Binding<Person, String> binding = binder.forField(field2)
-                .setDefaultValidatorDisabled(false)
+                .withDefaultValidator(true)
                 .bind(Person::getLastName, Person::setLastName);
 
         // Initial case: binder disabled & binding overrides to enable
-        binder.setDefaultValidatorsDisabled(true);
+        binder.setDefaultValidatorsEnabled(false);
         BinderValidationStatus<Person> status = binder.validate();
         assertEquals(
                 "Validation should have one error. "
@@ -1628,8 +1628,8 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         nonSkippedDidRun.getAndSet(false);
 
         // Cross-toggle false <-> true
-        binder.setDefaultValidatorsDisabled(false);
-        binding.setDefaultValidatorDisabled(true);
+        binder.setDefaultValidatorsEnabled(true);
+        binding.setDefaultValidatorEnabled(false);
         status = binder.validate();
         assertEquals(
                 "Validation should have one error. "


### PR DESCRIPTION
Rename default validator toggling API. Also fixes methods in binding to set/return `Boolean` instead of `boolean`.