### PR TITLE
feat: support exclusions property in versions.json

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/ExclusionFilter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/ExclusionFilter.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.server.frontend;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Serializable;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -35,7 +36,7 @@ import elemental.json.Json;
 /**
  * Filter for excluding dependencies from vaadin-*versions.json files.
  */
-public class ExclusionFilter {
+public class ExclusionFilter implements Serializable {
 
     private final ClassFinder finder;
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/ExclusionFilter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/ExclusionFilter.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.server.frontend;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.io.IOUtils;
+
+import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.frontend.scanner.ClassFinder;
+import elemental.json.Json;
+
+/**
+ * Filter for excluding dependencies from vaadin-*versions.json files.
+ */
+public class ExclusionFilter {
+
+    private final ClassFinder finder;
+
+    private boolean reactEnabled;
+
+    /**
+     * Create a new exclusion filter.
+     *
+     * @param finder
+     *            the class finder to use
+     * @param reactEnabled
+     *            whether React is enabled
+     */
+    public ExclusionFilter(ClassFinder finder, boolean reactEnabled) {
+        this.finder = finder;
+        this.reactEnabled = reactEnabled;
+    }
+
+    /**
+     * Exclude dependencies from the given map based on the
+     * vaadin-*versions.json files.
+     *
+     * @param dependencies
+     *            the dependencies to filter
+     * @return the filtered dependencies
+     * @throws IOException
+     *             if an I/O error occurs
+     */
+    public Map<String, String> exclude(Map<String, String> dependencies)
+            throws IOException {
+        var exclusions = getExclusions();
+        return dependencies.entrySet().stream()
+                .filter(entry -> !exclusions.contains(entry.getKey()))
+                .collect(Collectors.toMap(Map.Entry::getKey,
+                        Map.Entry::getValue));
+    }
+
+    private List<String> getExclusions() throws IOException {
+        List<String> exclusions = new ArrayList<>();
+        URL coreVersionsResource = finder
+                .getResource(Constants.VAADIN_CORE_VERSIONS_JSON);
+        if (coreVersionsResource != null) {
+            exclusions.addAll(getExclusions(coreVersionsResource));
+        }
+        URL vaadinVersionsResource = finder
+                .getResource(Constants.VAADIN_VERSIONS_JSON);
+        if (vaadinVersionsResource != null) {
+            exclusions.addAll(getExclusions(vaadinVersionsResource));
+        }
+        return exclusions;
+    }
+
+    private Set<String> getExclusions(URL versionsResource) throws IOException {
+        try (InputStream content = versionsResource.openStream()) {
+            VersionsJsonConverter convert = new VersionsJsonConverter(
+                    Json.parse(
+                            IOUtils.toString(content, StandardCharsets.UTF_8)),
+                    reactEnabled);
+            return convert.getExclusions();
+        }
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/ExclusionFilter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/ExclusionFilter.java
@@ -34,13 +34,14 @@ import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import elemental.json.Json;
 
 /**
- * Filter for excluding dependencies from vaadin-*versions.json files.
+ * Excludes dependencies listed in an "exclusions" array of
+ * vaadin-*versions.json file from a package.json.
  */
 public class ExclusionFilter implements Serializable {
 
     private final ClassFinder finder;
 
-    private boolean reactEnabled;
+    private final boolean reactEnabled;
 
     /**
      * Create a new exclusion filter.

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -184,7 +184,12 @@ public abstract class NodeUpdater implements FallibleCommand {
         return versionsJson;
     }
 
-    private boolean isReactModuleAvailable() {
+    /**
+     * Is the React module available in the classpath.
+     *
+     * @return true if the React module is available, false otherwise
+     */
+    boolean isReactModuleAvailable() {
         try {
             options.getClassFinder().loadClass(
                     "com.vaadin.flow.component.react.ReactAdapterComponent");

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -205,8 +205,13 @@ public class TaskUpdatePackages extends NodeUpdater {
             Map<String, String> applicationDevDependencies) throws IOException {
         int added = 0;
 
+        Map<String, String> filteredApplicationDependencies = new ExclusionFilter(
+                finder, options.isReactEnabled() && isReactModuleAvailable())
+                .exclude(applicationDependencies);
+
         // Add application dependencies
-        for (Entry<String, String> dep : applicationDependencies.entrySet()) {
+        for (Entry<String, String> dep : filteredApplicationDependencies
+                .entrySet()) {
             added += addDependency(packageJson, DEPENDENCIES, dep.getKey(),
                     dep.getValue());
         }
@@ -242,7 +247,7 @@ public class TaskUpdatePackages extends NodeUpdater {
 
         // Remove obsolete dependencies
         List<String> dependencyCollection = Stream
-                .concat(applicationDependencies.entrySet().stream(),
+                .concat(filteredApplicationDependencies.entrySet().stream(),
                         getDefaultDependencies().entrySet().stream())
                 .map(Entry::getKey).collect(Collectors.toList());
         dependencyCollection.addAll(pinnedPlatformDependencies);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -232,7 +232,7 @@ public class TaskUpdatePackages extends NodeUpdater {
             // need to double check that not overriding a scanned
             // dependency since add-ons should be able to downgrade
             // version through exclusion
-            if (!applicationDependencies.containsKey(key)
+            if (!filteredApplicationDependencies.containsKey(key)
                     && pinPlatformDependency(packageJson,
                             platformPinnedDependencies, key)) {
                 added++;

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/VersionsJsonConverterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/VersionsJsonConverterTest.java
@@ -314,4 +314,98 @@ public class VersionsJsonConverterTest {
         Assert.assertFalse(convertedJson.hasKey("react-components"));
         Assert.assertFalse(convertedJson.hasKey("react-components-pro"));
     }
+
+    @Test
+    public void testExclusionsArrayProperty() {
+        String json = """
+                {
+                  "core": {
+                    "flow": {
+                      "javaVersion": "3.0.0.alpha17"
+                    },
+                    "vaadin-progress-bar": {
+                      "npmName": "@vaadin/vaadin-progress-bar",
+                      "jsVersion": "1.1.2",
+                      "mode": "lit"
+                    },
+                  },
+                  "vaadin-upload": {
+                    "npmName": "@vaadin/vaadin-upload",
+                    "jsVersion": "4.2.2",
+                    "mode": ""
+                  },
+                  "iron-list": {
+                    "npmName": "@polymer/iron-list",
+                    "npmVersion": "3.0.2",
+                    "javaVersion": "3.0.0.beta1",
+                    "jsVersion": "2.0.19",
+                    "mode": "all"
+                  },
+                  "vaadin-core": {
+                      "jsVersion": "21.0.0.alpha1",
+                      "npmName": "%s"
+                  },
+                  "react": {
+                    "react-components": {
+                      "jsVersion": "24.4.0-alpha7",
+                      "npmName": "@vaadin/react-components",
+                      "mode": "react",
+                      "exclusions": [
+                        "@vaadin/vaadin-progress-bar",
+                        "@vaadin/vaadin-upload",
+                        "@polymer/iron-list",
+                        "@vaadin/react-components-pro"
+                        ]
+                    }
+                  },
+                  "react-pro": {
+                    "react-components-pro": {
+                      "jsVersion": "24.4.0-alpha7",
+                      "npmName": "@vaadin/react-components-pro",
+                      "mode": "react"
+                    }
+                  },
+                  "platform": "foo"
+                }
+                """.formatted(VAADIN_CORE_NPM_PACKAGE);
+
+        // react enabled
+        VersionsJsonConverter convert = new VersionsJsonConverter(
+                Json.parse(json), true);
+        JsonObject convertedJson = convert.getConvertedJson();
+        Assert.assertFalse(convertedJson.hasKey("@vaadin/vaadin-progress-bar"));
+        Assert.assertFalse(convertedJson.hasKey("@vaadin/vaadin-upload"));
+        Assert.assertFalse(convertedJson.hasKey("@polymer/iron-list"));
+        Assert.assertFalse(
+                convertedJson.hasKey("@vaadin/react-components-pro"));
+        Assert.assertTrue(convertedJson.hasKey("@vaadin/react-components"));
+
+        Assert.assertFalse(convertedJson.hasKey("flow"));
+        Assert.assertFalse(convertedJson.hasKey("core"));
+        Assert.assertFalse(convertedJson.hasKey(VAADIN_CORE_NPM_PACKAGE));
+        Assert.assertFalse(convertedJson.hasKey("platform"));
+        Assert.assertFalse(convertedJson.hasKey("react"));
+        Assert.assertFalse(convertedJson.hasKey("react-pro"));
+        Assert.assertFalse(convertedJson.hasKey("react-components"));
+        Assert.assertFalse(convertedJson.hasKey("react-components-pro"));
+
+        // react disabled
+        convert = new VersionsJsonConverter(Json.parse(json), false);
+        convertedJson = convert.getConvertedJson();
+        Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-progress-bar"));
+        Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-upload"));
+        Assert.assertTrue(convertedJson.hasKey("@polymer/iron-list"));
+        Assert.assertFalse(
+                convertedJson.hasKey("@vaadin/react-components-pro"));
+        Assert.assertFalse(convertedJson.hasKey("@vaadin/react-components"));
+
+        Assert.assertFalse(convertedJson.hasKey("flow"));
+        Assert.assertFalse(convertedJson.hasKey("core"));
+        Assert.assertFalse(convertedJson.hasKey(VAADIN_CORE_NPM_PACKAGE));
+        Assert.assertFalse(convertedJson.hasKey("platform"));
+        Assert.assertFalse(convertedJson.hasKey("react"));
+        Assert.assertFalse(convertedJson.hasKey("react-pro"));
+        Assert.assertFalse(convertedJson.hasKey("react-components"));
+        Assert.assertFalse(convertedJson.hasKey("react-components-pro"));
+    }
 }


### PR DESCRIPTION
vaadin-*versions.json has "exclusions" array of npm dependencies that Flow will not add in the package.json if dependencies would be otherwise added via versions.json or NpmPackage annotations.

 Fixes: #18684
