### PR TITLE
Create Fieldset - Legend Java API

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/FieldSet.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/FieldSet.java
@@ -131,6 +131,15 @@ public class FieldSet extends HtmlContainer implements HasAriaLabel {
     }
 
     /**
+     * Gets the text of the legend.
+     *
+     * @return the text of the legend, or null if no legend is present.
+     */
+    public String getLegendText() {
+        return (legend != null) ? legend.getText() : null;
+    }
+
+    /**
      * Returns the content of the fieldset.
      *
      * @return the content component, can be null.
@@ -147,10 +156,16 @@ public class FieldSet extends HtmlContainer implements HasAriaLabel {
      */
     public void setContent(Component content) {
         Objects.requireNonNull(content, "Content cannot be null");
+
         if (this.content != null) {
             this.content.getElement().removeFromParent();
         }
         this.content = content;
+        if (content.getParent().isPresent()) {
+            content.getElement().removeFromParent();
+        }
+
         getElement().appendChild(content.getElement());
     }
+
 }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/FieldSet.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/FieldSet.java
@@ -21,9 +21,9 @@ import java.util.stream.Stream;
 import com.vaadin.flow.component.*;
 
 /**
- * Represents an HTML <code>&lt;fieldset&gt;</code> element. This component is used to group
- * several UI components within a form, enhancing form accessibility and
- * organization.
+ * Represents an HTML <code>&lt;fieldset&gt;</code> element. This component is
+ * used to group several UI components within a form, enhancing form
+ * accessibility and organization.
  */
 @Tag("fieldset")
 public class FieldSet extends HtmlContainer implements HasAriaLabel {

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/FieldSet.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/FieldSet.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.html;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.component.*;
@@ -27,8 +28,6 @@ import com.vaadin.flow.component.*;
  */
 @Tag("fieldset")
 public class FieldSet extends HtmlContainer implements HasAriaLabel {
-
-    private Legend legend;
 
     /**
      * Represents an HTML <code>&lt;legend&gt;</code> element.
@@ -71,8 +70,7 @@ public class FieldSet extends HtmlContainer implements HasAriaLabel {
     public FieldSet(String legendText) {
         this();
         if (legendText != null && !legendText.isEmpty()) {
-            this.legend = new Legend(legendText);
-            addComponentAsFirst(legend);
+            addComponentAsFirst(new Legend(legendText));
         }
     }
 
@@ -105,7 +103,7 @@ public class FieldSet extends HtmlContainer implements HasAriaLabel {
      * @return the legend component.
      */
     public Legend getLegend() {
-        return legend;
+        return findLegend();
     }
 
     /**
@@ -115,6 +113,7 @@ public class FieldSet extends HtmlContainer implements HasAriaLabel {
      *            the text to set.
      */
     public void setLegendText(String text) {
+        Legend legend = findLegend();
         if (text != null && !text.isEmpty()) {
             if (legend == null) {
                 legend = new Legend(text);
@@ -124,7 +123,6 @@ public class FieldSet extends HtmlContainer implements HasAriaLabel {
             }
         } else if (legend != null) {
             remove(legend);
-            legend = null;
         }
     }
 
@@ -134,6 +132,7 @@ public class FieldSet extends HtmlContainer implements HasAriaLabel {
      * @return the text of the legend, or null if no legend is present.
      */
     public String getLegendText() {
+        Legend legend = findLegend();
         return (legend != null) ? legend.getText() : null;
     }
 
@@ -143,22 +142,39 @@ public class FieldSet extends HtmlContainer implements HasAriaLabel {
      * @return Stream of content components
      */
     public Stream<Component> getContent() {
-        return legend == null ? getChildren() : getChildren().skip(1);
+        return getChildren().filter(c -> !(c instanceof Legend));
     }
 
     /**
      * Sets the content of the fieldset and removes previously set content.
+     *
+     * Note: Do not include Legend in the content components. Use other FieldSet
+     * methods for setting Legend instead.
      *
      * @param content
      *            the content components of the fieldset to set.
      */
     public void setContent(Component... content) {
         Objects.requireNonNull(content, "Content should not be null");
+        for (Component c : content) {
+            if (c instanceof Legend) {
+                throw new IllegalArgumentException(
+                        "Legend should not be included in the content. "
+                                + "Use constructor params or setLegend.. methods instead.");
+            }
+        }
         removeAll();
+        Legend legend = findLegend();
         if (legend != null) {
             addComponentAsFirst(legend);
         }
         add(content);
+    }
+
+    private Legend findLegend() {
+        Optional<Component> legend = getChildren()
+                .filter(c -> c instanceof Legend).findFirst();
+        return (Legend) legend.orElse(null);
     }
 
 }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/FieldSet.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/FieldSet.java
@@ -1,46 +1,34 @@
 /*
+ * Copyright 2000-2024 Vaadin Ltd.
  *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
- *  * Copyright 2000-2024 Vaadin Ltd.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *  *
- *
- *  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- *
- *  * use this file except in compliance with the License. You may obtain a copy of
- *
- *  * the License at
- *
- *  *
- *
- *  * http://www.apache.org/licenses/LICENSE-2.0
- *
- *  *
- *
- *  * Unless required by applicable law or agreed to in writing, software
- *
- *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- *
- *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- *
- *  * License for the specific language governing permissions and limitations under
- *
- *  * the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
-
 package com.vaadin.flow.component.html;
+
 import java.util.Objects;
 
 import com.vaadin.flow.component.*;
 
 /**
- * Represents an HTML <fieldset> element with a nested <legend>. This component is used to group
- * several UI components within a form. Useful for organizing fields that share a common context.
- * For more complex forms, consider using Vaadin's built-in <a href="https://vaadin.com/docs/latest/components/form-layout">Form Layout</a> component.
+ * Represents an HTML <fieldset> element with a nested <legend>. This component
+ * is used to group several UI components within a form. Useful for organizing
+ * fields that share a common context. For more complex forms, consider using
+ * Vaadin's built-in
+ * <a href="https://vaadin.com/docs/latest/components/form-layout">Form
+ * Layout</a> component.
  *
- * @see <a href="https://vaadin.com/docs/latest/components/form-layout">Vaadin Form Layout Documentation</a>
+ * @see <a href="https://vaadin.com/docs/latest/components/form-layout">Vaadin
+ *      Form Layout Documentation</a>
  */
 @Tag("fieldset")
 public class FieldSet extends HtmlComponent implements ClickNotifier<FieldSet> {
@@ -49,7 +37,8 @@ public class FieldSet extends HtmlComponent implements ClickNotifier<FieldSet> {
      * Represents an HTML <legend> element.
      */
     @Tag("legend")
-    public static class Legend extends HtmlContainer implements ClickNotifier<Legend> {
+    public static class Legend extends HtmlContainer
+            implements ClickNotifier<Legend> {
 
         /**
          * Creates a new empty legend.
@@ -60,7 +49,9 @@ public class FieldSet extends HtmlComponent implements ClickNotifier<FieldSet> {
 
         /**
          * Creates a new legend with text.
-         * @param text the text to set as legend.
+         *
+         * @param text
+         *            the text to set as legend.
          */
         public Legend(String text) {
             this();
@@ -82,7 +73,9 @@ public class FieldSet extends HtmlComponent implements ClickNotifier<FieldSet> {
 
     /**
      * Creates a new fieldset with the given legend text.
-     * @param legendText the legend text to set.
+     *
+     * @param legendText
+     *            the legend text to set.
      */
     public FieldSet(String legendText) {
         this();
@@ -91,7 +84,9 @@ public class FieldSet extends HtmlComponent implements ClickNotifier<FieldSet> {
 
     /**
      * Creates a new fieldset with the given content.
-     * @param content the content component to set.
+     *
+     * @param content
+     *            the content component to set.
      */
     public FieldSet(Component content) {
         this();
@@ -100,8 +95,11 @@ public class FieldSet extends HtmlComponent implements ClickNotifier<FieldSet> {
 
     /**
      * Creates a new fieldset using the provided legend text and content.
-     * @param legendText the legend text to set.
-     * @param content the content component to set.
+     *
+     * @param legendText
+     *            the legend text to set.
+     * @param content
+     *            the content component to set.
      */
     public FieldSet(String legendText, Component content) {
         this(legendText);
@@ -110,6 +108,7 @@ public class FieldSet extends HtmlComponent implements ClickNotifier<FieldSet> {
 
     /**
      * Returns the legend component associated with this fieldset.
+     *
      * @return the legend component.
      */
     public Legend getLegend() {
@@ -118,7 +117,9 @@ public class FieldSet extends HtmlComponent implements ClickNotifier<FieldSet> {
 
     /**
      * Sets the text of the legend.
-     * @param text the text to set.
+     *
+     * @param text
+     *            the text to set.
      */
     public void setLegendText(String text) {
         legend.setText(text);
@@ -126,6 +127,7 @@ public class FieldSet extends HtmlComponent implements ClickNotifier<FieldSet> {
 
     /**
      * Returns the content of the fieldset.
+     *
      * @return the content component, can be null.
      */
     public Component getContent() {
@@ -134,7 +136,9 @@ public class FieldSet extends HtmlComponent implements ClickNotifier<FieldSet> {
 
     /**
      * Sets the content of the fieldset and removes previously set content.
-     * @param content the content of the fieldset to set.
+     *
+     * @param content
+     *            the content of the fieldset to set.
      */
     public void setContent(Component content) {
         Objects.requireNonNull(content, "Content cannot be null");

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/FieldSet.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/FieldSet.java
@@ -21,7 +21,7 @@ import java.util.stream.Stream;
 import com.vaadin.flow.component.*;
 
 /**
- * Represents an HTML <fieldset> element. This component is used to group
+ * Represents an HTML <code>&lt;fieldset&gt;</code> element. This component is used to group
  * several UI components within a form, enhancing form accessibility and
  * organization.
  */
@@ -31,7 +31,7 @@ public class FieldSet extends HtmlContainer implements HasAriaLabel {
     private Legend legend;
 
     /**
-     * Represents an HTML <legend> element.
+     * Represents an HTML <code>&lt;legend&gt;</code> element.
      */
     @Tag("legend")
     public static class Legend extends HtmlContainer {

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/FieldSet.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/FieldSet.java
@@ -1,0 +1,147 @@
+/*
+ *
+ *
+ *  * Copyright 2000-2024 Vaadin Ltd.
+ *
+ *  *
+ *
+ *  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *
+ *  * use this file except in compliance with the License. You may obtain a copy of
+ *
+ *  * the License at
+ *
+ *  *
+ *
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  *
+ *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *
+ *  * License for the specific language governing permissions and limitations under
+ *
+ *  * the License.
+ *
+ *
+ */
+
+package com.vaadin.flow.component.html;
+import java.util.Objects;
+
+import com.vaadin.flow.component.*;
+
+/**
+ * Represents an HTML <fieldset> element with a nested <legend>. This component is used to group
+ * several UI components within a form. Useful for organizing fields that share a common context.
+ * For more complex forms, consider using Vaadin's built-in <a href="https://vaadin.com/docs/latest/components/form-layout">Form Layout</a> component.
+ *
+ * @see <a href="https://vaadin.com/docs/latest/components/form-layout">Vaadin Form Layout Documentation</a>
+ */
+@Tag("fieldset")
+public class FieldSet extends HtmlComponent implements ClickNotifier<FieldSet> {
+
+    /**
+     * Represents an HTML <legend> element.
+     */
+    @Tag("legend")
+    public static class Legend extends HtmlContainer implements ClickNotifier<Legend> {
+
+        /**
+         * Creates a new empty legend.
+         */
+        public Legend() {
+            super();
+        }
+
+        /**
+         * Creates a new legend with text.
+         * @param text the text to set as legend.
+         */
+        public Legend(String text) {
+            this();
+            setText(text);
+        }
+    }
+
+    private final Legend legend;
+    private Component content;
+
+    /**
+     * Creates a new fieldset with an empty legend.
+     */
+    public FieldSet() {
+        super();
+        legend = new Legend();
+        getElement().appendChild(legend.getElement());
+    }
+
+    /**
+     * Creates a new fieldset with the given legend text.
+     * @param legendText the legend text to set.
+     */
+    public FieldSet(String legendText) {
+        this();
+        this.legend.setText(legendText);
+    }
+
+    /**
+     * Creates a new fieldset with the given content.
+     * @param content the content component to set.
+     */
+    public FieldSet(Component content) {
+        this();
+        setContent(content);
+    }
+
+    /**
+     * Creates a new fieldset using the provided legend text and content.
+     * @param legendText the legend text to set.
+     * @param content the content component to set.
+     */
+    public FieldSet(String legendText, Component content) {
+        this(legendText);
+        setContent(content);
+    }
+
+    /**
+     * Returns the legend component associated with this fieldset.
+     * @return the legend component.
+     */
+    public Legend getLegend() {
+        return legend;
+    }
+
+    /**
+     * Sets the text of the legend.
+     * @param text the text to set.
+     */
+    public void setLegendText(String text) {
+        legend.setText(text);
+    }
+
+    /**
+     * Returns the content of the fieldset.
+     * @return the content component, can be null.
+     */
+    public Component getContent() {
+        return content;
+    }
+
+    /**
+     * Sets the content of the fieldset and removes previously set content.
+     * @param content the content of the fieldset to set.
+     */
+    public void setContent(Component content) {
+        Objects.requireNonNull(content, "Content cannot be null");
+        if (this.content != null) {
+            this.content.getElement().removeFromParent();
+        }
+        this.content = content;
+        getElement().appendChild(content.getElement());
+    }
+}

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/FieldSet.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/FieldSet.java
@@ -20,25 +20,20 @@ import java.util.Objects;
 import com.vaadin.flow.component.*;
 
 /**
- * Represents an HTML <fieldset> element with a nested <legend>. This component
- * is used to group several UI components within a form. Useful for organizing
- * fields that share a common context. For more complex forms, consider using
- * Vaadin's built-in
- * <a href="https://vaadin.com/docs/latest/components/form-layout">Form
- * Layout</a> component.
- *
- * @see <a href="https://vaadin.com/docs/latest/components/form-layout">Vaadin
- *      Form Layout Documentation</a>
+ * Represents an HTML <fieldset> element. This component is used to group
+ * several UI components within a form, enhancing form accessibility and
+ * organization.
  */
 @Tag("fieldset")
-public class FieldSet extends HtmlComponent implements ClickNotifier<FieldSet> {
+public class FieldSet extends HtmlContainer implements HasAriaLabel {
+
+    private Legend legend;
 
     /**
      * Represents an HTML <legend> element.
      */
     @Tag("legend")
-    public static class Legend extends HtmlContainer
-            implements ClickNotifier<Legend> {
+    public static class Legend extends HtmlContainer {
 
         /**
          * Creates a new empty legend.
@@ -59,7 +54,6 @@ public class FieldSet extends HtmlComponent implements ClickNotifier<FieldSet> {
         }
     }
 
-    private final Legend legend;
     private Component content;
 
     /**
@@ -67,8 +61,6 @@ public class FieldSet extends HtmlComponent implements ClickNotifier<FieldSet> {
      */
     public FieldSet() {
         super();
-        legend = new Legend();
-        getElement().appendChild(legend.getElement());
     }
 
     /**
@@ -79,7 +71,10 @@ public class FieldSet extends HtmlComponent implements ClickNotifier<FieldSet> {
      */
     public FieldSet(String legendText) {
         this();
-        this.legend.setText(legendText);
+        if (legendText != null && !legendText.isEmpty()) {
+            this.legend = new Legend(legendText);
+            getElement().appendChild(legend.getElement());
+        }
     }
 
     /**
@@ -122,7 +117,17 @@ public class FieldSet extends HtmlComponent implements ClickNotifier<FieldSet> {
      *            the text to set.
      */
     public void setLegendText(String text) {
-        legend.setText(text);
+        if (text != null && !text.isEmpty()) {
+            if (legend == null) {
+                legend = new Legend(text);
+                getElement().appendChild(legend.getElement());
+            } else {
+                legend.setText(text);
+            }
+        } else if (legend != null) {
+            legend.getElement().removeFromParent();
+            legend = null;
+        }
     }
 
     /**

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/FieldSet.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/FieldSet.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.html;
 
 import java.util.Objects;
+import java.util.stream.Stream;
 
 import com.vaadin.flow.component.*;
 
@@ -54,8 +55,6 @@ public class FieldSet extends HtmlContainer implements HasAriaLabel {
         }
     }
 
-    private Component content;
-
     /**
      * Creates a new fieldset with an empty legend.
      */
@@ -73,7 +72,7 @@ public class FieldSet extends HtmlContainer implements HasAriaLabel {
         this();
         if (legendText != null && !legendText.isEmpty()) {
             this.legend = new Legend(legendText);
-            getElement().appendChild(legend.getElement());
+            addComponentAsFirst(legend);
         }
     }
 
@@ -83,9 +82,8 @@ public class FieldSet extends HtmlContainer implements HasAriaLabel {
      * @param content
      *            the content component to set.
      */
-    public FieldSet(Component content) {
-        this();
-        setContent(content);
+    public FieldSet(Component... content) {
+        super(content);
     }
 
     /**
@@ -98,7 +96,7 @@ public class FieldSet extends HtmlContainer implements HasAriaLabel {
      */
     public FieldSet(String legendText, Component content) {
         this(legendText);
-        setContent(content);
+        add(content);
     }
 
     /**
@@ -120,12 +118,12 @@ public class FieldSet extends HtmlContainer implements HasAriaLabel {
         if (text != null && !text.isEmpty()) {
             if (legend == null) {
                 legend = new Legend(text);
-                getElement().appendChild(legend.getElement());
+                addComponentAsFirst(legend);
             } else {
                 legend.setText(text);
             }
         } else if (legend != null) {
-            legend.getElement().removeFromParent();
+            remove(legend);
             legend = null;
         }
     }
@@ -142,30 +140,25 @@ public class FieldSet extends HtmlContainer implements HasAriaLabel {
     /**
      * Returns the content of the fieldset.
      *
-     * @return the content component, can be null.
+     * @return Stream of content components
      */
-    public Component getContent() {
-        return content;
+    public Stream<Component> getContent() {
+        return legend == null ? getChildren() : getChildren().skip(1);
     }
 
     /**
      * Sets the content of the fieldset and removes previously set content.
      *
      * @param content
-     *            the content of the fieldset to set.
+     *            the content components of the fieldset to set.
      */
-    public void setContent(Component content) {
-        Objects.requireNonNull(content, "Content cannot be null");
-
-        if (this.content != null) {
-            this.content.getElement().removeFromParent();
+    public void setContent(Component... content) {
+        Objects.requireNonNull(content, "Content should not be null");
+        removeAll();
+        if (legend != null) {
+            addComponentAsFirst(legend);
         }
-        this.content = content;
-        if (content.getParent().isPresent()) {
-            content.getElement().removeFromParent();
-        }
-
-        getElement().appendChild(content.getElement());
+        add(content);
     }
 
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/FieldSetTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/FieldSetTest.java
@@ -1,37 +1,19 @@
 /*
+ * Copyright 2000-2024 Vaadin Ltd.
  *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
- *  * Copyright 2000-2024 Vaadin Ltd.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *  *
- *
- *  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- *
- *  * use this file except in compliance with the License. You may obtain a copy of
- *
- *  * the License at
- *
- *  *
- *
- *  * http://www.apache.org/licenses/LICENSE-2.0
- *
- *  *
- *
- *  * Unless required by applicable law or agreed to in writing, software
- *
- *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- *
- *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- *
- *  * License for the specific language governing permissions and limitations under
- *
- *  * the License.
- *
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
-
 package com.vaadin.flow.component.html;
-
 
 import org.junit.Assert;
 import org.junit.Test;

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/FieldSetTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/FieldSetTest.java
@@ -68,4 +68,12 @@ public class FieldSetTest extends ComponentTest {
 
         Assert.assertNull(content1.getElement().getParent());
     }
+
+    @Test
+    public void testFieldSetLegendTextSetting() {
+        String expectedText = "Test Legend";
+        FieldSet fieldSet = new FieldSet(expectedText);
+        Assert.assertEquals("The legend text should be set correctly.",
+                expectedText, fieldSet.getLegend().getText());
+    }
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/FieldSetTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/FieldSetTest.java
@@ -31,17 +31,18 @@ public class FieldSetTest extends ComponentTest {
     public void testConstructorParams() {
         FieldSet fieldset = new FieldSet("sample-legend");
         Assert.assertEquals("sample-legend", fieldset.getLegend().getText());
-        Assert.assertNull(fieldset.getContent());
+        Assert.assertEquals(0, fieldset.getContent().count());
 
         fieldset = new FieldSet(new Paragraph("sample-content"));
         Assert.assertNull(fieldset.getLegend());
         Assert.assertEquals("sample-content",
-                ((Paragraph) fieldset.getContent()).getText());
+                ((Paragraph) fieldset.getContent().findFirst().get())
+                        .getText());
 
         Paragraph content = new Paragraph("content");
         fieldset = new FieldSet("sample-legend", content);
         Assert.assertEquals("sample-legend", fieldset.getLegend().getText());
-        Assert.assertEquals(content, fieldset.getContent());
+        Assert.assertEquals(content, fieldset.getContent().findFirst().get());
     }
 
     @Test
@@ -61,10 +62,11 @@ public class FieldSetTest extends ComponentTest {
         Paragraph content1 = new Paragraph("content1");
         Paragraph content2 = new Paragraph("content2");
         FieldSet fieldset = new FieldSet("text-legend", content1);
-        Assert.assertEquals(content1, fieldset.getContent());
+        Assert.assertEquals(content1, fieldset.getContent().findFirst().get());
 
-        fieldset.setContent(content2);
-        Assert.assertEquals(content2, fieldset.getContent());
+        fieldset.remove(content1);
+        fieldset.add(content2);
+        Assert.assertEquals(content2, fieldset.getContent().findFirst().get());
 
         Assert.assertNull(content1.getElement().getParent());
     }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/FieldSetTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/FieldSetTest.java
@@ -34,9 +34,9 @@ public class FieldSetTest extends ComponentTest {
         Assert.assertNull(fieldset.getContent());
 
         fieldset = new FieldSet(new Paragraph("sample-content"));
-        Assert.assertEquals("", fieldset.getLegend().getText());
+        Assert.assertNull(fieldset.getLegend());
         Assert.assertEquals("sample-content",
-                fieldset.getContent().getElement().getTextRecursively());
+                ((Paragraph) fieldset.getContent()).getText());
 
         Paragraph content = new Paragraph("content");
         fieldset = new FieldSet("sample-legend", content);
@@ -46,15 +46,14 @@ public class FieldSetTest extends ComponentTest {
 
     @Test
     public void testSetLegendReplacesLegendText() {
-        Paragraph legend2 = new Paragraph("legend2");
         FieldSet fieldset = new FieldSet("legend1", new Paragraph("content"));
         Assert.assertEquals("legend1", fieldset.getLegend().getText());
 
         fieldset.setLegendText("legend2");
         Assert.assertEquals("legend2", fieldset.getLegend().getText());
 
-        fieldset.getLegend().setText("legend3");
-        Assert.assertEquals("legend3", fieldset.getLegend().getText());
+        fieldset.setLegendText(null);
+        Assert.assertNull(fieldset.getLegend());
     }
 
     @Test
@@ -63,12 +62,10 @@ public class FieldSetTest extends ComponentTest {
         Paragraph content2 = new Paragraph("content2");
         FieldSet fieldset = new FieldSet("text-legend", content1);
         Assert.assertEquals(content1, fieldset.getContent());
-        Assert.assertTrue(content1.getParent().isPresent());
-        Assert.assertFalse(content2.getParent().isPresent());
 
         fieldset.setContent(content2);
         Assert.assertEquals(content2, fieldset.getContent());
-        Assert.assertTrue(content2.getParent().isPresent());
-        Assert.assertFalse(content1.getParent().isPresent());
+
+        Assert.assertNull(content1.getElement().getParent());
     }
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/FieldSetTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/FieldSetTest.java
@@ -1,0 +1,92 @@
+/*
+ *
+ *
+ *  * Copyright 2000-2024 Vaadin Ltd.
+ *
+ *  *
+ *
+ *  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *
+ *  * use this file except in compliance with the License. You may obtain a copy of
+ *
+ *  * the License at
+ *
+ *  *
+ *
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  *
+ *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *
+ *  * License for the specific language governing permissions and limitations under
+ *
+ *  * the License.
+ *
+ *
+ */
+
+package com.vaadin.flow.component.html;
+
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FieldSetTest extends ComponentTest {
+
+    @Override
+    protected void addProperties() {
+        whitelistProperty("content");
+        whitelistProperty("legend");
+        whitelistProperty("legendText");
+    }
+
+    @Test
+    public void testConstructorParams() {
+        FieldSet fieldset = new FieldSet("sample-legend");
+        Assert.assertEquals("sample-legend", fieldset.getLegend().getText());
+        Assert.assertNull(fieldset.getContent());
+
+        fieldset = new FieldSet(new Paragraph("sample-content"));
+        Assert.assertEquals("", fieldset.getLegend().getText());
+        Assert.assertEquals("sample-content",
+                fieldset.getContent().getElement().getTextRecursively());
+
+        Paragraph content = new Paragraph("content");
+        fieldset = new FieldSet("sample-legend", content);
+        Assert.assertEquals("sample-legend", fieldset.getLegend().getText());
+        Assert.assertEquals(content, fieldset.getContent());
+    }
+
+    @Test
+    public void testSetLegendReplacesLegendText() {
+        Paragraph legend2 = new Paragraph("legend2");
+        FieldSet fieldset = new FieldSet("legend1", new Paragraph("content"));
+        Assert.assertEquals("legend1", fieldset.getLegend().getText());
+
+        fieldset.setLegendText("legend2");
+        Assert.assertEquals("legend2", fieldset.getLegend().getText());
+
+        fieldset.getLegend().setText("legend3");
+        Assert.assertEquals("legend3", fieldset.getLegend().getText());
+    }
+
+    @Test
+    public void testSetContentReplacesContent() {
+        Paragraph content1 = new Paragraph("content1");
+        Paragraph content2 = new Paragraph("content2");
+        FieldSet fieldset = new FieldSet("text-legend", content1);
+        Assert.assertEquals(content1, fieldset.getContent());
+        Assert.assertTrue(content1.getParent().isPresent());
+        Assert.assertFalse(content2.getParent().isPresent());
+
+        fieldset.setContent(content2);
+        Assert.assertEquals(content2, fieldset.getContent());
+        Assert.assertTrue(content2.getParent().isPresent());
+        Assert.assertFalse(content1.getParent().isPresent());
+    }
+}

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
@@ -99,6 +99,7 @@ public class HtmlComponentSmokeTest {
     static {
         ignoredStringConstructors.add(IFrame.class);
         ignoredStringConstructors.add(NativeDetails.class);
+        ignoredStringConstructors.add(FieldSet.class);
     }
 
     @Test

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
@@ -243,6 +243,11 @@ public class HtmlComponentSmokeTest {
             return true;
         }
 
+        if (method.getDeclaringClass() == FieldSet.class
+                && method.getName().startsWith("setContent")) {
+            return true;
+        }
+
         return false;
     }
 


### PR DESCRIPTION
## Description

Java API to create a <fieldset> and <legend> html tag without using a custom Java class to group fields.

Fixes #18213

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
