### PR TITLE
Chore: Replace discord link with forum link in bug-report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -4,7 +4,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        For general support from the community, use https://stackoverflow.com/questions/tagged/vaadin (or tag vaadin-flow) or Vaadin discord chat https://discord.gg/MYFq5RTbBn instead.
+        For general support from the community, use https://stackoverflow.com/questions/tagged/vaadin (or tag vaadin-flow) or the Vaadin Forum https://vaadin.com/forum/ instead.
   - type: markdown
     attributes:
       value: |


### PR DESCRIPTION
## Description

The discord chat is discontinued in favor of the new/old Vaadin forum, this change reflects that in the bug report template.

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
