### PR TITLE
fix: Validate Control Center feature when used

### DIFF
--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -783,7 +783,7 @@ public class BuildFrontendUtil {
     }
 
     private static boolean isControlCenterAvailable(ClassFinder classFinder) {
-        if(classFinder == null) {
+        if (classFinder == null) {
             return false;
         }
         try {

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -766,17 +766,32 @@ public class BuildFrontendUtil {
                     adapter.logInfo("Daily Active User tracking enabled");
                     buildInfo.put(Constants.DAU_TOKEN, true);
                 }
-                if (LicenseChecker.isValidLicense("vaadin-commercial-cc-client",
-                        null, BuildType.PRODUCTION)) {
-                    adapter.logInfo("Premium Features are enabled");
-                    buildInfo.put(Constants.PREMIUM_FEATURES, true);
-                }
+            }
+            if (isControlCenterAvailable(adapter.getClassFinder())
+                    && LicenseChecker.isValidLicense(
+                            "vaadin-commercial-cc-client", null,
+                            BuildType.PRODUCTION)) {
+                adapter.logInfo("Premium Features are enabled");
+                buildInfo.put(Constants.PREMIUM_FEATURES, true);
             }
 
             FileUtils.write(tokenFile, JsonUtil.stringify(buildInfo, 2) + "\n",
                     StandardCharsets.UTF_8.name());
         } catch (IOException e) {
             adapter.logWarn("Unable to read token file", e);
+        }
+    }
+
+    private static boolean isControlCenterAvailable(ClassFinder classFinder) {
+        if(classFinder == null) {
+            return false;
+        }
+        try {
+            classFinder.loadClass(
+                    "com.vaadin.controlcenter.starter.actuate.endpoint.VaadinActuatorEndpoint");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
         }
     }
 

--- a/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/controlcenter/starter/actuate/endpoint/VaadinActuatorEndpoint.java
+++ b/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/controlcenter/starter/actuate/endpoint/VaadinActuatorEndpoint.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.controlcenter.starter.actuate.endpoint;
+
+/**
+ * Fake class to have mojo tests see Control Center.
+ */
+public class VaadinActuatorEndpoint {
+}

--- a/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
+++ b/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
@@ -423,6 +423,14 @@ public class BuildFrontendUtilTest {
 
         addPremiumFeatureAndDAUFlagTrue(tokenFile);
 
+        ClassLoader classLoader = new URLClassLoader(
+                new URL[] { new File(baseDir, "target/test-classes/").toURI()
+                        .toURL() },
+                BuildFrontendUtilTest.class.getClassLoader());
+        ClassFinder classFinder = new ClassFinder.DefaultClassFinder(
+                classLoader);
+        Mockito.when(adapter.getClassFinder()).thenReturn(classFinder);
+
         withMockedLicenseChecker(true, () -> {
             BuildFrontendUtil.updateBuildFile(adapter, true);
             Assert.assertTrue("Token file should still exist",
@@ -520,7 +528,8 @@ public class BuildFrontendUtilTest {
         File generatedFeatureFlagsFile = new File(adapter.generatedTsFolder(),
                 FEATURE_FLAGS_FILE_NAME);
         String featureFlagsJs = Files
-                .readString(generatedFeatureFlagsFile.toPath());
+                .readString(generatedFeatureFlagsFile.toPath())
+                .replace("\r\n", "\n");
 
         Assert.assertTrue("Example feature flag is not set",
                 featureFlagsJs.contains(


### PR DESCRIPTION
Changes production build info to validate Control Center feature only when VaadinActuatorEndpoint is in the class path. Class will be included with `control-center-starter` Vaadin platform dependency.

Fixes: #20013
