### PR TITLE
chore: upgrade spring framework to 5.3.32 (23.4)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,9 @@
 
         <!-- Dependencies -->
         <spring.boot.version>2.7.18</spring.boot.version>
+        <!-- spring-framework 5.3.32 has security fixes -->
+        <spring-framework.version>5.3.32</spring-framework.version>
+
         <gwt.version>2.9.0</gwt.version>
         <hibernate.validator.version>6.2.5.Final</hibernate.validator.version>
         <slf4j.version>1.7.36</slf4j.version>

--- a/vaadin-spring/pom.xml
+++ b/vaadin-spring/pom.xml
@@ -175,13 +175,20 @@
 
     <dependencyManagement>
         <dependencies>
-	        <dependency>
-	            <groupId>org.springframework.boot</groupId>
-	            <artifactId>spring-boot-dependencies</artifactId>
-	            <version>${spring.boot.version}</version>
-	            <type>pom</type>
-	            <scope>import</scope>
-	        </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-framework-bom</artifactId>
+                <version>${spring-framework.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>


### PR DESCRIPTION
default spring-framework version coming with sb 2.7 is 5.3.31.  currently, we cannot find the date when next sb 2.7 will come. so let us use it this to resolve the cve
https://www.cve.org/CVERecord?id=CVE-2024-22243