### PR TITLE
fix: Frontend folder is always correctly checked

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/AbstractConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AbstractConfiguration.java
@@ -54,10 +54,22 @@ public interface AbstractConfiguration extends Serializable {
         if (isProductionMode()) {
             return false;
         }
-        File frontendDirectory = FrontendUtils.getLegacyFrontendFolderIfExists(
-                getProjectFolder(), FrontendUtils.getProjectFrontendDir(this));
         return getBooleanProperty(InitParameters.FRONTEND_HOTDEPLOY,
-                FrontendUtils.isHillaUsed(frontendDirectory));
+                FrontendUtils.isHillaUsed(getFrontendFolder()));
+    }
+
+    default File getFrontendFolder() {
+        String frontendFolderPath = getStringProperty(
+                FrontendUtils.PARAM_FRONTEND_DIR,
+                FrontendUtils.DEFAULT_FRONTEND_DIR);
+
+        File frontend = new File(frontendFolderPath);
+        if (!frontend.isAbsolute()) {
+            frontend = new File(getProjectFolder(), frontendFolderPath);
+        }
+
+        return FrontendUtils.getLegacyFrontendFolderIfExists(getProjectFolder(),
+                frontend);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
@@ -444,9 +444,7 @@ public class DefaultDeploymentConfiguration
     }
 
     private boolean automaticHotdeployDefault() {
-        File frontendDir = FrontendUtils.getLegacyFrontendFolderIfExists(
-                getProjectFolder(), FrontendUtils.getProjectFrontendDir(this));
-        return FrontendUtils.isHillaUsed(frontendDir);
+        return FrontendUtils.isHillaUsed(getFrontendFolder());
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
@@ -159,6 +159,11 @@ public class PropertyDeploymentConfiguration
     }
 
     @Override
+    public File getFrontendFolder() {
+        return parentConfig.getFrontendFolder();
+    }
+
+    @Override
     public boolean isPnpmEnabled() {
         if (isOwnProperty(InitParameters.SERVLET_PARAMETER_ENABLE_PNPM)) {
             return super.isPnpmEnabled();

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -593,7 +593,7 @@ public class FrontendUtils {
     public static File resolveFrontendPath(File projectRoot,
             DeploymentConfiguration deploymentConfiguration, String path) {
         return resolveFrontendPath(projectRoot, path,
-                getFrontendFolder(projectRoot, deploymentConfiguration));
+                deploymentConfiguration.getFrontendFolder());
     }
 
     /**
@@ -615,20 +615,6 @@ public class FrontendUtils {
             }
         }
         return frontendDir;
-    }
-
-    private static File getFrontendFolder(File projectRoot,
-            AbstractConfiguration deploymentConfiguration) {
-        String frontendFolderPath = deploymentConfiguration.getStringProperty(
-                FrontendUtils.PARAM_FRONTEND_DIR,
-                FrontendUtils.DEFAULT_FRONTEND_DIR);
-
-        File f = new File(frontendFolderPath);
-        if (f.isAbsolute()) {
-            return f;
-        }
-
-        return new File(projectRoot, frontendFolderPath);
     }
 
     /**
@@ -717,8 +703,7 @@ public class FrontendUtils {
      */
     public static File getProjectFrontendDir(
             AbstractConfiguration configuration) {
-        return getFrontendFolder(configuration.getProjectFolder(),
-                configuration);
+        return configuration.getFrontendFolder();
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/ThemeUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/ThemeUtils.java
@@ -78,15 +78,15 @@ public class ThemeUtils {
             return getThemeAnnotation(context).map(Theme::value);
         } else {
             File themeJs;
-            String frontendFolderPath = config.getStringProperty(
-                    FrontendUtils.PARAM_FRONTEND_DIR,
-                    FrontendUtils.DEFAULT_FRONTEND_DIR);
-            if (frontendFolderPath.startsWith("./")) {
-                themeJs = Paths.get(config.getProjectFolder().getPath(),
-                        frontendFolderPath, FrontendUtils.GENERATED,
-                        FrontendUtils.THEME_IMPORTS_NAME).toFile();
+            File frontendFolder = config.getFrontendFolder();
+            if (frontendFolder.isAbsolute()) {
+                themeJs = Paths
+                        .get(frontendFolder.getPath(), FrontendUtils.GENERATED,
+                                FrontendUtils.THEME_IMPORTS_NAME)
+                        .toFile();
             } else {
-                themeJs = Paths.get(frontendFolderPath, FrontendUtils.GENERATED,
+                themeJs = Paths.get(config.getProjectFolder().getPath(),
+                        frontendFolder.getPath(), FrontendUtils.GENERATED,
                         FrontendUtils.THEME_IMPORTS_NAME).toFile();
             }
             if (!themeJs.exists()) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
@@ -1210,8 +1210,8 @@ public class StaticFileServerTest implements Serializable {
         Mockito.when(configuration.getProjectFolder())
                 .thenReturn(projectRootFolder);
         Mockito.when(configuration.getBuildFolder()).thenReturn("target");
-        Mockito.when(configuration.getStringProperty(PARAM_FRONTEND_DIR,
-                DEFAULT_FRONTEND_DIR)).thenReturn(DEFAULT_FRONTEND_DIR);
+        Mockito.when(configuration.getFrontendFolder())
+                .thenReturn(new File(projectRootFolder, DEFAULT_FRONTEND_DIR));
 
         setupRequestURI("", "", "/VAADIN/themes/my-theme/styles.css");
         Assert.assertTrue(fileServer.serveStaticResource(request, response));

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
@@ -83,11 +83,7 @@ import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
 import static com.vaadin.flow.server.Constants.VAADIN_WEBAPP_RESOURCES;
 import static com.vaadin.flow.server.InitParameters.REACT_ENABLE;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE;
-import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
-import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_PROJECT_FRONTEND_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.GENERATED;
-import static com.vaadin.flow.server.frontend.FrontendUtils.LEGACY_FRONTEND_DIR;
-import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_FRONTEND_DIR;
 
 /**
  * Initializer for starting node updaters as well as the dev mode server.
@@ -208,24 +204,14 @@ public class DevModeInitializer implements Serializable {
                     new StatisticsSender(storage));
         }
 
-        String frontendFolder = config.getStringProperty(PARAM_FRONTEND_DIR,
-                System.getProperty(PARAM_FRONTEND_DIR, DEFAULT_FRONTEND_DIR));
-
-        // If new default frontend folder not exists check for legacy folder.
-        if (frontendFolder.endsWith(DEFAULT_FRONTEND_DIR)
-                && !new File(frontendFolder).exists()) {
-            File legacy = new File(baseDir, LEGACY_FRONTEND_DIR);
-            if (legacy.exists()) {
-                frontendFolder = LEGACY_FRONTEND_DIR;
-            }
-        }
+        File frontendFolder = config.getFrontendFolder();
 
         Lookup lookupFromContext = context.getAttribute(Lookup.class);
         Lookup lookupForClassFinder = Lookup.of(new DevModeClassFinder(classes),
                 ClassFinder.class);
         Lookup lookup = Lookup.compose(lookupForClassFinder, lookupFromContext);
         Options options = new Options(lookup, baseDir)
-                .withFrontendDirectory(new File(frontendFolder))
+                .withFrontendDirectory(frontendFolder)
                 .withFrontendGeneratedFolder(
                         new File(frontendFolder + GENERATED))
                 .withBuildDirectory(config.getBuildFolder());
@@ -275,10 +261,7 @@ public class DevModeInitializer implements Serializable {
 
         String frontendGeneratedFolderName = config.getStringProperty(
                 PROJECT_FRONTEND_GENERATED_DIR_TOKEN,
-                new File(frontendFolder).isAbsolute()
-                        ? Paths.get(frontendFolder, GENERATED).toString()
-                        : Paths.get(baseDir.getAbsolutePath(), frontendFolder,
-                                GENERATED).toString());
+                Paths.get(frontendFolder.getPath(), GENERATED).toString());
         File frontendGeneratedFolder = new File(frontendGeneratedFolderName);
         File jarFrontendResourcesFolder = new File(frontendGeneratedFolder,
                 FrontendUtils.JAR_RESOURCES_FOLDER);

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/AbstractDevModeTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/AbstractDevModeTest.java
@@ -118,7 +118,7 @@ public abstract class AbstractDevModeTest {
     private void mockApplicationConfiguration(
             ApplicationConfiguration appConfig, boolean enablePnpm) {
         Mockito.when(appConfig.getStringProperty(Mockito.anyString(),
-                        Mockito.anyString()))
+                Mockito.anyString()))
                 .thenAnswer(invocation -> invocation.getArgument(1));
         Mockito.when(appConfig.isProductionMode()).thenReturn(false);
         try (MockedStatic<FrontendUtils> util = Mockito

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/AbstractDevModeTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/AbstractDevModeTest.java
@@ -117,6 +117,9 @@ public abstract class AbstractDevModeTest {
 
     private void mockApplicationConfiguration(
             ApplicationConfiguration appConfig, boolean enablePnpm) {
+        Mockito.when(appConfig.getStringProperty(Mockito.anyString(),
+                        Mockito.anyString()))
+                .thenAnswer(invocation -> invocation.getArgument(1));
         Mockito.when(appConfig.isProductionMode()).thenReturn(false);
         try (MockedStatic<FrontendUtils> util = Mockito
                 .mockStatic(FrontendUtils.class)) {
@@ -126,9 +129,6 @@ public abstract class AbstractDevModeTest {
         }
         Mockito.when(appConfig.isPnpmEnabled()).thenReturn(enablePnpm);
 
-        Mockito.when(appConfig.getStringProperty(Mockito.anyString(),
-                Mockito.anyString()))
-                .thenAnswer(invocation -> invocation.getArgument(1));
         Mockito.when(appConfig.getBooleanProperty(Mockito.anyString(),
                 Mockito.anyBoolean()))
                 .thenAnswer(invocation -> invocation.getArgument(1));


### PR DESCRIPTION
Fixes frontend folder check
so that it is correctly gotten
from configuration even when no
buildInfo is available.

Fixs #18894