### PR TITLE
fix: update title after navigation

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -720,7 +720,7 @@ public class UIInternals implements Serializable {
             // For react-router we should wait for navigation to finish
             // before updating the title.
             setTitleScript = String.format(
-                    "window.addEventListener('vaadin-navigated', function(event) {%s}, {once:true});",
+                    "if(window.Vaadin.Flow.navigation) { window.addEventListener('vaadin-navigated', function(event) {%s}, {once:true}); }  else { %1$s }",
                     setTitleScript);
         }
         return setTitleScript;

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -151,13 +151,16 @@ function extractPath(event: MouseEvent): void | string {
  * @param search search of navigation
  */
 function fireNavigated(pathname:string, search: string) {
-    setTimeout(() =>
-        window.dispatchEvent(new CustomEvent('vaadin-navigated', {
-            detail: {
-                pathname,
-                search
-            }
-        }))
+    setTimeout(() => {
+            window.dispatchEvent(new CustomEvent('vaadin-navigated', {
+                detail: {
+                    pathname,
+                    search
+                }
+            }));
+            // @ts-ignore
+            delete window.Vaadin.Flow.navigation;
+        }
     )
 }
 
@@ -255,6 +258,8 @@ function Flow() {
     }, [navigate]);
 
     const vaadinNavigateEventHandler = useCallback((event: CustomEvent<{state: unknown, url: string, replace?: boolean, callback: boolean}>) => {
+        // @ts-ignore
+        window.Vaadin.Flow.navigation = true;
         const path = '/' + event.detail.url;
         navigated.current = !event.detail.callback;
         fromAnchor.current = false;

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PageIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PageIT.java
@@ -56,7 +56,7 @@ public class PageIT extends ChromeBrowserTest {
         try {
             waitUntil(driver -> driver.getTitle().equals(title));
         } catch (TimeoutException te) {
-            Assert.fail("Page title does not match");
+            Assert.fail("Page title does not match. Expected: " + title + ", Actual: " + driver.getTitle());
         }
     }
 

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PageIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PageIT.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.TimeoutException;
 
 import com.vaadin.flow.component.html.testbench.DivElement;
 import com.vaadin.flow.component.html.testbench.InputTextElement;
@@ -52,8 +53,11 @@ public class PageIT extends ChromeBrowserTest {
     }
 
     private void verifyTitle(String title) {
-        Assert.assertEquals("Page title does not match", title,
-                getDriver().getTitle());
+        try {
+            waitUntil(driver -> driver.getTitle().equals(title));
+        } catch (TimeoutException te) {
+            Assert.fail("Page title does not match");
+        }
     }
 
     private void updateTitle(String title) {

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PageIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PageIT.java
@@ -56,7 +56,8 @@ public class PageIT extends ChromeBrowserTest {
         try {
             waitUntil(driver -> driver.getTitle().equals(title));
         } catch (TimeoutException te) {
-            Assert.fail("Page title does not match. Expected: " + title + ", Actual: " + driver.getTitle());
+            Assert.fail("Page title does not match. Expected: " + title
+                    + ", Actual: " + driver.getTitle());
         }
     }
 


### PR DESCRIPTION
Update the page title after
navigation has ended to
not have the wrong title in
history.

Fixes #19868
