### PR TITLE
fix: use maven project classpath to detect Hilla presence

### DIFF
--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -501,7 +501,7 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
             return frontendHotdeploy;
         }
         File frontendDirectory = BuildFrontendUtil.getFrontendDirectory(this);
-        return FrontendUtils.isHillaUsed(frontendDirectory);
+        return isHillaUsed(project, frontendDirectory);
     }
 
     @Override


### PR DESCRIPTION
If the project does not define the frontendHotdeploy property, the Flow maven plugins try to detect the correct value by analysing project files and looking for Hilla presence by checking for its classes in classpath. However, when FrontendUtils.isHillaUsed() method is called from the maven mojo it can return a wrong value, since Class.forName check is performed using the plugin classloader that does not contain Hilla artifacts.

This change makes the mojo isFrontendHotdeploy() method using the project classpath to check for Hilla presence.