### PR TITLE
chore: upgrade minimum supported Gradle version to 8.4

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
@@ -24,40 +24,6 @@ import kotlin.test.expect
 import org.junit.Ignore
 
 class MiscSingleModuleTest : AbstractGradleTest() {
-    /**
-     * Tests https://github.com/vaadin/vaadin-gradle-plugin/issues/26
-     */
-    @Test
-    fun testVaadin8VaadinPlatformMPRProject() {
-        testProject.buildFile.writeText(
-                """
-            plugins {
-                id "com.devsoap.plugin.vaadin" version "2.0.0.beta2"
-                id 'com.vaadin'
-            }
-            repositories {
-                mavenLocal()
-                mavenCentral()
-                maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
-            }
-            configurations {
-                compile
-                compile.extendsFrom(implementation)
-            }
-            // test that we can configure both plugins
-            vaadin {
-                version = "8.9.4"
-            }
-            vaadinPlatform {
-                optimizeBundle = true
-            }
-        """.trimIndent()
-        )
-
-        // the collision between devsoap's `vaadin` extension and com.vaadin's `vaadin`
-        // extension would crash even this very simple build.
-        testProject.build("tasks")
-    }
 
     /**
      * This test covers the [Base Starter Gradle](https://github.com/vaadin/base-starter-gradle)

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
@@ -338,27 +338,13 @@ class VaadinSmokeTest : AbstractGradleTest() {
             setup()
         }
 
-        if(JavaVersion.current().majorVersion.toInt() >= 20) {
-            // JDK 20 needs 8.3+
-            setupProjectForGradleVersion("8.3")
-            val result = testProject.build("vaadinClean")
-            result.expectTaskSucceded("vaadinClean")
-        } else {
-            // Works with supported versions
-            for (supportedVersion in arrayOf(VaadinPlugin.GRADLE_MINIMUM_SUPPORTED_VERSION, "7.6.2", "8.1", "8.2", "8.3") ) {
+        for (supportedVersion in arrayOf(VaadinPlugin.GRADLE_MINIMUM_SUPPORTED_VERSION, "8.5", "8.6") ) {
                 setupProjectForGradleVersion(supportedVersion)
                 val result = testProject.build("vaadinClean")
                 result.expectTaskSucceded("vaadinClean")
-            }
         }
 
-        // Cannot test versions older than 7.6 because of Java version
-        // incompatibilities with dependencies thar makes the build fail before
-        // the plugin is applied
-        // Code below is left here for future usage, when gradle supported
-        // version will be greater than 7.6
-        // emptyArray<String>() should be replaced by arrayOf("7.6")
-        for (unsupportedVersion in emptyArray<String>()) {
+        for (unsupportedVersion in arrayOf("7.6", "8.0", "8.1", "8.2", "8.3")) {
             setupProjectForGradleVersion(unsupportedVersion)
             val result = testProject.buildAndFail("vaadinClean")
             assertContains(

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinPlugin.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinPlugin.kt
@@ -28,7 +28,7 @@ import org.gradle.util.GradleVersion
  */
 public class VaadinPlugin : Plugin<Project> {
     public companion object {
-        public const val GRADLE_MINIMUM_SUPPORTED_VERSION: String = "7.6"
+        public const val GRADLE_MINIMUM_SUPPORTED_VERSION: String = "8.4"
     }
 
     override fun apply(project: Project) {


### PR DESCRIPTION
Close https://github.com/vaadin/platform/issues/5027.

Related to https://github.com/vaadin/flow/issues/18367.