### PR TITLE
feat: generate routes.tsx in Frontend/generated

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -236,6 +236,8 @@ public class FrontendUtils {
 
     public static final String ROUTES_TSX = "routes.tsx";
 
+    public static final String ROUTES_JS = "routes.js";
+
     public static final String VIEWS_TS = "views.ts";
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateIndexTs.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateIndexTs.java
@@ -20,10 +20,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 
 import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.Version;
 
 import static com.vaadin.flow.server.frontend.FrontendUtils.INDEX_JS;
@@ -40,6 +42,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  */
 public class TaskGenerateIndexTs extends AbstractTaskClientGenerator {
 
+    private static final String ROUTES_JS_IMPORT_PATH_TOKEN = "%routesJsImportPath%";
+
     private final File frontendDirectory;
     private Options options;
 
@@ -52,6 +56,22 @@ public class TaskGenerateIndexTs extends AbstractTaskClientGenerator {
     TaskGenerateIndexTs(Options options) {
         this.frontendDirectory = options.getFrontendDirectory();
         this.options = options;
+    }
+
+    @Override
+    public void execute() throws ExecutionFailedException {
+        if (!shouldGenerate()) {
+            cleanup();
+            return;
+        }
+        File generatedFile = getGeneratedFile();
+        try {
+            FileIOUtils.writeIfChanged(generatedFile, getFileContent());
+        } catch (IOException exception) {
+            String errorMessage = String.format("Error writing '%s'",
+                    generatedFile);
+            throw new ExecutionFailedException(errorMessage, exception);
+        }
     }
 
     @Override
@@ -84,8 +104,24 @@ public class TaskGenerateIndexTs extends AbstractTaskClientGenerator {
         try (InputStream indexTsStream = getClass()
                 .getResourceAsStream(indexFile)) {
             indexTemplate = IOUtils.toString(indexTsStream, UTF_8);
+            if (options.isReactEnabled()) {
+                File routesTsx = new File(frontendDirectory,
+                        FrontendUtils.ROUTES_TSX);
+                indexTemplate = indexTemplate.replace(
+                        ROUTES_JS_IMPORT_PATH_TOKEN,
+                        (routesTsx.exists())
+                                ? FrontendUtils.FRONTEND_FOLDER_ALIAS
+                                        + FrontendUtils.ROUTES_JS
+                                : FrontendUtils.FRONTEND_FOLDER_ALIAS
+                                        + FrontendUtils.GENERATED
+                                        + FrontendUtils.ROUTES_JS);
+            }
         }
         return indexTemplate;
+    }
+
+    private void cleanup() {
+        FileUtils.deleteQuietly(getGeneratedFile());
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
@@ -210,14 +210,17 @@ public class TaskGenerateReactFiles implements FallibleCommand {
         }
     }
 
-    private String getFlowTsxFileContent(boolean frontendRoutesTsExists) throws IOException {
-        String content = getFileContent(FLOW_TSX).replace(ROUTES_JS_IMPORT_PATH_TOKEN,
+    private String getFlowTsxFileContent(boolean frontendRoutesTsExists)
+            throws IOException {
+        String content = getFileContent(FLOW_TSX).replace(
+                ROUTES_JS_IMPORT_PATH_TOKEN,
                 (frontendRoutesTsExists)
                         ? FrontendUtils.FRONTEND_FOLDER_ALIAS
-                        + FrontendUtils.ROUTES_JS
+                                + FrontendUtils.ROUTES_JS
                         : FrontendUtils.FRONTEND_FOLDER_ALIAS
-                        + FrontendUtils.GENERATED
-                        + FrontendUtils.ROUTES_JS);;
+                                + FrontendUtils.GENERATED
+                                + FrontendUtils.ROUTES_JS);
+        ;
         if (FrontendUtils.isHillaUsed(options.getFrontendDirectory(),
                 options.getClassFinder())) {
             return content.replace("//%toReactRouterImport%",

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
@@ -97,7 +97,7 @@ public class TaskGenerateReactFiles implements FallibleCommand {
     private static final String REACT_ADAPTER_TSX = "ReactAdapter.tsx";
     static final String FLOW_FLOW_TSX = "flow/" + FLOW_TSX;
     static final String FLOW_REACT_ADAPTER_TSX = "flow/" + REACT_ADAPTER_TSX;
-
+    private static final String ROUTES_JS_IMPORT_PATH_TOKEN = "%routesJsImportPath%";
     static final String VIEWS_TS_FALLBACK = """
             const routes = { path: "", module: undefined, children: [] };
             export default routes;
@@ -136,8 +136,10 @@ public class TaskGenerateReactFiles implements FallibleCommand {
         File reactAdapterTsx = new File(frontendGeneratedFolder,
                 FLOW_REACT_ADAPTER_TSX);
         File routesTsx = new File(frontendDirectory, FrontendUtils.ROUTES_TSX);
+        File frontendGeneratedFolderRoutesTsx = new File(
+                frontendGeneratedFolder, FrontendUtils.ROUTES_TSX);
         try {
-            writeFile(flowTsx, getFlowTsFileContent());
+            writeFile(flowTsx, getFlowTsxFileContent(routesTsx.exists()));
             if (fileAvailable(REACT_ADAPTER_TSX)) {
                 writeFile(reactAdapterTsx, getFileContent(REACT_ADAPTER_TSX));
             }
@@ -145,7 +147,8 @@ public class TaskGenerateReactFiles implements FallibleCommand {
                 writeFile(viewsTs, VIEWS_TS_FALLBACK);
             }
             if (!routesTsx.exists()) {
-                writeFile(routesTsx, getFileContent(FrontendUtils.ROUTES_TSX));
+                writeFile(frontendGeneratedFolderRoutesTsx,
+                        getFileContent(FrontendUtils.ROUTES_TSX));
             } else {
                 String routesContent = FileUtils.readFileToString(routesTsx,
                         UTF_8);
@@ -172,8 +175,11 @@ public class TaskGenerateReactFiles implements FallibleCommand {
             File flowTsx = new File(frontendGeneratedFolder, FLOW_FLOW_TSX);
             File reactAdapterTsx = new File(frontendGeneratedFolder,
                     FLOW_REACT_ADAPTER_TSX);
+            File frontendGeneratedFolderRoutesTsx = new File(
+                    frontendGeneratedFolder, FrontendUtils.ROUTES_TSX);
             FileUtils.deleteQuietly(flowTsx);
             FileUtils.deleteQuietly(reactAdapterTsx);
+            FileUtils.deleteQuietly(frontendGeneratedFolderRoutesTsx);
 
             File routesTsx = new File(frontendDirectory,
                     FrontendUtils.ROUTES_TSX);
@@ -204,8 +210,14 @@ public class TaskGenerateReactFiles implements FallibleCommand {
         }
     }
 
-    private String getFlowTsFileContent() throws IOException {
-        String content = getFileContent(FLOW_TSX);
+    private String getFlowTsxFileContent(boolean frontendRoutesTsExists) throws IOException {
+        String content = getFileContent(FLOW_TSX).replace(ROUTES_JS_IMPORT_PATH_TOKEN,
+                (frontendRoutesTsExists)
+                        ? FrontendUtils.FRONTEND_FOLDER_ALIAS
+                        + FrontendUtils.ROUTES_JS
+                        : FrontendUtils.FRONTEND_FOLDER_ALIAS
+                        + FrontendUtils.GENERATED
+                        + FrontendUtils.ROUTES_JS);;
         if (FrontendUtils.isHillaUsed(options.getFrontendDirectory(),
                 options.getClassFinder())) {
             return content.replace("//%toReactRouterImport%",

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -22,7 +22,7 @@ import {
     useNavigate,
     RouteObject
 } from "react-router-dom";
-import { routes } from "Frontend/routes.js";
+import { routes } from "%routesJsImportPath%";
 //%viewsJsImport%
 //%toReactRouterImport%
 

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/index-react.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/index-react.tsx
@@ -13,7 +13,7 @@
 import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
-import router from 'Frontend/routes.js';
+import router from '%routesJsImportPath%';
 
 function App() {
     return <RouterProvider router={router} />;

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -176,6 +176,25 @@ public class FrontendUtilsTest {
                   ];
             """;
 
+    private static final String ROUTES_CONTENT_WITH_BUILD_ROUTE_TSX = """
+                import { buildRoute } from "Frontend/generated/flow/Flow";
+                export const routes = buildRoute();
+            """;
+
+    private static final String ROUTES_CONTENT_WITH_BUILD_ROUTE_WITH_ARGS_TSX = """
+                import { buildRoute } from "Frontend/generated/flow/Flow";
+                let routing: RouteObject[] = [
+                      {
+                          element: <MainLayout />,
+                          handle: { title: 'Hilla CRM' },
+                          children: [
+                              ...serverSideRoutes
+                          ],
+                      },
+                  ];
+                export const routes = buildRoute(routing, routing[0].children);
+            """;
+
     private static final String HILLA_VIEW_TSX = """
                 import { VerticalLayout } from "@vaadin/react-components/VerticalLayout.js";
                 export default function AboutView() {
@@ -615,6 +634,33 @@ public class FrontendUtilsTest {
     }
 
     @Test
+    public void isHillaViewsUsed_buildRouteTsxWithoutArgs_false()
+            throws IOException {
+        File frontend = prepareFrontendForRoutesFile(FrontendUtils.ROUTES_TSX,
+                ROUTES_CONTENT_WITH_BUILD_ROUTE_TSX);
+        Assert.assertFalse("hilla-views are not expected",
+                FrontendUtils.isHillaViewsUsed(frontend));
+    }
+
+    @Test
+    public void isHillaViewsUsed_buildRouteTsxWithoutArgsFSViewExists_false()
+            throws IOException {
+        File frontend = prepareFrontendForRoutesFile(FrontendUtils.ROUTES_TSX,
+                ROUTES_CONTENT_WITH_BUILD_ROUTE_TSX, true);
+        Assert.assertTrue("hilla-views are expected",
+                FrontendUtils.isHillaViewsUsed(frontend));
+    }
+
+    @Test
+    public void isHillaViewsUsed_buildRouteWithArgsTsx_true()
+            throws IOException {
+        File frontend = prepareFrontendForRoutesFile(FrontendUtils.ROUTES_TSX,
+                ROUTES_CONTENT_WITH_BUILD_ROUTE_WITH_ARGS_TSX);
+        Assert.assertTrue("hilla-views are expected",
+                FrontendUtils.isHillaViewsUsed(frontend));
+    }
+
+    @Test
     public void isHillaViewsUsed_nonEmptyHillaViewInViews_true()
             throws IOException {
         File frontend = null;
@@ -653,9 +699,19 @@ public class FrontendUtilsTest {
 
     private File prepareFrontendForRoutesFile(String fileName, String content)
             throws IOException {
+        return prepareFrontendForRoutesFile(fileName, content, false);
+    }
+
+    private File prepareFrontendForRoutesFile(String fileName, String content,
+            boolean generateDummyFSView) throws IOException {
         File frontend = tmpDir.newFolder(FrontendUtils.DEFAULT_FRONTEND_DIR);
         FileUtils.write(new File(frontend, fileName), content,
                 StandardCharsets.UTF_8);
+        if (generateDummyFSView) {
+            FileUtils.write(new File(frontend, "views/testFSView.ts"),
+                    "export default function TestFSView() { return 'TestFSView'; }",
+                    StandardCharsets.UTF_8);
+        }
         return frontend;
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateReactFilesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateReactFilesTest.java
@@ -77,7 +77,11 @@ public class TaskGenerateReactFilesTest {
         Assert.assertTrue("Missing ./frontend/generated/flow/Flow.tsx",
                 new File(new File(frontend, FrontendUtils.GENERATED),
                         "flow/Flow.tsx").exists());
-        Assert.assertTrue("Missing ./frontend/routes.tsx",
+        Assert.assertTrue(
+                "Missing ./frontend/" + FrontendUtils.GENERATED + "routes.tsx",
+                new File(new File(frontend, FrontendUtils.GENERATED),
+                        "routes.tsx").exists());
+        Assert.assertFalse("Missing ./frontend/routes.tsx",
                 new File(frontend, "routes.tsx").exists());
     }
 
@@ -308,6 +312,11 @@ public class TaskGenerateReactFilesTest {
         Assert.assertFalse(
                 "./frontend/routes.tsx should be removed when react is disabled",
                 new File(frontend, "routes.tsx").exists());
+        Assert.assertFalse(
+                "./frontend/" + FrontendUtils.GENERATED
+                        + "routes.tsx should be removed when react is disabled",
+                new File(new File(frontend, FrontendUtils.GENERATED),
+                        "routes.tsx").exists());
         Assert.assertTrue("./frontend/routes.tsx.flowBackup should exist",
                 new File(frontend, "routes.tsx.flowBackup").exists());
     }


### PR DESCRIPTION
Generate default routes.tsx in Frontend/generated folder instead of Frontend/. Imports to routes.js are now dynamic in Flow.ts and index-react.ts.

Fixes: #18871