### PR TITLE
fix: use instantiator to lookup DAUCustomizer implementation

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -239,11 +239,18 @@ public abstract class VaadinService implements Serializable {
         if (DAUUtils.isDauEnabled(this)) {
             getLogger().info("Daily Active User tracking enabled");
 
-            DAUCustomizer dauCustomizer = Optional
-                    .ofNullable(getContext().getAttribute(Lookup.class))
-                    .map(lookup -> lookup.lookup(DAUCustomizer.class))
-                    .orElse(null);
-            getContext().setAttribute(DAUCustomizer.class, dauCustomizer);
+            DAUCustomizer dauCustomizer;
+            try {
+                dauCustomizer = instantiator.getOrCreate(DAUCustomizer.class);
+                getContext().setAttribute(DAUCustomizer.class, dauCustomizer);
+            } catch (Exception e) {
+                getLogger().debug("DAUCustomizer not available");
+                if (getLogger().isTraceEnabled()) {
+                    getLogger().trace("Cannot get an instance of DAUCustomizer",
+                            e);
+                }
+                dauCustomizer = null;
+            }
 
             DAUVaadinRequestInterceptor dauInterceptor = new DAUVaadinRequestInterceptor(
                     getDeploymentConfiguration(), dauCustomizer);


### PR DESCRIPTION
Using instantiator instead of directly calling Lookup allows CDI and Quarkus projects to expose the implementation as a bean instead of registering it as a ServiceLoder component.