### PR TITLE
feat: Load Lumo utility CSS by default

### DIFF
--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
@@ -112,7 +112,7 @@ function writeThemeFiles(themeFolder, themeName, themeProperties, options) {
   let variable = camelCase(filename);
 
   /* LUMO */
-  const lumoImports = themeProperties.lumoImports || ['color', 'typography'];
+  const lumoImports = themeProperties.lumoImports || [ 'typography', 'color', 'spacing', 'badge', 'utility'] ;
   if (lumoImports) {
     lumoImports.forEach((lumoImport) => {
       imports.push(`import { ${lumoImport} } from '@vaadin/vaadin-lumo-styles/${lumoImport}.js';\n`);


### PR DESCRIPTION
The imports have been manually defined in all new starter projects for a long time so this is not supposed to break much anything
