### PR TITLE
fix: avoid blocking thread on ViteWebsocketConnection creation

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketConnection.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketConnection.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.base.devserver.viteproxy;
 
+import jakarta.websocket.CloseReason.CloseCodes;
+
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.WebSocket;
@@ -31,20 +33,18 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.base.devserver.ViteHandler;
 
-import jakarta.websocket.CloseReason.CloseCodes;
-
 /**
  * Communicates with a Vite server through a websocket connection.
  */
 public class ViteWebsocketConnection implements Listener {
 
     private final Consumer<String> onMessage;
-    private final WebSocket clientWebSocket;
     private final Runnable onClose;
-    private List<CharSequence> parts = new ArrayList<>();
+    private final CompletableFuture<WebSocket> clientWebsocketFuture;
+    private final List<CharSequence> parts = new ArrayList<>();
 
-    private Logger getLogger() {
-        return LoggerFactory.getLogger(getClass());
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(ViteWebsocketConnection.class);
     }
 
     /**
@@ -62,29 +62,32 @@ public class ViteWebsocketConnection implements Listener {
      * @param onClose
      *            a callback to invoke if the connection to Vite is closed
      *
-     * @throws InterruptedException
-     *             if there is a problem with the connection
-     * @throws ExecutionException
-     *             if there is a problem with the connection
      */
     public ViteWebsocketConnection(int port, String path, String subProtocol,
-            Consumer<String> onMessage, Runnable onClose)
-            throws InterruptedException, ExecutionException {
+            Consumer<String> onMessage, Runnable onClose,
+            Consumer<Throwable> onConnectionFailure) {
         this.onMessage = onMessage;
         this.onClose = onClose;
         String wsHost = ViteHandler.DEV_SERVER_HOST.replace("http://", "ws://");
         URI uri = URI.create(wsHost + ":" + port + path);
-        clientWebSocket = HttpClient.newHttpClient().newWebSocketBuilder()
-                .subprotocols(subProtocol).buildAsync(uri, this).get();
-        getLogger().debug("Connecting to {} using the {} protocol", uri,
-                clientWebSocket.getSubprotocol());
+        clientWebsocketFuture = HttpClient.newHttpClient().newWebSocketBuilder()
+                .subprotocols(subProtocol).buildAsync(uri, this)
+                .whenComplete(((webSocket, failure) -> {
+                    if (failure == null) {
+                        getLogger().debug(
+                                "Connection to {} using the {} protocol established",
+                                uri, webSocket.getSubprotocol());
+                    } else {
+                        getLogger().debug("Failed to connect to {}", uri);
+                        onConnectionFailure.accept(failure);
+                    }
+                }));
     }
 
     @Override
     public void onOpen(WebSocket webSocket) {
         getLogger().debug("Connected using the {} protocol",
                 webSocket.getSubprotocol());
-
         Listener.super.onOpen(webSocket);
     }
 
@@ -126,8 +129,8 @@ public class ViteWebsocketConnection implements Listener {
      */
     public void send(String message)
             throws InterruptedException, ExecutionException {
-        CompletableFuture<WebSocket> send = clientWebSocket.sendText(message,
-                false);
+        CompletableFuture<WebSocket> send = clientWebsocketFuture.get()
+                .sendText(message, false);
         send.get();
     }
 
@@ -141,7 +144,7 @@ public class ViteWebsocketConnection implements Listener {
      */
     public void close() throws InterruptedException, ExecutionException {
         getLogger().debug("Closing the connection");
-        CompletableFuture<WebSocket> closeRequest = clientWebSocket
+        CompletableFuture<WebSocket> closeRequest = clientWebsocketFuture.get()
                 .sendClose(CloseCodes.NORMAL_CLOSURE.getCode(), "");
         closeRequest.get();
     }

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketConnection.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketConnection.java
@@ -40,7 +40,7 @@ public class ViteWebsocketConnection implements Listener {
 
     private final Consumer<String> onMessage;
     private final Runnable onClose;
-    private final CompletableFuture<WebSocket> clientWebsocketFuture;
+    private final CompletableFuture<WebSocket> clientWebsocket;
     private final List<CharSequence> parts = new ArrayList<>();
 
     private static Logger getLogger() {
@@ -70,7 +70,7 @@ public class ViteWebsocketConnection implements Listener {
         this.onClose = onClose;
         String wsHost = ViteHandler.DEV_SERVER_HOST.replace("http://", "ws://");
         URI uri = URI.create(wsHost + ":" + port + path);
-        clientWebsocketFuture = HttpClient.newHttpClient().newWebSocketBuilder()
+        clientWebsocket = HttpClient.newHttpClient().newWebSocketBuilder()
                 .subprotocols(subProtocol).buildAsync(uri, this)
                 .whenComplete(((webSocket, failure) -> {
                     if (failure == null) {
@@ -129,7 +129,7 @@ public class ViteWebsocketConnection implements Listener {
      */
     public void send(String message)
             throws InterruptedException, ExecutionException {
-        CompletableFuture<WebSocket> send = clientWebsocketFuture.get()
+        CompletableFuture<WebSocket> send = clientWebsocket.get()
                 .sendText(message, false);
         send.get();
     }
@@ -144,7 +144,7 @@ public class ViteWebsocketConnection implements Listener {
      */
     public void close() throws InterruptedException, ExecutionException {
         getLogger().debug("Closing the connection");
-        CompletableFuture<WebSocket> closeRequest = clientWebsocketFuture.get()
+        CompletableFuture<WebSocket> closeRequest = clientWebsocket.get()
                 .sendClose(CloseCodes.NORMAL_CLOSURE.getCode(), "");
         closeRequest.get();
     }

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketProxy.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketProxy.java
@@ -15,14 +15,14 @@
  */
 package com.vaadin.base.devserver.viteproxy;
 
+import jakarta.websocket.MessageHandler;
+import jakarta.websocket.Session;
+
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import jakarta.websocket.MessageHandler;
-import jakarta.websocket.Session;
 
 /**
  * Connects a brower-server websocket connection with a server-Vite websocket
@@ -46,13 +46,9 @@ public class ViteWebsocketProxy implements MessageHandler.Whole<String> {
      *            the port the Vite server is running on
      * @param vitePath
      *            the path Vite is using
-     * @throws ExecutionException
-     *             if there is a problem with the connection
-     * @throws InterruptedException
-     *             if there is a problem with the connection
      */
     public ViteWebsocketProxy(Session browserSession, Integer vitePort,
-            String vitePath) throws InterruptedException, ExecutionException {
+            String vitePath) {
         viteConnection = new ViteWebsocketConnection(vitePort, vitePath,
                 browserSession.getNegotiatedSubprotocol(), msg -> {
                     try {
@@ -69,22 +65,30 @@ public class ViteWebsocketProxy implements MessageHandler.Whole<String> {
                         getLogger().debug("Error closing browser connection",
                                 e);
                     }
+                }, err -> {
+                    getLogger().error("Error creating Vite proxy connection",
+                            err);
+                    try {
+                        browserSession.close();
+                    } catch (IOException e1) {
+                        getLogger().debug("Error closing browser connection",
+                                e1);
+                    }
                 });
     }
 
-    protected Logger getLogger() {
-        return LoggerFactory.getLogger(getClass());
+    protected static Logger getLogger() {
+        return LoggerFactory.getLogger(ViteWebsocketProxy.class);
     }
 
     @Override
     public void onMessage(String message) {
-        getLogger().debug("Got message from browser: " + message);
+        getLogger().debug("Got message from browser: {}", message);
         try {
             viteConnection.send(message);
-            getLogger().debug("Sent message to Vite: " + message);
+            getLogger().debug("Sent message to Vite: {}", message);
         } catch (InterruptedException | ExecutionException e) {
-            getLogger().debug("Error sending message (" + message + ") to Vite",
-                    e);
+            getLogger().debug("Error sending message ({}) to Vite", message, e);
         }
 
     }

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketConnectionTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketConnectionTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.base.devserver.viteproxy;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ThrowingConsumer;
+
+public class ViteWebsocketConnectionTest {
+
+    private HttpServer httpServer;
+
+    private ThrowingConsumer<HttpExchange> handlerSupplier;
+
+    @Before
+    public void reservePort() throws IOException {
+        httpServer = HttpServer.create(new InetSocketAddress("127.0.0.1", 0),
+                10);
+        httpServer.createContext("/VAADIN",
+                exchange -> handlerSupplier.accept(exchange));
+        httpServer.start();
+    }
+
+    public void tearDown() throws Exception {
+        if (httpServer != null) {
+            httpServer.stop(0);
+        }
+    }
+
+    @Test(timeout = 2000)
+    public void waitForConnection_clientWebsocketAvailable_blocksUntilConnectionIsEstablished()
+            throws ExecutionException, InterruptedException {
+        CountDownLatch closeLatch = new CountDownLatch(1);
+        handlerSupplier = (exchange) -> {
+            // Simulate connection delay
+            Thread.sleep(500);
+            handshake(exchange);
+        };
+        long startTime = System.nanoTime();
+        new ViteWebsocketConnection(httpServer.getAddress().getPort(),
+                "/VAADIN", "proto", x -> {
+                }, () -> {
+                    closeLatch.countDown();
+                }, err -> {
+                });
+        closeLatch.await(2, TimeUnit.SECONDS);
+        long elapsedTime = Duration.ofNanos(System.nanoTime() - startTime)
+                .toMillis();
+        Assert.assertTrue(
+                "Should have waited for connection to be established (elapsed time: "
+                        + elapsedTime + ")",
+                elapsedTime > 500);
+        Assert.assertTrue(
+                "Should not have been blocked too long after connection (elapsed time: "
+                        + elapsedTime + ")",
+                elapsedTime < 1000);
+
+    }
+
+    @Test
+    public void waitForConnection_clientWebsocketNotAvailable_fails()
+            throws InterruptedException {
+        // Immediately closing connection to simulate connection failure
+        handlerSupplier = HttpExchange::close;
+        CountDownLatch errorLatch = new CountDownLatch(1);
+        new ViteWebsocketConnection(httpServer.getAddress().getPort(),
+                "/VAADIN", "proto", x -> {
+                }, () -> {
+                }, err -> errorLatch.countDown());
+        errorLatch.await(2, TimeUnit.SECONDS);
+    }
+
+    private static void handshake(HttpExchange exchange) throws IOException {
+        Headers requestHeaders = exchange.getRequestHeaders();
+        if ("GET".equalsIgnoreCase(exchange.getRequestMethod()) && "upgrade"
+                .equalsIgnoreCase(requestHeaders.getFirst("Connection"))) {
+            String wsKey = requestHeaders.getFirst("Sec-websocket-key");
+            String wsAcceptKey;
+            try {
+                wsAcceptKey = Base64.getEncoder().encodeToString(
+                        MessageDigest.getInstance("SHA-1").digest(
+                                (wsKey + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+                                        .getBytes(StandardCharsets.UTF_8)));
+            } catch (NoSuchAlgorithmException e) {
+                throw new RuntimeException(e);
+            }
+            Headers responseHeaders = exchange.getResponseHeaders();
+            responseHeaders.add("Connection", "Upgrade");
+            responseHeaders.add("Upgrade", "websocket");
+            responseHeaders.add("Sec-WebSocket-Accept", wsAcceptKey);
+            exchange.sendResponseHeaders(101, -1);
+        }
+    }
+}


### PR DESCRIPTION
It may happen that the thread that is createing ViteWebsocketConnection gets blocked when trying to create the internal websocket client, because a message from Vite server may be received and forwarded to the browser websocket before the websocket client creation future is completed, leaving the browser request thread pending indefinitely.

This change creates the websocket client asynchronously, but immediately closing the browser connection if the client connection cannote be established.

Fixes #19397