### PR TITLE
refactor: Avoid duplicate invocations of Component:getUI

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/ValueContext.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/ValueContext.java
@@ -214,17 +214,17 @@ public class ValueContext implements Serializable {
     }
 
     private Locale findLocale(Component component) {
-        if (component != null && component.getUI().isPresent()) {
-            return component.getUI().get().getLocale();
+    	UI ui = null;
+        if (component != null) {
+            ui = component.getUI().orElseGet(UI::getCurrent);
+        } else {
+        	ui = UI.getCurrent();
         }
-        Locale locale = null;
-        if (UI.getCurrent() != null) {
-            locale = UI.getCurrent().getLocale();
+        if (ui != null) {
+            return ui.getLocale();
+        } else {
+            return Locale.getDefault();
         }
-        if (locale == null) {
-            locale = Locale.getDefault();
-        }
-        return locale;
     }
 
     /**

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/ValueContext.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/ValueContext.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.data.binder;
 
 import java.io.Serializable;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.Optional;
 
 import com.vaadin.flow.component.Component;
@@ -214,11 +213,11 @@ public class ValueContext implements Serializable {
     }
 
     private Locale findLocale(Component component) {
-    	UI ui = null;
+        UI ui = null;
         if (component != null) {
             ui = component.getUI().orElseGet(UI::getCurrent);
         } else {
-        	ui = UI.getCurrent();
+            ui = UI.getCurrent();
         }
         if (ui != null) {
             return ui.getLocale();

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractComponentDataGenerator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractComponentDataGenerator.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.data.provider;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
@@ -134,8 +135,9 @@ public abstract class AbstractComponentDataGenerator<T>
         if (owner instanceof StateTree) {
             containerUi = ((StateTree) owner).getUI();
         }
-        if (containerUi != null && component.getUI().isPresent()
-                && containerUi != component.getUI().get()) {
+        Optional<UI> componentUi = component.getUI();
+        if (containerUi != null && componentUi.isPresent()
+                && containerUi != componentUi.get()) {
             throw new IllegalStateException("The component '"
                     + component.getClass()
                     + "' is already attached to a UI instance which differs "

--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
@@ -223,11 +223,13 @@ public class ComponentUtil {
                     initialAttach);
         }
 
-        Optional<UI> ui = component.getUI();
-        if (ui.isPresent() && component instanceof LocaleChangeObserver) {
-            LocaleChangeEvent localeChangeEvent = new LocaleChangeEvent(
-                    ui.get(), ui.get().getLocale());
-            ((LocaleChangeObserver) component).localeChange(localeChangeEvent);
+        if (component instanceof LocaleChangeObserver) {
+          Optional<UI> ui = component.getUI();
+          if (ui.isPresent()) {
+              LocaleChangeEvent localeChangeEvent = new LocaleChangeEvent(
+                      ui.get(), ui.get().getLocale());
+              ((LocaleChangeObserver) component).localeChange(localeChangeEvent);
+          }
         }
 
         AttachEvent attachEvent = new AttachEvent(component, initialAttach);

--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
@@ -224,12 +224,10 @@ public class ComponentUtil {
         }
 
         if (component instanceof LocaleChangeObserver) {
-          Optional<UI> ui = component.getUI();
-          if (ui.isPresent()) {
-              LocaleChangeEvent localeChangeEvent = new LocaleChangeEvent(
-                      ui.get(), ui.get().getLocale());
-              ((LocaleChangeObserver) component).localeChange(localeChangeEvent);
-          }
+            component.getUI()
+                    .ifPresent(ui -> ((LocaleChangeObserver) component)
+                            .localeChange(
+                                    new LocaleChangeEvent(ui, ui.getLocale())));
         }
 
         AttachEvent attachEvent = new AttachEvent(component, initialAttach);

--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
@@ -224,10 +224,8 @@ public class ComponentUtil {
         }
 
         if (component instanceof LocaleChangeObserver) {
-            component.getUI()
-                    .ifPresent(ui -> ((LocaleChangeObserver) component)
-                            .localeChange(
-                                    new LocaleChangeEvent(ui, ui.getLocale())));
+            component.getUI().ifPresent(ui -> ((LocaleChangeObserver) component)
+                    .localeChange(new LocaleChangeEvent(ui, ui.getLocale())));
         }
 
         AttachEvent attachEvent = new AttachEvent(component, initialAttach);

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -117,8 +117,8 @@ public class ShortcutRegistration implements Registration, Serializable {
              * initialization immediately.
              */
             for (Component component : listenOnComponents) {
-                if (component.getUI().isPresent()
-                        && component.getUI().get().isClosing()) {
+            	Optional<UI> ui = component.getUI();
+                if (ui.isPresent() && ui.get().isClosing()) {
                     reinit = true;
                     break;
                 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -117,8 +117,7 @@ public class ShortcutRegistration implements Registration, Serializable {
              * initialization immediately.
              */
             for (Component component : listenOnComponents) {
-                Optional<UI> ui = component.getUI();
-                if (ui.isPresent() && ui.get().isClosing()) {
+                if (component.getUI().map(UI::isClosing).orElse(false)) {
                     reinit = true;
                     break;
                 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -117,7 +117,7 @@ public class ShortcutRegistration implements Registration, Serializable {
              * initialization immediately.
              */
             for (Component component : listenOnComponents) {
-            	Optional<UI> ui = component.getUI();
+                Optional<UI> ui = component.getUI();
                 if (ui.isPresent() && ui.get().isClosing()) {
                     reinit = true;
                     break;

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -1346,7 +1346,8 @@ public class UI extends Component
                     "The 'execution' parameter may not be null");
         }
 
-        if (component.getUI().isPresent() && component.getUI().get() != this) {
+        Optional<UI> componentUi = component.getUI();
+        if (componentUi.isPresent() && componentUi.get() != this) {
             throw new IllegalArgumentException(
                     "The given component doesn't belong to the UI the task to be executed on");
         }


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Component.getUI() is potentially expensive operation, especially in complex UIs with deep component tree, since it traverses up to the root component. (Identified by profiling large application).

Do not unnecessarily invoke it multiple times like getUI().isPresent() + getUI().get(), but rather use local variable to avoid repeated component tree traversals.

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
