### PR TITLE
fix: ensure session is registered with Hotswapper

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/hotswap/Hotswapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/hotswap/Hotswapper.java
@@ -46,6 +46,8 @@ import com.vaadin.flow.server.SessionDestroyEvent;
 import com.vaadin.flow.server.SessionDestroyListener;
 import com.vaadin.flow.server.SessionInitEvent;
 import com.vaadin.flow.server.SessionInitListener;
+import com.vaadin.flow.server.UIInitEvent;
+import com.vaadin.flow.server.UIInitListener;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
 
@@ -83,7 +85,7 @@ import com.vaadin.flow.server.VaadinSession;
  * @since 24.5
  */
 public class Hotswapper implements ServiceDestroyListener, SessionInitListener,
-        SessionDestroyListener {
+        SessionDestroyListener, UIInitListener {
     private static final Logger LOGGER = LoggerFactory
             .getLogger(Hotswapper.class);
     private final Set<VaadinSession> sessions = ConcurrentHashMap.newKeySet();
@@ -413,6 +415,11 @@ public class Hotswapper implements ServiceDestroyListener, SessionInitListener,
         sessions.clear();
     }
 
+    @Override
+    public void uiInit(UIInitEvent event) {
+        sessions.add(event.getUI().getSession());
+    }
+
     /**
      * Register the hotwsapper entry point for the given {@link VaadinService}.
      * <p>
@@ -428,6 +435,7 @@ public class Hotswapper implements ServiceDestroyListener, SessionInitListener,
     public static Optional<Hotswapper> register(VaadinService vaadinService) {
         if (!vaadinService.getDeploymentConfiguration().isProductionMode()) {
             Hotswapper hotswapper = new Hotswapper(vaadinService);
+            vaadinService.addUIInitListener(hotswapper);
             vaadinService.addSessionInitListener(hotswapper);
             vaadinService.addSessionDestroyListener(hotswapper);
             vaadinService.addServiceDestroyListener(hotswapper);

--- a/flow-server/src/test/java/com/vaadin/flow/hotswap/HotswapperTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/hotswap/HotswapperTest.java
@@ -48,6 +48,7 @@ import com.vaadin.flow.server.SessionDestroyEvent;
 import com.vaadin.flow.server.SessionDestroyListener;
 import com.vaadin.flow.server.SessionInitEvent;
 import com.vaadin.flow.server.SessionInitListener;
+import com.vaadin.flow.server.UIInitListener;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
@@ -504,6 +505,7 @@ public class HotswapperTest {
         AtomicBoolean sessionInitInstalled = new AtomicBoolean();
         AtomicBoolean sessionDestroyInstalled = new AtomicBoolean();
         AtomicBoolean serviceDestroyInstalled = new AtomicBoolean();
+        AtomicBoolean uiInitInstalled = new AtomicBoolean();
         MockDeploymentConfiguration configuration = new MockDeploymentConfiguration();
         configuration.setProductionMode(false);
         VaadinService service = new MockVaadinServletService(configuration) {
@@ -527,6 +529,12 @@ public class HotswapperTest {
                 serviceDestroyInstalled.set(true);
                 return super.addServiceDestroyListener(listener);
             }
+
+            @Override
+            public Registration addUIInitListener(UIInitListener listener) {
+                uiInitInstalled.set(true);
+                return super.addUIInitListener(listener);
+            }
         };
         ApplicationConfiguration appConfig = Mockito
                 .mock(ApplicationConfiguration.class);
@@ -546,6 +554,9 @@ public class HotswapperTest {
         Assert.assertTrue(
                 "Expected hotswapper ServiceDestroyListener to be registered in development mode, but was not",
                 serviceDestroyInstalled.get());
+        Assert.assertTrue(
+                "Expected hotswapper UIInitListener to be registered in development mode, but was not",
+                uiInitInstalled.get());
     }
 
     @Test
@@ -553,6 +564,7 @@ public class HotswapperTest {
         AtomicBoolean sessionInitInstalled = new AtomicBoolean();
         AtomicBoolean sessionDestroyInstalled = new AtomicBoolean();
         AtomicBoolean serviceDestroyInstalled = new AtomicBoolean();
+        AtomicBoolean uiInitInstalled = new AtomicBoolean();
         MockDeploymentConfiguration configuration = new MockDeploymentConfiguration();
         configuration.setProductionMode(true);
         VaadinService service = new MockVaadinServletService(configuration) {
@@ -588,6 +600,9 @@ public class HotswapperTest {
         Assert.assertFalse(
                 "Expected hotswapper  ServiceDestroyListener not to be registered in production mode, but it was",
                 serviceDestroyInstalled.get());
+        Assert.assertFalse(
+                "Expected hotswapper  UIInitListener not to be registered in production mode, but it was",
+                uiInitInstalled.get());
     }
 
     @Tag("my-route")


### PR DESCRIPTION
## Description

VaadinSession references are registered in Hotswapper in a session init listener. However, the listener might not always been invoked, for example if the HTTP session is serialized and deserialized on server restart. This change registers a UI init listener to make sure VaadinSession reference is also registered for existing sessions.

Fixes #19973

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
