### PR TITLE
fix: Evaluate target not active

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -296,7 +296,7 @@ function Flow() {
             fromAnchor.current = false;
             const {pathname, search} = blocker.location;
             const routes = ((window as any)?.Vaadin?.routesConfig || []) as AgnosticRouteObject[];
-            let matched = matchRoutes(Array.from(routes), window.location.pathname);
+            let matched = matchRoutes(Array.from(routes), pathname);
 
             // Navigation between server routes
             // @ts-ignore


### PR DESCRIPTION
For deciding what action to
take we should evaluate where
we are going and not the current
active path.

Fixes vaadin/hilla#2726