### PR TITLE
fix: return empty list

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -373,6 +373,8 @@ export const serverSideRoutes = [
                 if (!eventListenerList) return [];
                 if (type == undefined) return eventListenerList;
                 // @ts-ignore
+                if(eventListenerList[type] == undefined) return [];
+                // @ts-ignore
                 return eventListenerList[type];
             }
 


### PR DESCRIPTION
Return an empty list if no
listeners for type exist.

Fixes #19073
