### PR TITLE
fix: add explicit dependency to JDK classes in vaadin-dev-server

### DIFF
--- a/vaadin-dev-server/pom.xml
+++ b/vaadin-dev-server/pom.xml
@@ -102,6 +102,17 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Dependencies>jdk.unsupported</Dependencies>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>3.2.0</version>


### PR DESCRIPTION
Adds the Dependencies manifest entry to the vaadin-dev-server artifact to prevent runtime errors raised by FileWatcher when application is deployed in Wildfly.

Fixes #17159
Fixes vaadin/skeleton-starter-flow-cdi#636