### PR TITLE
fix: fix cache resource validation on application reload

### DIFF
--- a/flow-tests/test-redeployment/pom.xml
+++ b/flow-tests/test-redeployment/pom.xml
@@ -103,6 +103,29 @@
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-clean-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>clean-test-files</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                        <configuration>
+                            <filesets>
+                                <fileset>
+                                    <directory>${project.basedir}/src/main/java/com/vaadin/flow/uitest/ui</directory>
+                                    <includes>
+                                        <include>reloadaddedviews/</include>
+                                    </includes>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -993,6 +993,11 @@ public class VaadinServletContextInitializer
 
                 if (devModeCachingEnabled && valid.contains(originalPath)) {
                     resourcesList.add(resource);
+                    // Restore root paths to ensure new resources are correctly
+                    // validate and cached after a reload
+                    if (originalPath.endsWith("/")) {
+                        rootPaths.add(originalPath);
+                    }
                 } else {
                     if (path.endsWith(".jar!/")) {
                         resourcesList.add(resource);


### PR DESCRIPTION
## Description

Restores known root paths from cache after an application reload to correctly validate new resources.

Fixes #18730

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
