### PR TITLE
feat: add alternative translate methods to I18NProvider

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/i18n/I18NProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/i18n/I18NProvider.java
@@ -19,6 +19,8 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Locale;
 
+import com.vaadin.flow.internal.LocaleUtil;
+
 /**
  * I18N provider interface for internationalization usage.
  *
@@ -66,5 +68,44 @@ public interface I18NProvider extends Serializable {
      */
     default String getTranslation(Object key, Locale locale, Object... params) {
         return getTranslation(key.toString(), locale, params);
+    }
+
+    /**
+     * Get the translation for key via {@link I18NProvider} instance retrieved
+     * from the current VaadinService. Uses the current UI locale, or if not
+     * available, then the default locale.
+     *
+     * @param key
+     *            translation key
+     * @param params
+     *            parameters used in translation string
+     * @return translation for key if found
+     * @throws IllegalStateException
+     *             thrown if no I18NProvider found from the VaadinService
+     */
+    static String translate(String key, Object... params) {
+        return translate(LocaleUtil.getLocale(LocaleUtil::getI18NProvider), key,
+                params);
+    }
+
+    /**
+     * Get the translation for key with given locale via {@link I18NProvider}
+     * instance retrieved from the current VaadinService.
+     *
+     * @param locale
+     *            locale to use
+     * @param key
+     *            translation key
+     * @param params
+     *            parameters used in translation string
+     * @return translation for key if found
+     * @throws IllegalStateException
+     *             thrown if no I18NProvider found from the VaadinService
+     */
+    static String translate(Locale locale, String key, Object... params) {
+        return LocaleUtil.getI18NProvider()
+                .orElseThrow(() -> new IllegalStateException(
+                        "No I18NProvider found from the VaadinService"))
+                .getTranslation(key, locale, params);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/i18n/I18NProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/i18n/I18NProvider.java
@@ -84,8 +84,7 @@ public interface I18NProvider extends Serializable {
      *             thrown if no I18NProvider found from the VaadinService
      */
     static String translate(String key, Object... params) {
-        return translate(LocaleUtil.getLocale(LocaleUtil::getI18NProvider), key,
-                params);
+        return translate(LocaleUtil.getLocale(), key, params);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/i18n/I18NProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/i18n/I18NProvider.java
@@ -104,7 +104,7 @@ public interface I18NProvider extends Serializable {
     static String translate(Locale locale, String key, Object... params) {
         return LocaleUtil.getI18NProvider()
                 .orElseThrow(() -> new IllegalStateException(
-                        "No I18NProvider found from the VaadinService"))
+                        "I18NProvider is not available via current VaadinService. VaadinService, Instantiator or I18NProvider is null."))
                 .getTranslation(key, locale, params);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/LocaleUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/LocaleUtil.java
@@ -103,7 +103,7 @@ public final class LocaleUtil {
     }
 
     /**
-     * Get the locale for the given UI.
+     * Get the locale from the current UI or from the given I18NProvider.
      * <p>
      * -> If UI is not null, then it is used to get the locale, -> if UI is
      * null, then the I18NProvider providedLocales first match will be returned,
@@ -120,5 +120,19 @@ public final class LocaleUtil {
                         .map(I18NProvider::getProvidedLocales)
                         .flatMap(locales -> locales.stream().findFirst()))
                 .orElseGet(Locale::getDefault);
+    }
+
+    /**
+     * Get the locale from the current UI or from the I18NProvider from the
+     * current VaadinService.
+     * <p>
+     * -> If UI is not null, then it is used to get the locale, -> if UI is
+     * null, then the I18NProvider providedLocales first match will be returned,
+     * -> if I18NProvider is null, then default locale is returned.
+     *
+     * @return the locale for the UI
+     */
+    public static Locale getLocale() {
+        return getLocale(LocaleUtil::getI18NProvider);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/LocaleUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/LocaleUtil.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.i18n.I18NProvider;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinService;
@@ -96,8 +97,9 @@ public final class LocaleUtil {
      * @return the optional value of I18nProvider
      */
     public static Optional<I18NProvider> getI18NProvider() {
-        return Optional.ofNullable(
-                VaadinService.getCurrent().getInstantiator().getI18NProvider());
+        return Optional.ofNullable(VaadinService.getCurrent())
+                .map(VaadinService::getInstantiator)
+                .map(Instantiator::getI18NProvider);
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/i18n/DefaultInstantiatorI18NTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/i18n/DefaultInstantiatorI18NTest.java
@@ -68,6 +68,7 @@ public class DefaultInstantiatorI18NTest {
     public void cleanup() throws NoSuchFieldException, IllegalAccessException {
         ResourceBundle.clearCache(urlClassLoader);
         I18NProviderTest.clearI18NProviderField();
+        VaadinService.setCurrent(null);
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/i18n/DefaultInstantiatorI18NTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/i18n/DefaultInstantiatorI18NTest.java
@@ -78,6 +78,7 @@ public class DefaultInstantiatorI18NTest {
 
         VaadinService service = Mockito.mock(VaadinService.class);
         mockLookup(service);
+        VaadinService.setCurrent(service);
 
         DefaultInstantiator defaultInstantiator = new DefaultInstantiator(
                 service) {
@@ -86,28 +87,40 @@ public class DefaultInstantiatorI18NTest {
                 return urlClassLoader;
             }
         };
+        Mockito.when(service.getInstantiator()).thenReturn(defaultInstantiator);
         I18NProvider i18NProvider = defaultInstantiator.getI18NProvider();
         Assert.assertNotNull(i18NProvider);
         Assert.assertTrue(i18NProvider instanceof DefaultI18NProvider);
 
         Assert.assertEquals("Suomi",
                 i18NProvider.getTranslation("title", new Locale("fi", "FI")));
+        Assert.assertEquals("Suomi",
+                I18NProvider.translate(new Locale("fi", "FI"), "title"));
 
         Assert.assertEquals("deutsch",
                 i18NProvider.getTranslation("title", new Locale("de")));
+        Assert.assertEquals("deutsch",
+                I18NProvider.translate(new Locale("de"), "title"));
 
         Assert.assertEquals(
                 "non existing country should select language bundle", "deutsch",
                 i18NProvider.getTranslation("title", new Locale("de", "AT")));
+        Assert.assertEquals(
+                "non existing country should select language bundle", "deutsch",
+                I18NProvider.translate(new Locale("de", "AT"), "title"));
 
         Assert.assertEquals("Korean",
                 i18NProvider.getTranslation("title", new Locale("ko", "KR")));
+        Assert.assertEquals("Korean",
+                I18NProvider.translate(new Locale("ko", "KR"), "title"));
 
         // Note!
         // default translations.properties will be used if
         // the locale AND system default locale is not found
         Assert.assertEquals("Default lang",
                 i18NProvider.getTranslation("title", new Locale("en", "GB")));
+        Assert.assertEquals("Default lang",
+                I18NProvider.translate(new Locale("en", "GB"), "title"));
     }
 
     @Test
@@ -120,6 +133,7 @@ public class DefaultInstantiatorI18NTest {
 
         VaadinService service = Mockito.mock(VaadinService.class);
         mockLookup(service);
+        VaadinService.setCurrent(service);
 
         DefaultInstantiator defaultInstantiator = new DefaultInstantiator(
                 service) {
@@ -128,24 +142,33 @@ public class DefaultInstantiatorI18NTest {
                 return urlClassLoader;
             }
         };
+        Mockito.when(service.getInstantiator()).thenReturn(defaultInstantiator);
         I18NProvider i18NProvider = defaultInstantiator.getI18NProvider();
         Assert.assertNotNull(i18NProvider);
         Assert.assertTrue(i18NProvider instanceof DefaultI18NProvider);
 
         Assert.assertEquals("Default lang",
                 i18NProvider.getTranslation("title", new Locale("fi", "FI")));
+        Assert.assertEquals("Default lang",
+                I18NProvider.translate(new Locale("fi", "FI"), "title"));
 
         Assert.assertEquals("Default lang",
                 i18NProvider.getTranslation("title", new Locale("de")));
+        Assert.assertEquals("Default lang",
+                I18NProvider.translate(new Locale("de"), "title"));
 
         Assert.assertEquals("Default lang",
                 i18NProvider.getTranslation("title", new Locale("ko", "KR")));
+        Assert.assertEquals("Default lang",
+                I18NProvider.translate(new Locale("ko", "KR"), "title"));
 
         // Note!
         // default translations.properties will be used if
         // the locale AND system default locale is not found
         Assert.assertEquals("Default lang",
                 i18NProvider.getTranslation("title", new Locale("en", "GB")));
+        Assert.assertEquals("Default lang",
+                I18NProvider.translate(new Locale("en", "GB"), "title"));
     }
 
     @Test
@@ -158,6 +181,7 @@ public class DefaultInstantiatorI18NTest {
 
         VaadinService service = Mockito.mock(VaadinService.class);
         mockLookup(service);
+        VaadinService.setCurrent(service);
 
         DefaultInstantiator defaultInstantiator = new DefaultInstantiator(
                 service) {
@@ -166,15 +190,31 @@ public class DefaultInstantiatorI18NTest {
                 return urlClassLoader;
             }
         };
+        Mockito.when(service.getInstantiator()).thenReturn(defaultInstantiator);
         I18NProvider i18NProvider = defaultInstantiator.getI18NProvider();
         Assert.assertNotNull(i18NProvider);
         Assert.assertTrue(i18NProvider instanceof DefaultI18NProvider);
 
         Assert.assertEquals("No Default",
                 i18NProvider.getTranslation("title", new Locale("ja")));
+        Assert.assertEquals("No Default",
+                I18NProvider.translate(new Locale("ja"), "title"));
 
         Assert.assertEquals("title",
                 i18NProvider.getTranslation("title", new Locale("en", "GB")));
+        Assert.assertEquals("title",
+                I18NProvider.translate(new Locale("en", "GB"), "title"));
+    }
+
+    @Test
+    public void translate_withoutInstantiator_throwsIllegalStateException() {
+        VaadinService service = Mockito.mock(VaadinService.class);
+        VaadinService.setCurrent(service);
+
+        Assert.assertThrows(
+                "Should throw exception without Instantiator in VaadinService",
+                IllegalStateException.class,
+                () -> I18NProvider.translate("foo.bar"));
     }
 
     private static void createTranslationFiles(File translationsFolder)

--- a/flow-server/src/test/java/com/vaadin/flow/server/I18NProviderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/I18NProviderTest.java
@@ -87,6 +87,34 @@ public class I18NProviderTest {
                 VaadinSession.getCurrent().getLocale());
     }
 
+    @Test
+    public void translate_calls_provider()
+            throws ServletException, ServiceException {
+        config.setApplicationOrSystemProperty(InitParameters.I18N_PROVIDER,
+                TestProvider.class.getName());
+
+        initServletAndService(config);
+
+        Assert.assertEquals("translate method should return a value",
+                "!foo.bar!", I18NProvider.translate("foo.bar"));
+    }
+
+    @Test
+    public void translate_withoutVaadinService_throwIllegalStateException()
+            throws ServletException, ServiceException {
+        config.setApplicationOrSystemProperty(InitParameters.I18N_PROVIDER,
+                TestProvider.class.getName());
+
+        initServletAndService(config);
+
+        VaadinService.setCurrent(null);
+
+        Assert.assertThrows(
+                "Should throw exception without active VaadinService",
+                IllegalStateException.class,
+                () -> I18NProvider.translate("foo.bar"));
+    }
+
     @Before
     public void initState()
             throws NoSuchFieldException, IllegalAccessException {

--- a/flow-tests/test-misc/src/main/java/com/vaadin/flow/misc/ui/TranslationView.java
+++ b/flow-tests/test-misc/src/main/java/com/vaadin/flow/misc/ui/TranslationView.java
@@ -71,7 +71,7 @@ public class TranslationView extends Div {
 
         Span staticMethod = new Span(
                 I18NProvider.translate(Locale.ENGLISH, "label"));
-        dynamic.setId("static-method");
+        staticMethod.setId("static-method");
 
         add(defaultLang, new Div(), german, new Div(), germany, new Div(),
                 finnish, new Div(), french, new Div(), japanese, new Div(),

--- a/flow-tests/test-misc/src/main/java/com/vaadin/flow/misc/ui/TranslationView.java
+++ b/flow-tests/test-misc/src/main/java/com/vaadin/flow/misc/ui/TranslationView.java
@@ -69,9 +69,13 @@ public class TranslationView extends Div {
         dynamic = new Span("waiting");
         dynamic.setId("dynamic");
 
+        Span staticMethod = new Span(
+                I18NProvider.translate(Locale.ENGLISH, "label"));
+        dynamic.setId("static-method");
+
         add(defaultLang, new Div(), german, new Div(), germany, new Div(),
                 finnish, new Div(), french, new Div(), japanese, new Div(),
-                dynamic);
+                dynamic, new Div(), staticMethod);
     }
 
     @Override

--- a/flow-tests/test-misc/src/test/java/com/vaadin/flow/misc/ui/TranslationIT.java
+++ b/flow-tests/test-misc/src/test/java/com/vaadin/flow/misc/ui/TranslationIT.java
@@ -55,6 +55,9 @@ public class TranslationIT extends ChromeBrowserTest {
                 $(SpanElement.class).id("french").getText());
         Assert.assertEquals("日本語",
                 $(SpanElement.class).id("japanese").getText());
+
+        Assert.assertEquals("Default",
+                $(SpanElement.class).id("static-method").getText());
     }
 
     @Test


### PR DESCRIPTION
Adds static `I18NProvider#translate` methods for alternative way to get translation. Compares to calling getTranslation via `VaadinService.getCurrent().getInstantiator().getI18NProvider()`. `translate` methods throws IllegalStateException without active VaadinService.

Fixes: #19333
