### PR TITLE
Revert "chore(deps): bump io.smallrye:jandex-maven-plugin from 3.1.8 to 3.2.0 (#19407)"

### DIFF
--- a/flow-jandex/pom.xml
+++ b/flow-jandex/pom.xml
@@ -104,7 +104,7 @@
             <plugin>
                 <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.1.8</version>
                 <executions>
                     <execution>
                         <id>make-index</id>


### PR DESCRIPTION
This reverts commit 0b914395da091ee7302baaefc4dd1bd4338165e7.

Jandex 3.2.0 will be supported in Quarkus 3.12.