### PR TITLE
fix: prepend npm folder to vaadin-dev-server setting paths

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateSettingsFile.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateSettingsFile.java
@@ -19,11 +19,9 @@ package com.vaadin.flow.server.frontend;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,10 +78,17 @@ public class TaskUpdateSettingsFile implements FallibleCommand, Serializable {
                 FrontendUtils.getUnixPath(jarFrontendResourcesFolder.toPath()));
         String webappResources, statsOutput;
         if (webappResourcesDirectory == null) {
-            webappResources = combinePath(buildDirectory, "classes",
-                    VAADIN_WEBAPP_RESOURCES);
-            statsOutput = combinePath(buildDirectory, "classes",
-                    VAADIN_WEBAPP_RESOURCES, "..", "config");
+            webappResources = FrontendUtils
+                    .getUnixPath(npmFolder.toPath()
+                            .resolve(Paths
+                                    .get(buildDirectory, "classes",
+                                            VAADIN_WEBAPP_RESOURCES)
+                                    .normalize()));
+            statsOutput = FrontendUtils
+                    .getUnixPath(npmFolder.toPath()
+                            .resolve(Paths.get(buildDirectory, "classes",
+                                    VAADIN_WEBAPP_RESOURCES, "..", "config")
+                                    .normalize()));
         } else {
             webappResources = webappResourcesDirectory.getPath();
             statsOutput = new File(webappResourcesDirectory.getParentFile(),

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateSettingsFileTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateSettingsFileTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.server.frontend;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.util.Set;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.server.PwaConfiguration;
+import com.vaadin.flow.server.frontend.scanner.ClassFinder;
+import com.vaadin.tests.util.MockOptions;
+
+import elemental.json.Json;
+import elemental.json.JsonObject;
+
+import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
+import static com.vaadin.flow.server.Constants.VAADIN_WEBAPP_RESOURCES;
+import static com.vaadin.flow.server.frontend.TaskUpdateSettingsFile.DEV_SETTINGS_FILE;
+
+public class TaskUpdateSettingsFileTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private Options options;
+
+    private File buildDirectory;
+
+    private static final Set<String> ABSOLUTE_PATH_ENTRIES = Set.of(
+            "frontendFolder", "themeResourceFolder", "staticOutput",
+            "statsOutput", "frontendBundleOutput", "devBundleOutput",
+            "devBundleStatsOutput", "jarResourcesFolder",
+            "clientServiceWorkerSource");
+
+    @Before
+    public void setUp() throws IOException {
+        ClassFinder finder = Mockito.spy(new ClassFinder.DefaultClassFinder(
+                this.getClass().getClassLoader()));
+        buildDirectory = temporaryFolder.newFolder("target");
+        options = new MockOptions(finder, temporaryFolder.getRoot())
+                .withBuildDirectory("target").withJarFrontendResourcesFolder(
+                        temporaryFolder.newFolder("resources"));
+    }
+
+    @Test
+    public void execute_withWebappResourcesDirectory_useAbsolutePaths()
+            throws IOException {
+
+        options.withWebpack(
+                Paths.get(buildDirectory.getPath(), "classes",
+                        VAADIN_WEBAPP_RESOURCES).toFile(),
+                Paths.get(buildDirectory.getPath(), "classes",
+                        VAADIN_SERVLET_RESOURCES).toFile());
+        TaskUpdateSettingsFile updateSettings = new TaskUpdateSettingsFile(
+                options, "theme", new PwaConfiguration());
+        updateSettings.execute();
+        JsonObject settingsJson = readSettingsFile();
+        assertPathsMatchProjectFolder(settingsJson);
+    }
+
+    @Test
+    public void execute_withoutWebappResourcesDirectory_useAbsolutePaths()
+            throws IOException {
+        TaskUpdateSettingsFile updateSettings = new TaskUpdateSettingsFile(
+                options, "theme", new PwaConfiguration());
+        updateSettings.execute();
+        JsonObject settingsJson = readSettingsFile();
+        assertPathsMatchProjectFolder(settingsJson);
+    }
+
+    private JsonObject readSettingsFile() throws IOException {
+        File settings = new File(temporaryFolder.getRoot(),
+                "target/" + DEV_SETTINGS_FILE);
+        JsonObject settingsJson = Json.parse(
+                IOUtils.toString(settings.toURI(), StandardCharsets.UTF_8));
+        return settingsJson;
+    }
+
+    private void assertPathsMatchProjectFolder(JsonObject json) {
+        ABSOLUTE_PATH_ENTRIES.forEach(key -> {
+            String path = json.getString(key);
+            Assert.assertTrue(
+                    "Expected '" + key + "' to have an absolute path matching "
+                            + temporaryFolder.getRoot().getPath() + ", but was "
+                            + path,
+                    path.startsWith(temporaryFolder.getRoot().getPath()));
+        });
+    }
+
+}


### PR DESCRIPTION
Currently, TaskUpdateSettingsFile produces a json with different content depending if the task is executed by DevModeInitializer or by the build tool plugin (prepare-frontend).
With DevModeInitializer path are prepended with the project path, whereas with prepare-frontend they are not.
This change makes the tasks behave the same regardless of who is the caller.

Part of #18907