### PR TITLE
fix: change type of Menu order to double

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/Menu.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/Menu.java
@@ -50,13 +50,13 @@ public @interface Menu {
     /**
      * Used to determine the order in the menu. Ties are resolved based on the
      * used title. Entries without explicitly defined ordering are put below
-     * entries with an order. {@link Long#MIN_VALUE} is the default value and
+     * entries with an order. {@link Double#MIN_VALUE} is the default value and
      * considered as undefined.
      *
-     * @return the order of the item in the menu. {@link Long#MIN_VALUE} by
+     * @return the order of the item in the menu. {@link Double#MIN_VALUE} by
      *         default.
      */
-    long order() default Long.MIN_VALUE;
+    double order() default Double.MIN_VALUE;
 
     /**
      * Icon to use in the menu. Value can go inside a {@code <vaadin-icon>}

--- a/flow-server/src/main/java/com/vaadin/flow/router/MenuData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/MenuData.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 public class MenuData implements Serializable {
 
     private final String title;
-    private final Long order;
+    private final Double order;
     private final boolean exclude;
     private final String icon;
 
@@ -43,7 +43,7 @@ public class MenuData implements Serializable {
      * @param icon
      *            the icon of the menu item
      */
-    public MenuData(String title, Long order, boolean exclude, String icon) {
+    public MenuData(String title, Double order, boolean exclude, String icon) {
         this.title = title;
         this.order = order;
         this.exclude = exclude;
@@ -64,7 +64,7 @@ public class MenuData implements Serializable {
      *
      * @return the order of the menu item
      */
-    public Long getOrder() {
+    public Double getOrder() {
         return order;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractRouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractRouteRegistry.java
@@ -309,7 +309,8 @@ public abstract class AbstractRouteRegistry implements RouteRegistry {
         MenuData menuData = AnnotationReader
                 .getAnnotationFor(target, Menu.class)
                 .map(menu -> new MenuData(menu.title(),
-                        (menu.order() == Long.MIN_VALUE) ? null : menu.order(),
+                        (Objects.equals(menu.order(), Double.MIN_VALUE)) ? null
+                                : menu.order(),
                         false, menu.icon()))
                 .orElse(null);
 

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/main/java/com/vaadin/flow/spring/flowsecurity/views/AdminView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/main/java/com/vaadin/flow/spring/flowsecurity/views/AdminView.java
@@ -14,7 +14,7 @@ import com.vaadin.flow.spring.flowsecurity.SecurityUtils;
 @Route(value = "admin", layout = MainView.class)
 @RouteAlias(value = "alias-for-admin", layout = MainView.class)
 @PageTitle("Admin View")
-@Menu(order = 3)
+@Menu(order = 1.10001)
 public class AdminView extends VerticalLayout {
 
     public AdminView(SecurityUtils securityUtils) {

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/main/java/com/vaadin/flow/spring/flowsecurity/views/PrivateView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/main/java/com/vaadin/flow/spring/flowsecurity/views/PrivateView.java
@@ -35,7 +35,7 @@ import org.springframework.security.concurrent.DelegatingSecurityContextExecutor
 @Route(value = "private", layout = MainView.class)
 @RouteAlias(value = "privateAndForbiddenForAll")
 @PageTitle("Private View")
-@Menu(order = 2)
+@Menu(order = 1.1)
 public class PrivateView extends VerticalLayout {
 
     private BankService bankService;

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/test/java/com/vaadin/flow/spring/flowsecurity/AppViewIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/test/java/com/vaadin/flow/spring/flowsecurity/AppViewIT.java
@@ -341,7 +341,9 @@ public class AppViewIT extends AbstractIT {
     private void assertMenuListContains(String expected) {
         TestBenchElement menuList = waitUntil(driver -> $("*").id("menu-list"));
         String menuListText = menuList.getText();
-        Assert.assertTrue(menuListText.contains(expected));
+        Assert.assertTrue(
+                "Expected " + expected + " but actual is " + menuListText,
+                menuListText.contains(expected));
     }
 
     private void navigateToClientMenuList() {

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/PrivateView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/PrivateView.java
@@ -34,7 +34,7 @@ import org.springframework.security.concurrent.DelegatingSecurityContextExecutor
 @Route(value = "private", layout = MainView.class)
 @PageTitle("Private View")
 @PermitAll
-@Menu(order = 2)
+@Menu(order = 1.5)
 public class PrivateView extends VerticalLayout {
 
     private BankService bankService;


### PR DESCRIPTION
Changing `Menu#order` type double and `MenuData#order` type to Double to match it with Hilla's `ViewConfig` type `number`.

Fixes: #19320
