### PR TITLE
test: Add tests for legacy frontend folder detection in app configuration

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
@@ -152,11 +152,8 @@ public class PropertyDeploymentConfiguration
     @Override
     public boolean frontendHotdeploy() {
         if (isOwnProperty(FRONTEND_HOTDEPLOY)) {
-            File frontendDirectory = FrontendUtils
-                    .getLegacyFrontendFolderIfExists(getProjectFolder(),
-                            FrontendUtils.getProjectFrontendDir(this));
             return getBooleanProperty(FRONTEND_HOTDEPLOY,
-                    FrontendUtils.isHillaUsed(frontendDirectory));
+                    FrontendUtils.isHillaUsed(getFrontendFolder()));
         }
         return parentConfig.frontendHotdeploy();
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
@@ -152,8 +152,11 @@ public class PropertyDeploymentConfiguration
     @Override
     public boolean frontendHotdeploy() {
         if (isOwnProperty(FRONTEND_HOTDEPLOY)) {
-            return getBooleanProperty(FRONTEND_HOTDEPLOY, FrontendUtils
-                    .isHillaUsed(FrontendUtils.getProjectFrontendDir(this)));
+            File frontendDirectory = FrontendUtils
+                    .getLegacyFrontendFolderIfExists(getProjectFolder(),
+                            FrontendUtils.getProjectFrontendDir(this));
+            return getBooleanProperty(FRONTEND_HOTDEPLOY,
+                    FrontendUtils.isHillaUsed(frontendDirectory));
         }
         return parentConfig.frontendHotdeploy();
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/DefaultDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DefaultDeploymentConfigurationTest.java
@@ -15,14 +15,21 @@
  */
 package com.vaadin.flow.server;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Properties;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import com.vaadin.flow.internal.hilla.EndpointRequestUtil;
+import com.vaadin.flow.server.frontend.FrontendUtils;
 import com.vaadin.flow.server.startup.ApplicationConfiguration;
 
 import static org.hamcrest.Matchers.is;
@@ -38,6 +45,9 @@ import static org.junit.Assert.assertTrue;
  * @since 1.0
  */
 public class DefaultDeploymentConfigurationTest {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
 
     VaadinContext context;
 
@@ -287,6 +297,37 @@ public class DefaultDeploymentConfigurationTest {
         Assert.assertFalse(
                 "Frontend hotdeploy should return false in production mode",
                 config.frontendHotdeploy());
+    }
+
+    @Test
+    public void frontendHotDeploy_legacyFrontendFolderExists_usesLegacy()
+            throws IOException {
+        File projectRoot = tempFolder.getRoot();
+        File legacyFrontend = tempFolder
+                .newFolder(FrontendUtils.LEGACY_FRONTEND_DIR);
+
+        File legacyFrontendViews = new File(legacyFrontend,
+                FrontendUtils.HILLA_VIEWS_PATH);
+        if (!legacyFrontendViews.mkdir()) {
+            Assert.fail("Failed to generate legacy frontend views folder");
+        }
+
+        File viewFile = new File(legacyFrontendViews, "MyView.tsx");
+        org.apache.commons.io.FileUtils.writeStringToFile(viewFile,
+                "export default function MyView(){}", "UTF-8");
+
+        try (MockedStatic<EndpointRequestUtil> util = Mockito
+                .mockStatic(EndpointRequestUtil.class)) {
+            util.when(EndpointRequestUtil::isHillaAvailable).thenReturn(true);
+            Properties init = new Properties();
+            init.put(FrontendUtils.PROJECT_BASEDIR,
+                    projectRoot.getAbsolutePath());
+            DefaultDeploymentConfiguration config = createDeploymentConfig(
+                    init);
+            boolean hotdeploy = config.frontendHotdeploy();
+            Assert.assertTrue("Should use the legacy frontend folder",
+                    hotdeploy);
+        }
     }
 
     private DefaultDeploymentConfiguration createDeploymentConfig(

--- a/flow-server/src/test/java/com/vaadin/flow/server/DefaultDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DefaultDeploymentConfigurationTest.java
@@ -349,6 +349,13 @@ public class DefaultDeploymentConfigurationTest {
     private ApplicationConfiguration setupAppConfig() {
         ApplicationConfiguration appConfig = Mockito
                 .mock(ApplicationConfiguration.class);
+        Mockito.when(appConfig.getFrontendFolder()).thenCallRealMethod();
+        Mockito.when(
+                appConfig.getStringProperty(FrontendUtils.PARAM_FRONTEND_DIR,
+                        FrontendUtils.DEFAULT_FRONTEND_DIR))
+                .thenReturn(FrontendUtils.DEFAULT_FRONTEND_DIR);
+        Mockito.when(appConfig.getProjectFolder())
+                .thenReturn(tempFolder.getRoot());
         Mockito.when(appConfig.getContext()).thenReturn(context);
         return appConfig;
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/DefaultDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DefaultDeploymentConfigurationTest.java
@@ -300,7 +300,7 @@ public class DefaultDeploymentConfigurationTest {
     }
 
     @Test
-    public void frontendHotDeploy_legacyFrontendFolderExists_usesLegacy()
+    public void frontendHotDeploy_hillaInLegacyFrontendFolderExists_usesLegacyAndHotdeploy()
             throws IOException {
         File projectRoot = tempFolder.getRoot();
         File legacyFrontend = tempFolder

--- a/flow-server/src/test/java/com/vaadin/flow/server/PropertyDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/PropertyDeploymentConfigurationTest.java
@@ -15,17 +15,28 @@
  */
 package com.vaadin.flow.server;
 
+import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.Properties;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import com.vaadin.flow.internal.hilla.EndpointRequestUtil;
+import com.vaadin.flow.server.frontend.FrontendUtils;
 import com.vaadin.flow.server.startup.ApplicationConfiguration;
 
 public class PropertyDeploymentConfigurationTest {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
 
     @Test
     public void isProductionMode_modeIsProvidedViaParentOnly_valueFromParentIsReturned() {
@@ -368,6 +379,71 @@ public class PropertyDeploymentConfigurationTest {
                     + ", so every API method should call parent config and may not use just default implementation of "
                     + AbstractConfiguration.class, AbstractConfiguration.class,
                     method.getDeclaringClass());
+        }
+    }
+
+    @Test
+    public void frontendHotDeploy_legacyFrontendFolderExists_usesLegacy()
+            throws IOException {
+        File projectRoot = tempFolder.getRoot();
+        File legacyFrontend = tempFolder
+                .newFolder(FrontendUtils.LEGACY_FRONTEND_DIR);
+
+        File legacyFrontendViews = new File(legacyFrontend,
+                FrontendUtils.HILLA_VIEWS_PATH);
+        if (!legacyFrontendViews.mkdir()) {
+            Assert.fail("Failed to generate legacy frontend views folder");
+        }
+
+        File viewFile = new File(legacyFrontendViews, "MyView.tsx");
+        org.apache.commons.io.FileUtils.writeStringToFile(viewFile,
+                "export default function MyView(){}", "UTF-8");
+
+        ApplicationConfiguration appConfig = new ApplicationConfiguration() {
+
+            @Override
+            public File getProjectFolder() {
+                return projectRoot;
+            }
+
+            @Override
+            public Enumeration<String> getPropertyNames() {
+                return Collections.emptyEnumeration();
+            }
+
+            @Override
+            public VaadinContext getContext() {
+                return null;
+            }
+
+            @Override
+            public boolean isDevModeSessionSerializationEnabled() {
+                return false;
+            }
+
+            @Override
+            public boolean isProductionMode() {
+                return false;
+            }
+
+            @Override
+            public String getStringProperty(String name, String defaultValue) {
+                return defaultValue;
+            }
+
+            @Override
+            public boolean getBooleanProperty(String name,
+                    boolean defaultValue) {
+                return defaultValue;
+            }
+        };
+
+        try (MockedStatic<EndpointRequestUtil> util = Mockito
+                .mockStatic(EndpointRequestUtil.class)) {
+            util.when(EndpointRequestUtil::isHillaAvailable).thenReturn(true);
+            boolean hotdeploy = appConfig.frontendHotdeploy();
+            Assert.assertTrue("Should use the legacy frontend folder",
+                    hotdeploy);
         }
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/PropertyDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/PropertyDeploymentConfigurationTest.java
@@ -383,7 +383,7 @@ public class PropertyDeploymentConfigurationTest {
     }
 
     @Test
-    public void frontendHotDeploy_legacyFrontendFolderExists_usesLegacy()
+    public void frontendHotDeploy_hillaInLegacyFrontendFolderExists_usesLegacyAndHotdeploy()
             throws IOException {
         File projectRoot = tempFolder.getRoot();
         File legacyFrontend = tempFolder


### PR DESCRIPTION
Plugin mojo and task changes aren't covered as for some reason static mocking of endpoint utils doesn't work.