### PR TITLE
chore: Import file routes from ts file

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/routes.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/routes.tsx
@@ -34,7 +34,7 @@
  ******************************************************************************/
 import { RouterConfigurationBuilder } from '@vaadin/hilla-file-router/runtime.js';
 import Flow from 'Frontend/generated/flow/Flow';
-import fileRoutes from 'Frontend/generated/file-routes.js';
+import fileRoutes from 'Frontend/generated/file-routes';
 
 export const { router, routes } = new RouterConfigurationBuilder()
     .withFileRoutes(fileRoutes) // (1)


### PR DESCRIPTION
file-routes.ts is only generated by Hilla, thus routes.tsx should import it without extension.