### PR TITLE
fix: detect Flow PUSH requests as internal framework requests

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/HandlerHelper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/HandlerHelper.java
@@ -199,6 +199,10 @@ public class HandlerHelper implements Serializable {
                 requestedPathWithoutServletMapping.get(),
                 requestTypeParameter)) {
             return true;
+        } else if (RequestType.PUSH.getIdentifier().equals(requestTypeParameter)
+                && "VAADIN/push"
+                        .equals(requestedPathWithoutServletMapping.get())) {
+            return true;
         } else if (isUploadRequest(requestedPathWithoutServletMapping.get())) {
             return true;
         } else if (isHillaPush(requestedPathWithoutServletMapping.get())) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/HandlerHelperTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/HandlerHelperTest.java
@@ -1,17 +1,17 @@
 package com.vaadin.flow.server;
 
+import jakarta.servlet.http.HttpServletRequest;
+
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
-import jakarta.servlet.http.HttpServletRequest;
-
-import com.vaadin.flow.server.HandlerHelper.RequestType;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import com.vaadin.flow.server.HandlerHelper.RequestType;
 
 public class HandlerHelperTest {
 
@@ -213,6 +213,24 @@ public class HandlerHelperTest {
                 null);
 
         Assert.assertTrue(HandlerHelper.isFrameworkInternalRequest("/*",
+                request.getHttpServletRequest()));
+    }
+
+    @Test
+    public void isFrameworkInternalRequest_flowPushUrl() {
+        VaadinServletRequest request = createVaadinRequest("VAADIN/push", "",
+                RequestType.PUSH);
+
+        Assert.assertTrue(HandlerHelper.isFrameworkInternalRequest("/*",
+                request.getHttpServletRequest()));
+    }
+
+    @Test
+    public void isFrameworkInternalRequest_vaadinServletMapping_flowPushUrl() {
+        VaadinServletRequest request = createVaadinRequest("/VAADIN/push",
+                "/ui", RequestType.PUSH);
+
+        Assert.assertTrue(HandlerHelper.isFrameworkInternalRequest("/ui/*",
                 request.getHttpServletRequest()));
     }
 


### PR DESCRIPTION
## Description

HandlerHelper is currently not considering Flow PUSH requests (/VAADIN/push) as internal, preventing VaadinWebSecurity to ignore CSRF checks.
The issues happen only for ping requests; the connection request is not affected because it is a GET request.

Fixes #19075

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
