### PR TITLE
fix: Add usage stats for react adapter

### DIFF
--- a/flow-react/src/main/resources/com/vaadin/flow/server/frontend/ReactAdapter.template
+++ b/flow-react/src/main/resources/com/vaadin/flow/server/frontend/ReactAdapter.template
@@ -121,6 +121,7 @@ export abstract class ReactAdapterElement extends HTMLElement {
             useCustomEvent: this.useCustomEvent.bind(this)
         };
         this.#Wrapper = this.#renderWrapper.bind(this);
+        this.#markAsUsed();
     }
 
     public async connectedCallback() {


### PR DESCRIPTION
this was removed in https://github.com/vaadin/flow/pull/19434 (maybe accidentally? )