### PR TITLE
fix: Use 8080 as the default launch port for opening the browser

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/DevModeBrowserLauncher.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/DevModeBrowserLauncher.java
@@ -89,6 +89,9 @@ public class DevModeBrowserLauncher
 
     static String getUrl(GenericWebApplicationContext app) {
         String port = app.getEnvironment().getProperty("server.port");
+        if (port == null) {
+            port = "8080";
+        }
         String sslEnabled = app.getEnvironment()
                 .getProperty("server.ssl.enabled");
         String proto;


### PR DESCRIPTION
Fixes #19832
