### PR TITLE
chore: fix dependency convergence: javassist

### DIFF
--- a/vaadin-spring/pom.xml
+++ b/vaadin-spring/pom.xml
@@ -173,8 +173,13 @@
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
             <version>0.10.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.javassist</groupId>
+                    <artifactId>javassist</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
-	<!-- overwrite the javassist version used in reflections -->
         <dependency>
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>


### PR DESCRIPTION
```
[ERROR] Dependency convergence error for org.javassist:javassist:jar:3.28.0-GA paths to dependency are:
[ERROR] +-com.example:spring-skeleton:jar:1.0-SNAPSHOT
[ERROR]   +-com.vaadin:vaadin-spring-boot-starter:jar:24.4.3:compile
[ERROR]     +-com.vaadin:vaadin-spring:jar:24.4.2:compile
[ERROR]       +-org.reflections:reflections:jar:0.10.2:compile
[ERROR]         +-org.javassist:javassist:jar:3.28.0-GA:compile
[ERROR] and
[ERROR] +-com.example:spring-skeleton:jar:1.0-SNAPSHOT
[ERROR]   +-com.vaadin:vaadin-spring-boot-starter:jar:24.4.3:compile
[ERROR]     +-com.vaadin:hilla:jar:24.4.1:compile
[ERROR]       +-com.vaadin:hilla-endpoint:jar:24.4.1:compile
[ERROR]         +-com.github.javaparser:javaparser-symbol-solver-core:jar:3.25.10:compile
[ERROR]           +-org.javassist:javassist:jar:3.30.2-GA:compile

```