### PR TITLE
test: Fix test path validation

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateSettingsFileTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateSettingsFileTest.java
@@ -107,7 +107,8 @@ public class TaskUpdateSettingsFileTest {
                     "Expected '" + key + "' to have an absolute path matching "
                             + temporaryFolder.getRoot().getPath() + ", but was "
                             + path,
-                    path.startsWith(temporaryFolder.getRoot().getPath()));
+                    Paths.get(path)
+                            .startsWith(temporaryFolder.getRoot().getPath()));
         });
     }
 


### PR DESCRIPTION
Wrap path string to get
same folder pathSeparator
as the system uses for the
temporary folder.

Fixes windows execution of test.