### PR TITLE
feat: add API for automatic main menu

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/di/DefaultInstantiator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/di/DefaultInstantiator.java
@@ -22,6 +22,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import org.slf4j.LoggerFactory;
+
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.function.SerializableSupplier;
@@ -160,6 +162,11 @@ public class DefaultInstantiator implements Instantiator {
 
                 return ReflectTools.createInstance(
                         (Class<? extends MenuAccessControl>) providerClass);
+            } else {
+                LoggerFactory.getLogger(DefaultInstantiator.class).warn(
+                        "Menu access control implementation class property '{}' is set to '{}' but it's not {} implementation",
+                        InitParameters.MENU_ACCESS_CONTROL, property,
+                        MenuAccessControl.class.getSimpleName());
             }
         } catch (ClassNotFoundException e) {
             throw new InvalidIMenuAccessControlException(

--- a/flow-server/src/main/java/com/vaadin/flow/di/DefaultInstantiator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/di/DefaultInstantiator.java
@@ -93,12 +93,14 @@ public class DefaultInstantiator implements Instantiator {
 
     @Override
     public I18NProvider getI18NProvider() {
-        return getAtomicReferenceInstance(i18nProvider, this::getI18NProviderInstance);
+        return getAtomicReferenceInstance(i18nProvider,
+                this::getI18NProviderInstance);
     }
 
     @Override
     public MenuAccessControl getMenuAccessControl() {
-        return getAtomicReferenceInstance(menuAccessControl, this::getMenuAccessControlInstance);
+        return getAtomicReferenceInstance(menuAccessControl,
+                this::getMenuAccessControlInstance);
     }
 
     private <T> T getAtomicReferenceInstance(AtomicReference<T> reference,
@@ -108,7 +110,7 @@ public class DefaultInstantiator implements Instantiator {
         }
         return reference.get();
     }
-    
+
     private I18NProvider getI18NProviderInstance() {
         String property = getInitProperty(InitParameters.I18N_PROVIDER);
         if (property == null) {
@@ -167,6 +169,7 @@ public class DefaultInstantiator implements Instantiator {
         }
         return null;
     }
+
     protected ClassLoader getClassLoader() {
         return getClass().getClassLoader();
     }
@@ -183,8 +186,7 @@ public class DefaultInstantiator implements Instantiator {
         if (deploymentConfiguration == null) {
             return null;
         }
-        return deploymentConfiguration
-                .getStringProperty(propertyName, null);
+        return deploymentConfiguration.getStringProperty(propertyName, null);
     }
 
     private <T> T create(Class<T> type) {

--- a/flow-server/src/main/java/com/vaadin/flow/di/DefaultInstantiator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/di/DefaultInstantiator.java
@@ -22,8 +22,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import org.slf4j.LoggerFactory;
-
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.function.SerializableSupplier;
@@ -33,7 +31,7 @@ import com.vaadin.flow.i18n.I18NUtil;
 import com.vaadin.flow.internal.ReflectTools;
 import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.InvalidI18NConfigurationException;
-import com.vaadin.flow.server.InvalidIMenuAccessControlException;
+import com.vaadin.flow.server.InvalidMenuAccessControlException;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServiceInitListener;
 import com.vaadin.flow.server.auth.DefaultMenuAccessControl;
@@ -163,18 +161,17 @@ public class DefaultInstantiator implements Instantiator {
                 return ReflectTools.createInstance(
                         (Class<? extends MenuAccessControl>) providerClass);
             } else {
-                LoggerFactory.getLogger(DefaultInstantiator.class).warn(
-                        "Menu access control implementation class property '{}' is set to '{}' but it's not {} implementation",
+                throw new InvalidMenuAccessControlException(String.format(
+                        "Menu access control implementation class property '%s' is set to '%s' but it's not %s implementation",
                         InitParameters.MENU_ACCESS_CONTROL, property,
-                        MenuAccessControl.class.getSimpleName());
+                        MenuAccessControl.class.getSimpleName()));
             }
         } catch (ClassNotFoundException e) {
-            throw new InvalidIMenuAccessControlException(
+            throw new InvalidMenuAccessControlException(
                     "Failed to load given provider class '" + property
                             + "' as it was not found by the class loader.",
                     e);
         }
-        return null;
     }
 
     protected ClassLoader getClassLoader() {

--- a/flow-server/src/main/java/com/vaadin/flow/di/Instantiator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/di/Instantiator.java
@@ -29,6 +29,7 @@ import com.vaadin.flow.server.DependencyFilter;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServiceInitListener;
 import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.server.auth.MenuAccessControl;
 import com.vaadin.flow.server.communication.IndexHtmlRequestListener;
 import com.vaadin.flow.server.communication.UidlWriter;
 
@@ -201,10 +202,18 @@ public interface Instantiator extends Serializable {
     /**
      * Get the I18NProvider if one has been defined.
      *
-     * @return I18NProvier instance
+     * @return I18NProvider instance
      */
     default I18NProvider getI18NProvider() {
         return getOrCreate(I18NProvider.class);
     }
 
+    /**
+     * Get the MenuAccessControl if one has been defined.
+     *
+     * @return MenuAccessControl instance
+     */
+    default MenuAccessControl getMenuAccessControl() {
+        return getOrCreate(MenuAccessControl.class);
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/di/Instantiator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/di/Instantiator.java
@@ -209,7 +209,7 @@ public interface Instantiator extends Serializable {
     }
 
     /**
-     * Get the MenuAccessControl if one has been defined.
+     * Get the MenuAccessControl.
      *
      * @return MenuAccessControl instance
      */

--- a/flow-server/src/main/java/com/vaadin/flow/router/Menu.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/Menu.java
@@ -58,14 +58,6 @@ public @interface Menu {
     long order() default Long.MIN_VALUE;
 
     /**
-     * Set to true to explicitly exclude a view from the automatically populated
-     * menu.
-     *
-     * @return true to exclude the view from the menu, false otherwise
-     */
-    boolean exclude() default false;
-
-    /**
      * Icon to use in the menu. Value can go inside a {@code <vaadin-icon>}
      * element's {@code icon} attribute which accepts icon group and name like
      * 'vaadin:file'. Or it can go to a {@code <vaadin-icon>} element's

--- a/flow-server/src/main/java/com/vaadin/flow/router/MenuData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/MenuData.java
@@ -34,10 +34,14 @@ public class MenuData implements Serializable {
     /**
      * Creates a new instance of the menu data.
      *
-     * @param title the title of the menu item
-     * @param order the order of the menu item
-     * @param exclude whether the menu item should be excluded
-     * @param icon the icon of the menu item
+     * @param title
+     *            the title of the menu item
+     * @param order
+     *            the order of the menu item
+     * @param exclude
+     *            whether the menu item should be excluded
+     * @param icon
+     *            the icon of the menu item
      */
     public MenuData(String title, Long order, boolean exclude, String icon) {
         this.title = title;
@@ -48,7 +52,7 @@ public class MenuData implements Serializable {
 
     /**
      * Gets the title of the menu item.
-     * 
+     *
      * @return the title of the menu item
      */
     public String getTitle() {
@@ -57,7 +61,7 @@ public class MenuData implements Serializable {
 
     /**
      * Gets the order of the menu item.
-     * 
+     *
      * @return the order of the menu item
      */
     public Long getOrder() {
@@ -66,7 +70,7 @@ public class MenuData implements Serializable {
 
     /**
      * Gets whether the menu item should be excluded.
-     * 
+     *
      * @return whether the menu item should be excluded
      */
     public boolean isExclude() {
@@ -75,7 +79,7 @@ public class MenuData implements Serializable {
 
     /**
      * Gets the icon of the menu item.
-     * 
+     *
      * @return the icon of the menu item
      */
     public String getIcon() {
@@ -84,13 +88,10 @@ public class MenuData implements Serializable {
 
     @Override
     public String toString() {
-        return "MenuData{" +
-                "title='" + title + '\'' +
-                ", order=" + order +
-                ", exclude=" + exclude +
-                ", icon='" + icon + '\'' +
-                '}';
+        return "MenuData{" + "title='" + title + '\'' + ", order=" + order
+                + ", exclude=" + exclude + ", icon='" + icon + '\'' + '}';
     }
+
     @Override
     public boolean equals(Object obj) {
         return obj instanceof MenuData other

--- a/flow-server/src/main/java/com/vaadin/flow/router/MenuData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/MenuData.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.router;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Data class for menu item information.
+ * <p>
+ * Only for read as data is immutable.
+ */
+public class MenuData implements Serializable {
+
+    private final String title;
+    private final Long order;
+    private final boolean exclude;
+    private final String icon;
+
+    /**
+     * Creates a new instance of the menu data.
+     *
+     * @param title the title of the menu item
+     * @param order the order of the menu item
+     * @param exclude whether the menu item should be excluded
+     * @param icon the icon of the menu item
+     */
+    public MenuData(String title, Long order, boolean exclude, String icon) {
+        this.title = title;
+        this.order = order;
+        this.exclude = exclude;
+        this.icon = icon;
+    }
+
+    /**
+     * Gets the title of the menu item.
+     * 
+     * @return the title of the menu item
+     */
+    public String getTitle() {
+        return title;
+    }
+
+    /**
+     * Gets the order of the menu item.
+     * 
+     * @return the order of the menu item
+     */
+    public Long getOrder() {
+        return order;
+    }
+
+    /**
+     * Gets whether the menu item should be excluded.
+     * 
+     * @return whether the menu item should be excluded
+     */
+    public boolean isExclude() {
+        return exclude;
+    }
+
+    /**
+     * Gets the icon of the menu item.
+     * 
+     * @return the icon of the menu item
+     */
+    public String getIcon() {
+        return icon;
+    }
+
+    @Override
+    public String toString() {
+        return "MenuData{" +
+                "title='" + title + '\'' +
+                ", order=" + order +
+                ", exclude=" + exclude +
+                ", icon='" + icon + '\'' +
+                '}';
+    }
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof MenuData other
+                && Objects.equals(title, other.title)
+                && Objects.equals(order, other.order)
+                && Objects.equals(exclude, other.exclude)
+                && Objects.equals(icon, other.icon);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(title, order, exclude, icon);
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteData.java
@@ -101,9 +101,9 @@ public class RouteData extends RouteBaseData<RouteData> {
      *            menu data for this route
      */
     public RouteData(List<Class<? extends RouterLayout>> parentLayouts,
-                     String template, Map<String, RouteParameterData> parameters,
-                     Class<? extends Component> navigationTarget,
-                     List<RouteAliasData> routeAliases, MenuData menuData) {
+            String template, Map<String, RouteParameterData> parameters,
+            Class<? extends Component> navigationTarget,
+            List<RouteAliasData> routeAliases, MenuData menuData) {
         super(parentLayouts, template, parameters, navigationTarget);
 
         Collections.sort(routeAliases);
@@ -122,7 +122,7 @@ public class RouteData extends RouteBaseData<RouteData> {
 
     /**
      * Get the menu data for this route.
-     * 
+     *
      * @return the menu data for this route
      */
     public MenuData getMenuData() {

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteData.java
@@ -31,6 +31,7 @@ import com.vaadin.flow.component.Component;
  */
 public class RouteData extends RouteBaseData<RouteData> {
     private final List<RouteAliasData> routeAliases;
+    private final MenuData menuData;
 
     /**
      * RouteData constructor. This constructor doesn't support parameters. When
@@ -58,6 +59,7 @@ public class RouteData extends RouteBaseData<RouteData> {
 
         Collections.sort(routeAliases);
         this.routeAliases = Collections.unmodifiableList(routeAliases);
+        this.menuData = null;
     }
 
     /**
@@ -78,10 +80,35 @@ public class RouteData extends RouteBaseData<RouteData> {
             String template, Map<String, RouteParameterData> parameters,
             Class<? extends Component> navigationTarget,
             List<RouteAliasData> routeAliases) {
+        this(parentLayouts, template, parameters, navigationTarget,
+                routeAliases, null);
+    }
+
+    /**
+     * RouteData constructor.
+     *
+     * @param parentLayouts
+     *            route parent layout class chain
+     * @param template
+     *            full route template
+     * @param parameters
+     *            navigation target path parameters
+     * @param navigationTarget
+     *            route navigation target
+     * @param routeAliases
+     *            list of aliases for this route
+     * @param menuData
+     *            menu data for this route
+     */
+    public RouteData(List<Class<? extends RouterLayout>> parentLayouts,
+                     String template, Map<String, RouteParameterData> parameters,
+                     Class<? extends Component> navigationTarget,
+                     List<RouteAliasData> routeAliases, MenuData menuData) {
         super(parentLayouts, template, parameters, navigationTarget);
 
         Collections.sort(routeAliases);
         this.routeAliases = Collections.unmodifiableList(routeAliases);
+        this.menuData = menuData;
     }
 
     /**
@@ -93,12 +120,22 @@ public class RouteData extends RouteBaseData<RouteData> {
         return routeAliases;
     }
 
+    /**
+     * Get the menu data for this route.
+     * 
+     * @return the menu data for this route
+     */
+    public MenuData getMenuData() {
+        return menuData;
+    }
+
     @Override
     public String toString() {
         return "RouteData{" + "parentLayout=" + getParentLayout() + ", url='"
                 + getTemplate() + '\'' + ", parameters=" + getRouteParameters()
                 + ", navigationTarget=" + getNavigationTarget()
-                + ", routeAliases=" + routeAliases + '}';
+                + ", routeAliases=" + routeAliases + ", menuData=" + menuData
+                + "}'";
     }
 
     @Override
@@ -108,7 +145,8 @@ public class RouteData extends RouteBaseData<RouteData> {
             return other.getParentLayouts().equals(this.getParentLayouts())
                     && other.getTemplate().equals(this.getTemplate())
                     && other.getNavigationTarget().equals(getNavigationTarget())
-                    && routeAliases.containsAll(other.routeAliases);
+                    && routeAliases.containsAll(other.routeAliases)
+                    && Objects.equals(menuData, other.getMenuData());
         }
         return false;
     }
@@ -116,6 +154,6 @@ public class RouteData extends RouteBaseData<RouteData> {
     @Override
     public int hashCode() {
         return Objects.hash(getParentLayouts(), getTemplate(),
-                getNavigationTarget(), routeAliases);
+                getNavigationTarget(), routeAliases, menuData);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractRouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractRouteRegistry.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.router.internal;
 
-import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -55,8 +54,6 @@ import com.vaadin.flow.server.auth.MenuAccessControl;
 import com.vaadin.flow.server.auth.NavigationAccessControl;
 import com.vaadin.flow.server.auth.NavigationContext;
 import com.vaadin.flow.server.auth.ViewAccessChecker;
-import com.vaadin.flow.server.frontend.FrontendUtils;
-import com.vaadin.flow.server.startup.ApplicationConfiguration;
 import com.vaadin.flow.shared.Registration;
 
 import static java.util.stream.Collectors.toList;
@@ -313,7 +310,7 @@ public abstract class AbstractRouteRegistry implements RouteRegistry {
                 .getAnnotationFor(target, Menu.class)
                 .map(menu -> new MenuData(menu.title(),
                         (menu.order() == Long.MIN_VALUE) ? null : menu.order(),
-                        menu.exclude(), menu.icon()))
+                        false, menu.icon()))
                 .orElse(null);
 
         RouteData route = new RouteData(parentLayouts, template,

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractRouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractRouteRegistry.java
@@ -266,7 +266,8 @@ public abstract class AbstractRouteRegistry implements RouteRegistry {
 
     private Stream<RouteData> getMenuRouteCandidates() {
         return getRegisteredRoutes().stream()
-                .filter(route -> route.getMenuData() != null);
+                .filter(route -> route.getMenuData() != null)
+                .filter(route -> !route.getMenuData().isExclude());
     }
 
     private <T> List<T> findListOf(Class<T> targetType, Collection<?> objects) {

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractRouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractRouteRegistry.java
@@ -211,9 +211,11 @@ public abstract class AbstractRouteRegistry implements RouteRegistry {
     }
 
     @Override
-    public List<RouteData> getRegisteredAccessibleMenuRoutes(VaadinRequest vaadinRequest, Collection<BeforeEnterListener> accessControls) {
+    public List<RouteData> getRegisteredAccessibleMenuRoutes(
+            VaadinRequest vaadinRequest,
+            Collection<BeforeEnterListener> accessControls) {
         final VaadinService vaadinService = VaadinService.getCurrent();
-        if(vaadinService == null) {
+        if (vaadinService == null) {
             return Collections.emptyList();
         }
         var populateClientSideMenu = vaadinService.getInstantiator()
@@ -236,7 +238,7 @@ public abstract class AbstractRouteRegistry implements RouteRegistry {
                 && legacyViewAccessCheckers.isEmpty()) {
             return routeCandidates.toList();
         }
-        if(VaadinService.getCurrentRequest() == null) {
+        if (VaadinService.getCurrentRequest() == null) {
             return Collections.emptyList();
         }
         return routeCandidates.filter(route -> navigationAccessControls.stream()
@@ -267,7 +269,7 @@ public abstract class AbstractRouteRegistry implements RouteRegistry {
                 .filter(event -> targetType.isAssignableFrom(event.getClass()))
                 .map(targetType::cast).toList();
     }
-    
+
     private boolean isClientMenuUsed(VaadinService vaadinService) {
         try {
             String fileRoutesJson = FrontendUtils.readFileRoutesJsonFile(
@@ -277,7 +279,7 @@ public abstract class AbstractRouteRegistry implements RouteRegistry {
             return false;
         }
     }
-    
+
     private List<RouteData> getRegisteredRoutes(
             ConfiguredRoutes configuration) {
         var routePathMap = new HashMap<>(configuration.getRoutesMap());

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractRouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractRouteRegistry.java
@@ -215,7 +215,10 @@ public abstract class AbstractRouteRegistry implements RouteRegistry {
     public List<RouteData> getRegisteredAccessibleMenuRoutes(
             VaadinRequest vaadinRequest,
             Collection<BeforeEnterListener> accessControls) {
-        final VaadinService vaadinService = VaadinService.getCurrent();
+        if (vaadinRequest == null) {
+            return Collections.emptyList();
+        }
+        final VaadinService vaadinService = vaadinRequest.getService();
         if (vaadinService == null) {
             return Collections.emptyList();
         }
@@ -236,9 +239,6 @@ public abstract class AbstractRouteRegistry implements RouteRegistry {
         if (navigationAccessControls.isEmpty()
                 && legacyViewAccessCheckers.isEmpty()) {
             return getMenuRouteCandidates().toList();
-        }
-        if (VaadinService.getCurrentRequest() == null) {
-            return Collections.emptyList();
         }
         return getMenuRouteCandidates().filter(route -> navigationAccessControls
                 .stream().allMatch(accessControl -> {

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractRouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractRouteRegistry.java
@@ -222,12 +222,11 @@ public abstract class AbstractRouteRegistry implements RouteRegistry {
         MenuAccessControl.PopulateClientMenu populateClientSideMenu = vaadinService
                 .getInstantiator().getMenuAccessControl()
                 .getPopulateClientSideMenu();
-        if (populateClientSideMenu == MenuAccessControl.PopulateClientMenu.AUTOMATIC
+        if (populateClientSideMenu == MenuAccessControl.PopulateClientMenu.NEVER) {
+            return Collections.emptyList();
+        } else if (populateClientSideMenu != MenuAccessControl.PopulateClientMenu.ALWAYS
                 && !isClientMenuUsed(vaadinService)) {
-            return getRegisteredRoutes();
-        } else if (populateClientSideMenu == MenuAccessControl.PopulateClientMenu.NEVER) {
-            // Continue only if the menu is populated on the client-side.
-            return getRegisteredRoutes();
+            return Collections.emptyList();
         }
 
         List<NavigationAccessControl> navigationAccessControls = findListOf(

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractRouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractRouteRegistry.java
@@ -227,9 +227,6 @@ public abstract class AbstractRouteRegistry implements RouteRegistry {
                 .getPopulateClientSideMenu();
         if (populateClientSideMenu == MenuAccessControl.PopulateClientMenu.NEVER) {
             return Collections.emptyList();
-        } else if (populateClientSideMenu != MenuAccessControl.PopulateClientMenu.ALWAYS
-                && !isClientMenuUsed(vaadinService)) {
-            return Collections.emptyList();
         }
 
         List<NavigationAccessControl> navigationAccessControls = findListOf(
@@ -273,16 +270,6 @@ public abstract class AbstractRouteRegistry implements RouteRegistry {
         return Stream.ofNullable(objects).flatMap(Collection::stream)
                 .filter(event -> targetType.isAssignableFrom(event.getClass()))
                 .map(targetType::cast).toList();
-    }
-
-    private boolean isClientMenuUsed(VaadinService vaadinService) {
-        try {
-            String fileRoutesJson = FrontendUtils.readFileRoutesJsonFile(
-                    ApplicationConfiguration.get(vaadinService.getContext()));
-            return fileRoutesJson.contains("\"title\":\"Layout\"");
-        } catch (IOException e) {
-            return false;
-        }
     }
 
     private List<RouteData> getRegisteredRoutes(

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -185,6 +185,11 @@ public class InitParameters implements Serializable {
     public static final String I18N_PROVIDER = "i18n.provider";
 
     /**
+     * Menu access control property.
+     */
+    public static final String MENU_ACCESS_CONTROL = "menu.access.control";
+
+    /**
      * Configuration name for the parameter that determines if Flow should
      * automatically register servlets needed for the application to work.
      */

--- a/flow-server/src/main/java/com/vaadin/flow/server/InvalidIMenuAccessControlException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InvalidIMenuAccessControlException.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server;
+
+/**
+ * Exception indicating that the application's Menu access control has been
+ * configured incorrectly.
+ *
+ * @since 1.0
+ */
+public class InvalidIMenuAccessControlException extends RuntimeException {
+
+    /**
+     * Constructs a new invalid Menu access control configuration runtime
+     * exception with the specified detail message.
+     *
+     * @param message
+     *            the detail message. The detail message is saved for later
+     *            retrieval by the {@link #getMessage()} method.
+     */
+    public InvalidIMenuAccessControlException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new invalid Menu access control configuration runtime
+     * exception with the specified detail message.
+     *
+     * @param message
+     *            the detail message. The detail message is saved for later
+     *            retrieval by the {@link #getMessage()} method.
+     * @param cause
+     *            the cause (which is saved for later retrieval by the
+     *            {@link #getCause()} method). (A <code>null</code> value is
+     *            permitted, and indicates that the cause is nonexistent or
+     *            unknown.)
+     */
+    public InvalidIMenuAccessControlException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/InvalidMenuAccessControlException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InvalidMenuAccessControlException.java
@@ -21,7 +21,7 @@ package com.vaadin.flow.server;
  *
  * @since 1.0
  */
-public class InvalidIMenuAccessControlException extends RuntimeException {
+public class InvalidMenuAccessControlException extends RuntimeException {
 
     /**
      * Constructs a new invalid Menu access control configuration runtime
@@ -31,7 +31,7 @@ public class InvalidIMenuAccessControlException extends RuntimeException {
      *            the detail message. The detail message is saved for later
      *            retrieval by the {@link #getMessage()} method.
      */
-    public InvalidIMenuAccessControlException(String message) {
+    public InvalidMenuAccessControlException(String message) {
         super(message);
     }
 
@@ -48,7 +48,7 @@ public class InvalidIMenuAccessControlException extends RuntimeException {
      *            permitted, and indicates that the cause is nonexistent or
      *            unknown.)
      */
-    public InvalidIMenuAccessControlException(String message, Throwable cause) {
+    public InvalidMenuAccessControlException(String message, Throwable cause) {
         super(message, cause);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/RouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/RouteRegistry.java
@@ -121,7 +121,7 @@ public interface RouteRegistry extends Serializable {
      * targets with a menu information. Access checking depends on the active
      * {@link VaadinService} and {@link VaadinRequest} and the given collection
      * of access controls.
-     * 
+     *
      * @param vaadinRequest
      *            the request to check access for
      * @param accessControls
@@ -129,7 +129,8 @@ public interface RouteRegistry extends Serializable {
      * @return list of accessible menu routes available for this registry
      */
     List<RouteData> getRegisteredAccessibleMenuRoutes(
-            VaadinRequest vaadinRequest, Collection<BeforeEnterListener> accessControls);
+            VaadinRequest vaadinRequest,
+            Collection<BeforeEnterListener> accessControls);
 
     /**
      * Search for a route target using given navigation <code>url</code>

--- a/flow-server/src/main/java/com/vaadin/flow/server/RouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/RouteRegistry.java
@@ -16,10 +16,12 @@
 package com.vaadin.flow.server;
 
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.router.BeforeEnterListener;
 import com.vaadin.flow.router.Location;
 import com.vaadin.flow.router.NotFoundException;
 import com.vaadin.flow.router.ParentLayout;
@@ -113,6 +115,21 @@ public interface RouteRegistry extends Serializable {
      * @return list of routes available for this registry
      */
     List<RouteData> getRegisteredRoutes();
+
+    /**
+     * Get the {@link RouteData} for all accessible registered navigation
+     * targets with a menu information. Access checking depends on the active
+     * {@link VaadinService} and {@link VaadinRequest} and the given collection
+     * of access controls.
+     * 
+     * @param vaadinRequest
+     *            the request to check access for
+     * @param accessControls
+     *            the access controls to use for checking access
+     * @return list of accessible menu routes available for this registry
+     */
+    List<RouteData> getRegisteredAccessibleMenuRoutes(
+            VaadinRequest vaadinRequest, Collection<BeforeEnterListener> accessControls);
 
     /**
      * Search for a route target using given navigation <code>url</code>

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/DefaultMenuAccessControl.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/DefaultMenuAccessControl.java
@@ -23,15 +23,16 @@ import java.util.Optional;
  */
 public class DefaultMenuAccessControl implements MenuAccessControl {
 
-    private Boolean populateClientSideMenu;
+    private PopulateClientMenu populateClientSideMenu = PopulateClientMenu.AUTOMATIC;
 
     @Override
-    public void setPopulateClientSideMenu(Boolean populateClientSideMenu) {
+    public void setPopulateClientSideMenu(
+            PopulateClientMenu populateClientSideMenu) {
         this.populateClientSideMenu = populateClientSideMenu;
     }
 
     @Override
-    public Optional<Boolean> getPopulateClientSideMenu() {
-        return Optional.ofNullable(populateClientSideMenu);
+    public PopulateClientMenu getPopulateClientSideMenu() {
+        return populateClientSideMenu;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/DefaultMenuAccessControl.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/DefaultMenuAccessControl.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.server.auth;
+
+import java.util.Optional;
+
+/**
+ * Default implementation of {@link MenuAccessControl}.
+ */
+public class DefaultMenuAccessControl implements MenuAccessControl {
+
+    private Boolean populateClientSideMenu;
+
+    @Override
+    public void setPopulateClientSideMenu(Boolean populateClientSideMenu) {
+        this.populateClientSideMenu = populateClientSideMenu;
+    }
+
+    @Override
+    public Optional<Boolean> getPopulateClientSideMenu() {
+        return Optional.ofNullable(populateClientSideMenu);
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/MenuAccessControl.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/MenuAccessControl.java
@@ -17,7 +17,6 @@
 package com.vaadin.flow.server.auth;
 
 import java.io.Serializable;
-import java.util.Optional;
 
 /**
  * Interface for controlling access to routes in the application's menu
@@ -26,29 +25,44 @@ import java.util.Optional;
 public interface MenuAccessControl extends Serializable {
 
     /**
+     * Enum for controlling how the client-side menu should be populated.
+     */
+    enum PopulateClientMenu {
+        /**
+         * Always populate the menu with server side routes.
+         */
+        ALWAYS,
+        /**
+         * Never populate the menu with server side routes.
+         */
+        NEVER,
+        /**
+         * Populate the menu with server side routes only if client-side menu
+         * exists.
+         */
+        AUTOMATIC
+    };
+
+    /**
      * Sets whether the Hilla application's main menu should be populated
      * automatically with server side routes and therefore routes information
-     * sent to the browser. Three possible values: {@link Boolean#TRUE} - always
-     * populate the menu with server side routes, {@link Boolean#FALSE} - never
-     * populate the menu with server side routes, {@code null} - populate the
-     * menu with server side routes only if client-side menu exists.
+     * sent to the browser. Three possible values:
+     * {@link PopulateClientMenu#ALWAYS}, {@link PopulateClientMenu#NEVER},
+     * {@link PopulateClientMenu#AUTOMATIC}.
      *
      * @param populateClientSideMenu
      *            whether the client-side menu should be populated with server
      *            side routes
      */
-    void setPopulateClientSideMenu(Boolean populateClientSideMenu);
+    void setPopulateClientSideMenu(PopulateClientMenu populateClientSideMenu);
 
     /**
      * Gets whether the Hilla application's main menu should be populated
      * automatically with server side routes and therefore routes information
      * sent to the browser.
      *
-     * @return {@link Boolean} wrapped in {@link Optional} where empty means
-     *         automatic mode, {@link Boolean#TRUE} means always populate the
-     *         menu with server side routes, {@link Boolean#FALSE} means never
-     *         populate the menu with server side routes.
+     * @return enum of type {@link PopulateClientMenu}
      */
-    Optional<Boolean> getPopulateClientSideMenu();
+    PopulateClientMenu getPopulateClientSideMenu();
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/MenuAccessControl.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/MenuAccessControl.java
@@ -32,7 +32,7 @@ public interface MenuAccessControl extends Serializable {
      * populate the menu with server side routes, {@link Boolean#FALSE} - never
      * populate the menu with server side routes, {@code null} - populate the
      * menu with server side routes only if client-side menu exists.
-     * 
+     *
      * @param populateClientSideMenu
      *            whether the client-side menu should be populated with server
      *            side routes
@@ -43,7 +43,7 @@ public interface MenuAccessControl extends Serializable {
      * Gets whether the Hilla application's main menu should be populated
      * automatically with server side routes and therefore routes information
      * sent to the browser.
-     * 
+     *
      * @return {@link Boolean} wrapped in {@link Optional} where empty means
      *         automatic mode, {@link Boolean#TRUE} means always populate the
      *         menu with server side routes, {@link Boolean#FALSE} means never

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/MenuAccessControl.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/MenuAccessControl.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.server.auth;
+
+import java.io.Serializable;
+import java.util.Optional;
+
+/**
+ * Interface for controlling access to routes in the application's menu
+ * component.
+ */
+public interface MenuAccessControl extends Serializable {
+
+    /**
+     * Sets whether the Hilla application's main menu should be populated
+     * automatically with server side routes and therefore routes information
+     * sent to the browser. Three possible values: {@link Boolean#TRUE} - always
+     * populate the menu with server side routes, {@link Boolean#FALSE} - never
+     * populate the menu with server side routes, {@code null} - populate the
+     * menu with server side routes only if client-side menu exists.
+     * 
+     * @param populateClientSideMenu
+     *            whether the client-side menu should be populated with server
+     *            side routes
+     */
+    void setPopulateClientSideMenu(Boolean populateClientSideMenu);
+
+    /**
+     * Gets whether the Hilla application's main menu should be populated
+     * automatically with server side routes and therefore routes information
+     * sent to the browser.
+     * 
+     * @return {@link Boolean} wrapped in {@link Optional} where empty means
+     *         automatic mode, {@link Boolean#TRUE} means always populate the
+     *         menu with server side routes, {@link Boolean#FALSE} means never
+     *         populate the menu with server side routes.
+     */
+    Optional<Boolean> getPopulateClientSideMenu();
+
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/NavigationAccessControl.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/NavigationAccessControl.java
@@ -437,7 +437,7 @@ public class NavigationAccessControl implements BeforeEnterListener {
         Objects.requireNonNull(vaadinService);
         return new NavigationContext(vaadinService.getRouter(),
                 navigationTarget, new Location(path), RouteParameters.empty(),
-                VaadinService.getCurrentRequest().getUserPrincipal(),
+                vaadinRequest.getUserPrincipal(),
                 getRolesChecker(vaadinRequest), false);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/NavigationAccessControl.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/NavigationAccessControl.java
@@ -422,15 +422,16 @@ public class NavigationAccessControl implements BeforeEnterListener {
      * @param navigationTarget
      *            the navigation target class. Not null.
      * @param path
-     *           the path to the navigation target. Not null.
+     *            the path to the navigation target. Not null.
      * @param vaadinService
      *            the Vaadin service. Not null.
      * @param vaadinRequest
      *            the Vaadin request.
      * @return a new navigation context instance.
      */
-    public NavigationContext createNavigationContext(Class<?> navigationTarget, String path,
-            VaadinService vaadinService, VaadinRequest vaadinRequest) {
+    public NavigationContext createNavigationContext(Class<?> navigationTarget,
+            String path, VaadinService vaadinService,
+            VaadinRequest vaadinRequest) {
         Objects.requireNonNull(navigationTarget);
         Objects.requireNonNull(path);
         Objects.requireNonNull(vaadinService);

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/NavigationAccessControl.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/NavigationAccessControl.java
@@ -30,9 +30,12 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.router.AccessDeniedException;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.BeforeEnterListener;
+import com.vaadin.flow.router.Location;
 import com.vaadin.flow.router.NotFoundException;
+import com.vaadin.flow.router.RouteParameters;
 import com.vaadin.flow.router.internal.PathUtil;
 import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.server.WrappedSession;
 
@@ -410,5 +413,30 @@ public class NavigationAccessControl implements BeforeEnterListener {
             Class<? extends NavigationAccessChecker> type) {
         return checkerList.stream()
                 .anyMatch(checker -> type.isAssignableFrom(checker.getClass()));
+    }
+
+    /**
+     * Creates a new {@link NavigationContext} instance based on the given route
+     * data and Vaadin service and request.
+     *
+     * @param navigationTarget
+     *            the navigation target class. Not null.
+     * @param path
+     *           the path to the navigation target. Not null.
+     * @param vaadinService
+     *            the Vaadin service. Not null.
+     * @param vaadinRequest
+     *            the Vaadin request.
+     * @return a new navigation context instance.
+     */
+    public NavigationContext createNavigationContext(Class<?> navigationTarget, String path,
+            VaadinService vaadinService, VaadinRequest vaadinRequest) {
+        Objects.requireNonNull(navigationTarget);
+        Objects.requireNonNull(path);
+        Objects.requireNonNull(vaadinService);
+        return new NavigationContext(vaadinService.getRouter(),
+                navigationTarget, new Location(path), RouteParameters.empty(),
+                VaadinService.getCurrentRequest().getUserPrincipal(),
+                getRolesChecker(vaadinRequest), false);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/ViewAccessChecker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/ViewAccessChecker.java
@@ -291,7 +291,7 @@ public class ViewAccessChecker implements BeforeEnterListener {
 
     /**
      * Checks access to the given navigation target.
-     * 
+     *
      * @param context
      *            the navigation context
      * @return the result of the access check
@@ -311,7 +311,7 @@ public class ViewAccessChecker implements BeforeEnterListener {
         }
         return context.deny("");
     }
-    
+
     /**
      * Creates a new {@link NavigationContext} instance based on the given route
      * data and Vaadin service and request.
@@ -319,7 +319,7 @@ public class ViewAccessChecker implements BeforeEnterListener {
      * @param navigationTarget
      *            the navigation target class. Not null.
      * @param path
-     *           the path to the navigation target. Not null.
+     *            the path to the navigation target. Not null.
      * @param vaadinService
      *            the Vaadin service. Not null.
      * @param vaadinRequest

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/ViewAccessChecker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/ViewAccessChecker.java
@@ -334,7 +334,7 @@ public class ViewAccessChecker implements BeforeEnterListener {
         Objects.requireNonNull(vaadinService);
         return new NavigationContext(vaadinService.getRouter(),
                 navigationTarget, new Location(path), RouteParameters.empty(),
-                VaadinService.getCurrentRequest().getUserPrincipal(),
+                vaadinRequest.getUserPrincipal(),
                 str -> getRolesChecker(vaadinRequest).apply(str), false);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/ViewAccessChecker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/ViewAccessChecker.java
@@ -22,6 +22,7 @@ import jakarta.servlet.http.HttpSession;
 
 import java.lang.reflect.AnnotatedElement;
 import java.security.Principal;
+import java.util.Objects;
 import java.util.function.Function;
 
 import org.slf4j.Logger;
@@ -31,8 +32,11 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.router.AccessDeniedException;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.BeforeEnterListener;
+import com.vaadin.flow.router.Location;
 import com.vaadin.flow.router.NotFoundException;
+import com.vaadin.flow.router.RouteParameters;
 import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServletRequest;
 
 /**
@@ -283,5 +287,54 @@ public class ViewAccessChecker implements BeforeEnterListener {
 
     private Logger getLogger() {
         return LoggerFactory.getLogger(getClass());
+    }
+
+    /**
+     * Checks access to the given navigation target.
+     * 
+     * @param context
+     *            the navigation context
+     * @return the result of the access check
+     */
+    public AccessCheckResult checkAccess(NavigationContext context) {
+        if (!enabled) {
+            return context.allow();
+        }
+        if (loginView != null && context.getNavigationTarget() == loginView) {
+            getLogger().debug("Allowing access for login view {}",
+                    context.getNavigationTarget().getName());
+            return context.allow();
+        }
+        if (accessAnnotationChecker.hasAccess(context.getNavigationTarget(),
+                context.getPrincipal(), context::hasRole)) {
+            return context.allow();
+        }
+        return context.deny("");
+    }
+    
+    /**
+     * Creates a new {@link NavigationContext} instance based on the given route
+     * data and Vaadin service and request.
+     *
+     * @param navigationTarget
+     *            the navigation target class. Not null.
+     * @param path
+     *           the path to the navigation target. Not null.
+     * @param vaadinService
+     *            the Vaadin service. Not null.
+     * @param vaadinRequest
+     *            the Vaadin request.
+     * @return a new navigation context instance.
+     */
+    public NavigationContext createNavigationContext(Class<?> navigationTarget,
+            String path, VaadinService vaadinService,
+            VaadinRequest vaadinRequest) {
+        Objects.requireNonNull(navigationTarget);
+        Objects.requireNonNull(path);
+        Objects.requireNonNull(vaadinService);
+        return new NavigationContext(vaadinService.getRouter(),
+                navigationTarget, new Location(path), RouteParameters.empty(),
+                VaadinService.getCurrentRequest().getUserPrincipal(),
+                str -> getRolesChecker(vaadinRequest).apply(str), false);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -1446,7 +1446,7 @@ public class FrontendUtils {
 
     /**
      * Get the content of the <code>file-routes.json</code>.
-     * 
+     *
      * @param configuration
      *            the vaadin configuration
      * @return the content of the file-routes.json file as a string

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -304,6 +304,10 @@ public class FrontendUtils {
      */
     public static final String JS_MODULES = "jsModules";
 
+    public static final String FILE_ROUTES_JSON_NAME = "file-routes.json";
+    public static final String FILE_ROUTES_JSON_PROD_PATH = "/META-INF/VAADIN/"
+            + FILE_ROUTES_JSON_NAME;
+
     /**
      * A parameter informing about the location of the
      * {@link FrontendUtils#TOKEN_FILE}.
@@ -1438,5 +1442,31 @@ public class FrontendUtils {
                         .lookupAll(ClientRoutesProvider.class).stream())
                 .flatMap(provider -> provider.getClientRoutes().stream())
                 .filter(Objects::nonNull).distinct().toList();
+    }
+
+    /**
+     * Get the content of the <code>file-routes.json</code>.
+     * 
+     * @param configuration
+     *            the vaadin configuration
+     * @return the content of the file-routes.json file as a string
+     * @throws IOException
+     *             if an I/O error occurs
+     */
+    public static String readFileRoutesJsonFile(
+            AbstractConfiguration configuration) throws IOException {
+        if (configuration.isProductionMode()) {
+            try (InputStream inputStream = FrontendUtils.class
+                    .getResourceAsStream(FILE_ROUTES_JSON_PROD_PATH)) {
+                if (inputStream != null) {
+                    return IOUtils.toString(inputStream, UTF_8);
+                }
+                return "";
+            }
+        }
+        return FileUtils.readFileToString(new File(
+                getFrontendGeneratedFolder(
+                        getProjectFrontendDir(configuration)),
+                FILE_ROUTES_JSON_NAME), UTF_8);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -304,10 +304,6 @@ public class FrontendUtils {
      */
     public static final String JS_MODULES = "jsModules";
 
-    public static final String FILE_ROUTES_JSON_NAME = "file-routes.json";
-    public static final String FILE_ROUTES_JSON_PROD_PATH = "/META-INF/VAADIN/"
-            + FILE_ROUTES_JSON_NAME;
-
     /**
      * A parameter informing about the location of the
      * {@link FrontendUtils#TOKEN_FILE}.
@@ -1444,29 +1440,4 @@ public class FrontendUtils {
                 .filter(Objects::nonNull).distinct().toList();
     }
 
-    /**
-     * Get the content of the <code>file-routes.json</code>.
-     *
-     * @param configuration
-     *            the vaadin configuration
-     * @return the content of the file-routes.json file as a string
-     * @throws IOException
-     *             if an I/O error occurs
-     */
-    public static String readFileRoutesJsonFile(
-            AbstractConfiguration configuration) throws IOException {
-        if (configuration.isProductionMode()) {
-            try (InputStream inputStream = FrontendUtils.class
-                    .getResourceAsStream(FILE_ROUTES_JSON_PROD_PATH)) {
-                if (inputStream != null) {
-                    return IOUtils.toString(inputStream, UTF_8);
-                }
-                return "";
-            }
-        }
-        return FileUtils.readFileToString(new File(
-                getFrontendGeneratedFolder(
-                        getProjectFrontendDir(configuration)),
-                FILE_ROUTES_JSON_NAME), UTF_8);
-    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/auth/CustomMenuAccessControl.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/auth/CustomMenuAccessControl.java
@@ -18,8 +18,7 @@ package com.vaadin.flow.server.auth;
 
 import java.util.Optional;
 
-public class CustomMenuAccessControl implements MenuAccessControl{
-
+public class CustomMenuAccessControl implements MenuAccessControl {
 
     @Override
     public void setPopulateClientSideMenu(Boolean populateClientSideMenu) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/auth/CustomMenuAccessControl.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/auth/CustomMenuAccessControl.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.server.auth;
+
+import java.util.Optional;
+
+public class CustomMenuAccessControl implements MenuAccessControl{
+
+
+    @Override
+    public void setPopulateClientSideMenu(Boolean populateClientSideMenu) {
+    }
+
+    @Override
+    public Optional<Boolean> getPopulateClientSideMenu() {
+        return Optional.of(Boolean.TRUE);
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/auth/CustomMenuAccessControl.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/auth/CustomMenuAccessControl.java
@@ -21,11 +21,12 @@ import java.util.Optional;
 public class CustomMenuAccessControl implements MenuAccessControl {
 
     @Override
-    public void setPopulateClientSideMenu(Boolean populateClientSideMenu) {
+    public void setPopulateClientSideMenu(
+            PopulateClientMenu populateClientSideMenu) {
     }
 
     @Override
-    public Optional<Boolean> getPopulateClientSideMenu() {
-        return Optional.of(Boolean.TRUE);
+    public PopulateClientMenu getPopulateClientSideMenu() {
+        return PopulateClientMenu.ALWAYS;
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/auth/DefaultInstantiatorMenuAccessControlTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/auth/DefaultInstantiatorMenuAccessControlTest.java
@@ -42,10 +42,13 @@ public class DefaultInstantiatorMenuAccessControlTest {
         mockLookup(service);
         DefaultInstantiator defaultInstantiator = new DefaultInstantiator(
                 service);
-        MenuAccessControl menuAccessControl = defaultInstantiator.getMenuAccessControl();
+        MenuAccessControl menuAccessControl = defaultInstantiator
+                .getMenuAccessControl();
         Assert.assertNotNull(menuAccessControl);
-        Assert.assertTrue(menuAccessControl instanceof DefaultMenuAccessControl);
-        Assert.assertTrue(menuAccessControl.getPopulateClientSideMenu().isEmpty());
+        Assert.assertTrue(
+                menuAccessControl instanceof DefaultMenuAccessControl);
+        Assert.assertTrue(
+                menuAccessControl.getPopulateClientSideMenu().isEmpty());
     }
 
     @Test
@@ -59,10 +62,12 @@ public class DefaultInstantiatorMenuAccessControlTest {
                 return "com.vaadin.flow.server.auth.CustomMenuAccessControl";
             }
         };
-        MenuAccessControl menuAccessControl = defaultInstantiator.getMenuAccessControl();
+        MenuAccessControl menuAccessControl = defaultInstantiator
+                .getMenuAccessControl();
         Assert.assertNotNull(menuAccessControl);
         Assert.assertTrue(menuAccessControl instanceof CustomMenuAccessControl);
-        Assert.assertTrue(menuAccessControl.getPopulateClientSideMenu().orElse(false));
+        Assert.assertTrue(
+                menuAccessControl.getPopulateClientSideMenu().orElse(false));
     }
 
     public static void clearMenuAccessControlField()

--- a/flow-server/src/test/java/com/vaadin/flow/server/auth/DefaultInstantiatorMenuAccessControlTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/auth/DefaultInstantiatorMenuAccessControlTest.java
@@ -47,8 +47,8 @@ public class DefaultInstantiatorMenuAccessControlTest {
         Assert.assertNotNull(menuAccessControl);
         Assert.assertTrue(
                 menuAccessControl instanceof DefaultMenuAccessControl);
-        Assert.assertTrue(
-                menuAccessControl.getPopulateClientSideMenu().isEmpty());
+        Assert.assertSame(menuAccessControl.getPopulateClientSideMenu(),
+                MenuAccessControl.PopulateClientMenu.AUTOMATIC);
     }
 
     @Test
@@ -66,8 +66,8 @@ public class DefaultInstantiatorMenuAccessControlTest {
                 .getMenuAccessControl();
         Assert.assertNotNull(menuAccessControl);
         Assert.assertTrue(menuAccessControl instanceof CustomMenuAccessControl);
-        Assert.assertTrue(
-                menuAccessControl.getPopulateClientSideMenu().orElse(false));
+        Assert.assertSame(menuAccessControl.getPopulateClientSideMenu(),
+                MenuAccessControl.PopulateClientMenu.ALWAYS);
     }
 
     public static void clearMenuAccessControlField()

--- a/flow-server/src/test/java/com/vaadin/flow/server/auth/DefaultInstantiatorMenuAccessControlTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/auth/DefaultInstantiatorMenuAccessControlTest.java
@@ -26,8 +26,12 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.di.DefaultInstantiator;
 import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.server.InitParameters;
+import com.vaadin.flow.server.InvalidMenuAccessControlException;
 import com.vaadin.flow.server.VaadinContext;
 import com.vaadin.flow.server.VaadinService;
+
+import static org.junit.Assert.assertThrows;
 
 public class DefaultInstantiatorMenuAccessControlTest {
 
@@ -68,6 +72,29 @@ public class DefaultInstantiatorMenuAccessControlTest {
         Assert.assertTrue(menuAccessControl instanceof CustomMenuAccessControl);
         Assert.assertSame(menuAccessControl.getPopulateClientSideMenu(),
                 MenuAccessControl.PopulateClientMenu.ALWAYS);
+    }
+
+    @Test
+    public void defaultInstantiator_getMenuAccessControlWithInvalidType_throwException() {
+        VaadinService service = Mockito.mock(VaadinService.class);
+        mockLookup(service);
+        DefaultInstantiator defaultInstantiator = new DefaultInstantiator(
+                service) {
+            @Override
+            protected String getInitProperty(String propertyName) {
+                return "com.vaadin.flow.server.auth.InvalidMenuAccessControl";
+            }
+        };
+        String errorMessage = assertThrows(
+                InvalidMenuAccessControlException.class,
+                () -> defaultInstantiator.getMenuAccessControl()).getMessage();
+        Assert.assertEquals(
+                "Menu access control implementation class property '"
+                        + InitParameters.MENU_ACCESS_CONTROL
+                        + "' is set to 'com.vaadin.flow.server.auth.InvalidMenuAccessControl' but it's not "
+                        + MenuAccessControl.class.getSimpleName()
+                        + " implementation",
+                errorMessage);
     }
 
     public static void clearMenuAccessControlField()

--- a/flow-server/src/test/java/com/vaadin/flow/server/auth/DefaultInstantiatorMenuAccessControlTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/auth/DefaultInstantiatorMenuAccessControlTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.server.auth;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.di.DefaultInstantiator;
+import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.server.VaadinContext;
+import com.vaadin.flow.server.VaadinService;
+
+public class DefaultInstantiatorMenuAccessControlTest {
+
+    @Before
+    public void init() throws NoSuchFieldException, IllegalAccessException {
+        clearMenuAccessControlField();
+    }
+
+    @Test
+    public void defaultInstantiator_getMenuAccessControl_defaultMenuAccessControl() {
+        VaadinService service = Mockito.mock(VaadinService.class);
+        mockLookup(service);
+        DefaultInstantiator defaultInstantiator = new DefaultInstantiator(
+                service);
+        MenuAccessControl menuAccessControl = defaultInstantiator.getMenuAccessControl();
+        Assert.assertNotNull(menuAccessControl);
+        Assert.assertTrue(menuAccessControl instanceof DefaultMenuAccessControl);
+        Assert.assertTrue(menuAccessControl.getPopulateClientSideMenu().isEmpty());
+    }
+
+    @Test
+    public void defaultInstantiator_getMenuAccessControl_customMenuAccessControl() {
+        VaadinService service = Mockito.mock(VaadinService.class);
+        mockLookup(service);
+        DefaultInstantiator defaultInstantiator = new DefaultInstantiator(
+                service) {
+            @Override
+            protected String getInitProperty(String propertyName) {
+                return "com.vaadin.flow.server.auth.CustomMenuAccessControl";
+            }
+        };
+        MenuAccessControl menuAccessControl = defaultInstantiator.getMenuAccessControl();
+        Assert.assertNotNull(menuAccessControl);
+        Assert.assertTrue(menuAccessControl instanceof CustomMenuAccessControl);
+        Assert.assertTrue(menuAccessControl.getPopulateClientSideMenu().orElse(false));
+    }
+
+    public static void clearMenuAccessControlField()
+            throws NoSuchFieldException, IllegalAccessException {
+        Field field = DefaultInstantiator.class
+                .getDeclaredField("menuAccessControl");
+        field.setAccessible(true);
+        ((AtomicReference<MenuAccessControl>) field.get(null)).set(null);
+        field.setAccessible(false);
+    }
+
+    private Lookup mockLookup(VaadinService service) {
+        VaadinContext context = Mockito.mock(VaadinContext.class);
+        Mockito.when(service.getContext()).thenReturn(context);
+
+        Lookup lookup = Mockito.mock(Lookup.class);
+        Mockito.when(context.getAttribute(Lookup.class)).thenReturn(lookup);
+        return lookup;
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/auth/InvalidMenuAccessControl.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/auth/InvalidMenuAccessControl.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.server.auth;
+
+/**
+ * Invalid type of and MenuAccessControl, not implementing the required
+ * interface.
+ */
+public class InvalidMenuAccessControl {
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/RouteRegistryMenuAccessTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/RouteRegistryMenuAccessTest.java
@@ -55,7 +55,7 @@ import static org.mockito.Mockito.mock;
 public class RouteRegistryMenuAccessTest {
 
     private static String FILE_ROUTES_JSON_WITH_LAYOUT = "{\"route\":\"\",\"params\":{},\"title\":\"Layout\",\"children\":[]}";
-    
+
     private ApplicationRouteRegistry registry;
 
     @Before
@@ -339,16 +339,18 @@ public class RouteRegistryMenuAccessTest {
         var instantiator = mock(Instantiator.class);
         when(VaadinService.getCurrent().getInstantiator())
                 .thenReturn(instantiator);
-        when(instantiator.getMenuAccessControl()).thenReturn(new MenuAccessControl() {
-            @Override
-            public void setPopulateClientSideMenu(Boolean populateClientSideMenu) {
-            }
+        when(instantiator.getMenuAccessControl())
+                .thenReturn(new MenuAccessControl() {
+                    @Override
+                    public void setPopulateClientSideMenu(
+                            Boolean populateClientSideMenu) {
+                    }
 
-            @Override
-            public Optional<Boolean> getPopulateClientSideMenu() {
-                return Optional.ofNullable(populateClientSideMenu);
-            }
-        });
+                    @Override
+                    public Optional<Boolean> getPopulateClientSideMenu() {
+                        return Optional.ofNullable(populateClientSideMenu);
+                    }
+                });
     }
 
     @Tag("div")

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/RouteRegistryMenuAccessTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/RouteRegistryMenuAccessTest.java
@@ -85,19 +85,19 @@ public class RouteRegistryMenuAccessTest {
     }
 
     @Test
-    public void getRegisteredAccessibleMenuRoutes_populateClientSideMenuIsFalse_oneMenuRoute() {
+    public void getRegisteredAccessibleMenuRoutes_populateClientSideMenuIsFalse_noMenuRoute() {
         mockInstantiator(MenuAccessControl.PopulateClientMenu.NEVER);
         registry.clean();
         registry.setRoute("home", RouteRegistryTestBase.MyRoute.class,
                 Collections.emptyList());
         Assert.assertEquals("One route should be registered.", 1,
                 registry.getRegisteredRoutes().size());
-        Assert.assertEquals("One route should be registered.", 1,
+        Assert.assertEquals("No routes should be registered.", 0,
                 registry.getRegisteredAccessibleMenuRoutes(null, null).size());
     }
 
     @Test
-    public void getRegisteredAccessibleMenuRoutes_populateClientSideMenuIsAutomaticWithoutFileRoutesJson_oneMenuRoute() {
+    public void getRegisteredAccessibleMenuRoutes_populateClientSideMenuIsAutomaticWithoutFileRoutesJson_noMenuRoute() {
         try (MockedStatic<FrontendUtils> utils = Mockito
                 .mockStatic(FrontendUtils.class, Mockito.CALLS_REAL_METHODS)) {
             utils.when(() -> FrontendUtils.readFileRoutesJsonFile(any()))
@@ -114,7 +114,7 @@ public class RouteRegistryMenuAccessTest {
                             Mockito.CALLS_REAL_METHODS)) {
                 config.when(() -> ApplicationConfiguration.get(any()))
                         .thenReturn(mock(ApplicationConfiguration.class));
-                Assert.assertEquals("One route should be registered.", 1,
+                Assert.assertEquals("No routes should be registered.", 0,
                         registry.getRegisteredAccessibleMenuRoutes(null, null)
                                 .size());
             }

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/RouteRegistryMenuAccessTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/RouteRegistryMenuAccessTest.java
@@ -160,6 +160,19 @@ public class RouteRegistryMenuAccessTest {
     }
 
     @Test
+    public void getRegisteredAccessibleMenuRoutes_withoutNavAccessControl_doNotReturnExcludedMenuRoute() {
+        mockInstantiator(MenuAccessControl.PopulateClientMenu.ALWAYS);
+        registry.clean();
+        registry.setRoute("hasmenu", MyMenuRouteExcluded.class,
+                Collections.emptyList());
+        Assert.assertEquals("One route should be registered.", 1,
+                registry.getRegisteredRoutes().size());
+        Assert.assertEquals("No accessible menu routes should be available.", 0,
+                registry.getRegisteredAccessibleMenuRoutes(null, List.of())
+                        .size());
+    }
+
+    @Test
     public void getRegisteredAccessibleMenuRoutes_withNavAccessControlWithoutRequest_noAccessibleMenuRoute() {
         mockInstantiator(MenuAccessControl.PopulateClientMenu.ALWAYS);
         registry.clean();
@@ -362,6 +375,12 @@ public class RouteRegistryMenuAccessTest {
     @Route("hasmenu")
     @Menu
     protected static class MyMenuRoute extends Component {
+    }
+
+    @Tag("div")
+    @Route("hasmenu")
+    @Menu(exclude = true)
+    protected static class MyMenuRouteExcluded extends Component {
     }
 
     @AnonymousAllowed

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/RouteRegistryMenuAccessTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/RouteRegistryMenuAccessTest.java
@@ -45,15 +45,12 @@ import com.vaadin.flow.server.auth.AnonymousAllowed;
 import com.vaadin.flow.server.auth.MenuAccessControl;
 import com.vaadin.flow.server.auth.NavigationAccessControl;
 import com.vaadin.flow.server.auth.ViewAccessChecker;
-import com.vaadin.flow.server.frontend.FrontendUtils;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
 
 public class RouteRegistryMenuAccessTest {
-
-    private static String FILE_ROUTES_JSON_WITH_LAYOUT = "{\"route\":\"\",\"params\":{},\"title\":\"Layout\",\"children\":[]}";
 
     private ApplicationRouteRegistry registry;
     private VaadinRequest vaadinRequest;
@@ -86,8 +83,7 @@ public class RouteRegistryMenuAccessTest {
     public void getRegisteredAccessibleMenuRoutes_withoutNavAccessControl_noMenuRoutes() {
         mockInstantiator(MenuAccessControl.PopulateClientMenu.ALWAYS);
         registry.clean();
-        registry.setRoute("home", RouteRegistryTestBase.MyRoute.class,
-                Collections.emptyList());
+        registry.setRoute("home", MyRoute.class, Collections.emptyList());
         Assert.assertEquals("One route should be registered.", 1,
                 registry.getRegisteredRoutes().size());
         Assert.assertEquals("No accessible menu routes should be available.", 0,
@@ -99,8 +95,7 @@ public class RouteRegistryMenuAccessTest {
     public void getRegisteredAccessibleMenuRoutes_populateClientSideMenuIsFalse_noMenuRoute() {
         mockInstantiator(MenuAccessControl.PopulateClientMenu.NEVER);
         registry.clean();
-        registry.setRoute("home", RouteRegistryTestBase.MyRoute.class,
-                Collections.emptyList());
+        registry.setRoute("home", MyMenuRoute.class, Collections.emptyList());
         Assert.assertEquals("One route should be registered.", 1,
                 registry.getRegisteredRoutes().size());
         Assert.assertEquals("No routes should be registered.", 0, registry
@@ -108,52 +103,20 @@ public class RouteRegistryMenuAccessTest {
     }
 
     @Test
-    public void getRegisteredAccessibleMenuRoutes_populateClientSideMenuIsAutomaticWithoutFileRoutesJson_noMenuRoute() {
-        try (MockedStatic<FrontendUtils> utils = Mockito
-                .mockStatic(FrontendUtils.class, Mockito.CALLS_REAL_METHODS)) {
-            utils.when(() -> FrontendUtils.readFileRoutesJsonFile(any()))
-                    .thenReturn("");
-            mockInstantiator(MenuAccessControl.PopulateClientMenu.AUTOMATIC);
-            registry.clean();
-            registry.setRoute("home", RouteRegistryTestBase.MyRoute.class,
-                    Collections.emptyList());
-            Assert.assertEquals("One route should be registered.", 1,
-                    registry.getRegisteredRoutes().size());
+    public void getRegisteredAccessibleMenuRoutes_populateClientSideMenuIsAutomatic_oneMenuRoute() {
+        mockInstantiator(MenuAccessControl.PopulateClientMenu.AUTOMATIC);
+        registry.clean();
+        registry.setRoute("home", MyMenuRoute.class, Collections.emptyList());
+        Assert.assertEquals("One route should be registered.", 1,
+                registry.getRegisteredRoutes().size());
 
-            try (MockedStatic<ApplicationConfiguration> config = Mockito
-                    .mockStatic(ApplicationConfiguration.class,
-                            Mockito.CALLS_REAL_METHODS)) {
-                config.when(() -> ApplicationConfiguration.get(any()))
-                        .thenReturn(mock(ApplicationConfiguration.class));
-                Assert.assertEquals("No routes should be registered.", 0,
-                        registry.getRegisteredAccessibleMenuRoutes(
-                                vaadinRequest, null).size());
-            }
-        }
-    }
-
-    @Test
-    public void getRegisteredAccessibleMenuRoutes_populateClientSideMenuIsAutomaticWithFileRoutesJson_noMenuRoute() {
-        try (MockedStatic<FrontendUtils> utils = Mockito
-                .mockStatic(FrontendUtils.class, Mockito.CALLS_REAL_METHODS)) {
-            utils.when(() -> FrontendUtils.readFileRoutesJsonFile(any()))
-                    .thenReturn(FILE_ROUTES_JSON_WITH_LAYOUT);
-            mockInstantiator(MenuAccessControl.PopulateClientMenu.AUTOMATIC);
-            registry.clean();
-            registry.setRoute("home", RouteRegistryTestBase.MyRoute.class,
-                    Collections.emptyList());
-            Assert.assertEquals("One route should be registered.", 1,
-                    registry.getRegisteredRoutes().size());
-
-            try (MockedStatic<ApplicationConfiguration> config = Mockito
-                    .mockStatic(ApplicationConfiguration.class,
-                            Mockito.CALLS_REAL_METHODS)) {
-                config.when(() -> ApplicationConfiguration.get(any()))
-                        .thenReturn(mock(ApplicationConfiguration.class));
-                Assert.assertEquals("No Menu routes should be registered.", 0,
-                        registry.getRegisteredAccessibleMenuRoutes(
-                                vaadinRequest, null).size());
-            }
+        try (MockedStatic<ApplicationConfiguration> config = Mockito.mockStatic(
+                ApplicationConfiguration.class, Mockito.CALLS_REAL_METHODS)) {
+            config.when(() -> ApplicationConfiguration.get(any()))
+                    .thenReturn(mock(ApplicationConfiguration.class));
+            Assert.assertEquals("One route should be registered.", 1, registry
+                    .getRegisteredAccessibleMenuRoutes(vaadinRequest, null)
+                    .size());
         }
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/RouteRegistryMenuAccessTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/RouteRegistryMenuAccessTest.java
@@ -23,7 +23,6 @@ import jakarta.servlet.ServletContext;
 import java.security.Principal;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.junit.Assert;
@@ -75,7 +74,7 @@ public class RouteRegistryMenuAccessTest {
 
     @Test
     public void getRegisteredAccessibleMenuRoutes_withoutNavAccessControl_noMenuRoutes() {
-        mockInstantiator(Boolean.TRUE);
+        mockInstantiator(MenuAccessControl.PopulateClientMenu.ALWAYS);
         registry.clean();
         registry.setRoute("home", RouteRegistryTestBase.MyRoute.class,
                 Collections.emptyList());
@@ -87,7 +86,7 @@ public class RouteRegistryMenuAccessTest {
 
     @Test
     public void getRegisteredAccessibleMenuRoutes_populateClientSideMenuIsFalse_oneMenuRoute() {
-        mockInstantiator(Boolean.FALSE);
+        mockInstantiator(MenuAccessControl.PopulateClientMenu.NEVER);
         registry.clean();
         registry.setRoute("home", RouteRegistryTestBase.MyRoute.class,
                 Collections.emptyList());
@@ -103,7 +102,7 @@ public class RouteRegistryMenuAccessTest {
                 .mockStatic(FrontendUtils.class, Mockito.CALLS_REAL_METHODS)) {
             utils.when(() -> FrontendUtils.readFileRoutesJsonFile(any()))
                     .thenReturn("");
-            mockInstantiator(null);
+            mockInstantiator(MenuAccessControl.PopulateClientMenu.AUTOMATIC);
             registry.clean();
             registry.setRoute("home", RouteRegistryTestBase.MyRoute.class,
                     Collections.emptyList());
@@ -128,7 +127,7 @@ public class RouteRegistryMenuAccessTest {
                 .mockStatic(FrontendUtils.class, Mockito.CALLS_REAL_METHODS)) {
             utils.when(() -> FrontendUtils.readFileRoutesJsonFile(any()))
                     .thenReturn(FILE_ROUTES_JSON_WITH_LAYOUT);
-            mockInstantiator(null);
+            mockInstantiator(MenuAccessControl.PopulateClientMenu.AUTOMATIC);
             registry.clean();
             registry.setRoute("home", RouteRegistryTestBase.MyRoute.class,
                     Collections.emptyList());
@@ -149,7 +148,7 @@ public class RouteRegistryMenuAccessTest {
 
     @Test
     public void getRegisteredAccessibleMenuRoutes_withoutNavAccessControl_oneMenuRoute() {
-        mockInstantiator(Boolean.TRUE);
+        mockInstantiator(MenuAccessControl.PopulateClientMenu.ALWAYS);
         registry.clean();
         registry.setRoute("hasmenu", MyMenuRoute.class,
                 Collections.emptyList());
@@ -162,7 +161,7 @@ public class RouteRegistryMenuAccessTest {
 
     @Test
     public void getRegisteredAccessibleMenuRoutes_withNavAccessControlWithoutRequest_noAccessibleMenuRoute() {
-        mockInstantiator(Boolean.TRUE);
+        mockInstantiator(MenuAccessControl.PopulateClientMenu.ALWAYS);
         registry.clean();
         registry.setRoute("hasmenu", MyMenuRoute.class,
                 Collections.emptyList());
@@ -225,7 +224,7 @@ public class RouteRegistryMenuAccessTest {
     private void setupForAnonymous(MockedStatic<VaadinService> vaadinService) {
         vaadinService.when(VaadinService::getCurrentRequest)
                 .thenReturn(mock(VaadinRequest.class));
-        mockInstantiator(Boolean.TRUE);
+        mockInstantiator(MenuAccessControl.PopulateClientMenu.ALWAYS);
         when(VaadinService.getCurrent().getRouter())
                 .thenReturn(mock(Router.class));
     }
@@ -284,7 +283,7 @@ public class RouteRegistryMenuAccessTest {
         when(vaadinRequest.isUserInRole("admin")).thenReturn(true);
         vaadinService.when(VaadinService::getCurrentRequest)
                 .thenReturn(vaadinRequest);
-        mockInstantiator(Boolean.TRUE);
+        mockInstantiator(MenuAccessControl.PopulateClientMenu.ALWAYS);
         when(VaadinService.getCurrent().getRouter())
                 .thenReturn(mock(Router.class));
     }
@@ -334,7 +333,8 @@ public class RouteRegistryMenuAccessTest {
         }
     }
 
-    private static void mockInstantiator(Boolean populateClientSideMenu) {
+    private static void mockInstantiator(
+            MenuAccessControl.PopulateClientMenu populateClientSideMenu) {
         VaadinService.setCurrent(mock(VaadinService.class));
         var instantiator = mock(Instantiator.class);
         when(VaadinService.getCurrent().getInstantiator())
@@ -343,12 +343,12 @@ public class RouteRegistryMenuAccessTest {
                 .thenReturn(new MenuAccessControl() {
                     @Override
                     public void setPopulateClientSideMenu(
-                            Boolean populateClientSideMenu) {
+                            PopulateClientMenu populateClientSideMenu) {
                     }
 
                     @Override
-                    public Optional<Boolean> getPopulateClientSideMenu() {
-                        return Optional.ofNullable(populateClientSideMenu);
+                    public PopulateClientMenu getPopulateClientSideMenu() {
+                        return populateClientSideMenu;
                     }
                 });
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/RouteRegistryMenuAccessTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/RouteRegistryMenuAccessTest.java
@@ -1,0 +1,376 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.server.startup;
+
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.servlet.ServletContext;
+
+import java.security.Principal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.router.BeforeEnterListener;
+import com.vaadin.flow.router.Menu;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.Router;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinServletContext;
+import com.vaadin.flow.server.auth.AnonymousAllowed;
+import com.vaadin.flow.server.auth.MenuAccessControl;
+import com.vaadin.flow.server.auth.NavigationAccessControl;
+import com.vaadin.flow.server.auth.ViewAccessChecker;
+import com.vaadin.flow.server.frontend.FrontendUtils;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
+
+public class RouteRegistryMenuAccessTest {
+
+    private static String FILE_ROUTES_JSON_WITH_LAYOUT = "{\"route\":\"\",\"params\":{},\"title\":\"Layout\",\"children\":[]}";
+    
+    private ApplicationRouteRegistry registry;
+
+    @Before
+    public void init() {
+        registry = ApplicationRouteRegistry.getInstance(
+                new VaadinServletContext(mock(ServletContext.class)));
+    }
+
+    @Test
+    public void getRegisteredAccessibleMenuRoutes_withoutVaadinService_returnEmpty() {
+        VaadinService.setCurrent(null);
+        Assert.assertEquals(
+                "No accessible menu routes should be available without VaadinService.",
+                0,
+                registry.getRegisteredAccessibleMenuRoutes(null, null).size());
+    }
+
+    @Test
+    public void getRegisteredAccessibleMenuRoutes_withoutNavAccessControl_noMenuRoutes() {
+        mockInstantiator(Boolean.TRUE);
+        registry.clean();
+        registry.setRoute("home", RouteRegistryTestBase.MyRoute.class,
+                Collections.emptyList());
+        Assert.assertEquals("One route should be registered.", 1,
+                registry.getRegisteredRoutes().size());
+        Assert.assertEquals("No accessible menu routes should be available.", 0,
+                registry.getRegisteredAccessibleMenuRoutes(null, null).size());
+    }
+
+    @Test
+    public void getRegisteredAccessibleMenuRoutes_populateClientSideMenuIsFalse_oneMenuRoute() {
+        mockInstantiator(Boolean.FALSE);
+        registry.clean();
+        registry.setRoute("home", RouteRegistryTestBase.MyRoute.class,
+                Collections.emptyList());
+        Assert.assertEquals("One route should be registered.", 1,
+                registry.getRegisteredRoutes().size());
+        Assert.assertEquals("One route should be registered.", 1,
+                registry.getRegisteredAccessibleMenuRoutes(null, null).size());
+    }
+
+    @Test
+    public void getRegisteredAccessibleMenuRoutes_populateClientSideMenuIsAutomaticWithoutFileRoutesJson_oneMenuRoute() {
+        try (MockedStatic<FrontendUtils> utils = Mockito
+                .mockStatic(FrontendUtils.class, Mockito.CALLS_REAL_METHODS)) {
+            utils.when(() -> FrontendUtils.readFileRoutesJsonFile(any()))
+                    .thenReturn("");
+            mockInstantiator(null);
+            registry.clean();
+            registry.setRoute("home", RouteRegistryTestBase.MyRoute.class,
+                    Collections.emptyList());
+            Assert.assertEquals("One route should be registered.", 1,
+                    registry.getRegisteredRoutes().size());
+
+            try (MockedStatic<ApplicationConfiguration> config = Mockito
+                    .mockStatic(ApplicationConfiguration.class,
+                            Mockito.CALLS_REAL_METHODS)) {
+                config.when(() -> ApplicationConfiguration.get(any()))
+                        .thenReturn(mock(ApplicationConfiguration.class));
+                Assert.assertEquals("One route should be registered.", 1,
+                        registry.getRegisteredAccessibleMenuRoutes(null, null)
+                                .size());
+            }
+        }
+    }
+
+    @Test
+    public void getRegisteredAccessibleMenuRoutes_populateClientSideMenuIsAutomaticWithFileRoutesJson_noMenuRoute() {
+        try (MockedStatic<FrontendUtils> utils = Mockito
+                .mockStatic(FrontendUtils.class, Mockito.CALLS_REAL_METHODS)) {
+            utils.when(() -> FrontendUtils.readFileRoutesJsonFile(any()))
+                    .thenReturn(FILE_ROUTES_JSON_WITH_LAYOUT);
+            mockInstantiator(null);
+            registry.clean();
+            registry.setRoute("home", RouteRegistryTestBase.MyRoute.class,
+                    Collections.emptyList());
+            Assert.assertEquals("One route should be registered.", 1,
+                    registry.getRegisteredRoutes().size());
+
+            try (MockedStatic<ApplicationConfiguration> config = Mockito
+                    .mockStatic(ApplicationConfiguration.class,
+                            Mockito.CALLS_REAL_METHODS)) {
+                config.when(() -> ApplicationConfiguration.get(any()))
+                        .thenReturn(mock(ApplicationConfiguration.class));
+                Assert.assertEquals("No Menu routes should be registered.", 0,
+                        registry.getRegisteredAccessibleMenuRoutes(null, null)
+                                .size());
+            }
+        }
+    }
+
+    @Test
+    public void getRegisteredAccessibleMenuRoutes_withoutNavAccessControl_oneMenuRoute() {
+        mockInstantiator(Boolean.TRUE);
+        registry.clean();
+        registry.setRoute("hasmenu", MyMenuRoute.class,
+                Collections.emptyList());
+        Assert.assertEquals("One route should be registered.", 1,
+                registry.getRegisteredRoutes().size());
+        Assert.assertEquals("One accessible menu routes should be available.",
+                1, registry.getRegisteredAccessibleMenuRoutes(null, List.of())
+                        .size());
+    }
+
+    @Test
+    public void getRegisteredAccessibleMenuRoutes_withNavAccessControlWithoutRequest_noAccessibleMenuRoute() {
+        mockInstantiator(Boolean.TRUE);
+        registry.clean();
+        registry.setRoute("hasmenu", MyMenuRoute.class,
+                Collections.emptyList());
+        Assert.assertEquals("One route should be registered.", 1,
+                registry.getRegisteredRoutes().size());
+        Assert.assertEquals(
+                "No accessible menu routes should be available without an active request.",
+                0, registry.getRegisteredAccessibleMenuRoutes(null,
+                        List.of(new NavigationAccessControl())).size());
+    }
+
+    @Test
+    public void getRegisteredAccessibleMenuRoutes_withNavAccessControl_anonymous() {
+        testAsAnonymous(new NavigationAccessControl());
+    }
+
+    @Test
+    public void getRegisteredAccessibleMenuRoutes_withNavAccessControl_admin() {
+        testAsAdmin(new NavigationAccessControl());
+    }
+
+    @Test
+    public void getRegisteredAccessibleMenuRoutes_withViewAccessChecker_anonymous() {
+        testAsAnonymous(new ViewAccessChecker());
+    }
+
+    @Test
+    public void getRegisteredAccessibleMenuRoutes_withViewAccessChecker_admin() {
+        testAsAdmin(new ViewAccessChecker());
+    }
+
+    @Test
+    public void getRegisteredAccessibleMenuRoutes_withNavAccessControlAndViewAccessChecker_admin() {
+        testAsAdmin(new NavigationAccessControl(), new ViewAccessChecker());
+    }
+
+    @Test
+    public void getRegisteredAccessibleMenuRoutes_withDisabledNavAccessControlAndViewAccessChecker_anonymous() {
+        try (MockedStatic<VaadinService> vaadinService = Mockito
+                .mockStatic(VaadinService.class, Mockito.CALLS_REAL_METHODS)) {
+            setupForAnonymous(vaadinService);
+            var navAccessControl = new NavigationAccessControl();
+            navAccessControl.setEnabled(false);
+            var viewAccessControl = new ViewAccessChecker(false);
+            List<BeforeEnterListener> accessControls = List.of(navAccessControl,
+                    viewAccessControl);
+
+            registry.clean();
+            registry.setRoute("hasmenu", MyMenuRoute.class,
+                    Collections.emptyList());
+            Assert.assertEquals("One route should be registered.", 1,
+                    registry.getRegisteredRoutes().size());
+            Assert.assertEquals(
+                    "One accessible menu routes should be available.", 1,
+                    registry.getRegisteredAccessibleMenuRoutes(null,
+                            accessControls).size());
+        }
+    }
+
+    private void setupForAnonymous(MockedStatic<VaadinService> vaadinService) {
+        vaadinService.when(VaadinService::getCurrentRequest)
+                .thenReturn(mock(VaadinRequest.class));
+        mockInstantiator(Boolean.TRUE);
+        when(VaadinService.getCurrent().getRouter())
+                .thenReturn(mock(Router.class));
+    }
+
+    private void testAsAnonymous(BeforeEnterListener... withAccessControls) {
+        try (MockedStatic<VaadinService> vaadinService = Mockito
+                .mockStatic(VaadinService.class, Mockito.CALLS_REAL_METHODS)) {
+            setupForAnonymous(vaadinService);
+
+            List<BeforeEnterListener> accessControls = Stream
+                    .of(withAccessControls).toList();
+
+            registry.clean();
+            registry.setRoute("hasmenu", MyMenuRoute.class,
+                    Collections.emptyList());
+            Assert.assertEquals("One route should be registered.", 1,
+                    registry.getRegisteredRoutes().size());
+            Assert.assertEquals(
+                    "No accessible menu routes should be available due to lack of security annotation.",
+                    0, registry.getRegisteredAccessibleMenuRoutes(null,
+                            accessControls).size());
+
+            registry.clean();
+            registry.setRoute("hasmenu", MyMenuRouteAnonymousAllowed.class,
+                    Collections.emptyList());
+            Assert.assertEquals(
+                    "One accessible menu routes should be available.", 1,
+                    registry.getRegisteredAccessibleMenuRoutes(null,
+                            accessControls).size());
+
+            registry.clean();
+            registry.setRoute("hasmenu", MyMenuRoutePermitAll.class,
+                    Collections.emptyList());
+            Assert.assertEquals(
+                    "no accessible menu routes should be available for anonymous user.",
+                    0, registry.getRegisteredAccessibleMenuRoutes(null,
+                            accessControls).size());
+
+            registry.clean();
+            registry.setRoute("hasmenu", MyMenuRouteRolesAllowedAdmin.class,
+                    Collections.emptyList());
+            Assert.assertEquals(
+                    "No accessible menu routes should be available without admin role.",
+                    0, registry.getRegisteredAccessibleMenuRoutes(null,
+                            accessControls).size());
+        }
+    }
+
+    private void setupForAdmin(MockedStatic<VaadinService> vaadinService, VaadinRequest vaadinRequest) {
+        when(vaadinRequest.getUserPrincipal()).thenReturn(new Principal() {
+            @Override
+            public String getName() {
+                return "vaadin_user";
+            }
+        });
+        when(vaadinRequest.isUserInRole("admin")).thenReturn(true);
+        vaadinService.when(VaadinService::getCurrentRequest)
+                .thenReturn(vaadinRequest);
+        mockInstantiator(Boolean.TRUE);
+        when(VaadinService.getCurrent().getRouter())
+                .thenReturn(mock(Router.class));
+    }
+
+    private void testAsAdmin(BeforeEnterListener... withAccessControls) {
+        try (MockedStatic<VaadinService> vaadinService = Mockito
+                .mockStatic(VaadinService.class, Mockito.CALLS_REAL_METHODS)) {
+            VaadinRequest vaadinRequest = mock(VaadinRequest.class);
+            setupForAdmin(vaadinService, vaadinRequest);
+
+            List<BeforeEnterListener> accessControls = Stream
+                    .of(withAccessControls).toList();
+
+            registry.clean();
+            registry.setRoute("hasmenu", MyMenuRoute.class,
+                    Collections.emptyList());
+            Assert.assertEquals("One route should be registered.", 1,
+                    registry.getRegisteredRoutes().size());
+            Assert.assertEquals(
+                    "No accessible menu routes should be available due to lack of security annotation.",
+                    0, registry.getRegisteredAccessibleMenuRoutes(vaadinRequest,
+                            accessControls).size());
+
+            registry.clean();
+            registry.setRoute("hasmenu", MyMenuRouteAnonymousAllowed.class,
+                    Collections.emptyList());
+            Assert.assertEquals(
+                    "One accessible menu routes should be available.", 1,
+                    registry.getRegisteredAccessibleMenuRoutes(vaadinRequest,
+                            accessControls).size());
+
+            registry.clean();
+            registry.setRoute("hasmenu", MyMenuRoutePermitAll.class,
+                    Collections.emptyList());
+            Assert.assertEquals(
+                    "One accessible menu route should be available.", 1,
+                    registry.getRegisteredAccessibleMenuRoutes(vaadinRequest,
+                            accessControls).size());
+
+            registry.clean();
+            registry.setRoute("hasmenu", MyMenuRouteRolesAllowedAdmin.class,
+                    Collections.emptyList());
+            Assert.assertEquals(
+                    "One accessible menu route should be available.", 1,
+                    registry.getRegisteredAccessibleMenuRoutes(vaadinRequest,
+                            accessControls).size());
+        }
+    }
+
+    private static void mockInstantiator(Boolean populateClientSideMenu) {
+        VaadinService.setCurrent(mock(VaadinService.class));
+        var instantiator = mock(Instantiator.class);
+        when(VaadinService.getCurrent().getInstantiator())
+                .thenReturn(instantiator);
+        when(instantiator.getMenuAccessControl()).thenReturn(new MenuAccessControl() {
+            @Override
+            public void setPopulateClientSideMenu(Boolean populateClientSideMenu) {
+            }
+
+            @Override
+            public Optional<Boolean> getPopulateClientSideMenu() {
+                return Optional.ofNullable(populateClientSideMenu);
+            }
+        });
+    }
+
+    @Tag("div")
+    @Route("home")
+    protected static class MyRoute extends Component {
+    }
+
+    @Tag("div")
+    @Route("hasmenu")
+    @Menu
+    protected static class MyMenuRoute extends Component {
+    }
+
+    @AnonymousAllowed
+    protected static class MyMenuRouteAnonymousAllowed extends MyMenuRoute {
+    }
+
+    @PermitAll
+    protected static class MyMenuRoutePermitAll extends MyMenuRoute {
+    }
+
+    @RolesAllowed("admin")
+    protected static class MyMenuRouteRolesAllowedAdmin extends MyMenuRoute {
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/RouteRegistryMenuAccessTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/RouteRegistryMenuAccessTest.java
@@ -134,19 +134,6 @@ public class RouteRegistryMenuAccessTest {
     }
 
     @Test
-    public void getRegisteredAccessibleMenuRoutes_withoutNavAccessControl_doNotReturnExcludedMenuRoute() {
-        mockInstantiator(MenuAccessControl.PopulateClientMenu.ALWAYS);
-        registry.clean();
-        registry.setRoute("hasmenu", MyMenuRouteExcluded.class,
-                Collections.emptyList());
-        Assert.assertEquals("One route should be registered.", 1,
-                registry.getRegisteredRoutes().size());
-        Assert.assertEquals("No accessible menu routes should be available.", 0,
-                registry.getRegisteredAccessibleMenuRoutes(vaadinRequest,
-                        List.of()).size());
-    }
-
-    @Test
     public void getRegisteredAccessibleMenuRoutes_withNavAccessControlWithoutRequest_noAccessibleMenuRoute() {
         mockInstantiator(MenuAccessControl.PopulateClientMenu.ALWAYS);
         registry.clean();
@@ -327,12 +314,6 @@ public class RouteRegistryMenuAccessTest {
     @Route("hasmenu")
     @Menu
     protected static class MyMenuRoute extends Component {
-    }
-
-    @Tag("div")
-    @Route("hasmenu")
-    @Menu(exclude = true)
-    protected static class MyMenuRouteExcluded extends Component {
     }
 
     @AnonymousAllowed

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/webcomponent/PaperInputIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/webcomponent/PaperInputIT.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.uitest.ui.webcomponent;
 
 import java.util.List;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
@@ -28,6 +29,7 @@ import com.vaadin.flow.testutil.ChromeBrowserTest;
 public class PaperInputIT extends ChromeBrowserTest {
 
     @Test
+    @Ignore("Inconsistent failures. Ignored until fixed.")
     public void paperInputIsFunctional() {
         open();
 
@@ -37,7 +39,6 @@ public class PaperInputIT extends ChromeBrowserTest {
         String originalValue = input.getAttribute("value");
         input.sendKeys(Keys.END + "bar");
 
-        waitForElementPresent(By.className("update-value"));
         List<WebElement> updateValueElements = findElements(
                 By.className("update-value"));
         WebElement lastUpdateValue = updateValueElements

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/webcomponent/PaperInputIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/webcomponent/PaperInputIT.java
@@ -37,6 +37,7 @@ public class PaperInputIT extends ChromeBrowserTest {
         String originalValue = input.getAttribute("value");
         input.sendKeys(Keys.END + "bar");
 
+        waitForElementPresent(By.className("update-value"));
         List<WebElement> updateValueElements = findElements(
                 By.className("update-value"));
         WebElement lastUpdateValue = updateValueElements

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/main/java/com/vaadin/flow/spring/flowsecurity/Application.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/main/java/com/vaadin/flow/spring/flowsecurity/Application.java
@@ -6,6 +6,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import com.vaadin.flow.server.auth.DefaultMenuAccessControl;
+import com.vaadin.flow.server.auth.MenuAccessControl;
+
 @SpringBootApplication
 public class Application {
 
@@ -18,4 +21,10 @@ public class Application {
         return new BCryptPasswordEncoder();
     }
 
+    @Bean
+    public MenuAccessControl customMenuAccessControl() {
+        var menuAccessControl = new DefaultMenuAccessControl();
+        menuAccessControl.setPopulateClientSideMenu(Boolean.TRUE);
+        return menuAccessControl;
+    }
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/main/java/com/vaadin/flow/spring/flowsecurity/Application.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/main/java/com/vaadin/flow/spring/flowsecurity/Application.java
@@ -24,7 +24,8 @@ public class Application {
     @Bean
     public MenuAccessControl customMenuAccessControl() {
         var menuAccessControl = new DefaultMenuAccessControl();
-        menuAccessControl.setPopulateClientSideMenu(Boolean.TRUE);
+        menuAccessControl.setPopulateClientSideMenu(
+                MenuAccessControl.PopulateClientMenu.ALWAYS);
         return menuAccessControl;
     }
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/main/java/com/vaadin/flow/spring/flowsecurity/SecurityConfig.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/main/java/com/vaadin/flow/spring/flowsecurity/SecurityConfig.java
@@ -69,7 +69,7 @@ public class SecurityConfig extends VaadinWebSecurity {
                     .hasAnyRole(ROLE_ADMIN)
                 .requestMatchers(antMatchers("/private"))
                     .authenticated()
-                .requestMatchers(antMatchers("/", "/public/**", "/another"))
+                .requestMatchers(antMatchers("/", "/public/**", "/another", "/menu-list"))
                     .permitAll()
                 .requestMatchers(antMatchers("/error"))
                     .permitAll()

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/main/java/com/vaadin/flow/spring/flowsecurity/views/AdminView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/main/java/com/vaadin/flow/spring/flowsecurity/views/AdminView.java
@@ -5,6 +5,7 @@ import jakarta.annotation.security.RolesAllowed;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.Menu;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteAlias;
@@ -13,6 +14,7 @@ import com.vaadin.flow.spring.flowsecurity.SecurityUtils;
 @Route(value = "admin", layout = MainView.class)
 @RouteAlias(value = "alias-for-admin", layout = MainView.class)
 @PageTitle("Admin View")
+@Menu(order = 3)
 public class AdminView extends VerticalLayout {
 
     public AdminView(SecurityUtils securityUtils) {

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/main/java/com/vaadin/flow/spring/flowsecurity/views/MenuListView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/main/java/com/vaadin/flow/spring/flowsecurity/views/MenuListView.java
@@ -47,8 +47,7 @@ public class MenuListView extends Div implements AfterNavigationObserver {
 
     @Override
     public void afterNavigation(AfterNavigationEvent event) {
-        String targetAccessibleMenuRoutes = RouteConfiguration.forSessionScope()
-                .getHandledRegistry()
+        String targetAccessibleMenuRoutes = event.getSource().getRegistry()
                 .getRegisteredAccessibleMenuRoutes(VaadinRequest.getCurrent(),
                         UI.getCurrent().getInternals()
                                 .getListeners(BeforeEnterHandler.class).stream()

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/main/java/com/vaadin/flow/spring/flowsecurity/views/MenuListView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/main/java/com/vaadin/flow/spring/flowsecurity/views/MenuListView.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.spring.flowsecurity.views;
+
+import java.util.Comparator;
+import java.util.stream.Collectors;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.AfterNavigationEvent;
+import com.vaadin.flow.router.AfterNavigationObserver;
+import com.vaadin.flow.router.BeforeEnterListener;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouteBaseData;
+import com.vaadin.flow.router.RouteConfiguration;
+import com.vaadin.flow.router.internal.BeforeEnterHandler;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.auth.AnonymousAllowed;
+
+/**
+ * Lists all accessible menu views collected with
+ * {@link com.vaadin.flow.server.RouteRegistry#getRegisteredAccessibleMenuRoutes}.
+ */
+@Route("menu-list")
+@PageTitle("Menu List View")
+public class MenuListView extends Div implements AfterNavigationObserver {
+
+    public MenuListView() {
+        add(new Span("Menu List View"));
+    }
+
+    @Override
+    public void afterNavigation(AfterNavigationEvent event) {
+        String targetAccessibleMenuRoutes = RouteConfiguration.forSessionScope()
+                .getHandledRegistry()
+                .getRegisteredAccessibleMenuRoutes(VaadinRequest.getCurrent(),
+                        UI.getCurrent().getInternals()
+                                .getListeners(BeforeEnterHandler.class).stream()
+                                .filter(handler -> handler instanceof BeforeEnterListener)
+                                .map(BeforeEnterListener.class::cast).toList())
+                .stream()
+                .sorted(Comparator.comparing(
+                        routeData -> ((routeData.getMenuData() != null)
+                                ? routeData.getMenuData().getOrder()
+                                : -1)))
+                .map(RouteBaseData::getNavigationTarget)
+                .map(Class::getSimpleName).collect(Collectors.joining(", "));
+        removeAll();
+
+        var span = new Span(targetAccessibleMenuRoutes);
+        span.setId("menu-list");
+        add(span);
+    }
+}

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/main/java/com/vaadin/flow/spring/flowsecurity/views/PrivateView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/main/java/com/vaadin/flow/spring/flowsecurity/views/PrivateView.java
@@ -21,6 +21,7 @@ import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.upload.Upload;
+import com.vaadin.flow.router.Menu;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteAlias;
@@ -34,6 +35,7 @@ import org.springframework.security.concurrent.DelegatingSecurityContextExecutor
 @Route(value = "private", layout = MainView.class)
 @RouteAlias(value = "privateAndForbiddenForAll")
 @PageTitle("Private View")
+@Menu(order = 2)
 public class PrivateView extends VerticalLayout {
 
     private BankService bankService;

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/main/java/com/vaadin/flow/spring/flowsecurity/views/PublicView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/main/java/com/vaadin/flow/spring/flowsecurity/views/PublicView.java
@@ -8,6 +8,7 @@ import com.vaadin.flow.component.html.Image;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.orderedlayout.FlexLayout;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.router.Menu;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteAlias;
@@ -17,6 +18,7 @@ import com.vaadin.flow.router.RouterLink;
 @Route(value = "", layout = MainView.class)
 @RouteAlias("home")
 @PageTitle("Public View")
+@Menu(order = 1)
 public class PublicView extends FlexLayout {
 
     public static final String BACKGROUND_NAVIGATION_ID = "backgroundNavi";

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/test/java/com/vaadin/flow/spring/flowsecurity/AppViewIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/test/java/com/vaadin/flow/spring/flowsecurity/AppViewIT.java
@@ -316,6 +316,39 @@ public class AppViewIT extends AbstractIT {
         assertNotFoundView("admin");
     }
 
+    @Test
+    public void client_menu_routes_correct_for_anonymous() {
+        navigateToClientMenuList();
+        assertMenuListContains("PublicView");
+    }
+
+    @Test
+    public void client_menu_routes_correct_for_user() {
+        open(LOGIN_PATH);
+        loginUser();
+        navigateToClientMenuList();
+        assertMenuListContains("PublicView, PrivateView");
+    }
+
+    @Test
+    public void client_menu_routes_correct_for_admin() {
+        open(LOGIN_PATH);
+        loginAdmin();
+        navigateToClientMenuList();
+        assertMenuListContains("PublicView, PrivateView, AdminView");
+    }
+
+    private void assertMenuListContains(String expected) {
+        TestBenchElement menuList = waitUntil(driver -> $("*").id("menu-list"));
+        String menuListText = menuList.getText();
+        Assert.assertTrue(menuListText.contains(expected));
+    }
+
+    private void navigateToClientMenuList() {
+        open("menu-list");
+        assertPathShown("menu-list");
+    }
+
     private void navigateTo(String path) {
         navigateTo(path, true);
     }

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/Application.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/Application.java
@@ -14,6 +14,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.vaadin.flow.i18n.DefaultI18NProvider;
 import com.vaadin.flow.i18n.I18NProvider;
+import com.vaadin.flow.server.auth.DefaultMenuAccessControl;
+import com.vaadin.flow.server.auth.MenuAccessControl;
 import com.vaadin.flow.spring.i18n.DefaultI18NProviderFactory;
 
 @SpringBootApplication
@@ -50,5 +52,12 @@ public class Application {
                         locale);
             }
         };
+    }
+
+    @Bean
+    public MenuAccessControl customMenuAccessControl() {
+        var menuAccessControl = new DefaultMenuAccessControl();
+        menuAccessControl.setPopulateClientSideMenu(Boolean.TRUE);
+        return menuAccessControl;
     }
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/Application.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/Application.java
@@ -57,7 +57,8 @@ public class Application {
     @Bean
     public MenuAccessControl customMenuAccessControl() {
         var menuAccessControl = new DefaultMenuAccessControl();
-        menuAccessControl.setPopulateClientSideMenu(Boolean.TRUE);
+        menuAccessControl.setPopulateClientSideMenu(
+                MenuAccessControl.PopulateClientMenu.ALWAYS);
         return menuAccessControl;
     }
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/AdminView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/AdminView.java
@@ -9,6 +9,7 @@ import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.Menu;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.spring.flowsecurity.SecurityUtils;
@@ -16,6 +17,7 @@ import com.vaadin.flow.spring.flowsecurity.SecurityUtils;
 @Route(value = "admin", layout = MainView.class)
 @PageTitle("Admin View")
 @RolesAllowed("admin")
+@Menu(order = 3)
 public class AdminView extends VerticalLayout {
 
     public final static String ROLE_PREFIX_TEST_BUTTON_ID = "role-prefix-test-button";

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/MenuListView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/MenuListView.java
@@ -52,8 +52,7 @@ public class MenuListView extends Div implements AfterNavigationObserver {
 
     @Override
     public void afterNavigation(AfterNavigationEvent event) {
-        String targetAccessibleMenuRoutes = RouteConfiguration.forSessionScope()
-                .getHandledRegistry()
+        String targetAccessibleMenuRoutes = event.getSource().getRegistry()
                 .getRegisteredAccessibleMenuRoutes(VaadinRequest.getCurrent(),
                         UI.getCurrent().getInternals()
                                 .getListeners(BeforeEnterHandler.class).stream()

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/MenuListView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/MenuListView.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.spring.flowsecurity.views;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.AfterNavigationEvent;
+import com.vaadin.flow.router.AfterNavigationObserver;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.BeforeEnterListener;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouteBaseData;
+import com.vaadin.flow.router.RouteConfiguration;
+import com.vaadin.flow.router.internal.AfterNavigationHandler;
+import com.vaadin.flow.router.internal.BeforeEnterHandler;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.auth.AnonymousAllowed;
+
+/**
+ * Lists all accessible menu views collected with
+ * {@link com.vaadin.flow.server.RouteRegistry#getRegisteredAccessibleMenuRoutes}.
+ */
+@Route("menu-list")
+@PageTitle("Menu List View")
+@AnonymousAllowed
+public class MenuListView extends Div implements AfterNavigationObserver {
+
+    public MenuListView() {
+        add(new Span("Menu List View"));
+    }
+
+    @Override
+    public void afterNavigation(AfterNavigationEvent event) {
+        String targetAccessibleMenuRoutes = RouteConfiguration.forSessionScope()
+                .getHandledRegistry()
+                .getRegisteredAccessibleMenuRoutes(VaadinRequest.getCurrent(),
+                        UI.getCurrent().getInternals()
+                                .getListeners(BeforeEnterHandler.class).stream()
+                                .filter(handler -> handler instanceof BeforeEnterListener)
+                                .map(BeforeEnterListener.class::cast).toList())
+                .stream()
+                .sorted(Comparator.comparing(
+                        routeData -> ((routeData.getMenuData() != null)
+                                ? routeData.getMenuData().getOrder()
+                                : -1)))
+                .map(RouteBaseData::getNavigationTarget)
+                .map(Class::getSimpleName).collect(Collectors.joining(", "));
+        removeAll();
+
+        var span = new Span(targetAccessibleMenuRoutes);
+        span.setId("menu-list");
+        add(span);
+    }
+}

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/PrivateView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/PrivateView.java
@@ -21,6 +21,7 @@ import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.upload.Upload;
+import com.vaadin.flow.router.Menu;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.StreamResource;
@@ -33,6 +34,7 @@ import org.springframework.security.concurrent.DelegatingSecurityContextExecutor
 @Route(value = "private", layout = MainView.class)
 @PageTitle("Private View")
 @PermitAll
+@Menu(order = 2)
 public class PrivateView extends VerticalLayout {
 
     private BankService bankService;

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/PublicView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/PublicView.java
@@ -6,6 +6,7 @@ import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.Image;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.orderedlayout.FlexLayout;
+import com.vaadin.flow.router.Menu;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.auth.AnonymousAllowed;
@@ -13,6 +14,7 @@ import com.vaadin.flow.server.auth.AnonymousAllowed;
 @Route(value = "", layout = MainView.class)
 @PageTitle("Public View")
 @AnonymousAllowed
+@Menu(order = 1)
 public class PublicView extends FlexLayout {
 
     public static final String BACKGROUND_NAVIGATION_ID = "backgroundNavi";

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AppViewIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AppViewIT.java
@@ -303,6 +303,39 @@ public class AppViewIT extends AbstractIT {
         assertLogoutViewShown();
     }
 
+    @Test
+    public void client_menu_routes_correct_for_anonymous() {
+        navigateToClientMenuList();
+        assertMenuListContains("PublicView");
+    }
+
+    @Test
+    public void client_menu_routes_correct_for_user() {
+        open(LOGIN_PATH);
+        loginUser();
+        navigateToClientMenuList();
+        assertMenuListContains("PublicView, PrivateView");
+    }
+
+    @Test
+    public void client_menu_routes_correct_for_admin() {
+        open(LOGIN_PATH);
+        loginAdmin();
+        navigateToClientMenuList();
+        assertMenuListContains("PublicView, PrivateView, AdminView");
+    }
+
+    private void assertMenuListContains(String expected) {
+        TestBenchElement menuList = waitUntil(driver -> $("*").id("menu-list"));
+        String menuListText = menuList.getText();
+        Assert.assertTrue(menuListText.contains(expected));
+    }
+
+    private void navigateToClientMenuList() {
+        open("menu-list");
+        assertPathShown("menu-list");
+    }
+
     private void navigateTo(String path) {
         navigateTo(path, true);
     }

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringInstantiator.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringInstantiator.java
@@ -32,6 +32,7 @@ import com.vaadin.flow.i18n.I18NProvider;
 import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServiceInitListener;
+import com.vaadin.flow.server.auth.MenuAccessControl;
 
 /**
  * Default Spring instantiator that is used if no other instantiator has been
@@ -102,6 +103,22 @@ public class SpringInstantiator extends DefaultInstantiator {
                                 I18NProvider.class.getSimpleName(), beansCount);
             }
             return super.getI18NProvider();
+        }
+    }
+
+    @Override
+    public MenuAccessControl getMenuAccessControl() {
+        int beansCount = context.getBeanNamesForType(MenuAccessControl.class).length;
+        if (beansCount == 1) {
+            return context.getBean(MenuAccessControl.class);
+        } else {
+            if (loggingEnabled.compareAndSet(true, false)) {
+                LoggerFactory.getLogger(SpringInstantiator.class.getName())
+                        .info("The number of beans implementing '{}' is {}. Cannot use Spring beans for I18N, "
+                                        + "falling back to the default behavior",
+                                MenuAccessControl.class.getSimpleName(), beansCount);
+            }
+            return super.getMenuAccessControl();
         }
     }
 

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringInstantiator.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringInstantiator.java
@@ -115,7 +115,7 @@ public class SpringInstantiator extends DefaultInstantiator {
         } else {
             if (loggingEnabled.compareAndSet(true, false)) {
                 LoggerFactory.getLogger(SpringInstantiator.class.getName())
-                        .info("The number of beans implementing '{}' is {}. Cannot use Spring beans for I18N, "
+                        .info("The number of beans implementing '{}' is {}. Cannot use Spring beans for Menu Access Control, "
                                 + "falling back to the default behavior",
                                 MenuAccessControl.class.getSimpleName(),
                                 beansCount);

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringInstantiator.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringInstantiator.java
@@ -108,15 +108,17 @@ public class SpringInstantiator extends DefaultInstantiator {
 
     @Override
     public MenuAccessControl getMenuAccessControl() {
-        int beansCount = context.getBeanNamesForType(MenuAccessControl.class).length;
+        int beansCount = context
+                .getBeanNamesForType(MenuAccessControl.class).length;
         if (beansCount == 1) {
             return context.getBean(MenuAccessControl.class);
         } else {
             if (loggingEnabled.compareAndSet(true, false)) {
                 LoggerFactory.getLogger(SpringInstantiator.class.getName())
                         .info("The number of beans implementing '{}' is {}. Cannot use Spring beans for I18N, "
-                                        + "falling back to the default behavior",
-                                MenuAccessControl.class.getSimpleName(), beansCount);
+                                + "falling back to the default behavior",
+                                MenuAccessControl.class.getSimpleName(),
+                                beansCount);
             }
             return super.getMenuAccessControl();
         }

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinApplicationConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinApplicationConfiguration.java
@@ -24,6 +24,8 @@ import org.springframework.context.annotation.Configuration;
 
 import com.vaadin.flow.i18n.DefaultI18NProvider;
 import com.vaadin.flow.i18n.I18NProvider;
+import com.vaadin.flow.server.auth.DefaultMenuAccessControl;
+import com.vaadin.flow.server.auth.MenuAccessControl;
 import com.vaadin.flow.server.startup.ApplicationConfigurationFactory;
 import com.vaadin.flow.spring.SpringLookupInitializer.SpringApplicationContextInit;
 import com.vaadin.flow.spring.i18n.DefaultI18NProviderFactory;
@@ -78,5 +80,17 @@ public class VaadinApplicationConfiguration {
                     + DefaultI18NProviderFactory.DEFAULT_LOCATION_PATTERN
                     + "}") String locationPattern) {
         return DefaultI18NProviderFactory.create(locationPattern);
+    }
+
+    /**
+     * Creates default {@link MenuAccessControl}. This is created only if
+     * there's no {@link MenuAccessControl} bean declared.
+     *
+     * @return default menu access control
+     */
+    @Bean
+    @ConditionalOnMissingBean(value = MenuAccessControl.class)
+    public MenuAccessControl vaadinMenuAccessControl() {
+        return new DefaultMenuAccessControl();
     }
 }


### PR DESCRIPTION
Adds API to get and control only accessible routes for automatically build routes based on `Menu` annotated routes. This change is targeting primarily client side menu build with Hilla.

Adds `RouteRegistry#getRegisteredAccessibleMenuRoutes` to get a list of accessible RouteData objects. Method takes in a collection of access control objects which are implementing `BeforeEnterListener`. Supports `NavigationAccessControl` and `ViewAccessChecker`.

Adds `MenuAccessControl` interface to control `getRegisteredAccessibleMenuRoutes` return value. This change adds first part of control by adding API to enable, disable or automate populating client side main menu with the server side routes. Interface has space for future for more advanced control.

Default `MenuAccessControl` implementation can be customized by implementing it as a Spring bean, or by providing the implementation class via 'menu.access.control' property.

Fixes: #19127
