### PR TITLE
test: enable PaperInputIT

### DIFF
--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/webcomponent/PaperInputIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/webcomponent/PaperInputIT.java
@@ -29,7 +29,6 @@ import com.vaadin.flow.testutil.ChromeBrowserTest;
 public class PaperInputIT extends ChromeBrowserTest {
 
     @Test
-    @Ignore("Inconsistent failures. Ignored until fixed.")
     public void paperInputIsFunctional() {
         open();
 


### PR DESCRIPTION
Single TestBench test was ignored due to inconsistent failures. This commit takes the test back in action.
