### PR TITLE
chore(deps): bump org.apache.commons:commons-compress (#18043)

### DIFF
--- a/flow-plugins/flow-dev-bundle-plugin/pom.xml
+++ b/flow-plugins/flow-dev-bundle-plugin/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.24.0</version>
+            <version>1.25.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>

--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -134,7 +134,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.24.0</version>
+            <version>1.25.0</version>
         </dependency>
         <!-- TESTING DEPENDENCIES -->
         <dependency>


### PR DESCRIPTION
Bumps org.apache.commons:commons-compress from 1.24.0 to 1.25.0.

---
updated-dependencies:
- dependency-name: org.apache.commons:commons-compress dependency-type: direct:production update-type: version-update:semver-minor ...

