### PR TITLE
fix: Reset the Premium Features flag before license checking

### DIFF
--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -752,6 +752,12 @@ public class BuildFrontendUtil {
             buildInfo.remove(Constants.CONNECT_OPEN_API_FILE_TOKEN);
             buildInfo.remove(Constants.PROJECT_FRONTEND_GENERATED_DIR_TOKEN);
             buildInfo.remove(InitParameters.BUILD_FOLDER);
+            // Premium features flag is always true, because Vaadin CI server
+            // uses Enterprise sub, thus it's always true.
+            // Thus, resets the premium feature flag before asking
+            // license-server
+            buildInfo.remove(Constants.PREMIUM_FEATURES);
+
             buildInfo.put(SERVLET_PARAMETER_PRODUCTION_MODE, true);
             buildInfo.put(APPLICATION_IDENTIFIER,
                     adapter.applicationIdentifier());

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -754,9 +754,10 @@ public class BuildFrontendUtil {
             buildInfo.remove(InitParameters.BUILD_FOLDER);
             // Premium features flag is always true, because Vaadin CI server
             // uses Enterprise sub, thus it's always true.
-            // Thus, resets the premium feature flag before asking
+            // Thus, resets the premium feature flag and DAU flag before asking
             // license-server
             buildInfo.remove(Constants.PREMIUM_FEATURES);
+            buildInfo.remove(Constants.DAU_TOKEN);
 
             buildInfo.put(SERVLET_PARAMETER_PRODUCTION_MODE, true);
             buildInfo.put(APPLICATION_IDENTIFIER,
@@ -764,7 +765,7 @@ public class BuildFrontendUtil {
             if (licenseRequired) {
                 if (LocalSubscriptionKey.get() != null) {
                     adapter.logInfo("Daily Active User tracking enabled");
-                    buildInfo.put(DAU_TOKEN, true);
+                    buildInfo.put(Constants.DAU_TOKEN, true);
                 }
                 if (LicenseChecker.isValidLicense("vaadin-commercial-cc-client",
                         null, BuildType.PRODUCTION)) {

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -68,7 +68,6 @@ import elemental.json.impl.JsonUtil;
 import static com.vaadin.flow.server.Constants.CONNECT_APPLICATION_PROPERTIES_TOKEN;
 import static com.vaadin.flow.server.Constants.CONNECT_JAVA_SOURCE_FOLDER_TOKEN;
 import static com.vaadin.flow.server.Constants.CONNECT_OPEN_API_FILE_TOKEN;
-import static com.vaadin.flow.server.Constants.DAU_TOKEN;
 import static com.vaadin.flow.server.Constants.DISABLE_PREPARE_FRONTEND_CACHE;
 import static com.vaadin.flow.server.Constants.FRONTEND_TOKEN;
 import static com.vaadin.flow.server.Constants.JAVA_RESOURCE_FOLDER_TOKEN;

--- a/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
+++ b/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
@@ -369,6 +369,8 @@ public class BuildFrontendUtilTest {
             throws Exception {
         File tokenFile = prepareAndAssertTokenFile();
 
+        addPremiumFeatureAndDAUFlagTrue(tokenFile);
+
         String subscriptionKey = System.getProperty("vaadin.subscriptionKey");
         System.setProperty("vaadin.subscriptionKey", "sub-123");
         try {
@@ -419,7 +421,7 @@ public class BuildFrontendUtilTest {
             throws Exception {
         File tokenFile = prepareAndAssertTokenFile();
 
-        addPremiumFeatureFlagTrue(tokenFile);
+        addPremiumFeatureAndDAUFlagTrue(tokenFile);
 
         withMockedLicenseChecker(true, () -> {
             BuildFrontendUtil.updateBuildFile(adapter, true);
@@ -439,7 +441,7 @@ public class BuildFrontendUtilTest {
             throws Exception {
         File tokenFile = prepareAndAssertTokenFile();
 
-        addPremiumFeatureFlagTrue(tokenFile);
+        addPremiumFeatureAndDAUFlagTrue(tokenFile);
 
         withMockedLicenseChecker(false, () -> {
             BuildFrontendUtil.updateBuildFile(adapter, true);
@@ -585,13 +587,15 @@ public class BuildFrontendUtilTest {
         Mockito.when(adapter.runNpmInstall()).thenReturn(true);
     }
 
-    private void addPremiumFeatureFlagTrue(File tokenFile) throws IOException {
+    private void addPremiumFeatureAndDAUFlagTrue(File tokenFile)
+            throws IOException {
         // simulates true value placed into pre-compiled bundle
         // when bundle is compiled on Vaadin CI server
         String tokenJson = FileUtils.readFileToString(tokenFile,
                 StandardCharsets.UTF_8);
         JsonObject buildInfo = JsonUtil.parse(tokenJson);
         buildInfo.put(Constants.PREMIUM_FEATURES, true);
+        buildInfo.put(Constants.DAU_TOKEN, true);
 
         FileIOUtils.writeIfChanged(tokenFile,
                 JsonUtil.stringify(buildInfo, 2) + "\n");


### PR DESCRIPTION
## Description

The pre-compiled production bundle comes with true value of this flag always, because Vaadin CI server has a sub that enables it. Thus, Flow need to reset this flag before it calls the license server.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
