### PR TITLE
docs: make onAttach docs advise a call to super method

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/Component.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Component.java
@@ -460,7 +460,8 @@ public abstract class Component
      * This method is invoked before the {@link AttachEvent} is fired for the
      * component.
      * </p>
-     * Make sure to call <code>super.onAttach</code> when overriding this method.
+     * Make sure to call <code>super.onAttach</code> when overriding this
+     * method.
      *
      * @param attachEvent
      *            the attach event
@@ -475,7 +476,8 @@ public abstract class Component
      * This method is invoked before the {@link DetachEvent} is fired for the
      * component.
      * <p>
-     * Make sure to call <code>super.onDetach</code> when overriding this method.
+     * Make sure to call <code>super.onDetach</code> when overriding this
+     * method.
      *
      * @param detachEvent
      *            the detach event

--- a/flow-server/src/main/java/com/vaadin/flow/component/Component.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Component.java
@@ -457,10 +457,10 @@ public abstract class Component
     /**
      * Called when the component is attached to a UI.
      * <p>
-     * The default implementation does nothing.
-     * <p>
      * This method is invoked before the {@link AttachEvent} is fired for the
      * component.
+     * </p>
+     * Make sure to call <code>super.onAttach</code> when overriding this method.
      *
      * @param attachEvent
      *            the attach event
@@ -472,10 +472,10 @@ public abstract class Component
     /**
      * Called when the component is detached from a UI.
      * <p>
-     * The default implementation does nothing.
-     * <p>
      * This method is invoked before the {@link DetachEvent} is fired for the
      * component.
+     * <p>
+     * Make sure to call <code>super.onDetach</code> when overriding this method.
      *
      * @param detachEvent
      *            the detach event


### PR DESCRIPTION
## Description

Some Flow Components override `onAttach` or `onDetach` methods defined in `Component.java` for various purposes. Since the (inherited) Javadoc states that the default implementation does nothing, one might assume they can safely omit the call to `super.onAttach` / `super.onDetach` upon overriding the method in a component extension.

This PR modifies the Javadoc to remove the mention of default behavior and advises users to call the super method when overriding.

> [!NOTE] 
> Refactoring the components to use `addAttachListener` may not be feasible without causing a breaking change so we opted for updating the documentation instead.

Fixes https://github.com/vaadin/flow-components/issues/6189

## Type of change

Documentation