### PR TITLE
chore: add utility method for DAU tracking

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/dau/DAUUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/dau/DAUUtilsTest.java
@@ -1,5 +1,7 @@
 package com.vaadin.flow.server.dau;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -10,22 +12,31 @@ import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.HandlerHelper;
 import com.vaadin.flow.server.SystemMessagesInfo;
+import com.vaadin.flow.server.VaadinContext;
 import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinResponse;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServiceDauTest;
+import com.vaadin.flow.server.VaadinServletService;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.shared.ApplicationConstants;
 import com.vaadin.pro.licensechecker.dau.DauIntegration;
 import com.vaadin.pro.licensechecker.dau.EnforcementException;
+import com.vaadin.tests.util.MockDeploymentConfiguration;
 
 import elemental.json.Json;
 import elemental.json.JsonObject;
 import elemental.json.JsonType;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class DAUUtilsTest {
 
@@ -159,6 +170,59 @@ public class DAUUtilsTest {
 
     }
 
+    @Test
+    public void trackDAU_trackingIntegratedWithRequest_noEnforcement() {
+        MocksForTrackDAU mocks = new MocksForTrackDAU();
+        VaadinService service = mocks.service;
+        HttpServletRequest request = mocks.request;
+        HttpServletResponse response = mocks.response;
+
+        try (MockedStatic<FlowDauIntegration> flowDauIntegration = Mockito
+                .mockStatic(FlowDauIntegration.class)) {
+
+            DAUUtils.EnforcementResult result = DAUUtils.trackDAU(service,
+                    request, response);
+
+            mocks.assertNoEnforcement(result);
+            flowDauIntegration.verify(() -> FlowDauIntegration
+                    .applyEnforcement(any(VaadinRequest.class), any()));
+
+            result.endRequestAction().run();
+
+            verify(service).requestEnd(any(VaadinRequest.class),
+                    Mockito.isNull(), Mockito.isNull());
+        }
+    }
+
+    @Test
+    public void trackDAU_trackingIntegratedWithRequest_enforcement() {
+        MocksForTrackDAU mocks = new MocksForTrackDAU();
+        VaadinService service = mocks.service;
+        HttpServletRequest request = mocks.request;
+        HttpServletResponse response = mocks.response;
+
+        try (MockedStatic<FlowDauIntegration> flowDauIntegration = Mockito
+                .mockStatic(FlowDauIntegration.class)) {
+            flowDauIntegration
+                    .when(() -> FlowDauIntegration
+                            .applyEnforcement(any(VaadinRequest.class), any()))
+                    .thenThrow(new DauEnforcementException(
+                            new EnforcementException("STOP")));
+
+            DAUUtils.EnforcementResult result = DAUUtils.trackDAU(service,
+                    request, response);
+
+            mocks.assertEnforcement(result);
+            flowDauIntegration.verify(() -> FlowDauIntegration
+                    .applyEnforcement(any(VaadinRequest.class), any()));
+
+            result.endRequestAction().run();
+
+            verify(service).requestEnd(any(VaadinRequest.class),
+                    Mockito.isNull(), Mockito.isNull());
+        }
+    }
+
     private void assertJsonErrorProperty(String expectedKey,
             String expectedValue, JsonObject json) {
         if (expectedValue != null) {
@@ -171,4 +235,51 @@ public class DAUUtilsTest {
 
     }
 
+    /**
+     * Mocks for
+     * {@link DAUUtils#trackDAU(VaadinService, HttpServletRequest, HttpServletResponse)}.
+     */
+    private static class MocksForTrackDAU {
+        private VaadinService service;
+        private HttpServletRequest request;
+        private HttpServletResponse response;
+
+        public MocksForTrackDAU() {
+            this.service = Mockito.mock(VaadinServletService.class);
+            this.request = Mockito.mock(HttpServletRequest.class);
+            this.response = Mockito.mock(HttpServletResponse.class);
+
+            VaadinContext vaadinContext = Mockito.mock(VaadinContext.class);
+            when(vaadinContext.getAttribute(any())).thenReturn(null);
+            MockDeploymentConfiguration config = new MockDeploymentConfiguration();
+            config.setProductionMode(true);
+            config.setApplicationOrSystemProperty(Constants.DAU_TOKEN, "true");
+            when(service.getDeploymentConfiguration()).thenReturn(config);
+            when(service.getContext()).thenReturn(vaadinContext);
+        }
+
+        private void assertNoEnforcement(DAUUtils.EnforcementResult result) {
+            assertNotNull(result);
+            assertNotNull(result.endRequestAction());
+            assertNull(result.messages());
+            assertNull(result.origin());
+            verify(service).requestStart(any(VaadinRequest.class),
+                    any(VaadinResponse.class));
+            verify(service, Mockito.never()).requestEnd(
+                    any(VaadinRequest.class), Mockito.isNull(),
+                    Mockito.isNull());
+        }
+
+        private void assertEnforcement(DAUUtils.EnforcementResult result) {
+            assertNotNull(result);
+            assertNotNull(result.endRequestAction());
+            assertNotNull(result.messages());
+            assertNotNull(result.origin());
+            verify(service).requestStart(any(VaadinRequest.class),
+                    any(VaadinResponse.class));
+            verify(service, Mockito.never()).requestEnd(
+                    any(VaadinRequest.class), Mockito.isNull(),
+                    Mockito.isNull());
+        }
+    }
 }


### PR DESCRIPTION
Needed for integrating DAU tracking with HTTP Servlet Request outside of normal VaadinService request handling context, like Hilla endpoint controller.
