### PR TITLE
fix: make prepare-frontend and DevModeInitializer work consistently

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
@@ -143,7 +143,6 @@ class VaadinSmokeTest : AbstractGradleTest() {
         expect(true) { generatedFolder.exists() }
         expect(false) { generatedFile.exists() }
         expect(false) { generatedOldFlowFile.exists() }
-        expect(false) { generatedFlowFolder.exists() }
     }
 
     /**

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
@@ -250,8 +250,6 @@ public class PrepareFrontendMojoTest {
                 generatedTsFolder.exists());
         Assert.assertFalse("Old file should have been removed",
                 oldFile.exists());
-        Assert.assertFalse("Flow folder should have been deleted",
-                flowFolder.exists());
     }
 
     @Test

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -15,26 +15,6 @@
  */
 package com.vaadin.flow.plugin.base;
 
-import static com.vaadin.flow.server.Constants.CONNECT_APPLICATION_PROPERTIES_TOKEN;
-import static com.vaadin.flow.server.Constants.CONNECT_JAVA_SOURCE_FOLDER_TOKEN;
-import static com.vaadin.flow.server.Constants.CONNECT_OPEN_API_FILE_TOKEN;
-import static com.vaadin.flow.server.Constants.DISABLE_PREPARE_FRONTEND_CACHE;
-import static com.vaadin.flow.server.Constants.FRONTEND_TOKEN;
-import static com.vaadin.flow.server.Constants.JAVA_RESOURCE_FOLDER_TOKEN;
-import static com.vaadin.flow.server.Constants.NPM_TOKEN;
-import static com.vaadin.flow.server.Constants.PROJECT_FRONTEND_GENERATED_DIR_TOKEN;
-import static com.vaadin.flow.server.InitParameters.FRONTEND_HOTDEPLOY;
-import static com.vaadin.flow.server.InitParameters.NODE_DOWNLOAD_ROOT;
-import static com.vaadin.flow.server.InitParameters.NODE_VERSION;
-import static com.vaadin.flow.server.InitParameters.REACT_ENABLE;
-import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_INITIAL_UIDL;
-import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE;
-import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
-import static com.vaadin.flow.server.frontend.FrontendUtils.GENERATED;
-import static com.vaadin.flow.server.frontend.FrontendUtils.LEGACY_FRONTEND_DIR;
-import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
-import static com.vaadin.flow.server.frontend.FrontendUtils.TOKEN_FILE;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -82,6 +62,24 @@ import com.vaadin.pro.licensechecker.Product;
 import elemental.json.Json;
 import elemental.json.JsonObject;
 import elemental.json.impl.JsonUtil;
+
+import static com.vaadin.flow.server.Constants.CONNECT_APPLICATION_PROPERTIES_TOKEN;
+import static com.vaadin.flow.server.Constants.CONNECT_JAVA_SOURCE_FOLDER_TOKEN;
+import static com.vaadin.flow.server.Constants.CONNECT_OPEN_API_FILE_TOKEN;
+import static com.vaadin.flow.server.Constants.DISABLE_PREPARE_FRONTEND_CACHE;
+import static com.vaadin.flow.server.Constants.FRONTEND_TOKEN;
+import static com.vaadin.flow.server.Constants.JAVA_RESOURCE_FOLDER_TOKEN;
+import static com.vaadin.flow.server.Constants.NPM_TOKEN;
+import static com.vaadin.flow.server.Constants.PROJECT_FRONTEND_GENERATED_DIR_TOKEN;
+import static com.vaadin.flow.server.InitParameters.FRONTEND_HOTDEPLOY;
+import static com.vaadin.flow.server.InitParameters.NODE_DOWNLOAD_ROOT;
+import static com.vaadin.flow.server.InitParameters.NODE_VERSION;
+import static com.vaadin.flow.server.InitParameters.REACT_ENABLE;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_INITIAL_UIDL;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE;
+import static com.vaadin.flow.server.frontend.FrontendUtils.GENERATED;
+import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
+import static com.vaadin.flow.server.frontend.FrontendUtils.TOKEN_FILE;
 
 /**
  * Util class provides all methods a Plugin will need.
@@ -149,6 +147,8 @@ public class BuildFrontendUtil {
         Options options = new Options(lookup, adapter.npmFolder())
                 .withFrontendDirectory(getFrontendDirectory(adapter))
                 .withBuildDirectory(adapter.buildFolder())
+                .withBuildResultFolders(adapter.webpackOutputDirectory(),
+                        adapter.servletResourceOutputDirectory())
                 .withJarFrontendResourcesFolder(
                         getJarFrontendResourcesFolder(adapter))
                 .createMissingPackageJson(true).enableImportsUpdate(false)
@@ -309,7 +309,7 @@ public class BuildFrontendUtil {
                     .withFrontendDirectory(getFrontendDirectory(adapter))
                     .withBuildDirectory(adapter.buildFolder())
                     .withRunNpmInstall(adapter.runNpmInstall())
-                    .withWebpack(adapter.webpackOutputDirectory(),
+                    .withBuildResultFolders(adapter.webpackOutputDirectory(),
                             adapter.servletResourceOutputDirectory())
                     .enablePackagesUpdate(true)
                     .useByteCodeScanner(adapter.optimizeBundle())
@@ -375,7 +375,7 @@ public class BuildFrontendUtil {
                     .withFrontendDirectory(getFrontendDirectory(adapter))
                     .withBuildDirectory(adapter.buildFolder())
                     .withRunNpmInstall(adapter.runNpmInstall())
-                    .withWebpack(adapter.webpackOutputDirectory(),
+                    .withBuildResultFolders(adapter.webpackOutputDirectory(),
                             adapter.servletResourceOutputDirectory())
                     .enablePackagesUpdate(true).useByteCodeScanner(false)
                     .withJarFrontendResourcesFolder(

--- a/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
+++ b/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
@@ -18,6 +18,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.ArgumentMatchers;
 import org.mockito.InOrder;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
@@ -53,7 +54,7 @@ public class BuildFrontendUtilTest {
     private File statsJson;
 
     @Before
-    public void setup() throws IOException {
+    public void setup() throws Exception {
         TemporaryFolder tmpDir = new TemporaryFolder();
         tmpDir.create();
         baseDir = tmpDir.newFolder();
@@ -65,6 +66,8 @@ public class BuildFrontendUtilTest {
         Mockito.when(adapter.projectBaseDirectory())
                 .thenReturn(tmpDir.getRoot().toPath());
         ClassFinder classFinder = Mockito.mock(ClassFinder.class);
+        Mockito.when(classFinder.loadClass(ArgumentMatchers.anyString())).then(
+                i -> getClass().getClassLoader().loadClass(i.getArgument(0)));
         lookup = Mockito.spy(new LookupImpl(classFinder));
         Mockito.when(adapter.createLookup(Mockito.any())).thenReturn(lookup);
         Mockito.doReturn(classFinder).when(lookup).lookup(ClassFinder.class);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -118,7 +118,7 @@ public class NodeTasks implements FallibleCommand {
         }
 
         if (options.isEnablePackagesUpdate() || options.isEnableImportsUpdate()
-                || options.isEnableWebpackConfigUpdate()) {
+                || options.isEnableConfigUpdate()) {
             frontendDependencies = new FrontendDependenciesScanner.FrontendDependenciesScannerFactory()
                     .createScanner(!options.isUseByteCodeScanner(), classFinder,
                             options.isGenerateEmbeddableWebComponents(),
@@ -422,8 +422,8 @@ public class NodeTasks implements FallibleCommand {
         }
     }
 
-    public record NodeTasksLockInfo(long pid, String commandLine)
-            implements Serializable {
+    public record NodeTasksLockInfo(long pid,
+            String commandLine) implements Serializable {
     }
 
     private NodeTasksLockInfo readLockFile()

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/Options.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/Options.java
@@ -38,7 +38,7 @@ public class Options implements Serializable {
 
     private boolean enableImportsUpdate = false;
 
-    private boolean enableWebpackConfigUpdate = false;
+    private boolean enableConfigUpdate = false;
 
     private boolean runNpmInstall = false;
 
@@ -181,6 +181,26 @@ public class Options implements Serializable {
     }
 
     /**
+     * Sets the folders where frontend build results should be stored.
+     *
+     * @param webappResourcesDirectory
+     *            the directory to set for build tool to output its build
+     *            results, meant for serving from context root.
+     * @param resourceOutputDirectory
+     *            the directory to output generated non-served resources, such
+     *            as the "config/stats.json" stats file, and the
+     *            "config/flow-build-info.json" token file.
+     * @return this builder
+     */
+    public Options withBuildResultFolders(File webappResourcesDirectory,
+            File resourceOutputDirectory) {
+        this.enableConfigUpdate = true;
+        this.webappResourcesDirectory = webappResourcesDirectory;
+        this.resourceOutputDirectory = resourceOutputDirectory;
+        return this;
+    }
+
+    /**
      * Sets the webpack related properties.
      *
      * @param webappResourcesDirectory
@@ -191,21 +211,22 @@ public class Options implements Serializable {
      *            as the "config/stats.json" stats file, and the
      *            "config/flow-build-info.json" token file.
      * @return this builder
+     * @deprecated to be removed, use
+     *             {@link #withBuildResultFolders(File, File)} instead.
      */
+    @Deprecated(since = "24.4", forRemoval = true)
     public Options withWebpack(File webappResourcesDirectory,
             File resourceOutputDirectory) {
-        this.enableWebpackConfigUpdate = true;
-        this.webappResourcesDirectory = webappResourcesDirectory;
-        this.resourceOutputDirectory = resourceOutputDirectory;
-        return this;
+        return withBuildResultFolders(webappResourcesDirectory,
+                resourceOutputDirectory);
     }
 
     /**
-     * Sets whether to enable packages and webpack file updates. Default is
+     * Sets whether to enable packages and frontend file updates. Default is
      * <code>true</code>.
      *
      * @param enablePackagesUpdate
-     *            <code>true</code> to enable packages and webpack update,
+     *            <code>true</code> to enable packages and frontend update,
      *            otherwise <code>false</code>
      * @return this builder
      */
@@ -280,7 +301,7 @@ public class Options implements Serializable {
 
     /**
      * Sets whether copy resources from classpath to the appropriate npm package
-     * folder so as they are available for webpack build.
+     * folder so as they are available for frontend build.
      *
      * @param jars
      *            set of class nodes to be visited. Not {@code null}
@@ -631,9 +652,9 @@ public class Options implements Serializable {
     }
 
     /**
-     * Get the output directory for webpack output.
+     * Get the output directory for frontend build output.
      *
-     * @return webpackOutputDirectory
+     * @return webappResourcesDirectory
      */
     public File getWebappResourcesDirectory() {
         return webappResourcesDirectory;
@@ -728,8 +749,16 @@ public class Options implements Serializable {
         return enableImportsUpdate;
     }
 
+    public boolean isEnableConfigUpdate() {
+        return enableConfigUpdate;
+    }
+
+    /**
+     * @deprecated use {@link #isEnableConfigUpdate()}
+     */
+    @Deprecated(since = "24.4", forRemoval = true)
     public boolean isEnableWebpackConfigUpdate() {
-        return enableWebpackConfigUpdate;
+        return isEnableConfigUpdate();
     }
 
     public boolean isRunNpmInstall() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendResourcesAreCopiedAfterCleaningTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendResourcesAreCopiedAfterCleaningTest.java
@@ -99,7 +99,7 @@ public class FrontendResourcesAreCopiedAfterCleaningTest {
                 .enablePackagesUpdate(true).withFrontendDirectory(npmFolder)
                 .withJarFrontendResourcesFolder(getJarFrontendResourcesFolder())
                 .copyResources(Collections.singleton(testJar))
-                .withWebpack(npmFolder, npmFolder)).execute();
+                .withBuildResultFolders(npmFolder, npmFolder)).execute();
     }
 
     private void performPackageClean() throws ExecutionFailedException {
@@ -116,7 +116,8 @@ public class FrontendResourcesAreCopiedAfterCleaningTest {
                 .enableNpmFileCleaning(true).withFrontendDirectory(npmFolder)
                 .withJarFrontendResourcesFolder(getJarFrontendResourcesFolder())
                 .copyResources(Collections.emptySet())
-                .withWebpack(npmFolder, npmFolder).enablePackagesUpdate(true);
+                .withBuildResultFolders(npmFolder, npmFolder)
+                .enablePackagesUpdate(true);
         new NodeTasks(options).execute();
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksHillaTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksHillaTest.java
@@ -15,11 +15,14 @@
  */
 package com.vaadin.flow.server.frontend;
 
-import com.vaadin.flow.di.Lookup;
-import com.vaadin.flow.server.ExecutionFailedException;
-import com.vaadin.flow.server.frontend.scanner.ClassFinder;
-import com.vaadin.flow.server.frontend.scanner.ClassFinder.DefaultClassFinder;
-import org.junit.*;
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -27,12 +30,16 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import java.io.File;
-import java.io.IOException;
+import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.server.ExecutionFailedException;
+import com.vaadin.flow.server.frontend.scanner.ClassFinder;
+import com.vaadin.flow.server.frontend.scanner.ClassFinder.DefaultClassFinder;
 
 import static com.vaadin.flow.server.Constants.TARGET;
-import static com.vaadin.flow.server.frontend.FrontendUtils.*;
-import static org.mockito.Mockito.*;
+import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_FRONTEND_DIR;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 public class NodeTasksHillaTest {
 
@@ -94,7 +101,7 @@ public class NodeTasksHillaTest {
                         FrontendUtils.GENERATED
                                 + FrontendUtils.JAR_RESOURCES_FOLDER))
                 .withFrontendGeneratedFolder(new File(userDir))
-                .withWebpack(npmFolder, npmFolder)
+                .withBuildResultFolders(npmFolder, npmFolder)
                 .setJavaResourceFolder(propertiesDir);
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksViteTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksViteTest.java
@@ -35,7 +35,6 @@ import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.di.Lookup;
-import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.Mode;
 import com.vaadin.flow.server.frontend.NodeTestComponents.ExampleExperimentalComponent;
@@ -102,7 +101,7 @@ public class NodeTasksViteTest {
                 .enableImportsUpdate(true).withRunNpmInstall(false)
                 .withEmbeddableWebComponents(false)
                 .withJarFrontendResourcesFolder(getJarFrontendResourcesFolder())
-                .withWebpack(npmFolder, npmFolder);
+                .withBuildResultFolders(npmFolder, npmFolder);
 
         assertEquals(1, finder.getAnnotatedClasses(JsModule.class).size());
         assertEquals(1, finder.getAnnotatedClasses(JavaScript.class).size());
@@ -142,7 +141,7 @@ public class NodeTasksViteTest {
                 .withEmbeddableWebComponents(false)
                 .setJavaResourceFolder(propertiesDir)
                 .withJarFrontendResourcesFolder(getJarFrontendResourcesFolder())
-                .withWebpack(npmFolder, npmFolder);
+                .withBuildResultFolders(npmFolder, npmFolder);
 
         new NodeTasks(options).execute();
         File importsFile = FrontendUtils
@@ -168,7 +167,7 @@ public class NodeTasksViteTest {
                 .enableImportsUpdate(true).withRunNpmInstall(false)
                 .withEmbeddableWebComponents(false)
                 .withJarFrontendResourcesFolder(getJarFrontendResourcesFolder())
-                .withWebpack(npmFolder, npmFolder);
+                .withBuildResultFolders(npmFolder, npmFolder);
 
         Assert.assertEquals(
                 new File(userDir, DEFAULT_FRONTEND_DIR).getAbsolutePath(),
@@ -191,7 +190,7 @@ public class NodeTasksViteTest {
                 .enableImportsUpdate(true).withRunNpmInstall(false)
                 .withEmbeddableWebComponents(false)
                 .withJarFrontendResourcesFolder(getJarFrontendResourcesFolder())
-                .withWebpack(npmFolder, npmFolder);
+                .withBuildResultFolders(npmFolder, npmFolder);
 
         Assert.assertEquals(
                 new File(userDir, DEFAULT_FRONTEND_DIR).getAbsolutePath(),
@@ -215,7 +214,7 @@ public class NodeTasksViteTest {
                 .enableImportsUpdate(true).withRunNpmInstall(false)
                 .withEmbeddableWebComponents(false)
                 .withJarFrontendResourcesFolder(getJarFrontendResourcesFolder())
-                .withWebpack(npmFolder, npmFolder);
+                .withBuildResultFolders(npmFolder, npmFolder);
 
         Assert.assertEquals(
                 new File(userDir, "my_custom_sources_folder").getAbsolutePath(),
@@ -247,7 +246,7 @@ public class NodeTasksViteTest {
                 .enableImportsUpdate(true).withRunNpmInstall(false)
                 .withEmbeddableWebComponents(false)
                 .withJarFrontendResourcesFolder(getJarFrontendResourcesFolder())
-                .withWebpack(npmFolder, npmFolder);
+                .withBuildResultFolders(npmFolder, npmFolder);
         new NodeTasks(options).execute();
 
         Assert.assertTrue(new File(userDir, "tsconfig.json").exists());
@@ -267,7 +266,7 @@ public class NodeTasksViteTest {
                 .withEmbeddableWebComponents(false)
                 .withJarFrontendResourcesFolder(getJarFrontendResourcesFolder())
                 .withFrontendHotdeploy(true).withProductionMode(false)
-                .withWebpack(npmFolder, npmFolder);
+                .withBuildResultFolders(npmFolder, npmFolder);
         try (MockedStatic<BundleUtils> bundleUtils = Mockito
                 .mockStatic(BundleUtils.class);
                 MockedStatic<BundleValidationUtil> validationUtil = Mockito

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskCopyTemplateFilesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskCopyTemplateFilesTest.java
@@ -89,7 +89,8 @@ public class TaskCopyTemplateFilesTest {
 
         Options options = new Options(Mockito.mock(Lookup.class),
                 projectDirectory)
-                .withWebpack(frontendDirectory, resourceOutputDirectory)
+                .withBuildResultFolders(frontendDirectory,
+                        resourceOutputDirectory)
                 .withFrontendDirectory(frontendDirectory);
         TaskCopyTemplateFiles task = new TaskCopyTemplateFiles(finder, options);
         task.execute();

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
@@ -225,7 +225,7 @@ public class DevModeInitializer implements Serializable {
         // config,
         // see https://github.com/vaadin/flow/issues/9082
         File target = new File(baseDir, config.getBuildFolder());
-        options.withWebpack(
+        options.withBuildResultFolders(
                 Paths.get(target.getPath(), "classes", VAADIN_WEBAPP_RESOURCES)
                         .toFile(),
                 Paths.get(target.getPath(), "classes", VAADIN_SERVLET_RESOURCES)


### PR DESCRIPTION
The prepare-frontend task run by build tool plugins and DevModeInitializer should produce the same output for dev-server settings.
Also deprecates and replaces methods whose name references webpack.

Part of #18907