### PR TITLE
Revert "chore(deps): bump jakarta.validation:jakarta.validation-api from 3.0.2 to 3.1.0 (#19426)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <polymer.version>2.6.1</polymer.version>
         <jackson.version>2.17.1</jackson.version>
         <jackson.databind.version>${jackson.version}</jackson.databind.version>
-        <jakarta.validation.version>3.1.0</jakarta.validation.version>
+        <jakarta.validation.version>3.0.2</jakarta.validation.version>
         <jakarta.annotation.api.version>2.1.1</jakarta.annotation.api.version>
         <jaxb.version>4.0.5</jaxb.version>
         <guava.version>33.2.0-jre</guava.version>


### PR DESCRIPTION
This reverts commit e8ee22a43d0c9ed62c395db7117ae99262534eae.

jakarta.validation-api is part of Jakarta EE 11, should not be bumped right now
