### PR TITLE
test: fix pwa production nightly test

### DIFF
--- a/flow-tests/test-pwa/pom-production.xml
+++ b/flow-tests/test-pwa/pom-production.xml
@@ -27,6 +27,13 @@
             <version>0.1.2</version>
             <scope>test</scope>
         </dependency>
+        <!-- To be removed after chrome used by CI gets upgraded to 124 or later -->
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-devtools-v123</artifactId>
+            <version>4.21.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Fixes nightly test using chrome 123.
Change should be removed once CI environments upgrades to chrome 124 or newer.

Same as in #19674