### PR TITLE
test: click on element before sending keys

### DIFF
--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/webcomponent/PaperInputIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/webcomponent/PaperInputIT.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
 
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
@@ -31,6 +32,8 @@ public class PaperInputIT extends ChromeBrowserTest {
         open();
 
         WebElement input = findElement(By.tagName("paper-input"));
+        new Actions(getDriver()).click(input).perform();
+
         String originalValue = input.getAttribute("value");
         input.sendKeys(Keys.END + "bar");
 


### PR DESCRIPTION
Workaround for PaperInput test, that is unexpectedly failing for a couple of days.
Sending keys fails with 'element non interactable' error, but clicking on it before send makes it work.