### PR TITLE
feat: do not require routes import

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/Options.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/Options.java
@@ -362,6 +362,9 @@ public class Options implements Serializable {
      * @return folder to generate frontend files in
      */
     public File getFrontendGeneratedFolder() {
+        if (frontendGeneratedFolder == null) {
+            return new File(getFrontendDirectory(), FrontendUtils.GENERATED);
+        }
         return frontendGeneratedFolder;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
@@ -248,24 +248,24 @@ public class TaskGenerateReactFiles implements FallibleCommand {
         if (customRoutesTsx.exists()) {
             String customRoutes = StringUtil.removeComments(
                     FileUtils.readFileToString(customRoutesTsx, UTF_8));
-            // If there is a manual serverSideRoutes used, but no buildRoute,
-            // import routes from routes file.
+            // If there is a manual serverSideRoutes used, but no buildRoute
+            // method call, import routes from routes file.
             if (customRoutes.contains("serverSideRoutes")
-                    && !customRoutes.contains("buildRoute")) {
+                    && !customRoutes.contains("buildRoute(")) {
                 content = content
                         .replace("//%routesImport%",
                                 "import { routes } from 'Frontend/routes';")
-                        .replace("let routes: RouteObject[];", "")
-                        .replace("routes = combinedRoutes;", "");
+                        .replace("const routes: RouteObject[] = props.routes;",
+                                "");
             }
-        } else if (options.isFrontendHotdeploy()
-                && !options.isProductionMode()) {
-            // For frontendHotdeploy we read the routes from file as re-loading
-            // has some sideffect to the stored data?
-            content = content.replace("//%routesImport%",
-                    "import { routes } from 'Frontend/generated/routes';")
-                    .replace("let routes: RouteObject[];", "")
-                    .replace("routes = combinedRoutes;", "");
+            // } else if (options.isFrontendHotdeploy()
+            // && !options.isProductionMode()) {
+            // // For frontendHotdeploy we read the routes from file as
+            // re-loading
+            // // has some sideffect to the stored data?
+            // content = content.replace("//%routesImport%",
+            // "import { routes } from 'Frontend/generated/routes';")
+            // .replace("const routes: RouteObject[] = props.routes;", "");
         }
         return content;
     }

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -22,9 +22,8 @@ import {
     useNavigate,
     RouteObject
 } from "react-router-dom";
-import { routes } from "%routesJsImportPath%";
-//%viewsJsImport%
-//%toReactRouterImport%
+//%fsRouterImports%
+//%routesImport%
 
 const flow = new _Flow({
     imports: () => import("Frontend/generated/flow/generated-flow-imports.js")
@@ -146,6 +145,7 @@ let mountedContainer: Awaited<ReturnType<typeof flow.serverSideRoutes[0]["action
 let lastNavigation: string;
 let prevNavigation: string;
 let popstateListener: { type: string, listener: EventListener, useCapture: boolean };
+let routes: RouteObject[];
 
 // @ts-ignore
 function navigateEventHandler(event) {
@@ -424,13 +424,13 @@ export const createWebComponent = (tag: string, props?: Properties, onload?: () 
 /**
  * Build routes for the application. Combines server side routes and FS routes.
  *
- * @param routes optional routes are for adding own route definition, giving routes will skip FS routes
+ * @param routesArray optional routes are for adding own route definition, giving routes will skip FS routes
  * @param serverSidePosition optional position where server routes should be put.
   *                          If non given they go to the root of the routes [].
  *
  * @returns RouteObject[] with combined routes
  */
-export const buildRoute = (routes?: RouteObject[], serverSidePosition?: RouteObject[]): RouteObject[] => {
+export const buildRoute = (routesArray?: RouteObject[], serverSidePosition?: RouteObject[]): RouteObject[] => {
     let combinedRoutes = [] as RouteObject[];
     //%buildRouteFunction%
     if(serverSidePosition) {
@@ -438,8 +438,9 @@ export const buildRoute = (routes?: RouteObject[], serverSidePosition?: RouteObj
     } else {
         combinedRoutes.push(...serverSideRoutes);
     }
-    if(routes) {
-        combinedRoutes.push(...routes);
+    if(routesArray) {
+        combinedRoutes.push(...routesArray);
     }
+    routes = combinedRoutes;
     return combinedRoutes;
 };

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendResourcesAreCopiedAfterCleaningTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendResourcesAreCopiedAfterCleaningTest.java
@@ -96,7 +96,7 @@ public class FrontendResourcesAreCopiedAfterCleaningTest {
         new NodeTasks(options.withEmbeddableWebComponents(false)
                 .enableImportsUpdate(false).createMissingPackageJson(true)
                 .enableImportsUpdate(true).withRunNpmInstall(false)
-                .enablePackagesUpdate(true)
+                .enablePackagesUpdate(true).withFrontendDirectory(npmFolder)
                 .withJarFrontendResourcesFolder(getJarFrontendResourcesFolder())
                 .copyResources(Collections.singleton(testJar))).execute();
     }
@@ -112,7 +112,7 @@ public class FrontendResourcesAreCopiedAfterCleaningTest {
                 .withBuildDirectory(TARGET).withEmbeddableWebComponents(false)
                 .enableImportsUpdate(false).createMissingPackageJson(true)
                 .enableImportsUpdate(true).withRunNpmInstall(false)
-                .enableNpmFileCleaning(true)
+                .enableNpmFileCleaning(true).withFrontendDirectory(npmFolder)
                 .withJarFrontendResourcesFolder(getJarFrontendResourcesFolder())
                 .copyResources(Collections.emptySet())
                 .enablePackagesUpdate(true);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksExecutionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksExecutionTest.java
@@ -58,7 +58,8 @@ public class NodeTasksExecutionTest {
         // Make a builder that doesn't add any commands.
         ClassFinder.DefaultClassFinder finder = new ClassFinder.DefaultClassFinder(
                 Collections.singleton(this.getClass()));
-        options = new MockOptions(finder, null).withBuildDirectory(TARGET);
+        options = new MockOptions(finder, null).withBuildDirectory(TARGET)
+                .withFrontendDirectory(temporaryFolder.getRoot());
         options.withProductionMode(false);
 
         nodeTasks = new NodeTasks(options);


### PR DESCRIPTION
Do not import routes from
routes.tsx if not needed.

Fixes tests so that files are not generated into the flow-server folder.

Fixes #18955