### PR TITLE
test: increase sleep time to allow GC to perform cleanup

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/ComponentTrackerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/ComponentTrackerTest.java
@@ -155,12 +155,11 @@ public class ComponentTrackerTest {
 
     private boolean isCleared(Map<?, ?> map) throws InterruptedException {
         for (int i = 0; i < 5; i++) {
-            System.out.println(i);
             System.gc();
             if (map.isEmpty()) {
                 return true;
             }
-            Thread.sleep(10);
+            Thread.sleep(100);
         }
         return false;
     }

--- a/flow-server/src/test/java/com/vaadin/flow/ComponentTrackerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/ComponentTrackerTest.java
@@ -155,11 +155,12 @@ public class ComponentTrackerTest {
 
     private boolean isCleared(Map<?, ?> map) throws InterruptedException {
         for (int i = 0; i < 5; i++) {
+            System.out.println(i);
             System.gc();
-            if (map.size() == 0) {
+            if (map.isEmpty()) {
                 return true;
             }
-            Thread.sleep(1);
+            Thread.sleep(10);
         }
         return false;
     }


### PR DESCRIPTION
On CI systems the test randomly fails because the GC seems not to clean up ComponentLocator memory within the 5 milliseconds. However, running the test in isolation works fine. This change increases the delay between the GC requests to try to make the test more reliable.
