### PR TITLE
chore: remove todos in DAUVaadinRequestInterceptor

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/dau/DAUVaadinRequestInterceptor.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/dau/DAUVaadinRequestInterceptor.java
@@ -92,13 +92,11 @@ public class DAUVaadinRequestInterceptor implements VaadinRequestInterceptor,
     @Override
     public void serviceInit(ServiceInitEvent event) {
         event.getSource().addServiceDestroyListener(this);
-        // TODO: error handling
         DauIntegration.startTracking(applicationName);
     }
 
     @Override
     public void serviceDestroy(ServiceDestroyEvent event) {
-        // TODO: error handling
         DauIntegration.stopTracking();
     }
 }


### PR DESCRIPTION
License Checker's DauStorage takes already care of error handling.