### PR TITLE
fix: revert path separator handling in StreamRequestHandler

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamRequestHandler.java
@@ -160,7 +160,7 @@ public class StreamRequestHandler implements RequestHandler {
     }
 
     private static Optional<URI> getPathUri(String path) {
-        int index = path.lastIndexOf(FrontendUtils.isWindows() ? '\\' : '/');
+        int index = path.lastIndexOf('/');
         boolean hasPrefix = index >= 0;
         if (!hasPrefix) {
             getLogger().info("Unsupported path structure, path={}", path);


### PR DESCRIPTION
Fixes #18945