### PR TITLE
fix: also scan changed files for routes

### DIFF
--- a/flow-tests/test-redeployment/src/test/java/com/vaadin/flow/uitest/ui/DevModeClassCacheIT.java
+++ b/flow-tests/test-redeployment/src/test/java/com/vaadin/flow/uitest/ui/DevModeClassCacheIT.java
@@ -97,7 +97,7 @@ public class DevModeClassCacheIT extends AbstractReloadIT {
 
         // Ensure newly created classes in packages not previously used for
         // routes are correctly added to the cache
-        createNewViewReloadAndWait(true);
+        createOrUpdateViewReloadAndWait(true);
 
         waitForElementPresent(By.id("last-span"));
 
@@ -115,7 +115,7 @@ public class DevModeClassCacheIT extends AbstractReloadIT {
 
         // Modify the class to remove Route annotation and ensure the package is
         // removed from route packages
-        createNewViewReloadAndWait(false);
+        createOrUpdateViewReloadAndWait(false);
         waitForElementPresent(By.id("last-span"));
         allSpans = $("span").all();
         Assert.assertEquals("Unexpected cached route packages.",
@@ -124,7 +124,7 @@ public class DevModeClassCacheIT extends AbstractReloadIT {
 
         // Modify the class to add Route annotation and ensure the package is
         // once again added to route packages
-        createNewViewReloadAndWait(true);
+        createOrUpdateViewReloadAndWait(true);
         waitForElementPresent(By.id("last-span"));
         allSpans = $("span").all();
         Assert.assertEquals("Unexpected cached route packages.",
@@ -132,8 +132,8 @@ public class DevModeClassCacheIT extends AbstractReloadIT {
                 allSpans.get(5).getText().split(":")[1]);
     }
 
-    // create class on the fly
-    protected void createNewViewReloadAndWait(boolean withRoute) {
+    // create or modify class on the fly
+    protected void createOrUpdateViewReloadAndWait(boolean withRoute) {
         String viewId = getViewId();
 
         Path baseDir = new File(System.getProperty("user.dir", ".")).toPath();

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/ReloadEvent.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/ReloadEvent.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.spring;
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * This event is fired by {@link ReloadListener} when Spring Boot DevTools is
@@ -39,5 +40,21 @@ class ReloadEvent implements Serializable {
 
     public Set<String> getRemovedClasses() {
         return removedClasses;
+    }
+
+    public Set<String> getAddedPackages() {
+        return extractPackageNames(addedClasses);
+    }
+
+    public Set<String> getChangedPackages() {
+        return extractPackageNames(changedClasses);
+    }
+
+    private Set<String> extractPackageNames(Set<String> classNames) {
+        return classNames.stream()
+                .map(name -> name.contains(".")
+                        ? name.substring(0, name.lastIndexOf("."))
+                        : name)
+                .collect(Collectors.toSet());
     }
 }

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -735,19 +735,14 @@ public class VaadinServletContextInitializer
                     ((ConfigurableApplicationContext) appContext)
                             .addApplicationListener(new ReloadListener(e -> {
                                 // Updates cached white list and route packages
-                                Set<String> addedPackages = new HashSet<>();
-                                e.getAddedClasses().forEach(c -> {
-                                    if (c.contains("/")) {
-                                        c = c.replaceAll("/", ".");
-                                    }
-                                    if (c.contains(".")) {
-                                        addedPackages.add(c.substring(0,
-                                                c.lastIndexOf(".")));
-                                    }
-                                });
                                 ReloadCache.dynamicWhiteList
-                                        .addAll(addedPackages);
-                                ReloadCache.routePackages.addAll(addedPackages);
+                                        .addAll(e.getAddedPackages());
+                                ReloadCache.dynamicWhiteList
+                                        .addAll(e.getChangedPackages());
+                                ReloadCache.routePackages
+                                        .addAll(e.getAddedPackages());
+                                ReloadCache.routePackages
+                                        .addAll(e.getChangedPackages());
                             }));
                 }
             }


### PR DESCRIPTION
Do Route scanning on packages of changed files also. Depending on the package/class structure, it some cases such change was not correctly scanned earlier.

Fixes #18794 