### PR TITLE
test: check field validity in addition to errormsg

### DIFF
--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderConverterValidatorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderConverterValidatorTest.java
@@ -321,6 +321,7 @@ public class BinderConverterValidatorTest
         assertEquals(msg1, error.getMessage().get());
         assertEquals(nameField, error.getField());
         assertEquals(msg1, nameField.getErrorMessage());
+        Assert.assertTrue(nameField.isInvalid());
     }
 
     @Test
@@ -653,10 +654,12 @@ public class BinderConverterValidatorTest
 
         // should not have error shown when initialized
         assertThat(lastNameField.getErrorMessage(), isEmptyString());
+        Assert.assertFalse(lastNameField.isInvalid());
 
         // Set a value that breaks the validation
         lastNameField.setValue("");
         assertNotNull(lastNameField.getErrorMessage());
+        Assert.assertTrue(lastNameField.isInvalid());
 
         // add status label to show bean level error
         TestLabel statusLabel = new TestLabel();

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -851,9 +851,11 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
                 .bind(Person::getFirstName, Person::setFirstName);
         binder.setBean(item);
         assertThat(textField.getErrorMessage(), isEmptyString());
+        Assert.assertFalse(textField.isInvalid());
 
         textField.setValue(textField.getEmptyValue());
         Assert.assertEquals("foobar", componentErrors.get(textField));
+        Assert.assertTrue(textField.isInvalid());
 
         textField.setValue("value");
         assertFalse(textField.isInvalid());
@@ -919,10 +921,12 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         binding.bind(Person::getFirstName, Person::setFirstName);
         binder.setBean(item);
         assertThat(textField.getErrorMessage(), isEmptyString());
+        Assert.assertFalse(textField.isInvalid());
         Assert.assertEquals(0, invokes.get());
 
         textField.setValue(textField.getEmptyValue());
         Assert.assertEquals("foobar", componentErrors.get(textField));
+        Assert.assertTrue(textField.isInvalid());
         // validation is done for all changed bindings once.
         Assert.assertEquals(1, invokes.get());
 
@@ -953,12 +957,14 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         binder.setBean(item);
 
         assertThat(textField.getErrorMessage(), isEmptyString());
+        Assert.assertFalse(textField.isInvalid());
         assertEquals(1, invokes.get());
 
         textField.setValue("        ");
         String errorMessage = textField.getErrorMessage();
         assertNotNull(errorMessage);
         assertEquals("Input is required.", componentErrors.get(textField));
+        Assert.assertTrue(textField.isInvalid());
         // validation is done for all changed bindings once.
         assertEquals(2, invokes.get());
 
@@ -1007,10 +1013,12 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
                 .bind(Person::getFirstName, Person::setFirstName);
         binder.setBean(item);
         assertThat(textField.getErrorMessage(), isEmptyString());
+        Assert.assertFalse(textField.isInvalid());
         assertEquals(1, invokes.get());
         textField.setValue(" ");
         assertNotNull(textField.getErrorMessage());
         assertEquals("Input required.", componentErrors.get(textField));
+        Assert.assertTrue(textField.isInvalid());
         // validation is done for all changed bindings once.
         assertEquals(2, invokes.get());
 
@@ -1035,18 +1043,21 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         Assert.assertFalse("binder should not have errors", hasErrors.get());
         Assert.assertEquals("Name field should not be in error.", "",
                 nameField.getErrorMessage());
+        Assert.assertFalse(nameField.isInvalid());
 
         // Set setAsRequiredEnabled false -> should still be valid
         nameBinding.setAsRequiredEnabled(false);
         Assert.assertFalse("binder should not have errors", hasErrors.get());
         Assert.assertEquals("Name field should not be in error.", "",
                 nameField.getErrorMessage());
+        Assert.assertFalse(nameField.isInvalid());
 
         // Set setAsRequiredEnabled true -> should still be valid
         nameBinding.setAsRequiredEnabled(true);
         Assert.assertFalse("binder should not have errors", hasErrors.get());
         Assert.assertEquals("Name field should not be in error.", "",
                 nameField.getErrorMessage());
+        Assert.assertFalse(nameField.isInvalid());
     }
 
     @Test
@@ -1444,6 +1455,7 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         ageField.setValue("foo");
         assertThat("Error message is not what was expected",
                 ageField.getErrorMessage(), containsString(ageError));
+        Assert.assertTrue(ageField.isInvalid());
 
         // Restore values and test no errors.
         ageField.setValue(String.valueOf(initialAge));
@@ -1572,24 +1584,30 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         binder.setBean(item);
         assertThat("Initially there should be no errors",
                 nameField.getErrorMessage(), isEmptyString());
+        Assert.assertFalse(nameField.isInvalid());
         assertThat("Initially there should be no errors",
                 ageField.getErrorMessage(), isEmptyString());
+        Assert.assertFalse(ageField.isInvalid());
 
         nameField.setValue("Foo");
         assertThat("Name with a value should not be an error",
                 nameField.getErrorMessage(), isEmptyString());
+        Assert.assertFalse(nameField.isInvalid());
 
         assertTrue(
                 "Age field should not be in error, since it was not modified.",
                 StringUtils.isEmpty(ageField.getErrorMessage()));
+        Assert.assertFalse(ageField.isInvalid());
 
         nameField.setValue("");
 
         assertFalse("Empty name should now be in error.",
                 StringUtils.isEmpty(nameField.getErrorMessage()));
+        Assert.assertTrue(nameField.isInvalid());
         assertTrue(
                 "Age field should still not be in error, since it was not modified.",
                 StringUtils.isEmpty(ageField.getErrorMessage()));
+        Assert.assertFalse(ageField.isInvalid());
     }
 
     @Test
@@ -1604,24 +1622,30 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         binder.readBean(item);
         assertThat("Initially there should be no errors",
                 nameField.getErrorMessage(), isEmptyString());
+        Assert.assertFalse(nameField.isInvalid());
         assertThat("Initially there should be no errors",
                 ageField.getErrorMessage(), isEmptyString());
+        Assert.assertFalse(ageField.isInvalid());
 
         nameField.setValue("Foo");
         assertThat("Name with a value should not be an error",
                 nameField.getErrorMessage(), isEmptyString());
+        Assert.assertFalse(nameField.isInvalid());
 
         assertTrue(
                 "Age field should not be in error, since it was not modified.",
                 StringUtils.isEmpty(ageField.getErrorMessage()));
+        Assert.assertFalse(ageField.isInvalid());
 
         nameField.setValue("");
         assertFalse("Empty name should now be in error.",
                 StringUtils.isEmpty(nameField.getErrorMessage()));
+        Assert.assertTrue(nameField.isInvalid());
 
         assertTrue(
                 "Age field should still not be in error, since it was not modified.",
                 StringUtils.isEmpty(ageField.getErrorMessage()));
+        Assert.assertFalse(ageField.isInvalid());
     }
 
     @Test
@@ -1976,12 +2000,14 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
 
         ageField.setValue("not a number");
         assertEquals(otherError, ageField.getErrorMessage());
+        Assert.assertTrue(ageField.isInvalid());
 
         testUI.setLocale(new Locale("fi", "FI"));
 
         // Re-validate to get the error message with correct locale
         binder.validate();
         assertEquals(fiError, ageField.getErrorMessage());
+        Assert.assertTrue(ageField.isInvalid());
     }
 
     @Test


### PR DESCRIPTION
Currently some tests only check error message. Adds checks for expected validity state as well.