### PR TITLE
fix: handle clicks outside container

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -269,11 +269,13 @@ function Flow() {
                                     blocker.reset();
                                 } else {
                                     blocker.proceed();
+                                    window.removeEventListener('click',  navigateEventHandler);
                                 }
                             }
                         } else {
                             // permitted navigation: proceed with the blocker
                             blocker.proceed();
+                            window.removeEventListener('click',  navigateEventHandler);
                         }
                     });
             }
@@ -291,7 +293,7 @@ function Flow() {
                 const outlet = ref.current?.parentNode;
                 if (outlet && outlet !== container.parentNode) {
                     outlet.append(container);
-                    container.onclick = navigateEventHandler;
+                    window.addEventListener('click',  navigateEventHandler);
                     containerRef.current = container
                 }
                 return container.onBeforeEnter?.call(container, {pathname, search}, {prevent, redirect, continue() {


### PR DESCRIPTION
Add the navigationEventHandler
to window to be able to handle
link clicks into dialogs that
are outside of the container element.

Fixes #19630