### PR TITLE
Adjust message with no routes

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/router/NoRoutesError_dev.html
+++ b/flow-server/src/main/resources/com/vaadin/flow/router/NoRoutesError_dev.html
@@ -2,8 +2,8 @@
     <h3>No views found</h3>
     <p>To get started, you can either</p>
     <ul>
-        <li><a href onclick="window.Vaadin.copilot.initEmptyApp('flow')">Create a view for coding the UI in Java/Flow</a></li>
-        <li><a href onclick="window.Vaadin.copilot.initEmptyApp('hilla')">Create a view for coding the UI in Hilla/React</a></li>
+        <li><a href onclick="window.Vaadin.copilot.initEmptyApp('flow')">Create a view for coding the UI in Java with Flow</a></li>
+        <li><a href onclick="window.Vaadin.copilot.initEmptyApp('hilla')">Create a view for coding the UI in TypeScript with Hilla and React</a></li>
     </ul>
     <p>
         You can also create a view manually in your IDE, see <a target="_blank" href="https://vaadin.com/docs/latest/tutorial">the tutorial</a>


### PR DESCRIPTION
Update the message to present the options in a consistent way: in [language] with [framework(s)]
