### PR TITLE
chore: use PopStateEvent in Flow.tsx

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -176,7 +176,7 @@ function Flow() {
         }
 
         event.preventDefault();
-        navigate(path, {replace: event.detail.replace || event.detail.clientNavigation});
+        navigate(path, {replace: event.detail.replace});
     }, [navigate]);
 
     const redirect = useCallback((path: string) => {

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HistoryIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HistoryIT.java
@@ -51,6 +51,9 @@ public class HistoryIT extends ChromeBrowserTest {
         pushButton.click();
 
         Assert.assertEquals(baseUrl.resolve("asdf"), getCurrentUrl());
+        Assert.assertEquals(Arrays.asList("New location: asdf",
+                "New state: {\"foo\":true}"), getStatusMessages());
+        clearButton.click();
 
         // Back to original state
         backButton.click();
@@ -68,6 +71,9 @@ public class HistoryIT extends ChromeBrowserTest {
         replaceButton.click();
 
         Assert.assertEquals(baseUrl.resolve("qwerty"), getCurrentUrl());
+        Assert.assertEquals(Arrays.asList("New location: qwerty"),
+                getStatusMessages());
+        clearButton.click();
 
         // Forward to originally pushed state
         forwardButton.click();


### PR DESCRIPTION
Takes custom popstate event handling back in use to avoid full page refresh on history events like pushState/back/forward.
