### PR TITLE
fix: pass deployment mode to FS Router vite plugin

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateVite.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateVite.java
@@ -143,7 +143,7 @@ public class TaskUpdateVite implements FallibleCommand, Serializable {
                             "import vitePluginFileSystemRouter from '"
                                     + FILE_SYSTEM_ROUTER_DEPENDENCY + "';")
                     .replace("//#vitePluginFileSystemRouter#",
-                            ", vitePluginFileSystemRouter()");
+                            ", vitePluginFileSystemRouter({isDevMode: devMode})");
         }
         return template.replace("//#vitePluginFileSystemRouterImport#", "")
                 .replace("//#vitePluginFileSystemRouter#", "");


### PR DESCRIPTION
## Description

This passes the deployment mode to the FS Router vite plugin so that it can decide where to generate needed file at runtime. This is to prevent file addition/modification under `classes` dir in dev mode to prevent spring-boot devtools
cause a restart during the startup. 

Related to: vaadin/hilla#2234
