### PR TITLE
fix: filter hilla and copilot packages better

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -130,7 +130,9 @@ public class VaadinServletContextInitializer
             "com/vaadin/external/gwt", "javassist/", "io/methvin",
             "com/github/javaparser", "oshi/", "io/micrometer", "jakarta/",
             "com/nimbusds", "elemental/util", "elemental/json",
-            "org/reflections", "org/aopalliance", "org/objectweb")
+            "org/reflections", "org/aopalliance", "org/objectweb",
+
+            "com/vaadin/hilla", "com/vaadin/copilot")
             .collect(Collectors.toList());
 
     /**
@@ -142,7 +144,9 @@ public class VaadinServletContextInitializer
                     Theme.class.getPackage().getName(),
                     // LitRenderer uses script annotation
                     "com.vaadin.flow.data.renderer", "com.vaadin.shrinkwrap",
-                    "com.vaadin.hilla")
+                    "com.vaadin.copilot.CopilotIndexHtmlLoader",
+                    "com.vaadin.copilot.CopilotLoader",
+                    "com.vaadin.hilla.startup")
             .collect(Collectors.toList());
 
     /**

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -146,7 +146,7 @@ public class VaadinServletContextInitializer
                     "com.vaadin.flow.data.renderer", "com.vaadin.shrinkwrap",
                     "com.vaadin.copilot.CopilotIndexHtmlLoader",
                     "com.vaadin.copilot.CopilotLoader",
-                    "com.vaadin.hilla.startup")
+                    "com.vaadin.copilot.startup", "com.vaadin.hilla.startup")
             .collect(Collectors.toList());
 
     /**

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -144,8 +144,6 @@ public class VaadinServletContextInitializer
                     Theme.class.getPackage().getName(),
                     // LitRenderer uses script annotation
                     "com.vaadin.flow.data.renderer", "com.vaadin.shrinkwrap",
-                    "com.vaadin.copilot.CopilotIndexHtmlLoader",
-                    "com.vaadin.copilot.CopilotLoader",
                     "com.vaadin.copilot.startup", "com.vaadin.hilla.startup")
             .collect(Collectors.toList());
 


### PR DESCRIPTION
Filter "com/vaadin/hilla" and "com/vaadin/copilot" packages by default from the class scanner in `VaadinServletContextInitializer` and include only what is really needed: `com.vaadin.copilot.startup` and `com.vaadin.hilla.startup`. This speeds up mostly reload time and also startup time a bit.

Related-to: #19112