### PR TITLE
feat: filterable class scanning of JAR

### DIFF
--- a/flow-tests/vaadin-spring-tests/pom.xml
+++ b/flow-tests/vaadin-spring-tests/pom.xml
@@ -335,6 +335,7 @@
 
                 <module>test-spring-boot-only-prepare</module>
                 <module>test-spring-white-list</module>
+                <module>test-spring-filter-packages</module>
 
             </modules>
         </profile>

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-allowed/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-allowed/pom.xml
@@ -35,12 +35,8 @@
 	<dependencies>
 		<dependency>
 			<groupId>com.vaadin</groupId>
-			<artifactId>vaadin-spring</artifactId>
+			<artifactId>flow-server</artifactId>
 			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-autoconfigure</artifactId>
 		</dependency>
 	</dependencies>
 </project>

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-allowed/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-allowed/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Copyright 2000-2024 Vaadin Ltd.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+~ use this file except in compliance with the License. You may obtain a copy of
+~ the License at
+~
+~ http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+~ License for the specific language governing permissions and limitations under
+~ the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<artifactId>vaadin-test-spring-filter-packages</artifactId>
+		<groupId>com.vaadin</groupId>
+		<version>24.4-SNAPSHOT</version>
+	</parent>
+	<artifactId>vaadin-test-spring-filter-packages-lib-allowed</artifactId>
+	<name>Library with vaadin.allowed-packages property
+    </name>
+
+	<packaging>jar</packaging>
+	<properties>
+		<maven.deploy.skip>true</maven.deploy.skip>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.vaadin</groupId>
+			<artifactId>vaadin-spring</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-allowed/src/main/java/com/vaadin/flow/spring/test/allowed/BlockedRoute.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-allowed/src/main/java/com/vaadin/flow/spring/test/allowed/BlockedRoute.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.spring.test.allowed;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+/**
+ * Blocked route in a jar package.
+ */
+@Route("blocked-route-in-jar")
+public class BlockedRoute extends Div {
+
+    public BlockedRoute() {
+    }
+}

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-allowed/src/main/java/com/vaadin/flow/spring/test/allowed/startup/CustomVaadinServiceInitListener.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-allowed/src/main/java/com/vaadin/flow/spring/test/allowed/startup/CustomVaadinServiceInitListener.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.spring.test.allowed.startup;
+
+import org.springframework.stereotype.Component;
+
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinServiceInitListener;
+
+@Component
+public class CustomVaadinServiceInitListener
+        implements VaadinServiceInitListener {
+
+    @Override
+    public void serviceInit(ServiceInitEvent event) {
+    }
+}

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-allowed/src/main/java/com/vaadin/flow/spring/test/allowed/startup/CustomVaadinServiceInitListener.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-allowed/src/main/java/com/vaadin/flow/spring/test/allowed/startup/CustomVaadinServiceInitListener.java
@@ -15,12 +15,9 @@
  */
 package com.vaadin.flow.spring.test.allowed.startup;
 
-import org.springframework.stereotype.Component;
-
 import com.vaadin.flow.server.ServiceInitEvent;
 import com.vaadin.flow.server.VaadinServiceInitListener;
 
-@Component
 public class CustomVaadinServiceInitListener
         implements VaadinServiceInitListener {
 

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-allowed/src/main/java/com/vaadin/flow/spring/test/allowed/startup/vaadin/AllowedRoute.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-allowed/src/main/java/com/vaadin/flow/spring/test/allowed/startup/vaadin/AllowedRoute.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.spring.test.allowed.startup.vaadin;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "allowed-route-in-jar")
+public class AllowedRoute extends Div {
+
+    public AllowedRoute() {
+    }
+}

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-allowed/src/main/resources/META-INF/VAADIN/package.properties
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-allowed/src/main/resources/META-INF/VAADIN/package.properties
@@ -1,0 +1,1 @@
+vaadin.allowed-packages=com/vaadin/flow/spring/test/allowed/startup

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-blocked/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-blocked/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Copyright 2000-2024 Vaadin Ltd.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+~ use this file except in compliance with the License. You may obtain a copy of
+~ the License at
+~
+~ http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+~ License for the specific language governing permissions and limitations under
+~ the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<artifactId>vaadin-test-spring-filter-packages</artifactId>
+		<groupId>com.vaadin</groupId>
+		<version>24.4-SNAPSHOT</version>
+	</parent>
+	<artifactId>vaadin-test-spring-filter-packages-lib-blocked</artifactId>
+	<name>Library with vaadin.blocked-packages property
+    </name>
+
+	<packaging>jar</packaging>
+	<properties>
+		<maven.deploy.skip>true</maven.deploy.skip>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.vaadin</groupId>
+			<artifactId>vaadin-spring</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-blocked/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-blocked/pom.xml
@@ -35,12 +35,8 @@
 	<dependencies>
 		<dependency>
 			<groupId>com.vaadin</groupId>
-			<artifactId>vaadin-spring</artifactId>
+			<artifactId>flow-server</artifactId>
 			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-autoconfigure</artifactId>
 		</dependency>
 	</dependencies>
 </project>

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-blocked/src/main/java/com/vaadin/flow/spring/test/blocked/ScannedAllowedRoute.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-blocked/src/main/java/com/vaadin/flow/spring/test/blocked/ScannedAllowedRoute.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.spring.test.blocked;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route("allowed-route-in-another-jar")
+public class ScannedAllowedRoute extends Div {
+
+    public ScannedAllowedRoute() {
+    }
+}

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-blocked/src/main/java/com/vaadin/flow/spring/test/blocked/startup/BlockedCustomVaadinServiceInitListener.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-blocked/src/main/java/com/vaadin/flow/spring/test/blocked/startup/BlockedCustomVaadinServiceInitListener.java
@@ -15,12 +15,9 @@
  */
 package com.vaadin.flow.spring.test.blocked.startup;
 
-import org.springframework.stereotype.Component;
-
 import com.vaadin.flow.server.ServiceInitEvent;
 import com.vaadin.flow.server.VaadinServiceInitListener;
 
-@Component
 public class BlockedCustomVaadinServiceInitListener
         implements VaadinServiceInitListener {
 

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-blocked/src/main/java/com/vaadin/flow/spring/test/blocked/startup/BlockedCustomVaadinServiceInitListener.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-blocked/src/main/java/com/vaadin/flow/spring/test/blocked/startup/BlockedCustomVaadinServiceInitListener.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.spring.test.blocked.startup;
+
+import org.springframework.stereotype.Component;
+
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinServiceInitListener;
+
+@Component
+public class BlockedCustomVaadinServiceInitListener
+        implements VaadinServiceInitListener {
+
+    @Override
+    public void serviceInit(ServiceInitEvent event) {
+    }
+}

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-blocked/src/main/java/com/vaadin/flow/spring/test/blocked/startup/vaadin/ScannedBlockedRoute.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-blocked/src/main/java/com/vaadin/flow/spring/test/blocked/startup/vaadin/ScannedBlockedRoute.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.spring.test.blocked.startup.vaadin;
 
-
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
 

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-blocked/src/main/java/com/vaadin/flow/spring/test/blocked/startup/vaadin/ScannedBlockedRoute.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-blocked/src/main/java/com/vaadin/flow/spring/test/blocked/startup/vaadin/ScannedBlockedRoute.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.spring.test.blocked.startup.vaadin;
+
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "blocked-route-in-scanned-jar")
+public class ScannedBlockedRoute extends Div {
+
+    public ScannedBlockedRoute() {
+    }
+}

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-blocked/src/main/resources/META-INF/VAADIN/package.properties
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-blocked/src/main/resources/META-INF/VAADIN/package.properties
@@ -1,0 +1,1 @@
+vaadin.blocked-packages=com/vaadin/flow/spring/test/blocked/startup

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-exclude/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-exclude/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Copyright 2000-2024 Vaadin Ltd.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+~ use this file except in compliance with the License. You may obtain a copy of
+~ the License at
+~
+~ http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+~ License for the specific language governing permissions and limitations under
+~ the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<artifactId>vaadin-test-spring-filter-packages</artifactId>
+		<groupId>com.vaadin</groupId>
+		<version>24.4-SNAPSHOT</version>
+	</parent>
+	<artifactId>vaadin-test-spring-filter-packages-lib-exclude</artifactId>
+	<name>Library with vaadin.blocked-jar property
+    </name>
+
+	<packaging>jar</packaging>
+	<properties>
+		<maven.deploy.skip>true</maven.deploy.skip>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.vaadin</groupId>
+			<artifactId>vaadin-spring</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-exclude/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/lib-exclude/pom.xml
@@ -35,12 +35,8 @@
 	<dependencies>
 		<dependency>
 			<groupId>com.vaadin</groupId>
-			<artifactId>vaadin-spring</artifactId>
+			<artifactId>flow-server</artifactId>
 			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-autoconfigure</artifactId>
 		</dependency>
 	</dependencies>
 </project>

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Copyright 2000-2024 Vaadin Ltd.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+~ use this file except in compliance with the License. You may obtain a copy of
+~ the License at
+~
+~ http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+~ License for the specific language governing permissions and limitations under
+~ the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<artifactId>vaadin-spring-tests</artifactId>
+		<groupId>com.vaadin</groupId>
+		<version>24.4-SNAPSHOT</version>
+	</parent>
+	<artifactId>vaadin-test-spring-filter-packages</artifactId>
+	<name>The main module for a Spring boot package filter tests
+    </name>
+
+	<packaging>pom</packaging>
+	<properties>
+		<maven.deploy.skip>true</maven.deploy.skip>
+	</properties>
+
+	<modules>
+		<module>lib-allowed</module>
+		<module>lib-blocked</module>
+		<module>lib-exclude</module>
+		<module>ui</module>
+	</modules>
+
+</project>

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/ui/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/ui/pom.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Copyright 2000-2024 Vaadin Ltd.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+~ use this file except in compliance with the License. You may obtain a copy of
+~ the License at
+~
+~ http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+~ License for the specific language governing permissions and limitations under
+~ the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<artifactId>vaadin-test-spring-filter-packages</artifactId>
+		<groupId>com.vaadin</groupId>
+		<version>24.4-SNAPSHOT</version>
+	</parent>
+	<artifactId>vaadin-test-spring-filter-packages-ui</artifactId>
+	<packaging>jar</packaging>
+
+	<properties>
+		<maven.deploy.skip>true</maven.deploy.skip>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.vaadin</groupId>
+			<artifactId>vaadin-spring</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.vaadin</groupId>
+			<artifactId>vaadin-dev-server</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-logging</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<!--		<dependency>-->
+		<!--			<groupId>org.springframework.boot</groupId>-->
+		<!--			<artifactId>spring-boot-starter-web</artifactId>-->
+		<!--			<exclusions>-->
+		<!--				<exclusion>-->
+		<!--					<groupId>org.springframework.boot</groupId>-->
+		<!--					<artifactId>spring-boot-starter-tomcat</artifactId>-->
+		<!--				</exclusion>-->
+		<!--				<exclusion>-->
+		<!--					<groupId>org.apache.logging.log4j</groupId>-->
+		<!--					<artifactId>log4j-api</artifactId>-->
+		<!--				</exclusion>-->
+		<!--			</exclusions>-->
+		<!--		</dependency>-->
+
+		<!--		<dependency>-->
+		<!--			<groupId>org.springframework.boot</groupId>-->
+		<!--			<artifactId>spring-boot-starter-jetty</artifactId>-->
+		<!--		</dependency>-->
+
+		<dependency>
+			<groupId>com.vaadin</groupId>
+			<artifactId>vaadin-test-spring-filter-packages-lib-allowed</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.vaadin</groupId>
+			<artifactId>vaadin-test-spring-filter-packages-lib-blocked</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.vaadin</groupId>
+				<artifactId>flow-maven-plugin</artifactId>
+				<version>${project.version}</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>prepare-frontend</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<version>${spring.boot.version}</version>
+				<configuration>
+					<maxAttempts>100</maxAttempts>
+					<wait>2500</wait>
+					<jmxPort>9009</jmxPort>
+					<jvmArguments>
+                        -Xdebug
+                        -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=18888
+                    </jvmArguments>
+				</configuration>
+				<executions>
+					<!-- start and stop application when running
+															                        integration tests -->
+					<execution>
+						<id>pre-integration-test</id>
+						<goals>
+							<goal>start</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>post-integration-test</id>
+						<goals>
+							<goal>stop</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+		</plugins>
+	</build>
+
+</project>

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/ui/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/ui/pom.xml
@@ -54,30 +54,19 @@
 			<exclusions>
 				<exclusion>
 					<groupId>org.springframework.boot</groupId>
-					<artifactId>spring-boot-starter-logging</artifactId>
+					<artifactId>spring-boot-starter-tomcat</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-api</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>
 
-		<!--		<dependency>-->
-		<!--			<groupId>org.springframework.boot</groupId>-->
-		<!--			<artifactId>spring-boot-starter-web</artifactId>-->
-		<!--			<exclusions>-->
-		<!--				<exclusion>-->
-		<!--					<groupId>org.springframework.boot</groupId>-->
-		<!--					<artifactId>spring-boot-starter-tomcat</artifactId>-->
-		<!--				</exclusion>-->
-		<!--				<exclusion>-->
-		<!--					<groupId>org.apache.logging.log4j</groupId>-->
-		<!--					<artifactId>log4j-api</artifactId>-->
-		<!--				</exclusion>-->
-		<!--			</exclusions>-->
-		<!--		</dependency>-->
-
-		<!--		<dependency>-->
-		<!--			<groupId>org.springframework.boot</groupId>-->
-		<!--			<artifactId>spring-boot-starter-jetty</artifactId>-->
-		<!--		</dependency>-->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-jetty</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>com.vaadin</groupId>

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/ui/src/main/java/com/vaadin/flow/spring/test/filtering/ClassScannerView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/ui/src/main/java/com/vaadin/flow/spring/test/filtering/ClassScannerView.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.spring.test.filtering;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.Route;
+
+@Route("")
+public class ClassScannerView extends Div {
+
+    public static Set<Class<?>> classes = Collections.emptySet();
+    public static final String SCANNED_CLASSES = "scanned-classes";
+
+    public ClassScannerView() {
+        Span scannedClasses = new Span(classes.stream()
+                .map(Class::getSimpleName).collect(Collectors.joining(",")));
+        scannedClasses.setId(SCANNED_CLASSES);
+        add(scannedClasses);
+    }
+
+}

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/ui/src/main/java/com/vaadin/flow/spring/test/filtering/TestServletInitializer.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/ui/src/main/java/com/vaadin/flow/spring/test/filtering/TestServletInitializer.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.spring.test.filtering;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.vaadin.flow.spring.VaadinServletContextInitializer;
+
+/**
+ * The entry point of the Spring Boot application.
+ */
+@SpringBootApplication
+@Configuration
+public class TestServletInitializer {
+
+    public static void main(String[] args) {
+        SpringApplication.run(TestServletInitializer.class, args);
+    }
+
+    @Bean
+    public VaadinServletContextInitializer vaadinServletContextInitializer(
+            ApplicationContext context) {
+
+        return new VaadinServletContextInitializer(context) {
+            @Override
+            protected Set<Class<?>> findClassesForDevMode(
+                    Set<String> basePackages,
+                    List<Class<? extends Annotation>> annotations,
+                    List<Class<?>> superTypes) {
+                ClassScannerView.classes = super.findClassesForDevMode(
+                        basePackages, annotations, superTypes);
+                return ClassScannerView.classes;
+            }
+        };
+    }
+}

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/ui/src/main/java/com/vaadin/flow/spring/test/filtering/blocked/BlockedView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/ui/src/main/java/com/vaadin/flow/spring/test/filtering/blocked/BlockedView.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.spring.test.filtering.blocked;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route("blocked")
+public class BlockedView extends Div {
+
+    public BlockedView() {
+    }
+}

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/ui/src/main/resources/application.properties
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/ui/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+server.port=8888
+vaadin.blocked-packages=blocked,com/vaadin/flow/spring/test/filtering/blocked

--- a/flow-tests/vaadin-spring-tests/test-spring-filter-packages/ui/src/test/java/com/vaadin/flow/spring/test/filtering/ClassScannerIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-filter-packages/ui/src/test/java/com/vaadin/flow/spring/test/filtering/ClassScannerIT.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.spring.test.filtering;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import com.vaadin.flow.spring.test.allowed.startup.CustomVaadinServiceInitListener;
+import com.vaadin.flow.spring.test.allowed.startup.vaadin.AllowedRoute;
+import com.vaadin.flow.spring.test.allowed.BlockedRoute;
+import com.vaadin.flow.spring.test.blocked.ScannedAllowedRoute;
+import com.vaadin.flow.spring.test.blocked.startup.BlockedCustomVaadinServiceInitListener;
+import com.vaadin.flow.spring.test.blocked.startup.vaadin.ScannedBlockedRoute;
+import com.vaadin.flow.spring.test.filtering.blocked.BlockedView;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+/**
+ * Primary target of this IT is class scanning of DevModeServletContextListener
+ * in {@link com.vaadin.flow.spring.VaadinServletContextInitializer} and
+ * especially usage of {@code vaadin.blocked-packages} and
+ * {@code vaadin.allowed-packages} in a multi-module Maven project with jar
+ * packaged dependencies.
+ */
+public class ClassScannerIT extends ChromeBrowserTest {
+
+    @Test
+    public void uiModule_withBlockedPackages() {
+        open();
+        assertClassAllowed(ClassScannerView.class.getSimpleName());
+        assertClassBlocked(BlockedView.class.getSimpleName());
+    }
+
+    @Test
+    public void libAllowedModule_withAllowedPackagesJar() {
+        open();
+        assertClassAllowed(AllowedRoute.class.getSimpleName());
+        assertClassAllowed(
+                CustomVaadinServiceInitListener.class.getSimpleName());
+        assertClassBlocked(BlockedRoute.class.getSimpleName());
+    }
+
+    @Test
+    public void libBlockedModule_withBlockedPackagesJar() {
+        open();
+        assertClassBlocked(ScannedBlockedRoute.class.getSimpleName());
+        assertClassBlocked(
+                BlockedCustomVaadinServiceInitListener.class.getSimpleName());
+        assertClassAllowed(ScannedAllowedRoute.class.getSimpleName());
+    }
+
+    private void assertClassAllowed(String className) {
+        Assert.assertTrue(className + " should be allowed.",
+                getScannedClasses().contains(className));
+    }
+
+    private void assertClassBlocked(String className) {
+        Assert.assertFalse(className + " should be blocked.",
+                getScannedClasses().contains(className));
+    }
+
+    private List<String> getScannedClasses() {
+        return Stream.of(findElement(By.id(ClassScannerView.SCANNED_CLASSES))
+                .getText().split(",")).map(String::trim).toList();
+    }
+
+    @Override
+    protected String getTestPath() {
+        return "/";
+    }
+}

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/io/FilterableResourceResolver.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/io/FilterableResourceResolver.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.spring.io;
+
+import java.io.IOException;
+import java.net.JarURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.stream.Stream;
+import java.util.zip.ZipException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.core.io.UrlResource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.io.support.PropertiesLoaderUtils;
+import org.springframework.util.ResourceUtils;
+
+public class FilterableResourceResolver
+        extends PathMatchingResourcePatternResolver {
+
+    private static final String JAR_PROTOCOL = "jar:";
+    private static final String JAR_KEY = ".jar!/";
+    private static final String PACKAGE_PROPERTIES_PATH = "META-INF/VAADIN/package.properties";
+
+    public static final String ALLOWED_PACKAGES_PROPERTY = "vaadin.allowed-packages";
+    public static final String BLOCKED_PACKAGES_PROPERTY = "vaadin.blocked-packages";
+
+    private Map<String, Properties> propertiesCache = new HashMap<>();
+
+    public FilterableResourceResolver(ResourceLoader resourceLoader) {
+        super(resourceLoader);
+    }
+
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(FilterableResourceResolver.class);
+    }
+
+    protected boolean isJar(String path) {
+        return path.lastIndexOf(JAR_KEY) != -1;
+    }
+
+    private Resource doResolveRootDirResource(Resource original)
+            throws IOException {
+        String rootDirPath = original.getURI().getPath();
+        if (rootDirPath != null) {
+            int index = rootDirPath.lastIndexOf(JAR_KEY);
+            if (index != -1) {
+                String jarPath = rootDirPath.substring(0,
+                        index + JAR_KEY.length());
+                return new UrlResource(jarPath);
+                // return new ClassPathResource(jarPath, getClassLoader());
+            }
+        }
+        return super.resolveRootDirResource(original);
+    }
+
+    @Override
+    protected Set<Resource> doFindPathMatchingJarResources(
+            Resource rootDirResource, URL rootDirUrl, String subPattern)
+            throws IOException {
+        String path = rootDirResource.getURI().toString();
+        cachePackageProperties(path, rootDirResource, rootDirUrl);
+
+        if(isBlockedJar(rootDirResource)) {
+            return Collections.emptySet();
+        }
+        return super.doFindPathMatchingJarResources(rootDirResource, rootDirUrl,
+                subPattern);
+    }
+
+    @Override
+    protected Set<Resource> doFindAllClassPathResources(String path)
+            throws IOException {
+        var result = super.doFindAllClassPathResources(path);
+        result.removeIf(res -> {
+            cachePackageProperties(res);
+            return isBlockedJar(res);
+        });
+        return result;
+    }
+
+    private void cachePackageProperties(String path, Resource rootDirResource,
+            URL rootDirUrl) throws IOException {
+        if (!propertiesCache.containsKey(path)) {
+            if (isJar(path)) {
+                String jarPath = path.substring(0, path.lastIndexOf(JAR_KEY));
+                if (jarPath.startsWith("jar:")) {
+                    jarPath = jarPath.substring(4);
+                }
+                propertiesCache.put(jarPath, readPackageProperties(rootDirUrl,
+                        path, doResolveRootDirResource(rootDirResource)));
+                getLogger().trace("Caching package.properties of JAR {}", path);
+            } else {
+                Resource resource = doFindPathMatchingFileResources(
+                        rootDirResource, PACKAGE_PROPERTIES_PATH).stream()
+                        .findFirst().orElse(null);
+                Properties properties = resource != null
+                        ? PropertiesLoaderUtils.loadProperties(resource)
+                        : null;
+                propertiesCache.put(path, properties);
+                getLogger().trace("Caching package.properties of directory {}",
+                        path);
+            }
+        }
+    }
+
+    private void cachePackageProperties(Resource res) {
+        try {
+            Resource rootDirResource = convertClassLoaderURL(res.getURL());
+            String rootDirPath = rootDirResource.getURI().toString();
+            String rootPath = rootDirResource.getURI().getPath();
+            if (rootPath != null && isJar(rootDirPath)) {
+                int index = rootDirPath.lastIndexOf(JAR_KEY);
+                if (index != -1) {
+                    String jarPath = rootDirPath.substring(0,
+                            index + JAR_KEY.length());
+                    String key = rootPath.substring(0,
+                            rootPath.lastIndexOf(JAR_KEY));
+                    if (key.startsWith(JAR_PROTOCOL)) {
+                        key = key.substring(4);
+                    }
+                    if (!propertiesCache.containsKey(key)) {
+                        propertiesCache.put(key, readPackageProperties(null,
+                                jarPath, rootDirResource));
+                        getLogger().trace(
+                                "Caching package.properties of JAR {}",
+                                rootPath);
+                    }
+                }
+            } else if (!propertiesCache.containsKey(rootPath)) {
+                Resource resource = doFindPathMatchingFileResources(
+                        rootDirResource, PACKAGE_PROPERTIES_PATH).stream()
+                        .findFirst().orElse(null);
+                Properties properties = resource != null
+                        ? PropertiesLoaderUtils.loadProperties(resource)
+                        : null;
+                propertiesCache.put(rootPath, properties);
+                getLogger().trace(
+                        "Caching package.properties of directory {}",
+                        rootPath);
+            }
+
+        } catch (IOException e) {
+            getLogger().warn("Failed to find " + PACKAGE_PROPERTIES_PATH
+                    + " for path " + res, e);
+        }
+    }
+
+    private boolean isBlockedJar(Resource resource) {
+        // TODO handle case of package.properties with vaadin.blocked-jar=true
+        return false;
+    }
+
+    /**
+     * See {@link super#doFindPathMatchingJarResources(Resource, URL, String)}.
+     * This method is slightly adjusted from the origin to just read
+     * META-INF/VAADIN/package.properties and transform it to Properties object.
+     */
+    private Properties readPackageProperties(URL jarPathURL, String jarPath,
+            Resource rootDirResource) throws IOException {
+        URLConnection con = null;
+        JarFile jarFile;
+        String jarFileUrl;
+        String urlFile = null;
+        boolean closeJarFile;
+        if (jarPathURL != null) {
+            con = jarPathURL.openConnection();
+            urlFile = jarPathURL.getPath();
+        }
+        if (con instanceof JarURLConnection jarCon) {
+            jarFile = jarCon.getJarFile();
+            closeJarFile = !jarCon.getUseCaches();
+        } else {
+            // No JarURLConnection -> need to resort to URL file parsing.
+            // We'll assume URLs of the format "jar:path!/entry", with the
+            // protocol
+            // being arbitrary as long as following the entry format.
+            // We'll also handle paths with and without leading "file:"
+            // prefix.
+            urlFile = urlFile != null ? urlFile : jarPath;
+            try {
+                int separatorIndex = urlFile
+                        .indexOf(ResourceUtils.WAR_URL_SEPARATOR);
+                if (separatorIndex == -1) {
+                    separatorIndex = urlFile
+                            .indexOf(ResourceUtils.JAR_URL_SEPARATOR);
+                }
+                if (separatorIndex != -1) {
+                    jarFileUrl = urlFile.substring(0, separatorIndex);
+                    jarFile = getJarFile(jarFileUrl);
+                } else {
+                    jarFile = new JarFile(urlFile);
+                }
+                closeJarFile = true;
+            } catch (ZipException ex) {
+                if (getLogger().isDebugEnabled()) {
+                    getLogger().debug("Skipping invalid jar class path entry ["
+                            + urlFile + "]");
+                }
+                return null;
+            }
+        }
+
+        try {
+            if (getLogger().isTraceEnabled()) {
+                getLogger().trace("Looking for package.properties in jar file ["
+                        + rootDirResource + "]");
+            }
+            for (Enumeration<JarEntry> entries = jarFile.entries(); entries
+                    .hasMoreElements();) {
+                JarEntry entry = entries.nextElement();
+                String entryPath = entry.getName();
+                if (entryPath.endsWith(PACKAGE_PROPERTIES_PATH)) {
+                    Resource resource = doFindPathMatchingFileResources(
+                            rootDirResource, PACKAGE_PROPERTIES_PATH).stream()
+                            .findFirst().orElseGet(() -> {
+                                try {
+                                    return rootDirResource.createRelative(
+                                            PACKAGE_PROPERTIES_PATH);
+                                } catch (IOException e) {
+                                    getLogger().warn(
+                                            "Could not read package.properties",
+                                            e);
+                                    return null;
+                                }
+                            });
+                    Properties prop = resource != null
+                            ? PropertiesLoaderUtils.loadProperties(resource)
+                            : null;
+                    if (getLogger().isTraceEnabled()) {
+                        getLogger().trace("Read package.properties: [{}]",
+                                prop);
+                    }
+                    return prop;
+                }
+            }
+            return null;
+        } finally {
+            if (closeJarFile) {
+                jarFile.close();
+            }
+        }
+    }
+
+    protected boolean isAllowedByPackageProperties(String rootPath,
+                                                   String targetPath, boolean defaultValue) {
+        Properties properties = propertiesCache.get(rootPath);
+        if (properties == null) {
+            return defaultValue;
+        }
+
+        List<String> allowedPackages = Stream.of(properties
+                        .getProperty(ALLOWED_PACKAGES_PROPERTY, "").split(","))
+                .filter(pkg -> !pkg.isBlank()).toList();
+        List<String> blockedPackages = Stream.of(properties
+                        .getProperty(BLOCKED_PACKAGES_PROPERTY, "").split(","))
+                .filter(pkg -> !pkg.isBlank()).toList();
+        if (!allowedPackages.isEmpty()) {
+            return allowedPackages.stream().anyMatch(targetPath::startsWith);
+        } else if (!blockedPackages.isEmpty()) {
+            return blockedPackages.stream().noneMatch(targetPath::startsWith);
+        }
+        return defaultValue;
+    }
+}


### PR DESCRIPTION
This change improves optimization of class scanning of `VaadinServletContextInitializer` by reading optional configuration file within a JAR dependency. Configuration file is a regular properties file that can contain `vaadin.allowed-packages` or `vaadin.blocked-packages` to exclude/include packages being scanned by `VaadinServletContextInitializer`. Package exclusion/inclusion effects only classes in the JAR/module where `META-INF/VAADIN/package.properties` is located at.

Notice that this is only affecting the performance of the class scanning of Vaadin specific annotations and types and this feature is not meant to be used for excluding packages from the whole application. E.g. excluding `VaadinServiceInitListener` in a Spring application is not stopping Spring and Vaadin initializing it anyway, although some time-consuming actions like `DevModeServletContextListener` would still exclude it for optimization.

Fixes: #19117