### PR TITLE
fix: path separator in vfs

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
@@ -469,7 +469,7 @@ public class DevModeInitializer implements Serializable {
             String vfsJarPath = url.toString();
             String fileNamePrefix = vfsJarPath.substring(
                     vfsJarPath.lastIndexOf(
-                            FrontendUtils.isWindows() ? '\\' : '/') + 1,
+                            vfsJarPath.contains("\\") ? '\\' : '/') + 1,
                     vfsJarPath.lastIndexOf(".jar"));
             Path tempJar = Files.createTempFile(fileNamePrefix, ".jar");
 

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/OpenInCurrentIdeTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/OpenInCurrentIdeTest.java
@@ -9,8 +9,11 @@ import java.util.List;
 import java.util.Optional;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import com.vaadin.open.OSUtils;
 
 public class OpenInCurrentIdeTest {
 
@@ -46,7 +49,8 @@ public class OpenInCurrentIdeTest {
         // The binary on Mac is /.../IntelliJ IDEA.app/Contents/MacOS/idea
         Assert.assertEquals(
                 new File(baseDirectory, "MacOS/idea").getAbsolutePath(),
-                OpenInCurrentIde.getBinary(ideCommand.get()));
+                new File(OpenInCurrentIde.getBinary(ideCommand.get()))
+                        .getAbsolutePath());
 
     }
 
@@ -605,6 +609,8 @@ public class OpenInCurrentIdeTest {
 
     @Test
     public void runThrowsExceptionOnFailure() throws InterruptedException {
+        Assume.assumeFalse(OSUtils.isWindows());
+
         try {
             OpenInCurrentIde.run("/bin/sh", "-c",
                     "echo 'output1'; echo 'output2'; exit 123");


### PR DESCRIPTION
Fix decision on file separator
character according to string
instead of OS.

Fix ide test to use same format
for file path.

Fixes #19046
