### PR TITLE
fix: preserve record prop order, sort for beans

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/BeanPropertySet.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/BeanPropertySet.java
@@ -331,8 +331,8 @@ public class BeanPropertySet<T> implements PropertySet<T> {
                     .map(descriptor -> new BeanPropertyDefinition<>(this,
                             instanceKey.type, descriptor))
                     .collect(Collectors.toMap(PropertyDefinition::getName,
-                            Function.identity(),
-                            this::mergePropertyDefinitions, LinkedHashMap::new));
+                            Function.identity(), this::mergePropertyDefinitions,
+                            LinkedHashMap::new));
         } catch (IntrospectionException e) {
             throw new IllegalArgumentException(
                     "Cannot find property descriptors for "

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/BeanPropertySet.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/BeanPropertySet.java
@@ -23,6 +23,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -331,7 +332,7 @@ public class BeanPropertySet<T> implements PropertySet<T> {
                             instanceKey.type, descriptor))
                     .collect(Collectors.toMap(PropertyDefinition::getName,
                             Function.identity(),
-                            this::mergePropertyDefinitions));
+                            this::mergePropertyDefinitions, LinkedHashMap::new));
         } catch (IntrospectionException e) {
             throw new IllegalArgumentException(
                     "Cannot find property descriptors for "

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BeanPropertySetTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BeanPropertySetTest.java
@@ -253,6 +253,12 @@ public class BeanPropertySetTest {
                 "name");
         Assert.assertEquals("Property type is unexpected", namePropertyType,
                 String.class);
+
+        // Ensure props for Record are not sorted, but are in code order
+        List<PropertyDefinition<TestRecord, ?>> propertyList = definition
+                .getPropertySet().getProperties().toList();
+        Assert.assertEquals("name", propertyList.get(0).getName());
+        Assert.assertEquals("age", propertyList.get(1).getName());
     }
 
     @Test


### PR DESCRIPTION
Until now, bean properties have not been ordered by Flow. Instead they have been ordered by components using the property set, e.g. Grid. Now that we support records, we'd like to maintain original definition ordering for record props, but do sorting for bean props (since for beans you can't get the definition order).

This PR makes `BeanPropertySet` differentiate the two cases and return an ordered stream of properties for beans only.