### PR TITLE
fix: Pass route data through window.Vaadin.routesConfig instead of an import

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrap.java
@@ -76,6 +76,9 @@ public class TaskGenerateBootstrap extends AbstractTaskClientGenerator {
         List<String> lines = new ArrayList<>();
         lines.add(String.format("import './%s';%n", FEATURE_FLAGS_FILE_NAME));
         lines.add(String.format("import '%s';%n", getIndexTsEntryPath()));
+        if (options.isReactEnabled()) {
+            lines.add("import './vaadin-react.js';");
+        }
         if (!options.isProductionMode()) {
             lines.add(DEV_TOOLS_IMPORT);
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
@@ -103,7 +103,6 @@ public class TaskGenerateReactFiles
     private static final String REACT_ADAPTER_TSX = "ReactAdapter.tsx";
     static final String FLOW_FLOW_TSX = "flow/" + FLOW_TSX;
     static final String FLOW_REACT_ADAPTER_TSX = "flow/" + REACT_ADAPTER_TSX;
-    private static final String ROUTES_JS_IMPORT_PATH_TOKEN = "%routesJsImportPath%";
 
     // matches setting the server-side routes from Flow.tsx:
     // import { serverSideRoutes } from "Frontend/generated/flow/Flow";
@@ -152,7 +151,7 @@ public class TaskGenerateReactFiles
         File frontendGeneratedFolderRoutesTsx = new File(
                 frontendGeneratedFolder, FrontendUtils.ROUTES_TSX);
         try {
-            writeFile(flowTsx, getFlowTsxFileContent(routesTsx.exists()));
+            writeFile(flowTsx, getFileContent(FLOW_TSX));
             if (fileAvailable(REACT_ADAPTER_TEMPLATE)) {
                 String reactAdapterContent = getFileContent(
                         REACT_ADAPTER_TEMPLATE);
@@ -228,17 +227,6 @@ public class TaskGenerateReactFiles
             throw new ExecutionFailedException("Failed to clean up .tsx files",
                     e);
         }
-    }
-
-    private String getFlowTsxFileContent(boolean frontendRoutesTsExists)
-            throws IOException {
-        return getFileContent(FLOW_TSX).replace(ROUTES_JS_IMPORT_PATH_TOKEN,
-                (frontendRoutesTsExists)
-                        ? FrontendUtils.FRONTEND_FOLDER_ALIAS
-                                + FrontendUtils.ROUTES_JS
-                        : FrontendUtils.FRONTEND_FOLDER_ALIAS
-                                + FrontendUtils.GENERATED
-                                + FrontendUtils.ROUTES_JS);
     }
 
     private boolean fileAvailable(String fileName) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
@@ -224,7 +224,7 @@ public class TaskGenerateReactFiles
                     Files.copy(routesTsx.toPath(),
                             new File(frontendDirectory,
                                     FrontendUtils.ROUTES_TSX + ".flowBackup")
-                                            .toPath(),
+                                    .toPath(),
                             StandardCopyOption.REPLACE_EXISTING);
                     routesTsx.delete();
                     log().warn(

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
@@ -99,10 +99,12 @@ public class TaskGenerateReactFiles
             """;
 
     private static final String FLOW_TSX = "Flow.tsx";
+    private static final String VAADIN_REACT_TSX = "vaadin-react.tsx";
     private static final String REACT_ADAPTER_TEMPLATE = "ReactAdapter.template";
     private static final String REACT_ADAPTER_TSX = "ReactAdapter.tsx";
     static final String FLOW_FLOW_TSX = "flow/" + FLOW_TSX;
     static final String FLOW_REACT_ADAPTER_TSX = "flow/" + REACT_ADAPTER_TSX;
+    private static final String ROUTES_JS_IMPORT_PATH_TOKEN = "%routesJsImportPath%";
 
     // matches setting the server-side routes from Flow.tsx:
     // import { serverSideRoutes } from "Frontend/generated/flow/Flow";
@@ -145,6 +147,8 @@ public class TaskGenerateReactFiles
         File frontendDirectory = options.getFrontendDirectory();
         File frontendGeneratedFolder = options.getFrontendGeneratedFolder();
         File flowTsx = new File(frontendGeneratedFolder, FLOW_FLOW_TSX);
+        File vaadinReactTsx = new File(frontendGeneratedFolder,
+                VAADIN_REACT_TSX);
         File reactAdapterTsx = new File(frontendGeneratedFolder,
                 FLOW_REACT_ADAPTER_TSX);
         File routesTsx = new File(frontendDirectory, FrontendUtils.ROUTES_TSX);
@@ -152,6 +156,8 @@ public class TaskGenerateReactFiles
                 frontendGeneratedFolder, FrontendUtils.ROUTES_TSX);
         try {
             writeFile(flowTsx, getFileContent(FLOW_TSX));
+            writeFile(vaadinReactTsx,
+                    getVaadinReactTsContent(routesTsx.exists()));
             if (fileAvailable(REACT_ADAPTER_TEMPLATE)) {
                 String reactAdapterContent = getFileContent(
                         REACT_ADAPTER_TEMPLATE);
@@ -191,11 +197,14 @@ public class TaskGenerateReactFiles
             File frontendDirectory = options.getFrontendDirectory();
             File frontendGeneratedFolder = options.getFrontendGeneratedFolder();
             File flowTsx = new File(frontendGeneratedFolder, FLOW_FLOW_TSX);
+            File vaadinReactTsx = new File(frontendGeneratedFolder,
+                    VAADIN_REACT_TSX);
             File reactAdapterTsx = new File(frontendGeneratedFolder,
                     FLOW_REACT_ADAPTER_TSX);
             File frontendGeneratedFolderRoutesTsx = new File(
                     frontendGeneratedFolder, FrontendUtils.ROUTES_TSX);
             FileUtils.deleteQuietly(flowTsx);
+            FileUtils.deleteQuietly(vaadinReactTsx);
             FileUtils.deleteQuietly(reactAdapterTsx);
             FileUtils.deleteQuietly(frontendGeneratedFolderRoutesTsx);
 
@@ -215,7 +224,7 @@ public class TaskGenerateReactFiles
                     Files.copy(routesTsx.toPath(),
                             new File(frontendDirectory,
                                     FrontendUtils.ROUTES_TSX + ".flowBackup")
-                                    .toPath(),
+                                            .toPath(),
                             StandardCopyOption.REPLACE_EXISTING);
                     routesTsx.delete();
                     log().warn(
@@ -227,6 +236,18 @@ public class TaskGenerateReactFiles
             throw new ExecutionFailedException("Failed to clean up .tsx files",
                     e);
         }
+    }
+
+    private String getVaadinReactTsContent(boolean frontendRoutesTsExists)
+            throws IOException {
+        return getFileContent(VAADIN_REACT_TSX).replace(
+                ROUTES_JS_IMPORT_PATH_TOKEN,
+                (frontendRoutesTsExists)
+                        ? FrontendUtils.FRONTEND_FOLDER_ALIAS
+                                + FrontendUtils.ROUTES_JS
+                        : FrontendUtils.FRONTEND_FOLDER_ALIAS
+                                + FrontendUtils.GENERATED
+                                + FrontendUtils.ROUTES_JS);
     }
 
     private boolean fileAvailable(String fileName) {

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -237,7 +237,7 @@ function Flow() {
                 return;
             }
             const {pathname, search} = blocker.location;
-            const routes = (window as any)?.Vaadin?.routesConfig || [];
+            const routes = ((window as any)?.Vaadin?.routesConfig || []) as AgnosticRouteObject[];
             let matched = matchRoutes(Array.from(routes), window.location.pathname);
 
             // Navigation between server routes

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -21,6 +21,7 @@ import {
     useBlocker,
     useLocation,
     useNavigate,
+    AgnosticRouteObject
 } from "react-router-dom";
 
 const flow = new _Flow({

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -20,9 +20,9 @@ import {
     matchRoutes,
     useBlocker,
     useLocation,
-    useNavigate,
-    AgnosticRouteObject
+    useNavigate
 } from "react-router-dom";
+import type { AgnosticRouteObject } from '@remix-run/router';
 
 const flow = new _Flow({
     imports: () => import("Frontend/generated/flow/generated-flow-imports.js")

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -238,7 +238,7 @@ function Flow() {
             }
             const {pathname, search} = blocker.location;
             const routes = (window as any)?.Vaadin?.routesConfig || [];
-            let matched = matchRoutes(routes, window.location.pathname);
+            let matched = matchRoutes(Array.from(routes), window.location.pathname);
 
             // Navigation between server routes
             // @ts-ignore

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -15,14 +15,13 @@
  */
 /// <reference lib="es2018" />
 import { Flow as _Flow } from "Frontend/generated/jar-resources/Flow.js";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import {
     matchRoutes,
     useBlocker,
     useLocation,
     useNavigate,
 } from "react-router-dom";
-import { routes } from "%routesJsImportPath%";
 
 const flow = new _Flow({
     imports: () => import("Frontend/generated/flow/generated-flow-imports.js")
@@ -238,7 +237,8 @@ function Flow() {
                 return;
             }
             const {pathname, search} = blocker.location;
-            let matched = matchRoutes(Array.from(routes), window.location.pathname);
+            const routes = (window as any)?.Vaadin?.routesConfig || [];
+            let matched = matchRoutes(routes, window.location.pathname);
 
             // Navigation between server routes
             // @ts-ignore

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -370,3 +370,17 @@ export const reactElement = (tag: string, props?: Properties, onload?: () => voi
 };
 
 export default Flow;
+
+// @ts-ignore
+if (import.meta.hot) {
+  // @ts-ignore
+  import.meta.hot.accept((newModule) => {
+    // A hot module replace for Flow.tsx happens when any JS/TS imported through @JsModule
+    // or similar is updated because this updates generated-flow-imports.js and that in turn
+    // is imported by this file. We have no means of hot replacing those files, e.g. some
+    // custom lit element so we need to reload the page. */
+    if (newModule) {
+      window.location.reload();
+    }
+  });
+}

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/routes-flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/routes-flow.tsx
@@ -16,7 +16,4 @@ function build() {
         routes
     };
 }
-export const { router, routes } = build();
-
-(window as any).Vaadin ??= {};
-(window as any).Vaadin.routesConfig = routes;
+export const { router, routes } = build()

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/routes-flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/routes-flow.tsx
@@ -16,4 +16,7 @@ function build() {
         routes
     };
 }
-export const { router, routes } = build()
+export const { router, routes } = build();
+
+(window as any).Vaadin ??= {};
+(window as any).Vaadin.routesConfig = routes;

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/vaadin-react.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/vaadin-react.tsx
@@ -1,0 +1,4 @@
+import { routes } from "%routesJsImportPath%";
+
+(window as any).Vaadin ??= {};
+(window as any).Vaadin.routesConfig = routes;


### PR DESCRIPTION
Instead of importing `routes.js/routes.ts/routes.tsx` from the project into `Flow.tsx` and creating a circular dependency, this moves importing of `routes.js` to a new file that is always included when react is used `vaadin-react.tsx`. This file publishes the routes as `window.Vaadin.routesConfig` so that `Flow.tsx` can read them from there without directly depending on `routes.js`

Fixes #19658
