### PR TITLE
test: Add/fix tests for binding cross-validation

### DIFF
--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -1871,7 +1871,7 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
                 nameField.getValue());
 
         binder.setBean(item); // refreshFields would read the values again from
-        // bean
+                              // bean
         item.setFirstName("bar");
         binder.refreshFields();
 
@@ -2551,8 +2551,6 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
             return value != null ? value.toString() : null;
         }
     }
-
-    ;
 
     /**
      * A converter that adds/removes the euro sign and formats currencies with

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -1561,7 +1561,7 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
     }
 
     @Test
-    public void two_asRequired_fields_without_initial_values() {
+    public void two_asRequired_fields_without_initial_values_setBean() {
         binder.forField(nameField).asRequired("Empty name").bind(p -> "",
                 (p, s) -> {
                 });
@@ -1579,16 +1579,17 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         assertThat("Name with a value should not be an error",
                 nameField.getErrorMessage(), isEmptyString());
 
-        assertNotNull(
-                "Age field should now be in error, since setBean is used.",
-                ageField.getErrorMessage());
+        assertTrue(
+                "Age field should not be in error, since it was not modified.",
+                StringUtils.isEmpty(ageField.getErrorMessage()));
 
         nameField.setValue("");
-        assertNotNull("Empty name should now be in error.",
-                nameField.getErrorMessage());
 
-        assertNotNull("Age field should still be in error.",
-                ageField.getErrorMessage());
+        assertFalse("Empty name should now be in error.",
+                StringUtils.isEmpty(nameField.getErrorMessage()));
+        assertTrue(
+                "Age field should still not be in error, since it was not modified.",
+                StringUtils.isEmpty(ageField.getErrorMessage()));
     }
 
     @Test
@@ -1610,16 +1611,99 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         assertThat("Name with a value should not be an error",
                 nameField.getErrorMessage(), isEmptyString());
 
-        assertThat(
-                "Age field should not be in error, since it has not been modified.",
-                ageField.getErrorMessage(), isEmptyString());
+        assertTrue(
+                "Age field should not be in error, since it was not modified.",
+                StringUtils.isEmpty(ageField.getErrorMessage()));
 
         nameField.setValue("");
-        assertNotNull("Empty name should now be in error.",
-                nameField.getErrorMessage());
+        assertFalse("Empty name should now be in error.",
+                StringUtils.isEmpty(nameField.getErrorMessage()));
 
-        assertThat("Age field should still be ok.", ageField.getErrorMessage(),
-                isEmptyString());
+        assertTrue(
+                "Age field should still not be in error, since it was not modified.",
+                StringUtils.isEmpty(ageField.getErrorMessage()));
+    }
+
+    @Test
+    public void validated_and_asRequired_fields_without_initial_values_setBean() {
+        binder.forField(nameField).asRequired("Empty name")
+                .bind(Person::getFirstName, Person::setFirstName);
+        TestTextField lastNameField = new TestTextField();
+        binder.forField(lastNameField)
+                .withValidator((v, c) -> StringUtils.isEmpty(v)
+                        ? ValidationResult.error("Empty last name")
+                        : ValidationResult.ok())
+                .bind(Person::getLastName, Person::setLastName);
+
+        binder.setBean(item);
+        assertFalse("Initially there should be no errors",
+                nameField.isInvalid());
+        assertFalse("Initially there should be no errors",
+                lastNameField.isInvalid());
+
+        nameField.setValue("Foo");
+        assertFalse("Name with a value should not be an error",
+                nameField.isInvalid());
+        assertFalse(
+                "Last name field should not be in error, since it was not modified.",
+                lastNameField.isInvalid());
+
+        nameField.setValue("");
+
+        assertTrue("Empty name should now be in error.", nameField.isInvalid());
+        assertFalse(
+                "Last name field should not be in error, since it was not modified.",
+                lastNameField.isInvalid());
+
+        nameField.setValue("Bar");
+        lastNameField.setValue("Bar");
+        lastNameField.setValue("");
+
+        assertFalse("Name with a value should not be an error",
+                nameField.isInvalid());
+        assertTrue("Empty last name field should now be in error.",
+                lastNameField.isInvalid());
+    }
+
+    @Test
+    public void validated_and_asRequired_fields_without_initial_values_readBean() {
+        binder.forField(nameField).asRequired("Empty name")
+                .bind(Person::getFirstName, Person::setFirstName);
+        TestTextField lastNameField = new TestTextField();
+        binder.forField(lastNameField)
+                .withValidator((v, c) -> StringUtils.isEmpty(v)
+                        ? ValidationResult.error("Empty last name")
+                        : ValidationResult.ok())
+                .bind(Person::getLastName, Person::setLastName);
+
+        binder.readBean(item);
+        assertFalse("Initially there should be no errors",
+                nameField.isInvalid());
+        assertFalse("Initially there should be no errors",
+                lastNameField.isInvalid());
+
+        nameField.setValue("Foo");
+        assertFalse("Name with a value should not be an error",
+                nameField.isInvalid());
+        assertFalse(
+                "Last name field should not be in error, since it was not modified.",
+                lastNameField.isInvalid());
+
+        nameField.setValue("");
+
+        assertTrue("Empty name should now be in error.", nameField.isInvalid());
+        assertFalse(
+                "Last name field should not be in error, since it was not modified.",
+                lastNameField.isInvalid());
+
+        nameField.setValue("Bar");
+        lastNameField.setValue("Bar");
+        lastNameField.setValue("");
+
+        assertFalse("Name with a value should not be an error",
+                nameField.isInvalid());
+        assertTrue("Empty last name field should now be in error.",
+                lastNameField.isInvalid());
     }
 
     @Test
@@ -1787,7 +1871,7 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
                 nameField.getValue());
 
         binder.setBean(item); // refreshFields would read the values again from
-                              // bean
+        // bean
         item.setFirstName("bar");
         binder.refreshFields();
 
@@ -2466,7 +2550,9 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
                 ValueContext context) {
             return value != null ? value.toString() : null;
         }
-    };
+    }
+
+    ;
 
     /**
      * A converter that adds/removes the euro sign and formats currencies with


### PR DESCRIPTION
Fixes and adds tests to ensure we don't get a regression like https://github.com/vaadin/flow/issues/18735.

Note to reviewer, if running these tests without [this patch](https://github.com/vaadin/flow/commit/76b862a8f6f962cdfbb370864a0c5a655693cd69), the following test failures should happen:
```
[ERROR]   BinderTest.two_asRequired_fields_without_initial_values_setBean:1582 Age field should not be in error, since it was not modified.
[ERROR]   BinderTest.validated_and_asRequired_fields_without_initial_values_setBean:1644 Last name field should not be in error, since it was not modified.
```