### PR TITLE
fix: set page title to documentTitleSignal

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -692,8 +692,12 @@ public class UIInternals implements Serializable {
      */
     public void setTitle(String title) {
         assert title != null;
-        JavaScriptInvocation invocation = new JavaScriptInvocation(
-                "document.title = $0", title);
+        JavaScriptInvocation invocation = new JavaScriptInvocation("""
+                    document.title = $0;
+                    if(window?.Vaadin?.documentTitleSignal) {
+                        window.Vaadin.documentTitleSignal.value = $0;
+                    }
+                """.stripIndent(), title);
 
         pendingTitleUpdateCanceler = new PendingJavaScriptInvocation(
                 getStateTree().getRootNode(), invocation);

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/UIInternalsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/UIInternalsTest.java
@@ -521,6 +521,35 @@ public class UIInternalsTest {
                 internals.isDirty());
     }
 
+    @Test
+    public void setTitle_titleAndPendingJsInvocationSetsCorrectTitle() {
+        internals.setTitle("new title");
+        Assert.assertEquals("new title", internals.getTitle());
+
+        Assert.assertEquals("one pending JavaScript invocation should exist", 1,
+                internals.getPendingJavaScriptInvocations().count());
+
+        var pendingJavaScriptInvocation = internals
+                .getPendingJavaScriptInvocations().findFirst().orElse(null);
+        Assert.assertNotNull("pendingJavaScriptInvocation should not be null",
+                pendingJavaScriptInvocation);
+        Assert.assertEquals("new title", pendingJavaScriptInvocation
+                .getInvocation().getParameters().get(0));
+        Assert.assertTrue("document.title should be set via JavaScript",
+                pendingJavaScriptInvocation.getInvocation().getExpression()
+                        .contains("document.title = $0"));
+        Assert.assertTrue(
+                "window.Vaadin.documentTitleSignal.value should be set conditionally via JavaScript",
+                pendingJavaScriptInvocation.getInvocation().getExpression()
+                        .contains(
+                                """
+                                            if(window?.Vaadin?.documentTitleSignal) {
+                                                window.Vaadin.documentTitleSignal.value = $0;
+                                            }
+                                        """
+                                        .stripIndent()));
+    }
+
     private PushConfiguration setUpInitialPush() {
         DeploymentConfiguration config = Mockito
                 .mock(DeploymentConfiguration.class);


### PR DESCRIPTION
`UIInternals#setTitle(String)` sets page title via JavaScript to `document.title` and optionally `window.Vaadin.documentTitleSignal.value` where documentTitleSignal is expected but not limited to be Signal<string> type with a value field. This allows Hilla main layout, when used, being kept in sync with the Flow page title even when set via PageTitle annotation or HasDynamicTitle interface.

Fixes: #19200
