### PR TITLE
feat: Add option to not modify readonly files during copy, add logging of time

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCopyLocalFrontendFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCopyLocalFrontendFiles.java
@@ -43,9 +43,9 @@ import org.slf4j.LoggerFactory;
 public class TaskCopyLocalFrontendFiles
         extends AbstractFileGeneratorFallibleCommand {
 
-    public static boolean PREVENT_READONLY_FILES = true;
-
     private final Options options;
+
+    private static boolean performReadonlyCheck = true;
 
     /**
      * Copy project local frontend files from defined frontendResourcesDirectory
@@ -55,6 +55,8 @@ public class TaskCopyLocalFrontendFiles
      */
     TaskCopyLocalFrontendFiles(Options options) {
         this.options = options;
+        performReadonlyCheck = !Boolean.valueOf(System.getProperty(
+                "vaadin.frontend.disableReadonlyCheckOnCopy", "false"));
     }
 
     @Override
@@ -103,7 +105,7 @@ public class TaskCopyLocalFrontendFiles
                     .getFilesInDirectory(source, relativePathExclusions));
             FileUtils.copyDirectory(source, target,
                     withoutExclusions(source, relativePathExclusions));
-            if (PREVENT_READONLY_FILES) {
+            if (performReadonlyCheck) {
                 try (Stream<Path> fileStream = Files
                         .walk(Paths.get(target.getPath()))) {
                     // used with try-with-resources as defined in walk API note

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCopyLocalFrontendFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCopyLocalFrontendFiles.java
@@ -29,7 +29,6 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.filefilter.FileFilterUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,9 +54,9 @@ public class TaskCopyLocalFrontendFiles
         this.options = options;
     }
 
-    private static boolean isperformReadonly() {
-        return !Boolean.valueOf(System.getProperty(
-                "vaadin.frontend.disableReadonlyCheckOnCopy", "false"));
+    private static boolean shouldApplyWriteableFlag() {
+        return !Boolean.parseBoolean(System.getProperty(
+                "vaadin.frontend.disableWritableFlagCheckOnCopy", "false"));
     }
 
     @Override
@@ -106,7 +105,7 @@ public class TaskCopyLocalFrontendFiles
                     .getFilesInDirectory(source, relativePathExclusions));
             FileUtils.copyDirectory(source, target,
                     withoutExclusions(source, relativePathExclusions));
-            if (isperformReadonly()) {
+            if (shouldApplyWriteableFlag()) {
                 try (Stream<Path> fileStream = Files
                         .walk(Paths.get(target.getPath()))) {
                     // used with try-with-resources as defined in walk API note

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCopyLocalFrontendFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCopyLocalFrontendFiles.java
@@ -45,8 +45,6 @@ public class TaskCopyLocalFrontendFiles
 
     private final Options options;
 
-    private static boolean performReadonlyCheck = true;
-
     /**
      * Copy project local frontend files from defined frontendResourcesDirectory
      * (by default 'src/main/resources/META-INF/resources/frontend'). This
@@ -55,7 +53,10 @@ public class TaskCopyLocalFrontendFiles
      */
     TaskCopyLocalFrontendFiles(Options options) {
         this.options = options;
-        performReadonlyCheck = !Boolean.valueOf(System.getProperty(
+    }
+
+    private static boolean isperformReadonly() {
+        return !Boolean.valueOf(System.getProperty(
                 "vaadin.frontend.disableReadonlyCheckOnCopy", "false"));
     }
 
@@ -105,7 +106,7 @@ public class TaskCopyLocalFrontendFiles
                     .getFilesInDirectory(source, relativePathExclusions));
             FileUtils.copyDirectory(source, target,
                     withoutExclusions(source, relativePathExclusions));
-            if (performReadonlyCheck) {
+            if (isperformReadonly()) {
                 try (Stream<Path> fileStream = Files
                         .walk(Paths.get(target.getPath()))) {
                     // used with try-with-resources as defined in walk API note

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCopyLocalFrontendFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCopyLocalFrontendFiles.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
 public class TaskCopyLocalFrontendFiles
         extends AbstractFileGeneratorFallibleCommand {
 
-    public static boolean PREVENT_READONLY_FILES = false;
+    public static boolean PREVENT_READONLY_FILES = true;
 
     private final Options options;
 


### PR DESCRIPTION
Allows to skip setting the writable flag on copied files, by providing the vaadin.frontend.disableWritableFlagCheckOnCopy system property.
This may improve performance in certain scenarios with Windows OS.

Fixes #19866