### PR TITLE
fix: delay initial poller call

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/webcomponent/webcomponent-script-template.js
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/webcomponent/webcomponent-script-template.js
@@ -108,6 +108,9 @@ _ThemeImport_class _TagCamel_ extends HTMLElement {
       }
     };
 
+    // Initial poll is not called immediately to give time for
+    // setting the attributes when client is already initialized.
+    // Mainly an issue in dynamic creation for React.
     setTimeout(poller, 10);
   }
   _getClient() {

--- a/flow-server/src/main/resources/com/vaadin/flow/server/webcomponent/webcomponent-script-template.js
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/webcomponent/webcomponent-script-template.js
@@ -108,7 +108,7 @@ _ThemeImport_class _TagCamel_ extends HTMLElement {
       }
     };
 
-    poller();
+    setTimeout(poller, 10);
   }
   _getClient() {
     if (_TagCamel_._getClientStrategy){


### PR DESCRIPTION
Delay the first poller call
for registerElement as if
we have already a live
client and the required method
react won't be fast enough
to set the attributes before
they are read.

Fixes #18645
