### PR TITLE
chore: test new upload/download test result artifacts.

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -138,7 +138,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ failure() || success() }}
         with:
-          name: tests-output-${{ matrix.module }}
+          name: tests-output-unit-${{ matrix.current }}
           path: tests-report-*.tgz
   it-tests:
     needs: build
@@ -224,7 +224,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ failure() || success() }}
         with:
-          name: tests-output-${{ matrix.module }}
+          name: tests-output-it-${{ matrix.current }}
           path: tests-report-*.tgz
   test-results:
     permissions:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -138,9 +138,8 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ failure() || success() }}
         with:
-          name: tests-output
+          name: tests-output-${{ matrix.module }}
           path: tests-report-*.tgz
-          overwrite: true
   it-tests:
     needs: build
     timeout-minutes: 30
@@ -225,9 +224,8 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ failure() || success() }}
         with:
-          name: tests-output
+          name: tests-output-${{ matrix.module }}
           path: tests-report-*.tgz
-          overwrite: true
   test-results:
     permissions:
       actions: write
@@ -238,6 +236,11 @@ jobs:
     needs: [unit-tests, it-tests]
     runs-on: ubuntu-22.04
     steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: tests-output
+          pattern: tests-output-*
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
based on the changes in `upload-artifact@v4`, the artifacts are not mutable any more. 
so we took the way they have recommended in [docs](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#merging-multiple-artifacts) that 
- create and upload the artifacts separately with different names
  - `test-output-it/unit-x`
  - the separated artifacts will 
- download all artifacts to a temporary directory and reupload them as a single artifact `test-outputs` 

test result can be found https://github.com/vaadin/flow/actions/runs/7976167633?pr=18762