### PR TITLE
feat: Open tab in dev mode less often

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -278,5 +278,5 @@ public class InitParameters implements Serializable {
      *
      * Time is given in minutes.
      */
-    public static final String LAUNCH_BROWSER_DELAY = "launch-browser.delay";
+    public static final String LAUNCH_BROWSER_DELAY = "launch-browser-delay";
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -271,4 +271,12 @@ public class InitParameters implements Serializable {
      * Configuration name for cleaning or leaving frontend files in build.
      */
     public static final String CLEAN_BUILD_FRONTEND_FILES = "vaadin.clean.build.frontend.files";
+
+    /**
+     * Configuration name for how long since last browser open before we open a
+     * new tab for the application in development mode.
+     *
+     * Time is given in minutes.
+     */
+    public static final String LAUNCH_BROWSER_DELAY = "launch-browser.delay";
 }

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/BrowserLauncher.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/BrowserLauncher.java
@@ -70,16 +70,19 @@ public class BrowserLauncher {
         if (launchFile.exists()
                 && TimeUnit.MILLISECONDS.toMinutes(System.currentTimeMillis()
                         - launchFile.lastModified()) < lastModifiedDelay) {
-            try {
-                Files.writeString(launchFile.toPath(),
-                        "" + System.currentTimeMillis());
-            } catch (IOException e) {
-                LoggerFactory.getLogger(BrowserLauncher.class)
-                        .debug("Failed to write browser launched file.", e);
-            }
+            writeLaunchFile(launchFile);
             return true;
         }
         return LAUNCHED_VALUE.equals(System.getProperty(LAUNCH_TRACKER));
+    }
+
+    private void writeLaunchFile(File launchFile) {
+        try {
+            Files.writeString(launchFile.toPath(),
+                    Long.toString(System.currentTimeMillis()));
+        } catch (IOException e) {
+            getLogger().debug("Failed to write browser launched file.", e);
+        }
     }
 
     private File getLaunchFile() {
@@ -92,13 +95,7 @@ public class BrowserLauncher {
 
     private void setLaunched() {
         // write launch file and update modified timestamp.
-        try {
-            Files.writeString(getLaunchFile().toPath(),
-                    "" + System.currentTimeMillis());
-        } catch (IOException e) {
-            LoggerFactory.getLogger(BrowserLauncher.class)
-                    .debug("Failed to write browser launched file.", e);
-        }
+        writeLaunchFile(getLaunchFile());
         System.setProperty(LAUNCH_TRACKER, LAUNCHED_VALUE);
     }
 

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/BrowserLauncher.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/BrowserLauncher.java
@@ -1,11 +1,18 @@
 package com.vaadin.base.devserver;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.concurrent.TimeUnit;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.server.VaadinContext;
 import com.vaadin.flow.server.startup.ApplicationConfiguration;
 import com.vaadin.open.Open;
+
+import static com.vaadin.flow.server.InitParameters.LAUNCH_BROWSER_DELAY;
 
 /**
  * Util for launching a browser instance.
@@ -52,11 +59,46 @@ public class BrowserLauncher {
         return applicationConfiguration.isProductionMode();
     }
 
-    private static boolean isLaunched() {
+    private boolean isLaunched() {
+        File launchFile = getLaunchFile();
+        ApplicationConfiguration applicationConfiguration = ApplicationConfiguration
+                .get(context);
+        int lastModifiedDelay = Integer.parseInt(applicationConfiguration
+                .getStringProperty(LAUNCH_BROWSER_DELAY, "30"));
+        // If launch file exists and is younger than time update file content
+        // and modified stamp
+        if (launchFile.exists()
+                && TimeUnit.MILLISECONDS.toMinutes(System.currentTimeMillis()
+                        - launchFile.lastModified()) < lastModifiedDelay) {
+            try {
+                Files.writeString(launchFile.toPath(),
+                        "" + System.currentTimeMillis());
+            } catch (IOException e) {
+                LoggerFactory.getLogger(BrowserLauncher.class)
+                        .debug("Failed to write browser launched file.", e);
+            }
+            return true;
+        }
         return LAUNCHED_VALUE.equals(System.getProperty(LAUNCH_TRACKER));
     }
 
-    private static void setLaunched() {
+    private File getLaunchFile() {
+        ApplicationConfiguration applicationConfiguration = ApplicationConfiguration
+                .get(context);
+        File buildFolder = new File(applicationConfiguration.getProjectFolder(),
+                applicationConfiguration.getBuildFolder());
+        return new File(buildFolder, "tab.launch");
+    }
+
+    private void setLaunched() {
+        // write launch file and update modified timestamp.
+        try {
+            Files.writeString(getLaunchFile().toPath(),
+                    "" + System.currentTimeMillis());
+        } catch (IOException e) {
+            LoggerFactory.getLogger(BrowserLauncher.class)
+                    .debug("Failed to write browser launched file.", e);
+        }
         System.setProperty(LAUNCH_TRACKER, LAUNCHED_VALUE);
     }
 

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinConfigurationProperties.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinConfigurationProperties.java
@@ -122,6 +122,12 @@ public class VaadinConfigurationProperties {
     private boolean launchBrowser = false;
 
     /**
+     * Timeout until a new browser should be launched on startup when in
+     * development mode.
+     */
+    private int launchBrowserDelay = 30;
+
+    /**
      * URL patterns that should not be handled by the Vaadin servlet when mapped
      * to the context root.
      */
@@ -397,6 +403,30 @@ public class VaadinConfigurationProperties {
      */
     public void setLaunchBrowser(boolean launchBrowser) {
         this.launchBrowser = launchBrowser;
+    }
+
+    /**
+     * Returns timout after which a browser should be launched again on startup
+     * when in development mode.
+     * <p>
+     *
+     * @return if a browser should be launched on startup when in development
+     *         mode
+     */
+    public int getLaunchBrowserDelay() {
+        return launchBrowserDelay;
+    }
+
+    /**
+     * Sets timout for launching a new browser on startup when in development
+     * mode.
+     *
+     * @param launchBrowser
+     *            {@code true} to launch a browser on startup when in
+     *            development mode, {@code false} otherwise
+     */
+    public void setLaunchBrowserDelay(int launchBrowser) {
+        this.launchBrowserDelay = launchBrowser;
     }
 
     /**


### PR DESCRIPTION
As we can not know if a tab
for the application is open
we add a file that is checked
for modification time and after
default 30 min we open a new tab on
server restart.

If server is restarted again before
timeout file timestamp is updated.

Clearing build folder will also
cause new tab to open on next restart.

Closes #18393
