### PR TITLE
Options should correct the reactEnable flag

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/Options.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/Options.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import org.slf4j.LoggerFactory;
+
 import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.server.Constants;
@@ -928,6 +930,12 @@ public class Options implements Serializable {
 
     public Options withReact(boolean reactEnable) {
         this.reactEnable = reactEnable;
+        if (reactEnable && !FrontendUtils
+                .isReactRouterRequired(getFrontendDirectory())) {
+            LoggerFactory.getLogger(Options.class).debug(
+                    "Setting reactEnable to false as Vaadin Router is used!");
+            this.reactEnable = false;
+        }
         return this;
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -568,6 +568,9 @@ public class NodeUpdaterTest {
                 .mockStatic(FrontendUtils.class)) {
             mock.when(() -> FrontendUtils.isHillaUsed(Mockito.any(File.class),
                     Mockito.any(ClassFinder.class))).thenReturn(true);
+            mock.when(() -> FrontendUtils
+                    .isReactRouterRequired(Mockito.any(File.class)))
+                    .thenReturn(true);
             options.withReact(true);
             Map<String, String> defaultDeps = nodeUpdater
                     .getDefaultDependencies();


### PR DESCRIPTION
The reactEnable flag should be
automatically corrected to
false if vaadin router is used
instead of react router.
