### PR TITLE
chore: Upgrade minimal supported Node.js to v18.12

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -118,7 +118,7 @@ public class FrontendTools {
             7, 0);
 
     private static final int SUPPORTED_NODE_MAJOR_VERSION = 18;
-    private static final int SUPPORTED_NODE_MINOR_VERSION = 0;
+    private static final int SUPPORTED_NODE_MINOR_VERSION = 12;
     private static final int SUPPORTED_NPM_MAJOR_VERSION = 8;
     private static final int SUPPORTED_NPM_MINOR_VERSION = 6;
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -138,7 +138,7 @@ public class FrontendTools {
     static final String SYSTEM_HTTPS_PROXY_PROPERTY_KEY = "HTTPS_PROXY";
     static final String SYSTEM_HTTP_PROXY_PROPERTY_KEY = "HTTP_PROXY";
 
-    private static final int SUPPORTED_PNPM_MAJOR_VERSION = 5;
+    private static final int SUPPORTED_PNPM_MAJOR_VERSION = 7;
     private static final int SUPPORTED_PNPM_MINOR_VERSION = 0;
 
     private static final FrontendVersion SUPPORTED_PNPM_VERSION = new FrontendVersion(

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -68,7 +68,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @Category(SlowTests.class)
 public class FrontendToolsTest {
 
-    private static final String SUPPORTED_NODE_BUT_OLDER_THAN_AUTOINSTALLED = "18.0.0";
+    private static final String SUPPORTED_NODE_BUT_OLDER_THAN_AUTOINSTALLED = "18.12.0";
 
     public static final String DEFAULT_NODE = FrontendUtils.isWindows()
             ? "node\\node.exe"
@@ -80,7 +80,7 @@ public class FrontendToolsTest {
 
     private static final String OLD_PNPM_VERSION = "4.5.0";
 
-    private static final String SUPPORTED_PNPM_VERSION = "5.15.0";
+    private static final String SUPPORTED_PNPM_VERSION = "7.0.0";
 
     private String baseDir;
 
@@ -693,7 +693,7 @@ public class FrontendToolsTest {
                     "Unexpected exception message content '"
                             + exception.getMessage() + "'",
                     exception.getMessage().contains(
-                            "Found too old globally installed 'pnpm'. Please upgrade 'pnpm' to at least 5.0.0"));
+                            "Found too old globally installed 'pnpm'. Please upgrade 'pnpm' to at least 7.0.0"));
         } finally {
             uninstallGlobalPnpm(OLD_PNPM_VERSION);
         }


### PR DESCRIPTION
Update supported node version to 18.12, because pnpm 9.0.0-rc0 updated node requirement to 18.12.
Updates minimal supported pnpm version to 7 as older are semi-supported:
![image](https://github.com/vaadin/flow/assets/61410877/e7979c7d-ba95-4ac9-882e-591ed493b1f7)

