### PR TITLE
fix: prevent NPE when creating init parameters (#19856) (CP: 23.5)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
@@ -13,6 +13,8 @@ import java.util.Enumeration;
 import java.util.Map;
 import java.util.Properties;
 
+import org.slf4j.LoggerFactory;
+
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.server.frontend.FallbackChunk;
@@ -95,8 +97,13 @@ public class DeploymentConfigurationFactory extends AbstractConfigurationFactory
         for (final Enumeration<String> e = vaadinConfig
                 .getConfigParameterNames(); e.hasMoreElements();) {
             final String name = e.nextElement();
-            initParameters.setProperty(name,
-                    vaadinConfig.getConfigParameter(name));
+            String value = vaadinConfig.getConfigParameter(name);
+            if (value != null) {
+                initParameters.setProperty(name, value);
+            } else {
+                LoggerFactory.getLogger(DeploymentConfigurationFactory.class)
+                        .debug("Ignoring NULL init parameter {}", name);
+            }
         }
 
         readBuildInfo(initParameters, vaadinConfig.getVaadinContext());

--- a/flow-server/src/test/java/com/vaadin/flow/server/DeploymentConfigurationFactoryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DeploymentConfigurationFactoryTest.java
@@ -215,6 +215,29 @@ public class DeploymentConfigurationFactoryTest {
     }
 
     @Test
+    public void servletConfigParameters_nullValues_ignored() throws Exception {
+        Class<NoSettings> servlet = NoSettings.class;
+
+        Map<String, String> servletConfigParams = new HashMap<>(
+                defaultServletParams);
+        servletConfigParams.put("someKey", null);
+        servletConfigParams.put("someNotNullKey", "NOT_NULL");
+
+        Map<String, String> servletContextParams = new HashMap<>();
+
+        DeploymentConfiguration config = new DeploymentConfigurationFactory()
+                .createDeploymentConfiguration(servlet, createVaadinConfigMock(
+                        servletConfigParams, servletContextParams));
+
+        Assert.assertFalse(
+                "Expecting null parameter to be ignored, but was in configuration",
+                config.getInitParameters().containsKey("someKey"));
+        Assert.assertTrue(
+                "Expecting not null parameter to be in configuration, but was not",
+                config.getInitParameters().containsKey("someNotNullKey"));
+    }
+
+    @Test
     public void should_readConfigurationFromTokenFile() throws Exception {
         FileUtils.writeLines(tokenFile,
                 Arrays.asList("{", "\"productionMode\": true", "}"));

--- a/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/routescope/PreserveOnRefreshIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/routescope/PreserveOnRefreshIT.java
@@ -29,6 +29,7 @@ public class PreserveOnRefreshIT extends AbstractSpringTest {
 
         // refresh
         getDriver().navigate().refresh();
+        waitForElementPresent(By.id("preserve-on-refresh"));
 
         Assert.assertEquals("Bean is not preserved after refresh", beanCall,
                 findElement(By.id("preserve-on-refresh")).getText());

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/SecurityConfig.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/SecurityConfig.java
@@ -9,7 +9,6 @@
 package com.vaadin.flow.spring.flowsecurity;
 
 import javax.servlet.ServletContext;
-
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,7 +24,6 @@ import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.internal.UrlUtil;
-import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.spring.RootMappedCondition;
 import com.vaadin.flow.spring.VaadinConfigurationProperties;
 import com.vaadin.flow.spring.flowsecurity.data.UserInfo;
@@ -67,7 +65,8 @@ public class SecurityConfig extends VaadinWebSecurity {
     public void configure(HttpSecurity http) throws Exception {
         http.authorizeRequests().antMatchers("/admin-only/**")
                 .hasAnyRole(ROLE_ADMIN);
-        http.authorizeRequests().antMatchers("/public/**").permitAll();
+        http.authorizeRequests().antMatchers("/favicon.ico", "/public/**")
+                .permitAll();
         super.configure(http);
         setLoginView(http, LoginView.class, getLogoutSuccessUrl());
         http.logout().addLogoutHandler((request, response, authentication) -> {


### PR DESCRIPTION
ServletConfig might contain init parameter with null values. This is however not supported by java Properties class.
This change adds a null check and logs offending keys for debugging purpose.

Fixes #19855