### PR TITLE
fix: reorder unhandled imports in CSS bundler

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/CssBundler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/CssBundler.java
@@ -3,6 +3,8 @@ package com.vaadin.flow.server.frontend;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -112,6 +114,19 @@ public class CssBundler {
             }
             return Matcher.quoteReplacement(result.group());
         });
+
+        // Move unhandled @import statements to the top, as they would be
+        // ignored by the browser if they appear after regular CSS rules
+        Matcher remainingImportMatcher = importPattern.matcher(content);
+        List<String> remainingImports = new ArrayList<>();
+        while (remainingImportMatcher.find()) {
+            remainingImports.add(remainingImportMatcher.group());
+        }
+        content = remainingImportMatcher.replaceAll("");
+        String remainingImportsString = String.join("\n", remainingImports);
+        boolean addNewLine = !content.isEmpty()
+                && !remainingImportsString.isEmpty();
+        content = remainingImportsString + (addNewLine ? "\n" : "") + content;
 
         return content;
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/CssBundlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/CssBundlerTest.java
@@ -135,6 +135,30 @@ public class CssBundlerTest {
                 .inlineImports(themeFolder, getThemeFile("styles.css")));
     }
 
+    @Test
+    public void unhandledImportsAreMovedToTop() throws IOException {
+        writeCss("body {background: blue};", "other.css");
+        writeCss(
+                """
+                        @import url('https://cdn.jsdelivr.net/fontsource/css/inter@latest/index.css');
+                        @import url('other.css');
+                        @import url('https://cdn.jsdelivr.net/fontsource/css/aclonica@latest/index.css');
+                        """,
+                "styles.css");
+
+        Assert.assertEquals(
+                """
+                        @import url('https://cdn.jsdelivr.net/fontsource/css/inter@latest/index.css');
+                        @import url('https://cdn.jsdelivr.net/fontsource/css/aclonica@latest/index.css');
+
+                        body {background: blue};
+                        """
+                        .trim(),
+                CssBundler
+                        .inlineImports(themeFolder, getThemeFile("styles.css"))
+                        .trim());
+    }
+
     private boolean createThemeFile(String filename) throws IOException {
         File f = getThemeFile(filename);
         f.getParentFile().mkdirs();


### PR DESCRIPTION
Currently `CssBundler` just replaces `@import`s with inlined file contents and returns the result. That can be problematic if an unprocessed import, for example to an external URL, comes after an inlined import. Now the unprocessed import comes after a regular CSS rule, which is invalid and ignored by the browser:
```css
/* inlined import content */
body { background: blue; }
/* unprocessed import */
@import url('https://cdn.jsdelivr.net/fontsource/css/aclonica@latest/index.css');
```

This change reorders unhandled imports so that they are at the top of the file:
```css
@import url('https://cdn.jsdelivr.net/fontsource/css/aclonica@latest/index.css');
body { background: blue; }
```