### PR TITLE
fix: Log debug connection issues as debug

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DebugWindowConnection.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DebugWindowConnection.java
@@ -201,8 +201,8 @@ public class DebugWindowConnection implements BrowserLiveReload {
                 .equals(resource.getRequest().getParameter("token"))) {
             handleConnect(resource);
         } else {
-            getLogger().warn(
-                    "Connection denied because of a missing or invalid token. The host is probably not on the allow list");
+            getLogger().debug(
+                    "Connection denied because of a missing or invalid token. Either the host is not on the 'vaadin.devmode.hosts-allowed' list or it is using an outdated token");
             try {
                 resource.close();
             } catch (IOException e) {


### PR DESCRIPTION
There is no value in seeing a lot of messages about denied connections if you e.g. leave browser tabs open. The warning is logged in the browser so you can understand why the connection is not working
