### PR TITLE
chore: upgrade commons-codec to 1.16.1 (2.11)

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -148,7 +148,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.15</version>
+            <version>1.16.1</version>
         </dependency>
         <!-- TESTING DEPENDENCIES -->
         <dependency>


### PR DESCRIPTION
after the `commons-compress` upgrade #19840 , the `codec` should be upgraded to avoid the dependency convergence failure