### PR TITLE
fix: update JWT cookie at every request

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -23,7 +23,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import javax.crypto.SecretKey;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.LinkedHashMap;
 import java.util.Objects;
 import java.util.Optional;
@@ -44,7 +43,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
-import org.springframework.security.config.annotation.web.configurers.SessionManagementConfigurer;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.web.DefaultSecurityFilterChain;
 import org.springframework.security.web.SecurityFilterChain;
@@ -56,7 +54,6 @@ import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.security.web.authentication.logout.SimpleUrlLogoutSuccessHandler;
-import org.springframework.security.web.context.SecurityContextRepository;
 import org.springframework.security.web.csrf.CsrfException;
 import org.springframework.security.web.savedrequest.RequestCache;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
@@ -151,6 +148,7 @@ public abstract class VaadinWebSecurity {
             cfg.invalidateHttpSession(true);
             addLogoutHandlers(cfg::addLogoutHandler);
         });
+
         DefaultSecurityFilterChain securityFilterChain = http.build();
         Optional.ofNullable(vaadinRolePrefixHolder)
                 .ifPresent(vaadinRolePrefixHolder -> vaadinRolePrefixHolder
@@ -552,23 +550,9 @@ public abstract class VaadinWebSecurity {
     protected void setStatelessAuthentication(HttpSecurity http,
             SecretKey secretKey, String issuer, long expiresIn)
             throws Exception {
-        VaadinStatelessSecurityConfigurer<HttpSecurity> vaadinStatelessSecurityConfigurer = new VaadinStatelessSecurityConfigurer<>();
-        vaadinStatelessSecurityConfigurer.setSharedObjects(http);
-        http.apply(vaadinStatelessSecurityConfigurer);
-
-        // Workaround
-        // https://github.com/spring-projects/spring-security/issues/12579 until
-        // it is released
-        SessionManagementConfigurer sessionManagementConfigurer = http
-                .getConfigurer(SessionManagementConfigurer.class);
-        Field f = SessionManagementConfigurer.class
-                .getDeclaredField("sessionManagementSecurityContextRepository");
-        f.setAccessible(true);
-        f.set(sessionManagementConfigurer,
-                http.getSharedObject(SecurityContextRepository.class));
-
-        vaadinStatelessSecurityConfigurer.withSecretKey().secretKey(secretKey)
-                .and().issuer(issuer).expiresIn(expiresIn);
+        VaadinStatelessSecurityConfigurer.apply(http,
+                cfg -> cfg.withSecretKey().secretKey(secretKey).and()
+                        .issuer(issuer).expiresIn(expiresIn));
     }
 
     /**

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/stateless/JwtSecurityContextRepository.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/stateless/JwtSecurityContextRepository.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.spring.security.stateless;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -191,7 +192,6 @@ class JwtSecurityContextRepository implements SecurityContextRepository {
                     .convert(jwt);
             context.setAuthentication(authentication);
         }
-
         return context;
     }
 

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/stateless/SerializedJwtSplitCookieRepository.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/stateless/SerializedJwtSplitCookieRepository.java
@@ -92,6 +92,12 @@ class SerializedJwtSplitCookieRepository {
         }
     }
 
+    static boolean containsCookie(HttpServletResponse response) {
+        return response.getHeaders("Set-Cookie").stream()
+                .anyMatch(cookie -> cookie
+                        .startsWith(JWT_HEADER_AND_PAYLOAD_COOKIE_NAME));
+    }
+
     /**
      * Checks the presence of JWT cookies in request.
      *
@@ -131,20 +137,26 @@ class SerializedJwtSplitCookieRepository {
 
     private void removeJwtSplitCookies(HttpServletRequest request,
             HttpServletResponse response) {
-        Cookie jwtHeaderAndPayloadRemove = new Cookie(
-                JWT_HEADER_AND_PAYLOAD_COOKIE_NAME, null);
-        jwtHeaderAndPayloadRemove.setPath(getRequestContextPath(request));
-        jwtHeaderAndPayloadRemove.setMaxAge(0);
-        jwtHeaderAndPayloadRemove.setSecure(request.isSecure());
-        jwtHeaderAndPayloadRemove.setHttpOnly(false);
-        response.addCookie(jwtHeaderAndPayloadRemove);
 
-        Cookie jwtSignatureRemove = new Cookie(JWT_SIGNATURE_COOKIE_NAME, null);
-        jwtSignatureRemove.setPath(getRequestContextPath(request));
-        jwtSignatureRemove.setMaxAge(0);
-        jwtSignatureRemove.setSecure(request.isSecure());
-        jwtSignatureRemove.setHttpOnly(true);
-        response.addCookie(jwtSignatureRemove);
+        // No need to send JWT cookies with max-age 0 if the current request
+        // does not contain them
+        if (containsSerializedJwt(request)) {
+            Cookie jwtHeaderAndPayloadRemove = new Cookie(
+                    JWT_HEADER_AND_PAYLOAD_COOKIE_NAME, null);
+            jwtHeaderAndPayloadRemove.setPath(getRequestContextPath(request));
+            jwtHeaderAndPayloadRemove.setMaxAge(0);
+            jwtHeaderAndPayloadRemove.setSecure(request.isSecure());
+            jwtHeaderAndPayloadRemove.setHttpOnly(false);
+            response.addCookie(jwtHeaderAndPayloadRemove);
+
+            Cookie jwtSignatureRemove = new Cookie(JWT_SIGNATURE_COOKIE_NAME,
+                    null);
+            jwtSignatureRemove.setPath(getRequestContextPath(request));
+            jwtSignatureRemove.setMaxAge(0);
+            jwtSignatureRemove.setSecure(request.isSecure());
+            jwtSignatureRemove.setHttpOnly(true);
+            response.addCookie(jwtSignatureRemove);
+        }
     }
 
     private String getRequestContextPath(HttpServletRequest request) {

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/stateless/VaadinStatelessSecurityConfigurer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/stateless/VaadinStatelessSecurityConfigurer.java
@@ -97,6 +97,40 @@ public final class VaadinStatelessSecurityConfigurer<H extends HttpSecurityBuild
 
     private SecretKeyConfigurer secretKeyConfigurer;
 
+    /**
+     * Sets {@link JwtSecurityContextRepository} as a shared object to be used
+     * by multiple {@code SecurityConfigurer}.
+     *
+     * @param http
+     *            the http security builder to store the shared object.
+     * @deprecated to be removed. There is no direct replacement for this
+     *             method. Shared object setup must be done along with other
+     *             required configurations by calling
+     *             {@link #apply(HttpSecurity, Customizer)}.
+     * @see #apply(HttpSecurity, Customizer)
+     */
+    @Deprecated(since = "24.4", forRemoval = true)
+    public void setSharedObjects(HttpSecurity http) {
+        JwtSecurityContextRepository jwtSecurityContextRepository = new JwtSecurityContextRepository(
+                new SerializedJwtSplitCookieRepository());
+        http.setSharedObject(SecurityContextRepository.class,
+                jwtSecurityContextRepository);
+    }
+
+    /**
+     * Applies configuration required to enable stateless security for a Vaadin
+     * application.
+     * <p>
+     * </p>
+     * Use {@code customizer} to tune {@link VaadinStatelessSecurityConfigurer},
+     * or {@link Customizer#withDefaults()} to accept the default values.
+     *
+     * @param http
+     *            the http security builder
+     * @param customizer
+     *            the {@link Customizer} to provide more options for the
+     *            {@link VaadinStatelessSecurityConfigurer}
+     */
     public static void apply(HttpSecurity http,
             Customizer<VaadinStatelessSecurityConfigurer<HttpSecurity>> customizer)
             throws Exception {

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringClassesSerializableTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringClassesSerializableTest.java
@@ -112,10 +112,11 @@ public class SpringClassesSerializableTest extends ClassesSerializableTest {
                 "com\\.vaadin\\.flow\\.spring\\.security\\.VaadinSavedRequestAwareAuthenticationSuccessHandler\\$RedirectStrategy",
                 "com\\.vaadin\\.flow\\.spring\\.security\\.WebIconsRequestMatcher(\\$.*)?",
                 "com\\.vaadin\\.flow\\.spring\\.security\\.stateless\\.JwtSecurityContextRepository",
-                "com\\.vaadin\\.flow\\.spring\\.security\\.stateless\\.JwtSecurityContextRepository\\$UpdateJwtResponseWrapper",
                 "com\\.vaadin\\.flow\\.spring\\.security\\.stateless\\.SerializedJwtSplitCookieRepository",
                 "com\\.vaadin\\.flow\\.spring\\.security\\.stateless\\.VaadinStatelessSecurityConfigurer",
                 "com\\.vaadin\\.flow\\.spring\\.security\\.stateless\\.VaadinStatelessSecurityConfigurer\\$SecretKeyConfigurer",
+                "com\\.vaadin\\.flow\\.spring\\.security\\.stateless\\.VaadinStatelessSecurityConfigurer\\$UpdateJwtCookiesFilter",
+                "com\\.vaadin\\.flow\\.spring\\.security\\.stateless\\.VaadinStatelessSecurityConfigurer\\$UpdateJWTCookieOnCommitResponseWrapper",
                 "com\\.vaadin\\.flow\\.spring\\.VaadinServletContextInitializer\\$ClassPathScanner",
                 "com\\.vaadin\\.flow\\.spring\\.VaadinServletContextInitializer\\$CustomResourceLoader"),
                 super.getExcludedPatterns());

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/stateless/JwtStatelessAuthenticationTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/stateless/JwtStatelessAuthenticationTest.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.spring.security.stateless;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+
+import javax.crypto.spec.SecretKeySpec;
+
+import java.util.Arrays;
+import java.util.Base64;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.oauth2.jose.jws.JwsAlgorithms;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.web.support.WebTestUtils;
+import org.springframework.security.web.FilterChainProxy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.security.web.csrf.CsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfTokenRequestHandler;
+import org.springframework.security.web.csrf.DeferredCsrfToken;
+import org.springframework.stereotype.Controller;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.vaadin.flow.spring.SpringBootAutoConfiguration;
+import com.vaadin.flow.spring.SpringSecurityAutoConfiguration;
+import com.vaadin.flow.spring.security.RequestUtil;
+import com.vaadin.flow.spring.security.VaadinWebSecurity;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.authenticated;
+import static org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.unauthenticated;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@WebMvcTest
+@ContextConfiguration(classes = { SecurityAutoConfiguration.class,
+        SpringBootAutoConfiguration.class,
+        SpringSecurityAutoConfiguration.class,
+        JwtStatelessAuthenticationTest.WorkaroundConfig.class,
+        JwtStatelessAuthenticationTest.SecurityConfig.class })
+@TestPropertySource(properties = """
+        spring.main.allow-bean-definition-overriding=true
+        """)
+class JwtStatelessAuthenticationTest {
+
+    @Autowired
+    WebApplicationContext context;
+
+    @Autowired
+    @Qualifier("VaadinSecurityFilterChainBean")
+    SecurityFilterChain securityFilterChain;
+
+    private MockMvc mvc;
+
+    @BeforeEach
+    void setup() {
+        mvc = MockMvcBuilders.webAppContextSetup(context).apply(
+                springSecurity(new FilterChainProxy(securityFilterChain)))
+                .build();
+    }
+
+    @Test
+    void publicResource_notAuthenticated_jwtCookieNotSet() throws Exception {
+        mvc.perform(get("/")).andExpect(status().isOk())
+                .andExpect(cookie().doesNotExist("jwt.headerAndPayload"))
+                .andExpect(cookie().doesNotExist("jwt.signature"));
+    }
+
+    @Test
+    @WithMockUser
+    void publicResource_authenticated_jwtCookieSet() throws Exception {
+        mvc.perform(get("/")).andExpect(status().isOk())
+                .andExpect(
+                        cookie().maxAge("jwt.headerAndPayload", greaterThan(0)))
+                .andExpect(cookie().maxAge("jwt.signature", greaterThan(0)));
+    }
+
+    @Test
+    void successfulAuthentication_jwtCookieSet() throws Exception {
+        doLogin();
+    }
+
+    @Test
+    void authenticated_jwtCookieUpdatedAtEveryRequest() throws Exception {
+        MvcResult result = doLogin();
+
+        Cookie jwtCookie = result.getResponse()
+                .getCookie("jwt.headerAndPayload");
+        Cookie jwtSignature = result.getResponse().getCookie("jwt.signature");
+
+        // Wait for a while, to be sure expire time is different
+        Thread.sleep(1500);
+        result = this.mvc
+                .perform(get("/protected").with(csrfCookie()).cookie(jwtCookie,
+                        jwtSignature))
+                .andExpect(status().isOk())
+                .andExpect(authenticated().withUsername("user"))
+                .andExpect(cookie().exists("jwt.signature"))
+                .andExpect(cookie().exists("jwt.headerAndPayload")).andReturn();
+
+        Cookie jwtCookie2 = result.getResponse()
+                .getCookie("jwt.headerAndPayload");
+        Assertions.assertNotEquals(jwtCookie.getValue(), jwtCookie2.getValue());
+        Cookie jwtSignature2 = result.getResponse().getCookie("jwt.signature");
+        Assertions.assertNotEquals(jwtSignature.getValue(),
+                jwtSignature2.getValue());
+    }
+
+    @Test
+    void logout_jwtCookieExpired() throws Exception {
+        MvcResult loginResult = doLogin();
+        this.mvc.perform(post("/logout").with(csrfCookie())
+                .cookie(jwtCookiesFromResult(loginResult)))
+                .andExpect(status().isFound()).andExpect(redirectedUrl("/"))
+                .andExpect(unauthenticated())
+                .andExpect(cookie().maxAge("jwt.signature", 0))
+                .andExpect(cookie().maxAge("jwt.headerAndPayload", 0));
+    }
+
+    private Cookie[] jwtCookiesFromResult(MvcResult result) {
+        Cookie jwtCookie = result.getResponse()
+                .getCookie("jwt.headerAndPayload");
+        Cookie jwtSignature = result.getResponse().getCookie("jwt.signature");
+        return new Cookie[] { jwtCookie, jwtSignature };
+    }
+
+    private MvcResult doLogin() throws Exception {
+        return this.mvc
+                .perform(post("/login").param("username", "user")
+                        .param("password", "password").with(csrfCookie()))
+                .andExpect(status().isFound()).andExpect(redirectedUrl("/"))
+                .andExpect(authenticated().withUsername("user"))
+                .andExpect(cookie().maxAge("jwt.signature", greaterThan(0)))
+                .andExpect(
+                        cookie().maxAge("jwt.headerAndPayload", greaterThan(0)))
+                .andReturn();
+    }
+
+    private static RequestPostProcessor csrfCookie() {
+        return request -> {
+            CsrfTokenRepository repository = WebTestUtils
+                    .getCsrfTokenRepository(request);
+            CsrfTokenRequestHandler handler = WebTestUtils
+                    .getCsrfTokenRequestHandler(request);
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            DeferredCsrfToken deferredCsrfToken = repository
+                    .loadDeferredToken(request, response);
+            handler.handle(request, response, deferredCsrfToken::get);
+            CsrfToken token = (CsrfToken) request
+                    .getAttribute(CsrfToken.class.getName());
+            token.getToken();
+            Cookie csrfCookie = response.getCookie("XSRF-TOKEN");
+            request.addHeader("X-XSRF-TOKEN", csrfCookie.getValue());
+
+            Cookie[] cookies = request.getCookies();
+            if (cookies != null) {
+                cookies = Arrays.copyOf(cookies, cookies.length + 1);
+                cookies[cookies.length - 1] = csrfCookie;
+            } else {
+                cookies = new Cookie[] { csrfCookie };
+            }
+
+            request.setCookies(cookies);
+
+            return request;
+        };
+    }
+
+    @TestConfiguration
+    @Import(FakeController.class)
+    public static class SecurityConfig extends VaadinWebSecurity {
+
+        @Override
+        protected void configure(HttpSecurity http) throws Exception {
+            http.authorizeHttpRequests(
+                    auth -> auth.requestMatchers(antMatchers("/")).permitAll());
+            super.configure(http);
+            setLoginView(http, "login");
+            setStatelessAuthentication(http,
+                    new SecretKeySpec(Base64.getDecoder().decode(
+                            "YOc+XUfRA/cPGNTEsHfU897W0VYF1nrLNWrsGEI1rBw="),
+                            JwsAlgorithms.HS256),
+                    "someone", 2000);
+        }
+
+        @Bean
+        UserDetailsService userDetailsService() {
+            UserDetails user = User.withDefaultPasswordEncoder()
+                    .username("user").password("password").roles("USER")
+                    .build();
+            return new InMemoryUserDetailsManager(user);
+        }
+
+    }
+
+    @TestConfiguration
+    static class WorkaroundConfig {
+
+        // Workaround for https://github.com/vaadin/flow/issues/18965
+        // Needs 'spring.main.allow-bean-definition-overriding=true' to be set
+        @Bean("requestUtil")
+        RequestUtil requestUtilWorkAround() {
+            return new RequestUtil() {
+                @Override
+                public boolean isCustomWebIcon(HttpServletRequest request) {
+                    return false;
+                }
+            };
+        }
+
+    }
+
+    @Controller
+    static class FakeController {
+
+        @GetMapping
+        public String index() {
+            return "OK";
+        }
+
+        @GetMapping("/protected")
+        public String protectedView() {
+            return "PROTECTED";
+        }
+
+    }
+}

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/stateless/SerializedJwtSplitCookieRepositoryTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/stateless/SerializedJwtSplitCookieRepositoryTest.java
@@ -3,12 +3,14 @@ package com.vaadin.flow.spring.security.stateless;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
 import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 public class SerializedJwtSplitCookieRepositoryTest {
@@ -142,7 +144,17 @@ public class SerializedJwtSplitCookieRepositoryTest {
     }
 
     @Test
-    public void saveSerializedJwt_resets_cookiePair() {
+    public void saveSerializedJwt_unauthenticatedRequest_doNotSet_cookiePair() {
+        serializedJwtSplitCookieRepository.saveSerializedJwt(null, request,
+                response);
+        Mockito.verify(response, Mockito.never())
+                .addCookie(ArgumentMatchers.any());
+    }
+
+    @Test
+    public void saveSerializedJwt_authenticatedRequest_resets_cookiePair() {
+        Mockito.when(request.getCookies()).thenReturn(new Cookie[] {
+                JWT_SIGNATURE_COOKIE, JWT_HEADER_AND_PAYLOAD_COOKIE });
         serializedJwtSplitCookieRepository.saveSerializedJwt(null, request,
                 response);
         checkResponseCookiePair(null, null, true, 0, CONTEXT_PATH);
@@ -159,6 +171,8 @@ public class SerializedJwtSplitCookieRepositoryTest {
 
     @Test
     public void saveSerializedJwt_resetsWithoutMaxAge_after_setExpireIn() {
+        Mockito.when(request.getCookies()).thenReturn(new Cookie[] {
+                JWT_SIGNATURE_COOKIE, JWT_HEADER_AND_PAYLOAD_COOKIE });
         serializedJwtSplitCookieRepository.setExpiresIn(CUSTOM_MAX_AGE);
         serializedJwtSplitCookieRepository.saveSerializedJwt(null, request,
                 response);


### PR DESCRIPTION
## Description

Fixes stateless authentication, by updating the JWT cookies at every request, preventing the browser to remove the cookie after initial max-age time is expired.

Fixes https://github.com/vaadin/flow/issues/18895

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
