### PR TITLE
fix: fail fast if view defines same path for route and route alias

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractRouteRegistryInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractRouteRegistryInitializer.java
@@ -100,9 +100,9 @@ public abstract class AbstractRouteRegistryInitializer implements Serializable {
 
         }
 
-        Route routeAnnotation = route.getAnnotation(Route.class);
         RouteAlias[] aliases = route.getAnnotationsByType(RouteAlias.class);
-        if (routeAnnotation != null && aliases.length > 0) {
+        if (aliases.length > 0) {
+            Route routeAnnotation = route.getAnnotation(Route.class);
             Map<String, Long> stats = Arrays.stream(aliases)
                     .map(RouteAlias::value).collect(Collectors.groupingBy(
                             Function.identity(), Collectors.counting()));

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractRouteRegistryInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractRouteRegistryInitializer.java
@@ -19,8 +19,11 @@ import jakarta.servlet.annotation.HandlesTypes;
 
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -34,6 +37,7 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteAlias;
 import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.router.internal.RouteUtil;
+import com.vaadin.flow.server.InvalidRouteConfigurationException;
 import com.vaadin.flow.server.InvalidRouteLayoutConfigurationException;
 import com.vaadin.flow.server.PWA;
 import com.vaadin.flow.server.VaadinContext;
@@ -96,6 +100,30 @@ public abstract class AbstractRouteRegistryInitializer implements Serializable {
 
         }
 
+        Route routeAnnotation = route.getAnnotation(Route.class);
+        RouteAlias[] aliases = route.getAnnotationsByType(RouteAlias.class);
+        if (routeAnnotation != null && aliases.length > 0) {
+            Map<String, Long> stats = Arrays.stream(aliases)
+                    .map(RouteAlias::value).collect(Collectors.groupingBy(
+                            Function.identity(), Collectors.counting()));
+            if (stats.containsKey(routeAnnotation.value())) {
+                throw new InvalidRouteConfigurationException(String.format(
+                        "'%s' declares '@%s' and '@%s' with the same path '%s'",
+                        route.getCanonicalName(), Route.class.getSimpleName(),
+                        RouteAlias.class.getSimpleName(),
+                        routeAnnotation.value()));
+            }
+            String repeatedAliases = stats.entrySet().stream()
+                    .filter(e -> e.getValue() > 1).map(Map.Entry::getKey)
+                    .collect(Collectors.joining(", "));
+            if (!repeatedAliases.isEmpty()) {
+                throw new InvalidRouteConfigurationException(String.format(
+                        "'%s' declares multiple '@%s' with same paths: %s.",
+                        route.getCanonicalName(),
+                        RouteAlias.class.getSimpleName(), repeatedAliases));
+            }
+        }
+
         if (route.isAnnotationPresent(PageTitle.class)
                 && HasDynamicTitle.class.isAssignableFrom(route)) {
             throw new DuplicateNavigationTitleException(String.format(
@@ -110,8 +138,7 @@ public abstract class AbstractRouteRegistryInitializer implements Serializable {
 
             validateRouteAnnotation(context, route, annotation);
 
-            for (RouteAlias alias : route
-                    .getAnnotationsByType(RouteAlias.class)) {
+            for (RouteAlias alias : aliases) {
                 validateRouteAliasAnnotation(context, route, alias, annotation);
             }
         });


### PR DESCRIPTION
Currently, if a view defines `@Route` and `@RouteAlias` with the same path, the alias is rejected at startup, but there is no evidence of the error.
However, when hot swap is enabled and the view class is reloaded, an exception is thrown.
This change adds an explicit check for duplicate paths, preventing the application from starting if the configuration is invalid.

Fixes #19972 