### PR TITLE
fix: unwrap router target class in getRouteTarget

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/di/Instantiator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/di/Instantiator.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.di;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.stream.Stream;
 
@@ -115,6 +116,38 @@ public interface Instantiator extends Serializable {
      * @return an instance of the given type
      */
     <T> T getOrCreate(Class<T> type);
+
+    /**
+     * Return the application-defined class for the given instance: usually
+     * simply the class of the given instance, but the original class in case of
+     * a runtime generated subclass.
+     *
+     * @param instance
+     *            the instance to check
+     * @return the user-defined class
+     */
+    default Class<?> getApplicationClass(Object instance) {
+        Objects.requireNonNull(instance, "Instance cannot be null");
+        return getApplicationClass(instance.getClass());
+    }
+
+    /**
+     * Return the application-defined class for the given class: usually simply
+     * the given class, but the original class in case of a runtime generated
+     * subclass.
+     *
+     * @param clazz
+     *            the class to check
+     * @return the user-defined class
+     */
+    default Class<?> getApplicationClass(Class<?> clazz) {
+        Class<?> appClass = clazz;
+        while (appClass != null && appClass != Object.class
+                && appClass.isSynthetic()) {
+            appClass = appClass.getSuperclass();
+        }
+        return appClass;
+    }
 
     /**
      * Creates an instance of a navigation target or router layout. This method

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -123,13 +123,14 @@ public abstract class AbstractNavigationStateRenderer
     static <T extends HasElement> T getRouteTarget(Class<T> routeTargetType,
             NavigationEvent event) {
         UI ui = event.getUI();
+        Instantiator instantiator = Instantiator.get(ui);
         Optional<HasElement> currentInstance = ui.getInternals()
                 .getActiveRouterTargetsChain().stream()
-                .filter(component -> component.getClass()
+                .filter(component -> instantiator.getApplicationClass(component)
                         .equals(routeTargetType))
                 .findAny();
-        return (T) currentInstance.orElseGet(() -> Instantiator.get(ui)
-                .createRouteTarget(routeTargetType, event));
+        return (T) currentInstance.orElseGet(
+                () -> instantiator.createRouteTarget(routeTargetType, event));
     }
 
     @Override

--- a/flow-tests/vaadin-spring-tests/test-spring-boot/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot/pom.xml
@@ -135,6 +135,7 @@
                                     <artifactId>vaadin-test-spring-common</artifactId>
                                     <version>${project.version}</version>
                                     <type>test-jar</type>
+                                    <classifier>tests</classifier>
                                     <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
                                 </artifactItem>
                             </artifactItems>

--- a/flow-tests/vaadin-spring-tests/test-spring-boot/src/main/java/com/vaadin/flow/spring/test/TestServletInitializer.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot/src/main/java/com/vaadin/flow/spring/test/TestServletInitializer.java
@@ -19,11 +19,13 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 
 @SpringBootApplication
 @Configuration
 @EnableWebSecurity
+@EnableAsync(proxyTargetClass = true)
 @Import(DummyOAuth2Server.class)
 public class TestServletInitializer {
 

--- a/flow-tests/vaadin-spring-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/test/ProxiedNavigationTarget.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/test/ProxiedNavigationTarget.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.spring.test;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.BeforeEvent;
+import com.vaadin.flow.router.HasUrlParameter;
+import com.vaadin.flow.router.OptionalParameter;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouterLink;
+
+import static com.vaadin.flow.spring.scopes.VaadinUIScope.VAADIN_UI_SCOPE_NAME;
+
+@Route("proxied")
+public class ProxiedNavigationTarget extends Div
+        implements HasUrlParameter<Integer> {
+
+    private final String uuid = UUID.randomUUID().toString();
+    private final AtomicInteger counter = new AtomicInteger();
+    private final RouterLink routerLink;
+    private final Div clickCounter;
+
+    public ProxiedNavigationTarget() {
+        Div uuid = new Div(this.uuid);
+        uuid.setId("COMPONENT_ID");
+        add(uuid);
+
+        clickCounter = new Div("P:0, C:0");
+        clickCounter.setId("CLICK_COUNTER");
+        add(clickCounter);
+
+        // Self navigation should use the same view instance
+        routerLink = new RouterLink("Self Link", ProxiedNavigationTarget.class,
+                counter.incrementAndGet());
+        add(routerLink);
+    }
+
+    // @Async annotation should cause Spring to create a proxy for the
+    // bean instance
+    @Async
+    public void asyncMethod() {
+
+    }
+
+    @Override
+    public void setParameter(BeforeEvent event,
+            @OptionalParameter Integer parameter) {
+        if (parameter != null) {
+            clickCounter.setText("P:" + parameter + ", C:" + counter.get());
+            routerLink.setRoute(ProxiedNavigationTarget.class,
+                    counter.incrementAndGet());
+        }
+    }
+}

--- a/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/RouteBasicIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/RouteBasicIT.java
@@ -16,9 +16,12 @@
 
 package com.vaadin.flow.spring.test;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.slf4j.LoggerFactory;
 
 public class RouteBasicIT extends AbstractSpringTest {
 
@@ -36,5 +39,37 @@ public class RouteBasicIT extends AbstractSpringTest {
         findElement(By.id("foo")).click();
 
         waitUntil(driver -> isElementPresent(By.id("singleton-in-ui")));
+    }
+
+    @Test
+    public void uiScopedProxiedTargetView_shouldUseSameViewInstance()
+            throws Exception {
+        getDriver().get(getTestURL() + "proxied");
+        waitForDevServer();
+
+        String prevUuid = null;
+        AtomicReference<String> prevCounter = new AtomicReference<>("");
+        for (int i = 0; i < 5; i++) {
+            String uuid = waitUntil(d -> d.findElement(By.id("COMPONENT_ID")))
+                    .getText();
+
+            waitUntil(d -> !prevCounter.get()
+                    .equals(d.findElement(By.id("CLICK_COUNTER")).getText()));
+
+            if (prevUuid != null) {
+                Assert.assertEquals("UUID should not have been changed",
+                        prevUuid, uuid);
+            }
+            String counter = findElement(By.id("CLICK_COUNTER")).getText();
+            Assert.assertEquals(
+                    "Parameter and counter should have the same value",
+                    "P:" + i + ", C:" + i, counter);
+
+            prevUuid = uuid;
+            prevCounter.set(counter);
+
+            $("a").first().click();
+        }
+
     }
 }

--- a/flow-tests/vaadin-spring-tests/test-spring/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring/pom.xml
@@ -93,6 +93,7 @@
                                     <artifactId>vaadin-test-spring-common</artifactId>
                                     <version>${project.version}</version>
                                     <type>test-jar</type>
+                                    <classifier>tests</classifier>
                                     <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
                                 </artifactItem>
                             </artifactItems>

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringInstantiator.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringInstantiator.java
@@ -24,6 +24,7 @@ import org.springframework.beans.BeanInstantiationException;
 import org.springframework.boot.SpringBootVersion;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.SpringVersion;
+import org.springframework.util.ClassUtils;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.di.DefaultInstantiator;
@@ -134,5 +135,10 @@ public class SpringInstantiator extends DefaultInstantiator {
             // If there is no bean, try to instantiate one
             return context.getAutowireCapableBeanFactory().createBean(type);
         }
+    }
+
+    @Override
+    public Class<?> getApplicationClass(Class<?> clazz) {
+        return ClassUtils.getUserClass(clazz);
     }
 }


### PR DESCRIPTION
## Description

AbstractNavigationStateRenderer.getRouteTarget filters the active router targets chain, comparing collection items class with the route target type. The filter may fail if routes instances are proxy objects created by frameworks like spring, since the class will not match the required one. This change ensures that synthetic and proxy classes are discarded, allowing for more accurate comparison when filtering objects based on their real application class.

Fixes #19100

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
