### PR TITLE
chore: pin preset-react version

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/react-router/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/react-router/package.json
@@ -14,6 +14,7 @@
     "react-router-dom": "6.22.3"
   },
   "devDependencies": {
+    "@babel/preset-react": "7.23.3",
     "@types/react": "18.2.64",
     "@types/react-dom": "18.2.21"
   }

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/react-router/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/react-router/package.json
@@ -14,7 +14,6 @@
     "react-router-dom": "6.22.3"
   },
   "devDependencies": {
-    "@babel/preset-react": "7.23.3",
     "@types/react": "18.2.64",
     "@types/react-dom": "18.2.21"
   }

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
@@ -14,7 +14,7 @@
     "@vitejs/plugin-react": "4.2.1",
     "@rollup/plugin-replace": "5.0.5",
     "@rollup/pluginutils": "5.1.0",
-    "@babel/preset-react": "^7",
+    "@babel/preset-react": "7.23.3",
     "rollup-plugin-visualizer": "5.12.0",
     "rollup-plugin-brotli": "3.1.0",
     "vite-plugin-checker": "0.6.4",


### PR DESCRIPTION
Fixes runtime issues when using pnpm >=8 and <= 8.6.12 for frontend build.

Fixes #18978
