### PR TITLE
chore: Add 503 status code when enforcing request

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlRequestHandler.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.server.HandlerHelper;
 import com.vaadin.flow.server.HandlerHelper.RequestType;
+import com.vaadin.flow.server.HttpStatusCode;
 import com.vaadin.flow.server.SessionExpiredHandler;
 import com.vaadin.flow.server.SynchronizedRequestHandler;
 import com.vaadin.flow.server.VaadinRequest;
@@ -129,6 +130,8 @@ public class UidlRequestHandler extends SynchronizedRequestHandler
         } catch (DauEnforcementException e) {
             getLogger().warn(
                     "Daily Active User limit reached. Blocking new user request");
+            response.setHeader(DAUUtils.STATUS_CODE_KEY, String
+                    .valueOf(HttpStatusCode.SERVICE_UNAVAILABLE.getCode()));
             String json = DAUUtils.jsonEnforcementResponse(request, e);
             commitJsonResponse(response, json);
             return true;

--- a/flow-server/src/main/java/com/vaadin/flow/server/dau/DAUUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/dau/DAUUtils.java
@@ -50,6 +50,8 @@ public final class DAUUtils {
     public static final String ENFORCEMENT_EXCEPTION_KEY = DAUUtils.class
             .getName() + ".EnforcementException";
 
+    public static final String STATUS_CODE_KEY = "Vaadin-DAU-Status-Code";
+
     private DAUUtils() {
     }
 


### PR DESCRIPTION
Adds "Service Unavailable" status code to http response header, so it can be used for response processing, if needed.
We cannot currently add this status code for UIDL requests, because of issue like https://github.com/vaadin/flow/issues/18781.