### PR TITLE
fix: rename lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,7 +91,7 @@ flow-tests/test-root-context/src/main/bundles/
 flow-tests/test-theme-no-polymer/src/main/bundles/
 flow-tests/test-themes/src/main/bundles/
 
-.flow-node-tasks.lock
+.vaadin-node-tasks.lock
 
 # Exclude generated vaadin dev tools frontend
 vaadin-dev-server/src/main/resources/META-INF/frontend

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -105,7 +105,7 @@ public class NodeTasks implements FallibleCommand {
     public NodeTasks(Options options) {
         // Lock file is created in the project root folder and not in target/ so
         // that Maven does not remove it
-        lockFile = new File(options.getNpmFolder(), ".flow-node-tasks.lock")
+        lockFile = new File(options.getNpmFolder(), ".vaadin-node-tasks.lock")
                 .toPath();
 
         ClassFinder classFinder = options.getClassFinder();


### PR DESCRIPTION
Rename the flow-node-tasks
lock file to vaadin-node-tasks
so it doesn't confuse application
state when running a non flow
build.

Closes #19187