### PR TITLE
fix: Ignore all flow internal packages in tracker

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentTracker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentTracker.java
@@ -50,7 +50,7 @@ public class ComponentTracker {
 
     private static Boolean disabled = null;
     private static String[] prefixesToSkip = new String[] { "com.vaadin.flow.",
-            "java.", "jdk.", "org.springframework.beans.", };
+            "java.", "jakarta.", "jdk.", "org.springframework.beans.", };
 
     /**
      * Represents a location in the source code.

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentTracker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentTracker.java
@@ -49,9 +49,8 @@ public class ComponentTracker {
             .synchronizedMap(new WeakHashMap<>());
 
     private static Boolean disabled = null;
-    private static String[] prefixesToSkip = new String[] {
-            "com.vaadin.flow.", "java.", "jdk.",
-            "org.springframework.beans.", };
+    private static String[] prefixesToSkip = new String[] { "com.vaadin.flow.",
+            "java.", "jdk.", "org.springframework.beans.", };
 
     /**
      * Represents a location in the source code.

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentTracker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentTracker.java
@@ -50,9 +50,7 @@ public class ComponentTracker {
 
     private static Boolean disabled = null;
     private static String[] prefixesToSkip = new String[] {
-            "com.vaadin.flow.component.", "com.vaadin.flow.di.",
-            "com.vaadin.flow.dom.", "com.vaadin.flow.internal.",
-            "com.vaadin.flow.spring.", "java.", "jdk.",
+            "com.vaadin.flow.", "java.", "jdk.",
             "org.springframework.beans.", };
 
     /**

--- a/flow-server/src/test/java/com/vaadin/notreallyflow/ComponentTrackerLocationTest.java
+++ b/flow-server/src/test/java/com/vaadin/notreallyflow/ComponentTrackerLocationTest.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package com.vaadin.flow;
+package com.vaadin.notreallyflow;
 
 import java.io.File;
 import java.nio.file.Path;

--- a/flow-server/src/test/java/com/vaadin/notreallyflow/ComponentTrackerTest.java
+++ b/flow-server/src/test/java/com/vaadin/notreallyflow/ComponentTrackerTest.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.flow;
+package com.vaadin.notreallyflow;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasComponents;

--- a/flow-server/src/test/java/com/vaadin/notreallyflow/DisableComponentTrackerTest.java
+++ b/flow-server/src/test/java/com/vaadin/notreallyflow/DisableComponentTrackerTest.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package com.vaadin.flow;
+package com.vaadin.notreallyflow;
 
 import java.lang.reflect.Field;
 import java.util.Map;


### PR DESCRIPTION
The interesting location is always in the user project and not in Flow classes
