### PR TITLE
feat: refresh browser using dev-tools connection

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -274,6 +274,8 @@ public class UI extends Component
                     this::leaveNavigation);
             getEventBus().addListener(BrowserNavigateEvent.class,
                     this::browserNavigate);
+            getEventBus().addListener(BrowserRefreshEvent.class,
+                    this::browserRefresh);
 
         }
 
@@ -1257,6 +1259,10 @@ public class UI extends Component
         getInternals().refreshCurrentRoute(refreshRouteChain);
     }
 
+    private void browserRefresh(BrowserRefreshEvent event) {
+        refreshCurrentRoute(event.refreshRouteChain);
+    }
+
     /**
      * Returns true if this UI instance supports navigation.
      *
@@ -1769,6 +1775,19 @@ public class UI extends Component
             this.trigger = trigger;
         }
 
+    }
+
+    @DomEvent(BrowserRefreshEvent.EVENT_NAME)
+    public static class BrowserRefreshEvent extends ComponentEvent<UI> {
+        public static final String EVENT_NAME = "ui-refresh";
+
+        private final boolean refreshRouteChain;
+
+        public BrowserRefreshEvent(UI source, boolean fromClient,
+                @EventData("fullRefresh") boolean refreshRouteChain) {
+            super(source, true);
+            this.refreshRouteChain = refreshRouteChain;
+        }
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -1778,12 +1778,36 @@ public class UI extends Component
 
     }
 
+    /**
+     * Event fired by the client to request a refresh of the user interface, by
+     * re-navigating to the current route.
+     * <p>
+     * </p>
+     * The route target component is re-instantiated, as well as all layouts in
+     * the route chain if the {@code fullRefresh} event flag is active.
+     *
+     * @see #refreshCurrentRoute(boolean)
+     */
     @DomEvent(BrowserRefreshEvent.EVENT_NAME)
     public static class BrowserRefreshEvent extends ComponentEvent<UI> {
         public static final String EVENT_NAME = "ui-refresh";
 
         private final boolean refreshRouteChain;
 
+        /**
+         * Creates a new event instance.
+         *
+         * @param source
+         *            the UI for which the refresh is requested.
+         * @param fromClient
+         *            <code>true</code> if the event originated from the client
+         *            side, <code>false</code> otherwise. NOTE: for technical
+         *            reason the argument must be added to the constructor, but
+         *            this event the value is always true.
+         * @param refreshRouteChain
+         *            {@code true} to refresh all layouts in the route chain,
+         *            {@code false} to only refresh the route instance
+         */
         public BrowserRefreshEvent(UI source, boolean fromClient,
                 @EventData("fullRefresh") boolean refreshRouteChain) {
             super(source, true);

--- a/flow-server/src/main/java/com/vaadin/flow/hotswap/Hotswapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/hotswap/Hotswapper.java
@@ -219,12 +219,7 @@ public class Hotswapper implements ServiceDestroyListener, SessionInitListener,
         }
         EnumMap<UIRefreshStrategy, List<UI>> refreshActions = computeRefreshStrategies(
                 vaadinSessions, classes);
-        // forceBrowserReload |= refreshActions
-        // .containsKey(UIRefreshStrategy.RELOAD);
         boolean uiTreeNeedsRefresh = !refreshActions.isEmpty();
-        // .containsKey(UIRefreshStrategy.PUSH_REFRESH_CHAIN)
-        // || refreshActions
-        // .containsKey(UIRefreshStrategy.PUSH_REFRESH_ROUTE);
         if (forceBrowserReload || uiTreeNeedsRefresh) {
             triggerClientUpdate(refreshActions, forceBrowserReload);
         }
@@ -313,7 +308,7 @@ public class Hotswapper implements ServiceDestroyListener, SessionInitListener,
                     changedClasses, targetsChain, route);
         }
 
-        // If push is not enabled we can only request a full page reload
+        // If push is not enabled we can only request a full page refresh
         if (refreshStrategy != UIRefreshStrategy.SKIP && !pushEnabled) {
             refreshStrategy = UIRefreshStrategy.REFRESH;
         }
@@ -365,8 +360,8 @@ public class Hotswapper implements ServiceDestroyListener, SessionInitListener,
 
         // If some UI has push not enabled, BrowserLiveReload should be used to
         // trigger a client update. However, BrowserLiveReload broadcasts the
-        // reload request to all active client connection, making calls to
-        // UI.refreshCurrentRoute() useless.
+        // reload/refresh request to all active client connection, making calls
+        // to UI.refreshCurrentRoute() useless.
         if (forceReload || refreshRequested) {
             if (liveReload == null) {
                 LOGGER.debug(

--- a/flow-server/src/main/java/com/vaadin/flow/hotswap/Hotswapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/hotswap/Hotswapper.java
@@ -219,11 +219,12 @@ public class Hotswapper implements ServiceDestroyListener, SessionInitListener,
         }
         EnumMap<UIRefreshStrategy, List<UI>> refreshActions = computeRefreshStrategies(
                 vaadinSessions, classes);
-        forceBrowserReload |= refreshActions
-                .containsKey(UIRefreshStrategy.RELOAD);
-        boolean uiTreeNeedsRefresh = refreshActions
-                .containsKey(UIRefreshStrategy.REFRESH_CHAIN)
-                || refreshActions.containsKey(UIRefreshStrategy.REFRESH_ROUTE);
+        // forceBrowserReload |= refreshActions
+        // .containsKey(UIRefreshStrategy.RELOAD);
+        boolean uiTreeNeedsRefresh = !refreshActions.isEmpty();
+        // .containsKey(UIRefreshStrategy.PUSH_REFRESH_CHAIN)
+        // || refreshActions
+        // .containsKey(UIRefreshStrategy.PUSH_REFRESH_ROUTE);
         if (forceBrowserReload || uiTreeNeedsRefresh) {
             triggerClientUpdate(refreshActions, forceBrowserReload);
         }
@@ -239,13 +240,17 @@ public class Hotswapper implements ServiceDestroyListener, SessionInitListener,
          */
         RELOAD,
         /**
-         * Refresh only route instance.
+         * Refresh UI without a page reload.
          */
-        REFRESH_ROUTE,
+        REFRESH,
         /**
-         * Refresh all layouts in the route chain.
+         * Refresh only route instance via UI PUSH connection.
          */
-        REFRESH_CHAIN,
+        PUSH_REFRESH_ROUTE,
+        /**
+         * Refresh all layouts in the route chain via UI PUSH connection.
+         */
+        PUSH_REFRESH_CHAIN,
         /**
          * Refresh not needed.
          */
@@ -298,8 +303,8 @@ public class Hotswapper implements ServiceDestroyListener, SessionInitListener,
         if (!targetChainChangedItems.isEmpty()) {
             refreshStrategy = targetChainChangedItems.stream()
                     .allMatch(chainItem -> chainItem == route)
-                            ? UIRefreshStrategy.REFRESH_ROUTE
-                            : UIRefreshStrategy.REFRESH_CHAIN;
+                            ? UIRefreshStrategy.PUSH_REFRESH_ROUTE
+                            : UIRefreshStrategy.PUSH_REFRESH_CHAIN;
         } else {
             // Look into the UI tree to find if any component is instance of
             // a changed class. If so, detect its parent route or layout to
@@ -310,7 +315,7 @@ public class Hotswapper implements ServiceDestroyListener, SessionInitListener,
 
         // If push is not enabled we can only request a full page reload
         if (refreshStrategy != UIRefreshStrategy.SKIP && !pushEnabled) {
-            refreshStrategy = UIRefreshStrategy.RELOAD;
+            refreshStrategy = UIRefreshStrategy.REFRESH;
         }
         return refreshStrategy;
     }
@@ -336,10 +341,10 @@ public class Hotswapper implements ServiceDestroyListener, SessionInitListener,
                     if (!targetsChain.contains(parent)) {
                         parent = parent.getParent().orElse(null);
                     } else if (parent == route) {
-                        refreshStrategy = UIRefreshStrategy.REFRESH_ROUTE;
+                        refreshStrategy = UIRefreshStrategy.PUSH_REFRESH_ROUTE;
                         parent = null;
                     } else {
-                        refreshStrategy = UIRefreshStrategy.REFRESH_CHAIN;
+                        refreshStrategy = UIRefreshStrategy.PUSH_REFRESH_CHAIN;
                         parent = null;
                         stack.clear();
                     }
@@ -355,19 +360,26 @@ public class Hotswapper implements ServiceDestroyListener, SessionInitListener,
             EnumMap<UIRefreshStrategy, List<UI>> uisToRefresh,
             boolean forceReload) {
 
-        // If some UI has push not enabled, BrowserLiveReload should be used
-        // to trigger a client update. However, BrowserLiveReload broadcasts
-        // the reload request to all active client connection, making calls to
+        boolean refreshRequested = uisToRefresh
+                .containsKey(UIRefreshStrategy.REFRESH);
+
+        // If some UI has push not enabled, BrowserLiveReload should be used to
+        // trigger a client update. However, BrowserLiveReload broadcasts the
+        // reload request to all active client connection, making calls to
         // UI.refreshCurrentRoute() useless.
-        if (forceReload) {
-            if (liveReload != null) {
-                LOGGER.debug(
-                        "Triggering browser live reload triggered because of classes changes");
-                liveReload.reload();
-            } else {
+        if (forceReload || refreshRequested) {
+            if (liveReload == null) {
                 LOGGER.debug(
                         "A change to one or more classes requires a browser page reload, but BrowserLiveReload is not available. "
                                 + "Please reload the browser page manually to make changes effective.");
+            } else if (forceReload) {
+                LOGGER.debug(
+                        "Triggering browser live reload because of classes changes");
+                liveReload.reload();
+            } else {
+                LOGGER.debug(
+                        "Triggering browser live refresh because of classes changes");
+                liveReload.refresh(true);
             }
         } else {
             LOGGER.debug(
@@ -375,7 +387,7 @@ public class Hotswapper implements ServiceDestroyListener, SessionInitListener,
             for (UIRefreshStrategy action : uisToRefresh.keySet()) {
                 uisToRefresh.get(action)
                         .forEach(ui -> ui.access(() -> ui.refreshCurrentRoute(
-                                action == UIRefreshStrategy.REFRESH_CHAIN)));
+                                action == UIRefreshStrategy.PUSH_REFRESH_CHAIN)));
             }
         }
     }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReload.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReload.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.internal;
 
 import org.atmosphere.cpr.AtmosphereResource;
 
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.server.communication.FragmentedMessageHolder;
 
 /**
@@ -83,6 +84,18 @@ public interface BrowserLiveReload extends FragmentedMessageHolder {
      * {@link #onConnect(AtmosphereResource)} call.
      */
     void reload();
+
+    /**
+     * Requests a refresh of the current view in the browser, without reloading
+     * the whole page.
+     *
+     * @param refreshLayouts
+     *            {@code true} to refresh all layouts in the route chain,
+     *            {@code false} to only refresh the route component
+     */
+    default void refresh(boolean refreshLayouts) {
+        reload();
+    }
 
     /**
      * Request an update of the resource with the given path.

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ElementListenerMap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ElementListenerMap.java
@@ -42,6 +42,7 @@ import com.vaadin.flow.internal.ConstantPoolKey;
 import com.vaadin.flow.internal.JsonUtils;
 import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.shared.JsonConstants;
+
 import elemental.json.Json;
 import elemental.json.JsonObject;
 import elemental.json.JsonValue;
@@ -441,7 +442,8 @@ public class ElementListenerMap extends NodeMap {
         final boolean isNavigationRequest = UI.BrowserNavigateEvent.EVENT_NAME
                 .equals(event.getType())
                 || UI.BrowserLeaveNavigationEvent.EVENT_NAME
-                        .equals(event.getType());
+                        .equals(event.getType())
+                || UI.BrowserRefreshEvent.EVENT_NAME.equals(event.getType());
 
         final boolean inert = event.getSource().getNode().isInert();
 

--- a/flow-server/src/test/java/com/vaadin/flow/hotswap/HotswapperTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/hotswap/HotswapperTest.java
@@ -263,7 +263,7 @@ public class HotswapperTest {
         hotswapper.onHotswap(new String[] { MyRoute.class.getName() }, true);
 
         ui.assertNotRefreshed();
-        Mockito.verify(liveReload).reload();
+        Mockito.verify(liveReload).refresh(anyBoolean());
     }
 
     @Test
@@ -277,7 +277,7 @@ public class HotswapperTest {
         hotswapper.onHotswap(new String[] { MyLayout.class.getName() }, true);
 
         ui.assertNotRefreshed();
-        Mockito.verify(liveReload).reload();
+        Mockito.verify(liveReload).refresh(anyBoolean());
     }
 
     @Test
@@ -292,7 +292,7 @@ public class HotswapperTest {
                 true);
 
         ui.assertNotRefreshed();
-        Mockito.verify(liveReload).reload();
+        Mockito.verify(liveReload).refresh(anyBoolean());
     }
 
     @Test
@@ -307,7 +307,7 @@ public class HotswapperTest {
                 true);
 
         ui.assertNotRefreshed();
-        Mockito.verify(liveReload).reload();
+        Mockito.verify(liveReload).refresh(anyBoolean());
     }
 
     @Test
@@ -322,7 +322,7 @@ public class HotswapperTest {
                 MyLayout.class.getName() }, true);
 
         ui.assertNotRefreshed();
-        Mockito.verify(liveReload).reload();
+        Mockito.verify(liveReload).refresh(anyBoolean());
     }
 
     @Test
@@ -337,7 +337,7 @@ public class HotswapperTest {
                 true);
 
         ui.assertNotRefreshed();
-        Mockito.verify(liveReload).reload();
+        Mockito.verify(liveReload).refresh(anyBoolean());
     }
 
     @Test
@@ -352,6 +352,7 @@ public class HotswapperTest {
 
         ui.assertNotRefreshed();
         Mockito.verify(liveReload, never()).reload();
+        Mockito.verify(liveReload, never()).refresh(anyBoolean());
     }
 
     @Test
@@ -367,6 +368,7 @@ public class HotswapperTest {
 
         ui.assertRouteRefreshed();
         Mockito.verify(liveReload, never()).reload();
+        Mockito.verify(liveReload, never()).refresh(anyBoolean());
     }
 
     @Test
@@ -383,6 +385,7 @@ public class HotswapperTest {
 
         ui.assertChainRefreshed();
         Mockito.verify(liveReload, never()).reload();
+        Mockito.verify(liveReload, never()).refresh(anyBoolean());
     }
 
     @Test
@@ -400,6 +403,7 @@ public class HotswapperTest {
 
         ui.assertRouteRefreshed();
         Mockito.verify(liveReload, never()).reload();
+        Mockito.verify(liveReload, never()).refresh(anyBoolean());
     }
 
     @Test
@@ -417,6 +421,7 @@ public class HotswapperTest {
 
         ui.assertChainRefreshed();
         Mockito.verify(liveReload, never()).reload();
+        Mockito.verify(liveReload, never()).refresh(anyBoolean());
     }
 
     @Test
@@ -434,6 +439,7 @@ public class HotswapperTest {
 
         ui.assertChainRefreshed();
         Mockito.verify(liveReload, never()).reload();
+        Mockito.verify(liveReload, never()).refresh(anyBoolean());
     }
 
     @Test
@@ -451,6 +457,7 @@ public class HotswapperTest {
 
         ui.assertChainRefreshed();
         Mockito.verify(liveReload, never()).reload();
+        Mockito.verify(liveReload, never()).refresh(anyBoolean());
     }
 
     @Test
@@ -467,6 +474,7 @@ public class HotswapperTest {
 
         ui.assertNotRefreshed();
         Mockito.verify(liveReload, never()).reload();
+        Mockito.verify(liveReload, never()).refresh(anyBoolean());
     }
 
     @Test
@@ -488,7 +496,7 @@ public class HotswapperTest {
 
         pushUI.assertNotRefreshed();
         notPushUI.assertNotRefreshed();
-        Mockito.verify(liveReload).reload();
+        Mockito.verify(liveReload).refresh(anyBoolean());
     }
 
     @Test

--- a/vaadin-dev-server/src/main/frontend/live-reload-connection.ts
+++ b/vaadin-dev-server/src/main/frontend/live-reload-connection.ts
@@ -22,7 +22,7 @@ export class LiveReloadConnection extends Connection {
     }, Connection.HEARTBEAT_INTERVAL);
   }
 
-  onReload() {
+  onReload(_strategy: string) {
     // Intentionally empty
   }
 
@@ -40,7 +40,8 @@ export class LiveReloadConnection extends Connection {
       this.onHandshake();
     } else if (json.command === 'reload') {
       if (this.status === ConnectionStatus.ACTIVE) {
-        this.onReload();
+        const strategy = json.strategy || 'reload'
+        this.onReload(strategy);
       }
     } else {
       this.handleError(`Unknown message from the livereload server: ${msg}`);

--- a/vaadin-dev-server/src/main/frontend/vaadin-dev-tools.ts
+++ b/vaadin-dev-server/src/main/frontend/vaadin-dev-tools.ts
@@ -656,13 +656,27 @@ export class VaadinDevTools extends LitElement {
       return;
     }
     const onConnectionError = (msg: string) => console.error(msg);
-    const onReload = () => {
-      this.showSplashMessage('Reloading…');
-      const lastReload = window.sessionStorage.getItem(VaadinDevTools.TRIGGERED_COUNT_KEY_IN_SESSION_STORAGE);
-      const nextReload = lastReload ? parseInt(lastReload, 10) + 1 : 1;
-      window.sessionStorage.setItem(VaadinDevTools.TRIGGERED_COUNT_KEY_IN_SESSION_STORAGE, nextReload.toString());
-      window.sessionStorage.setItem(VaadinDevTools.TRIGGERED_KEY_IN_SESSION_STORAGE, 'true');
-      window.location.reload();
+    const onReload = (strategy: string = 'reload') => {
+      if (strategy === 'refresh' || strategy === 'full-refresh') {
+        const anyVaadin = window.Vaadin as any;
+        // TODO: do it in Flow client. Maybe raise a custom vaadin-refresh-ui event
+        //  and handle it in Flow client?
+        Object.keys(anyVaadin.Flow.clients)
+            .filter((key) => key !== 'TypeScript')
+            .map((id) => anyVaadin.Flow.clients[id])
+            .forEach((client) => {
+              client.sendEventMessage(1, "ui-refresh", {
+                fullRefresh: strategy === 'full-refresh'
+              })
+            });
+      } else {
+        this.showSplashMessage('Reloading…');
+        const lastReload = window.sessionStorage.getItem(VaadinDevTools.TRIGGERED_COUNT_KEY_IN_SESSION_STORAGE);
+        const nextReload = lastReload ? parseInt(lastReload, 10) + 1 : 1;
+        window.sessionStorage.setItem(VaadinDevTools.TRIGGERED_COUNT_KEY_IN_SESSION_STORAGE, nextReload.toString());
+        window.sessionStorage.setItem(VaadinDevTools.TRIGGERED_KEY_IN_SESSION_STORAGE, 'true');
+        window.location.reload();
+      }
     };
     const onUpdate = (path: string, content: string) => {
       let styleTag = document.head.querySelector(`style[data-file-path='${path}']`);

--- a/vaadin-dev-server/src/main/frontend/websocket-connection.ts
+++ b/vaadin-dev-server/src/main/frontend/websocket-connection.ts
@@ -57,7 +57,7 @@ export class WebSocketConnection extends Connection {
     });
   }
 
-  onReload() {
+  onReload(_strategy: string) {
     // Intentionally empty
   }
 
@@ -81,7 +81,8 @@ export class WebSocketConnection extends Connection {
       this.onHandshake();
     } else if (json.command === 'reload') {
       if (this.status === ConnectionStatus.ACTIVE) {
-        this.onReload();
+        const strategy = json.strategy || 'reload'
+        this.onReload(strategy);
       }
     } else if (json.command === 'update') {
       if (this.status === ConnectionStatus.ACTIVE) {

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DebugWindowConnection.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DebugWindowConnection.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.base.devserver.stats.DevModeUsageStatistics;
 import com.vaadin.experimental.FeatureFlags;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.internal.BrowserLiveReload;
 import com.vaadin.flow.server.DevToolsToken;
 import com.vaadin.flow.server.VaadinContext;
@@ -263,6 +264,14 @@ public class DebugWindowConnection implements BrowserLiveReload {
     public void reload() {
         JsonObject msg = Json.createObject();
         msg.put("command", "reload");
+        send(msg);
+    }
+
+    @Override
+    public void refresh(boolean refreshLayouts) {
+        JsonObject msg = Json.createObject();
+        msg.put("command", "reload");
+        msg.put("strategy", refreshLayouts ? "full-refresh" : "refresh");
         send(msg);
     }
 


### PR DESCRIPTION
Uses the dev-tools web socket connection to refresh the UI when PUSH is not available, instead of forcing a page reload.
