### PR TITLE
fix: force page reload on re-sync with MPR

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
@@ -42,6 +42,7 @@ import com.vaadin.flow.shared.ApplicationConstants;
 import com.vaadin.flow.shared.JsonConstants;
 import com.vaadin.flow.shared.ui.LoadMode;
 
+import elemental.client.Browser;
 import elemental.dom.Node;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
@@ -222,6 +223,23 @@ public class MessageHandler {
 
         if (!hasResynchronize && registry.getMessageSender()
                 .getResynchronizationState() == ResynchronizationState.WAITING_FOR_RESPONSE) {
+
+            JsonObject json = valueMap.cast();
+            if (json.hasKey(JsonConstants.UIDL_KEY_EXECUTE)) {
+                JsonArray commands = json
+                        .getArray(JsonConstants.UIDL_KEY_EXECUTE);
+                for (int i = 0; i < commands.length(); i++) {
+                    JsonArray command = commands.getArray(i);
+                    if (command.length() > 0 && "window.location.reload();"
+                            .equals(command.getString(0))) {
+                        Console.warn(
+                                "Executing forced page reload while a resync request is ongoing.");
+                        Browser.getWindow().getLocation().reload();
+                        return;
+                    }
+                }
+            }
+
             Console.warn(
                     "Ignoring message from the server as a resync request is ongoing.");
             return;

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
@@ -331,6 +331,15 @@ public class ServerRpcHandler implements Serializable {
                     + " the network infrastructure (load balancer, proxy) terminating a push (websocket or long-polling) connection."
                     + " If you are using push with a proxy, make sure the push timeout is set to be smaller than the proxy connection timeout");
 
+            if (request.getWrappedSession().getAttributeNames().stream()
+                    .anyMatch(name -> name
+                            .startsWith("com.vaadin.server.VaadinSession"))) {
+                getLogger().warn(
+                        "MPR is in use, so full page reload will be done to achieve re-sync.");
+                ui.getPage().reload();
+                return;
+            }
+
             // Run detach listeners and re-attach all nodes again to the
             // state tree, in order to send changes for a full re-build of
             // the client-side state tree in the response

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/ServerRpcHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/ServerRpcHandlerTest.java
@@ -20,6 +20,7 @@ import com.vaadin.flow.internal.StateTree;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.server.WrappedSession;
 import com.vaadin.flow.server.communication.ServerRpcHandler.InvalidUIDLSecurityKeyException;
 import com.vaadin.flow.shared.ApplicationConstants;
 
@@ -27,6 +28,7 @@ public class ServerRpcHandlerTest {
     private VaadinRequest request;
     private VaadinService service;
     private VaadinSession session;
+    private WrappedSession wrappedSession;
     private UI ui;
     private UIInternals uiInternals;
     private DependencyList dependencyList;
@@ -44,11 +46,13 @@ public class ServerRpcHandlerTest {
         request = Mockito.mock(VaadinRequest.class);
         service = Mockito.mock(VaadinService.class);
         session = Mockito.mock(VaadinSession.class);
+        wrappedSession = Mockito.mock(WrappedSession.class);
         ui = Mockito.mock(UI.class);
         uiInternals = Mockito.mock(UIInternals.class);
         dependencyList = Mockito.mock(DependencyList.class);
 
         Mockito.when(request.getService()).thenReturn(service);
+        Mockito.when(request.getWrappedSession()).thenReturn(wrappedSession);
         Mockito.when(session.getService()).thenReturn(service);
 
         Mockito.when(ui.getInternals()).thenReturn(uiInternals);


### PR DESCRIPTION
Workaround for MPR & resynchronization being broken. If MPR is detected, a full page reload will be forced when resynchronization is requested.

Fixes https://github.com/vaadin/multiplatform-runtime/issues/133 