### PR TITLE
fix: update browser URL on preserve on refresh navigation

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -38,7 +38,6 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.page.ExtendedClientDetails;
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.Element;
-import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.Pair;
 import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.internal.UsageStatistics;
@@ -68,7 +67,6 @@ import com.vaadin.flow.router.Router;
 import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.HttpStatusCode;
-import com.vaadin.flow.server.Mode;
 import com.vaadin.flow.server.VaadinSession;
 
 /**
@@ -300,7 +298,8 @@ public abstract class AbstractNavigationStateRenderer
     }
 
     protected boolean shouldPushHistoryState(NavigationEvent event) {
-        return NavigationTrigger.UI_NAVIGATE.equals(event.getTrigger());
+        return NavigationTrigger.UI_NAVIGATE.equals(event.getTrigger())
+                || NavigationTrigger.REFRESH.equals(event.getTrigger());
     }
 
     private boolean isRouterLinkNotFoundNavigationError(

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PreserveOnRefreshNavigationView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PreserveOnRefreshNavigationView.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.ElementFactory;
+import com.vaadin.flow.router.PreserveOnRefresh;
+import com.vaadin.flow.router.QueryParameters;
+import com.vaadin.flow.router.Route;
+
+@Route(value = PreserveOnRefreshNavigationView.VIEW_PATH)
+@PreserveOnRefresh
+public class PreserveOnRefreshNavigationView extends Div {
+
+    static final String VIEW_PATH = "com.vaadin.flow.uitest.ui.PreserveOnRefreshNavigationView";
+
+    public PreserveOnRefreshNavigationView() {
+        add(createNavigationButton("one"));
+        add(createNavigationButton("two"));
+        add(createNavigationButton("three"));
+
+        getElement().appendChild(createRouterLink("one"),
+                createRouterLink("two"), createRouterLink("three"));
+    }
+
+    private NativeButton createNavigationButton(String param) {
+        NativeButton button = new NativeButton("navigate to " + param,
+                ev -> selfNavigate(param));
+        button.setId("button-" + param);
+        return button;
+    }
+
+    private void selfNavigate(String param) {
+        UI.getCurrent().navigate(PreserveOnRefreshNavigationView.class,
+                QueryParameters.of("param", param));
+    }
+
+    private Element createRouterLink(String param) {
+        Element routerLink = ElementFactory.createRouterLink(
+                VIEW_PATH + "?param=" + param, "link to " + param);
+        routerLink.setAttribute("id", "link-" + param);
+        return routerLink;
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PreserveOnRefreshNavigationIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PreserveOnRefreshNavigationIT.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+import com.vaadin.testbench.TestBenchElement;
+
+public class PreserveOnRefreshNavigationIT extends ChromeBrowserTest {
+
+    @Test
+    public void routerLink_selfNavigationWithQueryParams_urlChanges() {
+        open();
+        $(TestBenchElement.class).id("link-one").click();
+        Assert.assertTrue(driver.getCurrentUrl().contains("?param=one"));
+        $(TestBenchElement.class).id("link-two").click();
+        Assert.assertTrue(driver.getCurrentUrl().contains("?param=two"));
+        $(TestBenchElement.class).id("link-three").click();
+        Assert.assertTrue(driver.getCurrentUrl().contains("?param=three"));
+    }
+
+    @Test
+    public void programmaticNavigation_selfNavigationWithQueryParams_urlChanges() {
+        open();
+        $(TestBenchElement.class).id("button-one").click();
+        Assert.assertTrue(driver.getCurrentUrl().contains("?param=one"));
+        $(TestBenchElement.class).id("button-two").click();
+        Assert.assertTrue(driver.getCurrentUrl().contains("?param=two"));
+        $(TestBenchElement.class).id("button-three").click();
+        Assert.assertTrue(driver.getCurrentUrl().contains("?param=three"));
+    }
+
+}


### PR DESCRIPTION
## Description

Programmatic self navigation with query parameters on view with preserve on refresh do not update the URL in the browser.
This change fixes the regression introduced by #15331, updating push history also for navigation events with trigger REFRESH.

Fixes #19701

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
