### PR TITLE
fix: Side-nav navigation ignored

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -59,7 +59,9 @@ export function fireRouterEvent(type, detail) {
 // @ts-ignore
 function vaadinRouterGlobalClickHandler(event) {
     // ignore the click if the default action is prevented
-    if (event.defaultPrevented) {
+    // Prevented side-nav click should be handled if targeting Flow route.
+    if (event.defaultPrevented &&
+        (event.target.tagName !== "VAADIN-SIDE-NAV-ITEM" && mountedContainer)) {
         return;
     }
 


### PR DESCRIPTION
Navigation inside flow doesn't
happen when side-nav is used
as the link is marked as defaultPrevented

To have server update the site
allow link handling even if
default prevented for side-nav-item

Fixes #19272
