### PR TITLE
fix: Only minify in production

### DIFF
--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -718,6 +718,7 @@ export const vaadinConfig: UserConfigFn = (env) => {
       }
     },
     build: {
+      minify: productionMode,
       outDir: buildOutputFolder,
       emptyOutDir: devBundle,
       assetsDir: 'VAADIN/build',


### PR DESCRIPTION
Only minify in production mode.
For development and devBundle builds
do not minify sources.

Fixes #19180
