### PR TITLE
chore: Node 22.9.0

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -66,7 +66,7 @@ public class FrontendTools {
      * the installed version is older than {@link #SUPPORTED_NODE_VERSION}, i.e.
      * {@value #SUPPORTED_NODE_MAJOR_VERSION}.{@value #SUPPORTED_NODE_MINOR_VERSION}.
      */
-    public static final String DEFAULT_NODE_VERSION = "v20.17.0";
+    public static final String DEFAULT_NODE_VERSION = "v22.9.0";
     /**
      * This is the version shipped with the default Node version.
      */


### PR DESCRIPTION
Node 22 will become LTS well before the 24.6 release
