### PR TITLE
fix: always generate routes.tsx

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
@@ -165,13 +165,14 @@ public class TaskGenerateReactFiles
                         "{{VAADIN_VERSION}}", Version.getFullVersion());
                 writeFile(reactAdapterTsx, reactAdapterContent);
             }
-            if (!routesTsx.exists()) {
-                boolean isHillaUsed = FrontendUtils.isHillaUsed(
-                        frontendDirectory, options.getClassFinder());
-                writeFile(frontendGeneratedFolderRoutesTsx,
-                        getFileContent(isHillaUsed ? FrontendUtils.ROUTES_TSX
-                                : FrontendUtils.ROUTES_FLOW_TSX));
-            } else {
+
+            boolean isHillaUsed = FrontendUtils.isHillaUsed(frontendDirectory,
+                    options.getClassFinder());
+            writeFile(frontendGeneratedFolderRoutesTsx,
+                    getFileContent(isHillaUsed ? FrontendUtils.ROUTES_TSX
+                            : FrontendUtils.ROUTES_FLOW_TSX));
+
+            if (routesTsx.exists()) {
                 track(routesTsx);
                 String routesContent = FileUtils.readFileToString(routesTsx,
                         UTF_8);


### PR DESCRIPTION
Always generate the routes.tsx
into frontend/generated. Even
when routes.tsx is defined in
frontend by the developer so
that it can be used as an example.

Fixes #19179
