### PR TITLE
chore: rebuild bundle if React is disabled

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleValidationUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleValidationUtil.java
@@ -117,6 +117,7 @@ public final class BundleValidationUtil {
             getLogger().info("No dev-bundle found.");
             return true;
         }
+
         if (!DevBundleUtils
                 .getDevBundleFolder(npmFolder, options.getBuildDirectoryName())
                 .exists() && compressedDevBundle.exists()) {
@@ -125,6 +126,7 @@ public final class BundleValidationUtil {
                             new File(npmFolder,
                                     options.getBuildDirectoryName()),
                             Constants.DEV_BUNDLE_LOCATION));
+
         }
 
         if (options.isSkipDevBundle()) {
@@ -133,6 +135,15 @@ public final class BundleValidationUtil {
             getLogger()
                     .info("Skip dev bundle requested. Using existing bundle.");
             return false;
+        }
+
+        if (!DevBundleUtils
+                .getDevBundleFolder(npmFolder, options.getBuildDirectoryName())
+                .exists() && !options.isReactEnabled()) {
+            // Using default dev bundle in a Jar.
+            // Default dev bundle is packaged with react router only. With react
+            // disabled, let's rebuild bundle to get vaadin router instead.
+            return true;
         }
 
         String statsJsonContent = DevBundleUtils.findBundleStatsJson(npmFolder,
@@ -152,6 +163,15 @@ public final class BundleValidationUtil {
     private static boolean needsBuildProdBundle(Options options,
             FrontendDependenciesScanner frontendDependencies)
             throws IOException {
+
+        if (!options.isReactEnabled() && !ProdBundleUtils
+                .getProdBundle(options.getNpmFolder()).exists()) {
+            // Using default prod bundle in a Jar.
+            // Default prod bundle is packaged with react router only. With
+            // react disabled, let's rebuild bundle to get vaadin router
+            // instead.
+            return true;
+        }
         String statsJsonContent = ProdBundleUtils.findBundleStatsJson(
                 options.getNpmFolder(), options.getClassFinder());
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleValidationUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleValidationUtil.java
@@ -143,6 +143,7 @@ public final class BundleValidationUtil {
             // Using default dev bundle in a Jar.
             // Default dev bundle is packaged with react router only. With react
             // disabled, let's rebuild bundle to get vaadin router instead.
+            getLogger().info("Bundle build required for non default router.");
             return true;
         }
 
@@ -170,6 +171,7 @@ public final class BundleValidationUtil {
             // Default prod bundle is packaged with react router only. With
             // react disabled, let's rebuild bundle to get vaadin router
             // instead.
+            getLogger().info("Bundle build required for non default router.");
             return true;
         }
         String statsJsonContent = ProdBundleUtils.findBundleStatsJson(

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/BundleValidationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/BundleValidationTest.java
@@ -2089,6 +2089,37 @@ public class BundleValidationTest {
     }
 
     @Test
+    public void defaultDevBundleExists_noCompressedDevBundleFile_reactDisabled_buildRequired()
+            throws IOException {
+        options.withReact(false);
+        Assume.assumeTrue(!mode.isProduction());
+
+        File packageJson = new File(temporaryFolder.getRoot(), "package.json");
+        packageJson.createNewFile();
+
+        FileUtils.write(packageJson, "{\"vaadin\": { \"hash\": \"aHash\"} }",
+                StandardCharsets.UTF_8);
+
+        final FrontendDependenciesScanner depScanner = Mockito
+                .mock(FrontendDependenciesScanner.class);
+
+        JsonObject stats = getBasicStats();
+
+        URL url = Mockito.mock(URL.class);
+        Mockito.when(
+                finder.getResource(DEV_BUNDLE_JAR_PATH + "config/stats.json"))
+                .thenReturn(url);
+        ioUtils.when(() -> IOUtils.toString(url, StandardCharsets.UTF_8))
+                .thenReturn(stats.toJson());
+
+        boolean needsBuild = BundleValidationUtil.needsBuild(options,
+                depScanner, mode);
+        Assert.assertTrue(
+                "Dev bundle build is expected when react is disabled and using otherwise default dev bundle.",
+                needsBuild);
+    }
+
+    @Test
     public void defaultProdBundleExists_noCompressedProdBundleFile_noBuildRequired()
             throws IOException {
         Assume.assumeTrue(mode.isProduction());
@@ -2118,6 +2149,37 @@ public class BundleValidationTest {
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
                 depScanner, mode);
         Assert.assertFalse("Jar frontend file content hash should match.",
+                needsBuild);
+    }
+
+    @Test
+    public void defaultProdBundleExists_noCompressedProdBundleFile_reactDisabled_noBuildRequired()
+            throws IOException {
+        options.withReact(false);
+        Assume.assumeTrue(mode.isProduction());
+
+        File packageJson = new File(temporaryFolder.getRoot(), "package.json");
+        packageJson.createNewFile();
+
+        FileUtils.write(packageJson, "{\"vaadin\": { \"hash\": \"aHash\"} }",
+                StandardCharsets.UTF_8);
+
+        final FrontendDependenciesScanner depScanner = Mockito
+                .mock(FrontendDependenciesScanner.class);
+
+        JsonObject stats = getBasicStats();
+
+        URL url = Mockito.mock(URL.class);
+        Mockito.when(
+                finder.getResource(PROD_BUNDLE_JAR_PATH + "config/stats.json"))
+                .thenReturn(url);
+        ioUtils.when(() -> IOUtils.toString(url, StandardCharsets.UTF_8))
+                .thenReturn(stats.toJson());
+
+        boolean needsBuild = BundleValidationUtil.needsBuild(options,
+                depScanner, mode);
+        Assert.assertTrue(
+                "Prod bundle build is expected when react is disabled and using otherwise default prod bundle.",
                 needsBuild);
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/BundleValidationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/BundleValidationTest.java
@@ -2153,7 +2153,7 @@ public class BundleValidationTest {
     }
 
     @Test
-    public void defaultProdBundleExists_noCompressedProdBundleFile_reactDisabled_noBuildRequired()
+    public void defaultProdBundleExists_noCompressedProdBundleFile_reactDisabled_buildRequired()
             throws IOException {
         options.withReact(false);
         Assume.assumeTrue(mode.isProduction());


### PR DESCRIPTION
Default production and development bundles are packaged with react router only. With this change, bundle is always rebuild if React is disabled and default bundle would be used otherwise. Rebuilding ensures that Vaadin router is used instead of the React router.

Fixes: #18656