### PR TITLE
fix: hide root output element

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -367,7 +367,7 @@ function Flow() {
     }, [pathname, search, hash]);
 
     return <>
-        <output ref={ref} />
+        <output ref={ref} style={{display: "none"}}/>
         {portals.map(({children, domNode}) => createPortal(children, domNode))}
     </>;
 }


### PR DESCRIPTION
Ensures that root output element added for React router in Flow.tsx doesn't accidentally change the main layout with CSS rules targeting it.

Fixes: #19871
