### PR TITLE
feat: push and replace without navigation callback

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/page/History.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/History.java
@@ -194,7 +194,7 @@ public class History implements Serializable {
 
     /**
      * Invokes <code>history.pushState</code> in the browser with the given
-     * parameters.
+     * parameters. Does not make a callback to the server by default.
      *
      * @param state
      *            the JSON state to push to the history stack, or
@@ -281,7 +281,7 @@ public class History implements Serializable {
 
     /**
      * Invokes <code>history.replaceState</code> in the browser with the given
-     * parameters.
+     * parameters. Does not make a callback to the server by default.
      *
      * @param state
      *            the JSON state to push to the history stack, or
@@ -291,7 +291,7 @@ public class History implements Serializable {
      *            to only change the JSON state
      */
     public void replaceState(JsonValue state, Location location) {
-        replaceState(state, location, true);
+        replaceState(state, location, false);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/History.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/History.java
@@ -173,8 +173,8 @@ public class History implements Serializable {
     /**
      * Invokes <code>history.pushState</code> in the browser with the given
      * parameters. This is a shorthand method for
-     * {@link History#pushState(JsonValue, Location)}, creating {@link Location}
-     * from the string provided.
+     * {@link History#pushState(JsonValue, Location, boolean)}, creating
+     * {@link Location} from the string provided.
      *
      * @param state
      *            the JSON state to push to the history stack, or
@@ -259,7 +259,7 @@ public class History implements Serializable {
     /**
      * Invokes <code>history.replaceState</code> in the browser with the given
      * parameters. This is a shorthand method for
-     * {@link History#replaceState(JsonValue, Location)}, creating
+     * {@link History#replaceState(JsonValue, Location, boolean)}, creating
      * {@link Location} from the string provided.
      *
      * @param state

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/History.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/History.java
@@ -172,6 +172,28 @@ public class History implements Serializable {
 
     /**
      * Invokes <code>history.pushState</code> in the browser with the given
+     * parameters. This is a shorthand method for
+     * {@link History#pushState(JsonValue, Location)}, creating {@link Location}
+     * from the string provided.
+     *
+     * @param state
+     *            the JSON state to push to the history stack, or
+     *            <code>null</code> to only change the location
+     * @param location
+     *            the new location to set in the browser, or <code>null</code>
+     *            to only change the JSON state
+     * @param callback
+     *            {@code true} if the change should make a return call to the
+     *            server
+     */
+    public void pushState(JsonValue state, String location, boolean callback) {
+        pushState(state,
+                Optional.ofNullable(location).map(Location::new).orElse(null),
+                callback);
+    }
+
+    /**
+     * Invokes <code>history.pushState</code> in the browser with the given
      * parameters.
      *
      * @param state
@@ -182,14 +204,33 @@ public class History implements Serializable {
      *            to only change the JSON state
      */
     public void pushState(JsonValue state, Location location) {
+        pushState(state, location, false);
+    }
+
+    /**
+     * Invokes <code>history.pushState</code> in the browser with the given
+     * parameters.
+     *
+     * @param state
+     *            the JSON state to push to the history stack, or
+     *            <code>null</code> to only change the location
+     * @param location
+     *            the new location to set in the browser, or <code>null</code>
+     *            to only change the JSON state
+     * @param callback
+     *            {@code true} if the change should make a return call to the
+     *            server
+     */
+    public void pushState(JsonValue state, Location location,
+            boolean callback) {
         final String pathWithQueryParameters = getPathWithQueryParameters(
                 location);
         // Second parameter is title which is currently ignored according to
         // https://developer.mozilla.org/en-US/docs/Web/API/History_API
         if (ui.getSession().getConfiguration().isReactEnabled()) {
             ui.getPage().executeJs(
-                    "window.dispatchEvent(new CustomEvent('vaadin-navigate', { detail: { state: $0, url: $1, replace: false } }));",
-                    state, pathWithQueryParameters);
+                    "window.dispatchEvent(new CustomEvent('vaadin-navigate', { detail: { state: $0, url: $1, replace: false, callback: $2 } }));",
+                    state, pathWithQueryParameters, callback);
         } else {
             ui.getPage().executeJs(
                     "setTimeout(() => { window.history.pushState($0, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigated')); })",
@@ -217,6 +258,29 @@ public class History implements Serializable {
 
     /**
      * Invokes <code>history.replaceState</code> in the browser with the given
+     * parameters. This is a shorthand method for
+     * {@link History#replaceState(JsonValue, Location)}, creating
+     * {@link Location} from the string provided.
+     *
+     * @param state
+     *            the JSON state to push to the history stack, or
+     *            <code>null</code> to only change the location
+     * @param location
+     *            the new location to set in the browser, or <code>null</code>
+     *            to only change the JSON state
+     * @param callback
+     *            {@code true} if the change should make a return call to the
+     *            server
+     */
+    public void replaceState(JsonValue state, String location,
+            boolean callback) {
+        replaceState(state,
+                Optional.ofNullable(location).map(Location::new).orElse(null),
+                callback);
+    }
+
+    /**
+     * Invokes <code>history.replaceState</code> in the browser with the given
      * parameters.
      *
      * @param state
@@ -227,14 +291,33 @@ public class History implements Serializable {
      *            to only change the JSON state
      */
     public void replaceState(JsonValue state, Location location) {
+        replaceState(state, location, true);
+    }
+
+    /**
+     * Invokes <code>history.replaceState</code> in the browser with the given
+     * parameters.
+     *
+     * @param state
+     *            the JSON state to push to the history stack, or
+     *            <code>null</code> to only change the location
+     * @param location
+     *            the new location to set in the browser, or <code>null</code>
+     *            to only change the JSON state
+     * @param callback
+     *            {@code true} if the change should make a return call to the
+     *            server
+     */
+    public void replaceState(JsonValue state, Location location,
+            boolean callback) {
         final String pathWithQueryParameters = getPathWithQueryParameters(
                 location);
         // Second parameter is title which is currently ignored according to
         // https://developer.mozilla.org/en-US/docs/Web/API/History_API
         if (ui.getSession().getConfiguration().isReactEnabled()) {
             ui.getPage().executeJs(
-                    "window.dispatchEvent(new CustomEvent('vaadin-navigate', { detail: { state: $0, url: $1, replace: true } }));",
-                    state, pathWithQueryParameters);
+                    "window.dispatchEvent(new CustomEvent('vaadin-navigate', { detail: { state: $0, url: $1, replace: true, callback: $2 } }));",
+                    state, pathWithQueryParameters, callback);
         } else {
             ui.getPage().executeJs(
                     "setTimeout(() => { window.history.replaceState($0, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigated')); })",

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -727,7 +727,7 @@ public abstract class AbstractNavigationStateRenderer
         NavigationEvent newNavigationEvent = getNavigationEvent(event,
                 beforeNavigation);
         newNavigationEvent.getUI().getPage().getHistory().replaceState(null,
-                newNavigationEvent.getLocation());
+                newNavigationEvent.getLocation(), true);
 
         return handler.handle(newNavigationEvent);
     }

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -201,9 +201,9 @@ function Flow() {
         navigate(path);
     }, [navigate]);
 
-    const vaadinNavigateEventHandler = useCallback((event: CustomEvent<{state: unknown, url: string, replace?: boolean}>) => {
+    const vaadinNavigateEventHandler = useCallback((event: CustomEvent<{state: unknown, url: string, replace?: boolean, callback: boolean}>) => {
         const path = '/' + event.detail.url;
-        navigated.current = !event.detail.replace;
+        navigated.current = !event.detail.callback;
         navigate(path, { state: event.detail.state, replace: event.detail.replace});
     }, [navigate]);
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
@@ -50,7 +50,7 @@ import com.vaadin.flow.server.VaadinSessionState;
 public class JavaScriptBootstrapUITest {
 
     private static final String CLIENT_PUSHSTATE_TO = "setTimeout(() => { window.history.pushState($0, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigated')); })";
-    private static final String REACT_PUSHSTATE_TO = "window.dispatchEvent(new CustomEvent('vaadin-navigate', { detail: { state: $0, url: $1, replace: false } }));";
+    private static final String REACT_PUSHSTATE_TO = "window.dispatchEvent(new CustomEvent('vaadin-navigate', { detail: { state: $0, url: $1, replace: false, callback: $2 } }));";
 
     private MockServletServiceSessionSetup mocks;
     private UI ui;
@@ -501,7 +501,7 @@ public class JavaScriptBootstrapUITest {
         } else {
             assertEquals(CLIENT_PUSHSTATE_TO, execJs.getValue());
         }
-        assertEquals(2, execValues.length);
+        assertEquals(3, execValues.length);
         assertNull(execValues[0]);
         assertEquals("dirty", execValues[1]);
     }

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/HistoryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/HistoryTest.java
@@ -73,8 +73,8 @@ public class HistoryTest {
     private static final String PUSH_STATE_JS = "setTimeout(() => { window.history.pushState($0, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigated')); })";
     private static final String REPLACE_STATE_JS = "setTimeout(() => { window.history.replaceState($0, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigated')); })";
 
-    private static final String PUSH_STATE_REACT = "window.dispatchEvent(new CustomEvent('vaadin-navigate', { detail: { state: $0, url: $1, replace: false } }));";
-    private static final String REPLACE_STATE_REACT = "window.dispatchEvent(new CustomEvent('vaadin-navigate', { detail: { state: $0, url: $1, replace: true } }));";
+    private static final String PUSH_STATE_REACT = "window.dispatchEvent(new CustomEvent('vaadin-navigate', { detail: { state: $0, url: $1, replace: false, callback: $2 } }));";
+    private static final String REPLACE_STATE_REACT = "window.dispatchEvent(new CustomEvent('vaadin-navigate', { detail: { state: $0, url: $1, replace: true, callback: $2 } }));";
 
     @Before
     public void setup() {

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HistoryIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HistoryIT.java
@@ -73,9 +73,8 @@ public class HistoryIT extends ChromeBrowserTest {
         // Forward to originally pushed state
         forwardButton.click();
         Assert.assertEquals(baseUrl.resolve("asdf"), getCurrentUrl());
-        Assert.assertEquals(Arrays.asList("New location: qwerty",
-                "New location: asdf", "New state: {\"foo\":true}"),
-                getStatusMessages());
+        Assert.assertEquals(Arrays.asList("New location: asdf",
+                "New state: {\"foo\":true}"), getStatusMessages());
         clearButton.click();
 
         // Back to the replaced state


### PR DESCRIPTION
Add feature to support replace and
push without getting a callback
to the server for the change.

fixes #19613

