### PR TITLE
chore: remove Copilot I18n feature flag

### DIFF
--- a/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
+++ b/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
@@ -82,10 +82,6 @@ public class FeatureFlags implements Serializable {
             "https://github.com/vaadin/hilla/tree/main/packages/ts/react-i18n",
             true, null);
 
-    public static final Feature COPILOT_I18N = new Feature(
-            "Internationalization plugin for Copilot", "copilotI18n",
-            "https://vaadin.com/docs/latest/tools", false, null);
-
     public static final Feature COPILOT_EXPERIMENTAL = new Feature(
             "Copilot experimental features", "copilotExperimentalFeatures",
             "https://vaadin.com/docs/latest/tools", false, null);
@@ -120,7 +116,6 @@ public class FeatureFlags implements Serializable {
         features.add(new Feature(FORM_FILLER_ADDON));
         features.add(new Feature(HILLA_I18N));
         features.add(new Feature(HILLA_FULLSTACK_SIGNALS));
-        features.add(new Feature(COPILOT_I18N));
         features.add(new Feature(COPILOT_EXPERIMENTAL));
         loadProperties();
     }


### PR DESCRIPTION
## Description

Follow up from https://github.com/vaadin/copilot-internal/pull/2972. Feature flag won't be needed in V24.5.