### PR TITLE
Fix: update tsconfig and log message

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsConfig.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsConfig.java
@@ -44,7 +44,7 @@ public class TaskGenerateTsConfig extends AbstractTaskClientGenerator {
      * Keeps track of whether a warning update has already been logged. This is
      * used to avoid spamming the log with the same message.
      */
-    private static boolean warningEmitted = false;
+    protected static boolean warningEmitted = false;
 
     private static final String COMPILER_OPTIONS = "compilerOptions";
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsConfig.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsConfig.java
@@ -52,15 +52,17 @@ public class TaskGenerateTsConfig extends AbstractTaskClientGenerator {
             "v23.3.0", "v23.2", "v23.1", "v22", "v14", "osgi", "v23.3.4",
             "v23.3.4-hilla" };
 
-    //@formatter:off
-    static final String ERROR_MESSAGE =
-            "%n%n**************************************************************************"
-            + "%n*  TypeScript config file 'tsconfig.json' has been updated to the latest *"
-            + "%n*  version by Vaadin. Please verify that the updated 'tsconfig.json'     *"
-            + "%n*  file contains configuration needed for your project (add missing part *"
-            + "%n*  from the old file if necessary) and restart the application.          *"
-            + "%n**************************************************************************%n%n";
-    //@formatter:on
+    static final String ERROR_MESSAGE = """
+
+            **************************************************************************
+            *  TypeScript config file 'tsconfig.json' has been updated to the latest *
+            *  version by Vaadin. Please verify that the updated 'tsconfig.json'     *
+            *  file contains configuration needed for your project (add any missing  *
+            *  parts from the old file if necessary) and restart the application.    *
+            *  Old configuration is stored as a '.bak' file.                         *
+            **************************************************************************
+
+            """;
 
     private Options options;
 
@@ -216,11 +218,14 @@ public class TaskGenerateTsConfig extends AbstractTaskClientGenerator {
                 }
             }
 
+            File backupFile = File.createTempFile(projectTsConfigFile.getName(),
+                    ".bak", projectTsConfigFile.getParentFile());
+            FileIOUtils.writeIfChanged(backupFile, projectTsConfigAsString);
             // Project's TS config has a custom content -
             // rewrite and throw an exception with explanations
             FileIOUtils.writeIfChanged(projectTsConfigFile,
                     latestTsConfigTemplate);
-            throw new ExecutionFailedException(String.format(ERROR_MESSAGE));
+            log().info(String.format(ERROR_MESSAGE));
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsConfig.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsConfig.java
@@ -218,14 +218,15 @@ public class TaskGenerateTsConfig extends AbstractTaskClientGenerator {
                 }
             }
 
-            File backupFile = File.createTempFile(projectTsConfigFile.getName(),
-                    ".bak", projectTsConfigFile.getParentFile());
+            File backupFile = File.createTempFile(
+                    projectTsConfigFile.getName() + ".", ".bak",
+                    projectTsConfigFile.getParentFile());
             FileIOUtils.writeIfChanged(backupFile, projectTsConfigAsString);
             // Project's TS config has a custom content -
             // rewrite and throw an exception with explanations
             FileIOUtils.writeIfChanged(projectTsConfigFile,
                     latestTsConfigTemplate);
-            log().info(String.format(ERROR_MESSAGE));
+            log().warn(String.format(ERROR_MESSAGE));
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsConfig.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsConfig.java
@@ -40,6 +40,12 @@ import elemental.json.JsonObject;
  */
 public class TaskGenerateTsConfig extends AbstractTaskClientGenerator {
 
+    /**
+     * Keeps track of whether a warning update has already been logged. This is
+     * used to avoid spamming the log with the same message.
+     */
+    private static boolean warningEmitted = false;
+
     private static final String COMPILER_OPTIONS = "compilerOptions";
 
     static final String TSCONFIG_JSON = "tsconfig.json";
@@ -226,7 +232,10 @@ public class TaskGenerateTsConfig extends AbstractTaskClientGenerator {
             // rewrite and throw an exception with explanations
             FileIOUtils.writeIfChanged(projectTsConfigFile,
                     latestTsConfigTemplate);
-            log().warn(String.format(ERROR_MESSAGE));
+            if (!warningEmitted) {
+                log().warn(String.format(ERROR_MESSAGE));
+                warningEmitted = true;
+            }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsConfig.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsConfig.java
@@ -233,7 +233,7 @@ public class TaskGenerateTsConfig extends AbstractTaskClientGenerator {
             FileIOUtils.writeIfChanged(projectTsConfigFile,
                     latestTsConfigTemplate);
             if (!warningEmitted) {
-                log().warn(String.format(ERROR_MESSAGE));
+                log().warn(ERROR_MESSAGE);
                 warningEmitted = true;
             }
         } catch (IOException e) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsDefinitions.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsDefinitions.java
@@ -69,6 +69,11 @@ public class TaskGenerateTsDefinitions extends AbstractTaskClientGenerator {
 
 
             """;
+    /**
+     * Keeps track of whether a warning update has already been logged. This is
+     * used to avoid spamming the log with the same message.
+     */
+    private static boolean warningEmitted = false;
 
     static final String TS_DEFINITIONS = "types.d.ts";
     static final Pattern COMMENT_LINE = Pattern.compile("(?m)^/[/*].*\\R");
@@ -171,8 +176,10 @@ public class TaskGenerateTsDefinitions extends AbstractTaskClientGenerator {
                         Files.writeString(tsDefinitions.toPath(),
                                 uncommentedDefaultContent,
                                 StandardOpenOption.APPEND);
-                        if (updateMode == UpdateMode.UPDATE_AND_BACKUP) {
+                        if (updateMode == UpdateMode.UPDATE_AND_BACKUP
+                                && !warningEmitted) {
                             log().warn(UPDATE_MESSAGE);
+                            warningEmitted = true;
                         }
                     }
                 } catch (IOException ex) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsDefinitions.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsDefinitions.java
@@ -45,9 +45,9 @@ public class TaskGenerateTsDefinitions extends AbstractTaskClientGenerator {
             ***************************************************************************
             *  The TypeScript type declaration file 'types.d.ts' has been updated     *
             *  to the latest version by Vaadin. Previous content has been backed up   *
-            *  on 'types.d.ts.flowBackup' file. Please verify that the updated        *
-            *  'types.d.ts' file contains configuration needed for your project, and  *
-            *  then delete the backup file.                                           *
+            *  as a '.bak' file.. Please verify that the updated 'types.d.ts' file    *
+            *  contains configuration needed for your project, and then delete the    *
+            *  backup file.                                                           *
             ***************************************************************************
 
             """;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsDefinitions.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsDefinitions.java
@@ -42,7 +42,6 @@ public class TaskGenerateTsDefinitions extends AbstractTaskClientGenerator {
     private static final String DECLARE_CSS_MODULE = "declare module '*.css?inline' {";
     static final String UPDATE_MESSAGE = """
 
-
             ***************************************************************************
             *  The TypeScript type declaration file 'types.d.ts' has been updated     *
             *  to the latest version by Vaadin. Previous content has been backed up   *
@@ -51,11 +50,9 @@ public class TaskGenerateTsDefinitions extends AbstractTaskClientGenerator {
             *  then delete the backup file.                                           *
             ***************************************************************************
 
-
             """;
 
     static final String CHECK_CONTENT_MESSAGE = """
-
 
             ****************************************************************************
             *  The TypeScript type declaration file 'types.d.ts' has been customized.  *
@@ -66,7 +63,6 @@ public class TaskGenerateTsDefinitions extends AbstractTaskClientGenerator {
             *  As an alternative you can rename the file, make Vaadin re-generate it,  *
             *  and then update it with your custom contents.                           *
             ****************************************************************************"
-
 
             """;
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsDefinitions.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsDefinitions.java
@@ -45,7 +45,7 @@ public class TaskGenerateTsDefinitions extends AbstractTaskClientGenerator {
             ***************************************************************************
             *  The TypeScript type declaration file 'types.d.ts' has been updated     *
             *  to the latest version by Vaadin. Previous content has been backed up   *
-            *  as a '.bak' file.. Please verify that the updated 'types.d.ts' file    *
+            *  as a '.bak' file. Please verify that the updated 'types.d.ts' file    *
             *  contains configuration needed for your project, and then delete the    *
             *  backup file.                                                           *
             ***************************************************************************

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsDefinitions.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsDefinitions.java
@@ -73,7 +73,7 @@ public class TaskGenerateTsDefinitions extends AbstractTaskClientGenerator {
      * Keeps track of whether a warning update has already been logged. This is
      * used to avoid spamming the log with the same message.
      */
-    private static boolean warningEmitted = false;
+    protected static boolean warningEmitted = false;
 
     static final String TS_DEFINITIONS = "types.d.ts";
     static final Pattern COMMENT_LINE = Pattern.compile("(?m)^/[/*].*\\R");

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateTsConfigTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateTsConfigTest.java
@@ -26,6 +26,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
 
+import net.jcip.annotations.NotThreadSafe;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
@@ -40,6 +41,7 @@ import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.server.ExecutionFailedException;
 
+@NotThreadSafe
 public class TaskGenerateTsConfigTest {
     static private String LATEST_VERSION = "9.1";
 
@@ -59,6 +61,7 @@ public class TaskGenerateTsConfigTest {
                 .withFeatureFlags(featureFlags);
 
         taskGenerateTsConfig = new TaskGenerateTsConfig(options);
+        taskGenerateTsConfig.warningEmitted = false;
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateTsDefinitionsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateTsDefinitionsTest.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 
+import net.jcip.annotations.NotThreadSafe;
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
@@ -39,6 +40,7 @@ import com.vaadin.flow.server.ExecutionFailedException;
 import static com.vaadin.flow.server.frontend.TaskGenerateTsDefinitions.TS_DEFINITIONS;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+@NotThreadSafe
 public class TaskGenerateTsDefinitionsTest {
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -51,6 +53,7 @@ public class TaskGenerateTsDefinitionsTest {
         Options options = new Options(Mockito.mock(Lookup.class), outputFolder);
 
         taskGenerateTsDefinitions = new TaskGenerateTsDefinitions(options);
+        taskGenerateTsDefinitions.warningEmitted = false;
     }
 
     @Test


### PR DESCRIPTION
Instead of updating and throwing
exception for 'tsconfig.json'.
Generate .bak file,
update file and log info if the
file is updated.

Fixes #18984