### PR TITLE
test: reset UI poll interval in UI.access block

### DIFF
--- a/flow-tests/test-misc/src/main/java/com/vaadin/flow/misc/ui/TranslationView.java
+++ b/flow-tests/test-misc/src/main/java/com/vaadin/flow/misc/ui/TranslationView.java
@@ -84,9 +84,10 @@ public class TranslationView extends Div {
             } catch (Exception e) {
                 e.printStackTrace();
             } finally {
-                ui.access(() -> dynamic
-                        .setText(getTranslation("label", Locale.FRANCE)));
-                ui.setPollInterval(-1);
+                ui.access(() -> {
+                    dynamic.setText(getTranslation("label", Locale.FRANCE));
+                    ui.setPollInterval(-1);
+                });
             }
         });
 


### PR DESCRIPTION
Resets the poll interval in the UI.access block so that the change is immediately pushed to the client and polling is stopped. Otherwise, the client will continue to poll until a UIDL request is sent the server.