### PR TITLE
fix: forward/back navigation in hybrid app

### DIFF
--- a/flow-client/src/main/frontend/Flow.ts
+++ b/flow-client/src/main/frontend/Flow.ts
@@ -249,6 +249,7 @@ export class Flow {
           } else if (cmd && cmd.redirect && redirectContext) {
             resolve(cmd.redirect(redirectContext.pathname));
           } else {
+            cmd?.continue?.();
             this.container.style.display = '';
             resolve(this.container);
           }

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -1670,7 +1670,11 @@ public class UI extends Component
     }
 
     static final String SERVER_CONNECTED = "this.serverConnected($0)";
-    public static final String CLIENT_NAVIGATE_TO = "window.dispatchEvent(new CustomEvent('vaadin-router-go', {detail: new URL($0, document.baseURI)}))";
+    public static final String CLIENT_NAVIGATE_TO = """
+            const url = new URL($0, document.baseURI);
+            url["nav"] = true;
+            window.dispatchEvent(new CustomEvent('vaadin-router-go', { detail: url}));
+            """;
 
     public Element wrapperElement;
     private NavigationState clientViewNavigationState;

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -1773,13 +1773,6 @@ public class UI extends Component
         }
 
         final String trimmedRoute = PathUtil.trimPath(event.route);
-        if(getForwardToClientUrl() == null && !isPostponed()) {
-            // Only replace route if not forwarding or postponing.
-            if (!trimmedRoute.equals(event.route)) {
-                // See InternalRedirectHandler invoked via Router.
-                getPage().getHistory().replaceState(null, trimmedRoute);
-            }
-        }
         final Location location = new Location(trimmedRoute,
                 QueryParameters.fromString(event.query));
         NavigationTrigger navigationTrigger;
@@ -1816,8 +1809,14 @@ public class UI extends Component
         } else if (isPostponed()) {
             serverPaused();
         } else {
+            // acknowledge client, but cancel if session not open
             serverConnected(
                     !getSession().getState().equals(VaadinSessionState.OPEN));
+            if (!trimmedRoute.equals(event.route) && !getInternals()
+                    .containsPendingJavascript("window.history.replaceState")) {
+                // See InternalRedirectHandler invoked via Router.
+                getPage().getHistory().replaceState(null, trimmedRoute);
+            }
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -1812,11 +1812,25 @@ public class UI extends Component
             // acknowledge client, but cancel if session not open
             serverConnected(
                     !getSession().getState().equals(VaadinSessionState.OPEN));
-            if (!trimmedRoute.equals(event.route) && !getInternals()
-                    .containsPendingJavascript("window.history.replaceState")) {
-                // See InternalRedirectHandler invoked via Router.
-                getPage().getHistory().replaceState(null, trimmedRoute);
-            }
+            replaceStateIfDiffersAndNoReplacePending(event.route, trimmedRoute);
+        }
+    }
+
+    /**
+     * Do a history replaceState if the trimmed route differs from the event
+     * route and there is no pending replaceState command.
+     *
+     * @param route
+     *            the event.route
+     * @param trimmedRoute
+     *            the trimmed route
+     */
+    private void replaceStateIfDiffersAndNoReplacePending(String route,
+            String trimmedRoute) {
+        if (!trimmedRoute.equals(route) && !getInternals()
+                .containsPendingJavascript("window.history.replaceState")) {
+            // See InternalRedirectHandler invoked via Router.
+            getPage().getHistory().replaceState(null, trimmedRoute);
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -1773,6 +1773,13 @@ public class UI extends Component
         }
 
         final String trimmedRoute = PathUtil.trimPath(event.route);
+        if(getForwardToClientUrl() == null && !isPostponed()) {
+            // Only replace route if not forwarding or postponing.
+            if (!trimmedRoute.equals(event.route)) {
+                // See InternalRedirectHandler invoked via Router.
+                getPage().getHistory().replaceState(null, trimmedRoute);
+            }
+        }
         final Location location = new Location(trimmedRoute,
                 QueryParameters.fromString(event.query));
         NavigationTrigger navigationTrigger;
@@ -1811,10 +1818,6 @@ public class UI extends Component
         } else {
             serverConnected(
                     !getSession().getState().equals(VaadinSessionState.OPEN));
-            if (!trimmedRoute.equals(event.route)) {
-                // See InternalRedirectHandler invoked via Router.
-                getPage().getHistory().replaceState(null, trimmedRoute);
-            }
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -1672,7 +1672,7 @@ public class UI extends Component
     static final String SERVER_CONNECTED = "this.serverConnected($0)";
     public static final String CLIENT_NAVIGATE_TO = """
             const url = new URL($0, document.baseURI);
-            url["nav"] = true;
+            url["clientNavigation"] = true;
             window.dispatchEvent(new CustomEvent('vaadin-router-go', { detail: url}));
             """;
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -1772,10 +1772,6 @@ public class UI extends Component
         }
 
         final String trimmedRoute = PathUtil.trimPath(event.route);
-        if (!trimmedRoute.equals(event.route)) {
-            // See InternalRedirectHandler invoked via Router.
-            getPage().getHistory().replaceState(null, trimmedRoute);
-        }
         final Location location = new Location(trimmedRoute,
                 QueryParameters.fromString(event.query));
         NavigationTrigger navigationTrigger;
@@ -1813,6 +1809,10 @@ public class UI extends Component
             serverPaused();
         } else {
             acknowledgeClient();
+            if (!trimmedRoute.equals(event.route)) {
+                // See InternalRedirectHandler invoked via Router.
+                getPage().getHistory().replaceState(null, trimmedRoute);
+            }
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -82,6 +82,7 @@ import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServlet;
 import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.server.VaadinSessionState;
 import com.vaadin.flow.server.auth.AnonymousAllowed;
 import com.vaadin.flow.server.communication.PushConnection;
 import com.vaadin.flow.shared.Registration;
@@ -1808,7 +1809,8 @@ public class UI extends Component
         } else if (isPostponed()) {
             serverPaused();
         } else {
-            acknowledgeClient();
+            serverConnected(
+                    !getSession().getState().equals(VaadinSessionState.OPEN));
             if (!trimmedRoute.equals(event.route)) {
                 // See InternalRedirectHandler invoked via Router.
                 getPage().getHistory().replaceState(null, trimmedRoute);

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptNavigationStateRenderer.java
@@ -101,18 +101,10 @@ public class JavaScriptNavigationStateRenderer extends NavigationStateRenderer {
 
     @Override
     protected boolean shouldPushHistoryState(NavigationEvent event) {
-        if (NavigationTrigger.CLIENT_SIDE.equals(event.getTrigger())
-                || NavigationTrigger.ROUTER_LINK.equals(event.getTrigger())) {
+        if (NavigationTrigger.ROUTER_LINK.equals(event.getTrigger())) {
             return true;
         } else {
-            // For react router the server should push history state for
-            // server rendering even when client previously updated url with
-            // vaadin-router.
-            return super.shouldPushHistoryState(event)
-                    || (event.getUI().getInternals().getSession()
-                            .getConfiguration().isReactEnabled()
-                            && NavigationTrigger.CLIENT_SIDE
-                                    .equals(event.getTrigger()));
+            return super.shouldPushHistoryState(event);
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptNavigationStateRenderer.java
@@ -101,11 +101,15 @@ public class JavaScriptNavigationStateRenderer extends NavigationStateRenderer {
 
     @Override
     protected boolean shouldPushHistoryState(NavigationEvent event) {
-        if (NavigationTrigger.ROUTER_LINK.equals(event.getTrigger())) {
-            return true;
-        } else {
+        if (event.getUI().getInternals().getSession().getConfiguration()
+                .isReactEnabled()) {
             return super.shouldPushHistoryState(event);
         }
+        if (NavigationTrigger.CLIENT_SIDE.equals(event.getTrigger())
+                || NavigationTrigger.ROUTER_LINK.equals(event.getTrigger())) {
+            return true;
+        }
+        return super.shouldPushHistoryState(event);
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -677,8 +677,8 @@ public class UIInternals implements Serializable {
      * @return true if any invocation with given expression is found.
      */
     public boolean containsPendingJavascript(String containsFilter) {
-        return getPendingJavaScriptInvocations().filter(js -> js.getInvocation()
-                .getExpression().contains(containsFilter)).count() > 0;
+        return getPendingJavaScriptInvocations().anyMatch(js -> js
+                .getInvocation().getExpression().contains(containsFilter));
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -669,6 +669,19 @@ public class UIInternals implements Serializable {
     }
 
     /**
+     * Filter pendingJsInvocations to see if an invocation expression is set
+     * with given filter string.
+     *
+     * @param containsFilter
+     *            string to filter invocation expressions with
+     * @return true if any invocation with given expression is found.
+     */
+    public boolean containsPendingJavascript(String containsFilter) {
+        return getPendingJavaScriptInvocations().filter(js -> js.getInvocation()
+                .getExpression().contains(containsFilter)).count() > 0;
+    }
+
+    /**
      * Records the page title set with {@link Page#setTitle(String)}.
      * <p>
      * You should not set the page title for the browser with this method, use

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -190,14 +190,14 @@ function navigateEventHandler(event) {
                 continue() {
                     mountedContainer?.parentNode?.removeChild(mountedContainer);
                     mountedContainer = undefined;
-                    navigation(event.detail.pathname, {replace: false});
+                    popstateListener.listener(new PopStateEvent('popstate', {state: 'vaadin-router-ignore'}));
                 }
             }, router);
         } else {
             // Navigate to a non flow view. Clean nodes and undefine container.
             mountedContainer?.parentNode?.removeChild(mountedContainer);
             mountedContainer = undefined;
-            navigation(event.detail.pathname, {replace: false});
+            popstateListener.listener(new PopStateEvent('popstate', {state: 'vaadin-router-ignore'}));
         }
     }
     lastNavigation = event.detail.pathname;
@@ -254,6 +254,10 @@ export default function Flow() {
             }
         }
         flow.serverSideRoutes[0].action({pathname, search}).then((container) => {
+            // Update last navigation when coming into serverside as we might come
+            // in using the forward/back buttons.
+            lastNavigation = pathname;
+            lastNavigationSearch = search;
             const outlet = ref.current?.parentNode;
             if (outlet && outlet !== container.parentNode) {
                 outlet.append(container);
@@ -433,7 +437,7 @@ export const createWebComponent = (tag: string, props?: Properties, onload?: () 
  *
  * @param routes optional routes are for adding own route definition, giving routes will skip FS routes
  * @param serverSidePosition optional position where server routes should be put.
-  *                          If non given they go to the root of the routes [].
+ *                          If non given they go to the root of the routes [].
  *
  * @returns RouteObject[] with combined routes
  */

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -132,7 +132,7 @@ function vaadinRouterGlobalClickHandler(event) {
 
     // if none of the above, convert the click into a navigation event
     const {pathname, search, hash} = anchor;
-    if (fireRouterEvent('go', {pathname, search, hash})) {
+    if (fireRouterEvent('go', {pathname, search, hash, nav: true})) {
         event.preventDefault();
         // for a click event, the scroll is reset to the top position.
         if (event && event.type === 'click') {
@@ -196,14 +196,18 @@ function navigateEventHandler(event) {
                 continue() {
                     mountedContainer?.parentNode?.removeChild(mountedContainer);
                     mountedContainer = undefined;
-                    popstateListener.listener(new PopStateEvent('popstate', {state: 'vaadin-router-ignore'}));
+                    if(event.detail.nav) {
+                        navigation(event.detail.pathname, {replace: false});
+                    } else {
+                        popstateListener.listener(new PopStateEvent('popstate', {state: 'vaadin-router-ignore'}));
+                    }
                 }
             }, router);
         } else {
             // Navigate to a non flow view. Clean nodes and undefine container.
             mountedContainer?.parentNode?.removeChild(mountedContainer);
             mountedContainer = undefined;
-            popstateListener.listener(new PopStateEvent('popstate', {state: 'vaadin-router-ignore'}));
+            navigation(event.detail.pathname, {replace: false});
         }
     }
     lastNavigation = event.detail.pathname;

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -176,6 +176,12 @@ function navigateEventHandler(event) {
                     // @ts-ignore
                     redirect: (path) => {
                         navigation(path, {replace: false});
+                    },
+                    continue: () => {
+                        if(window.location.pathname !== event.detail.pathname) {
+                            window.history.pushState(window.history.state, '', event.detail.pathname);
+                            window.dispatchEvent(new PopStateEvent('popstate', {state: 'vaadin-router-ignore'}));
+                        }
                     }
                 },
                 router,

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
@@ -45,6 +45,7 @@ import com.vaadin.flow.router.RouterLink;
 import com.vaadin.flow.server.MockServletServiceSessionSetup;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.server.VaadinSessionState;
 
 public class JavaScriptBootstrapUITest {
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/MockServletServiceSessionSetup.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/MockServletServiceSessionSetup.java
@@ -374,6 +374,8 @@ public class MockServletServiceSessionSetup {
 
             Mockito.when(wrappedSession.getHttpSession())
                     .thenReturn(httpSession);
+            Mockito.when(session.getState())
+                    .thenReturn(VaadinSessionState.OPEN);
 
             Mockito.when(session.getService()).thenAnswer(i -> service);
             Mockito.when(session.hasLock()).thenReturn(true);

--- a/flow-tests/test-react-router/src/main/frontend/ReactView.tsx
+++ b/flow-tests/test-react-router/src/main/frontend/ReactView.tsx
@@ -1,0 +1,8 @@
+export default function ReactView() {
+
+    return (
+        <>
+            <p id="react">This is a simple view for a React route</p>
+        </>
+    );
+}

--- a/flow-tests/test-react-router/src/main/frontend/routes.tsx
+++ b/flow-tests/test-react-router/src/main/frontend/routes.tsx
@@ -1,11 +1,12 @@
 import ReactView from "Frontend/ReactView";
-import { buildRoute } from "Frontend/generated/flow/Flow";
+import { serverSideRoutes } from "Frontend/generated/flow/Flow";
 import { createBrowserRouter, RouteObject } from "react-router-dom";
 
 
-export const routes = buildRoute([
-    {path: '/react', element: <ReactView/>, handle: { title: 'React Test View' }}
-] as RouteObject[]);
+export const routes = [
+    {path: '/react', element: <ReactView/>, handle: { title: 'React Test View' }},
+    ...serverSideRoutes
+] as RouteObject[];
 
 export default createBrowserRouter([...routes], { basename: new URL(document.baseURI).pathname });
 

--- a/flow-tests/test-react-router/src/main/frontend/routes.tsx
+++ b/flow-tests/test-react-router/src/main/frontend/routes.tsx
@@ -1,0 +1,11 @@
+import ReactView from "Frontend/ReactView";
+import { buildRoute } from "Frontend/generated/flow/Flow";
+import { createBrowserRouter, RouteObject } from "react-router-dom";
+
+
+export const routes = buildRoute([
+    {path: '/react', element: <ReactView/>, handle: { title: 'React Test View' }}
+] as RouteObject[]);
+
+export default createBrowserRouter([...routes], { basename: new URL(document.baseURI).pathname });
+

--- a/flow-tests/test-react-router/src/main/java/com/vaadin/flow/NavigationView.java
+++ b/flow-tests/test-react-router/src/main/java/com/vaadin/flow/NavigationView.java
@@ -59,8 +59,8 @@ public class NavigationView extends Div {
         reactAnchorNavigation.setId(REACT_ANCHOR_ID);
         NativeButton reactServerNavigation = new NativeButton(
                 "Navigate to react through Server", event -> {
-            event.getSource().getUI().get().navigate("react");
-        });
+                    event.getSource().getUI().get().navigate("react");
+                });
         reactServerNavigation.setId(REACT_ID);
 
         add(new Div(), reactAnchorNavigation, new Div(), reactServerNavigation);

--- a/flow-tests/test-react-router/src/main/java/com/vaadin/flow/NavigationView.java
+++ b/flow-tests/test-react-router/src/main/java/com/vaadin/flow/NavigationView.java
@@ -31,6 +31,9 @@ public class NavigationView extends Div {
     public static final String ROUTER_LINK_ID = "router-link-navigation";
     public static final String POSTPONE_ID = "postpone-view-link";
 
+    public static final String REACT_ANCHOR_ID = "anchor-react-navigation";
+    public static final String REACT_ID = "react-navigation";
+
     public NavigationView() {
         Anchor anchorNavigation = new Anchor("com.vaadin.flow.AnchorView",
                 "Navigate to AnchorView");
@@ -49,6 +52,18 @@ public class NavigationView extends Div {
 
         add(new Span("NavigationView"), new Div(), anchorNavigation, new Div(),
                 serverNavigation, new Div(), link, new Div(), postponeView);
+
+        // React navigation
+        Anchor reactAnchorNavigation = new Anchor("react",
+                "Navigate to react with Anchor");
+        reactAnchorNavigation.setId(REACT_ANCHOR_ID);
+        NativeButton reactServerNavigation = new NativeButton(
+                "Navigate to react through Server", event -> {
+            event.getSource().getUI().get().navigate("react");
+        });
+        reactServerNavigation.setId(REACT_ID);
+
+        add(new Div(), reactAnchorNavigation, new Div(), reactServerNavigation);
     }
 
 }

--- a/flow-tests/test-react-router/src/test/java/com/vaadin/flow/NavigationIT.java
+++ b/flow-tests/test-react-router/src/test/java/com/vaadin/flow/NavigationIT.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 import com.vaadin.flow.component.html.testbench.AnchorElement;
 import com.vaadin.flow.component.html.testbench.NativeButtonElement;
+import com.vaadin.flow.component.html.testbench.ParagraphElement;
 import com.vaadin.flow.component.html.testbench.SpanElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
@@ -230,4 +231,49 @@ public class NavigationIT extends ChromeBrowserTest {
         Assert.assertEquals("NavigationView",
                 $(SpanElement.class).first().getText());
     }
+
+    @Test
+    public void testreactNavigationBrowserHistoryBack_anchor() {
+        open();
+
+        Assert.assertEquals("NavigationView",
+                $(SpanElement.class).first().getText());
+
+        $(AnchorElement.class).id(NavigationView.REACT_ANCHOR_ID).click();
+        Assert.assertEquals("This is a simple view for a React route",
+                $(ParagraphElement.class).id("react").getText());
+        getDriver().navigate().back();
+        Assert.assertEquals("NavigationView",
+                $(SpanElement.class).first().getText());
+
+        $(AnchorElement.class).id(NavigationView.REACT_ANCHOR_ID).click();
+        Assert.assertEquals("This is a simple view for a React route",
+                $(ParagraphElement.class).id("react").getText());
+        getDriver().navigate().back();
+        Assert.assertEquals("NavigationView",
+                $(SpanElement.class).first().getText());
+    }
+
+    @Test
+    public void testReactNavigationBrowserHistoryBack_serverNavigation() {
+        open();
+
+        Assert.assertEquals("NavigationView",
+                $(SpanElement.class).first().getText());
+
+        $(NativeButtonElement.class).id(NavigationView.REACT_ID).click();
+        Assert.assertEquals("This is a simple view for a React route",
+                $(ParagraphElement.class).id("react").getText());
+        getDriver().navigate().back();
+        Assert.assertEquals("NavigationView",
+                $(SpanElement.class).first().getText());
+
+        $(NativeButtonElement.class).id(NavigationView.REACT_ID).click();
+        Assert.assertEquals("This is a simple view for a React route",
+                $(ParagraphElement.class).id("react").getText());
+        getDriver().navigate().back();
+        Assert.assertEquals("NavigationView",
+                $(SpanElement.class).first().getText());
+    }
+
 }


### PR DESCRIPTION
Going back to Hilla view from
Flow view should not override
history so that forward button
also works to get "back" to Flow view.

Fixes #19003
