### PR TITLE
Revert "fix: make property change listener trigger on removeProperty (#19196)"

### DIFF
--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -2613,7 +2613,8 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
                     throw new NullPointerException();
                 }, name -> name))
                 .bind(Person::getFirstName, Person::setFirstName)
-                .read(Person.createTestPerson1());
+                .read(new Person());
+
     }
 
     @Test(expected = BindingException.class)

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/AbstractPropertyMap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/AbstractPropertyMap.java
@@ -81,7 +81,7 @@ public abstract class AbstractPropertyMap extends NodeMap {
      *            the name of the property to remove
      */
     public void removeProperty(String name) {
-        remove(name);
+        super.remove(name);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ElementPropertyMap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ElementPropertyMap.java
@@ -193,7 +193,7 @@ public class ElementPropertyMap extends AbstractPropertyMap {
         Serializable oldValue = super.remove(key);
 
         fireEvent(new PropertyChangeEvent(Element.get(getNode()), key, oldValue,
-                false));
+                true));
 
         return oldValue;
     }

--- a/flow-server/src/test/java/com/vaadin/flow/component/AbstractSinglePropertyFieldTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/AbstractSinglePropertyFieldTest.java
@@ -33,6 +33,9 @@ import com.vaadin.flow.dom.DomListenerRegistration;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableRunnable;
 import com.vaadin.flow.internal.JsonUtils;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.server.MockServletServiceSessionSetup.TestVaadinServlet;
 import com.vaadin.flow.server.MockServletServiceSessionSetup.TestVaadinServletService;
 import com.vaadin.tests.PublicApiAnalyzer;
 import com.vaadin.tests.util.MockUI;
@@ -83,7 +86,9 @@ public class AbstractSinglePropertyFieldTest {
         Assert.assertEquals("bar", field.getValue());
         monitor.assertEvent(false, "foo", "bar");
 
-        field.getElement().removeProperty("property");
+        // Cannot do removeProperty because
+        // https://github.com/vaadin/flow/issues/3994
+        field.getElement().setProperty("property", null);
         Assert.assertEquals("", field.getValue());
         monitor.assertEvent(false, "bar", "");
     }
@@ -184,38 +189,6 @@ public class AbstractSinglePropertyFieldTest {
     }
 
     @Tag("tag")
-    private static class StringNullFieldWithDefaultEmpty extends
-            AbstractSinglePropertyField<StringNullFieldWithDefaultEmpty, String> {
-        public StringNullFieldWithDefaultEmpty() {
-            super("property", "", true);
-        }
-    }
-
-    @Test
-    public void stringNullFieldWithDefaultEmpty_basicCases() {
-        StringNullFieldWithDefaultEmpty field = new StringNullFieldWithDefaultEmpty();
-        ValueChangeMonitor<String> monitor = new ValueChangeMonitor<>(field);
-
-        Assert.assertEquals("", field.getValue());
-        Assert.assertFalse(field.getElement().hasProperty("property"));
-        monitor.assertNoEvent();
-
-        field.setValue("foo");
-        Assert.assertEquals("foo", field.getValue());
-        monitor.assertEvent(false, "", "foo");
-
-        field.setValue("");
-        Assert.assertEquals("", field.getValue());
-        Assert.assertTrue(field.getElement().hasProperty("property"));
-        monitor.assertEvent(false, "foo", "");
-
-        field.setValue(null);
-        Assert.assertFalse(field.getElement().hasProperty("property"));
-        Assert.assertEquals("", field.getValue());
-        monitor.assertNoEvent();
-    }
-
-    @Tag("tag")
     private static class DoubleField
             extends AbstractSinglePropertyField<DoubleField, Double> {
         public DoubleField() {
@@ -241,7 +214,9 @@ public class AbstractSinglePropertyFieldTest {
         Assert.assertEquals(1.1, field.getValue(), 0);
         monitor.assertEvent(false, 10.1, 1.1);
 
-        field.getElement().removeProperty("property");
+        // Cannot do removeProperty because
+        // https://github.com/vaadin/flow/issues/3994
+        field.getElement().setProperty("property", null);
         Assert.assertEquals(0.0, field.getValue(), 0);
         monitor.assertEvent(false, 1.1, 0.0);
     }
@@ -271,7 +246,9 @@ public class AbstractSinglePropertyFieldTest {
         Assert.assertEquals(1, field.getValue().intValue());
         monitor.assertEvent(false, 0, 1);
 
-        field.getElement().removeProperty("property");
+        // Cannot do removeProperty because
+        // https://github.com/vaadin/flow/issues/3994
+        field.getElement().setProperty("property", null);
         Assert.assertEquals(42, field.getValue().intValue());
         monitor.assertEvent(false, 1, 42);
     }
@@ -305,7 +282,9 @@ public class AbstractSinglePropertyFieldTest {
         field.setValue(true);
         monitor.discard();
 
-        field.getElement().removeProperty("property");
+        // Cannot do removeProperty because
+        // https://github.com/vaadin/flow/issues/3994
+        field.getElement().setProperty("property", null);
         Assert.assertFalse(field.getValue());
         monitor.assertEvent(false, true, false);
     }
@@ -353,7 +332,9 @@ public class AbstractSinglePropertyFieldTest {
         monitor.assertEvent(false, LocalDate.of(2018, 4, 25),
                 LocalDate.of(2017, 3, 24));
 
-        field.getElement().removeProperty("property");
+        // Cannot do removeProperty because
+        // https://github.com/vaadin/flow/issues/3994
+        field.getElement().setProperty("property", null);
         Assert.assertEquals(null, field.getValue());
         monitor.assertEvent(false, LocalDate.of(2017, 3, 24), null);
     }

--- a/flow-server/src/test/java/com/vaadin/flow/component/PropertyDescriptorsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/PropertyDescriptorsTest.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component;
 
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -320,110 +319,6 @@ public class PropertyDescriptorsTest {
     @Test(expected = IllegalArgumentException.class)
     public void booleanPropertyDefaultTrue_setToNull() {
         booleanPropertyDefaultTrue.set(component, null);
-    }
-
-    @Test
-    public void booleanPropertyDefaultFalse_resetToDefault_propertyChangeListenerTriggered() {
-        booleanPropertyDefaultFalse.set(component, true);
-
-        AtomicBoolean listenerTriggered = new AtomicBoolean(false);
-        component.getElement().addPropertyChangeListener(TEST_PROPERTY,
-                event -> listenerTriggered.set(true));
-
-        booleanPropertyDefaultFalse.set(component, false);
-
-        Assert.assertTrue(listenerTriggered.get());
-    }
-
-    @Test
-    public void booleanPropertyDefaultTrue_resetToDefault_propertyChangeListenerTriggered() {
-        booleanPropertyDefaultTrue.set(component, false);
-
-        AtomicBoolean listenerTriggered = new AtomicBoolean(false);
-        component.getElement().addPropertyChangeListener(TEST_PROPERTY,
-                event -> listenerTriggered.set(true));
-
-        booleanPropertyDefaultTrue.set(component, true);
-
-        Assert.assertTrue(listenerTriggered.get());
-    }
-
-    @Test
-    public void stringPropertyDefaultEmpty_resetToDefault_propertyChangeListenerTriggered() {
-        stringPropertyDefaultEmpty.set(component, SOME_STRING_VALUE);
-
-        AtomicBoolean listenerTriggered = new AtomicBoolean(false);
-        component.getElement().addPropertyChangeListener(TEST_PROPERTY,
-                event -> listenerTriggered.set(true));
-
-        stringPropertyDefaultEmpty.set(component, EMPTY_STRING);
-
-        Assert.assertTrue(listenerTriggered.get());
-    }
-
-    @Test
-    public void stringPropertyDefaultFoo_resetToDefault_propertyChangeListenerTriggered() {
-        stringPropertyDefaultFoo.set(component, SOME_STRING_VALUE);
-
-        AtomicBoolean listenerTriggered = new AtomicBoolean(false);
-        component.getElement().addPropertyChangeListener(TEST_PROPERTY,
-                event -> listenerTriggered.set(true));
-
-        stringPropertyDefaultFoo.set(component, FOO);
-
-        Assert.assertTrue(listenerTriggered.get());
-    }
-
-    @Test
-    public void integerPropertyDefaultZero_resetToDefault_propertyChangeListenerTriggered() {
-        integerPropertyDefaultZero.set(component, SOME_INTEGER_VALUE);
-
-        AtomicBoolean listenerTriggered = new AtomicBoolean(false);
-        component.getElement().addPropertyChangeListener(TEST_PROPERTY,
-                event -> listenerTriggered.set(true));
-
-        integerPropertyDefaultZero.set(component, ZERO);
-
-        Assert.assertTrue(listenerTriggered.get());
-    }
-
-    @Test
-    public void integerPropertyDefaultOne_resetToDefault_propertyChangeListenerTriggered() {
-        integerPropertyDefaultOne.set(component, SOME_INTEGER_VALUE);
-
-        AtomicBoolean listenerTriggered = new AtomicBoolean(false);
-        component.getElement().addPropertyChangeListener(TEST_PROPERTY,
-                event -> listenerTriggered.set(true));
-
-        integerPropertyDefaultOne.set(component, ONE);
-
-        Assert.assertTrue(listenerTriggered.get());
-    }
-
-    @Test
-    public void doublePropertyDefaultZero_resetToDefault_propertyChangeListenerTriggered() {
-        doublePropertyDefaultZero.set(component, SOME_DOUBLE_VALUE);
-
-        AtomicBoolean listenerTriggered = new AtomicBoolean(false);
-        component.getElement().addPropertyChangeListener(TEST_PROPERTY,
-                event -> listenerTriggered.set(true));
-
-        doublePropertyDefaultZero.set(component, ZERO_DOUBLE);
-
-        Assert.assertTrue(listenerTriggered.get());
-    }
-
-    @Test
-    public void doublePropertyDefaultOne_resetToDefault_propertyChangeListenerTriggered() {
-        doublePropertyDefaultOne.set(component, SOME_DOUBLE_VALUE);
-
-        AtomicBoolean listenerTriggered = new AtomicBoolean(false);
-        component.getElement().addPropertyChangeListener(TEST_PROPERTY,
-                event -> listenerTriggered.set(true));
-
-        doublePropertyDefaultOne.set(component, ONE_DOUBLE);
-
-        Assert.assertTrue(listenerTriggered.get());
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/ElementPropertyMapTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/ElementPropertyMapTest.java
@@ -58,14 +58,14 @@ public class ElementPropertyMapTest {
             event.set(ev);
         };
         map.addPropertyChangeListener("foo", listener);
-        map.removeProperty("foo");
 
+        map.remove("foo");
         Assert.assertNull(event.get().getValue());
         Assert.assertEquals("bar", event.get().getOldValue());
         Assert.assertEquals("foo", event.get().getPropertyName());
         Assert.assertEquals(Element.get(map.getNode()),
                 event.get().getSource());
-        Assert.assertFalse(event.get().isUserOriginated());
+        Assert.assertTrue(event.get().isUserOriginated());
     }
 
     @Test


### PR DESCRIPTION
This reverts commit 63e6dfd9b188ba35f895a259582a37ae071757b5.

The original fix for the property change event is correct per se, but, unfortunately, we faced an odd side effect in the RadioButtonGroup component that blocks our development process and would be a breaking change for RadioButtonGroup's users.

Here are some details: 

The `getValue()` method of the `RadioButtonGroup` (and probably other similar components, like `Select` and `CheckboxGroup`) returned an item that was set in `setValue()` before, even if it was an invalid item, e.g. it's key/id wasn't in the list of items for this component.

With this change, the `PropertyChangeEvent` is triggered, that causes `handlePropertyChange` and `hasValidValue` method to be called. `hasValidValue` doesn't properly check if the item is in the list of items on the server and returns true, that causes a state change in `setModelValue`, that eventually resets the value to `null`. In other words, if one wants to set a new value, which isn't present in the item's list, the component set the value to `null`, which sounds like even a bigger bug.

The proper behaviour, in my opinion, should be to not accept invalid values and make `hasValidValue` implementation properly check if the item is present or not, but this turns into more complicated work that may even have a breaking changes in behaviour.