### PR TITLE
fix: Generate tsconfig frontend path as in project.

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsConfig.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsConfig.java
@@ -91,6 +91,11 @@ public class TaskGenerateTsConfig extends AbstractTaskClientGenerator {
         try (InputStream tsConfStream = getClass()
                 .getResourceAsStream(fileName)) {
             String config = IOUtils.toString(tsConfStream, UTF_8);
+
+            config = config.replaceAll("%FRONTEND%",
+                    options.getNpmFolder().toPath()
+                            .relativize(options.getFrontendDirectory().toPath())
+                            .toString().replaceAll("\\\\", "/"));
             return config;
         }
     }

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/tsconfig.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/tsconfig.json
@@ -34,7 +34,6 @@
     "types.d.ts"
   ],
   "exclude": [
-    "frontend/generated/jar-resources/**",
-    "src/main/frontend/generated/jar-resources/**"
+    "%FRONTEND%/generated/jar-resources/**"
   ]
 }

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/tsconfig.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/tsconfig.json
@@ -4,7 +4,7 @@
 // You might want to change the configurations to fit your preferences
 // For more information about the configurations, please refer to http://www.typescriptlang.org/docs/handbook/tsconfig-json.html
 {
-  "_version": "9",
+  "_version": "9.1",
   "compilerOptions": {
     "sourceMap": true,
     "jsx": "react-jsx",
@@ -22,7 +22,7 @@
     "noUnusedParameters": false,
     "experimentalDecorators": true,
     "useDefineForClassFields": false,
-    "baseUrl": "frontend",
+    "baseUrl": "%FRONTEND%",
     "paths": {
       "@vaadin/flow-frontend": ["generated/jar-resources"],
       "@vaadin/flow-frontend/*": ["generated/jar-resources/*"],
@@ -30,7 +30,7 @@
     }
   },
   "include": [
-    "frontend/**/*",
+    "%FRONTEND%/**/*",
     "types.d.ts"
   ],
   "exclude": [

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateTsConfigTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateTsConfigTest.java
@@ -39,7 +39,7 @@ import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.server.ExecutionFailedException;
 
 public class TaskGenerateTsConfigTest {
-    static private String LATEST_VERSION = "9";
+    static private String LATEST_VERSION = "9.1";
 
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();

--- a/flow-server/src/test/resources/tsconfig-reference.json
+++ b/flow-server/src/test/resources/tsconfig-reference.json
@@ -4,7 +4,7 @@
 // You might want to change the configurations to fit your preferences
 // For more information about the configurations, please refer to http://www.typescriptlang.org/docs/handbook/tsconfig-json.html
 {
-  "_version": "9",
+  "_version": "9.1",
   "compilerOptions": {
     "sourceMap": true,
     "jsx": "react-jsx",

--- a/flow-server/src/test/resources/tsconfig-reference.json
+++ b/flow-server/src/test/resources/tsconfig-reference.json
@@ -22,7 +22,7 @@
     "noUnusedParameters": false,
     "experimentalDecorators": true,
     "useDefineForClassFields": false,
-    "baseUrl": "frontend",
+    "baseUrl": "src/main/frontend",
     "paths": {
       "@vaadin/flow-frontend": ["generated/jar-resources"],
       "@vaadin/flow-frontend/*": ["generated/jar-resources/*"],
@@ -30,11 +30,10 @@
     }
   },
   "include": [
-    "frontend/**/*",
+    "src/main/frontend/**/*",
     "types.d.ts"
   ],
   "exclude": [
-    "frontend/generated/jar-resources/**",
     "src/main/frontend/generated/jar-resources/**"
   ]
 }


### PR DESCRIPTION
Set the frontend path to tsconfig correctly for
the project depending on where it is found.

Fixes #18973
