### PR TITLE
chore: upgrade commons-compress to 1.26.1 (#18923)

### DIFF
--- a/flow-plugins/flow-dev-bundle-plugin/pom.xml
+++ b/flow-plugins/flow-dev-bundle-plugin/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.24.0</version>
+            <version>1.26.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>

--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -134,7 +134,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.24.0</version>
+            <version>1.26.1</version>
         </dependency>
         <!-- TESTING DEPENDENCIES -->
         <dependency>

--- a/flow-test-util/pom.xml
+++ b/flow-test-util/pom.xml
@@ -43,6 +43,11 @@
                     <groupId>org.asynchttpclient</groupId>
                     <artifactId>async-http-client</artifactId>
                 </exclusion>
+                <!-- remove this after TB 9.2.5 release -->
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
* chore: upgrade commons-compress to 1.26.1

* chore: upgrade commons-compress to 1.26.1

* add workaround

