### PR TITLE
chore(deps): bump component.version from 24.3.11 to 24.3.12 (#19364)

### DIFF
--- a/flow-tests/vaadin-spring-tests/pom.xml
+++ b/flow-tests/vaadin-spring-tests/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <component.version>24.3.10</component.version>
+        <component.version>24.3.12</component.version>
         <nimbus-jose-jwt.version>9.37.3</nimbus-jose-jwt.version>
     </properties>
 


### PR DESCRIPTION
Bumps `component.version` from 24.3.11 to 24.3.12.

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>