### PR TITLE
fix: Fix failure when Vite sends many messages in sequence

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketConnection.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketConnection.java
@@ -148,7 +148,7 @@ public class ViteWebsocketConnection implements Listener {
 
     @Override
     public void onError(WebSocket webSocket, Throwable error) {
-        getLogger().error("Error from Vite websocket connection", error);
+        getLogger().debug("Error from Vite websocket connection", error);
         Listener.super.onError(webSocket, error);
     }
 }

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketConnection.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketConnection.java
@@ -145,4 +145,10 @@ public class ViteWebsocketConnection implements Listener {
                 .sendClose(CloseCodes.NORMAL_CLOSURE.getCode(), "");
         closeRequest.get();
     }
+
+    @Override
+    public void onError(WebSocket webSocket, Throwable error) {
+        getLogger().error("Error from Vite websocket connection", error);
+        Listener.super.onError(webSocket, error);
+    }
 }

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketProxy.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketProxy.java
@@ -54,15 +54,14 @@ public class ViteWebsocketProxy implements MessageHandler.Whole<String> {
     public ViteWebsocketProxy(Session browserSession, Integer vitePort,
             String vitePath) throws InterruptedException, ExecutionException {
         viteConnection = new ViteWebsocketConnection(vitePort, vitePath,
-                browserSession.getNegotiatedSubprotocol(),
-                msg -> browserSession.getAsyncRemote().sendText(msg, result -> {
-                    if (result.isOK()) {
-                        getLogger().debug("Message sent to browser: {}", msg);
-                    } else {
+                browserSession.getNegotiatedSubprotocol(), msg -> {
+                    try {
+                        browserSession.getBasicRemote().sendText(msg);
+                    } catch (IOException e) {
                         getLogger().debug("Error sending message to browser",
-                                result.getException());
+                                e);
                     }
-                }), () -> {
+                }, () -> {
                     try {
                         browserSession.close();
                     } catch (IOException e) {


### PR DESCRIPTION
Sending multiple messages at the same time resulted in

```
java.lang.IllegalStateException: The remote endpoint was in state [TEXT_FULL_WRITING] which is an invalid state for called method
```

which originates in calling `browserSession.getAsyncRemote().sendText` a second time before the complete callback for the first call has been called.

Now the getBasicRemote() method is used instead which blocks until the message has been sent.
