### PR TITLE
fix: prevent embedded styles to leak main document (#19221) (CP: 23.5)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -132,6 +132,17 @@ abstract class AbstractUpdateImports implements Runnable {
 
     protected abstract void writeImportLines(List<String> lines);
 
+    // Visible for test
+    List<String> filterWebComponentImports(List<String> lines) {
+        if (lines != null) {
+            // Exclude Lumo global imports for exported web-component
+            return lines.stream()
+                    .filter(line -> !line.contains("/lumo-includes.ts"))
+                    .collect(Collectors.toList());
+        }
+        return lines;
+    }
+
     /**
      * Get all ES6 modules needed for run the application. Modules that are
      * theme dependencies are guaranteed to precede other modules in the result.

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -28,7 +28,6 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -181,6 +180,12 @@ public class FrontendUtils {
      * file.
      */
     public static final String IMPORTS_D_TS_NAME = "generated-flow-imports.d.ts";
+
+    /**
+     * Name of the file that contains application imports, javascript, theme and
+     * style annotations used when embedding Flow as web-component.
+     */
+    public static final String IMPORTS_WEB_COMPONENT_NAME = "generated-flow-webcomponent-imports.js";
 
     public static final String THEME_IMPORTS_D_TS_NAME = "theme.d.ts";
     public static final String THEME_IMPORTS_NAME = "theme.js";

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -23,6 +23,7 @@ import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 
 import static com.vaadin.flow.server.frontend.FrontendUtils.IMPORTS_NAME;
+import static com.vaadin.flow.server.frontend.FrontendUtils.IMPORTS_WEB_COMPONENT_NAME;
 
 /**
  * An executor that it's run when the servlet context is initialised in dev-mode
@@ -114,7 +115,8 @@ public class NodeTasks implements FallibleCommand {
                             options.frontendDirectory));
                     commands.add(new TaskGenerateWebComponentBootstrap(
                             options.frontendDirectory,
-                            new File(options.generatedFolder, IMPORTS_NAME)));
+                            new File(options.generatedFolder,
+                                    IMPORTS_WEB_COMPONENT_NAME)));
                 }
             }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -46,6 +46,7 @@ import elemental.json.impl.JsonUtil;
 
 import static com.vaadin.flow.server.frontend.FrontendUtils.IMPORTS_D_TS_NAME;
 import static com.vaadin.flow.server.frontend.FrontendUtils.IMPORTS_NAME;
+import static com.vaadin.flow.server.frontend.FrontendUtils.IMPORTS_WEB_COMPONENT_NAME;
 
 /**
  * An updater that it's run when the servlet context is initialised in dev-mode
@@ -79,6 +80,7 @@ public class TaskUpdateImports extends NodeUpdater {
 
         private final File generatedFlowImports;
         private final File generatedFlowDefinitions;
+        final File generatedFlowWebComponentImports;
         private final File fallBackImports;
         private final ClassFinder finder;
 
@@ -92,6 +94,8 @@ public class TaskUpdateImports extends NodeUpdater {
             generatedFlowImports = new File(generatedDirectory, IMPORTS_NAME);
             generatedFlowDefinitions = new File(generatedDirectory,
                     IMPORTS_D_TS_NAME);
+            generatedFlowWebComponentImports = new File(generatedDirectory,
+                    IMPORTS_WEB_COMPONENT_NAME);
             finder = classFinder;
             this.fallBackImports = fallBackImports;
         }
@@ -130,6 +134,8 @@ public class TaskUpdateImports extends NodeUpdater {
                 updateImportsFile(generatedFlowImports, lines);
                 updateImportsFile(generatedFlowDefinitions,
                         getDefinitionLines());
+                updateImportsFile(generatedFlowWebComponentImports,
+                        filterWebComponentImports(lines));
             } catch (IOException e) {
                 throw new IllegalStateException(String.format(
                         "Failed to update the Flow imports file '%s'",
@@ -195,6 +201,7 @@ public class TaskUpdateImports extends NodeUpdater {
         protected Collection<String> getGeneratedModules() {
             final Set<String> exclude = new HashSet<>(
                     Arrays.asList(generatedFlowImports.getName(),
+                            generatedFlowWebComponentImports.getName(),
                             FrontendUtils.FALLBACK_IMPORTS_NAME));
             return NodeUpdater.getGeneratedModules(generatedFolder, exclude);
         }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTestComponents.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTestComponents.java
@@ -145,6 +145,7 @@ public class NodeTestComponents extends NodeUpdateTestUtil {
     @JsModule("@vaadin/vaadin-lumo-styles/spacing.js")
     @JsModule("@vaadin/vaadin-lumo-styles/style.js")
     @JsModule("@vaadin/vaadin-lumo-styles/icons.js")
+    @JsModule("./lumo-includes.ts")
     public static class LumoTest implements AbstractTheme {
 
         public static final String LIGHT = "light";

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateTestUtil.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateTestUtil.java
@@ -78,7 +78,7 @@ public class NodeUpdateTestUtil {
                 "@vaadin/vaadin-lumo-styles/style.js",
                 "@vaadin/vaadin-lumo-styles/typography.js",
                 "@vaadin/vaadin-lumo-styles/color.js",
-                "@vaadin/vaadin-lumo-styles/sizing.js",
+                "@vaadin/vaadin-lumo-styles/sizing.js", "./lumo-includes.ts",
                 "@vaadin/vaadin-date-picker/theme/lumo/vaadin-date-picker.js",
                 "@vaadin/vaadin-date-picker/src/vaadin-month-calendar.js",
                 "@vaadin/vaadin-element-mixin/vaadin-element-mixin.js",

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateWebComponentBootstrapTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateWebComponentBootstrapTest.java
@@ -11,7 +11,6 @@ package com.vaadin.flow.server.frontend;
 import java.io.File;
 
 import com.vaadin.flow.server.ExecutionFailedException;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -19,8 +18,9 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import static com.vaadin.flow.server.Constants.TARGET;
-import static com.vaadin.flow.server.frontend.FrontendUtils.FRONTEND;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
+import static com.vaadin.flow.server.frontend.FrontendUtils.FRONTEND;
+import static com.vaadin.flow.server.frontend.FrontendUtils.IMPORTS_WEB_COMPONENT_NAME;
 
 public class TaskGenerateWebComponentBootstrapTest {
     @Rule
@@ -35,7 +35,8 @@ public class TaskGenerateWebComponentBootstrapTest {
         frontendDirectory = temporaryFolder.newFolder(DEFAULT_FRONTEND_DIR);
         File generatedFolder = temporaryFolder.newFolder(TARGET, FRONTEND);
         generatedImports = new File(generatedFolder,
-                "flow-generated-imports.js");
+                IMPORTS_WEB_COMPONENT_NAME);
+        generatedImports.getParentFile().mkdirs();
         generatedImports.createNewFile();
         taskGenerateWebComponentBootstrap = new TaskGenerateWebComponentBootstrap(
                 frontendDirectory, generatedImports);
@@ -47,7 +48,7 @@ public class TaskGenerateWebComponentBootstrapTest {
         taskGenerateWebComponentBootstrap.execute();
         String content = taskGenerateWebComponentBootstrap.getFileContent();
         Assert.assertTrue(content.contains(
-                "import '../../target/frontend/flow-generated-imports.js'"));
+                "import '../../target/frontend/generated-flow-webcomponent-imports.js'"));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScannerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScannerTest.java
@@ -305,7 +305,7 @@ public class FullDependenciesScannerTest {
                 }, false, null, false);
 
         List<String> modules = scanner.getModules();
-        Assert.assertEquals(25, modules.size());
+        Assert.assertEquals(26, modules.size());
         assertJsModules(modules);
 
         // Theme modules should be included now

--- a/flow-tests/test-embedding/test-embedding-application-theme/src/main/webapp/index.html
+++ b/flow-tests/test-embedding/test-embedding-application-theme/src/main/webapp/index.html
@@ -9,17 +9,19 @@
 
 -->
 <!doctype html>
-
-<head>
-  <script type="module"
-          src="web-component/themed-component.js"></script>
-</head>
-
-<body>
-
-  <span class="internal global" id="overflow">Internal should not apply</span>
-
-  <themed-component id="first"></themed-component>
-  <themed-component id="second"></themed-component>
-
-</body>
+<html>
+    <head>
+        <script type="module" src="web-component/themed-component.js"></script>
+    </head>
+    <body>
+        <h1>Lumo styles should not be applied</h1>
+        <div class="internal" id="internal">
+            Internal should not apply, this should be black
+        </div>
+        <div class="global" id="global">
+            Document styles should apply, this should be blue
+        </div>
+        <themed-component id="first"></themed-component>
+        <themed-component id="second"></themed-component>
+    </body>
+</html>


### PR DESCRIPTION
When using an exported a themed Flow web-component, Lumo style may leak the embedding document, causing invalid CSS rules to be applied. This change prevents applying Lumo global imports when the theme is applied to a web-component.

Fixes #12704