### PR TITLE
fix: safely handle nested removal of menu routes

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/menu/MenuRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/menu/MenuRegistry.java
@@ -340,9 +340,13 @@ public class MenuRegistry {
 
         Set<String> clientEntries = new HashSet<>(configurations.keySet());
         for (String key : clientEntries) {
+            if (!configurations.containsKey(key)) {
+                // view may have been removed together with parent
+                continue;
+            }
             AvailableViewInfo viewInfo = configurations.get(key);
             boolean routeValid = validateViewAccessible(viewInfo,
-                    isUserAuthenticated, vaadinRequest::isUserInRole);
+                                isUserAuthenticated, vaadinRequest::isUserInRole);
 
             if (!routeValid) {
                 configurations.remove(key);

--- a/flow-server/src/main/java/com/vaadin/flow/server/menu/MenuRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/menu/MenuRegistry.java
@@ -346,7 +346,7 @@ public class MenuRegistry {
             }
             AvailableViewInfo viewInfo = configurations.get(key);
             boolean routeValid = validateViewAccessible(viewInfo,
-                                isUserAuthenticated, vaadinRequest::isUserInRole);
+                    isUserAuthenticated, vaadinRequest::isUserInRole);
 
             if (!routeValid) {
                 configurations.remove(key);

--- a/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuRegistryTest.java
@@ -132,7 +132,8 @@ public class MenuRegistryTest {
     }
 
     @Test
-    public void getMenuItemsWithNestedFiltering_doesNotThrow() throws IOException {
+    public void getMenuItemsWithNestedFiltering_doesNotThrow()
+            throws IOException {
         File generated = tmpDir.newFolder(GENERATED);
         File clientFiles = new File(generated, FILE_ROUTES_JSON_NAME);
         Files.writeString(clientFiles.toPath(), nestedLoginRequiredRouteFile);

--- a/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuRegistryTest.java
@@ -132,6 +132,18 @@ public class MenuRegistryTest {
     }
 
     @Test
+    public void getMenuItemsWithNestedFiltering_doesNotThrow() throws IOException {
+        File generated = tmpDir.newFolder(GENERATED);
+        File clientFiles = new File(generated, FILE_ROUTES_JSON_NAME);
+        Files.writeString(clientFiles.toPath(), nestedLoginRequiredRouteFile);
+
+        Map<String, AvailableViewInfo> menuItems = new MenuRegistry()
+                .getMenuItems(true);
+
+        Assert.assertEquals(0, menuItems.size());
+    }
+
+    @Test
     public void getMenuItemsNoFilteringContainsAllClientPaths()
             throws IOException {
         File generated = tmpDir.newFolder(GENERATED);
@@ -457,6 +469,46 @@ public class MenuRegistryTest {
                     },
                     "params": {},
                     "title": "Login"
+                  }
+                ]
+              }
+            ]
+            """;
+
+    String nestedLoginRequiredRouteFile = """
+            [
+              {
+                "route": "",
+                "params": {},
+                "title": "current Title",
+                "children": [
+                  {
+                    "route": "",
+                    "loginRequired": true,
+                    "params": {},
+                    "title": "navigate"
+                  },
+                  {
+                    "route": "admin",
+                    "loginRequired": true,
+                    "title": "Admin",
+                    "params": {},
+                    "children": [
+                      {
+                        "route": "planets",
+                        "loginRequired": true,
+                        "title": "Planets",
+                        "params": {},
+                        "children": [
+                          {
+                            "route": "",
+                            "loginRequired": true,
+                            "title": "Planets",
+                            "params": {}
+                          }
+                        ]
+                      }
+                    ]
                   }
                 ]
               }


### PR DESCRIPTION
`MenuRegistry.filterClientViews` removes inaccessible routes and their child routes from the menu items. When iterating the list of all routes, a NPE can occur if a child route has already been removed together with its parent route. This adds a check that prevents the NPE.