### PR TITLE
fix: remove routes.tsx when React is disabled

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FileIOUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FileIOUtils.java
@@ -29,6 +29,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
@@ -180,6 +181,30 @@ public class FileIOUtils {
             }
         });
         return matchingPaths;
+    }
+
+    /**
+     * Compare two file content strings ignoring indentation and EOL characters.
+     *
+     * @param content1
+     *            the first file content to compare
+     * @param content2
+     *            the second file content to compare
+     * @param compareFn
+     *            a function to compare the normalized strings
+     * @return true if the normalized strings are equal, false otherwise
+     */
+    public static boolean compareIgnoringIndentationAndEOL(String content1,
+            String content2, BiPredicate<String, String> compareFn) {
+        return compareFn.test(replaceIndentationAndEOL(content1),
+                replaceIndentationAndEOL(content2));
+    }
+
+    // Normalize EOL and removes indentation and potential EOL at the end of the
+    // FILE
+    private static String replaceIndentationAndEOL(String text) {
+        return text.replace("\r\n", "\n").replaceFirst("\n$", "")
+                .replaceAll("(?m)^\\s+", "");
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -282,9 +282,7 @@ public class NodeTasks implements FallibleCommand {
         if (options.isProductionMode() || options.isFrontendHotdeploy()
                 || options.isBundleBuild()) {
             commands.add(new TaskGenerateIndexTs(options));
-            if (options.isReactEnabled()) {
-                commands.add(new TaskGenerateReactFiles(options));
-            }
+            commands.add(new TaskGenerateReactFiles(options));
             if (!options.isProductionMode()) {
                 commands.add(new TaskGenerateViteDevMode(options));
             }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
@@ -145,7 +145,8 @@ public class TaskGenerateReactFiles implements FallibleCommand {
                         getFileContent(FrontendUtils.ROUTES_TSX),
                         String::equals)) {
                     routesTsx.delete();
-                    log().debug("Default routes.tsx file has been removed.");
+                    log().debug("Default {} file has been removed.",
+                            FrontendUtils.ROUTES_TSX);
                 } else {
                     Files.copy(routesTsx.toPath(),
                             new File(frontendDirectory,
@@ -159,7 +160,8 @@ public class TaskGenerateReactFiles implements FallibleCommand {
                 }
             }
         } catch (IOException e) {
-            throw new ExecutionFailedException("Failed to clean routes.tsx", e);
+            throw new ExecutionFailedException(
+                    "Failed to clean " + FrontendUtils.ROUTES_TSX, e);
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
@@ -155,8 +155,8 @@ public class TaskGenerateReactFiles implements FallibleCommand {
                             StandardCopyOption.REPLACE_EXISTING);
                     routesTsx.delete();
                     log().warn(
-                            "Custom routes.tsx file has been removed. Backup is created in {}.flowBackup file.",
-                            FrontendUtils.ROUTES_TSX);
+                            "Custom {} file has been removed. Backup is created in {}.flowBackup file.",
+                            FrontendUtils.ROUTES_TSX, FrontendUtils.ROUTES_TSX);
                 }
             }
         } catch (IOException e) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsDefinitions.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsDefinitions.java
@@ -21,7 +21,6 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.function.BiPredicate;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.IOUtils;
@@ -29,6 +28,7 @@ import org.apache.commons.io.IOUtils;
 import com.vaadin.flow.server.ExecutionFailedException;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static com.vaadin.flow.server.frontend.FileIOUtils.compareIgnoringIndentationAndEOL;
 
 /**
  * Generate <code>types.d.ts</code> if it is missing in project folder and
@@ -225,19 +225,6 @@ public class TaskGenerateTsDefinitions extends AbstractTaskClientGenerator {
 
     private static String removeComments(String content) {
         return COMMENT_LINE.matcher(content).replaceAll("");
-    }
-
-    private static boolean compareIgnoringIndentationAndEOL(String content1,
-            String content2, BiPredicate<String, String> compareFn) {
-        return compareFn.test(replaceIndentationAndEOL(content1),
-                replaceIndentationAndEOL(content2));
-    }
-
-    // Normalize EOL and removes indentation and potential EOL at the end of the
-    // FILE
-    static String replaceIndentationAndEOL(String text) {
-        return text.replace("\r\n", "\n").replaceFirst("\n$", "")
-                .replaceAll("(?m)^\\s+", "");
     }
 
     private String getTemplateContent(String suffix) throws IOException {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateReactFilesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateReactFilesTest.java
@@ -265,6 +265,40 @@ public class TaskGenerateReactFilesTest {
                 exception.getMessage());
     }
 
+    @Test
+    public void frontendReactFilesAreCleanedWhenReactIsDisabled()
+            throws ExecutionFailedException {
+        TaskGenerateReactFiles task = new TaskGenerateReactFiles(options);
+        task.execute();
+
+        options.withReact(false);
+        task.execute();
+
+        Assert.assertFalse(
+                "./frontend/routes.tsx should be removed when react is disabled",
+                new File(frontend, "routes.tsx").exists());
+        Assert.assertFalse(
+                "./frontend/routes.tsx.flowBackup should not be created with default content",
+                new File(frontend, "routes.tsx.flowBackup").exists());
+    }
+
+    @Test
+    public void frontendCustomReactFilesAreCleanedAndBackUppedWhenReactIsDisabled()
+            throws ExecutionFailedException, IOException {
+        TaskGenerateReactFiles task = new TaskGenerateReactFiles(options);
+        task.execute();
+        FileUtils.write(routesTsx, "Custom content", StandardCharsets.UTF_8);
+
+        options.withReact(false);
+        task.execute();
+
+        Assert.assertFalse(
+                "./frontend/routes.tsx should be removed when react is disabled",
+                new File(frontend, "routes.tsx").exists());
+        Assert.assertTrue("./frontend/routes.tsx.flowBackup should exist",
+                new File(frontend, "routes.tsx.flowBackup").exists());
+    }
+
     @Tag("div")
     @Route("test")
     private class TestRoute extends Component {


### PR DESCRIPTION
When reactEnable=false, TaskGenerateReactFiles removes routes.tsx. If routes.tsx doesn't match the default generated content, then a backup file is created.

Fixes: #18810