### PR TITLE
fix: postpone serverSyncId computation after changes are applied (#16…

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -10,6 +10,7 @@ package com.vaadin.flow.component.internal;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -308,6 +309,13 @@ public class UIInternals implements Serializable {
      */
     public void incrementServerId() {
         serverSyncId++;
+        if (getLogger().isTraceEnabled()) {
+            getLogger().trace("Increment syncId {} -> {}:\n{}",
+                    (serverSyncId - 1), serverSyncId,
+                    Arrays.stream(Thread.currentThread().getStackTrace())
+                            .skip(1).map(String::valueOf).collect(Collectors
+                                    .joining(System.lineSeparator())));
+        }
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlWriter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlWriter.java
@@ -140,11 +140,6 @@ public class UidlWriter implements Serializable {
         // Paints components
         getLogger().debug("* Creating response to client");
 
-        int syncId = service.getDeploymentConfiguration().isSyncIdCheckEnabled()
-                ? uiInternals.getServerSyncId()
-                : -1;
-
-        response.put(ApplicationConstants.SERVER_SYNC_ID, syncId);
         if (resync) {
             response.put(ApplicationConstants.RESYNCHRONIZE_ID, true);
         }
@@ -186,6 +181,14 @@ public class UidlWriter implements Serializable {
         if (service.getDeploymentConfiguration().isRequestTiming()) {
             response.put("timings", createPerformanceData(ui));
         }
+
+        // Get serverSyncId after all changes has been computed, as push may
+        // have been invoked, thus incrementing the counter.
+        // This way the client will receive messages in the correct order
+        int syncId = service.getDeploymentConfiguration().isSyncIdCheckEnabled()
+                ? uiInternals.getServerSyncId()
+                : -1;
+        response.put(ApplicationConstants.SERVER_SYNC_ID, syncId);
         uiInternals.incrementServerId();
         return response;
     }


### PR DESCRIPTION
…660) (CP: 9.2)

While UIDLWriter is encoding changes, it may happen that a push operation is invoked, thus incrementing the serverSyncId counter. If this happens, the client may receive the messages in the wrong order and and subsequently there may be a gap in the counter, so that a message will never be created for an expected id, and the client will force a resynchronization.
This change reads the serverSyncId for the current request after all changes are applied, so the client will receive messages in the expected order.

Fixes #16635

<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Please list all relevant dependencies in this section and provide summary of the change, motivation and context.

Fixes # (issue)

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
