### PR TITLE
fix: use URLClassLoader with ResourceProvider in Maven plugins (#19781)

### DIFF
--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/utils/LookupImpl.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/utils/LookupImpl.java
@@ -45,7 +45,7 @@ public class LookupImpl implements Lookup {
     @Override
     public <T> T lookup(Class<T> serviceClass) {
         if (ResourceProvider.class.isAssignableFrom(serviceClass)) {
-            return serviceClass.cast(new ResourceProviderImpl());
+            return serviceClass.cast(new ResourceProviderImpl(classFinder));
         }
         return lookupAll(serviceClass).stream().findFirst().orElse(null);
     }

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/utils/ResourceProviderImpl.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/utils/ResourceProviderImpl.java
@@ -18,10 +18,12 @@ package com.vaadin.flow.utils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.Collections;
 import java.util.List;
 
 import com.vaadin.flow.di.ResourceProvider;
+import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 
 /**
  * {@link ResourceProvider} for use with plugin execution.
@@ -31,15 +33,24 @@ import com.vaadin.flow.di.ResourceProvider;
  */
 class ResourceProviderImpl implements ResourceProvider {
 
+    private ClassLoader classLoader = null;
+
+    ResourceProviderImpl() {
+        this.classLoader = ResourceProviderImpl.class.getClassLoader();
+    }
+
+    ResourceProviderImpl(ClassFinder classFinder) {
+        this.classLoader = classFinder.getClassLoader();
+    }
+
     @Override
     public URL getApplicationResource(String path) {
-        return ResourceProviderImpl.class.getClassLoader().getResource(path);
+        return classLoader.getResource(path);
     }
 
     @Override
     public List<URL> getApplicationResources(String path) throws IOException {
-        return Collections.list(
-                ResourceProviderImpl.class.getClassLoader().getResources(path));
+        return Collections.list(classLoader.getResources(path));
     }
 
     @Override


### PR DESCRIPTION
Fixes vaadin/hilla#2637

ResourceProvider ignored the actual project's resources when using the default ClassLoader. This resulted in loading `vaadin-featureflags.properties` from the vaadin-dev-bundle jar, even though there is a file in the project.
