### PR TITLE
fix: No react module for Vaadin Router

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesScanner.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesScanner.java
@@ -100,7 +100,8 @@ public interface FrontendDependenciesScanner extends Serializable {
             if (allDependenciesScan) {
                 // this dep scanner can't distinguish embeddable web component
                 // frontend related annotations
-                return new FullDependenciesScanner(finder, featureFlags);
+                return new FullDependenciesScanner(finder, featureFlags,
+                        reactEnabled);
             } else {
                 return new FrontendDependencies(finder,
                         generateEmbeddableWebComponents, featureFlags,

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScanner.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScanner.java
@@ -164,9 +164,8 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
         cssData = discoverCss();
 
         if (!reactEnabled) {
-            modulesSet.stream().filter(
-                    module -> module.contains("ReactRouterOutletElement.tsx"))
-                    .findFirst().ifPresent(outlet -> modulesSet.remove(outlet));
+            modulesSet.removeIf(
+                    module -> module.contains("ReactRouterOutletElement.tsx"));
         }
 
         modules = new ArrayList<>(modulesSet);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScannerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScannerTest.java
@@ -336,7 +336,7 @@ public class FullDependenciesScannerTest {
                     }
                     Assert.fail();
                     return null;
-                }, null);
+                }, null, true);
 
         DepsTests.assertImportCount(28, scanner.getModules());
         List<String> modules = DepsTests.merge(scanner.getModules());
@@ -405,7 +405,7 @@ public class FullDependenciesScannerTest {
 
         return new FullDependenciesScanner(finder,
                 (type, annotation) -> findAnnotations(type, annotationType),
-                null);
+                null, true);
     }
 
     private FullDependenciesScanner setUpThemeScanner(
@@ -425,7 +425,8 @@ public class FullDependenciesScannerTest {
         Mockito.when(finder.getAnnotatedClasses(fakeNoThemeClass))
                 .thenReturn(noThemeClasses);
 
-        return new FullDependenciesScanner(finder, annotationFinder, null) {
+        return new FullDependenciesScanner(finder, annotationFinder, null,
+                true) {
             @Override
             protected Class<? extends AbstractTheme> getLumoTheme() {
                 return FakeLumoTheme.class;

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FullScannerPwaTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FullScannerPwaTest.java
@@ -27,7 +27,8 @@ public class FullScannerPwaTest extends AbstractScannerPwaTest {
                 .getAnnotatedClasses(clazz);
 
         FullDependenciesScanner fullDependenciesScanner = new FullDependenciesScanner(
-                finder, (type, annotation) -> findPwaAnnotations(type), null);
+                finder, (type, annotation) -> findPwaAnnotations(type), null,
+                true);
         return fullDependenciesScanner.getPwaConfiguration();
     }
 


### PR DESCRIPTION
Remove reactOutlet module
if we are not running react,
but are using Vaadin Router
inferred from index.ts

Fixes #19870