### PR TITLE
fix: prevent runWhenAttached command to execute immediately by detach listeners

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
@@ -344,17 +344,23 @@ public class StateNode implements Serializable {
         List<StateNode> nodes = new ArrayList<>();
         visitNodeTreeBottomUp(nodes::add);
         nodes.forEach(StateNode::handleOnDetach);
-        for (StateNode node : nodes) {
-            if (node.hasBeenAttached) {
-                node.hasBeenDetached = true;
-                detaching = true;
-                try {
-                    node.fireDetachListeners();
-                } finally {
-                    detaching = false;
+        try {
+            detaching = true;
+            for (StateNode node : nodes) {
+                if (node.hasBeenAttached) {
+                    node.hasBeenDetached = true;
+                    node.detaching = true;
+                    try {
+                        node.fireDetachListeners();
+                    } finally {
+                        node.detaching = false;
+                    }
                 }
             }
+        } finally {
+            detaching = false;
         }
+
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/internal/StateNodeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/StateNodeTest.java
@@ -590,6 +590,29 @@ public class StateNodeTest {
     }
 
     @Test
+    public void runWhenAttached_detachingNode_childNodeSchedulesCommandOnAttach() {
+        AtomicInteger commandRun = new AtomicInteger(0);
+        StateNode parent = createParentNode("PARENT");
+        StateNode child = createEmptyNode("CHILD");
+        StateTree tree = createStateTree();
+        setParent(parent, tree.getRootNode());
+        setParent(child, parent);
+
+        child.addDetachListener(() -> {
+            child.runWhenAttached(ui -> {
+                Assert.assertEquals(tree.getUI(), ui);
+                commandRun.incrementAndGet();
+            });
+        });
+
+        setParent(parent, null);
+        Assert.assertEquals(0, commandRun.get());
+
+        setParent(parent, tree.getRootNode());
+        Assert.assertEquals(1, commandRun.get());
+    }
+
+    @Test
     public void requiredFeatures() {
         StateNode stateNode = new StateNode(
                 Arrays.asList(ElementClassList.class, ElementPropertyMap.class),


### PR DESCRIPTION
Fixes #18983
