### PR TITLE
test: Extend test to use vaadinVersions

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonConverter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonConverter.java
@@ -132,7 +132,7 @@ class VersionsJsonConverter {
         }
     }
 
-    private boolean isIncludedByMode(String npmName, String mode) {
+    private boolean isIncludedByMode(String mode) {
         if (mode == null || mode.isBlank() || MODE_ALL.equalsIgnoreCase(mode)) {
             return true;
         } else if (reactEnabled) {
@@ -151,7 +151,7 @@ class VersionsJsonConverter {
         if (Objects.equals(npmName, VAADIN_CORE_NPM_PACKAGE)) {
             return;
         }
-        if (!isIncludedByMode(npmName, mode)) {
+        if (!isIncludedByMode(mode)) {
             return;
         }
         if (obj.hasKey(NPM_VERSION)) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -471,12 +471,15 @@ public class NodeUpdaterTest {
             throws IOException, ClassNotFoundException {
         File coreVersionsFile = File.createTempFile("vaadin-core-versions",
                 ".json", temporaryFolder.newFolder());
+        File vaadinVersionsFile = File.createTempFile("vaadin-versions",
+                ".json", temporaryFolder.newFolder());
         JsonObject mockedVaadinCoreJson = getMockVaadinCoreVersionsJson();
 
         JsonObject reactComponents = Json.createObject();
         JsonObject reactData = Json.createObject();
         reactData.put("jsVersion", "24.4.0-alpha13");
         reactData.put("npmName", "@vaadin/react-components");
+        reactData.put("mode", "react");
 
         reactComponents.put("react-components", reactData);
 
@@ -487,12 +490,26 @@ public class NodeUpdaterTest {
                 mockedVaadinCoreJson.getObject("core").hasKey("button"));
         Assert.assertFalse(mockedVaadinCoreJson.hasKey("vaadin"));
 
+        JsonObject mockedVaadinJson = getMockVaadinVersionsJson();
+
+        reactComponents = Json.createObject();
+        reactData = Json.createObject();
+        reactData.put("jsVersion", "24.4.0-alpha13");
+        reactData.put("npmName", "@vaadin/react-components-pro");
+        reactData.put("mode", "react");
+
+        reactComponents.put("react-components-pro", reactData);
+
+        mockedVaadinJson.put("react", reactComponents);
+
         FileUtils.write(coreVersionsFile, mockedVaadinCoreJson.toJson(),
+                StandardCharsets.UTF_8);
+        FileUtils.write(vaadinVersionsFile, mockedVaadinJson.toJson(),
                 StandardCharsets.UTF_8);
         Mockito.when(finder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(coreVersionsFile.toURI().toURL());
         Mockito.when(finder.getResource(Constants.VAADIN_VERSIONS_JSON))
-                .thenReturn(null);
+                .thenReturn(vaadinVersionsFile.toURI().toURL());
         Class clazz = FeatureFlags.class; // actual class doesn't matter
         Mockito.doReturn(clazz).when(finder).loadClass(
                 "com.vaadin.flow.component.react.ReactAdapterComponent");
@@ -501,6 +518,8 @@ public class NodeUpdaterTest {
 
         Assert.assertTrue(pinnedVersions.hasKey("@vaadin/button"));
         Assert.assertTrue(pinnedVersions.hasKey("@vaadin/react-components"));
+        Assert.assertTrue(
+                pinnedVersions.hasKey("@vaadin/react-components-pro"));
     }
 
     @Test


### PR DESCRIPTION
Extend the test so that we test using
react-components-pro from the
vaadin-versions.json file.

Remove unused parameter.

part of vaadin/platform#5204
