### PR TITLE
fix!: rename createWebComponent method

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -446,7 +446,7 @@ interface Properties {
  * @param onload optional callback to be called for script onload
  * @param onerror optional callback for error loading the script
  */
-export const createWebComponent = (tag: string, props?: Properties, onload?: () => void, onerror?: (err:any) => void) => {
+export const webComponentTSX = (tag: string, props?: Properties, onload?: () => void, onerror?: (err:any) => void) => {
     loadComponentScript(tag).then(() => onload?.(), (err) => {
         if(onerror) {
             onerror(err);

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -446,7 +446,7 @@ interface Properties {
  * @param onload optional callback to be called for script onload
  * @param onerror optional callback for error loading the script
  */
-export const webComponentTSX = (tag: string, props?: Properties, onload?: () => void, onerror?: (err:any) => void) => {
+export const reactElement = (tag: string, props?: Properties, onload?: () => void, onerror?: (err:any) => void) => {
     loadComponentScript(tag).then(() => onload?.(), (err) => {
         if(onerror) {
             onerror(err);


### PR DESCRIPTION
Rename the createWebComponent function
as the create gives the impression that
the function is heavy.