### PR TITLE
fix: Unify client route to match server route format

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/AbstractRouteNotFoundError.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/AbstractRouteNotFoundError.java
@@ -175,6 +175,9 @@ public abstract class AbstractRouteNotFoundError extends Component {
         if (text.isEmpty()) {
             text = "<root>";
         }
+        if (text.startsWith("/")) {
+            text = text.substring(1);
+        }
         if (!route.contains(":")) {
             return elementAsLink(route, text);
         } else {


### PR DESCRIPTION
Make the client route string
on the error page in dev mode
not start with / so it is the
same as for server-side routes.

Fixes #19182