### PR TITLE
test: pin selenium devtools version compatible with chrome 128 (24.3)

### DIFF
--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -81,6 +81,19 @@
             <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <!-- To be removed after TestBench 9.2.8 release -->
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-devtools-v128</artifactId>
+            <version>4.24.0</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.seleniumhq.selenium</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>        
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
Temporarily pin selenium devtools to a version compatible with chrome
128. This workaround should be removed after TB 9.2.8 is released.
