### PR TITLE
fix: clear preseved chain cache for inactive UI (#19360) (CP: 23.4)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -23,10 +23,14 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
@@ -36,6 +40,7 @@ import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.Pair;
+import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.router.AfterNavigationEvent;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.BeforeEnterObserver;
@@ -990,6 +995,45 @@ public abstract class AbstractNavigationStateRenderer
                     cache.remove(windowName);
                 }
             });
+        }
+    }
+
+    /**
+     * Removes preserved component cache for an inactive UI.
+     *
+     * @param inactiveUI
+     *            the inactive UI
+     * @throws IllegalStateException
+     *             if the UI is not in closing state
+     */
+    public static void purgeInactiveUIPreservedChainCache(UI inactiveUI) {
+        if (!inactiveUI.isClosing()) {
+            throw new IllegalStateException(
+                    "Cannot purge preserved chain cache for an active UI");
+        }
+        final VaadinSession session = inactiveUI.getSession();
+        final PreservedComponentCache cache = session
+                .getAttribute(PreservedComponentCache.class);
+        if (cache != null && !cache.isEmpty()) {
+            StateNode uiNode = inactiveUI.getElement().getNode();
+            Set<String> inactiveWindows = cache.entrySet().stream()
+                    .filter(e -> {
+                        ArrayList<HasElement> chain = e.getValue().getSecond();
+                        // chain is never empty
+                        StateNode chainNode = chain.get(0).getElement()
+                                .getNode();
+                        while (chainNode.getParent() != null) {
+                            chainNode = chainNode.getParent();
+                        }
+                        return uiNode == chainNode;
+                    }).map(Map.Entry::getKey).collect(Collectors.toSet());
+            if (!inactiveWindows.isEmpty()) {
+                LoggerFactory.getLogger(AbstractNavigationStateRenderer.class)
+                        .debug("Removing preserved chain cache for inactive UI {} on VaadinSession {} (windows: {})",
+                                inactiveUI.getUIId(),
+                                session.getSession().getId(), inactiveWindows);
+            }
+            inactiveWindows.forEach(cache::remove);
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -63,6 +63,7 @@ import com.vaadin.flow.internal.LocaleUtil;
 import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.router.RouteData;
 import com.vaadin.flow.router.Router;
+import com.vaadin.flow.router.internal.AbstractNavigationStateRenderer;
 import com.vaadin.flow.server.HandlerHelper.RequestType;
 import com.vaadin.flow.server.communication.AtmospherePushConnection;
 import com.vaadin.flow.server.communication.HeartbeatHandler;
@@ -1347,6 +1348,8 @@ public abstract class VaadinService implements Serializable {
                     getLogger().debug("Closing inactive UI #{} in session {}",
                             ui.getUIId(), sessionId);
                     ui.close();
+                    AbstractNavigationStateRenderer
+                            .purgeInactiveUIPreservedChainCache(ui);
                 });
             }
         }

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -67,6 +68,7 @@ import com.vaadin.flow.server.MockVaadinServletService;
 import com.vaadin.flow.server.MockVaadinSession;
 import com.vaadin.flow.server.RouteRegistry;
 import com.vaadin.flow.server.ServiceException;
+import com.vaadin.flow.server.WrappedSession;
 import com.vaadin.flow.server.startup.ApplicationRouteRegistry;
 import com.vaadin.tests.util.AlwaysLockedVaadinSession;
 import com.vaadin.tests.util.MockDeploymentConfiguration;
@@ -742,5 +744,67 @@ public class NavigationStateRendererTest {
         Assert.assertFalse(
                 "No pushState invocation is expected when navigating to the current location.",
                 pushStateCalled.get());
+    }
+
+    @Test
+    public void purgeInactiveUIPreservedChainCache_activeUI_throws() {
+        MockVaadinServletService service = createMockServiceWithInstantiator();
+        MockVaadinSession session = new AlwaysLockedVaadinSession(service);
+
+        MockUI activeUI = new MockUI(session);
+        Component attachedToActiveUI = new PreservedView();
+        activeUI.add(attachedToActiveUI);
+
+        Assert.assertThrows(IllegalStateException.class,
+                () -> AbstractNavigationStateRenderer
+                        .purgeInactiveUIPreservedChainCache(activeUI));
+
+    }
+
+    @Test
+    public void purgeInactiveUIPreservedChainCache_inactiveUI_clearsCache() {
+        MockVaadinServletService service = createMockServiceWithInstantiator();
+        WrappedSession wrappedSession = Mockito.mock(WrappedSession.class);
+        Mockito.when(wrappedSession.getId()).thenReturn("A-SESSION-ID");
+        MockVaadinSession session = new AlwaysLockedVaadinSession(service) {
+            @Override
+            public WrappedSession getSession() {
+                return wrappedSession;
+            }
+        };
+
+        MockUI activeUI = new MockUI(session);
+        Component attachedToActiveUI = new PreservedView();
+        activeUI.add(attachedToActiveUI);
+
+        MockUI inActiveUI = new MockUI(session);
+        Component attachedToInactiveUI = new PreservedView();
+        inActiveUI.add(attachedToInactiveUI);
+        inActiveUI.close();
+
+        // Simulate two tabs on the same view, but one has been closed
+        Location location = new Location("preserved");
+        AbstractNavigationStateRenderer.setPreservedChain(session, "ACTIVE",
+                location,
+                new ArrayList<>(Collections.singletonList(attachedToActiveUI)));
+        AbstractNavigationStateRenderer.setPreservedChain(session, "INACTIVE",
+                location, new ArrayList<>(
+                        Collections.singletonList(attachedToInactiveUI)));
+
+        AbstractNavigationStateRenderer
+                .purgeInactiveUIPreservedChainCache(inActiveUI);
+
+        Optional<ArrayList<HasElement>> active = AbstractNavigationStateRenderer
+                .getPreservedChain(session, "ACTIVE", location);
+        Assert.assertTrue(
+                "Expected preserved chain for active window to be present",
+                active.isPresent());
+
+        Optional<ArrayList<HasElement>> inactive = AbstractNavigationStateRenderer
+                .getPreservedChain(session, "INACTIVE", location);
+        Assert.assertFalse(
+                "Expected preserved chain for inactive window to be removed",
+                inactive.isPresent());
+
     }
 }

--- a/flow-tests/test-misc/pom.xml
+++ b/flow-tests/test-misc/pom.xml
@@ -17,6 +17,12 @@
             <artifactId>flow-test-resources</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-html-components-testbench</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/flow-tests/test-misc/src/main/java/com/vaadin/flow/misc/ui/ActiveUIsView.java
+++ b/flow-tests/test-misc/src/main/java/com/vaadin/flow/misc/ui/ActiveUIsView.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.misc.ui;
+
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+
+@Route("active-uis")
+public class ActiveUIsView extends Div {
+
+    public ActiveUIsView() {
+        Div uis = new Div();
+        uis.setId("uis");
+        NativeButton listUIsButton = new NativeButton("List active UIs",
+                event -> {
+                    UI current = UI.getCurrent();
+                    listUIs(current, uis);
+                });
+        listUIsButton.setId("list-uis");
+
+        Div gcCollectedUIs = new Div();
+        gcCollectedUIs.setId("gcuis");
+        NativeButton listGCCollectedUIsButton = new NativeButton(
+                "List GC collected UIs", event -> {
+                    listGCCollectedUIs(gcCollectedUIs);
+                });
+        listGCCollectedUIsButton.setId("list-gc-collected-uis");
+        NativeButton gcHintButton = new NativeButton("Run GC",
+                event -> System.gc());
+        gcHintButton.setId("gc-hint");
+
+        add(listUIsButton, new H1("Active UIs (excluding current)"), uis,
+                listGCCollectedUIsButton, gcHintButton,
+                new H1("GC collected UIs"), gcCollectedUIs);
+    }
+
+    private void listGCCollectedUIs(Div gcCollectedUIs) {
+        gcCollectedUIs.removeAll();
+        UI ui = UI.getCurrent();
+        ComponentUtil.getData(ui, UITrackerListener.UITracker.class)
+                .getCollectedUIs(ui.getSession()).forEach(uiId -> {
+                    Div div = new Div();
+                    div.setText("GC Collected UI: " + uiId);
+                    gcCollectedUIs.add(div);
+                });
+    }
+
+    private void listUIs(UI currentUI, Div uis) {
+        uis.removeAll();
+        currentUI.getSession().getUIs().stream().filter(ui -> ui != currentUI)
+                .map(ui -> {
+                    Div div = new Div();
+                    div.setText("UI: " + ui.getUIId() + ", Path: " + ui
+                            .getInternals().getActiveViewLocation().getPath());
+                    return div;
+                }).forEach(uis::add);
+    }
+
+}

--- a/flow-tests/test-misc/src/main/java/com/vaadin/flow/misc/ui/CustomServlet.java
+++ b/flow-tests/test-misc/src/main/java/com/vaadin/flow/misc/ui/CustomServlet.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.misc.ui;
+
+import javax.servlet.annotation.WebInitParam;
+import javax.servlet.annotation.WebServlet;
+
+import com.vaadin.flow.server.VaadinServlet;
+
+@WebServlet(urlPatterns = "/*", asyncSupported = true, initParams = {
+        @WebInitParam(name = "heartbeatInterval", value = "5") })
+public class CustomServlet extends VaadinServlet {
+    public static long HEARTBEAT_INTERVAL = 5;
+}

--- a/flow-tests/test-misc/src/main/java/com/vaadin/flow/misc/ui/PreserveOnRefreshView.java
+++ b/flow-tests/test-misc/src/main/java/com/vaadin/flow/misc/ui/PreserveOnRefreshView.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.misc.ui;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.component.html.H3;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.AfterNavigationEvent;
+import com.vaadin.flow.router.AfterNavigationObserver;
+import com.vaadin.flow.router.PreserveOnRefresh;
+import com.vaadin.flow.router.Route;
+
+@PreserveOnRefresh
+@Route("preserve")
+public class PreserveOnRefreshView extends Div
+        implements AfterNavigationObserver {
+
+    private final Div uiId;
+
+    public PreserveOnRefreshView() {
+
+        uiId = new Div();
+        uiId.setId("uiId");
+        NativeButton reloadButton = new NativeButton("Reload page",
+                ev -> UI.getCurrent().getPage().reload());
+        reloadButton.setId("reload");
+        add(new H1("This view is preserved on refresh"));
+        add(new H3("Initial UI: " + UI.getCurrent().getUIId()));
+        add(uiId, reloadButton);
+    }
+
+    @Override
+    public void afterNavigation(AfterNavigationEvent event) {
+        uiId.setText("UI: " + UI.getCurrent().getUIId());
+    }
+}

--- a/flow-tests/test-misc/src/main/java/com/vaadin/flow/misc/ui/UITrackerListener.java
+++ b/flow-tests/test-misc/src/main/java/com/vaadin/flow/misc/ui/UITrackerListener.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.misc.ui;
+
+import java.io.Serializable;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinServiceInitListener;
+import com.vaadin.flow.server.VaadinSession;
+
+public class UITrackerListener implements VaadinServiceInitListener {
+
+    @Override
+    public void serviceInit(ServiceInitEvent event) {
+        UITracker tracker = new UITracker();
+        event.getSource().addUIInitListener(uiEvent -> {
+            UI ui = uiEvent.getUI();
+            tracker.add(ui);
+            ComponentUtil.setData(ui, UITracker.class, tracker);
+        });
+    }
+
+    public static class UITracker {
+        private Map<Key, WeakReference<UI>> uiMap = new HashMap<>();
+
+        private static class Key implements Serializable {
+            private final String sessionId;
+            private final int uIid;
+
+            public Key(String sessionId, int uIid) {
+                this.sessionId = sessionId;
+                this.uIid = uIid;
+            }
+
+            String sessionId() {
+                return sessionId;
+            }
+
+            int uIid() {
+                return uIid;
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o)
+                    return true;
+                if (o == null || getClass() != o.getClass())
+                    return false;
+
+                Key key = (Key) o;
+                return uIid == key.uIid && sessionId.equals(key.sessionId);
+            }
+
+            @Override
+            public int hashCode() {
+                int result = sessionId.hashCode();
+                result = 31 * result + uIid;
+                return result;
+            }
+        }
+
+        private void add(UI ui) {
+            Key key = new Key(
+                    ui.getInternals().getSession().getSession().getId(),
+                    ui.getUIId());
+            uiMap.put(key, new WeakReference<>(ui, new ReferenceQueue<>()));
+        }
+
+        public Set<Integer> getCollectedUIs(VaadinSession vaadinSession) {
+            String sessionId = vaadinSession.getSession().getId();
+            return uiMap.entrySet().stream()
+                    .filter(e -> sessionId.equals(e.getKey().sessionId()))
+                    .filter(e -> e.getValue().get() == null)
+                    .map(e -> e.getKey().uIid()).collect(Collectors.toSet());
+        }
+    }
+}

--- a/flow-tests/test-misc/src/main/resources/META-INF/services/com.vaadin.flow.server.VaadinServiceInitListener
+++ b/flow-tests/test-misc/src/main/resources/META-INF/services/com.vaadin.flow.server.VaadinServiceInitListener
@@ -1,0 +1,17 @@
+#
+# Copyright 2000-2024 Vaadin Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+com.vaadin.flow.misc.ui.UITrackerListener

--- a/flow-tests/test-misc/src/test/java/com/vaadin/flow/misc/ui/PreserveOnRefreshCloseUIsIT.java
+++ b/flow-tests/test-misc/src/test/java/com/vaadin/flow/misc/ui/PreserveOnRefreshCloseUIsIT.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.misc.ui;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WindowType;
+import org.slf4j.LoggerFactory;
+
+import com.vaadin.flow.component.html.testbench.DivElement;
+import com.vaadin.flow.component.html.testbench.H3Element;
+import com.vaadin.flow.component.html.testbench.NativeButtonElement;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+import com.vaadin.testbench.TestBenchElement;
+
+public class PreserveOnRefreshCloseUIsIT extends ChromeBrowserTest {
+
+    @Override
+    protected String getTestPath() {
+        return "/active-uis";
+    }
+
+    @Test
+    public void preserveOnRefreshView_pageReload_previousUIImmediatelyClosed() {
+        open();
+        String activeUIsHandle = driver.getWindowHandle();
+        String preserverHandle = openPreserveOnRefreshView(WindowType.TAB);
+        int initialUIid = getInitialUIId();
+        int preserveUIid = getPreserveUIId();
+
+        driver.switchTo().window(activeUIsHandle);
+        List<Integer> activeUIs = getActivePreserveUIs();
+        Assert.assertTrue("PreserveOnRefresh UI is not listed as active",
+                activeUIs.contains(preserveUIid));
+
+        driver.switchTo().window(preserverHandle);
+        $(NativeButtonElement.class).id("reload").click();
+        int preserveUIidAfterReload = getPreserveUIId();
+        Assert.assertEquals("Initial UI ID should not change on reload",
+                initialUIid, getInitialUIId());
+
+        driver.switchTo().window(activeUIsHandle);
+        activeUIs = getActivePreserveUIs();
+
+        Assert.assertFalse("Previous PreserveOnRefresh UI has not been closed",
+                activeUIs.contains(preserveUIid));
+        Assert.assertTrue("New PreserveOnRefresh UI is not listed as active",
+                activeUIs.contains(preserveUIidAfterReload));
+    }
+
+    @Test
+    public void preserveOnRefreshView_tabClosed_uiClosedAfterHeartbeatTimeout() {
+        open();
+        String activeUIsHandle = driver.getWindowHandle();
+        String preserverHandle = openPreserveOnRefreshView(WindowType.TAB);
+        int preserveUIid = getPreserveUIId();
+
+        driver.switchTo().window(activeUIsHandle);
+        List<Integer> activeUIs = getActivePreserveUIs();
+        Assert.assertTrue("PreserveOnRefresh UI is not listed as active",
+                activeUIs.contains(preserveUIid));
+
+        driver.switchTo().window(preserverHandle);
+        driver.close();
+
+        driver.switchTo().window(activeUIsHandle);
+        // Verify that the closed tab UI is closed after three heartbeat
+        // intervals have elapsed
+        waitUntil(d -> !getActivePreserveUIs().contains(preserveUIid),
+                CustomServlet.HEARTBEAT_INTERVAL * 4);
+    }
+
+    @Test
+    public void preserveOnRefreshView_windowClosed_uiClosedAfterHeartbeatTimeout() {
+        open();
+        String activeUIsHandle = driver.getWindowHandle();
+        String preserverHandle = openPreserveOnRefreshView(WindowType.WINDOW);
+        int preserveUIid = getPreserveUIId();
+
+        driver.switchTo().window(activeUIsHandle);
+        List<Integer> activeUIs = getActivePreserveUIs();
+        Assert.assertTrue("PreserveOnRefresh UI is not listed as active",
+                activeUIs.contains(preserveUIid));
+
+        driver.switchTo().window(preserverHandle);
+        driver.close();
+
+        driver.switchTo().window(activeUIsHandle);
+        // Verify that the closed tab UI is closed after three heartbeat
+        // intervals have elapsed
+        waitUntil(d -> !getActivePreserveUIs().contains(preserveUIid),
+                CustomServlet.HEARTBEAT_INTERVAL * 4);
+    }
+
+    @Test
+    public void preserveOnRefreshUiClosed_weakReferenceCleanedAfterGC() {
+        open();
+        String activeUIsHandle = driver.getWindowHandle();
+        String preserverHandle = openPreserveOnRefreshView(WindowType.TAB);
+        List<Integer> expectedGCIds = new ArrayList<>();
+        int initialUIid = getInitialUIId();
+        int preserveUIid = getPreserveUIId();
+
+        driver.switchTo().window(activeUIsHandle);
+        List<Integer> uiIdList = getGCCollectedUIs();
+        Assert.assertFalse(
+                "PreserveOnRefresh UI has been already collected by GC",
+                uiIdList.contains(preserveUIid));
+
+        driver.switchTo().window(preserverHandle);
+        for (int i = 0; i < 5; i++) {
+            int currentUIid = getPreserveUIId();
+            expectedGCIds.add(currentUIid);
+            $(NativeButtonElement.class).id("reload").click();
+            waitUntil(d -> getPreserveUIId() != currentUIid);
+            Assert.assertEquals("Initial UI ID should not change on reload",
+                    initialUIid, getInitialUIId());
+        }
+
+        driver.switchTo().window(activeUIsHandle);
+        // waitUntil(d -> $(NativeButtonElement.class).id("gc-hint")).click();
+        waitForElementPresent(By.id("gc-hint"));
+        // Give some time to the GC to clean up some memory
+        waitUntil(d -> {
+            $(NativeButtonElement.class).id("gc-hint").click();
+            List<Integer> gcCollectedUIs = getGCCollectedUIs();
+            boolean cleaned = gcCollectedUIs.containsAll(expectedGCIds);
+            if (!cleaned) {
+                LoggerFactory.getLogger(PreserveOnRefreshCloseUIsIT.class)
+                        .debug("Not all expected UI have been GC collect yet. Expecting {} UIs to be collected but was {}.",
+                                expectedGCIds, gcCollectedUIs);
+            }
+            return cleaned;
+        }, 3);
+
+        // Close preserve view tab and wait for heartbeat cleanup
+        driver.switchTo().window(preserverHandle);
+        int lastPreserveUIid = getPreserveUIId();
+        driver.close();
+        driver.switchTo().window(activeUIsHandle);
+        waitUntil(d -> !getActivePreserveUIs().contains(lastPreserveUIid),
+                CustomServlet.HEARTBEAT_INTERVAL * 4);
+
+        expectedGCIds.add(lastPreserveUIid);
+        $(NativeButtonElement.class).id("gc-hint").click();
+        // Give some time to the GC to clean up some memory
+        waitUntil(d -> getGCCollectedUIs().containsAll(expectedGCIds), 20);
+    }
+
+    private String openPreserveOnRefreshView(WindowType windowType) {
+        String url = getTestURL().replace("/active-uis", "/preserve");
+        driver.switchTo().newWindow(WindowType.TAB).get(url);
+        return driver.getWindowHandle();
+    }
+
+    private int getInitialUIId() {
+        return Integer.parseInt(waitUntil(d -> $(H3Element.class).first())
+                .getText().replace("Initial UI: ", ""));
+    }
+
+    private int getPreserveUIId() {
+        waitForElementPresent(By.id("uiId"));
+        return Integer.parseInt(
+                $(DivElement.class).id("uiId").getText().replace("UI: ", ""));
+    }
+
+    private List<Integer> getActivePreserveUIs() {
+        $(NativeButtonElement.class).id("list-uis").click();
+        return $(DivElement.class).id("uis").$(DivElement.class).all().stream()
+                .map(TestBenchElement::getText)
+                .filter(text -> text.endsWith("Path: preserve"))
+                .map(text -> Integer
+                        .parseInt(text.replaceFirst("^UI: (\\d+), .*$", "$1")))
+                .collect(Collectors.toList());
+    }
+
+    private List<Integer> getGCCollectedUIs() {
+        $(NativeButtonElement.class).id("list-gc-collected-uis").click();
+        return $(DivElement.class).id("gcuis").$(DivElement.class).all()
+                .stream().map(TestBenchElement::getText)
+                .map(text -> Integer.parseInt(
+                        text.replaceFirst("^GC Collected UI: (\\d+)$", "$1")))
+                .collect(Collectors.toList());
+    }
+
+}


### PR DESCRIPTION
Prevents potential memory leaks caused by UIs being retained by the preserve on refresh cache when the browser page is closed.