### PR TITLE
feat: add check for Hilla routes in VaadinWebSecurity

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/hilla/FileRouterRequestUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/hilla/FileRouterRequestUtil.java
@@ -1,0 +1,23 @@
+package com.vaadin.flow.internal.hilla;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * A container for utility methods related with Hilla file-based router.
+ * <p>
+ * For internal use only. May be renamed or removed in a future release.
+ *
+ * @author Vaadin Ltd
+ * @since 24.4
+ */
+public interface FileRouterRequestUtil {
+    /**
+     * Checks if the request corresponds to a Hilla route and, if so, applies
+     * the corresponding access control.
+     *
+     * @param request
+     *            the HTTP request to check
+     * @return {@code true} if the request is allowed, {@code false} otherwise
+     */
+    boolean isRouteAllowed(HttpServletRequest request);
+}

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/RequestUtil.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/RequestUtil.java
@@ -16,6 +16,7 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.stereotype.Component;
 
 import com.vaadin.flow.internal.hilla.EndpointRequestUtil;
+import com.vaadin.flow.internal.hilla.FileRouterRequestUtil;
 import com.vaadin.flow.router.Location;
 import com.vaadin.flow.router.QueryParameters;
 import com.vaadin.flow.router.Router;
@@ -49,6 +50,9 @@ public class RequestUtil {
 
     @Autowired(required = false)
     private EndpointRequestUtil endpointRequestUtil;
+
+    @Autowired(required = false)
+    private FileRouterRequestUtil fileRouterRequestUtil;
 
     @Autowired
     private ServletRegistrationBean<SpringServlet> springServletRegistration;
@@ -95,12 +99,28 @@ public class RequestUtil {
      *
      * @param request
      *            the servlet request
-     * @return {@code true} if the request is targeting an anonymous enpoint,
+     * @return {@code true} if the request is targeting an anonymous endpoint,
      *         {@code false} otherwise
      */
     public boolean isAnonymousEndpoint(HttpServletRequest request) {
         if (endpointRequestUtil != null) {
             return endpointRequestUtil.isAnonymousEndpoint(request);
+        }
+        return false;
+    }
+
+    /**
+     * Checks if the request targets a Hilla view that is allowed according to
+     * its configuration and the current user.
+     *
+     * @param request
+     *            the HTTP request to check
+     * @return {@code true} if the request corresponds to an accessible Hilla
+     *         view, {@code false} otherwise
+     */
+    public boolean isAllowedHillaView(HttpServletRequest request) {
+        if (fileRouterRequestUtil != null) {
+            return fileRouterRequestUtil.isRouteAllowed(request);
         }
         return false;
     }

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -209,6 +209,9 @@ public abstract class VaadinWebSecurity {
             // Public endpoints are OK to access
             urlRegistry.requestMatchers(requestUtil::isAnonymousEndpoint)
                     .permitAll();
+            // Checks for known Hilla views
+            urlRegistry.requestMatchers(requestUtil::isAllowedHillaView)
+                    .permitAll();
             // Public routes are OK to access
             urlRegistry.requestMatchers(requestUtil::isAnonymousRoute)
                     .permitAll();


### PR DESCRIPTION
This PR adds a check for Hilla routes so that developers (and our Start) do not have to do themselves.

As the check happens in a Spring bean, nothing changes if Hilla is not on the classpath, as the implementation will be added in Hilla.