### PR TITLE
fix: support exclusions in bundle validation

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleValidationUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleValidationUtil.java
@@ -313,8 +313,14 @@ public final class BundleValidationUtil {
             final Map<String, String> applicationDependencies = frontendDependencies
                     .getPackages();
 
+            Map<String, String> filteredApplicationDependencies = new ExclusionFilter(
+                    options.getClassFinder(),
+                    options.isReactEnabled()
+                            && FrontendUtils.isReactModuleAvailable(options))
+                    .exclude(applicationDependencies);
+
             // Add application dependencies
-            for (Map.Entry<String, String> dep : applicationDependencies
+            for (Map.Entry<String, String> dep : filteredApplicationDependencies
                     .entrySet()) {
                 nodeUpdater.addDependency(packageJson, NodeUpdater.DEPENDENCIES,
                         dep.getKey(), dep.getValue());
@@ -331,7 +337,7 @@ public final class BundleValidationUtil {
                 // need to double check that not overriding a scanned
                 // dependency since add-ons should be able to downgrade
                 // version through exclusion
-                if (!applicationDependencies.containsKey(key)) {
+                if (!filteredApplicationDependencies.containsKey(key)) {
                     TaskUpdatePackages.pinPlatformDependency(packageJson,
                             platformPinnedDependencies, key);
                 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -1347,4 +1347,18 @@ public class FrontendUtils {
         return false;
     }
 
+    /**
+     * Is the React module available in the classpath.
+     *
+     * @return true if the React module is available, false otherwise
+     */
+    public static boolean isReactModuleAvailable(Options options) {
+        try {
+            options.getClassFinder().loadClass(
+                    "com.vaadin.flow.component.react.ReactAdapterComponent");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -175,28 +175,14 @@ public abstract class NodeUpdater implements FallibleCommand {
             VersionsJsonConverter convert = new VersionsJsonConverter(
                     Json.parse(
                             IOUtils.toString(content, StandardCharsets.UTF_8)),
-                    options.isReactEnabled() && isReactModuleAvailable());
+                    options.isReactEnabled()
+                            && FrontendUtils.isReactModuleAvailable(options));
             versionsJson = convert.getConvertedJson();
             versionsJson = new VersionsJsonFilter(getPackageJson(),
                     DEPENDENCIES)
                     .getFilteredVersions(versionsJson, versionsOrigin);
         }
         return versionsJson;
-    }
-
-    /**
-     * Is the React module available in the classpath.
-     *
-     * @return true if the React module is available, false otherwise
-     */
-    boolean isReactModuleAvailable() {
-        try {
-            options.getClassFinder().loadClass(
-                    "com.vaadin.flow.component.react.ReactAdapterComponent");
-            return true;
-        } catch (ClassNotFoundException e) {
-            return false;
-        }
     }
 
     static Set<String> getGeneratedModules(File frontendFolder) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -206,7 +206,9 @@ public class TaskUpdatePackages extends NodeUpdater {
         int added = 0;
 
         Map<String, String> filteredApplicationDependencies = new ExclusionFilter(
-                finder, options.isReactEnabled() && isReactModuleAvailable())
+                finder,
+                options.isReactEnabled()
+                        && FrontendUtils.isReactModuleAvailable(options))
                 .exclude(applicationDependencies);
 
         // Add application dependencies


### PR DESCRIPTION
When using default bundle, bundle validation should generate package.json in the same way as TaskUpdatePackages does it. With a support of `exlusions` property in the vaadin-*versions.json files.

Fixes: #18817
