### PR TITLE
feat: Add HasLabelAsText interface to NativeButtonElement

### DIFF
--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/NativeButtonElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/NativeButtonElement.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.html.testbench;
 
+import com.vaadin.testbench.HasLabelAsText;
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;
 
@@ -24,6 +25,6 @@ import com.vaadin.testbench.elementsbase.Element;
  * @since 1.0
  */
 @Element("button")
-public class NativeButtonElement extends TestBenchElement {
+public class NativeButtonElement extends TestBenchElement implements HasLabelAsText {
 
 }

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/NativeButtonElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/NativeButtonElement.java
@@ -25,6 +25,7 @@ import com.vaadin.testbench.elementsbase.Element;
  * @since 1.0
  */
 @Element("button")
-public class NativeButtonElement extends TestBenchElement implements HasLabelAsText {
+public class NativeButtonElement extends TestBenchElement
+        implements HasLabelAsText {
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <jsoup.version>1.17.2</jsoup.version>
         <!-- Note that this should be kept in sync with the class Constants -->
         <atmosphere.runtime.version>3.0.5.slf4jvaadin1</atmosphere.runtime.version>
-        <atmosphere.client.version>3.1.3</atmosphere.client.version>
+        <atmosphere.client.version>4.0.0</atmosphere.client.version>
 
         <!-- OSGi -->
         <!-- Note: the parserVersion value is set by build-helper-maven-plugin -->


### PR DESCRIPTION
## Description

Elements having their labels in their text (such as buttons) must implement a new, method-less interface `HasLabelAsText` in their element tester (such as `NativeButtonElement` for the `NativeButton` component and `ButtonElement` for the `Button` component) in order for the `withCaption[Containing]` selectors to work for them.

Related Flow change for https://github.com/vaadin/testbench/issues/1183

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
