### PR TITLE
fix: Use class finder to load package.json templates

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinBuildFrontendTask.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinBuildFrontendTask.kt
@@ -73,7 +73,8 @@ public open class VaadinBuildFrontendTask : DefaultTask() {
         check(tokenFile.exists()) { "token file $tokenFile doesn't exist!" }
 
         val cleanTask = TaskCleanFrontendFiles(config.npmFolder.get(),
-            config.frontendDirectory.get())
+            config.frontendDirectory.get(), adapter.classFinder
+        )
         BuildFrontendUtil.runNodeUpdater(adapter)
 
         if (adapter.generateBundle() && BundleValidationUtil.needsBundleBuild

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -133,7 +133,7 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo
         long start = System.nanoTime();
 
         TaskCleanFrontendFiles cleanTask = new TaskCleanFrontendFiles(
-                npmFolder(), frontendDirectory());
+                npmFolder(), frontendDirectory(), getClassFinder());
         try {
             BuildFrontendUtil.runNodeUpdater(this);
         } catch (ExecutionFailedException | URISyntaxException exception) {

--- a/flow-server/src/main/java/com/vaadin/flow/internal/hilla/EndpointRequestUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/hilla/EndpointRequestUtil.java
@@ -19,6 +19,8 @@ package com.vaadin.flow.internal.hilla;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.Serializable;
 
+import com.vaadin.flow.server.frontend.scanner.ClassFinder;
+
 /**
  * A container for utility methods related with Hilla endpoints.
  * <p>
@@ -28,6 +30,9 @@ import java.io.Serializable;
  * @since 23.2
  */
 public interface EndpointRequestUtil extends Serializable {
+
+    String HILLA_ENDPOINT_CLASS = "com.vaadin.hilla.EndpointController";
+
     /**
      * Checks if the request is for an endpoint.
      * <p>
@@ -59,7 +64,23 @@ public interface EndpointRequestUtil extends Serializable {
      */
     static boolean isHillaAvailable() {
         try {
-            Class.forName("com.vaadin.hilla.EndpointController");
+            Class.forName(HILLA_ENDPOINT_CLASS);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Checks if Hilla is available using the given class finder.
+     *
+     * @param classFinder
+     *            class finder to check the presence of Hilla endpoint class
+     * @return true if Hilla is available, false otherwise
+     */
+    static boolean isHillaAvailable(ClassFinder classFinder) {
+        try {
+            classFinder.loadClass(HILLA_ENDPOINT_CLASS);
             return true;
         } catch (ClassNotFoundException e) {
             return false;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -110,11 +110,11 @@ abstract class AbstractUpdateImports implements Runnable {
     private final File generatedFlowDefinitions;
     private File chunkFolder;
 
-    AbstractUpdateImports(Options options, FrontendDependenciesScanner scanner,
-            ClassFinder classFinder) {
+    AbstractUpdateImports(Options options,
+            FrontendDependenciesScanner scanner) {
         this.options = options;
         this.scanner = scanner;
-        this.classFinder = classFinder;
+        this.classFinder = options.getClassFinder();
         this.themeToLocalPathConverter = createThemeToLocalPathConverter(
                 scanner.getTheme());
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleValidationUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleValidationUtil.java
@@ -71,7 +71,7 @@ public final class BundleValidationUtil {
             boolean needsBuild;
             if (mode.isProduction()) {
                 if (options.isForceProductionBuild() || FrontendUtils
-                        .isHillaUsed(options.getFrontendDirectory())) {
+                        .isHillaUsed(options.getFrontendDirectory(), finder)) {
                     if (options.isForceProductionBuild()) {
                         UsageStatistics.markAsUsed("flow/prod-build-requested",
                                 null);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleValidationUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleValidationUtil.java
@@ -26,7 +26,6 @@ import com.vaadin.flow.component.WebComponentExporter;
 import com.vaadin.flow.component.WebComponentExporterFactory;
 import com.vaadin.flow.internal.StringUtil;
 import com.vaadin.flow.internal.UsageStatistics;
-import com.vaadin.flow.internal.hilla.EndpointRequestUtil;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.LoadDependenciesOnStartup;
 import com.vaadin.flow.server.Mode;
@@ -57,21 +56,19 @@ public final class BundleValidationUtil {
      *            Flow plugin options
      * @param frontendDependencies
      *            frontend dependencies scanner to lookup for frontend imports
-     * @param finder
-     *            class finder to obtain classes and resources from class-path
      * @param mode
      *            Vaadin application mode
      * @return true if a new frontend bundle is needed, false otherwise
      */
     public static boolean needsBuild(Options options,
-            FrontendDependenciesScanner frontendDependencies,
-            ClassFinder finder, Mode mode) {
+            FrontendDependenciesScanner frontendDependencies, Mode mode) {
         getLogger().info("Checking if a {} mode bundle build is needed", mode);
         try {
             boolean needsBuild;
             if (mode.isProduction()) {
                 if (options.isForceProductionBuild() || FrontendUtils
-                        .isHillaUsed(options.getFrontendDirectory(), finder)) {
+                        .isHillaUsed(options.getFrontendDirectory(),
+                                options.getClassFinder())) {
                     if (options.isForceProductionBuild()) {
                         UsageStatistics.markAsUsed("flow/prod-build-requested",
                                 null);
@@ -81,12 +78,11 @@ public final class BundleValidationUtil {
                     return true;
                 } else {
                     needsBuild = needsBuildProdBundle(options,
-                            frontendDependencies, finder);
+                            frontendDependencies);
                     saveResultInFile(needsBuild, options);
                 }
             } else if (Mode.DEVELOPMENT_BUNDLE == mode) {
-                needsBuild = needsBuildDevBundle(options, frontendDependencies,
-                        finder);
+                needsBuild = needsBuildDevBundle(options, frontendDependencies);
             } else if (Mode.DEVELOPMENT_FRONTEND_LIVERELOAD == mode) {
                 return false;
             } else {
@@ -108,15 +104,16 @@ public final class BundleValidationUtil {
     }
 
     private static boolean needsBuildDevBundle(Options options,
-            FrontendDependenciesScanner frontendDependencies,
-            ClassFinder finder) throws IOException {
+            FrontendDependenciesScanner frontendDependencies)
+            throws IOException {
         File npmFolder = options.getNpmFolder();
         File compressedDevBundle = new File(npmFolder,
                 Constants.DEV_BUNDLE_COMPRESSED_FILE_LOCATION);
         if (!DevBundleUtils
                 .getDevBundleFolder(npmFolder, options.getBuildDirectoryName())
                 .exists() && !compressedDevBundle.exists()
-                && !hasJarBundle(DEV_BUNDLE_JAR_PATH, finder)) {
+                && !hasJarBundle(DEV_BUNDLE_JAR_PATH,
+                        options.getClassFinder())) {
             getLogger().info("No dev-bundle found.");
             return true;
         }
@@ -148,17 +145,18 @@ public final class BundleValidationUtil {
             return true;
         }
 
-        return needsBuildInternal(options, frontendDependencies, finder,
+        return needsBuildInternal(options, frontendDependencies,
                 statsJsonContent);
     }
 
     private static boolean needsBuildProdBundle(Options options,
-            FrontendDependenciesScanner frontendDependencies,
-            ClassFinder finder) throws IOException {
-        String statsJsonContent = ProdBundleUtils
-                .findBundleStatsJson(options.getNpmFolder(), finder);
+            FrontendDependenciesScanner frontendDependencies)
+            throws IOException {
+        String statsJsonContent = ProdBundleUtils.findBundleStatsJson(
+                options.getNpmFolder(), options.getClassFinder());
 
-        if (!finder.getAnnotatedClasses(LoadDependenciesOnStartup.class)
+        if (!options.getClassFinder()
+                .getAnnotatedClasses(LoadDependenciesOnStartup.class)
                 .isEmpty()) {
             getLogger()
                     .info("Custom eager routes defined. Require bundle build.");
@@ -174,16 +172,15 @@ public final class BundleValidationUtil {
             return true;
         }
 
-        return needsBuildInternal(options, frontendDependencies, finder,
+        return needsBuildInternal(options, frontendDependencies,
                 statsJsonContent);
     }
 
     private static boolean needsBuildInternal(Options options,
             FrontendDependenciesScanner frontendDependencies,
-            ClassFinder finder, String statsJsonContent) throws IOException {
+            String statsJsonContent) throws IOException {
 
-        JsonObject packageJson = getPackageJson(options, frontendDependencies,
-                finder);
+        JsonObject packageJson = getPackageJson(options, frontendDependencies);
         JsonObject statsJson = Json.parse(statsJsonContent);
 
         // Get scanned @NpmPackage annotations
@@ -199,14 +196,14 @@ public final class BundleValidationUtil {
             return true;
         }
         if (!BundleValidationUtil.frontendImportsFound(statsJson, options,
-                finder, frontendDependencies)) {
+                frontendDependencies)) {
             UsageStatistics.markAsUsed(
                     "flow/rebundle-reason-missing-frontend-import", null);
             return true;
         }
 
         if (ThemeValidationUtil.themeConfigurationChanged(options, statsJson,
-                frontendDependencies, finder)) {
+                frontendDependencies)) {
             UsageStatistics.markAsUsed(
                     "flow/rebundle-reason-changed-theme-config", null);
             return true;
@@ -220,7 +217,8 @@ public final class BundleValidationUtil {
             return true;
         }
 
-        if (BundleValidationUtil.exportedWebComponents(statsJson, finder)) {
+        if (BundleValidationUtil.exportedWebComponents(statsJson,
+                options.getClassFinder())) {
             UsageStatistics.markAsUsed(
                     "flow/rebundle-reason-added-exported-component", null);
             return true;
@@ -251,13 +249,10 @@ public final class BundleValidationUtil {
      *            the task options
      * @param frontendDependencies
      *            frontend dependency scanner
-     * @param finder
-     *            classfinder
      * @return package.json content as JsonObject
      */
     public static JsonObject getPackageJson(Options options,
-            FrontendDependenciesScanner frontendDependencies,
-            ClassFinder finder) {
+            FrontendDependenciesScanner frontendDependencies) {
         File packageJsonFile = new File(options.getNpmFolder(), "package.json");
 
         if (packageJsonFile.exists()) {
@@ -267,21 +262,20 @@ public final class BundleValidationUtil {
                                 StandardCharsets.UTF_8));
                 cleanOldPlatformDependencies(packageJson);
                 return getDefaultPackageJson(options, frontendDependencies,
-                        finder, packageJson);
+                        packageJson);
             } catch (IOException e) {
                 getLogger().warn("Failed to read package.json", e);
             }
         } else {
-            return getDefaultPackageJson(options, frontendDependencies, finder,
-                    null);
+            return getDefaultPackageJson(options, frontendDependencies, null);
         }
         return null;
     }
 
     public static JsonObject getDefaultPackageJson(Options options,
             FrontendDependenciesScanner frontendDependencies,
-            ClassFinder finder, JsonObject packageJson) {
-        NodeUpdater nodeUpdater = new NodeUpdater(finder, frontendDependencies,
+            JsonObject packageJson) {
+        NodeUpdater nodeUpdater = new NodeUpdater(frontendDependencies,
                 options) {
             @Override
             public void execute() {
@@ -577,13 +571,12 @@ public final class BundleValidationUtil {
     }
 
     public static boolean frontendImportsFound(JsonObject statsJson,
-            Options options, ClassFinder finder,
-            FrontendDependenciesScanner frontendDependencies)
+            Options options, FrontendDependenciesScanner frontendDependencies)
             throws IOException {
 
         // Validate frontend requirements in flow-generated-imports.js
         final GenerateMainImports generateMainImports = new GenerateMainImports(
-                finder, frontendDependencies, options, statsJson);
+                frontendDependencies, options, statsJson);
         generateMainImports.run();
         final List<String> imports = generateMainImports.getLines().stream()
                 .filter(line -> line.startsWith("import"))
@@ -631,7 +624,7 @@ public final class BundleValidationUtil {
 
         for (String jarImport : jarImports) {
             final String jarResourceString = FrontendUtils
-                    .getJarResourceString(jarImport, finder);
+                    .getJarResourceString(jarImport, options.getClassFinder());
             if (jarResourceString == null) {
                 getLogger().info("No file found for '{}'", jarImport);
                 return false;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -1272,6 +1272,24 @@ public class FrontendUtils {
                 && isHillaViewsUsed(frontendDirectory);
     }
 
+    /**
+     * Checks if Hilla is available and Hilla views are used in the project
+     * based on what is in routes.ts or routes.tsx file.
+     * {@link FrontendUtils#getProjectFrontendDir(AbstractConfiguration)} can be
+     * used to get the frontend directory. Given class finder is used to check
+     * the presence of Hilla in a classpath.
+     *
+     * @param classFinder
+     *            class finder to check the presence of Hilla endpoint class
+     * @return {@code true} if Hilla is available and Hilla views are used,
+     *         {@code false} otherwise
+     */
+    public static boolean isHillaUsed(File frontendDirectory,
+            ClassFinder classFinder) {
+        return EndpointRequestUtil.isHillaAvailable(classFinder)
+                && isHillaViewsUsed(frontendDirectory);
+    }
+
     private static boolean isRoutesContentUsingHillaViews(
             String routesContent) {
         routesContent = StringUtil.removeComments(routesContent);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/GenerateMainImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/GenerateMainImports.java
@@ -45,10 +45,9 @@ public class GenerateMainImports extends AbstractUpdateImports {
     private JsonObject statsJson;
     private Map<File, List<String>> output;
 
-    public GenerateMainImports(ClassFinder classFinder,
-            FrontendDependenciesScanner frontendDepScanner, Options options,
-            JsonObject statsJson) {
-        super(options, frontendDepScanner, classFinder);
+    public GenerateMainImports(FrontendDependenciesScanner frontendDepScanner,
+            Options options, JsonObject statsJson) {
+        super(options, frontendDepScanner);
         this.statsJson = statsJson;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -106,8 +106,7 @@ public class NodeTasks implements FallibleCommand {
         lockFile = new File(options.getNpmFolder(), ".flow-node-tasks.lock")
                 .toPath();
 
-        ClassFinder classFinder = new ClassFinder.CachedClassFinder(
-                options.getClassFinder());
+        ClassFinder classFinder = options.getClassFinder();
         FrontendDependenciesScanner frontendDependencies = null;
 
         Set<String> webComponentTags = new HashSet<>();
@@ -127,7 +126,7 @@ public class NodeTasks implements FallibleCommand {
 
             if (options.isProductionMode()) {
                 boolean needBuild = BundleValidationUtil.needsBuild(options,
-                        frontendDependencies, classFinder,
+                        frontendDependencies,
                         Mode.PRODUCTION_PRECOMPILED_BUNDLE);
                 options.withRunNpmInstall(needBuild);
                 options.withBundleBuild(needBuild);
@@ -152,8 +151,7 @@ public class NodeTasks implements FallibleCommand {
                 // immediately
                 // and no update tasks are executed before it.
                 if (BundleValidationUtil.needsBuild(options,
-                        frontendDependencies, classFinder,
-                        Mode.DEVELOPMENT_BUNDLE)) {
+                        frontendDependencies, Mode.DEVELOPMENT_BUNDLE)) {
                     commands.add(new TaskCleanFrontendFiles(
                             options.getNpmFolder(),
                             options.getFrontendDirectory(), classFinder));
@@ -218,7 +216,7 @@ public class NodeTasks implements FallibleCommand {
 
         if (options.isCreateMissingPackageJson()) {
             TaskGeneratePackageJson packageCreator = new TaskGeneratePackageJson(
-                    options, classFinder);
+                    options);
             commands.add(packageCreator);
         }
 
@@ -267,8 +265,7 @@ public class NodeTasks implements FallibleCommand {
         }
 
         if (options.isEnableImportsUpdate()) {
-            commands.add(new TaskUpdateImports(classFinder,
-                    frontendDependencies, options));
+            commands.add(new TaskUpdateImports(frontendDependencies, options));
 
             commands.add(new TaskUpdateThemeImport(
                     frontendDependencies.getThemeDefinition(), options));

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -154,9 +154,9 @@ public class NodeTasks implements FallibleCommand {
                 if (BundleValidationUtil.needsBuild(options,
                         frontendDependencies, classFinder,
                         Mode.DEVELOPMENT_BUNDLE)) {
-                    commands.add(
-                            new TaskCleanFrontendFiles(options.getNpmFolder(),
-                                    options.getFrontendDirectory()));
+                    commands.add(new TaskCleanFrontendFiles(
+                            options.getNpmFolder(),
+                            options.getFrontendDirectory(), classFinder));
                     options.withRunNpmInstall(true);
                     options.withCopyTemplates(true);
                     BundleUtils.copyPackageLockFromBundle(options);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -218,7 +218,7 @@ public class NodeTasks implements FallibleCommand {
 
         if (options.isCreateMissingPackageJson()) {
             TaskGeneratePackageJson packageCreator = new TaskGeneratePackageJson(
-                    options);
+                    options, classFinder);
             commands.add(packageCreator);
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -197,8 +197,8 @@ public class NodeTasks implements FallibleCommand {
             TaskUpdatePackages packageUpdater = null;
             if (options.isEnablePackagesUpdate()
                     && options.getJarFrontendResourcesFolder() != null) {
-                packageUpdater = new TaskUpdatePackages(classFinder,
-                        frontendDependencies, options);
+                packageUpdater = new TaskUpdatePackages(frontendDependencies,
+                        options);
                 commands.add(packageUpdater);
             }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -109,6 +109,8 @@ public abstract class NodeUpdater implements FallibleCommand {
     /**
      * Constructor.
      *
+     * @param frontendDependencies
+     *            a reusable frontend dependencies
      * @param options
      *            the task options
      */

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -601,7 +601,8 @@ public abstract class NodeUpdater implements FallibleCommand {
     private static void putHillaComponentsDependencies(Options options,
             Map<String, String> dependencies, String packageJsonKey,
             ClassFinder classFinder) {
-        if (FrontendUtils.isHillaUsed(options.getFrontendDirectory())) {
+        if (FrontendUtils.isHillaUsed(options.getFrontendDirectory(),
+                classFinder)) {
             if (options.isReactRouterEnabled()) {
                 dependencies.putAll(readDependencies("hilla/components/react",
                         packageJsonKey, classFinder));

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/Options.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/Options.java
@@ -128,11 +128,27 @@ public class Options implements Serializable {
      *
      * @param lookup
      *            a {@link Lookup} to discover services used by Flow (SPI)
+     * @param npmFolder
+     *            a project's base folder
      */
     public Options(Lookup lookup, File npmFolder) {
+        this(lookup, new ClassFinder.CachedClassFinder(
+                lookup.lookup(ClassFinder.class)), npmFolder);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param lookup
+     *            a {@link Lookup} to discover services used by Flow (SPI)
+     * @param classFinder
+     *            a class finder to use in node tasks
+     * @param npmFolder
+     *            a project's base folder
+     */
+    public Options(Lookup lookup, ClassFinder classFinder, File npmFolder) {
         this.lookup = lookup;
-        this.classFinder = new ClassFinder.CachedClassFinder(
-                lookup.lookup(ClassFinder.class));
+        this.classFinder = classFinder;
         this.npmFolder = npmFolder;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/Options.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/Options.java
@@ -131,7 +131,8 @@ public class Options implements Serializable {
      */
     public Options(Lookup lookup, File npmFolder) {
         this.lookup = lookup;
-        this.classFinder = lookup.lookup(ClassFinder.class);
+        this.classFinder = new ClassFinder.CachedClassFinder(
+                lookup.lookup(ClassFinder.class));
         this.npmFolder = npmFolder;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCleanFrontendFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCleanFrontendFiles.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import com.vaadin.flow.internal.hilla.EndpointRequestUtil;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.ExecutionFailedException;
+import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 
 /**
  * Clean any frontend files generated for creation on a new development or
@@ -63,7 +64,8 @@ public class TaskCleanFrontendFiles implements FallibleCommand {
      * @param frontendDirectory
      *            frontend directory
      */
-    public TaskCleanFrontendFiles(File projectRoot, File frontendDirectory) {
+    public TaskCleanFrontendFiles(File projectRoot, File frontendDirectory,
+            ClassFinder classFinder) {
         this.projectRoot = projectRoot;
 
         Arrays.stream(projectRoot
@@ -74,7 +76,7 @@ public class TaskCleanFrontendFiles implements FallibleCommand {
         // node_modules
         if (existingFiles
                 .contains(new File(projectRoot, Constants.PACKAGE_JSON))
-                || FrontendUtils.isHillaUsed(frontendDirectory)) {
+                || FrontendUtils.isHillaUsed(frontendDirectory, classFinder)) {
             existingFiles.add(new File(projectRoot, NODE_MODULES));
         }
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGeneratePackageJson.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGeneratePackageJson.java
@@ -18,6 +18,8 @@ package com.vaadin.flow.server.frontend;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
+import com.vaadin.flow.server.frontend.scanner.ClassFinder;
+
 import elemental.json.JsonObject;
 
 /**
@@ -39,8 +41,8 @@ public class TaskGeneratePackageJson extends NodeUpdater {
      * @param buildDir
      *            the used build directory
      */
-    TaskGeneratePackageJson(Options options) {
-        super(null, null, options);
+    TaskGeneratePackageJson(Options options, ClassFinder classFinder) {
+        super(classFinder, null, options);
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGeneratePackageJson.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGeneratePackageJson.java
@@ -18,8 +18,6 @@ package com.vaadin.flow.server.frontend;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
-import com.vaadin.flow.server.frontend.scanner.ClassFinder;
-
 import elemental.json.JsonObject;
 
 /**
@@ -34,15 +32,11 @@ public class TaskGeneratePackageJson extends NodeUpdater {
     /**
      * Create an instance of the updater given all configurable parameters.
      *
-     * @param npmFolder
-     *            folder with the `package.json` file.
-     * @param generatedPath
-     *            folder where flow generated files will be placed.
-     * @param buildDir
-     *            the used build directory
+     * @param options
+     *            build options
      */
-    TaskGeneratePackageJson(Options options, ClassFinder classFinder) {
-        super(classFinder, null, options);
+    TaskGeneratePackageJson(Options options) {
+        super(null, options);
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -36,9 +36,9 @@ import com.vaadin.flow.theme.Theme;
 public class TaskUpdateImports extends NodeUpdater {
 
     private class UpdateMainImportsFile extends AbstractUpdateImports {
-        UpdateMainImportsFile(ClassFinder classFinder, Options options,
+        UpdateMainImportsFile(Options options,
                 FrontendDependenciesScanner scanner) {
-            super(options, scanner, classFinder);
+            super(options, scanner);
         }
 
         @Override
@@ -56,22 +56,20 @@ public class TaskUpdateImports extends NodeUpdater {
     /**
      * Create an instance of the updater given all configurable parameters.
      *
-     * @param finder
-     *            a reusable class finder
      * @param frontendDepScanner
      *            a reusable frontend dependencies scanner
      * @param options
      *            options for the task
      */
-    TaskUpdateImports(ClassFinder finder,
-            FrontendDependenciesScanner frontendDepScanner, Options options) {
-        super(finder, frontendDepScanner, options);
+    TaskUpdateImports(FrontendDependenciesScanner frontendDepScanner,
+            Options options) {
+        super(frontendDepScanner, options);
     }
 
     @Override
     public void execute() {
-        UpdateMainImportsFile mainUpdate = new UpdateMainImportsFile(finder,
-                options, frontDeps);
+        UpdateMainImportsFile mainUpdate = new UpdateMainImportsFile(options,
+                frontDeps);
         mainUpdate.run();
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -74,7 +74,7 @@ public class TaskUpdatePackages extends NodeUpdater {
      */
     TaskUpdatePackages(ClassFinder finder,
             FrontendDependenciesScanner frontendDependencies, Options options) {
-        super(finder, frontendDependencies, options);
+        super(frontendDependencies, options);
         this.jarResourcesFolder = options.getJarFrontendResourcesFolder();
         this.forceCleanUp = options.isCleanNpmFiles();
         this.enablePnpm = options.isEnablePnpm();

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -65,15 +65,13 @@ public class TaskUpdatePackages extends NodeUpdater {
     /**
      * Create an instance of the updater given all configurable parameters.
      *
-     * @param finder
-     *            a reusable class finder
      * @param frontendDependencies
      *            a reusable frontend dependencies
      * @param options
      *            the task options
      */
-    TaskUpdatePackages(ClassFinder finder,
-            FrontendDependenciesScanner frontendDependencies, Options options) {
+    TaskUpdatePackages(FrontendDependenciesScanner frontendDependencies,
+            Options options) {
         super(frontendDependencies, options);
         this.jarResourcesFolder = options.getJarFrontendResourcesFolder();
         this.forceCleanUp = options.isCleanNpmFiles();

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/ThemeValidationUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/ThemeValidationUtil.java
@@ -50,8 +50,7 @@ public class ThemeValidationUtil {
 
     public static boolean themeConfigurationChanged(Options options,
             JsonObject statsJson,
-            FrontendDependenciesScanner frontendDependencies,
-            ClassFinder finder) {
+            FrontendDependenciesScanner frontendDependencies) {
         Map<String, JsonObject> themeJsonContents = new HashMap<>();
 
         if (options.getJarFiles() != null) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdateImportsTest.java
@@ -77,7 +77,9 @@ public abstract class AbstractNodeUpdateImportsTest extends NodeUpdateTestUtil {
         importsFile = FrontendUtils.getFlowGeneratedImports(frontendDirectory);
 
         ClassFinder classFinder = getClassFinder();
-        Options options = new Options(Mockito.mock(Lookup.class), tmpRoot)
+        Lookup lookup = Mockito.mock(Lookup.class);
+        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(classFinder);
+        Options options = new Options(lookup, tmpRoot)
                 .withFrontendDirectory(frontendDirectory)
                 .withBuildDirectory(TARGET).withProductionMode(true)
                 .withBundleBuild(true);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdateImportsTest.java
@@ -81,8 +81,7 @@ public abstract class AbstractNodeUpdateImportsTest extends NodeUpdateTestUtil {
                 .withFrontendDirectory(frontendDirectory)
                 .withBuildDirectory(TARGET).withProductionMode(true)
                 .withBundleBuild(true);
-        updater = new TaskUpdateImports(classFinder, getScanner(classFinder),
-                options) {
+        updater = new TaskUpdateImports(getScanner(classFinder), options) {
             @Override
             Logger log() {
                 return logger;

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdateImportsTest.java
@@ -41,9 +41,9 @@ import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 
-import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
+import com.vaadin.tests.util.MockOptions;
 
 import static com.vaadin.flow.server.Constants.TARGET;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
@@ -77,9 +77,7 @@ public abstract class AbstractNodeUpdateImportsTest extends NodeUpdateTestUtil {
         importsFile = FrontendUtils.getFlowGeneratedImports(frontendDirectory);
 
         ClassFinder classFinder = getClassFinder();
-        Lookup lookup = Mockito.mock(Lookup.class);
-        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(classFinder);
-        Options options = new Options(lookup, tmpRoot)
+        Options options = new MockOptions(classFinder, tmpRoot)
                 .withFrontendDirectory(frontendDirectory)
                 .withBuildDirectory(TARGET).withProductionMode(true)
                 .withBundleBuild(true);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
@@ -88,9 +88,8 @@ public abstract class AbstractNodeUpdatePackagesTest
         options = new Options(Mockito.mock(Lookup.class), baseDir)
                 .withBuildDirectory(TARGET).withBundleBuild(true);
         // .withJarFrontendResourcesFolder(jarResourceFolder);
-        packageCreator = new TaskGeneratePackageJson(options);
-
         classFinder = Mockito.spy(getClassFinder());
+        packageCreator = new TaskGeneratePackageJson(options, classFinder);
         versions = temporaryFolder.newFile();
         FileUtils.write(versions, "{}", StandardCharsets.UTF_8);
         Mockito.when(

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
@@ -85,11 +85,12 @@ public abstract class AbstractNodeUpdatePackagesTest
         baseDir = temporaryFolder.getRoot();
 
         FrontendStubs.createStubNode(true, true, baseDir.getAbsolutePath());
-        options = new Options(Mockito.mock(Lookup.class), baseDir)
-                .withBuildDirectory(TARGET).withBundleBuild(true);
-        // .withJarFrontendResourcesFolder(jarResourceFolder);
         classFinder = Mockito.spy(getClassFinder());
-        packageCreator = new TaskGeneratePackageJson(options, classFinder);
+        Lookup lookup = Mockito.mock(Lookup.class);
+        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(classFinder);
+        options = new Options(lookup, baseDir).withBuildDirectory(TARGET)
+                .withBundleBuild(true);
+        packageCreator = new TaskGeneratePackageJson(options);
         versions = temporaryFolder.newFile();
         FileUtils.write(versions, "{}", StandardCharsets.UTF_8);
         Mockito.when(

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
@@ -37,13 +37,13 @@ import org.junit.rules.TemporaryFolder;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
-import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.Platform;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 import com.vaadin.flow.testutil.FrontendStubs;
+import com.vaadin.tests.util.MockOptions;
 
 import elemental.json.Json;
 import elemental.json.JsonObject;
@@ -86,10 +86,8 @@ public abstract class AbstractNodeUpdatePackagesTest
 
         FrontendStubs.createStubNode(true, true, baseDir.getAbsolutePath());
         classFinder = Mockito.spy(getClassFinder());
-        Lookup lookup = Mockito.mock(Lookup.class);
-        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(classFinder);
-        options = new Options(lookup, baseDir).withBuildDirectory(TARGET)
-                .withBundleBuild(true);
+        options = new MockOptions(classFinder, baseDir)
+                .withBuildDirectory(TARGET).withBundleBuild(true);
         packageCreator = new TaskGeneratePackageJson(options);
         versions = temporaryFolder.newFile();
         FileUtils.write(versions, "{}", StandardCharsets.UTF_8);
@@ -97,8 +95,8 @@ public abstract class AbstractNodeUpdatePackagesTest
                 classFinder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(versions.toURI().toURL());
 
-        packageUpdater = new TaskUpdatePackages(classFinder,
-                getScanner(classFinder), options);
+        packageUpdater = new TaskUpdatePackages(getScanner(classFinder),
+                options);
         packageJson = new File(baseDir, PACKAGE_JSON);
 
         mainNodeModules = new File(baseDir, FrontendUtils.NODE_MODULES);
@@ -138,8 +136,8 @@ public abstract class AbstractNodeUpdatePackagesTest
     public void pnpmIsInUse_packageJsonContainsFlowDeps_removeFlowDeps()
             throws IOException {
         // use package updater with disabled PNPM
-        packageUpdater = new TaskUpdatePackages(classFinder,
-                getScanner(classFinder), options);
+        packageUpdater = new TaskUpdatePackages(getScanner(classFinder),
+                options);
         // Generate package json in a proper format first
         packageCreator.execute();
         packageUpdater.execute();
@@ -153,8 +151,8 @@ public abstract class AbstractNodeUpdatePackagesTest
                 Collections.singletonList(json.toJson()));
 
         options.withEnablePnpm(true);
-        packageUpdater = new TaskUpdatePackages(classFinder,
-                getScanner(classFinder), options);
+        packageUpdater = new TaskUpdatePackages(getScanner(classFinder),
+                options);
         packageUpdater.execute();
 
         assertPackageJsonFlowDeps();
@@ -164,8 +162,8 @@ public abstract class AbstractNodeUpdatePackagesTest
     public void pnpmIsInUse_packageJsonContainsFlowFrontend_removeFlowFrontend()
             throws IOException {
         // use package updater with disabled PNPM
-        packageUpdater = new TaskUpdatePackages(classFinder,
-                getScanner(classFinder), options);
+        packageUpdater = new TaskUpdatePackages(getScanner(classFinder),
+                options);
         // Generate package json in a proper format first
         packageCreator.execute();
         packageUpdater.execute();
@@ -179,8 +177,8 @@ public abstract class AbstractNodeUpdatePackagesTest
                 Collections.singletonList(json.toJson()));
 
         options.withEnablePnpm(true);
-        packageUpdater = new TaskUpdatePackages(classFinder,
-                getScanner(classFinder), options);
+        packageUpdater = new TaskUpdatePackages(getScanner(classFinder),
+                options);
         packageUpdater.execute();
 
         assertPackageJsonFlowDeps();
@@ -190,8 +188,8 @@ public abstract class AbstractNodeUpdatePackagesTest
     public void pnpmIsInUse_packageLockExists_removePackageLock()
             throws IOException {
         // use package updater with disabled PNPM
-        packageUpdater = new TaskUpdatePackages(classFinder,
-                getScanner(classFinder), options);
+        packageUpdater = new TaskUpdatePackages(getScanner(classFinder),
+                options);
         // Generate package json in a proper format first
         packageCreator.execute();
         packageUpdater.execute();
@@ -200,8 +198,8 @@ public abstract class AbstractNodeUpdatePackagesTest
 
         options.withEnablePnpm(true);
 
-        packageUpdater = new TaskUpdatePackages(classFinder,
-                getScanner(classFinder), options);
+        packageUpdater = new TaskUpdatePackages(getScanner(classFinder),
+                options);
         packageUpdater.execute();
         Assert.assertFalse("npm package-lock should be removed for pnpm",
                 packageLock.exists());
@@ -341,7 +339,7 @@ public abstract class AbstractNodeUpdatePackagesTest
             throws IOException {
         options.withEnablePnpm(true);
 
-        packageUpdater = new TaskUpdatePackages(classFinder,
+        packageUpdater = new TaskUpdatePackages(
                 Mockito.mock(FrontendDependencies.class), options);
 
         // Generate package json in a proper format first
@@ -380,8 +378,7 @@ public abstract class AbstractNodeUpdatePackagesTest
 
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
-        packageUpdater = new TaskUpdatePackages(classFinder,
-                frontendDependencies, options);
+        packageUpdater = new TaskUpdatePackages(frontendDependencies, options);
 
         // Generate package json in a proper format first
         packageCreator.execute();
@@ -409,8 +406,8 @@ public abstract class AbstractNodeUpdatePackagesTest
         ClassFinder classFinder = getClassFinder();
         // create a new package updater, with forced clean up enabled
         options.enableNpmFileCleaning(true);
-        packageUpdater = new TaskUpdatePackages(classFinder,
-                getScanner(classFinder), options);
+        packageUpdater = new TaskUpdatePackages(getScanner(classFinder),
+                options);
         packageUpdater.execute();
 
         // clean up happened
@@ -431,8 +428,7 @@ public abstract class AbstractNodeUpdatePackagesTest
 
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
-        packageUpdater = new TaskUpdatePackages(classFinder,
-                frontendDependencies, options);
+        packageUpdater = new TaskUpdatePackages(frontendDependencies, options);
 
         packageCreator.execute();
         packageUpdater.execute();
@@ -461,8 +457,7 @@ public abstract class AbstractNodeUpdatePackagesTest
 
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
-        packageUpdater = new TaskUpdatePackages(classFinder,
-                frontendDependencies, options);
+        packageUpdater = new TaskUpdatePackages(frontendDependencies, options);
 
         packageCreator.execute();
         packageUpdater.execute();
@@ -506,8 +501,7 @@ public abstract class AbstractNodeUpdatePackagesTest
 
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
-        packageUpdater = new TaskUpdatePackages(classFinder,
-                frontendDependencies, options);
+        packageUpdater = new TaskUpdatePackages(frontendDependencies, options);
 
         packageCreator.execute();
         packageUpdater.execute();
@@ -537,8 +531,7 @@ public abstract class AbstractNodeUpdatePackagesTest
 
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
-        packageUpdater = new TaskUpdatePackages(classFinder,
-                frontendDependencies, options);
+        packageUpdater = new TaskUpdatePackages(frontendDependencies, options);
 
         packageCreator.execute();
         packageUpdater.execute();
@@ -560,8 +553,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         Map<String, String> packages = new HashMap<>();
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
-        packageUpdater = new TaskUpdatePackages(classFinder,
-                frontendDependencies, options);
+        packageUpdater = new TaskUpdatePackages(frontendDependencies, options);
 
         packageCreator.execute();
         packageUpdater.execute();
@@ -586,8 +578,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         Map<String, String> packages = new HashMap<>();
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
-        packageUpdater = new TaskUpdatePackages(classFinder,
-                frontendDependencies, options);
+        packageUpdater = new TaskUpdatePackages(frontendDependencies, options);
 
         packageCreator.execute();
         packageUpdater.execute();
@@ -614,8 +605,7 @@ public abstract class AbstractNodeUpdatePackagesTest
 
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
-        packageUpdater = new TaskUpdatePackages(classFinder,
-                frontendDependencies, options);
+        packageUpdater = new TaskUpdatePackages(frontendDependencies, options);
 
         packageCreator.execute();
         JsonObject json = getPackageJson(packageJson);
@@ -640,8 +630,8 @@ public abstract class AbstractNodeUpdatePackagesTest
                 Collections.singletonList(legacyPackageContent));
         options.withEnablePnpm(true);
 
-        packageUpdater = new TaskUpdatePackages(classFinder,
-                getScanner(classFinder), options);
+        packageUpdater = new TaskUpdatePackages(getScanner(classFinder),
+                options);
         packageUpdater.execute();
 
         assertPackageJsonFlowDeps();
@@ -654,8 +644,8 @@ public abstract class AbstractNodeUpdatePackagesTest
         Files.write(packageJson.toPath(),
                 Collections.singletonList(legacyPackageContent));
 
-        packageUpdater = new TaskUpdatePackages(classFinder,
-                getScanner(classFinder), options);
+        packageUpdater = new TaskUpdatePackages(getScanner(classFinder),
+                options);
         packageUpdater.execute();
 
         assertPackageJsonFlowDeps();
@@ -676,8 +666,7 @@ public abstract class AbstractNodeUpdatePackagesTest
 
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
-        packageUpdater = new TaskUpdatePackages(classFinder,
-                frontendDependencies, options);
+        packageUpdater = new TaskUpdatePackages(frontendDependencies, options);
 
         packageCreator.execute();
         packageUpdater.execute();
@@ -722,8 +711,7 @@ public abstract class AbstractNodeUpdatePackagesTest
 
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
-        packageUpdater = new TaskUpdatePackages(classFinder,
-                frontendDependencies, options);
+        packageUpdater = new TaskUpdatePackages(frontendDependencies, options);
 
         packageCreator.execute();
         packageUpdater.execute();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
@@ -170,9 +170,11 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
 
         ClassFinder classFinder = getClassFinder();
         featureFlags = Mockito.mock(FeatureFlags.class);
-        options = new Options(Mockito.mock(Lookup.class), tmpRoot)
-                .withTokenFile(tokenFile).withProductionMode(true)
-                .withFeatureFlags(featureFlags).withBundleBuild(true);
+        Lookup lookup = Mockito.mock(Lookup.class);
+        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(classFinder);
+        options = new Options(lookup, tmpRoot).withTokenFile(tokenFile)
+                .withProductionMode(true).withFeatureFlags(featureFlags)
+                .withBundleBuild(true);
         updater = new UpdateImports(getScanner(classFinder), options);
         assertTrue(nodeModulesPath.mkdirs());
         createExpectedImports(frontendDirectory, nodeModulesPath);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
@@ -65,6 +65,7 @@ import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.DepsTests;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 import com.vaadin.flow.theme.AbstractTheme;
+import com.vaadin.tests.util.MockOptions;
 
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
@@ -170,9 +171,7 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
 
         ClassFinder classFinder = getClassFinder();
         featureFlags = Mockito.mock(FeatureFlags.class);
-        Lookup lookup = Mockito.mock(Lookup.class);
-        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(classFinder);
-        options = new Options(lookup, tmpRoot).withTokenFile(tokenFile)
+        options = new MockOptions(classFinder, tmpRoot).withTokenFile(tokenFile)
                 .withProductionMode(true).withFeatureFlags(featureFlags)
                 .withBundleBuild(true);
         updater = new UpdateImports(getScanner(classFinder), options);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
@@ -124,9 +124,8 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
 
         private Map<File, List<String>> output;
 
-        UpdateImports(ClassFinder classFinder,
-                FrontendDependenciesScanner scanner, Options options) {
-            super(options, scanner, classFinder);
+        UpdateImports(FrontendDependenciesScanner scanner, Options options) {
+            super(options, scanner);
         }
 
         @Override
@@ -174,8 +173,7 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
         options = new Options(Mockito.mock(Lookup.class), tmpRoot)
                 .withTokenFile(tokenFile).withProductionMode(true)
                 .withFeatureFlags(featureFlags).withBundleBuild(true);
-        updater = new UpdateImports(classFinder, getScanner(classFinder),
-                options);
+        updater = new UpdateImports(getScanner(classFinder), options);
         assertTrue(nodeModulesPath.mkdirs());
         createExpectedImports(frontendDirectory, nodeModulesPath);
         assertTrue(
@@ -239,8 +237,7 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
             throws Exception {
         ClassFinder classFinder = getClassFinder();
         options.withTokenFile(null);
-        updater = new UpdateImports(classFinder, getScanner(classFinder),
-                options);
+        updater = new UpdateImports(getScanner(classFinder), options);
 
         Files.move(frontendDirectory.toPath(),
                 new File(tmpRoot, "_frontend").toPath());
@@ -420,8 +417,7 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
         Class<?>[] testClasses = { FooCssImport.class, FooCssImport2.class,
                 UI.class, AllEagerAppConf.class };
         ClassFinder classFinder = getClassFinder(testClasses);
-        updater = new UpdateImports(classFinder, getScanner(classFinder),
-                options);
+        updater = new UpdateImports(getScanner(classFinder), options);
         updater.run();
 
         Map<File, List<String>> output = updater.getOutput();
@@ -443,8 +439,7 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
         Class<?>[] testClasses = { FooCssImport.class, BarCssImport.class,
                 UI.class, AllEagerAppConf.class };
         ClassFinder classFinder = getClassFinder(testClasses);
-        updater = new UpdateImports(classFinder, getScanner(classFinder),
-                options);
+        updater = new UpdateImports(getScanner(classFinder), options);
         updater.run();
 
         Map<File, List<String>> output = updater.getOutput();
@@ -470,8 +465,7 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
     public void themeForCssImports_eagerLoaded() throws Exception {
         Class<?>[] testClasses = { ThemeForCssImport.class, UI.class };
         ClassFinder classFinder = getClassFinder(testClasses);
-        updater = new UpdateImports(classFinder, getScanner(classFinder),
-                options);
+        updater = new UpdateImports(getScanner(classFinder), options);
         updater.run();
 
         Map<File, List<String>> output = updater.getOutput();
@@ -588,8 +582,7 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
                 DevelopmentAndProductionDependencies.class);
 
         options.withProductionMode(productionMode);
-        updater = new UpdateImports(classFinder, getScanner(classFinder),
-                options);
+        updater = new UpdateImports(getScanner(classFinder), options);
         updater.run();
 
     }
@@ -630,8 +623,7 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
                 LumoTest.class };
         ClassFinder classFinder = getClassFinder(testClasses);
 
-        updater = new UpdateImports(classFinder, getScanner(classFinder),
-                options);
+        updater = new UpdateImports(getScanner(classFinder), options);
         updater.run();
         String output = String.join("\n", updater.getMergedOutput());
 
@@ -655,8 +647,7 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
         ClassFinder classFinder = getClassFinder(testClasses);
 
         options.withTokenFile(new File(tmpRoot, TOKEN_FILE));
-        updater = new UpdateImports(classFinder, getScanner(classFinder),
-                options);
+        updater = new UpdateImports(getScanner(classFinder), options);
         updater.run();
 
         // Imports are collected as

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/BundleUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/BundleUtilsTest.java
@@ -155,7 +155,7 @@ public class BundleUtilsTest {
         final String jarPackageLockContent = "{ \"jarData\"}";
         FileUtils.write(jarPackageLock, jarPackageLockContent);
 
-        Mockito.when(finder
+        Mockito.when(options.getClassFinder()
                 .getResource(DEV_BUNDLE_JAR_PATH + Constants.PACKAGE_LOCK_JSON))
                 .thenReturn(jarPackageLock.toURI().toURL());
 
@@ -190,7 +190,7 @@ public class BundleUtilsTest {
         final String jarPackageLockContent = "{ \"jarData\"}";
         FileUtils.write(jarPackageLock, jarPackageLockContent);
 
-        Mockito.when(finder
+        Mockito.when(options.getClassFinder()
                 .getResource(DEV_BUNDLE_JAR_PATH + Constants.PACKAGE_LOCK_JSON))
                 .thenReturn(jarPackageLock.toURI().toURL());
 
@@ -214,7 +214,7 @@ public class BundleUtilsTest {
         final String jarPackageLockContent = "{ \"jarData\"}";
         FileUtils.write(jarPackageLock, jarPackageLockContent);
 
-        Mockito.when(finder
+        Mockito.when(options.getClassFinder()
                 .getResource(DEV_BUNDLE_JAR_PATH + Constants.PACKAGE_LOCK_YAML))
                 .thenReturn(jarPackageLock.toURI().toURL());
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/BundleUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/BundleUtilsTest.java
@@ -18,7 +18,7 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.server.Constants;
-import com.vaadin.flow.server.frontend.scanner.ClassFinder;
+import com.vaadin.tests.util.MockOptions;
 
 import elemental.json.Json;
 import elemental.json.JsonArray;
@@ -148,11 +148,7 @@ public class BundleUtilsTest {
     @Test
     public void noPackageLockExists_devBundleLockIsCopied_notJarLock()
             throws IOException {
-        final Lookup lookup = Mockito.mock(Lookup.class);
-        ClassFinder finder = Mockito.mock(ClassFinder.class);
-        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(finder);
-
-        Options options = new Options(lookup, temporaryFolder.getRoot())
+        Options options = new MockOptions(temporaryFolder.getRoot())
                 .withBuildDirectory("target");
 
         File jarPackageLock = new File(options.getNpmFolder(), "temp.json");
@@ -187,11 +183,7 @@ public class BundleUtilsTest {
     @Test
     public void noPackageLockExists_jarDevBundleLockIsCopied()
             throws IOException {
-        final Lookup lookup = Mockito.mock(Lookup.class);
-        ClassFinder finder = Mockito.mock(ClassFinder.class);
-        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(finder);
-
-        Options options = new Options(lookup, temporaryFolder.getRoot())
+        Options options = new MockOptions(temporaryFolder.getRoot())
                 .withBuildDirectory("target");
 
         File jarPackageLock = new File(options.getNpmFolder(), "temp.json");
@@ -215,11 +207,7 @@ public class BundleUtilsTest {
     @Test
     public void pnpm_noPackageLockExists_devBundleLockYamlIsCopied_notJarLockOrJson()
             throws IOException {
-        final Lookup lookup = Mockito.mock(Lookup.class);
-        ClassFinder finder = Mockito.mock(ClassFinder.class);
-        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(finder);
-
-        Options options = new Options(lookup, temporaryFolder.getRoot())
+        Options options = new MockOptions(temporaryFolder.getRoot())
                 .withBuildDirectory("target").withEnablePnpm(true);
 
         File jarPackageLock = new File(options.getNpmFolder(), "temp.json");

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/BundleValidationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/BundleValidationTest.java
@@ -152,7 +152,7 @@ public class BundleValidationTest {
         stats.put(THEME_JSON_CONTENTS, themeJsonContents);
         stats.put(PACKAGE_JSON_HASH, "aHash");
 
-        NodeUpdater nodeUpdater = new NodeUpdater(finder,
+        NodeUpdater nodeUpdater = new NodeUpdater(
                 Mockito.mock(FrontendDependenciesScanner.class), options) {
             @Override
             public void execute() {
@@ -177,7 +177,7 @@ public class BundleValidationTest {
     @Test
     public void noDevBundle_bundleCompilationRequires() {
         final boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                Mockito.mock(FrontendDependenciesScanner.class), finder, mode);
+                Mockito.mock(FrontendDependenciesScanner.class), mode);
         Assert.assertTrue("Bundle should require creation if not available",
                 needsBuild);
     }
@@ -192,7 +192,7 @@ public class BundleValidationTest {
                 .thenReturn(null);
 
         final boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                Mockito.mock(FrontendDependenciesScanner.class), finder, mode);
+                Mockito.mock(FrontendDependenciesScanner.class), mode);
         Assert.assertTrue("Missing stats.json should require bundling",
                 needsBuild);
     }
@@ -221,7 +221,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         final boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse("Matching hashes should not require compilation",
                 needsBuild);
     }
@@ -255,7 +255,7 @@ public class BundleValidationTest {
                 .thenReturn(Collections.singleton(AllEagerAppConf.class));
 
         final boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertTrue(
                 "'LoadDependenciesOnStartup' annotation requires build",
                 needsBuild);
@@ -287,7 +287,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         final boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertTrue("Missing npmPackage should require bundling",
                 needsBuild);
     }
@@ -316,7 +316,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         final boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertTrue("Bundle missing module dependency should rebuild",
                 needsBuild);
     }
@@ -346,7 +346,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         final boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse(
                 "Not missing npmPackage in stats.json should not require compilation",
                 needsBuild);
@@ -393,7 +393,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         final boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse(
                 "vaadin-core-versions.json should have updated version to expected.",
                 needsBuild);
@@ -427,7 +427,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         final boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse(
                 "Not missing npmPackage in stats.json should not require compilation",
                 needsBuild);
@@ -463,7 +463,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         final boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse(
                 "Not missing npmPackage in stats.json should not require compilation",
                 needsBuild);
@@ -494,7 +494,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         final boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertTrue(
                 "Missing npmPackage in stats.json should require compilation",
                 needsBuild);
@@ -524,7 +524,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         final boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse(
                 "Not missing npmPackage in stats.json should not require compilation",
                 needsBuild);
@@ -554,7 +554,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse("No compilation if tilde range only patch update",
                 needsBuild);
 
@@ -562,8 +562,7 @@ public class BundleValidationTest {
                 "1.8.1");
         setupFrontendUtilsMock(stats);
 
-        needsBuild = BundleValidationUtil.needsBuild(options, depScanner,
-                finder, mode);
+        needsBuild = BundleValidationUtil.needsBuild(options, depScanner, mode);
         Assert.assertTrue(
                 "Compilation required if minor version change for tilde range",
                 needsBuild);
@@ -593,7 +592,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse(
                 "No compilation if caret range only minor version update",
                 needsBuild);
@@ -602,8 +601,7 @@ public class BundleValidationTest {
                 "2.0.0");
         setupFrontendUtilsMock(stats);
 
-        needsBuild = BundleValidationUtil.needsBuild(options, depScanner,
-                finder, mode);
+        needsBuild = BundleValidationUtil.needsBuild(options, depScanner, mode);
         Assert.assertTrue(
                 "Compilation required if major version change for caret range",
                 needsBuild);
@@ -637,7 +635,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse("No compilation expected if package.json has "
                 + "only dependencies from older Vaadin version not "
                 + "presenting in a newer version", needsBuild);
@@ -651,7 +649,7 @@ public class BundleValidationTest {
                 .thenReturn(Collections.singletonMap("@vaadin/text", "1.0.0"));
 
         String defaultHash = BundleValidationUtil
-                .getDefaultPackageJson(options, depScanner, finder, null)
+                .getDefaultPackageJson(options, depScanner, null)
                 .getObject(NodeUpdater.VAADIN_DEP_KEY)
                 .getString(NodeUpdater.HASH_KEY);
 
@@ -664,7 +662,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         final boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse("Default package.json should be built and validated",
                 needsBuild);
     }
@@ -677,7 +675,7 @@ public class BundleValidationTest {
                 .thenReturn(Collections.singletonMap("@vaadin/text", "1.0.0"));
 
         String defaultHash = BundleValidationUtil
-                .getDefaultPackageJson(options, depScanner, finder, null)
+                .getDefaultPackageJson(options, depScanner, null)
                 .getObject(NodeUpdater.VAADIN_DEP_KEY)
                 .getString(NodeUpdater.HASH_KEY);
 
@@ -689,7 +687,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         final boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertTrue(
                 "Missing NpmPackage with default bundle should require rebuild",
                 needsBuild);
@@ -703,7 +701,7 @@ public class BundleValidationTest {
                 .thenReturn(Collections.emptyMap());
 
         String defaultHash = BundleValidationUtil
-                .getDefaultPackageJson(options, depScanner, finder, null)
+                .getDefaultPackageJson(options, depScanner, null)
                 .getObject(NodeUpdater.VAADIN_DEP_KEY)
                 .getString(NodeUpdater.HASH_KEY);
 
@@ -715,7 +713,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         final boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse("Default package.json should be built and validated",
                 needsBuild);
     }
@@ -753,7 +751,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertTrue("Compilation required as stats.json missing import",
                 needsBuild);
     }
@@ -795,7 +793,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse("All imports in stats, no compilation required",
                 needsBuild);
     }
@@ -838,7 +836,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse(
                 "All themed imports in stats, no compilation required",
                 needsBuild);
@@ -878,7 +876,7 @@ public class BundleValidationTest {
                 .thenReturn(temporaryFolder.getRoot());
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse("Jar fronted file content hash should match.",
                 needsBuild);
     }
@@ -921,7 +919,7 @@ public class BundleValidationTest {
                 .thenReturn(stats.toJson());
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertTrue("Content should not have been validated.",
                 needsBuild);
     }
@@ -966,7 +964,7 @@ public class BundleValidationTest {
                 .thenReturn(stats.toJson());
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertTrue(
                 "Jar fronted file content hash should not be a match.",
                 needsBuild);
@@ -1001,7 +999,7 @@ public class BundleValidationTest {
         jarResources.put("my-styles.css", "body{color:yellow}");
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse(
                 "CSS 'inline' suffix should be ignored for imports checking",
                 needsBuild);
@@ -1025,7 +1023,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertTrue("Project frontend file change should trigger rebuild",
                 needsBuild);
     }
@@ -1051,7 +1049,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse(
                 "No bundle rebuild expected when no changes in frontend file",
                 needsBuild);
@@ -1075,7 +1073,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertTrue("Project frontend file delete should trigger rebuild",
                 needsBuild);
     }
@@ -1094,7 +1092,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse("Shouldn't rebuild the bundle if no reused themes",
                 needsBuild);
     }
@@ -1118,7 +1116,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(getBasicStats());
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse(
                 "Should not trigger a bundle rebuild when the new theme has no theme.json",
                 needsBuild);
@@ -1139,7 +1137,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(getBasicStats());
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertTrue(
                 "Should trigger a bundle rebuild when a new reusable theme is added",
                 needsBuild);
@@ -1163,7 +1161,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertTrue(
                 "Should trigger a bundle rebuild when a new reusable theme is added",
                 needsBuild);
@@ -1194,7 +1192,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertTrue(
                 "Should trigger a bundle rebuild when the assets updated",
                 needsBuild);
@@ -1227,7 +1225,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse(
                 "Should not trigger a bundle rebuild when the themes not changed",
                 needsBuild);
@@ -1254,7 +1252,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertTrue(
                 "Should trigger a bundle rebuild when no themeJsonContents, but project has theme.json",
                 needsBuild);
@@ -1284,7 +1282,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse(
                 "Should not trigger a bundle rebuild when parent theme is used",
                 needsBuild);
@@ -1312,7 +1310,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse(
                 "Should not trigger a bundle rebuild when project has no theme.json",
                 needsBuild);
@@ -1350,7 +1348,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse(
                 "Should not trigger a bundle rebuild when project theme.json has the same content as in the bundle",
                 needsBuild);
@@ -1385,7 +1383,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertTrue(
                 "Should rebuild when project theme.json adds extra entries",
                 needsBuild);
@@ -1418,7 +1416,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse(
                 "Shouldn't re-bundle when the dev bundle already have all"
                         + " the entries defined in the project's theme.json",
@@ -1445,7 +1443,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertTrue(
                 "Should trigger a bundle rebuild when project has theme"
                         + ".json but stats doesn't",
@@ -1475,7 +1473,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertTrue(
                 "Should rebuild when 'theme.json' from parent theme in "
                         + "frontend folder adds extra entries",
@@ -1665,7 +1663,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertTrue("Adding 'index.ts' should require bundling",
                 needsBuild);
     }
@@ -1691,7 +1689,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse(
                 "'index.ts' equal content should not require bundling",
                 needsBuild);
@@ -1699,8 +1697,7 @@ public class BundleValidationTest {
         FileUtils.write(indexTs, "window.alert('hello');",
                 StandardCharsets.UTF_8);
 
-        needsBuild = BundleValidationUtil.needsBuild(options, depScanner,
-                finder, mode);
+        needsBuild = BundleValidationUtil.needsBuild(options, depScanner, mode);
         Assert.assertTrue(
                 "changed content for 'index.ts' should require bundling",
                 needsBuild);
@@ -1720,7 +1717,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertTrue("'index.ts' delete should require re-bundling",
                 needsBuild);
     }
@@ -1744,7 +1741,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse(
                 "Should not require bundling if component JS is missing in jar-resources",
                 needsBuild);
@@ -1771,7 +1768,7 @@ public class BundleValidationTest {
         // Should not throw an IllegalStateException:
         // "Failed to find the following css files in the...."
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertTrue(
                 "Should re-bundle if CSS is imported from META-INF/resources",
                 needsBuild);
@@ -1791,7 +1788,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse(
                 "Shouldn't re-bundle when old @vaadin/flow-frontend package is in package.json",
                 needsBuild);
@@ -1812,7 +1809,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse(
                 "Shouldn't re-bundle when referencing local packages in package.json",
                 needsBuild);
@@ -1834,7 +1831,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertTrue(
                 "Should re-bundle when local packages have different values",
                 needsBuild);
@@ -1855,7 +1852,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertTrue(
                 "Should re-bundle when local package in package.json but parsable version in stats",
                 needsBuild);
@@ -1876,7 +1873,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertTrue(
                 "Should re-bundle when local package in stats but parsable version in package.json",
                 needsBuild);
@@ -1908,7 +1905,7 @@ public class BundleValidationTest {
         setupFrontendUtilsMock(stats);
 
         final boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse("Rebuild should be skipped", needsBuild);
     }
 
@@ -1919,7 +1916,7 @@ public class BundleValidationTest {
         options.withForceProductionBuild(true);
 
         final boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                Mockito.mock(FrontendDependenciesScanner.class), finder, mode);
+                Mockito.mock(FrontendDependenciesScanner.class), mode);
         Assert.assertTrue(
                 "Production bundle required due to force.production.bundle flag.",
                 needsBuild);
@@ -1972,7 +1969,7 @@ public class BundleValidationTest {
                 bundleSourceFolder);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse("Jar fronted file content hash should match.",
                 needsBuild);
     }
@@ -2024,7 +2021,7 @@ public class BundleValidationTest {
                 bundleSourceFolder);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse("Jar fronted file content hash should match.",
                 needsBuild);
     }
@@ -2085,7 +2082,7 @@ public class BundleValidationTest {
         }
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse("Jar frontend file content hash should match.",
                 needsBuild);
     }
@@ -2120,7 +2117,7 @@ public class BundleValidationTest {
                 .thenReturn(stats.toJson());
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                depScanner, finder, mode);
+                depScanner, mode);
         Assert.assertFalse("Jar frontend file content hash should match.",
                 needsBuild);
     }
@@ -2275,8 +2272,7 @@ public class BundleValidationTest {
 
         setupFrontendUtilsMock(stats);
 
-        return BundleValidationUtil.needsBuild(options, depScanner, finder,
-                mode);
+        return BundleValidationUtil.needsBuild(options, depScanner, mode);
     }
 
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/BundleValidationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/BundleValidationTest.java
@@ -102,14 +102,16 @@ public class BundleValidationTest {
 
     @Before
     public void init() {
-        options = new Options(Mockito.mock(Lookup.class),
-                temporaryFolder.getRoot()).withBuildDirectory("target");
+        finder = Mockito.spy(new ClassFinder.DefaultClassFinder(
+                this.getClass().getClassLoader()));
+        Lookup lookup = Mockito.mock(Lookup.class);
+        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(finder);
+        options = new Options(lookup, temporaryFolder.getRoot())
+                .withBuildDirectory("target");
         options.copyResources(Collections.emptySet());
         options.withProductionMode(mode.isProduction());
         bundleLocation = mode.isProduction() ? Constants.PROD_BUNDLE_NAME
                 : Constants.DEV_BUNDLE_NAME;
-        finder = Mockito.spy(new ClassFinder.DefaultClassFinder(
-                this.getClass().getClassLoader()));
         frontendUtils = Mockito.mockStatic(FrontendUtils.class,
                 Mockito.CALLS_REAL_METHODS);
         devBundleUtils = Mockito.mockStatic(DevBundleUtils.class,

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/BundleValidationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/BundleValidationTest.java
@@ -35,6 +35,7 @@ import com.vaadin.flow.server.frontend.scanner.CssData;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 import com.vaadin.flow.testutil.TestUtils;
 import com.vaadin.flow.theme.ThemeDefinition;
+import com.vaadin.tests.util.MockOptions;
 
 import elemental.json.Json;
 import elemental.json.JsonArray;
@@ -104,9 +105,7 @@ public class BundleValidationTest {
     public void init() {
         finder = Mockito.spy(new ClassFinder.DefaultClassFinder(
                 this.getClass().getClassLoader()));
-        Lookup lookup = Mockito.mock(Lookup.class);
-        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(finder);
-        options = new Options(lookup, temporaryFolder.getRoot())
+        options = new MockOptions(finder, temporaryFolder.getRoot())
                 .withBuildDirectory("target");
         options.copyResources(Collections.emptySet());
         options.withProductionMode(mode.isProduction());

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/BundleValidationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/BundleValidationTest.java
@@ -108,7 +108,8 @@ public class BundleValidationTest {
         options.withProductionMode(mode.isProduction());
         bundleLocation = mode.isProduction() ? Constants.PROD_BUNDLE_NAME
                 : Constants.DEV_BUNDLE_NAME;
-        finder = Mockito.mock(ClassFinder.class);
+        finder = Mockito.spy(new ClassFinder.DefaultClassFinder(
+                this.getClass().getClassLoader()));
         frontendUtils = Mockito.mockStatic(FrontendUtils.class,
                 Mockito.CALLS_REAL_METHODS);
         devBundleUtils = Mockito.mockStatic(DevBundleUtils.class,

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/ComponentFlagsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/ComponentFlagsTest.java
@@ -35,6 +35,7 @@ import com.vaadin.flow.server.LoadDependenciesOnStartup;
 import com.vaadin.flow.server.frontend.NodeTestComponents.FlagView;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
+import com.vaadin.tests.util.MockOptions;
 
 import static com.vaadin.flow.server.Constants.TARGET;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
@@ -145,10 +146,7 @@ public class ComponentFlagsTest extends NodeUpdateTestUtil {
     private TaskUpdateImports createUpdater() throws IOException {
         ClassFinder classFinder = getClassFinder(testClasses);
 
-        Lookup lookup = Mockito.mock(Lookup.class);
-        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(classFinder);
-
-        Options options = new Options(lookup, tmpRoot)
+        Options options = new MockOptions(classFinder, tmpRoot)
                 .withFrontendDirectory(frontendDirectory)
                 .withBuildDirectory(TARGET).withProductionMode(true);
         return new TaskUpdateImports(getScanner(classFinder, featureFlags),

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/ComponentFlagsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/ComponentFlagsTest.java
@@ -145,7 +145,10 @@ public class ComponentFlagsTest extends NodeUpdateTestUtil {
     private TaskUpdateImports createUpdater() throws IOException {
         ClassFinder classFinder = getClassFinder(testClasses);
 
-        Options options = new Options(Mockito.mock(Lookup.class), tmpRoot)
+        Lookup lookup = Mockito.mock(Lookup.class);
+        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(classFinder);
+
+        Options options = new Options(lookup, tmpRoot)
                 .withFrontendDirectory(frontendDirectory)
                 .withBuildDirectory(TARGET).withProductionMode(true);
         return new TaskUpdateImports(getScanner(classFinder, featureFlags),

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/ComponentFlagsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/ComponentFlagsTest.java
@@ -148,7 +148,7 @@ public class ComponentFlagsTest extends NodeUpdateTestUtil {
         Options options = new Options(Mockito.mock(Lookup.class), tmpRoot)
                 .withFrontendDirectory(frontendDirectory)
                 .withBuildDirectory(TARGET).withProductionMode(true);
-        return new TaskUpdateImports(classFinder,
-                getScanner(classFinder, featureFlags), options);
+        return new TaskUpdateImports(getScanner(classFinder, featureFlags),
+                options);
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -398,7 +398,9 @@ public class FrontendUtilsTest {
         ClassFinder finder = Mockito.mock(ClassFinder.class);
 
         Logger logger = Mockito.spy(LoggerFactory.getLogger(NodeUpdater.class));
-        Options options = new Options(Mockito.mock(Lookup.class), npmFolder)
+        Lookup lookup = Mockito.mock(Lookup.class);
+        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(finder);
+        Options options = new Options(lookup, npmFolder)
                 .withBuildDirectory(TARGET);
         NodeUpdater nodeUpdater = new NodeUpdater(
                 Mockito.mock(FrontendDependencies.class), options) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -41,8 +41,8 @@ import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.internal.Pair;
 import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.frontend.installer.NodeInstaller;
-import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
+import com.vaadin.tests.util.MockOptions;
 
 import elemental.json.Json;
 import elemental.json.JsonObject;
@@ -395,13 +395,8 @@ public class FrontendUtilsTest {
         FileUtils.writeStringToFile(new File(npmFolder, PACKAGE_JSON),
                 packageJson.toJson(), StandardCharsets.UTF_8);
 
-        ClassFinder finder = Mockito.mock(ClassFinder.class);
-
         Logger logger = Mockito.spy(LoggerFactory.getLogger(NodeUpdater.class));
-        Lookup lookup = Mockito.mock(Lookup.class);
-        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(finder);
-        Options options = new Options(lookup, npmFolder)
-                .withBuildDirectory(TARGET);
+        Options options = new MockOptions(npmFolder).withBuildDirectory(TARGET);
         NodeUpdater nodeUpdater = new NodeUpdater(
                 Mockito.mock(FrontendDependencies.class), options) {
             @Override

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -400,7 +400,7 @@ public class FrontendUtilsTest {
         Logger logger = Mockito.spy(LoggerFactory.getLogger(NodeUpdater.class));
         Options options = new Options(Mockito.mock(Lookup.class), npmFolder)
                 .withBuildDirectory(TARGET);
-        NodeUpdater nodeUpdater = new NodeUpdater(finder,
+        NodeUpdater nodeUpdater = new NodeUpdater(
                 Mockito.mock(FrontendDependencies.class), options) {
             @Override
             public void execute() throws ExecutionFailedException {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksExecutionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksExecutionTest.java
@@ -21,6 +21,7 @@ import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
+import com.vaadin.tests.util.MockOptions;
 
 import static com.vaadin.flow.server.Constants.TARGET;
 
@@ -55,11 +56,9 @@ public class NodeTasksExecutionTest {
     public void init() throws Exception {
 
         // Make a builder that doesn't add any commands.
-        Lookup lookup = Mockito.mock(Lookup.class);
         ClassFinder.DefaultClassFinder finder = new ClassFinder.DefaultClassFinder(
                 Collections.singleton(this.getClass()));
-        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(finder);
-        options = new Options(lookup, null).withBuildDirectory(TARGET);
+        options = new MockOptions(finder, null).withBuildDirectory(TARGET);
         options.withProductionMode(false);
 
         nodeTasks = new NodeTasks(options);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksViteTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksViteTest.java
@@ -276,11 +276,9 @@ public class NodeTasksViteTest {
             bundleUtils.verify(
                     () -> BundleUtils.copyPackageLockFromBundle(options),
                     Mockito.times(1));
-            validationUtil.verify(
-                    () -> BundleValidationUtil.needsBuild(any(Options.class),
-                            any(FrontendDependenciesScanner.class),
-                            any(ClassFinder.class), any(Mode.class)),
-                    Mockito.never());
+            validationUtil.verify(() -> BundleValidationUtil.needsBuild(
+                    any(Options.class), any(FrontendDependenciesScanner.class),
+                    any(Mode.class)), Mockito.never());
         }
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdatePackagesNpmVersionLockingTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdatePackagesNpmVersionLockingTest.java
@@ -36,6 +36,7 @@ import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 import com.vaadin.flow.testcategory.SlowTests;
 import com.vaadin.flow.testutil.FrontendStubs;
+import com.vaadin.tests.util.MockOptions;
 
 import elemental.json.Json;
 import elemental.json.JsonObject;
@@ -162,13 +163,10 @@ public class NodeUpdatePackagesNpmVersionLockingTest
     private TaskUpdatePackages createPackageUpdater(boolean enablePnpm) {
         FrontendDependenciesScanner scanner = Mockito
                 .mock(FrontendDependenciesScanner.class);
-        Lookup lookup = Mockito.mock(Lookup.class);
-        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(classFinder);
-        Options options = new Options(lookup, baseDir)
-                .withEnablePnpm(enablePnpm).withBuildDirectory(TARGET)
-                .withProductionMode(true);
+        Options options = new MockOptions(baseDir).withEnablePnpm(enablePnpm)
+                .withBuildDirectory(TARGET).withProductionMode(true);
 
-        return new TaskUpdatePackages(classFinder, scanner, options);
+        return new TaskUpdatePackages(scanner, options);
     }
 
     private TaskUpdatePackages createPackageUpdater() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdatePackagesNpmVersionLockingTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdatePackagesNpmVersionLockingTest.java
@@ -162,7 +162,9 @@ public class NodeUpdatePackagesNpmVersionLockingTest
     private TaskUpdatePackages createPackageUpdater(boolean enablePnpm) {
         FrontendDependenciesScanner scanner = Mockito
                 .mock(FrontendDependenciesScanner.class);
-        Options options = new Options(Mockito.mock(Lookup.class), baseDir)
+        Lookup lookup = Mockito.mock(Lookup.class);
+        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(classFinder);
+        Options options = new Options(lookup, baseDir)
                 .withEnablePnpm(enablePnpm).withBuildDirectory(TARGET)
                 .withProductionMode(true);
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -70,8 +70,8 @@ public class NodeUpdaterTest {
     public void setUp() throws IOException {
         npmFolder = temporaryFolder.newFolder();
         FeatureFlags featureFlags = Mockito.mock(FeatureFlags.class);
-        finder = new ClassFinder.DefaultClassFinder(
-                this.getClass().getClassLoader());
+        finder = Mockito.spy(new ClassFinder.DefaultClassFinder(
+                this.getClass().getClassLoader()));
         options = new Options(Mockito.mock(Lookup.class), npmFolder)
                 .withBuildDirectory(TARGET).withFeatureFlags(featureFlags);
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -37,11 +37,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.experimental.FeatureFlags;
-import com.vaadin.flow.di.Lookup;
-import com.vaadin.flow.internal.hilla.EndpointRequestUtil;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
+import com.vaadin.tests.util.MockOptions;
 
 import elemental.json.Json;
 import elemental.json.JsonException;
@@ -72,9 +71,7 @@ public class NodeUpdaterTest {
         FeatureFlags featureFlags = Mockito.mock(FeatureFlags.class);
         finder = Mockito.spy(new ClassFinder.DefaultClassFinder(
                 this.getClass().getClassLoader()));
-        Lookup lookup = Mockito.mock(Lookup.class);
-        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(finder);
-        options = new Options(lookup, npmFolder).withBuildDirectory(TARGET)
+        options = new MockOptions(finder, npmFolder).withBuildDirectory(TARGET)
                 .withFeatureFlags(featureFlags);
 
         nodeUpdater = new NodeUpdater(Mockito.mock(FrontendDependencies.class),

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -72,8 +72,10 @@ public class NodeUpdaterTest {
         FeatureFlags featureFlags = Mockito.mock(FeatureFlags.class);
         finder = Mockito.spy(new ClassFinder.DefaultClassFinder(
                 this.getClass().getClassLoader()));
-        options = new Options(Mockito.mock(Lookup.class), npmFolder)
-                .withBuildDirectory(TARGET).withFeatureFlags(featureFlags);
+        Lookup lookup = Mockito.mock(Lookup.class);
+        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(finder);
+        options = new Options(lookup, npmFolder).withBuildDirectory(TARGET)
+                .withFeatureFlags(featureFlags);
 
         nodeUpdater = new NodeUpdater(Mockito.mock(FrontendDependencies.class),
                 options) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -476,8 +476,8 @@ public class NodeUpdaterTest {
         boolean reactRouterEnabled = options.isReactRouterEnabled();
         try (MockedStatic<FrontendUtils> mock = Mockito
                 .mockStatic(FrontendUtils.class)) {
-            mock.when(() -> FrontendUtils.isHillaUsed(Mockito.any(File.class)))
-                    .thenReturn(true);
+            mock.when(() -> FrontendUtils.isHillaUsed(Mockito.any(File.class),
+                    Mockito.any(ClassFinder.class))).thenReturn(true);
             options.withReactRouter(true);
             Map<String, String> defaultDeps = nodeUpdater
                     .getDefaultDependencies();
@@ -510,8 +510,8 @@ public class NodeUpdaterTest {
         boolean reactRouterEnabled = options.isReactRouterEnabled();
         try (MockedStatic<FrontendUtils> mock = Mockito
                 .mockStatic(FrontendUtils.class)) {
-            mock.when(() -> FrontendUtils.isHillaUsed(Mockito.any(File.class)))
-                    .thenReturn(true);
+            mock.when(() -> FrontendUtils.isHillaUsed(Mockito.any(File.class),
+                    Mockito.any(ClassFinder.class))).thenReturn(true);
             options.withReactRouter(false);
             Map<String, String> defaultDeps = nodeUpdater
                     .getDefaultDependencies();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -75,8 +75,8 @@ public class NodeUpdaterTest {
         options = new Options(Mockito.mock(Lookup.class), npmFolder)
                 .withBuildDirectory(TARGET).withFeatureFlags(featureFlags);
 
-        nodeUpdater = new NodeUpdater(finder,
-                Mockito.mock(FrontendDependencies.class), options) {
+        nodeUpdater = new NodeUpdater(Mockito.mock(FrontendDependencies.class),
+                options) {
 
             @Override
             public void execute() {
@@ -558,13 +558,13 @@ public class NodeUpdaterTest {
     @Test
     public void readPackageJson_nonExistingFile_doesNotThrow()
             throws IOException {
-        NodeUpdater.readPackageJson("non-existing-folder", finder);
+        nodeUpdater.readPackageJson("non-existing-folder");
     }
 
     @Test
     public void readDependencies_doesntHaveDependencies_doesNotThrow() {
-        NodeUpdater.readDependencies("no-deps", "dependencies", finder);
-        NodeUpdater.readDependencies("no-deps", "devDependencies", finder);
+        nodeUpdater.readDependencies("no-deps", "dependencies");
+        nodeUpdater.readDependencies("no-deps", "devDependencies");
     }
 
     private String getPolymerVersion(JsonObject object) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -70,7 +70,8 @@ public class NodeUpdaterTest {
     public void setUp() throws IOException {
         npmFolder = temporaryFolder.newFolder();
         FeatureFlags featureFlags = Mockito.mock(FeatureFlags.class);
-        finder = Mockito.mock(ClassFinder.class);
+        finder = new ClassFinder.DefaultClassFinder(
+                this.getClass().getClassLoader());
         options = new Options(Mockito.mock(Lookup.class), npmFolder)
                 .withBuildDirectory(TARGET).withFeatureFlags(featureFlags);
 
@@ -557,13 +558,13 @@ public class NodeUpdaterTest {
     @Test
     public void readPackageJson_nonExistingFile_doesNotThrow()
             throws IOException {
-        NodeUpdater.readPackageJson("non-existing-folder");
+        NodeUpdater.readPackageJson("non-existing-folder", finder);
     }
 
     @Test
     public void readDependencies_doesntHaveDependencies_doesNotThrow() {
-        NodeUpdater.readDependencies("no-deps", "dependencies");
-        NodeUpdater.readDependencies("no-deps", "devDependencies");
+        NodeUpdater.readDependencies("no-deps", "dependencies", finder);
+        NodeUpdater.readDependencies("no-deps", "devDependencies", finder);
     }
 
     private String getPolymerVersion(JsonObject object) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskCleanFrontendFilesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskCleanFrontendFilesTest.java
@@ -13,11 +13,13 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.ExecutionFailedException;
+import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 
 public class TaskCleanFrontendFilesTest {
     @Rule
@@ -25,6 +27,8 @@ public class TaskCleanFrontendFilesTest {
 
     private File projectRoot;
     private File frontendDirectory;
+    @Mock
+    private ClassFinder classFinder;
 
     @Before
     public void init() {
@@ -36,7 +40,7 @@ public class TaskCleanFrontendFilesTest {
     public void createdFileAreRemoved()
             throws IOException, ExecutionFailedException {
         TaskCleanFrontendFiles clean = new TaskCleanFrontendFiles(projectRoot,
-                frontendDirectory);
+                frontendDirectory, classFinder);
 
         final Set<String> generatedFiles = Stream
                 .of(FrontendUtils.VITE_CONFIG,
@@ -62,7 +66,7 @@ public class TaskCleanFrontendFilesTest {
         createFiles(existingfiles);
 
         TaskCleanFrontendFiles clean = new TaskCleanFrontendFiles(projectRoot,
-                frontendDirectory);
+                frontendDirectory, classFinder);
 
         final Set<String> generatedFiles = Stream
                 .of(FrontendUtils.VITE_GENERATED_CONFIG,
@@ -81,7 +85,7 @@ public class TaskCleanFrontendFilesTest {
     public void nodeModulesFolderIsCleared()
             throws IOException, ExecutionFailedException {
         TaskCleanFrontendFiles clean = new TaskCleanFrontendFiles(projectRoot,
-                frontendDirectory);
+                frontendDirectory, classFinder);
 
         final File nodeModules = rootFolder.newFolder("node_modules");
         new File(nodeModules, "file").createNewFile();
@@ -99,7 +103,7 @@ public class TaskCleanFrontendFilesTest {
             throws IOException, ExecutionFailedException {
         createFiles(Collections.singleton(Constants.PACKAGE_JSON));
         TaskCleanFrontendFiles clean = new TaskCleanFrontendFiles(projectRoot,
-                frontendDirectory);
+                frontendDirectory, classFinder);
 
         final File nodeModules = rootFolder.newFolder("node_modules");
         new File(nodeModules, "file").createNewFile();
@@ -120,7 +124,8 @@ public class TaskCleanFrontendFilesTest {
                 .mockStatic(FrontendUtils.class)) {
             util.when(() -> FrontendUtils.isHillaUsed(Mockito.any()))
                     .thenReturn(true);
-            clean = new TaskCleanFrontendFiles(projectRoot, frontendDirectory);
+            clean = new TaskCleanFrontendFiles(projectRoot, frontendDirectory,
+                    classFinder);
         }
 
         final File nodeModules = rootFolder.newFolder("node_modules");

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskCleanFrontendFilesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskCleanFrontendFilesTest.java
@@ -27,13 +27,13 @@ public class TaskCleanFrontendFilesTest {
 
     private File projectRoot;
     private File frontendDirectory;
-    @Mock
     private ClassFinder classFinder;
 
     @Before
     public void init() {
         projectRoot = rootFolder.getRoot();
         frontendDirectory = new File(projectRoot, "target/frontend");
+        classFinder = Mockito.mock(ClassFinder.class);
     }
 
     @Test
@@ -122,8 +122,8 @@ public class TaskCleanFrontendFilesTest {
         TaskCleanFrontendFiles clean;
         try (MockedStatic<FrontendUtils> util = Mockito
                 .mockStatic(FrontendUtils.class)) {
-            util.when(() -> FrontendUtils.isHillaUsed(Mockito.any()))
-                    .thenReturn(true);
+            util.when(() -> FrontendUtils.isHillaUsed(Mockito.any(),
+                    Mockito.any(ClassFinder.class))).thenReturn(true);
             clean = new TaskCleanFrontendFiles(projectRoot, frontendDirectory,
                     classFinder);
         }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskCopyFrontendFilesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskCopyFrontendFilesTest.java
@@ -85,7 +85,8 @@ public class TaskCopyFrontendFilesTest extends NodeUpdateTestUtil {
         Options options = new Options(Mockito.mock(Lookup.class), npmFolder)
                 .withBuildDirectory(TARGET).withBundleBuild(true);
 
-        TaskGeneratePackageJson task = new TaskGeneratePackageJson(options);
+        TaskGeneratePackageJson task = new TaskGeneratePackageJson(options,
+                getClassFinder());
         task.execute();
         Assert.assertTrue(new File(npmFolder, PACKAGE_JSON).exists());
         Assert.assertFalse(new File(generatedFolder, PACKAGE_JSON).exists());

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskCopyFrontendFilesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskCopyFrontendFilesTest.java
@@ -34,6 +34,7 @@ import org.mockito.Mockito;
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.testutil.TestUtils;
+import com.vaadin.tests.util.MockOptions;
 
 import elemental.json.JsonObject;
 
@@ -83,10 +84,7 @@ public class TaskCopyFrontendFilesTest extends NodeUpdateTestUtil {
 
     @Test
     public void should_createPackageJson() throws IOException {
-        Lookup lookup = Mockito.mock(Lookup.class);
-        Mockito.when(lookup.lookup(ClassFinder.class))
-                .thenReturn(getClassFinder());
-        Options options = new Options(lookup, npmFolder)
+        Options options = new MockOptions(getClassFinder(), npmFolder)
                 .withBuildDirectory(TARGET).withBundleBuild(true);
 
         TaskGeneratePackageJson task = new TaskGeneratePackageJson(options);
@@ -114,7 +112,7 @@ public class TaskCopyFrontendFilesTest extends NodeUpdateTestUtil {
         // - resourceInFolder.js.map
         File dir = TestUtils.getTestFolder(fsDir);
 
-        Options options = new Options(Mockito.mock(Lookup.class), null);
+        Options options = new MockOptions(null);
         options.withJarFrontendResourcesFolder(frontendDepsFolder)
                 .copyResources(jars(jar, dir));
         TaskCopyFrontendFiles task = new TaskCopyFrontendFiles(options);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskCopyFrontendFilesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskCopyFrontendFilesTest.java
@@ -32,6 +32,7 @@ import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.testutil.TestUtils;
 
 import elemental.json.JsonObject;
@@ -82,11 +83,13 @@ public class TaskCopyFrontendFilesTest extends NodeUpdateTestUtil {
 
     @Test
     public void should_createPackageJson() throws IOException {
-        Options options = new Options(Mockito.mock(Lookup.class), npmFolder)
+        Lookup lookup = Mockito.mock(Lookup.class);
+        Mockito.when(lookup.lookup(ClassFinder.class))
+                .thenReturn(getClassFinder());
+        Options options = new Options(lookup, npmFolder)
                 .withBuildDirectory(TARGET).withBundleBuild(true);
 
-        TaskGeneratePackageJson task = new TaskGeneratePackageJson(options,
-                getClassFinder());
+        TaskGeneratePackageJson task = new TaskGeneratePackageJson(options);
         task.execute();
         Assert.assertTrue(new File(npmFolder, PACKAGE_JSON).exists());
         Assert.assertFalse(new File(generatedFolder, PACKAGE_JSON).exists());

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrapTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrapTest.java
@@ -28,9 +28,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.mockito.Mockito;
 
-import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.frontend.scanner.ChunkInfo;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
@@ -38,6 +36,7 @@ import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 import com.vaadin.flow.theme.AbstractTheme;
 import com.vaadin.flow.theme.ThemeDefinition;
+import com.vaadin.tests.util.MockOptions;
 
 import static com.vaadin.flow.server.frontend.FrontendUtils.FEATURE_FLAGS_FILE_NAME;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FRONTEND;
@@ -60,8 +59,6 @@ public class TaskGenerateBootstrapTest {
 
     private Options options;
 
-    private Lookup lookup;
-
     @Before
     public void setUp() throws Exception {
         ClassFinder.DefaultClassFinder finder = new ClassFinder.DefaultClassFinder(
@@ -70,9 +67,7 @@ public class TaskGenerateBootstrapTest {
                 .createScanner(false, finder, false);
 
         frontendFolder = temporaryFolder.newFolder(FRONTEND);
-        lookup = Mockito.mock(Lookup.class);
-        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(finder);
-        options = new Options(lookup, null)
+        options = new MockOptions(finder, null)
                 .withFrontendDirectory(frontendFolder).withProductionMode(true);
 
         taskGenerateBootstrap = new TaskGenerateBootstrap(frontDeps, options);
@@ -133,8 +128,7 @@ public class TaskGenerateBootstrapTest {
     @Test
     public void should_load_AppTheme()
             throws MalformedURLException, ExecutionFailedException {
-        Options options = new Options(lookup, null)
-                .withFrontendDirectory(frontendFolder).withProductionMode(true);
+        options.withFrontendDirectory(frontendFolder).withProductionMode(true);
 
         taskGenerateBootstrap = new TaskGenerateBootstrap(getThemedDependency(),
                 options);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateReactFilesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateReactFilesTest.java
@@ -35,6 +35,7 @@ import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
+import com.vaadin.tests.util.MockOptions;
 
 public class TaskGenerateReactFilesTest {
 
@@ -48,13 +49,11 @@ public class TaskGenerateReactFilesTest {
     @Before
     public void setup() throws IOException {
         classFinder = Mockito.mock(ClassFinder.class);
-        Lookup lookup = Mockito.mock(Lookup.class);
-        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(classFinder);
 
         Mockito.when(classFinder.getAnnotatedClasses(Route.class))
                 .thenReturn(Collections.singleton(TestRoute.class));
 
-        options = new Options(lookup, temporaryFolder.getRoot())
+        options = new MockOptions(classFinder, temporaryFolder.getRoot())
                 .withBuildDirectory("target");
         frontend = temporaryFolder.newFolder("frontend");
         options.withFrontendDirectory(frontend);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskInstallFrontendBuildPluginsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskInstallFrontendBuildPluginsTest.java
@@ -36,6 +36,7 @@ import org.mockito.Mockito;
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
+import com.vaadin.tests.util.MockOptions;
 
 import elemental.json.Json;
 import elemental.json.JsonArray;
@@ -95,10 +96,7 @@ public class TaskInstallFrontendBuildPluginsTest {
 
     @Test
     public void pluginsNotAddedToPackageJson() throws IOException {
-        ClassFinder finder = Mockito.mock(ClassFinder.class);
-        Lookup lookup = Mockito.mock(Lookup.class);
-        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(finder);
-        Options options = new Options(lookup, rootFolder)
+        Options options = new MockOptions(rootFolder)
                 .withBuildDirectory(BUILD_DIRECTORY);
         NodeUpdater nodeUpdater = new NodeUpdater(
                 Mockito.mock(FrontendDependencies.class), options) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskInstallFrontendBuildPluginsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskInstallFrontendBuildPluginsTest.java
@@ -96,7 +96,9 @@ public class TaskInstallFrontendBuildPluginsTest {
     @Test
     public void pluginsNotAddedToPackageJson() throws IOException {
         ClassFinder finder = Mockito.mock(ClassFinder.class);
-        Options options = new Options(Mockito.mock(Lookup.class), rootFolder)
+        Lookup lookup = Mockito.mock(Lookup.class);
+        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(finder);
+        Options options = new Options(lookup, rootFolder)
                 .withBuildDirectory(BUILD_DIRECTORY);
         NodeUpdater nodeUpdater = new NodeUpdater(
                 Mockito.mock(FrontendDependencies.class), options) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskInstallFrontendBuildPluginsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskInstallFrontendBuildPluginsTest.java
@@ -98,7 +98,7 @@ public class TaskInstallFrontendBuildPluginsTest {
         ClassFinder finder = Mockito.mock(ClassFinder.class);
         Options options = new Options(Mockito.mock(Lookup.class), rootFolder)
                 .withBuildDirectory(BUILD_DIRECTORY);
-        NodeUpdater nodeUpdater = new NodeUpdater(finder,
+        NodeUpdater nodeUpdater = new NodeUpdater(
                 Mockito.mock(FrontendDependencies.class), options) {
             @Override
             public void execute() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -89,8 +89,10 @@ public class TaskRunNpmInstallTest {
     public void setUp() throws IOException {
         npmFolder = temporaryFolder.newFolder();
         finder = Mockito.mock(ClassFinder.class);
-        options = new Options(Mockito.mock(Lookup.class), npmFolder)
-                .withBuildDirectory(TARGET).withBundleBuild(true);
+        Lookup lookup = Mockito.mock(Lookup.class);
+        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(finder);
+        options = new Options(lookup, npmFolder).withBuildDirectory(TARGET)
+                .withBundleBuild(true);
         nodeUpdater = new NodeUpdater(Mockito.mock(FrontendDependencies.class),
                 options) {
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -91,8 +91,8 @@ public class TaskRunNpmInstallTest {
         finder = Mockito.mock(ClassFinder.class);
         options = new Options(Mockito.mock(Lookup.class), npmFolder)
                 .withBuildDirectory(TARGET).withBundleBuild(true);
-        nodeUpdater = new NodeUpdater(finder,
-                Mockito.mock(FrontendDependencies.class), options) {
+        nodeUpdater = new NodeUpdater(Mockito.mock(FrontendDependencies.class),
+                options) {
 
             @Override
             public void execute() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -49,6 +49,7 @@ import com.vaadin.flow.server.frontend.installer.NodeInstaller;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
 import com.vaadin.flow.testcategory.SlowTests;
+import com.vaadin.tests.util.MockOptions;
 
 import elemental.json.Json;
 import elemental.json.JsonObject;
@@ -88,11 +89,9 @@ public class TaskRunNpmInstallTest {
     @Before
     public void setUp() throws IOException {
         npmFolder = temporaryFolder.newFolder();
-        finder = Mockito.mock(ClassFinder.class);
-        Lookup lookup = Mockito.mock(Lookup.class);
-        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(finder);
-        options = new Options(lookup, npmFolder).withBuildDirectory(TARGET)
+        options = new MockOptions(npmFolder).withBuildDirectory(TARGET)
                 .withBundleBuild(true);
+        finder = options.getClassFinder();
         nodeUpdater = new NodeUpdater(Mockito.mock(FrontendDependencies.class),
                 options) {
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -507,7 +507,7 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         Options options = new Options(Mockito.mock(Lookup.class), npmFolder)
                 .withBuildDirectory(TARGET);
 
-        return new NodeUpdater(finder, Mockito.mock(FrontendDependencies.class),
+        return new NodeUpdater(Mockito.mock(FrontendDependencies.class),
                 options) {
 
             @Override

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -447,7 +447,6 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
 
     private TaskRunNpmInstall createCiTask() {
         NodeUpdater updater = getNodeUpdater();
-        Options options = new Options(Mockito.mock(Lookup.class), npmFolder);
         options.withEnablePnpm(true)
                 .withNodeVersion(FrontendTools.DEFAULT_NODE_VERSION)
                 .withNodeDownloadRoot(
@@ -459,7 +458,6 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
     @Override
     protected TaskRunNpmInstall createTask(List<String> additionalPostInstall) {
         NodeUpdater updater = createAndRunNodeUpdater(null);
-        Options options = new Options(Mockito.mock(Lookup.class), npmFolder);
         options.withEnablePnpm(true)
                 .withNodeVersion(FrontendTools.DEFAULT_NODE_VERSION)
                 .withNodeDownloadRoot(
@@ -470,7 +468,6 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
 
     protected TaskRunNpmInstall createTask(String versionsContent) {
         NodeUpdater updater = createAndRunNodeUpdater(versionsContent);
-        Options options = new Options(Mockito.mock(Lookup.class), npmFolder);
         options.withEnablePnpm(true)
                 .withNodeVersion(FrontendTools.DEFAULT_NODE_VERSION)
                 .withNodeDownloadRoot(
@@ -504,8 +501,7 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
     }
 
     private NodeUpdater createNodeUpdater(String versionsContent) {
-        Options options = new Options(Mockito.mock(Lookup.class), npmFolder)
-                .withBuildDirectory(TARGET);
+        options.withBuildDirectory(TARGET);
 
         return new NodeUpdater(Mockito.mock(FrontendDependencies.class),
                 options) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
@@ -52,6 +52,7 @@ import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
+import com.vaadin.tests.util.MockOptions;
 
 import elemental.json.Json;
 import elemental.json.JsonObject;
@@ -94,8 +95,6 @@ public class TaskUpdatePackagesNpmTest {
         generatedPath.mkdir();
         versionJsonFile = new File(npmFolder, "versions.json");
         finder = Mockito.mock(ClassFinder.class);
-        Lookup lookup = Mockito.mock(Lookup.class);
-        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(finder);
         Mockito.when(finder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(versionJsonFile.toURI().toURL());
 
@@ -696,14 +695,11 @@ public class TaskUpdatePackagesNpmTest {
                 .mock(FrontendDependencies.class);
         Mockito.when(frontendDependenciesScanner.getPackages())
                 .thenReturn(applicationDependencies);
-        Lookup lookup = Mockito.mock(Lookup.class);
-        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(finder);
-        Options options = new Options(lookup, npmFolder)
+        Options options = new MockOptions(finder, npmFolder)
                 .withBuildDirectory(TARGET).withEnablePnpm(enablePnpm)
                 .withBundleBuild(true);
 
-        return new TaskUpdatePackages(finder, frontendDependenciesScanner,
-                options) {
+        return new TaskUpdatePackages(frontendDependenciesScanner, options) {
         };
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
@@ -94,6 +94,8 @@ public class TaskUpdatePackagesNpmTest {
         generatedPath.mkdir();
         versionJsonFile = new File(npmFolder, "versions.json");
         finder = Mockito.mock(ClassFinder.class);
+        Lookup lookup = Mockito.mock(Lookup.class);
+        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(finder);
         Mockito.when(finder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(versionJsonFile.toURI().toURL());
 
@@ -694,7 +696,9 @@ public class TaskUpdatePackagesNpmTest {
                 .mock(FrontendDependencies.class);
         Mockito.when(frontendDependenciesScanner.getPackages())
                 .thenReturn(applicationDependencies);
-        Options options = new Options(Mockito.mock(Lookup.class), npmFolder)
+        Lookup lookup = Mockito.mock(Lookup.class);
+        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(finder);
+        Options options = new Options(lookup, npmFolder)
                 .withBuildDirectory(TARGET).withEnablePnpm(enablePnpm)
                 .withBundleBuild(true);
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/UpdateImportsWithByteCodeScannerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/UpdateImportsWithByteCodeScannerTest.java
@@ -134,8 +134,7 @@ public class UpdateImportsWithByteCodeScannerTest
 
         createExpectedLazyImports();
         ClassFinder classFinder = getClassFinder(testClasses);
-        updater = new UpdateImports(classFinder, getScanner(classFinder),
-                options);
+        updater = new UpdateImports(getScanner(classFinder), options);
         updater.run();
 
         Map<File, List<String>> output = updater.getOutput();
@@ -173,8 +172,7 @@ public class UpdateImportsWithByteCodeScannerTest
 
         createExpectedLazyImports();
         ClassFinder classFinder = getClassFinder(testClasses);
-        updater = new UpdateImports(classFinder, getScanner(classFinder),
-                options);
+        updater = new UpdateImports(getScanner(classFinder), options);
         updater.run();
 
         Map<File, List<String>> output = updater.getOutput();
@@ -233,8 +231,7 @@ public class UpdateImportsWithByteCodeScannerTest
                 LazyAppConf.class, UI.class };
 
         ClassFinder classFinder = getClassFinder(testClasses);
-        updater = new UpdateImports(classFinder, getScanner(classFinder),
-                options);
+        updater = new UpdateImports(getScanner(classFinder), options);
         updater.run();
 
         Map<File, List<String>> output = updater.getOutput();
@@ -267,8 +264,7 @@ public class UpdateImportsWithByteCodeScannerTest
                 LazyAppConf.class, UI.class };
 
         ClassFinder classFinder = getClassFinder(testClasses);
-        updater = new UpdateImports(classFinder, getScanner(classFinder),
-                options);
+        updater = new UpdateImports(getScanner(classFinder), options);
         updater.run();
 
         Map<File, List<String>> output = updater.getOutput();
@@ -301,8 +297,7 @@ public class UpdateImportsWithByteCodeScannerTest
     public void cssInLazyChunkWorks() throws Exception {
         Class<?>[] testClasses = { FooCssImport.class, UI.class };
         ClassFinder classFinder = getClassFinder(testClasses);
-        updater = new UpdateImports(classFinder, getScanner(classFinder),
-                options);
+        updater = new UpdateImports(getScanner(classFinder), options);
         updater.run();
 
         Map<File, List<String>> output = updater.getOutput();
@@ -383,8 +378,7 @@ public class UpdateImportsWithByteCodeScannerTest
                 OtherView.class, UI.class };
 
         ClassFinder classFinder = getClassFinder(testClasses);
-        updater = new UpdateImports(classFinder, getScanner(classFinder),
-                options);
+        updater = new UpdateImports(getScanner(classFinder), options);
         updater.run();
 
         Map<File, List<String>> output = updater.getOutput();
@@ -410,8 +404,7 @@ public class UpdateImportsWithByteCodeScannerTest
         Class<?>[] testClasses = { OtherView.class, CloneView.class };
 
         ClassFinder classFinder = getClassFinder(testClasses);
-        updater = new UpdateImports(classFinder, getScanner(classFinder),
-                options);
+        updater = new UpdateImports(getScanner(classFinder), options);
         updater.run();
 
         Map<File, List<String>> output = updater.getOutput();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/UpdateThemedImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/UpdateThemedImportsTest.java
@@ -143,7 +143,7 @@ public class UpdateThemedImportsTest extends NodeUpdateTestUtil {
         Options options = new Options(Mockito.mock(Lookup.class), tmpRoot)
                 .withFrontendDirectory(frontendDirectory)
                 .withBuildDirectory(TARGET).withProductionMode(true);
-        updater = new TaskUpdateImports(finder, deps, options);
+        updater = new TaskUpdateImports(deps, options);
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/UpdateThemedImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/UpdateThemedImportsTest.java
@@ -43,6 +43,7 @@ import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
 import com.vaadin.flow.theme.AbstractTheme;
 import com.vaadin.flow.theme.ThemeDefinition;
+import com.vaadin.tests.util.MockOptions;
 
 import static com.vaadin.flow.server.Constants.TARGET;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
@@ -140,9 +141,7 @@ public class UpdateThemedImportsTest extends NodeUpdateTestUtil {
                 return new ThemeDefinition(MyTheme.class, "", "");
             }
         };
-        Lookup lookup = Mockito.mock(Lookup.class);
-        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(finder);
-        Options options = new Options(lookup, tmpRoot)
+        Options options = new MockOptions(finder, tmpRoot)
                 .withFrontendDirectory(frontendDirectory)
                 .withBuildDirectory(TARGET).withProductionMode(true);
         updater = new TaskUpdateImports(deps, options);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/UpdateThemedImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/UpdateThemedImportsTest.java
@@ -140,7 +140,9 @@ public class UpdateThemedImportsTest extends NodeUpdateTestUtil {
                 return new ThemeDefinition(MyTheme.class, "", "");
             }
         };
-        Options options = new Options(Mockito.mock(Lookup.class), tmpRoot)
+        Lookup lookup = Mockito.mock(Lookup.class);
+        Mockito.when(lookup.lookup(ClassFinder.class)).thenReturn(finder);
+        Options options = new Options(lookup, tmpRoot)
                 .withFrontendDirectory(frontendDirectory)
                 .withBuildDirectory(TARGET).withProductionMode(true);
         updater = new TaskUpdateImports(deps, options);

--- a/flow-server/src/test/java/com/vaadin/tests/util/MockOptions.java
+++ b/flow-server/src/test/java/com/vaadin/tests/util/MockOptions.java
@@ -1,0 +1,41 @@
+package com.vaadin.tests.util;
+
+import java.io.File;
+
+import org.mockito.Mockito;
+
+import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.server.frontend.Options;
+import com.vaadin.flow.server.frontend.scanner.ClassFinder;
+
+/**
+ * Mocked Options that creates a lookup mock and class finder mock, if it's not
+ * given.
+ */
+public class MockOptions extends Options {
+
+    /**
+     * Creates a new instance of mocked Options with a given class finder.
+     *
+     * @param classFinder
+     *            class finder instance to use
+     * @param projectFolder
+     *            project base folder
+     */
+    public MockOptions(ClassFinder classFinder, File projectFolder) {
+        super(Mockito.mock(Lookup.class), projectFolder);
+
+        Mockito.when(getLookup().lookup(ClassFinder.class))
+                .thenReturn(classFinder);
+    }
+
+    /**
+     * Creates a new instance of mocked Options with mocked class finder.
+     *
+     * @param projectFolder
+     *            project base folder
+     */
+    public MockOptions(File projectFolder) {
+        this(Mockito.mock(ClassFinder.class), projectFolder);
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/tests/util/MockOptions.java
+++ b/flow-server/src/test/java/com/vaadin/tests/util/MockOptions.java
@@ -23,7 +23,7 @@ public class MockOptions extends Options {
      *            project base folder
      */
     public MockOptions(ClassFinder classFinder, File projectFolder) {
-        super(Mockito.mock(Lookup.class), projectFolder);
+        super(Mockito.mock(Lookup.class), classFinder, projectFolder);
 
         Mockito.when(getLookup().lookup(ClassFinder.class))
                 .thenReturn(classFinder);

--- a/flow-tests/test-scalability/pom.xml
+++ b/flow-tests/test-scalability/pom.xml
@@ -106,7 +106,7 @@
             <plugin>
                 <groupId>io.gatling</groupId>
                 <artifactId>gatling-maven-plugin</artifactId>
-                <version>4.8.0</version>
+                <version>4.8.1</version>
                 <executions>
                     <!-- Warmup for Jetty -->
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,7 @@
             <dependency>
                 <groupId>com.vaadin</groupId>
                 <artifactId>license-checker</artifactId>
-                <version>1.12.6</version>
+                <version>1.12.7</version>
             </dependency>
 
             <!-- Test dependencies -->

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/annotation/SpringComponent.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/annotation/SpringComponent.java
@@ -19,6 +19,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import org.springframework.core.annotation.AliasFor;
 import org.springframework.stereotype.Component;
 
 /**
@@ -40,5 +41,6 @@ public @interface SpringComponent {
      *
      * @return the suggested component name, if any
      */
+    @AliasFor(annotation = Component.class)
     String value() default "";
 }


### PR DESCRIPTION
Uses class finder instead of Class.forName to:
- lookup for Hilla endpoint class at build time,
- load package.json templates 

Fixes errors in https://github.com/vaadin/hilla/pull/2015, and along with it fixes https://github.com/vaadin/platform/issues/5013, https://github.com/vaadin/platform/issues/5023