### PR TITLE
fix: upgrade vulnerable dependency

### DIFF
--- a/flow-webpush/pom.xml
+++ b/flow-webpush/pom.xml
@@ -31,6 +31,18 @@
             <groupId>dev.blanke.webpush.jwt</groupId>
             <artifactId>webpush-jwt-jose4j</artifactId>
             <version>6.1.2</version>
+            <exclusions>
+                <!-- workaround: resolve CVE-2024-29857, CVE-2024-30172, CVE-2024-30171 -->
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk18on</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>1.78</version>
         </dependency>
 
         <!-- DefaultApplicationConfigurationFactory is declared as an OSGi


### PR DESCRIPTION
upgrade the dependency to resolve CVE: CVE-2024-29857, CVE-2024-30172, CVE-2024-30171

PR has been created to the original vulnerable dependency project.

```
-  dev.blanke.webpush.jwt:webpush-jwt-jose4j:jar:6.1.2:compile
|     +- dev.blanke.webpush:webpush:jar:6.1.1:compile
|     |  \- org.bouncycastle:bcprov-jdk18on:jar:1.76:compile
```