### PR TITLE
refactor: import file-routes.js instead of views.js in Flow.tsx

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
@@ -223,7 +223,7 @@ public class TaskGenerateReactFiles implements FallibleCommand {
             return content.replace("//%toReactRouterImport%",
                     "import { toReactRouter } from '@vaadin/hilla-file-router/runtime.js';")
                     .replace("//%viewsJsImport%",
-                            "import views from 'Frontend/generated/views.js';")
+                            "import views from 'Frontend/generated/file-routes.js';")
                     .replace("//%buildRouteFunction%",
                             """
                                     if(!routes) {


### PR DESCRIPTION
Follow up for vaadin/hilla#2271

NOTE: the vaadin/hilla#2271 also keeps the generation of views.ts temporarily to prevent possible snapshot build failures.
Please feel free to add any changes needed for a smooth transition, if needed.
After these two PRs (on both sides) merged successfully, the generation of views.ts would be removed from Hilla codebase.

