### PR TITLE
fix: prevent Flow navigation for Hilla route

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -68,6 +68,7 @@ import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.HttpStatusCode;
 import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.server.menu.MenuRegistry;
 
 /**
  * Base class for navigation handlers that target a navigation state.
@@ -172,6 +173,12 @@ public abstract class AbstractNavigationStateRenderer
 
         if (result.isPresent()) {
             return result.get();
+        }
+
+        // If navigation target is Hilla route, terminate Flow navigation logic
+        // here.
+        if (MenuRegistry.hasClientRoute(event.getLocation().getPath(), true)) {
+            return HttpStatusCode.OK.getCode();
         }
 
         final ArrayList<HasElement> chain;

--- a/flow-server/src/main/java/com/vaadin/flow/server/menu/MenuRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/menu/MenuRegistry.java
@@ -406,7 +406,7 @@ public class MenuRegistry {
     }
 
     /**
-     * See if there is a client route available for give route path.
+     * See if there is a client route available for given route path.
      *
      * @param route
      *            route path to check
@@ -416,6 +416,17 @@ public class MenuRegistry {
         return hasClientRoute(route, false);
     }
 
+    /**
+     * See if there is a client route available for given route path, optionally
+     * excluding layouts (routes with children) from the check.
+     *
+     * @param route
+     *            route path to check
+     * @param excludeLayouts
+     *            {@literal true} to exclude layouts from the check,
+     *            {@literal false} to include them
+     * @return true if a client route is found.
+     */
     public static boolean hasClientRoute(String route, boolean excludeLayouts) {
         if (VaadinSession.getCurrent() == null || route == null) {
             return false;

--- a/flow-server/src/main/java/com/vaadin/flow/server/menu/MenuRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/menu/MenuRegistry.java
@@ -318,10 +318,12 @@ public class MenuRegistry {
             return getClassLoader().getResource(FILE_ROUTES_JSON_PROD_PATH);
         }
         try {
-            Path fileRoutes = configuration.getFrontendFolder().toPath()
-                    .resolve(GENERATED).resolve(FILE_ROUTES_JSON_NAME);
-            if (fileRoutes.toFile().exists()) {
-                return fileRoutes.toUri().toURL();
+            if (configuration.getFrontendFolder() != null) {
+                Path fileRoutes = configuration.getFrontendFolder().toPath()
+                        .resolve(GENERATED).resolve(FILE_ROUTES_JSON_NAME);
+                if (fileRoutes.toFile().exists()) {
+                    return fileRoutes.toUri().toURL();
+                }
             }
             return null;
         } catch (MalformedURLException e) {
@@ -411,6 +413,10 @@ public class MenuRegistry {
      * @return true if a client route is found.
      */
     public static boolean hasClientRoute(String route) {
+        return hasClientRoute(route, false);
+    }
+
+    public static boolean hasClientRoute(String route, boolean excludeLayouts) {
         if (VaadinSession.getCurrent() == null || route == null) {
             return false;
         }
@@ -419,8 +425,16 @@ public class MenuRegistry {
         Map<String, AvailableViewInfo> clientItems = MenuRegistry
                 .collectClientMenuItems(true,
                         VaadinSession.getCurrent().getConfiguration());
-        Set<String> clientRoutes = clientItems.keySet();
+        final Set<String> clientRoutes = new HashSet<>();
+        clientItems.forEach((path, info) -> {
+            if (excludeLayouts) {
+                if (info.children() == null || info.children().isEmpty()) {
+                    clientRoutes.add(path);
+                }
+            } else {
+                clientRoutes.add(path);
+            }
+        });
         return clientRoutes.contains(route);
     }
-
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/menu/MenuRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/menu/MenuRegistry.java
@@ -318,12 +318,10 @@ public class MenuRegistry {
             return getClassLoader().getResource(FILE_ROUTES_JSON_PROD_PATH);
         }
         try {
-            if (configuration.getFrontendFolder() != null) {
-                Path fileRoutes = configuration.getFrontendFolder().toPath()
-                        .resolve(GENERATED).resolve(FILE_ROUTES_JSON_NAME);
-                if (fileRoutes.toFile().exists()) {
-                    return fileRoutes.toUri().toURL();
-                }
+            Path fileRoutes = configuration.getFrontendFolder().toPath()
+                    .resolve(GENERATED).resolve(FILE_ROUTES_JSON_NAME);
+            if (fileRoutes.toFile().exists()) {
+                return fileRoutes.toUri().toURL();
             }
             return null;
         } catch (MalformedURLException e) {

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
@@ -437,27 +437,30 @@ public class JavaScriptBootstrapUITest {
         ArgumentCaptor<Serializable[]> execArg = ArgumentCaptor
                 .forClass(Serializable[].class);
 
-        MockedStatic<MenuRegistry> menuRegistry = Mockito
-                .mockStatic(MenuRegistry.class);
-        menuRegistry.when(() -> MenuRegistry.hasClientRoute("clean/1", true))
-                .thenReturn(false);
+        try (MockedStatic<MenuRegistry> menuRegistry = Mockito
+                .mockStatic(MenuRegistry.class)) {
 
-        ui.navigate("clean/1");
-        Mockito.verify(page).executeJs(execJs.capture(), execArg.capture());
+            menuRegistry
+                    .when(() -> MenuRegistry.hasClientRoute("clean/1", true))
+                    .thenReturn(false);
 
-        boolean reactEnabled = ui.getSession().getConfiguration()
-                .isReactEnabled();
+            ui.navigate("clean/1");
+            Mockito.verify(page).executeJs(execJs.capture(), execArg.capture());
 
-        final Serializable[] execValues = execArg.getValue();
-        if (reactEnabled) {
-            assertEquals(REACT_PUSHSTATE_TO, execJs.getValue());
-            assertEquals(1, execValues.length);
-            assertEquals("clean/1", execValues[0]);
-        } else {
-            assertEquals(CLIENT_PUSHSTATE_TO, execJs.getValue());
-            assertEquals(2, execValues.length);
-            assertNull(execValues[0]);
-            assertEquals("clean/1", execValues[1]);
+            boolean reactEnabled = ui.getSession().getConfiguration()
+                    .isReactEnabled();
+
+            final Serializable[] execValues = execArg.getValue();
+            if (reactEnabled) {
+                assertEquals(REACT_PUSHSTATE_TO, execJs.getValue());
+                assertEquals(1, execValues.length);
+                assertEquals("clean/1", execValues[0]);
+            } else {
+                assertEquals(CLIENT_PUSHSTATE_TO, execJs.getValue());
+                assertEquals(2, execValues.length);
+                assertNull(execValues[0]);
+                assertEquals("clean/1", execValues[1]);
+            }
         }
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
@@ -15,6 +15,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
@@ -46,6 +47,7 @@ import com.vaadin.flow.server.MockServletServiceSessionSetup;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.VaadinSessionState;
+import com.vaadin.flow.server.menu.MenuRegistry;
 
 public class JavaScriptBootstrapUITest {
 
@@ -434,6 +436,11 @@ public class JavaScriptBootstrapUITest {
         ArgumentCaptor<String> execJs = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<Serializable[]> execArg = ArgumentCaptor
                 .forClass(Serializable[].class);
+
+        MockedStatic<MenuRegistry> menuRegistry = Mockito
+                .mockStatic(MenuRegistry.class);
+        menuRegistry.when(() -> MenuRegistry.hasClientRoute("clean/1", true))
+                .thenReturn(false);
 
         ui.navigate("clean/1");
         Mockito.verify(page).executeJs(execJs.capture(), execArg.capture());

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
@@ -796,19 +796,20 @@ public class NavigationStateRendererTest {
 
         ui.getInternals().clearLastHandledNavigation();
 
-        MockedStatic<MenuRegistry> menuRegistry = Mockito
-                .mockStatic(MenuRegistry.class);
-        menuRegistry
-                .when(() -> MenuRegistry.hasClientRoute("client-route", true))
-                .thenReturn(true);
+        try (MockedStatic<MenuRegistry> menuRegistry = Mockito
+                .mockStatic(MenuRegistry.class)) {
+            menuRegistry.when(
+                    () -> MenuRegistry.hasClientRoute("client-route", true))
+                    .thenReturn(true);
 
-        // This should not call attach or beforeEnter on root route
-        renderer.handle(
-                new NavigationEvent(router, new Location("client-route"), ui,
-                        NavigationTrigger.CLIENT_SIDE));
+            // This should not call attach or beforeEnter on root route
+            renderer.handle(
+                    new NavigationEvent(router, new Location("client-route"),
+                            ui, NavigationTrigger.CLIENT_SIDE));
 
-        Assert.assertEquals(1, beforeEnterCount.get());
-        Assert.assertEquals(1, viewAttachCount.get());
+            Assert.assertEquals(1, beforeEnterCount.get());
+            Assert.assertEquals(1, viewAttachCount.get());
+        }
     }
 
     private MockVaadinServletService createMockServiceWithInstantiator() {

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
@@ -37,6 +37,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
@@ -65,6 +66,7 @@ import com.vaadin.flow.router.ParentLayout;
 import com.vaadin.flow.router.PreserveOnRefresh;
 import com.vaadin.flow.router.QueryParameters;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouteAlias;
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.flow.router.Router;
 import com.vaadin.flow.router.RouterLayout;
@@ -77,6 +79,7 @@ import com.vaadin.flow.server.MockVaadinSession;
 import com.vaadin.flow.server.RouteRegistry;
 import com.vaadin.flow.server.ServiceException;
 import com.vaadin.flow.server.WrappedSession;
+import com.vaadin.flow.server.menu.MenuRegistry;
 import com.vaadin.flow.server.startup.ApplicationRouteRegistry;
 import com.vaadin.tests.util.AlwaysLockedVaadinSession;
 import com.vaadin.tests.util.MockDeploymentConfiguration;
@@ -320,6 +323,21 @@ public class NavigationStateRendererTest {
         SingleView() {
             addAttachListener(e -> viewAttachCount.getAndIncrement());
             viewUUID = UUID.randomUUID().toString();
+        }
+    }
+
+    @Route(value = "/:samplePersonID?/:action?(edit)")
+    @RouteAlias(value = "")
+    @Tag("div")
+    private static class RootRouteWithParam extends Component
+            implements BeforeEnterObserver {
+        RootRouteWithParam() {
+            addAttachListener(e -> viewAttachCount.getAndIncrement());
+        }
+
+        @Override
+        public void beforeEnter(BeforeEnterEvent event) {
+            beforeEnterCount.getAndIncrement();
         }
     }
 
@@ -636,6 +654,7 @@ public class NavigationStateRendererTest {
 
     private static AtomicInteger layoutAttachCount;
     private static AtomicInteger viewAttachCount;
+    private static AtomicInteger beforeEnterCount;
     private static String layoutUUID;
     private static String viewUUID;
 
@@ -745,6 +764,51 @@ public class NavigationStateRendererTest {
         Assert.assertNotEquals(currentLayoutUUID, layoutUUID);
         Assert.assertNotEquals(currentViewUUID, viewUUID);
 
+    }
+
+    @Test
+    public void handle_clientNavigation_withMatchingFlowRoute() {
+        viewAttachCount = new AtomicInteger();
+        beforeEnterCount = new AtomicInteger();
+
+        // given a service with instantiator
+        MockVaadinServletService service = createMockServiceWithInstantiator();
+
+        // given a locked session
+        MockVaadinSession session = new AlwaysLockedVaadinSession(service);
+        session.setConfiguration(new MockDeploymentConfiguration());
+
+        // given a NavigationStateRenderer mapping to PreservedNestedView
+        Router router = session.getService().getRouter();
+        NavigationStateRenderer renderer = new NavigationStateRenderer(
+                new NavigationStateBuilder(router)
+                        .withTarget(RootRouteWithParam.class).withPath("")
+                        .build());
+        router.getRegistry().setRoute("", RootRouteWithParam.class, null);
+
+        MockUI ui = new MockUI(session);
+
+        renderer.handle(new NavigationEvent(router, new Location(""), ui,
+                NavigationTrigger.PAGE_LOAD));
+
+        Assert.assertEquals(1, beforeEnterCount.get());
+        Assert.assertEquals(1, viewAttachCount.get());
+
+        ui.getInternals().clearLastHandledNavigation();
+
+        MockedStatic<MenuRegistry> menuRegistry = Mockito
+                .mockStatic(MenuRegistry.class);
+        menuRegistry
+                .when(() -> MenuRegistry.hasClientRoute("client-route", true))
+                .thenReturn(true);
+
+        // This should not call attach or beforeEnter on root route
+        renderer.handle(
+                new NavigationEvent(router, new Location("client-route"), ui,
+                        NavigationTrigger.CLIENT_SIDE));
+
+        Assert.assertEquals(1, beforeEnterCount.get());
+        Assert.assertEquals(1, viewAttachCount.get());
     }
 
     private MockVaadinServletService createMockServiceWithInstantiator() {


### PR DESCRIPTION
Prevents Flow navigation actions for cases where a client route exists and is navigated to, but there is also a Flow route with a parameter that could potentially match the target URL.

Fixes https://github.com/vaadin/flow/issues/19831