### PR TITLE
fix: block new users immediately when enforcement=ON

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/dau/DAUUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/dau/DAUUtils.java
@@ -110,7 +110,7 @@ public final class DAUUtils {
      *         contains invalid data.
      * @see FlowDauIntegration#generateNewCookie(VaadinRequest)
      */
-    static Optional<DauCookie> parserCookie(Cookie cookie) {
+    static Optional<DauCookie> parseCookie(Cookie cookie) {
         String cookieValue = cookie.getValue();
         String[] tokens = cookieValue.split("\\$");
         if (tokens.length != 2) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/dau/DAUVaadinRequestInterceptor.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/dau/DAUVaadinRequestInterceptor.java
@@ -62,7 +62,8 @@ public class DAUVaadinRequestInterceptor implements VaadinRequestInterceptor,
             // Enforce new users immediately, even if they are not yet active
             // and tracked
             if (FlowDauIntegration.shouldEnforce()) {
-                trackUser(request, DAUUtils.parseCookie(cookie).orElseThrow().trackingHash());
+                trackUser(request, DAUUtils.parseCookie(cookie).orElseThrow()
+                        .trackingHash());
             }
         }
     }
@@ -71,8 +72,7 @@ public class DAUVaadinRequestInterceptor implements VaadinRequestInterceptor,
         VaadinSession vaadinSession = VaadinSession.getCurrent();
         String userIdentity = Optional.ofNullable(userIdentitySupplier)
                 .flatMap(supplier -> supplier
-                        .apply(new UserIdentityContext(request,
-                                vaadinSession)))
+                        .apply(new UserIdentityContext(request, vaadinSession)))
                 .orElse(null);
         FlowDauIntegration.trackUser(request, trackingHash, userIdentity);
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/dau/FlowDauIntegration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/dau/FlowDauIntegration.java
@@ -101,7 +101,7 @@ public final class FlowDauIntegration {
      * not yet counted, should be blocked immediately.
      *
      * @return {@literal true} if the current request/user should be blocked,
-     *     {@literal false} otherwise.
+     *         {@literal false} otherwise.
      */
     static boolean shouldEnforce() {
         return DauIntegration.shouldEnforce();

--- a/flow-server/src/main/java/com/vaadin/flow/server/dau/FlowDauIntegration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/dau/FlowDauIntegration.java
@@ -97,6 +97,17 @@ public final class FlowDauIntegration {
     }
 
     /**
+     * Tells whether new user, i.e. who just opens the browser, not yet tracked,
+     * not yet counted, should be blocked immediately.
+     *
+     * @return {@literal true} if the current request/user should be blocked,
+     *     {@literal false} otherwise.
+     */
+    static boolean shouldEnforce() {
+        return DauIntegration.shouldEnforce();
+    }
+
+    /**
      * Potentially applies enforcement to the current request if DAU limit is
      * exceeded.
      * <p>


### PR DESCRIPTION
Blocks new requests immediately, if:
- DAU tracking is enabled,
- enforcement is ON,
- remaining limit is <=0

Depends on https://github.com/vaadin/flow/pull/19820