### PR TITLE
chore!: bump jackson.version from 2.16.0 to 2.16.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <hibernate.validator.version>8.0.1.Final</hibernate.validator.version>
         <slf4j.version>2.0.12</slf4j.version>
         <polymer.version>2.6.1</polymer.version>
-        <jackson.version>2.16.0</jackson.version>
+        <jackson.version>2.16.1</jackson.version>
         <jackson.databind.version>${jackson.version}</jackson.databind.version>
         <jakarta.validation.version>3.0.2</jakarta.validation.version>
         <jakarta.annotation.api.version>2.1.1</jakarta.annotation.api.version>


### PR DESCRIPTION
This is proposed to be applied to Vaadin 24.4 and we should update minimal requirement for Gradle from 7 to 8, see https://github.com/vaadin/flow/pull/18683.