### PR TITLE
fix: show available client routes

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/AbstractRouteNotFoundError.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/AbstractRouteNotFoundError.java
@@ -42,6 +42,7 @@ import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.router.internal.ClientRoutesProvider;
 import com.vaadin.flow.server.HttpStatusCode;
 import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.frontend.FrontendUtils;
 
 /**
  * This is abstract error view for routing exceptions.
@@ -141,13 +142,8 @@ public abstract class AbstractRouteNotFoundError extends Component {
     }
 
     private List<Element> getClientRoutes() {
-        return Optional.ofNullable(VaadinService.getCurrent())
-                .map(VaadinService::getContext)
-                .map(ctx -> ctx.getAttribute(Lookup.class)
-                        .lookup(ClientRoutesProvider.class))
-                .stream()
-                .flatMap(provider -> provider.getClientRoutes().stream())
-                .filter(Objects::nonNull).map(this::clientRouteToHtml).toList();
+        return FrontendUtils.getClientRoutes().stream()
+                .map(this::clientRouteToHtml).toList();
     }
 
     private Element routeTemplateToHtml(String routeTemplate,

--- a/flow-server/src/main/java/com/vaadin/flow/router/AbstractRouteNotFoundError.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/AbstractRouteNotFoundError.java
@@ -143,7 +143,8 @@ public abstract class AbstractRouteNotFoundError extends Component {
 
     private List<Element> getClientRoutes() {
         return FrontendUtils.getClientRoutes().stream()
-                .filter(route -> !route.startsWith("$"))
+                .filter(route -> !route.contains("$layout"))
+                .map(route -> route.replace("$index", ""))
                 .map(this::clientRouteToHtml).toList();
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/router/AbstractRouteNotFoundError.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/AbstractRouteNotFoundError.java
@@ -141,9 +141,9 @@ public abstract class AbstractRouteNotFoundError extends Component {
     }
 
     private List<Element> getClientRoutes() {
-        return Optional
-                .ofNullable(VaadinService.getCurrent().getContext()
-                        .getAttribute(Lookup.class)
+        return Optional.ofNullable(VaadinService.getCurrent())
+                .map(VaadinService::getContext)
+                .map(ctx -> ctx.getAttribute(Lookup.class)
                         .lookup(ClientRoutesProvider.class))
                 .stream()
                 .flatMap(provider -> provider.getClientRoutes().stream())

--- a/flow-server/src/main/java/com/vaadin/flow/router/AbstractRouteNotFoundError.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/AbstractRouteNotFoundError.java
@@ -143,6 +143,7 @@ public abstract class AbstractRouteNotFoundError extends Component {
 
     private List<Element> getClientRoutes() {
         return FrontendUtils.getClientRoutes().stream()
+                .filter(route -> !route.startsWith("$"))
                 .map(this::clientRouteToHtml).toList();
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/router/AbstractRouteNotFoundError.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/AbstractRouteNotFoundError.java
@@ -82,7 +82,7 @@ public abstract class AbstractRouteNotFoundError extends Component {
         boolean productionMode = event.getUI().getSession().getConfiguration()
                 .isProductionMode();
         String template;
-        String routes = getServerRoutes(event);
+        String routes = getRoutes(event);
 
         if (productionMode) {
             template = AbstractRouteNotFoundError.LazyInit.PRODUCTION_MODE_TEMPLATE;
@@ -118,7 +118,7 @@ public abstract class AbstractRouteNotFoundError extends Component {
         }
     }
 
-    private String getServerRoutes(BeforeEnterEvent event) {
+    private String getRoutes(BeforeEnterEvent event) {
         List<Element> routeElements = new ArrayList<>();
         List<RouteData> routes = event.getSource().getRegistry()
                 .getRegisteredRoutes();

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/ClientRoutesProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/ClientRoutesProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.router.internal;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Interface for providing client side routes.
+ */
+public interface ClientRoutesProvider extends Serializable {
+
+    /**
+     * Get a list of client side routes.
+     *
+     * @return a list of client side routes
+     */
+    default List<String> getClientRoutes() {
+        return List.of();
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/ClientRoutesProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/ClientRoutesProvider.java
@@ -27,9 +27,7 @@ public interface ClientRoutesProvider extends Serializable {
     /**
      * Get a list of client side routes.
      *
-     * @return a list of client side routes
+     * @return a list of client side routes. Not null.
      */
-    default List<String> getClientRoutes() {
-        return List.of();
-    }
+    List<String> getClientRoutes();
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -53,6 +53,7 @@ import com.vaadin.flow.internal.DevModeHandlerManager;
 import com.vaadin.flow.internal.Pair;
 import com.vaadin.flow.internal.StringUtil;
 import com.vaadin.flow.internal.hilla.EndpointRequestUtil;
+import com.vaadin.flow.router.internal.ClientRoutesProvider;
 import com.vaadin.flow.server.AbstractConfiguration;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.VaadinService;
@@ -1433,5 +1434,21 @@ public class FrontendUtils {
         } catch (ClassNotFoundException e) {
             return false;
         }
+    }
+
+    /**
+     * Get all available client routes in a distinct list of route paths
+     * collected from all {@link ClientRoutesProvider} implementations found
+     * with Vaadin {@link Lookup}.
+     *
+     * @return a list of available client routes
+     */
+    public static List<String> getClientRoutes() {
+        return Optional.ofNullable(VaadinService.getCurrent())
+                .map(VaadinService::getContext).stream()
+                .flatMap(ctx -> ctx.getAttribute(Lookup.class)
+                        .lookupAll(ClientRoutesProvider.class).stream())
+                .flatMap(provider -> provider.getClientRoutes().stream())
+                .filter(Objects::nonNull).distinct().toList();
     }
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-only-prepare/src/main/java/com/vaadin/flow/spring/test/TestServletInitializer.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-only-prepare/src/main/java/com/vaadin/flow/spring/test/TestServletInitializer.java
@@ -40,7 +40,7 @@ public class TestServletInitializer {
         return new ClientRoutesProvider() {
             @Override
             public List<String> getClientRoutes() {
-                return List.of("/hilla", "/hilla/person/:id",
+                return List.of("$index", "/hilla", "/hilla/person/:id",
                         "/hilla/persons/:id?");
             }
         };
@@ -51,7 +51,7 @@ public class TestServletInitializer {
         return new ClientRoutesProvider() {
             @Override
             public List<String> getClientRoutes() {
-                return List.of("/hilla", "/anotherhilla");
+                return List.of("$layout", "/hilla", "/anotherhilla");
             }
         };
     }

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-only-prepare/src/main/java/com/vaadin/flow/spring/test/TestServletInitializer.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-only-prepare/src/main/java/com/vaadin/flow/spring/test/TestServletInitializer.java
@@ -15,11 +15,16 @@
  */
 package com.vaadin.flow.spring.test;
 
+import java.util.List;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+
+import com.vaadin.flow.router.internal.ClientRoutesProvider;
 
 @SpringBootApplication
 @Configuration
@@ -30,4 +35,14 @@ public class TestServletInitializer {
         SpringApplication.run(TestServletInitializer.class, args);
     }
 
+    @Bean
+    public ClientRoutesProvider hillaClientRoutesProvider() {
+        return new ClientRoutesProvider() {
+            @Override
+            public List<String> getClientRoutes() {
+                return List.of("/hilla", "/hilla/person/:id",
+                        "/hilla/persons/:id?");
+            }
+        };
+    }
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-only-prepare/src/main/java/com/vaadin/flow/spring/test/TestServletInitializer.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-only-prepare/src/main/java/com/vaadin/flow/spring/test/TestServletInitializer.java
@@ -45,4 +45,14 @@ public class TestServletInitializer {
             }
         };
     }
+
+    @Bean
+    public ClientRoutesProvider anotherhillaClientRoutesProvider() {
+        return new ClientRoutesProvider() {
+            @Override
+            public List<String> getClientRoutes() {
+                return List.of("/hilla", "/anotherhilla");
+            }
+        };
+    }
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-only-prepare/src/main/java/com/vaadin/flow/spring/test/TestServletInitializer.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-only-prepare/src/main/java/com/vaadin/flow/spring/test/TestServletInitializer.java
@@ -40,8 +40,8 @@ public class TestServletInitializer {
         return new ClientRoutesProvider() {
             @Override
             public List<String> getClientRoutes() {
-                return List.of("$index", "/hilla", "/hilla/person/:id",
-                        "/hilla/persons/:id?");
+                return List.of("$index", "$layout", "/hilla",
+                        "/hilla/person/:id", "/hilla/persons/:id?");
             }
         };
     }
@@ -51,7 +51,8 @@ public class TestServletInitializer {
         return new ClientRoutesProvider() {
             @Override
             public List<String> getClientRoutes() {
-                return List.of("$layout", "/hilla", "/anotherhilla");
+                return List.of("/$layout", "/hilla", "/hilla/hilla/$index",
+                        "/anotherhilla");
             }
         };
     }

--- a/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/HillaRoutesRegisteredIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/HillaRoutesRegisteredIT.java
@@ -33,10 +33,10 @@ public class HillaRoutesRegisteredIT extends AbstractSpringTest {
 
         if (getDriver().getPageSource().contains(
                 "This detailed message is only shown when running in development mode.")) {
-            var expectedClientRoutes = List.of("/hilla",
+            var expectedClientRoutes = List.of("root", "/hilla",
                     "/hilla/person/:id (requires parameter)",
                     "/hilla/persons/:id? (supports optional parameter)",
-                    "/anotherhilla");
+                    "/hilla/hilla", "/anotherhilla", "/");
             for (String route : expectedClientRoutes) {
                 Assert.assertTrue(
                         String.format("Expected client route %s is missing",

--- a/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/HillaRoutesRegisteredIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/HillaRoutesRegisteredIT.java
@@ -33,10 +33,10 @@ public class HillaRoutesRegisteredIT extends AbstractSpringTest {
 
         if (getDriver().getPageSource().contains(
                 "This detailed message is only shown when running in development mode.")) {
-            System.out.println(getDriver().getPageSource());
             var expectedClientRoutes = List.of("/hilla",
                     "/hilla/person/:id (requires parameter)",
-                    "/hilla/persons/:id? (supports optional parameter)");
+                    "/hilla/persons/:id? (supports optional parameter)",
+                    "/anotherhilla");
             for (String route : expectedClientRoutes) {
                 Assert.assertTrue(
                         String.format("Expected client route %s is missing",

--- a/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/HillaRoutesRegisteredIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/HillaRoutesRegisteredIT.java
@@ -33,10 +33,12 @@ public class HillaRoutesRegisteredIT extends AbstractSpringTest {
 
         if (getDriver().getPageSource().contains(
                 "This detailed message is only shown when running in development mode.")) {
-            var expectedClientRoutes = List.of("root", "/hilla",
-                    "/hilla/person/:id (requires parameter)",
-                    "/hilla/persons/:id? (supports optional parameter)",
-                    "/hilla/hilla/", "/anotherhilla", "/");
+            var expectedClientRoutes = List.of("<a href=\"\">&lt;root&gt;</a>",
+                    "<a href=\"/hilla\">/hilla</a>",
+                    "<li>/hilla/person/:id (requires parameter)</li>",
+                    "<li>/hilla/persons/:id? (supports optional parameter)</li>",
+                    "<a href=\"/hilla/hilla/\">/hilla/hilla/</a>",
+                    "<a href=\"/anotherhilla\">/anotherhilla</a>");
             for (String route : expectedClientRoutes) {
                 Assert.assertTrue(
                         String.format("Expected client route %s is missing",

--- a/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/HillaRoutesRegisteredIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/HillaRoutesRegisteredIT.java
@@ -36,7 +36,7 @@ public class HillaRoutesRegisteredIT extends AbstractSpringTest {
             var expectedClientRoutes = List.of("root", "/hilla",
                     "/hilla/person/:id (requires parameter)",
                     "/hilla/persons/:id? (supports optional parameter)",
-                    "/hilla/hilla", "/anotherhilla", "/");
+                    "/hilla/hilla/", "/anotherhilla", "/");
             for (String route : expectedClientRoutes) {
                 Assert.assertTrue(
                         String.format("Expected client route %s is missing",

--- a/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/HillaRoutesRegisteredIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/HillaRoutesRegisteredIT.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.spring.test;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HillaRoutesRegisteredIT extends AbstractSpringTest {
+
+    @Test
+    public void assertClientRoutesRegistered() {
+        String nonExistingRoutePath = "non-existing-route";
+        getDriver().get(getContextRootURL() + '/' + nonExistingRoutePath);
+        waitForDevServer();
+        Assert.assertTrue(getDriver().getPageSource().contains(String
+                .format("Could not navigate to '%s'", nonExistingRoutePath)));
+
+        if (getDriver().getPageSource().contains(
+                "This detailed message is only shown when running in development mode.")) {
+            System.out.println(getDriver().getPageSource());
+            var expectedClientRoutes = List.of("/hilla",
+                    "/hilla/person/:id (requires parameter)",
+                    "/hilla/persons/:id? (supports optional parameter)");
+            for (String route : expectedClientRoutes) {
+                Assert.assertTrue(
+                        String.format("Expected client route %s is missing",
+                                route),
+                        getDriver().getPageSource().contains(route));
+            }
+        }
+    }
+}

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinApplicationConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinApplicationConfiguration.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.spring;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -24,6 +25,7 @@ import org.springframework.context.annotation.Configuration;
 
 import com.vaadin.flow.i18n.DefaultI18NProvider;
 import com.vaadin.flow.i18n.I18NProvider;
+import com.vaadin.flow.router.internal.ClientRoutesProvider;
 import com.vaadin.flow.server.startup.ApplicationConfigurationFactory;
 import com.vaadin.flow.spring.SpringLookupInitializer.SpringApplicationContextInit;
 import com.vaadin.flow.spring.i18n.DefaultI18NProviderFactory;
@@ -78,5 +80,21 @@ public class VaadinApplicationConfiguration {
                     + DefaultI18NProviderFactory.DEFAULT_LOCATION_PATTERN
                     + "}") String locationPattern) {
         return DefaultI18NProviderFactory.create(locationPattern);
+    }
+
+    /**
+     * Creates default {@link ClientRoutesProvider}. This is created only if
+     * there's no {@link ClientRoutesProvider} bean declared.
+     *
+     * @param context
+     *            the application context
+     * @return default client routes provider
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public ClientRoutesProvider vaadinClientRoutesProvider(
+            ApplicationContext context) {
+        return new ClientRoutesProvider() {
+        };
     }
 }

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinApplicationConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinApplicationConfiguration.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.spring;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -25,7 +24,6 @@ import org.springframework.context.annotation.Configuration;
 
 import com.vaadin.flow.i18n.DefaultI18NProvider;
 import com.vaadin.flow.i18n.I18NProvider;
-import com.vaadin.flow.router.internal.ClientRoutesProvider;
 import com.vaadin.flow.server.startup.ApplicationConfigurationFactory;
 import com.vaadin.flow.spring.SpringLookupInitializer.SpringApplicationContextInit;
 import com.vaadin.flow.spring.i18n.DefaultI18NProviderFactory;
@@ -81,5 +79,4 @@ public class VaadinApplicationConfiguration {
                     + "}") String locationPattern) {
         return DefaultI18NProviderFactory.create(locationPattern);
     }
-
 }

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinApplicationConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinApplicationConfiguration.java
@@ -82,19 +82,4 @@ public class VaadinApplicationConfiguration {
         return DefaultI18NProviderFactory.create(locationPattern);
     }
 
-    /**
-     * Creates default {@link ClientRoutesProvider}. This is created only if
-     * there's no {@link ClientRoutesProvider} bean declared.
-     *
-     * @param context
-     *            the application context
-     * @return default client routes provider
-     */
-    @Bean
-    @ConditionalOnMissingBean
-    public ClientRoutesProvider vaadinClientRoutesProvider(
-            ApplicationContext context) {
-        return new ClientRoutesProvider() {
-        };
-    }
 }


### PR DESCRIPTION
Adds client views in the list of available routes when viewing "Route not found" page in development mode. Adds ClientRoutesProvider interface to get available client routes. Client routes means mainly Hilla views, but not limited to.

Fixes: #18857
