### PR TITLE
fix: wait for output reading to complete before parsing version

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -559,8 +560,14 @@ public class NodeInstaller {
                 throw new IOException("Process exited with non 0 exit code. ("
                         + exitCode + ")");
             }
-            return FrontendUtils.parseFrontendVersion(
-                    streamConsumer.getNow(new Pair<>("", "")).getFirst());
+            String version;
+            try {
+                version = streamConsumer.get().getFirst();
+            } catch (ExecutionException e) {
+                getLogger().debug("Cannot read {} version", tool, e);
+                version = "";
+            }
+            return FrontendUtils.parseFrontendVersion(version);
         } catch (InterruptedException | IOException e) {
             throw new InstallationException(String.format(
                     "Unable to detect version of %s. %s", tool,

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
@@ -27,6 +27,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -562,8 +564,8 @@ public class NodeInstaller {
             }
             String version;
             try {
-                version = streamConsumer.get().getFirst();
-            } catch (ExecutionException e) {
+                version = streamConsumer.get(1, TimeUnit.SECONDS).getFirst();
+            } catch (ExecutionException | TimeoutException e) {
                 getLogger().debug("Cannot read {} version", tool, e);
                 version = "";
             }


### PR DESCRIPTION
NodeInstall.getVersion currently does not block waiting for STDOUT and STDERR to be read completely. This causes random failure during node installation because of forcing an empty version.
This change waits for future to complete before parsing the version value.
