### PR TITLE
fix: normalize and replace line separator in node task lock file

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -363,7 +363,7 @@ public class NodeTasks implements FallibleCommand {
                         .of(lockInfo.pid());
 
                 if (processHandle.isPresent()
-                        && processHandle.get().info().commandLine().orElse("")
+                        && normalizeCommandLine(processHandle.get().info())
                                 .equals(lockInfo.commandLine())) {
                     if (!loggedWaiting) {
                         getLogger().info("Waiting for a previous instance of "
@@ -442,9 +442,14 @@ public class NodeTasks implements FallibleCommand {
     private void writeLockFile() throws IOException {
         ProcessHandle currentProcess = ProcessHandle.current();
         long myPid = currentProcess.pid();
-        String commandLine = currentProcess.info().commandLine().orElse("");
+        String commandLine = normalizeCommandLine(currentProcess.info());
         List<String> lines = List.of(Long.toString(myPid), commandLine);
         Files.write(lockFile, lines, StandardCharsets.UTF_8);
+    }
+
+    private String normalizeCommandLine(ProcessHandle.Info processInfo) {
+        return processInfo.commandLine()
+                .map(line -> line.replaceAll("\\r?\\n", " \\\\n")).orElse("");
     }
 
     private Logger getLogger() {


### PR DESCRIPTION
Normalizes and replaces line separators potentially present in the process command line before writing the lock file, so that it will contain only two lines. Same normalization is applied when getting the command line for the process identified by the pid in the lock file before comparing it with the value stored in the lock file.

Fixes #19091