### PR TITLE
fix: avoid blocking thread on ViteWebsocketConnection creation

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketEndpoint.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketEndpoint.java
@@ -15,6 +15,15 @@
  */
 package com.vaadin.base.devserver.viteproxy;
 
+import jakarta.servlet.ServletContext;
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.DeploymentException;
+import jakarta.websocket.Endpoint;
+import jakarta.websocket.EndpointConfig;
+import jakarta.websocket.Session;
+import jakarta.websocket.server.ServerContainer;
+import jakarta.websocket.server.ServerEndpointConfig;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -27,15 +36,6 @@ import org.slf4j.LoggerFactory;
 import com.vaadin.base.devserver.ViteHandler;
 import com.vaadin.flow.server.VaadinContext;
 import com.vaadin.flow.server.VaadinServletContext;
-
-import jakarta.servlet.ServletContext;
-import jakarta.websocket.CloseReason;
-import jakarta.websocket.DeploymentException;
-import jakarta.websocket.Endpoint;
-import jakarta.websocket.EndpointConfig;
-import jakarta.websocket.Session;
-import jakarta.websocket.server.ServerContainer;
-import jakarta.websocket.server.ServerEndpointConfig;
 
 /**
  * The websocket endpoint for Vite.
@@ -92,7 +92,7 @@ public class ViteWebsocketEndpoint extends Endpoint {
                 .get(VITE_HANDLER);
         ViteWebsocketProxy proxy;
         try {
-            proxy = new ViteWebsocketProxy(session, viteHandler.getPort(),
+            proxy = ViteWebsocketProxy.newProxy(session, viteHandler.getPort(),
                     viteHandler.getPathToVaadin());
             proxies.put(session.getId(), proxy);
             session.addMessageHandler(proxy);

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketConnectionTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketConnectionTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.base.devserver.viteproxy;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.concurrent.ExecutionException;
+
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ThrowingConsumer;
+
+public class ViteWebsocketConnectionTest {
+
+    private HttpServer httpServer;
+
+    private ThrowingConsumer<HttpExchange> handlerSupplier;
+
+    @Before
+    public void reservePort() throws IOException {
+        httpServer = HttpServer.create(new InetSocketAddress("127.0.0.1", 0),
+                10);
+        httpServer.createContext("/VAADIN",
+                exchange -> handlerSupplier.accept(exchange));
+        httpServer.start();
+    }
+
+    public void tearDown() throws Exception {
+        if (httpServer != null) {
+            httpServer.stop(0);
+        }
+    }
+
+    @Test(timeout = 2000)
+    public void waitForConnection_clientWebsocketAvailable_blocksUntilConnectionIsEstablished()
+            throws ExecutionException, InterruptedException {
+        handlerSupplier = (exchange) -> {
+            // Simulate connection delay
+            Thread.sleep(500);
+            handshake(exchange);
+        };
+        long startTime = System.nanoTime();
+        ViteWebsocketConnection connection = new ViteWebsocketConnection(
+                httpServer.getAddress().getPort(), "/VAADIN", "proto", x -> {
+                }, () -> {
+                });
+        connection.waitForConnection();
+        long elapsedTime = Duration.ofNanos(System.nanoTime() - startTime)
+                .toMillis();
+        Assert.assertTrue(
+                "Should have waited for connection to be established (elapsed time: "
+                        + elapsedTime + ")",
+                elapsedTime > 500);
+        Assert.assertTrue(
+                "Should not have been blocked too long after connection (elapsed time: "
+                        + elapsedTime + ")",
+                elapsedTime < 1000);
+    }
+
+    @Test
+    public void waitForConnection_clientWebsocketNotAvailable_fails()
+            throws ExecutionException, InterruptedException {
+        // Immediately closing connection to simulate connection failure
+        handlerSupplier = HttpExchange::close;
+        ViteWebsocketConnection connection = new ViteWebsocketConnection(
+                httpServer.getAddress().getPort(), "/VAADIN", "proto", x -> {
+                }, () -> {
+                });
+        Assert.assertThrows(ExecutionException.class,
+                connection::waitForConnection);
+    }
+
+    private static void handshake(HttpExchange exchange) throws IOException {
+        Headers requestHeaders = exchange.getRequestHeaders();
+        if ("GET".equalsIgnoreCase(exchange.getRequestMethod()) && "upgrade"
+                .equalsIgnoreCase(requestHeaders.getFirst("Connection"))) {
+            String wsKey = requestHeaders.getFirst("Sec-websocket-key");
+            String wsAcceptKey;
+            try {
+                wsAcceptKey = Base64.getEncoder().encodeToString(
+                        MessageDigest.getInstance("SHA-1").digest(
+                                (wsKey + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+                                        .getBytes(StandardCharsets.UTF_8)));
+            } catch (NoSuchAlgorithmException e) {
+                throw new RuntimeException(e);
+            }
+            Headers responseHeaders = exchange.getResponseHeaders();
+            responseHeaders.add("Connection", "Upgrade");
+            responseHeaders.add("Upgrade", "websocket");
+            responseHeaders.add("Sec-WebSocket-Accept", wsAcceptKey);
+            exchange.sendResponseHeaders(101, -1);
+        }
+    }
+}


### PR DESCRIPTION
It may happen that the thread that is createing ViteWebsocketConnection gets blocked when trying to create the internal websocket client, because the instance is also set as lister for the client and it might receive incoming messages before it is fully instantiated.

This change creates the websocket client asynchronously and then waits for the connection to be established before starting the communication between front and back websockets.