### PR TITLE
fix: do not block navigation to current url

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -233,10 +233,6 @@ function Flow() {
 
     useEffect(() => {
         if (blocker.state === 'blocked') {
-            if(navigated.current) {
-                blocker.proceed();
-                return;
-            }
             const {pathname, search} = blocker.location;
             const routes = ((window as any)?.Vaadin?.routesConfig || []) as AgnosticRouteObject[];
             let matched = matchRoutes(Array.from(routes), window.location.pathname);

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -184,6 +184,8 @@ function Flow() {
         }
 
         navigated.current = false;
+        // When navigation is triggered by click on a link, fromAnchor is set to true
+        // in order to get a server round-trip even when navigating to the same URL again
         fromAnchor.current = true;
         navigate(path);
     }, [navigate]);
@@ -234,6 +236,7 @@ function Flow() {
 
     useEffect(() => {
         if (blocker.state === 'blocked') {
+            // Do not skip server round-trip if navigation originates from a click on a link
             if (navigated.current && !fromAnchor.current) {
                 blocker.proceed();
                 return;

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -170,7 +170,7 @@ function Flow() {
     });
     const {pathname, search, hash} = useLocation();
     const navigated = useRef<boolean>(false);
-
+    const fromAnchor = useRef<boolean>(false);
     const containerRef = useRef<RouterContainer | undefined>(undefined);
 
     const navigateEventHandler = useCallback((event: MouseEvent) => {
@@ -184,6 +184,7 @@ function Flow() {
         }
 
         navigated.current = false;
+        fromAnchor.current = true;
         navigate(path);
     }, [navigate]);
 
@@ -233,6 +234,11 @@ function Flow() {
 
     useEffect(() => {
         if (blocker.state === 'blocked') {
+            if (navigated.current && !fromAnchor.current) {
+                fromAnchor.current = false;
+                blocker.proceed();
+                return;
+            }
             const {pathname, search} = blocker.location;
             const routes = ((window as any)?.Vaadin?.routesConfig || []) as AgnosticRouteObject[];
             let matched = matchRoutes(Array.from(routes), window.location.pathname);
@@ -280,7 +286,7 @@ function Flow() {
     }, [blocker.state, blocker.location]);
 
     useEffect(() => {
-        if(navigated.current) {
+        if (navigated.current) {
             navigated.current = false;
             fireNavigated(pathname,search);
             return;

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -235,10 +235,10 @@ function Flow() {
     useEffect(() => {
         if (blocker.state === 'blocked') {
             if (navigated.current && !fromAnchor.current) {
-                fromAnchor.current = false;
                 blocker.proceed();
                 return;
             }
+            fromAnchor.current = false;
             const {pathname, search} = blocker.location;
             const routes = ((window as any)?.Vaadin?.routesConfig || []) as AgnosticRouteObject[];
             let matched = matchRoutes(Array.from(routes), window.location.pathname);

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/NavigationEventsView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/NavigationEventsView.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.html.Anchor;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.router.AfterNavigationEvent;
+import com.vaadin.flow.router.AfterNavigationObserver;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.BeforeEnterObserver;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouterLink;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+@Route(value = "com.vaadin.flow.uitest.ui.NavigationEventsView", layout = ViewTestLayout.class)
+public class NavigationEventsView extends Div
+        implements BeforeEnterObserver, AfterNavigationObserver {
+
+    private final Element messages = new Element("div");
+
+    public NavigationEventsView() {
+        messages.setAttribute("id", "messages");
+        getElement().appendChild(messages);
+
+        RouterLink routerLink = new RouterLink("RouterLink to self",
+                NavigationEventsView.class);
+        routerLink.setId("router-link");
+        Anchor anchor = new Anchor(
+                "http://localhost:8888/view/com.vaadin.flow.uitest.ui.NavigationEventsView",
+                "Anchor to self");
+        anchor.setId("anchor");
+        add(routerLink, anchor);
+    }
+
+    @Override
+    public void beforeEnter(BeforeEnterEvent event) {
+        addMessage("BeforeEnterEvent");
+    }
+
+    @Override
+    public void afterNavigation(AfterNavigationEvent afterNavigationEvent) {
+        addMessage("AfterNavigationEvent");
+    }
+
+    private void addMessage(String message) {
+        Element element = new Element("div");
+        element.setText(message);
+        messages.appendChild(element);
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/NavigationEventsView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/NavigationEventsView.java
@@ -41,9 +41,10 @@ public class NavigationEventsView extends Div
                 NavigationEventsView.class);
         routerLink.setId("router-link");
         Anchor anchor = new Anchor(
-                "http://localhost:8888/view/com.vaadin.flow.uitest.ui.NavigationEventsView",
+                "/view/com.vaadin.flow.uitest.ui.NavigationEventsView",
                 "Anchor to self");
         anchor.setId("anchor");
+
         add(routerLink, anchor);
     }
 

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/NavigationEventsView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/NavigationEventsView.java
@@ -31,6 +31,9 @@ import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 public class NavigationEventsView extends Div
         implements BeforeEnterObserver, AfterNavigationObserver {
 
+    public static final String BEFORE_ENTER = "BeforeEnterEvent";
+    public static final String AFTER_NAVIGATION = "AfterNavigationEvent";
+
     private final Element messages = new Element("div");
 
     public NavigationEventsView() {
@@ -50,12 +53,12 @@ public class NavigationEventsView extends Div
 
     @Override
     public void beforeEnter(BeforeEnterEvent event) {
-        addMessage("BeforeEnterEvent");
+        addMessage(BEFORE_ENTER);
     }
 
     @Override
     public void afterNavigation(AfterNavigationEvent afterNavigationEvent) {
-        addMessage("AfterNavigationEvent");
+        addMessage(AFTER_NAVIGATION);
     }
 
     private void addMessage(String message) {

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/NavigationEventsIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/NavigationEventsIT.java
@@ -46,10 +46,13 @@ public class NavigationEventsIT extends ChromeBrowserTest {
 
     private void assertMessages(int expectedSize) {
         List<String> messages = getMessages();
-        Assert.assertEquals(expectedSize, messages.size());
-        Assert.assertEquals(NavigationEventsView.BEFORE_ENTER,
+        Assert.assertEquals("Unexpected amount of navigation events",
+                expectedSize, messages.size());
+        Assert.assertEquals("Second to last event should be BeforeEnter",
+                NavigationEventsView.BEFORE_ENTER,
                 messages.get(expectedSize - 2));
-        Assert.assertEquals(NavigationEventsView.AFTER_NAVIGATION,
+        Assert.assertEquals("Last event should be AfterNavigation",
+                NavigationEventsView.AFTER_NAVIGATION,
                 messages.get(expectedSize - 1));
 
     }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/NavigationEventsIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/NavigationEventsIT.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.component.html.testbench.AnchorElement;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class NavigationEventsIT extends ChromeBrowserTest {
+
+    @Test
+    public void assertNavigationToSelfProducesNavigationEvents() {
+        open();
+
+        assertMessages(0, "BeforeEnterEvent", "AfterNavigationEvent");
+
+        $(AnchorElement.class).id("router-link").click();
+        assertMessages(2, "BeforeEnterEvent", "AfterNavigationEvent");
+
+        $(AnchorElement.class).id("anchor").click();
+        assertMessages(4, "BeforeEnterEvent", "AfterNavigationEvent");
+    }
+
+    private void assertMessages(int skip, String... expectedTail) {
+        List<WebElement> messages = getMessages();
+        if (messages.size() < skip) {
+            Assert.fail("Cannot skip " + skip + " messages when there are only "
+                    + messages.size() + "messages. " + joinMessages(messages));
+        }
+
+        messages = messages.subList(skip, messages.size());
+
+        if (messages.size() < expectedTail.length) {
+            Assert.fail("Expected " + expectedTail.length
+                    + " messages, but there are only " + messages.size() + ". "
+                    + joinMessages(messages));
+        }
+
+        for (int i = 0; i < expectedTail.length; i++) {
+            Assert.assertEquals("Unexpected message at index " + i,
+                    expectedTail[i], messages.get(i).getText());
+        }
+
+        if (messages.size() > expectedTail.length) {
+            Assert.fail("There are unexpected messages at the end. "
+                    + joinMessages(messages.subList(expectedTail.length,
+                            messages.size())));
+        }
+    }
+
+    private static String joinMessages(List<WebElement> messages) {
+        return messages.stream().map(WebElement::getText)
+                .collect(Collectors.joining("\n", "\n", ""));
+    }
+
+    private List<WebElement> getMessages() {
+        WebElement messagesHolder = findElement(By.id("messages"));
+        List<WebElement> messages = messagesHolder
+                .findElements(By.cssSelector("div"));
+        return messages;
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/NavigationEventsIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/NavigationEventsIT.java
@@ -32,51 +32,31 @@ public class NavigationEventsIT extends ChromeBrowserTest {
     public void assertNavigationToSelfProducesNavigationEvents() {
         open();
 
-        assertMessages(0, "BeforeEnterEvent", "AfterNavigationEvent");
+        // Initially there should be one round of navigation events
+        assertMessages(2);
 
+        // RouterLink click should cause second set of events
         $(AnchorElement.class).id("router-link").click();
-        assertMessages(2, "BeforeEnterEvent", "AfterNavigationEvent");
+        assertMessages(4);
 
+        // Anchor click should cause third set of events
         $(AnchorElement.class).id("anchor").click();
-        assertMessages(4, "BeforeEnterEvent", "AfterNavigationEvent");
+        assertMessages(6);
     }
 
-    private void assertMessages(int skip, String... expectedTail) {
-        List<WebElement> messages = getMessages();
-        if (messages.size() < skip) {
-            Assert.fail("Cannot skip " + skip + " messages when there are only "
-                    + messages.size() + "messages. " + joinMessages(messages));
-        }
+    private void assertMessages(int expectedSize) {
+        List<String> messages = getMessages();
+        Assert.assertEquals(expectedSize, messages.size());
+        Assert.assertEquals(NavigationEventsView.BEFORE_ENTER,
+                messages.get(expectedSize - 2));
+        Assert.assertEquals(NavigationEventsView.AFTER_NAVIGATION,
+                messages.get(expectedSize - 1));
 
-        messages = messages.subList(skip, messages.size());
-
-        if (messages.size() < expectedTail.length) {
-            Assert.fail("Expected " + expectedTail.length
-                    + " messages, but there are only " + messages.size() + ". "
-                    + joinMessages(messages));
-        }
-
-        for (int i = 0; i < expectedTail.length; i++) {
-            Assert.assertEquals("Unexpected message at index " + i,
-                    expectedTail[i], messages.get(i).getText());
-        }
-
-        if (messages.size() > expectedTail.length) {
-            Assert.fail("There are unexpected messages at the end. "
-                    + joinMessages(messages.subList(expectedTail.length,
-                            messages.size())));
-        }
     }
 
-    private static String joinMessages(List<WebElement> messages) {
-        return messages.stream().map(WebElement::getText)
-                .collect(Collectors.joining("\n", "\n", ""));
-    }
-
-    private List<WebElement> getMessages() {
-        WebElement messagesHolder = findElement(By.id("messages"));
-        List<WebElement> messages = messagesHolder
-                .findElements(By.cssSelector("div"));
-        return messages;
+    private List<String> getMessages() {
+        return findElement(By.id("messages"))
+                .findElements(By.cssSelector("div")).stream()
+                .map(WebElement::getText).collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
Lets navigation cause server round-trip, when navigation is triggered by clicking a link.

Fixes https://github.com/vaadin/flow/issues/19635