### PR TITLE
chore: log message when requested range does not match fetched items

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/CallbackDataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/CallbackDataProvider.java
@@ -149,4 +149,11 @@ public class CallbackDataProvider<T, F>
                 : "CallbackDataProvider got null as an id for item: " + item;
         return itemId;
     }
+
+    @Override
+    public String toString() {
+        return "CallbackDataProvider(" + "fetchCallback=" + fetchCallback
+                + ", countCallback=" + countCallback + ", idGetter=" + idGetter
+                + ')';
+    }
 }

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/ConfigurableFilterDataProviderWrapper.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/ConfigurableFilterDataProviderWrapper.java
@@ -82,4 +82,9 @@ public abstract class ConfigurableFilterDataProviderWrapper<T, Q, C, F>
         this.configuredFilter = filter;
         refreshAll();
     }
+
+    @Override
+    public String toString() {
+        return "ConfigurableFilterDataProviderWrapper(" + dataProvider + ")";
+    }
 }

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -1396,6 +1396,19 @@ public class DataCommunicator<T> implements Serializable {
                         previousActive.length());
             }
 
+            if (activeKeyOrder.isEmpty() && !effectiveRequested.isEmpty()) {
+                getLogger().error(
+                        "Requested data for {} but data provider did not fetch any item. "
+                                + "It might be a bug in the data provider callbacks implementation ({}).",
+                        effectiveRequested, getDataProvider());
+            } else if (activeKeyOrder.size() < effectiveRequested.length()) {
+                getLogger().error(
+                        "Requested data for {} but data provider fetched only {} items. "
+                                + "It might be a bug in the data provider callbacks implementation ({}).",
+                        effectiveRequested, activeKeyOrder.size(),
+                        getDataProvider());
+            }
+
             update.set(activeStart, getJsonItems(effectiveRequested));
             updated = true;
         } else if (!previousActive.equals(effectiveRequested)) {

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataProviderWrapper.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataProviderWrapper.java
@@ -109,4 +109,9 @@ public abstract class DataProviderWrapper<T, F, M>
      * @return filter for the modified Query
      */
     protected abstract M getFilter(Query<T, F> query);
+
+    @Override
+    public String toString() {
+        return "DataProviderWrapper(" + dataProvider + ')';
+    }
 }


### PR DESCRIPTION
## Description

When DataCommunicator flushes data and IndexOutOfBound exception can happen if data provider callbacks are not implemented properly. This change adds a log message that should help the user in debugging the cause of the error.

References #18541

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
