### PR TITLE
feat: add file system router plugin for vite

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateVite.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateVite.java
@@ -43,6 +43,8 @@ public class TaskUpdateVite implements FallibleCommand, Serializable {
             getSimplifiedTemplate("vite.config-react.ts"),
             getSimplifiedTemplate("vite.config-react-swc.ts") };
 
+    private static final String FILE_SYSTEM_ROUTER_DEPENDENCY = "@vaadin/hilla-file-router/vite-plugin.js";
+
     TaskUpdateVite(Options options, Set<String> webComponentTags) {
         this.options = options;
         this.webComponentTags = webComponentTags;
@@ -126,9 +128,25 @@ public class TaskUpdateVite implements FallibleCommand, Serializable {
                         webComponentTags == null || webComponentTags.isEmpty()
                                 ? ""
                                 : String.join(";", webComponentTags));
+        template = updateFileSystemRouterVitePlugin(template);
+
         FileIOUtils.writeIfChanged(generatedConfigFile, template);
         log().debug("Created vite generated configuration file: '{}'",
                 generatedConfigFile);
+    }
+
+    private String updateFileSystemRouterVitePlugin(String template) {
+        if (options.isReactEnabled() && FrontendUtils.isHillaUsed(
+                options.getFrontendDirectory(), options.getClassFinder())) {
+            return template
+                    .replace("//#vitePluginFileSystemRouterImport#",
+                            "import vitePluginFileSystemRouter from '"
+                                    + FILE_SYSTEM_ROUTER_DEPENDENCY + "';")
+                    .replace("//#vitePluginFileSystemRouter#",
+                            ", vitePluginFileSystemRouter()");
+        }
+        return template.replace("//#vitePluginFileSystemRouterImport#", "")
+                .replace("//#vitePluginFileSystemRouter#", "");
     }
 
     private Logger log() {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateVite.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateVite.java
@@ -43,7 +43,7 @@ public class TaskUpdateVite implements FallibleCommand, Serializable {
             getSimplifiedTemplate("vite.config-react.ts"),
             getSimplifiedTemplate("vite.config-react-swc.ts") };
 
-    private static final String FILE_SYSTEM_ROUTER_DEPENDENCY = "@vaadin/hilla-file-router/vite-plugin.js";
+    static final String FILE_SYSTEM_ROUTER_DEPENDENCY = "@vaadin/hilla-file-router/vite-plugin.js";
 
     TaskUpdateVite(Options options, Set<String> webComponentTags) {
         this.options = options;

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
@@ -19,6 +19,7 @@
     "rollup-plugin-brotli": "3.1.0",
     "vite-plugin-checker": "0.6.4",
     "workbox-build": "7.0.0",
-    "transform-ast": "2.4.4"
+    "transform-ast": "2.4.4",
+    "@vaadin/hilla-file-router": "24.4.0-alpha7"
   }
 }

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
@@ -19,7 +19,6 @@
     "rollup-plugin-brotli": "3.1.0",
     "vite-plugin-checker": "0.6.4",
     "workbox-build": "7.0.0",
-    "transform-ast": "2.4.4",
-    "@vaadin/hilla-file-router": "24.4.0-alpha7"
+    "transform-ast": "2.4.4"
   }
 }

--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -36,6 +36,8 @@ import { createRequire } from 'module';
 import { visualizer } from 'rollup-plugin-visualizer';
 import reactPlugin from '@vitejs/plugin-react';
 
+//#vitePluginFileSystemRouterImport#
+
 // Make `require` compatible with ES modules
 const require = createRequire(import.meta.url);
 
@@ -846,6 +848,7 @@ export const vaadinConfig: UserConfigFn = (env) => {
         typescript: true
       }),
       productionMode && visualizer({ brotliSize: true, filename: bundleSizeFile })
+      //#vitePluginFileSystemRouter#
     ]
   };
 };

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateViteTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateViteTest.java
@@ -9,13 +9,15 @@ import java.util.regex.Pattern;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 
-import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.server.PwaConfiguration;
+import com.vaadin.flow.server.frontend.scanner.ClassFinder;
+import com.vaadin.tests.util.MockOptions;
 
 import elemental.json.Json;
 import elemental.json.JsonObject;
@@ -26,10 +28,20 @@ public class TaskUpdateViteTest {
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
+    private ClassFinder finder;
+
+    private Options options;
+
+    @Before
+    public void setUp() throws IOException {
+        finder = Mockito.spy(new ClassFinder.DefaultClassFinder(
+                this.getClass().getClassLoader()));
+        options = new MockOptions(finder, temporaryFolder.getRoot())
+                .withBuildDirectory("build");
+    }
+
     @Test
     public void generatedTemplate_correctSettingsPath() throws IOException {
-        Options options = new Options(Mockito.mock(Lookup.class),
-                temporaryFolder.getRoot()).withBuildDirectory("build");
         TaskUpdateVite task = new TaskUpdateVite(options, null);
         task.execute();
 
@@ -49,8 +61,6 @@ public class TaskUpdateViteTest {
                 FrontendUtils.VITE_CONFIG);
         final String importString = "Hello Fake configuration";
         FileUtils.write(configFile, importString, StandardCharsets.UTF_8);
-        Options options = new Options(Mockito.mock(Lookup.class),
-                temporaryFolder.getRoot()).withBuildDirectory("build");
 
         new TaskUpdateVite(options, null).execute();
 
@@ -70,9 +80,6 @@ public class TaskUpdateViteTest {
         FileUtils.write(generatedConfigFile, importString,
                 StandardCharsets.UTF_8);
 
-        Options options = new Options(Mockito.mock(Lookup.class),
-                temporaryFolder.getRoot()).withBuildDirectory("build");
-
         new TaskUpdateVite(options, null).execute();
 
         String template = IOUtils.toString(generatedConfigFile.toURI(),
@@ -85,9 +92,6 @@ public class TaskUpdateViteTest {
     @Test
     public void usedSettings_matchThoseCreatedToSettingsFile()
             throws IOException {
-        Options options = new Options(Mockito.mock(Lookup.class),
-                temporaryFolder.getRoot()).withBuildDirectory("build");
-
         TaskUpdateVite task = new TaskUpdateVite(options, null);
         task.execute();
 

--- a/flow-server/src/test/resources/com/vaadin/flow/server/frontend/dependencies/hilla/components/react/package.json
+++ b/flow-server/src/test/resources/com/vaadin/flow/server/frontend/dependencies/hilla/components/react/package.json
@@ -11,9 +11,11 @@
   "dependencies": {
     "@vaadin/hilla-react-auth": "24.4.0-alpha2",
     "@vaadin/hilla-react-crud": "24.4.0-alpha2",
-    "@vaadin/hilla-react-form": "24.4.0-alpha2"
+    "@vaadin/hilla-react-form": "24.4.0-alpha2",
+    "@vaadin/hilla-file-router": "24.4.0-alpha2"
   },
   "devDependencies": {
-    "react-dev-dependency": "1.0.0"
+    "react-dev-dependency": "1.0.0",
+    "@vaadin/hilla-file-router": "24.4.0-alpha2"
   }
 }

--- a/flow-server/src/test/resources/com/vaadin/flow/server/frontend/dependencies/hilla/components/react/package.json
+++ b/flow-server/src/test/resources/com/vaadin/flow/server/frontend/dependencies/hilla/components/react/package.json
@@ -15,7 +15,6 @@
     "@vaadin/hilla-file-router": "24.4.0-alpha2"
   },
   "devDependencies": {
-    "react-dev-dependency": "1.0.0",
-    "@vaadin/hilla-file-router": "24.4.0-alpha2"
+    "react-dev-dependency": "1.0.0"
   }
 }


### PR DESCRIPTION
Adds vitePluginFileSystemRouter to Vite plugins by default when React and Hilla is in use.

Fixes: #18832
