### PR TITLE
chore: update flow-maven-plugin goals for unified platform

### DIFF
--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -176,6 +176,15 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo
      * @return {@code true} to remove created files, {@code false} to keep files
      */
     protected boolean cleanFrontendFiles() {
+        if (FrontendUtils.isHillaUsed(frontendDirectory())) {
+            /*
+             * Override this to not clean generated frontend files after the
+             * build. For Hilla, the generated files can still be useful for
+             * developers after the build. For example, a developer can use
+             * {@code vite.generated.ts} to run tests with vitest in CI.
+             */
+            return false;
+        }
         return cleanFrontendFiles;
     }
 

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -176,7 +176,7 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo
      * @return {@code true} to remove created files, {@code false} to keep files
      */
     protected boolean cleanFrontendFiles() {
-        if (FrontendUtils.isHillaUsed(frontendDirectory())) {
+        if (isHillaUsed(project, frontendDirectory())) {
             /*
              * Override this to not clean generated frontend files after the
              * build. For Hilla, the generated files can still be useful for

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/CleanFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/CleanFrontendMojo.java
@@ -132,6 +132,13 @@ public class CleanFrontendMojo extends FlowModeAbstractMojo {
 
     @Override
     public void execute() throws MojoFailureException {
+        if (FrontendUtils.isHillaUsed(frontendDirectory())) {
+            getLog().warn(
+                    """
+                                    The 'clean-frontend' goal is not meant to be used in Hilla projects as it delete 'package-lock.json' and also clearing out the content of 'package.json'.
+                            """
+                            .stripIndent());
+        }
         runCleaning(new Options());
     }
 

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/CleanFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/CleanFrontendMojo.java
@@ -132,14 +132,11 @@ public class CleanFrontendMojo extends FlowModeAbstractMojo {
 
     @Override
     public void execute() throws MojoFailureException {
-        if (FrontendUtils.isHillaUsed(frontendDirectory())) {
-            getLog().warn(
-                    """
-                                    The 'clean-frontend' goal is not meant to be used in Hilla projects as it delete 'package-lock.json' and also clearing out the content of 'package.json'.
-                            """
-                            .stripIndent());
+        Options options = new Options();
+        if (isHillaUsed(project, frontendDirectory())) {
+            options.withRemovePackageLock(false).withRemoveNodeModules(false);
         }
-        runCleaning(new Options());
+        runCleaning(options);
     }
 
     protected void runCleaning(Options options) throws MojoFailureException {

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/ConvertPolymerMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/ConvertPolymerMojo.java
@@ -52,7 +52,7 @@ public class ConvertPolymerMojo extends FlowModeAbstractMojo {
 
     @Override
     public void execute() throws MojoFailureException {
-        if (FrontendUtils.isHillaUsed(frontendDirectory())) {
+        if (isHillaUsed(project, frontendDirectory())) {
             getLog().warn(
                     """
                             The 'convert-polymer' goal is not meant to be used in Hilla projects as polymer templates are not supported.

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/ConvertPolymerMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/ConvertPolymerMojo.java
@@ -20,6 +20,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
 import com.vaadin.flow.plugin.base.ConvertPolymerCommand;
+import com.vaadin.flow.server.frontend.FrontendUtils;
 
 /**
  * A Maven goal that converts Polymer-based source files to Lit.
@@ -51,6 +52,13 @@ public class ConvertPolymerMojo extends FlowModeAbstractMojo {
 
     @Override
     public void execute() throws MojoFailureException {
+        if (FrontendUtils.isHillaUsed(frontendDirectory())) {
+            getLog().warn(
+                    """
+                            The 'convert-polymer' goal is not meant to be used in Hilla projects as polymer templates are not supported.
+                            """
+                            .stripIndent());
+        }
         try (ConvertPolymerCommand command = new ConvertPolymerCommand(this,
                 path, useLit1, disableOptionalChaining)) {
             command.execute();

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/ConvertPolymerMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/ConvertPolymerMojo.java
@@ -20,7 +20,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
 import com.vaadin.flow.plugin.base.ConvertPolymerCommand;
-import com.vaadin.flow.server.frontend.FrontendUtils;
 
 /**
  * A Maven goal that converts Polymer-based source files to Lit.

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -263,9 +263,8 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
     public static boolean isHillaAvailable(MavenProject mavenProject) {
         List<String> classpathElements = FlowModeAbstractMojo
                 .getClasspathElements(mavenProject);
-        var resource = BuildFrontendUtil.getClassFinder(classpathElements)
-                .getResource("com/vaadin/hilla/EndpointController.class");
-        return resource != null;
+        return BuildFrontendUtil.getClassFinder(classpathElements).getResource(
+                "com/vaadin/hilla/EndpointController.class") != null;
     }
 
     /**

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -253,6 +253,32 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
         }
     }
 
+    /**
+     * Checks if Hilla is available based on the Maven project's classpath.
+     *
+     * @return true if Hilla is available, false otherwise
+     */
+    public static boolean isHillaAvailable(MavenProject mavenProject) {
+        List<String> classpathElements = FlowModeAbstractMojo
+                .getClasspathElements(mavenProject);
+        var resource = BuildFrontendUtil.getClassFinder(classpathElements)
+                .getResource("com/vaadin/hilla/EndpointController.class");
+        return resource != null;
+    }
+
+    /**
+     * Checks if Hilla is available and Hilla views are used in the Maven
+     * project based on what is in routes.ts or routes.tsx file.
+     *
+     * @return {@code true} if Hilla is available and Hilla views are used,
+     *         {@code false} otherwise
+     */
+    public static boolean isHillaUsed(MavenProject mavenProject,
+            File frontendDirectory) {
+        return isHillaAvailable(mavenProject)
+                && FrontendUtils.isHillaViewsUsed(frontendDirectory);
+    }
+
     @Override
     public File applicationProperties() {
 

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -256,6 +256,8 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
     /**
      * Checks if Hilla is available based on the Maven project's classpath.
      *
+     * @param mavenProject
+     *            Target Maven project
      * @return true if Hilla is available, false otherwise
      */
     public static boolean isHillaAvailable(MavenProject mavenProject) {
@@ -270,6 +272,10 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
      * Checks if Hilla is available and Hilla views are used in the Maven
      * project based on what is in routes.ts or routes.tsx file.
      *
+     * @param mavenProject
+     *            Target Maven project
+     * @param frontendDirectory
+     *            Target frontend directory.
      * @return {@code true} if Hilla is available and Hilla views are used,
      *         {@code false} otherwise
      */

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FrontendDanceMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FrontendDanceMojo.java
@@ -15,11 +15,8 @@
  */
 package com.vaadin.flow.plugin.maven;
 
-import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
-
-import com.vaadin.flow.server.frontend.FrontendUtils;
 
 /**
  * This is the hidden `vaadin:dance` to clean up the frontend files.

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FrontendDanceMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FrontendDanceMojo.java
@@ -29,15 +29,4 @@ import com.vaadin.flow.server.frontend.FrontendUtils;
 @Mojo(name = "dance", defaultPhase = LifecyclePhase.PRE_CLEAN)
 public class FrontendDanceMojo extends CleanFrontendMojo {
 
-    @Override
-    public void execute() throws MojoFailureException {
-        if (FrontendUtils.isHillaUsed(frontendDirectory())) {
-            getLog().warn(
-                    """
-                            The 'dance' goal is not meant to be used in Hilla projects as it delete 'package-lock.json' and also clearing out the content of 'package.json'.
-                            """
-                            .stripIndent());
-        }
-        runCleaning(new Options());
-    }
 }

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FrontendDanceMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FrontendDanceMojo.java
@@ -15,8 +15,11 @@
  */
 package com.vaadin.flow.plugin.maven;
 
+import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+
+import com.vaadin.flow.server.frontend.FrontendUtils;
 
 /**
  * This is the hidden `vaadin:dance` to clean up the frontend files.
@@ -25,4 +28,16 @@ import org.apache.maven.plugins.annotations.Mojo;
  */
 @Mojo(name = "dance", defaultPhase = LifecyclePhase.PRE_CLEAN)
 public class FrontendDanceMojo extends CleanFrontendMojo {
+
+    @Override
+    public void execute() throws MojoFailureException {
+        if (FrontendUtils.isHillaUsed(frontendDirectory())) {
+            getLog().warn(
+                    """
+                            The 'dance' goal is not meant to be used in Hilla projects as it delete 'package-lock.json' and also clearing out the content of 'package.json'.
+                            """
+                            .stripIndent());
+        }
+        runCleaning(new Options());
+    }
 }

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
@@ -23,6 +23,7 @@ import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.OpenOption;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
@@ -106,9 +107,11 @@ public class BuildFrontendMojoTest {
 
     @Before
     public void setup() throws Exception {
+        projectBase = temporaryFolder.getRoot();
+
         MavenProject project = Mockito.mock(MavenProject.class);
         Mockito.when(project.getRuntimeClasspathElements())
-                .thenReturn(getClassPath());
+                .thenReturn(getClassPath(projectBase.toPath()));
 
         List<String> packages = Arrays
                 .stream(System.getProperty("java.class.path")
@@ -118,8 +121,6 @@ public class BuildFrontendMojoTest {
                 .thenReturn(packages);
         Mockito.when(project.getCompileClasspathElements())
                 .thenReturn(Collections.emptyList());
-
-        projectBase = temporaryFolder.getRoot();
 
         tokenFile = new File(temporaryFolder.getRoot(),
                 VAADIN_SERVLET_RESOURCES + TOKEN_FILE);
@@ -236,7 +237,8 @@ public class BuildFrontendMojoTest {
         MavenProject project = mock(MavenProject.class);
         when(project.getBasedir()).thenReturn(baseFolder);
         when(project.getBuild()).thenReturn(buildMock);
-        when(project.getRuntimeClasspathElements()).thenReturn(getClassPath());
+        when(project.getRuntimeClasspathElements())
+                .thenReturn(getClassPath(baseFolder.toPath()));
         ReflectionUtils.setVariableValueInObject(mojo, "project", project);
     }
 
@@ -659,14 +661,15 @@ public class BuildFrontendMojoTest {
         }
     }
 
-    static List<String> getClassPath() {
+    static List<String> getClassPath(Path projectFolder) {
         // Add folder with test classes
-        List<String> classPaths = new ArrayList<>(
-                Arrays.asList("target/test-classes",
-                        // Add this test jar which has some frontend resources
-                        // used in tests
-                        TestUtils.getTestJar("jar-with-frontend-resources.jar")
-                                .getPath()));
+        List<String> classPaths = new ArrayList<>(Arrays.asList(
+                projectFolder.resolve("target").resolve("test-classes")
+                        .toString(),
+                // Add this test jar which has some frontend resources
+                // used in tests
+                TestUtils.getTestJar("jar-with-frontend-resources.jar")
+                        .getPath()));
 
         // Add other paths already present in the system classpath
         ClassLoader classLoader = ClassLoader.getSystemClassLoader();

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/CleanFrontendMojoTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/CleanFrontendMojoTest.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.plugin.maven;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
 
@@ -116,6 +117,26 @@ public class CleanFrontendMojoTest {
                 nodeModules.mkdirs());
         mojo.execute();
         Assert.assertFalse("'node_modules' was not removed.",
+                nodeModules.exists());
+    }
+
+    @Test
+    public void should_notRemoveNodeModulesFolder_hilla()
+            throws MojoFailureException, IOException {
+        // Add fake com.vaadin.hilla.EndpointController class to make project
+        // detected as Hilla project with endpoints.
+        Files.createDirectories(Paths.get(projectBase.toString(), "target")
+                .resolve("test-classes/com/vaadin/hilla"));
+        Files.createFile(Paths.get(projectBase.toString(), "target").resolve(
+                "test-classes/com/vaadin/hilla/EndpointController.class"));
+        Files.createDirectories(Paths.get(projectBase.toString(), "frontend"));
+        Files.createFile(Paths.get(projectBase.toString(), "frontend")
+                .resolve("index.ts"));
+        final File nodeModules = new File(projectBase, NODE_MODULES);
+        Assert.assertTrue("Failed to create 'node_modules'",
+                nodeModules.mkdirs());
+        mojo.execute();
+        Assert.assertTrue("'node_modules' should not be removed.",
                 nodeModules.exists());
     }
 

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/CleanFrontendMojoTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/CleanFrontendMojoTest.java
@@ -123,15 +123,7 @@ public class CleanFrontendMojoTest {
     @Test
     public void should_notRemoveNodeModulesFolder_hilla()
             throws MojoFailureException, IOException {
-        // Add fake com.vaadin.hilla.EndpointController class to make project
-        // detected as Hilla project with endpoints.
-        Files.createDirectories(Paths.get(projectBase.toString(), "target")
-                .resolve("test-classes/com/vaadin/hilla"));
-        Files.createFile(Paths.get(projectBase.toString(), "target").resolve(
-                "test-classes/com/vaadin/hilla/EndpointController.class"));
-        Files.createDirectories(Paths.get(projectBase.toString(), "frontend"));
-        Files.createFile(Paths.get(projectBase.toString(), "frontend")
-                .resolve("index.ts"));
+        enableHilla();
         final File nodeModules = new File(projectBase, NODE_MODULES);
         Assert.assertTrue("Failed to create 'node_modules'",
                 nodeModules.mkdirs());
@@ -216,6 +208,18 @@ public class CleanFrontendMojoTest {
     }
 
     @Test
+    public void should_notRemoveNpmPackageLockFile_hilla()
+            throws MojoFailureException, IOException {
+        enableHilla();
+        final File packageLock = new File(projectBase, "package-lock.json");
+        FileUtils.fileWrite(packageLock, "{ \"fake\": \"lock\"}");
+
+        mojo.execute();
+        Assert.assertTrue("package-lock.json should not be removed",
+                packageLock.exists());
+    }
+
+    @Test
     public void should_removePnpmFile()
             throws MojoFailureException, IOException {
         final File pnpmFile = new File(projectBase, ".pnpmfile.cjs");
@@ -288,6 +292,18 @@ public class CleanFrontendMojoTest {
 
         assertNotContainsPackage(packageJsonObject.getObject("devDependencies"),
                 "vite");
+    }
+
+    private void enableHilla() throws IOException {
+        // Add fake com.vaadin.hilla.EndpointController class to make project
+        // detected as Hilla project with endpoints.
+        Files.createDirectories(Paths.get(projectBase.toString(), "target")
+                .resolve("test-classes/com/vaadin/hilla"));
+        Files.createFile(Paths.get(projectBase.toString(), "target").resolve(
+                "test-classes/com/vaadin/hilla/EndpointController.class"));
+        Files.createDirectories(Paths.get(projectBase.toString(), "frontend"));
+        Files.createFile(Paths.get(projectBase.toString(), "frontend")
+                .resolve("index.ts"));
     }
 
     static void assertNotContainsPackage(JsonObject dependencies,


### PR DESCRIPTION
Adds warnings when running clean-frontend, dance and convert-polymer goals if Hilla is used. Also skip cleanFrontendFiles for build-frontend goal if Hilla is used.

Related-to: #18567