### PR TITLE
fix: Add optional .js extension for Flow import

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
@@ -141,7 +141,7 @@ public class TaskGenerateReactFiles implements FallibleCommand {
 
     private boolean missingServerImport(String routesContent) {
         Pattern serverImport = Pattern.compile(
-                "import[\\s\\S]?\\{[\\s\\S]?serverSideRoutes[\\s\\S]?\\}[\\s\\S]?from[\\s\\S]?(\"|'|`)Frontend\\/generated\\/flow\\/Flow\\1;");
+                "import[\\s\\S]?\\{[\\s\\S]?serverSideRoutes[\\s\\S]?\\}[\\s\\S]?from[\\s\\S]?(\"|'|`)Frontend\\/generated\\/flow\\/Flow(\\.js)?\\1;");
         return !serverImport.matcher(routesContent).find();
     }
 


### PR DESCRIPTION
Both imports
- `import { serverSideRoutes } from "Frontend/generated/flow/Flow";`
- `import { serverSideRoutes } from "Frontend/generated/flow/Flow.js";`
are considered valid imports.