### PR TITLE
fix: Possibly missing packages should not show error

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -363,8 +363,8 @@ public abstract class NodeUpdater implements FallibleCommand {
         defaults.putAll(readDependencies("vite", "devDependencies"));
         putHillaComponentsDependencies(defaults, "devDependencies");
         if (options.isReactEnabled()) {
-            defaults.putAll(readDependenciesIfAvailable("react-router",
-                    "devDependencies"));
+            defaults.putAll(
+                    readDependencies("react-router", "devDependencies"));
         }
 
         return defaults;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -313,9 +313,8 @@ public abstract class NodeUpdater implements FallibleCommand {
             JsonObject dependencies = readPackageJson(id)
                     .getObject(packageJsonKey);
             if (dependencies == null) {
-                LoggerFactory.getLogger(NodeUpdater.class)
-                        .error("Unable to find " + packageJsonKey + " from '"
-                                + id + "'");
+                log().error("Unable to find " + packageJsonKey + " from '" + id
+                        + "'");
                 return new HashMap<>();
             }
             for (String key : dependencies.keys()) {
@@ -324,7 +323,7 @@ public abstract class NodeUpdater implements FallibleCommand {
 
             return map;
         } catch (IOException e) {
-            LoggerFactory.getLogger(NodeUpdater.class).error(
+            log().error(
                     "Unable to read " + packageJsonKey + " from '" + id + "'",
                     e);
             return new HashMap<>();
@@ -337,11 +336,25 @@ public abstract class NodeUpdater implements FallibleCommand {
                 .getResource(FRONTEND_RESOURCES_PATH + "dependencies/" + id
                         + "/package.json");
         if (resource == null) {
-            LoggerFactory.getLogger(NodeUpdater.class)
-                    .error("Unable to find package.json from '" + id + "'");
-            return Json.createObject();
+            log().error("Unable to find package.json from '" + id + "'");
+
+            return Json.parse("{\"%s\":{},\"%s\":{}}".formatted(DEPENDENCIES,
+                    DEV_DEPENDENCIES));
         }
         return Json.parse(IOUtils.toString(resource, StandardCharsets.UTF_8));
+    }
+
+    boolean hasPackageJson(String id) {
+        return options.getClassFinder().getResource(FRONTEND_RESOURCES_PATH
+                + "dependencies/" + id + "/package.json") != null;
+    }
+
+    Map<String, String> readDependenciesIfAvailable(String id,
+            String packageJsonKey) {
+        if (hasPackageJson(id)) {
+            return readDependencies(id, packageJsonKey);
+        }
+        return new HashMap<>();
     }
 
     Map<String, String> getDefaultDevDependencies() {
@@ -350,8 +363,8 @@ public abstract class NodeUpdater implements FallibleCommand {
         defaults.putAll(readDependencies("vite", "devDependencies"));
         putHillaComponentsDependencies(defaults, "devDependencies");
         if (options.isReactEnabled()) {
-            defaults.putAll(
-                    readDependencies("react-router", "devDependencies"));
+            defaults.putAll(readDependenciesIfAvailable("react-router",
+                    "devDependencies"));
         }
 
         return defaults;
@@ -600,11 +613,11 @@ public abstract class NodeUpdater implements FallibleCommand {
         if (FrontendUtils.isHillaUsed(options.getFrontendDirectory(),
                 options.getClassFinder())) {
             if (options.isReactEnabled()) {
-                dependencies.putAll(readDependencies("hilla/components/react",
-                        packageJsonKey));
+                dependencies.putAll(readDependenciesIfAvailable(
+                        "hilla/components/react", packageJsonKey));
             } else {
-                dependencies.putAll(readDependencies("hilla/components/lit",
-                        packageJsonKey));
+                dependencies.putAll(readDependenciesIfAvailable(
+                        "hilla/components/lit", packageJsonKey));
             }
         }
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -561,9 +561,42 @@ public class NodeUpdaterTest {
     }
 
     @Test
+    public void readPackageJson_nonExistingFile_jsonContainsDepsAndDevDeps()
+            throws IOException {
+        JsonObject jsonObject = nodeUpdater
+                .readPackageJson("non-existing-folder");
+        Assert.assertTrue(jsonObject.hasKey("dependencies"));
+        Assert.assertTrue(jsonObject.hasKey("devDependencies"));
+    }
+
+    @Test
     public void readDependencies_doesntHaveDependencies_doesNotThrow() {
         nodeUpdater.readDependencies("no-deps", "dependencies");
         nodeUpdater.readDependencies("no-deps", "devDependencies");
+    }
+
+    @Test
+    public void readPackageJsonIfAvailable_nonExistingFile_noErrorLog() {
+        Logger log = Mockito.mock(Logger.class);
+        nodeUpdater = new NodeUpdater(Mockito.mock(FrontendDependencies.class),
+                options) {
+
+            @Override
+            public void execute() {
+            }
+
+            @Override
+            Logger log() {
+                return log;
+            }
+        };
+        nodeUpdater.readDependenciesIfAvailable("non-existing-folder",
+                "dependencies");
+        Mockito.verifyNoInteractions(log);
+
+        nodeUpdater.readDependenciesIfAvailable("non-existing-folder",
+                "devDpendencies");
+        Mockito.verifyNoInteractions(log);
     }
 
     private String getPolymerVersion(JsonObject object) {


### PR DESCRIPTION
When getting outside package json
files we should not log errors for
them if they are missing as they may
or may not be availabe.

Fixes vaadin/platform#5023
