### PR TITLE
test: assert after browser resize event listener completes (2.11)

### DIFF
--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/BrowserWindowResizeIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/BrowserWindowResizeIT.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedCondition;
 
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
@@ -22,19 +23,24 @@ public class BrowserWindowResizeIT extends ChromeBrowserTest {
     public void listenResizeEvent() {
         open();
         Dimension currentSize = getDriver().manage().window().getSize();
-
         int newWidth = currentSize.getWidth() - 10;
         getDriver().manage().window()
                 .setSize(new Dimension(newWidth, currentSize.getHeight()));
 
         WebElement info = findElement(By.id("size-info"));
+        waitForWidthChange(info, currentSize.getWidth());
 
         Assert.assertEquals(String.valueOf(newWidth), info.getText());
 
+        currentSize = getDriver().manage().window().getSize();
         newWidth -= 30;
         getDriver().manage().window()
                 .setSize(new Dimension(newWidth, currentSize.getHeight()));
-
+        waitForWidthChange(info, currentSize.getWidth());
         Assert.assertEquals(String.valueOf(newWidth), info.getText());
+    }
+
+    private void waitForWidthChange(WebElement info, int currentWidth) {
+        waitUntil(d -> !String.valueOf(currentWidth).equals(info.getText()));
     }
 }


### PR DESCRIPTION
Waits for the browser resize event listener to update the UI before asserting on the window width.