### PR TITLE
fix: handle exception from BrowserLiveReloadAccessor

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PushHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PushHandler.java
@@ -390,8 +390,14 @@ public class PushHandler {
         // In development mode we may have a live-reload push channel
         // that should be closed.
 
-        Optional<BrowserLiveReload> liveReload = BrowserLiveReloadAccessor
-                .getLiveReloadFromService(service);
+        Optional<BrowserLiveReload> liveReload = Optional.empty();
+        try {
+            liveReload = BrowserLiveReloadAccessor
+                    .getLiveReloadFromService(service);
+        } catch (IllegalStateException e) {
+            getLogger().debug(
+                    "Could not get live-reload push channel to close it.", e);
+        }
         if (isDebugWindowConnection(resource) && liveReload.isPresent()
                 && liveReload.get().isLiveReload(resource)) {
             liveReload.get().onDisconnect(resource);


### PR DESCRIPTION
Updates PushHandler to catch and log debug message of IllegalStateException from BrowserLiveReloadAccessor when it's thrown from already closed Spring context.

Fixes: #18835
