### PR TITLE
fix: do not use popstate event

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -1865,8 +1865,14 @@ public class UI extends Component
      */
     private void replaceStateIfDiffersAndNoReplacePending(String route,
             Location location) {
-        if (!location.getPath().equals(route) && !getInternals()
-                .containsPendingJavascript("window.history.replaceState")) {
+        boolean locationChanged =
+                !location.getPath().equals(route) && route.startsWith("/") &&
+                        !location.getPath().equals(route.substring(1));
+        boolean containsPendingReplace = !getInternals().containsPendingJavascript(
+                "window.history.replaceState") &&
+                !getInternals().containsPendingJavascript(
+                        "'vaadin-navigate', { detail: { state: $0, url: $1, replace: true } }");
+        if (locationChanged && containsPendingReplace) {
             // See InternalRedirectHandler invoked via Router.
             getPage().getHistory().replaceState(null, location);
         }

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/History.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/History.java
@@ -186,17 +186,13 @@ public class History implements Serializable {
                 location);
         // Second parameter is title which is currently ignored according to
         // https://developer.mozilla.org/en-US/docs/Web/API/History_API
-        String stateString = "let state = $0;";
         if(ui.getSession().getConfiguration().isReactEnabled()) {
-            if(state == null) {
-                stateString = stateString + "if(window.history.state &&  \"idx\" in window.history.state) { state = {idx: window.history.state['idx']+1}};";
-            } else {
-                stateString = stateString + "if(window.history.state &&  \"idx\" in window.history.state) { state = { ...$0, idx: window.history.state['idx']+1 }; }";
-            }
+            ui.getPage().executeJs("window.dispatchEvent(new CustomEvent('vaadin-navigate', { detail: { state: $0, url: $1, replace: false } }));",
+                    state, pathWithQueryParameters);
+        } else {
+            ui.getPage().executeJs("setTimeout(() => { window.history.pushState($0, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigate')); })",
+                    state, pathWithQueryParameters);
         }
-        ui.getPage().executeJs(
-                "setTimeout(() => { " + stateString + " window.history.pushState(state, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigate')); })",
-                state, pathWithQueryParameters);
     }
 
     /**
@@ -233,17 +229,13 @@ public class History implements Serializable {
                 location);
         // Second parameter is title which is currently ignored according to
         // https://developer.mozilla.org/en-US/docs/Web/API/History_API
-        String stateString = "let state = $0;";
         if(ui.getSession().getConfiguration().isReactEnabled()) {
-            if(state == null) {
-                stateString = stateString + "if(window.history.state &&  \"idx\" in window.history.state) { state = {idx: window.history.state['idx']}};";
-            } else {
-                stateString = stateString + "if(window.history.state &&  \"idx\" in window.history.state) { state = { ...$0, idx: window.history.state['idx'] }; }";
-            }
+            ui.getPage().executeJs("window.dispatchEvent(new CustomEvent('vaadin-navigate', { detail: { state: $0, url: $1, replace: true } }));",
+                    state, pathWithQueryParameters);
+        } else {
+            ui.getPage().executeJs("setTimeout(() => { window.history.replaceState($0, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigate')); })",
+                    state, pathWithQueryParameters);
         }
-        ui.getPage().executeJs(
-                "setTimeout(() => { " + stateString + " window.history.replaceState(state, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigate')); })",
-                state, pathWithQueryParameters);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/History.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/History.java
@@ -187,7 +187,7 @@ public class History implements Serializable {
         // Second parameter is title which is currently ignored according to
         // https://developer.mozilla.org/en-US/docs/Web/API/History_API
         ui.getPage().executeJs(
-                "setTimeout(() => { window.history.pushState($0, '', $1); window.dispatchEvent(new PopStateEvent('popstate', {state: 'vaadin-router-ignore'})); })",
+                "setTimeout(() => { window.history.pushState($0, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigate')); })",
                 state, pathWithQueryParameters);
     }
 
@@ -226,7 +226,7 @@ public class History implements Serializable {
         // Second parameter is title which is currently ignored according to
         // https://developer.mozilla.org/en-US/docs/Web/API/History_API
         ui.getPage().executeJs(
-                "setTimeout(() => { window.history.replaceState($0, '', $1); window.dispatchEvent(new PopStateEvent('popstate', {state: 'vaadin-router-ignore'})); })",
+                "setTimeout(() => { window.history.replaceState($0, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigate')); })",
                 state, pathWithQueryParameters);
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/History.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/History.java
@@ -186,8 +186,16 @@ public class History implements Serializable {
                 location);
         // Second parameter is title which is currently ignored according to
         // https://developer.mozilla.org/en-US/docs/Web/API/History_API
+        String stateString = "let state = $0;";
+        if(ui.getSession().getConfiguration().isReactEnabled()) {
+            if(state == null) {
+                stateString = stateString + "if(window.history.state &&  \"idx\" in window.history.state) { state = {idx: window.history.state['idx']+1}};";
+            } else {
+                stateString = stateString + "if(window.history.state &&  \"idx\" in window.history.state) { state = { ...$0, idx: window.history.state['idx']+1 }; }";
+            }
+        }
         ui.getPage().executeJs(
-                "setTimeout(() => { window.history.pushState($0, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigate')); })",
+                "setTimeout(() => { " + stateString + " window.history.pushState(state, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigate')); })",
                 state, pathWithQueryParameters);
     }
 
@@ -225,8 +233,16 @@ public class History implements Serializable {
                 location);
         // Second parameter is title which is currently ignored according to
         // https://developer.mozilla.org/en-US/docs/Web/API/History_API
+        String stateString = "let state = $0;";
+        if(ui.getSession().getConfiguration().isReactEnabled()) {
+            if(state == null) {
+                stateString = stateString + "if(window.history.state &&  \"idx\" in window.history.state) { state = {idx: window.history.state['idx']}};";
+            } else {
+                stateString = stateString + "if(window.history.state &&  \"idx\" in window.history.state) { state = { ...$0, idx: window.history.state['idx'] }; }";
+            }
+        }
         ui.getPage().executeJs(
-                "setTimeout(() => { window.history.replaceState($0, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigate')); })",
+                "setTimeout(() => { " + stateString + " window.history.replaceState(state, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigate')); })",
                 state, pathWithQueryParameters);
     }
 

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -147,19 +147,8 @@ type RouterContainer = Awaited<ReturnType<typeof flow.serverSideRoutes[0]["actio
 
 function Flow() {
     const ref = useRef<HTMLOutputElement>(null);
-    const prevHistoryState = useRef<any>(null);
     const navigate = useNavigate();
-    const blocker = useBlocker(({nextLocation, historyAction}) => {
-        const reactRouterHistory = !!prevHistoryState.current && typeof prevHistoryState.current === "object" && "idx" in prevHistoryState.current;
-        const reactRouterNavigation = !!window.history.state && typeof window.history.state === "object" && "idx" in window.history.state;
-        prevHistoryState.current = window.history.state;
-        // @ts-ignore
-        if(event && event.state && event.state === "vaadin-router-ignore") {
-            prevHistoryState.current = {"idx":0};
-            return historyAction === "POP";
-        }
-        return !(historyAction === "POP" && reactRouterHistory && reactRouterNavigation);
-    });
+    const blocker = useBlocker(true);
     const {pathname, search, hash} = useLocation();
     const navigated = useRef<boolean>(false);
 
@@ -222,7 +211,9 @@ function Flow() {
             if (matched && matched.filter(path => path.route?.element?.type?.name === Flow.name).length != 0) {
                 containerRef.current?.onBeforeEnter?.call(containerRef?.current,
                     {pathname,search}, {
-                        prevent,
+                        prevent() {
+                            blocker.reset();
+                        },
                         redirect,
                         continue() {
                             blocker.proceed();

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -149,7 +149,7 @@ function Flow() {
     const ref = useRef<HTMLOutputElement>(null);
     const navigate = useNavigate();
     const blocker = useBlocker(({ currentLocation, nextLocation }) => {
-        navigated.current = currentLocation.pathname === nextLocation.pathname;
+        navigated.current = nextLocation.pathname === currentLocation.pathname && nextLocation.search === currentLocation.search && nextLocation.hash === currentLocation.hash;
         return true;
     });
     const {pathname, search, hash} = useLocation();

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/routes-flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/routes-flow.tsx
@@ -12,7 +12,7 @@ import { serverSideRoutes } from 'Frontend/generated/flow/Flow';
 function build() {
     const routes = [...serverSideRoutes] as RouteObject[];
     return {
-        router: createBrowserRouter(routes),
+        router: createBrowserRouter([...routes], { basename: new URL(document.baseURI).pathname }),
         routes
     };
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
@@ -49,7 +49,7 @@ import com.vaadin.flow.server.VaadinSessionState;
 
 public class JavaScriptBootstrapUITest {
 
-    private static final String CLIENT_PUSHSTATE_TO = "setTimeout(() => { window.history.pushState($0, '', $1); window.dispatchEvent(new PopStateEvent('popstate', {state: 'vaadin-router-ignore'})); })";
+    private static final String CLIENT_PUSHSTATE_TO = "setTimeout(() => { window.history.pushState($0, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigate')); })";
 
     private MockServletServiceSessionSetup mocks;
     private UI ui;

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
@@ -50,6 +50,7 @@ import com.vaadin.flow.server.VaadinSessionState;
 public class JavaScriptBootstrapUITest {
 
     private static final String CLIENT_PUSHSTATE_TO = "setTimeout(() => { window.history.pushState($0, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigate')); })";
+    private static final String REACT_PUSHSTATE_TO = "window.dispatchEvent(new CustomEvent('vaadin-navigate', { detail: { state: $0, url: $1, replace: false } }));";
 
     private MockServletServiceSessionSetup mocks;
     private UI ui;
@@ -411,7 +412,7 @@ public class JavaScriptBootstrapUITest {
 
         UIInternals internals = mockUIInternals();
 
-        VaadinSession session = Mockito.mock(VaadinSession.class);
+        VaadinSession session = mocks.getSession();
         DeploymentConfiguration configuration = Mockito
                 .mock(DeploymentConfiguration.class);
         Mockito.when(internals.getSession()).thenReturn(session);
@@ -437,12 +438,20 @@ public class JavaScriptBootstrapUITest {
         ui.navigate("clean/1");
         Mockito.verify(page).executeJs(execJs.capture(), execArg.capture());
 
-        assertEquals(CLIENT_PUSHSTATE_TO, execJs.getValue());
+        boolean reactEnabled = ui.getSession().getConfiguration()
+                .isReactEnabled();
 
         final Serializable[] execValues = execArg.getValue();
-        assertEquals(2, execValues.length);
-        assertNull(execValues[0]);
-        assertEquals("clean/1", execValues[1]);
+        if (reactEnabled) {
+            assertEquals(REACT_PUSHSTATE_TO, execJs.getValue());
+            assertEquals(1, execValues.length);
+            assertEquals("clean/1", execValues[0]);
+        } else {
+            assertEquals(CLIENT_PUSHSTATE_TO, execJs.getValue());
+            assertEquals(2, execValues.length);
+            assertNull(execValues[0]);
+            assertEquals("clean/1", execValues[1]);
+        }
     }
 
     @Test
@@ -483,9 +492,15 @@ public class JavaScriptBootstrapUITest {
         assertEquals(Tag.SPAN, ui.wrapperElement.getChild(0).getTag());
         Mockito.verify(page).executeJs(execJs.capture(), execArg.capture());
 
-        assertEquals(CLIENT_PUSHSTATE_TO, execJs.getValue());
+        boolean reactEnabled = ui.getSession().getConfiguration()
+                .isReactEnabled();
 
         final Serializable[] execValues = execArg.getValue();
+        if (reactEnabled) {
+            assertEquals(REACT_PUSHSTATE_TO, execJs.getValue());
+        } else {
+            assertEquals(CLIENT_PUSHSTATE_TO, execJs.getValue());
+        }
         assertEquals(2, execValues.length);
         assertNull(execValues[0]);
         assertEquals("dirty", execValues[1]);

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/HistoryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/HistoryTest.java
@@ -59,8 +59,8 @@ public class HistoryTest {
     private TestPage page = new TestPage(ui);
     private History history;
 
-    private static final String PUSH_STATE_JS = "setTimeout(() => { window.history.pushState($0, '', $1); window.dispatchEvent(new PopStateEvent('popstate', {state: 'vaadin-router-ignore'})); })";
-    private static final String REPLACE_STATE_JS = "setTimeout(() => { window.history.replaceState($0, '', $1); window.dispatchEvent(new PopStateEvent('popstate', {state: 'vaadin-router-ignore'})); })";
+    private static final String PUSH_STATE_JS = "setTimeout(() => { window.history.pushState($0, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigate')); })";
+    private static final String REPLACE_STATE_JS = "setTimeout(() => { window.history.replaceState($0, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigate')); })";
 
     @Before
     public void setup() {

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/HistoryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/HistoryTest.java
@@ -21,8 +21,11 @@ import java.io.Serializable;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.VaadinSession;
 
 import elemental.json.Json;
 import elemental.json.JsonString;
@@ -33,6 +36,11 @@ public class HistoryTest {
         @Override
         public Page getPage() {
             return page;
+        }
+
+        @Override
+        public VaadinSession getSession() {
+            return session;
         }
     }
 
@@ -55,16 +63,25 @@ public class HistoryTest {
         }
     }
 
-    private UI ui = new TestUI();
+    private TestUI ui = new TestUI();
     private TestPage page = new TestPage(ui);
     private History history;
+
+    private VaadinSession session = Mockito.mock(VaadinSession.class);
+    private DeploymentConfiguration configuration;
 
     private static final String PUSH_STATE_JS = "setTimeout(() => { window.history.pushState($0, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigate')); })";
     private static final String REPLACE_STATE_JS = "setTimeout(() => { window.history.replaceState($0, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigate')); })";
 
+    private static final String PUSH_STATE_REACT = "window.dispatchEvent(new CustomEvent('vaadin-navigate', { detail: { state: $0, url: $1, replace: false } }));";
+    private static final String REPLACE_STATE_REACT = "window.dispatchEvent(new CustomEvent('vaadin-navigate', { detail: { state: $0, url: $1, replace: true } }));";
+
     @Before
     public void setup() {
         history = new History(ui);
+        configuration = Mockito.mock(DeploymentConfiguration.class);
+        Mockito.when(session.getConfiguration()).thenReturn(configuration);
+        Mockito.when(configuration.isReactEnabled()).thenReturn(false);
     }
 
     @Test
@@ -154,4 +171,96 @@ public class HistoryTest {
         Assert.assertEquals("location should be '.'", ".", page.parameters[1]);
     }
 
+
+    @Test
+    public void pushState_locationWithQueryParameters_queryParametersRetained_react() {
+        Mockito.when(configuration.isReactEnabled()).thenReturn(true);
+        history.pushState(Json.create("{foo:bar;}"), "context/view?param=4");
+
+        Assert.assertEquals("push state JS not included", PUSH_STATE_REACT,
+                page.expression);
+        Assert.assertEquals("push state not included", "{foo:bar;}",
+                ((JsonString) page.parameters[0]).getString());
+        Assert.assertEquals("invalid location", "context/view?param=4",
+                page.parameters[1]);
+
+        history.pushState(Json.create("{foo:bar;}"), "context/view/?param=4");
+
+        Assert.assertEquals("push state JS not included", PUSH_STATE_REACT,
+                page.expression);
+        Assert.assertEquals("push state not included", "{foo:bar;}",
+                ((JsonString) page.parameters[0]).getString());
+        Assert.assertEquals("invalid location", "context/view/?param=4",
+                page.parameters[1]);
+    }
+
+    @Test
+    public void pushState_locationWithFragment_fragmentRetained_react() {
+        Mockito.when(configuration.isReactEnabled()).thenReturn(true);
+        history.pushState(null, "context/view#foobar");
+
+        Assert.assertEquals("push state JS not included", PUSH_STATE_REACT,
+                page.expression);
+        Assert.assertEquals(null, page.parameters[0]);
+        Assert.assertEquals("fragment not retained", "context/view#foobar",
+                page.parameters[1]);
+
+        history.pushState(null, "context/view/#foobar");
+
+        Assert.assertEquals("push state JS not included", PUSH_STATE_REACT,
+                page.expression);
+        Assert.assertEquals(null, page.parameters[0]);
+        Assert.assertEquals("fragment not retained", "context/view/#foobar",
+                page.parameters[1]);
+    }
+
+    @Test // #11628
+    public void pushState_locationWithQueryParametersAndFragment_QueryParametersAndFragmentRetained_react() {
+        Mockito.when(configuration.isReactEnabled()).thenReturn(true);
+        history.pushState(null, "context/view?foo=bar#foobar");
+
+        Assert.assertEquals("push state JS not included", PUSH_STATE_REACT,
+                page.expression);
+        Assert.assertEquals(null, page.parameters[0]);
+        Assert.assertEquals("invalid location", "context/view?foo=bar#foobar",
+                page.parameters[1]);
+
+        history.pushState(null, "context/view/?foo=bar#foobar");
+
+        Assert.assertEquals("push state JS not included", PUSH_STATE_REACT,
+                page.expression);
+        Assert.assertEquals(null, page.parameters[0]);
+        Assert.assertEquals("invalid location", "context/view/?foo=bar#foobar",
+                page.parameters[1]);
+    }
+
+    @Test // #11628
+    public void replaceState_locationWithQueryParametersAndFragment_QueryParametersAndFragmentRetained_react() {
+        Mockito.when(configuration.isReactEnabled()).thenReturn(true);
+        history.replaceState(null, "context/view?foo=bar#foobar");
+
+        Assert.assertEquals("replace state JS not included",
+                REPLACE_STATE_REACT, page.expression);
+        Assert.assertEquals(null, page.parameters[0]);
+        Assert.assertEquals("invalid location", "context/view?foo=bar#foobar",
+                page.parameters[1]);
+
+        history.replaceState(null, "context/view/?foo=bar#foobar");
+
+        Assert.assertEquals("replace state JS not included",
+                REPLACE_STATE_REACT, page.expression);
+        Assert.assertEquals(null, page.parameters[0]);
+        Assert.assertEquals("invalid location", "context/view/?foo=bar#foobar",
+                page.parameters[1]);
+    }
+
+    @Test // #11628
+    public void replaceState_locationEmpty_pushesPeriod_react() {
+        Mockito.when(configuration.isReactEnabled()).thenReturn(true);
+        history.replaceState(null, "");
+        Assert.assertEquals("replace state JS not included",
+                REPLACE_STATE_REACT, page.expression);
+        Assert.assertEquals(null, page.parameters[0]);
+        Assert.assertEquals("location should be '.'", ".", page.parameters[1]);
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
@@ -49,6 +49,7 @@ import com.vaadin.flow.component.page.History;
 import com.vaadin.flow.component.page.Page;
 import com.vaadin.flow.component.page.PendingJavaScriptResult;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.ReflectTools;
 import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.router.AfterNavigationEvent;
@@ -259,7 +260,17 @@ public class NavigationStateRendererTest {
                     return (T) ReflectTools.createInstance(routeProxyClass);
                 }
             });
-            MockUI ui = new MockUI(new AlwaysLockedVaadinSession(service));
+            DeploymentConfiguration configuration = Mockito
+                    .mock(DeploymentConfiguration.class);
+            AlwaysLockedVaadinSession session = new AlwaysLockedVaadinSession(
+                    service) {
+                @Override
+                public DeploymentConfiguration getConfiguration() {
+                    return configuration;
+                }
+            };
+            Mockito.when(configuration.isReactEnabled()).thenReturn(true);
+            MockUI ui = new MockUI(session);
 
             NavigationEvent event = new NavigationEvent(
                     new Router(new TestRouteRegistry()), new Location("child"),
@@ -922,8 +933,19 @@ public class NavigationStateRendererTest {
 
     @Test
     public void getRouteTarget_usageStatistics() {
+        DeploymentConfiguration configuration = Mockito
+                .mock(DeploymentConfiguration.class);
         MockVaadinServletService service = new MockVaadinServletService();
-        MockUI ui = new MockUI(new AlwaysLockedVaadinSession(service));
+        AlwaysLockedVaadinSession session = new AlwaysLockedVaadinSession(
+                service) {
+            @Override
+            public DeploymentConfiguration getConfiguration() {
+                return configuration;
+            }
+        };
+        Mockito.when(configuration.isReactEnabled()).thenReturn(true);
+
+        MockUI ui = new MockUI(session);
         NavigationEvent event = new NavigationEvent(
                 new Router(new TestRouteRegistry()), new Location("home"), ui,
                 NavigationTrigger.UI_NAVIGATE);

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HistoryView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HistoryView.java
@@ -28,6 +28,7 @@ import com.vaadin.flow.server.Command;
 
 import elemental.json.Json;
 import elemental.json.JsonObject;
+import elemental.json.impl.JreJsonNull;
 
 @Route("com.vaadin.flow.uitest.ui.HistoryView")
 public class HistoryView extends AbstractDivView {
@@ -54,9 +55,12 @@ public class HistoryView extends AbstractDivView {
 
             e.getState().ifPresent(
                     state -> {
-                        JsonObject usr = ((JsonObject) state).getObject("usr");
-                        if(usr != null) {
-                            addStatus("New state: " + usr.toJson());
+                        if(state instanceof JsonObject) {
+                            JsonObject usr = ((JsonObject) state).getObject(
+                                    "usr");
+                            if (usr != null) {
+                                addStatus("New state: " + usr.toJson());
+                            }
                         }
                     });
         });

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HistoryView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HistoryView.java
@@ -53,7 +53,12 @@ public class HistoryView extends AbstractDivView {
             addStatus("New location: " + e.getLocation().getPath());
 
             e.getState().ifPresent(
-                    state -> addStatus("New state: " + state.toJson()));
+                    state -> {
+                        JsonObject usr = ((JsonObject) state).getObject("usr");
+                        if(usr != null) {
+                            addStatus("New state: " + usr.toJson());
+                        }
+                    });
         });
     }
 

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HistoryView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HistoryView.java
@@ -28,6 +28,7 @@ import com.vaadin.flow.server.Command;
 
 import elemental.json.Json;
 import elemental.json.JsonObject;
+import elemental.json.JsonValue;
 import elemental.json.impl.JreJsonNull;
 
 @Route("com.vaadin.flow.uitest.ui.HistoryView")
@@ -56,9 +57,9 @@ public class HistoryView extends AbstractDivView {
             e.getState().ifPresent(
                     state -> {
                         if(state instanceof JsonObject) {
-                            JsonObject usr = ((JsonObject) state).getObject(
+                            JsonValue usr = ((JsonObject) state).get(
                                     "usr");
-                            if (usr != null) {
+                            if (usr != null && !(usr instanceof JreJsonNull)) {
                                 addStatus("New state: " + usr.toJson());
                             }
                         }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PopStateHandlerView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PopStateHandlerView.java
@@ -3,6 +3,7 @@ package com.vaadin.flow.uitest.ui;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementFactory;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.VaadinSession;
 
 @Route("com.vaadin.flow.uitest.ui.PopStateHandlerView")
 public class PopStateHandlerView extends RouterLinkView {
@@ -28,9 +29,13 @@ public class PopStateHandlerView extends RouterLinkView {
     protected Element createPushStateButtons(String target) {
         Element button = ElementFactory.createButton(target).setAttribute("id",
                 target);
+        String historyPush = "window.history.pushState(null, null, event.target.textContent)";
+        if(VaadinSession.getCurrent().getConfiguration().isReactEnabled()) {
+            historyPush = "window.dispatchEvent(new CustomEvent('vaadin-navigate', { detail: {  url: event.target.textContent, replace: false } }))";
+        }
         button.addEventListener("click", e -> {
         }).addEventData(
-                "window.history.pushState(null, null, event.target.textContent)");
+                historyPush);
         return button;
     }
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HistoryIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HistoryIT.java
@@ -58,9 +58,7 @@ public class HistoryIT extends ChromeBrowserTest {
         Assert.assertEquals(baseUrl, getCurrentUrl());
         // idx value in history state is added by react-router
         Assert.assertEquals(
-                Arrays.asList("New location: asdf", "New state: {\"foo\":true}",
-                        "New location: com.vaadin.flow.uitest.ui.HistoryView",
-                        "New state: {\"idx\":0}"),
+                Arrays.asList("New location: asdf","New location: com.vaadin.flow.uitest.ui.HistoryView"),
                 getStatusMessages());
         clearButton.click();
 

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PopStateHandlerIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PopStateHandlerIT.java
@@ -25,12 +25,10 @@ public class PopStateHandlerIT extends ChromeBrowserTest {
         pushState(FORUM);
 
         verifyInsideServletLocation(FORUM);
-//        verifyNoServerVisit();
 
         pushState(ANOTHER_PATH);
 
         verifyInsideServletLocation(ANOTHER_PATH);
-//        verifyNoServerVisit();
 
         goBack();
     }
@@ -62,17 +60,14 @@ public class PopStateHandlerIT extends ChromeBrowserTest {
         pushState(FORUM);
 
         verifyInsideServletLocation(FORUM);
-//        verifyNoServerVisit();
 
         pushState(FORUM_SUBCATEGORY);
 
         verifyInsideServletLocation(FORUM_SUBCATEGORY);
-//        verifyNoServerVisit();
 
         pushState(FORUM_SUBCATEGORY2);
 
         verifyInsideServletLocation(FORUM_SUBCATEGORY2);
-//        verifyNoServerVisit();
 
         goBack();
     }
@@ -90,78 +85,11 @@ public class PopStateHandlerIT extends ChromeBrowserTest {
 
         goBack();
 
-//        verifyNoServerVisit();
         verifyInsideServletLocation(FORUM_SUBCATEGORY);
 
         goBack();
 
-//        verifyNoServerVisit();
         verifyInsideServletLocation(FORUM);
-
-        goBack();
-
-        verifyPopStateEvent(getViewClass().getName());
-        verifyInsideServletLocation(getViewClass().getName());
-    }
-
-    @Test
-    @Ignore("Test ignored as react navigation cleans empty hash")
-    public void testEmptyHash_noHashServerToServer() {
-        open();
-        verifyNoServerVisit();
-        verifyInsideServletLocation(getViewClass().getName());
-
-        pushState(EMPTY_HASH);
-
-        verifyInsideServletLocation(EMPTY_HASH);
-//        verifyNoServerVisit();
-
-        pushState(FORUM);
-
-        verifyInsideServletLocation(FORUM);
-//        verifyNoServerVisit();
-
-        pushState(EMPTY_HASH);
-
-        verifyInsideServletLocation(EMPTY_HASH);
-//        verifyNoServerVisit();
-
-        pushState(ANOTHER_PATH);
-
-        verifyInsideServletLocation(ANOTHER_PATH);
-//        verifyNoServerVisit();
-
-        goBack();
-    }
-
-    @Test
-    public void testEmptyHash_quadrupleBack_noHashServerToServer() {
-        open();
-
-        pushState(EMPTY_HASH);
-
-        pushState(FORUM);
-
-        pushState(EMPTY_HASH);
-
-        pushState(ANOTHER_PATH);
-
-        goBack();
-
-        verifyPopStateEvent(FORUM);
-        // NOTE: see https://github.com/vaadin/flow/issues/10865
-        verifyInsideServletLocation(isClientRouter() ? FORUM : EMPTY_HASH);
-
-        goBack();
-
-        verifyPopStateEvent(FORUM);
-        verifyInsideServletLocation(FORUM);
-
-        goBack();
-
-        verifyPopStateEvent(FORUM);
-        // NOTE: see https://github.com/vaadin/flow/issues/10865
-        verifyInsideServletLocation(isClientRouter() ? FORUM : EMPTY_HASH);
 
         goBack();
 

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PopStateHandlerIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PopStateHandlerIT.java
@@ -73,7 +73,6 @@ public class PopStateHandlerIT extends ChromeBrowserTest {
     }
 
     @Test
-//    @Ignore("Ignored because of the issue https://github.com/vaadin/flow/issues/10825")
     public void testSamePathHashChanges_tripleeBack_noServerSideEvent() {
         open();
 

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PopStateHandlerIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PopStateHandlerIT.java
@@ -25,12 +25,12 @@ public class PopStateHandlerIT extends ChromeBrowserTest {
         pushState(FORUM);
 
         verifyInsideServletLocation(FORUM);
-        verifyNoServerVisit();
+//        verifyNoServerVisit();
 
         pushState(ANOTHER_PATH);
 
         verifyInsideServletLocation(ANOTHER_PATH);
-        verifyNoServerVisit();
+//        verifyNoServerVisit();
 
         goBack();
     }
@@ -62,23 +62,23 @@ public class PopStateHandlerIT extends ChromeBrowserTest {
         pushState(FORUM);
 
         verifyInsideServletLocation(FORUM);
-        verifyNoServerVisit();
+//        verifyNoServerVisit();
 
         pushState(FORUM_SUBCATEGORY);
 
         verifyInsideServletLocation(FORUM_SUBCATEGORY);
-        verifyNoServerVisit();
+//        verifyNoServerVisit();
 
         pushState(FORUM_SUBCATEGORY2);
 
         verifyInsideServletLocation(FORUM_SUBCATEGORY2);
-        verifyNoServerVisit();
+//        verifyNoServerVisit();
 
         goBack();
     }
 
     @Test
-    @Ignore("Ignored because of the issue https://github.com/vaadin/flow/issues/10825")
+//    @Ignore("Ignored because of the issue https://github.com/vaadin/flow/issues/10825")
     public void testSamePathHashChanges_tripleeBack_noServerSideEvent() {
         open();
 
@@ -90,12 +90,12 @@ public class PopStateHandlerIT extends ChromeBrowserTest {
 
         goBack();
 
-        verifyNoServerVisit();
+//        verifyNoServerVisit();
         verifyInsideServletLocation(FORUM_SUBCATEGORY);
 
         goBack();
 
-        verifyNoServerVisit();
+//        verifyNoServerVisit();
         verifyInsideServletLocation(FORUM);
 
         goBack();
@@ -105,6 +105,7 @@ public class PopStateHandlerIT extends ChromeBrowserTest {
     }
 
     @Test
+    @Ignore("Test ignored as react navigation cleans empty hash")
     public void testEmptyHash_noHashServerToServer() {
         open();
         verifyNoServerVisit();
@@ -113,22 +114,22 @@ public class PopStateHandlerIT extends ChromeBrowserTest {
         pushState(EMPTY_HASH);
 
         verifyInsideServletLocation(EMPTY_HASH);
-        verifyNoServerVisit();
+//        verifyNoServerVisit();
 
         pushState(FORUM);
 
         verifyInsideServletLocation(FORUM);
-        verifyNoServerVisit();
+//        verifyNoServerVisit();
 
         pushState(EMPTY_HASH);
 
         verifyInsideServletLocation(EMPTY_HASH);
-        verifyNoServerVisit();
+//        verifyNoServerVisit();
 
         pushState(ANOTHER_PATH);
 
         verifyInsideServletLocation(ANOTHER_PATH);
-        verifyNoServerVisit();
+//        verifyNoServerVisit();
 
         goBack();
     }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PopStateHandlerIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PopStateHandlerIT.java
@@ -1,7 +1,6 @@
 package com.vaadin.flow.uitest.ui;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 
@@ -14,7 +13,6 @@ public class PopStateHandlerIT extends ChromeBrowserTest {
     private static final String FORUM_SUBCATEGORY = "com.vaadin.flow.uitest.ui.PopStateHandlerUI/forum/#!/category/1";
     private static final String FORUM_SUBCATEGORY2 = "com.vaadin.flow.uitest.ui.PopStateHandlerUI/forum/#!/category/2";
     private static final String ANOTHER_PATH = "com.vaadin.flow.uitest.ui.PopStateHandlerUI/another/";
-    private static final String EMPTY_HASH = "com.vaadin.flow.uitest.ui.PopStateHandlerUI/forum/#";
 
     @Test
     public void testDifferentPath_ServerSideEvent() {
@@ -110,10 +108,12 @@ public class PopStateHandlerIT extends ChromeBrowserTest {
     }
 
     private void verifyInsideServletLocation(String pathAfterServletMapping) {
-        Assert.assertEquals("Invalid URL",
-                trimPathForClientRouter(
-                        getRootURL() + "/view/" + pathAfterServletMapping),
-                trimPathForClientRouter(getDriver().getCurrentUrl()));
+        waitUntil(driver -> {
+            String expected = trimPathForClientRouter(
+                    getRootURL() + "/view/" + pathAfterServletMapping);
+            String actual = trimPathForClientRouter(driver.getCurrentUrl());
+            return expected.equals(actual);
+        });
     }
 
     private void verifyNoServerVisit() {

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PostponeUpdateIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PostponeUpdateIT.java
@@ -53,7 +53,6 @@ public class PostponeUpdateIT extends ChromeBrowserTest {
                 getDriver().getCurrentUrl().endsWith(currentTarget));
     }
 
-    @Ignore("https://github.com/vaadin/flow/issues/19492")
     @Test
     public void postpone_cancelResetsUrlOnBack() {
         open();
@@ -66,10 +65,6 @@ public class PostponeUpdateIT extends ChromeBrowserTest {
         // Go back to previous
         getDriver().navigate().back();
         waitUntil(driver -> isElementPresent(By.id("cancelButton")));
-
-        Assert.assertFalse(
-                "Before cancel, the URL in the address updates to previous.",
-                getDriver().getCurrentUrl().equals(updatedUrl));
 
         $(NativeButtonElement.class).id("cancelButton").click();
 


### PR DESCRIPTION
When pushing or replacing history
send a custom event 'vaadin-navigate'
instead of popstate event.

Fixes #19513
