### PR TITLE
fix: Also take into account the application.properties value

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
@@ -426,7 +426,7 @@ public class PluginEffectiveConfiguration(
         .convention(false)
 
     public val reactEnable: Provider<Boolean> = extension.reactEnable
-        .convention(FrontendUtils.isReactRouterRequired(BuildFrontendUtil.getFrontendDirectory(GradlePluginAdapter(project, this, true))))
+        .convention(FrontendUtils.isReactRouterRequired(BuildFrontendUtil.getFrontendDirectory(GradlePluginAdapter(project, this, true)), File(projectBuildDir.get())))
         .overrideWithSystemPropertyFlag(InitParameters.REACT_ENABLE)
 
     public val cleanFrontendFiles: Property<Boolean> = extension.cleanFrontendFiles

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -529,7 +529,8 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
             return reactEnable;
         }
         File frontendDirectory = BuildFrontendUtil.getFrontendDirectory(this);
-        return FrontendUtils.isReactRouterRequired(frontendDirectory);
+        return FrontendUtils.isReactRouterRequired(frontendDirectory,
+                new File(projectBaseDirectory().toFile(), buildFolder()));
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/Options.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/Options.java
@@ -930,8 +930,9 @@ public class Options implements Serializable {
 
     public Options withReact(boolean reactEnable) {
         this.reactEnable = reactEnable;
-        if (reactEnable && !FrontendUtils
-                .isReactRouterRequired(getFrontendDirectory())) {
+        if (reactEnable
+                && !FrontendUtils.isReactRouterRequired(getFrontendDirectory(),
+                        getBuildDirectory())) {
             LoggerFactory.getLogger(Options.class).debug(
                     "Setting reactEnable to false as Vaadin Router is used!");
             this.reactEnable = false;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesScanner.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesScanner.java
@@ -111,7 +111,8 @@ public interface FrontendDependenciesScanner extends Serializable {
 
         public FrontendDependenciesScanner createScanner(Options options) {
             boolean reactEnabled = options.isReactEnabled() && FrontendUtils
-                    .isReactRouterRequired(options.getFrontendDirectory());
+                    .isReactRouterRequired(options.getFrontendDirectory(),
+                            options.getBuildDirectory());
             return createScanner(!options.isUseByteCodeScanner(),
                     options.getClassFinder(),
                     options.isGenerateEmbeddableWebComponents(),

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -568,9 +568,9 @@ public class NodeUpdaterTest {
                 .mockStatic(FrontendUtils.class)) {
             mock.when(() -> FrontendUtils.isHillaUsed(Mockito.any(File.class),
                     Mockito.any(ClassFinder.class))).thenReturn(true);
-            mock.when(() -> FrontendUtils
-                    .isReactRouterRequired(Mockito.any(File.class)))
-                    .thenReturn(true);
+            mock.when(() -> FrontendUtils.isReactRouterRequired(
+                    options.getFrontendDirectory(),
+                    options.getBuildDirectory())).thenReturn(true);
             options.withReact(true);
             Map<String, String> defaultDeps = nodeUpdater
                     .getDefaultDependencies();

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
@@ -268,8 +268,9 @@ public class DevModeInitializer implements Serializable {
         JsonObject tokenFileData = Json.createObject();
         Mode mode = config.getMode();
         boolean reactEnable = config.getBooleanProperty(REACT_ENABLE,
-                FrontendUtils
-                        .isReactRouterRequired(options.getFrontendDirectory()));
+                FrontendUtils.isReactRouterRequired(
+                        options.getFrontendDirectory(),
+                        options.getBuildDirectory()));
         options.enablePackagesUpdate(true)
                 .useByteCodeScanner(useByteCodeScanner)
                 .withFrontendGeneratedFolder(frontendGeneratedFolder)


### PR DESCRIPTION
When checking for react enable
also look if we have a application.properties
with the vaadin.react.enable flag.

This is especially for production build when only
application.properties has react disabled.

Touches #19951 and #19911
