### PR TITLE
fix: Use @preact/signals-react-transform

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "vite": "5.3.1",
     "@vitejs/plugin-react": "4.3.1",
+    "@preact/signals-react-transform": "0.3.1",
     "@rollup/plugin-replace": "5.0.7",
     "@rollup/pluginutils": "5.1.0",
     "@babel/preset-react": "7.24.7",

--- a/flow-server/src/main/resources/plugins/react-function-location-plugin/react-function-location-plugin.js
+++ b/flow-server/src/main/resources/plugins/react-function-location-plugin/react-function-location-plugin.js
@@ -66,7 +66,9 @@ export function addFunctionComponentSourceLocationBabel() {
           return;
         }
         const filename = state.file.opts.filename;
-        addDebugInfo(path, name, filename, node.body.loc);
+        if (node.body.loc) {
+          addDebugInfo(path, name, filename, node.body.loc);
+        }
       }
     }
   };

--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -784,7 +784,13 @@ export const vaadinConfig: UserConfigFn = (env) => {
           presets: [['@babel/preset-react', { runtime: 'automatic', development: !productionMode }]],
           // React writes the source location for where components are used, this writes for where they are defined
           plugins: [
-            !productionMode && addFunctionComponentSourceLocationBabel()
+            !productionMode && addFunctionComponentSourceLocationBabel(),
+            [
+              'module:@preact/signals-react-transform',
+              {
+                mode: 'all' // Needed to include translations which do not use something.value
+              }
+            ]
           ].filter(Boolean)
         }
       }),

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -147,6 +147,7 @@ public class NodeUpdaterTest {
         expectedDependencies.add("@babel/preset-react");
         expectedDependencies.add("@types/react");
         expectedDependencies.add("@types/react-dom");
+        expectedDependencies.add("@preact/signals-react-transform");
 
         Set<String> actualDependendencies = defaultDeps.keySet();
 


### PR DESCRIPTION
This is to be able to remove usage of installAutoSignalTracking in Hilla, which will not work with React 19, as stated in https://github.com/preactjs/signals/issues/576
