### PR TITLE
fix: use URLClassLoader with ResourceProvider in Maven plugins

### DIFF
--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/utils/LookupImpl.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/utils/LookupImpl.java
@@ -45,7 +45,7 @@ public class LookupImpl implements Lookup {
     @Override
     public <T> T lookup(Class<T> serviceClass) {
         if (ResourceProvider.class.isAssignableFrom(serviceClass)) {
-            return serviceClass.cast(new ResourceProviderImpl(classFinder.getClassLoader()));
+            return serviceClass.cast(new ResourceProviderImpl(classFinder));
         }
         return lookupAll(serviceClass).stream().findFirst().orElse(null);
     }

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/utils/LookupImpl.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/utils/LookupImpl.java
@@ -45,7 +45,7 @@ public class LookupImpl implements Lookup {
     @Override
     public <T> T lookup(Class<T> serviceClass) {
         if (ResourceProvider.class.isAssignableFrom(serviceClass)) {
-            return serviceClass.cast(new ResourceProviderImpl());
+            return serviceClass.cast(new ResourceProviderImpl(classFinder.getClassLoader()));
         }
         return lookupAll(serviceClass).stream().findFirst().orElse(null);
     }

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/utils/ResourceProviderImpl.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/utils/ResourceProviderImpl.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.List;
 
 import com.vaadin.flow.di.ResourceProvider;
+import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 
 /**
  * {@link ResourceProvider} for use with plugin execution.
@@ -32,25 +33,24 @@ import com.vaadin.flow.di.ResourceProvider;
  */
 class ResourceProviderImpl implements ResourceProvider {
 
-    private ClassLoader classLoader;
+    private ClassLoader classLoader = null;
 
     ResourceProviderImpl() {
-        this(ResourceProviderImpl.class.getClassLoader());
+        this.classLoader = ResourceProviderImpl.class.getClassLoader();
     }
 
-    ResourceProviderImpl(ClassLoader classLoader) {
-        this.classLoader = classLoader;
+    ResourceProviderImpl(ClassFinder classFinder) {
+        this.classLoader = classFinder.getClassLoader();
     }
 
     @Override
     public URL getApplicationResource(String path) {
-        return ResourceProviderImpl.class.getClassLoader().getResource(path);
+        return classLoader.getResource(path);
     }
 
     @Override
     public List<URL> getApplicationResources(String path) throws IOException {
-        return Collections.list(
-                ResourceProviderImpl.class.getClassLoader().getResources(path));
+        return Collections.list(classLoader.getResources(path));
     }
 
     @Override

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/utils/ResourceProviderImpl.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/utils/ResourceProviderImpl.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.utils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.Collections;
 import java.util.List;
 
@@ -30,6 +31,16 @@ import com.vaadin.flow.di.ResourceProvider;
  * @since
  */
 class ResourceProviderImpl implements ResourceProvider {
+
+    private ClassLoader classLoader;
+
+    ResourceProviderImpl() {
+        this(ResourceProviderImpl.class.getClassLoader());
+    }
+
+    ResourceProviderImpl(ClassLoader classLoader) {
+        this.classLoader = classLoader;
+    }
 
     @Override
     public URL getApplicationResource(String path) {

--- a/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
+++ b/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
@@ -5,6 +5,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -32,6 +34,7 @@ import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.ExecutionFailedException;
@@ -52,6 +55,7 @@ import com.vaadin.pro.licensechecker.Product;
 import elemental.json.Json;
 import elemental.json.JsonObject;
 
+import static com.vaadin.flow.server.frontend.FrontendUtils.FEATURE_FLAGS_FILE_NAME;
 import static com.vaadin.flow.server.frontend.FrontendUtils.TOKEN_FILE;
 
 public class BuildFrontendUtilTest {
@@ -446,6 +450,47 @@ public class BuildFrontendUtilTest {
                 .parse(Files.readString(tokenFile.toPath()));
         Assert.assertFalse("DAU flag should not be present in token file",
                 buildInfoJsonProd.hasKey(Constants.DAU_TOKEN));
+    }
+
+    @Test
+    public void runNodeUpdater_generateFeatureFlagsJsFile() throws Exception {
+        setupPluginAdapterDefaults();
+
+        File targetDir = baseDir.toPath().resolve(adapter.buildFolder())
+                .toFile();
+        targetDir.mkdirs();
+        targetDir.deleteOnExit();
+        File testClassesDir = targetDir.toPath().resolve("test-classes")
+                .toFile();
+        testClassesDir.mkdirs();
+        testClassesDir.deleteOnExit();
+        File featureFlagsResourceFile = new File(testClassesDir,
+                FeatureFlags.PROPERTIES_FILENAME);
+        FileUtils.write(featureFlagsResourceFile,
+                "com.vaadin.experimental.exampleFeatureFlag = true\n");
+        featureFlagsResourceFile.deleteOnExit();
+
+        ClassLoader classLoader = new URLClassLoader(
+                new URL[] { new File(baseDir, "target/test-classes/").toURI()
+                        .toURL() },
+                BuildFrontendUtilTest.class.getClassLoader());
+        ClassFinder classFinder = new ClassFinder.DefaultClassFinder(
+                classLoader);
+        Mockito.when(adapter.getClassFinder()).thenReturn(classFinder);
+        lookup = Mockito.spy(new LookupImpl(classFinder));
+        Mockito.when(adapter.createLookup(Mockito.any())).thenReturn(lookup);
+        Mockito.doReturn(classFinder).when(lookup).lookup(ClassFinder.class);
+
+        BuildFrontendUtil.runNodeUpdater(adapter);
+
+        File generatedFeatureFlagsFile = new File(adapter.generatedTsFolder(),
+                FEATURE_FLAGS_FILE_NAME);
+        String featureFlagsJs = Files
+                .readString(generatedFeatureFlagsFile.toPath());
+
+        Assert.assertTrue("Example feature flag is not set",
+                featureFlagsJs.contains(
+                        "window.Vaadin.featureFlags.exampleFeatureFlag = true;\n"));
     }
 
     private void fillAdapter() throws URISyntaxException {

--- a/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
+++ b/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
@@ -82,9 +82,8 @@ public class BuildFrontendUtilTest {
         Mockito.when(adapter.projectBaseDirectory())
                 .thenReturn(tmpDir.getRoot().toPath());
         Mockito.when(adapter.applicationIdentifier()).thenReturn("TEST_APP_ID");
-        ClassFinder classFinder = Mockito.mock(ClassFinder.class);
-        Mockito.when(classFinder.loadClass(ArgumentMatchers.anyString())).then(
-                i -> getClass().getClassLoader().loadClass(i.getArgument(0)));
+        ClassFinder classFinder = new ClassFinder.DefaultClassFinder(
+                getClass().getClassLoader());
         lookup = Mockito.spy(new LookupImpl(classFinder));
         Mockito.when(adapter.createLookup(Mockito.any())).thenReturn(lookup);
         Mockito.doReturn(classFinder).when(lookup).lookup(ClassFinder.class);


### PR DESCRIPTION
Fixes vaadin/hilla#2637

ResourceProvider ignored the actual project's resources when using the default ClassLoader. This resulted in loading `vaadin-featureflags.properties` from the vaadin-dev-bundle jar, even though there is a file in the project.
