### PR TITLE
chore: log class causing failure in frontend dependency scan

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScanner.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScanner.java
@@ -111,7 +111,17 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
         super(finder, featureFlags);
 
         long start = System.currentTimeMillis();
-        this.annotationFinder = annotationFinder;
+        // Wraps the finder function to provide debugging information in case of
+        // failures
+        this.annotationFinder = (clazz, loadedAnnotation) -> {
+            try {
+                return annotationFinder.apply(clazz, loadedAnnotation);
+            } catch (RuntimeException exception) {
+                getLogger().error("Could not read {} annotation from class {}.",
+                        loadedAnnotation.getName(), clazz.getName(), exception);
+                throw exception;
+            }
+        };
 
         try {
             abstractTheme = finder.loadClass(AbstractTheme.class.getName());


### PR DESCRIPTION
Wraps the annotation finder function to log potential errors during class scanning and the class that originates the failure.

References #19616
