### PR TITLE
fix: fix path depending on frontent folder

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
@@ -275,8 +275,10 @@ public class DevModeInitializer implements Serializable {
 
         String frontendGeneratedFolderName = config.getStringProperty(
                 PROJECT_FRONTEND_GENERATED_DIR_TOKEN,
-                Paths.get(baseDir.getAbsolutePath(), frontendFolder, GENERATED)
-                        .toString());
+                new File(frontendFolder).isAbsolute()
+                        ? Paths.get(frontendFolder, GENERATED).toString()
+                        : Paths.get(baseDir.getAbsolutePath(), frontendFolder,
+                                GENERATED).toString());
         File frontendGeneratedFolder = new File(frontendGeneratedFolderName);
         File jarFrontendResourcesFolder = new File(frontendGeneratedFolder,
                 FrontendUtils.JAR_RESOURCES_FOLDER);


### PR DESCRIPTION
Check if the frontend folder
is absolute or not so that we
do not end up with a path like:
`C:\Users\user\example\C:\Users\user\example\.\frontend\generated/`
