### PR TITLE
fix: close overlay drawer on click

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -257,6 +257,7 @@ function Flow() {
     const vaadinNavigateEventHandler = useCallback((event: CustomEvent<{state: unknown, url: string, replace?: boolean, callback: boolean}>) => {
         const path = '/' + event.detail.url;
         navigated.current = !event.detail.callback;
+        fromAnchor.current = false;
         navigate(path, { state: event.detail.state, replace: event.detail.replace});
     }, [navigate]);
 

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -239,6 +239,8 @@ function Flow() {
         // in order to get a server round-trip even when navigating to the same URL again
         fromAnchor.current = true;
         navigate(path);
+        // Dispatch close event for overlay drawer on click navigation.
+        window.dispatchEvent(new CustomEvent('close-overlay-drawer'));
     }, [navigate]);
 
     const vaadinRouterGoEventHandler = useCallback((event: CustomEvent<URL>) => {


### PR DESCRIPTION
Close the overlay drawer
even when clicking on
same link and no actual
navigation happens.

Fixes #19823
