### PR TITLE
chore: Add possibility to register shutdown commands for development mode

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/DevModeHandlerManager.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/DevModeHandlerManager.java
@@ -51,7 +51,7 @@ public interface DevModeHandlerManager {
      * @param classes
      *            classes to check for npm- and js modules
      * @param context
-     *            servlet context we are running in
+     *            Vaadin Context we are running in
      *
      * @throws VaadinInitializerException
      *             if dev mode can't be initialized
@@ -100,8 +100,7 @@ public interface DevModeHandlerManager {
     void setApplicationUrl(String applicationUrl);
 
     /**
-     * Registers a command that will be run then the servlet context is shut
-     * down.
+     * Registers a command that will run when DevModeHandler is shut down
      *
      * @param command
      *            the command to run

--- a/flow-server/src/main/java/com/vaadin/flow/internal/DevModeHandlerManager.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/DevModeHandlerManager.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.internal;
 
+import java.io.Closeable;
 import java.util.Optional;
 import java.util.Set;
 
@@ -96,6 +97,23 @@ public interface DevModeHandlerManager {
      *            the application url
      */
     void setApplicationUrl(String applicationUrl);
+
+    /**
+     * Adds watcher to watcher list.
+     *
+     * @param watcher
+     *            Closable interface that will be closed on shut down
+     */
+    void addWatcher(Closeable watcher);
+
+    /**
+     * Removes watcher from the list.
+     *
+     * @param watcher
+     *            watcher
+     * @return true if removed, false otherwise.
+     */
+    boolean removeWatcher(Closeable watcher);
 
     /**
      * Gets the {@link DevModeHandler}.

--- a/flow-server/src/main/java/com/vaadin/flow/internal/DevModeHandlerManager.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/DevModeHandlerManager.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.server.Command;
 import com.vaadin.flow.server.VaadinContext;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.startup.VaadinInitializerException;
@@ -99,21 +100,13 @@ public interface DevModeHandlerManager {
     void setApplicationUrl(String applicationUrl);
 
     /**
-     * Adds watcher to watcher list.
+     * Registers a command that will be run then the servlet context is shut
+     * down.
      *
-     * @param watcher
-     *            Closable interface that will be closed on shut down
+     * @param command
+     *            the command to run
      */
-    void addWatcher(Closeable watcher);
-
-    /**
-     * Removes watcher from the list.
-     *
-     * @param watcher
-     *            watcher
-     * @return true if removed, false otherwise.
-     */
-    boolean removeWatcher(Closeable watcher);
+    void registerShutdownCommand(Command command);
 
     /**
      * Gets the {@link DevModeHandler}.

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerManagerImpl.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerManagerImpl.java
@@ -196,6 +196,16 @@ public class DevModeHandlerManagerImpl implements DevModeHandlerManager {
                 new DevModeHandlerAlreadyStartedAttribute());
     }
 
+    @Override
+    public void addWatcher(Closeable closeable) {
+        this.watchers.add(closeable);
+    }
+
+    @Override
+    public boolean removeWatcher(Closeable closeable) {
+        return this.watchers.remove(closeable);
+    }
+
     /**
      * Shows whether {@link DevModeHandler} has been already started or not.
      *

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerManagerImpl.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerManagerImpl.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.base.devserver;
 
+import com.vaadin.flow.server.Command;
 import jakarta.servlet.annotation.HandlesTypes;
 
 import java.io.Closeable;
@@ -66,7 +67,7 @@ public class DevModeHandlerManagerImpl implements DevModeHandlerManager {
 
     private DevModeHandler devModeHandler;
     private BrowserLauncher browserLauncher;
-    final private Set<Closeable> watchers = new HashSet<>();
+    private final Set<Command> shutdownCommands = new HashSet<>();
 
     private String applicationUrl;
     private boolean fullyStarted = false;
@@ -107,7 +108,6 @@ public class DevModeHandlerManagerImpl implements DevModeHandlerManager {
 
             ApplicationConfiguration config = ApplicationConfiguration
                     .get(context);
-
             startWatchingThemeFolder(context, config);
             watchExternalDependencies(context, config);
             setFullyStarted(true);
@@ -121,7 +121,7 @@ public class DevModeHandlerManagerImpl implements DevModeHandlerManager {
         File frontendFolder = FrontendUtils.getProjectFrontendDir(config);
         File jarFrontendResourcesFolder = FrontendUtils
                 .getJarResourcesFolder(frontendFolder);
-        watchers.add(new ExternalDependencyWatcher(context,
+        registerWatcherShutdownCommand(new ExternalDependencyWatcher(context,
                 jarFrontendResourcesFolder));
 
     }
@@ -146,7 +146,8 @@ public class DevModeHandlerManagerImpl implements DevModeHandlerManager {
             for (String themeName : activeThemes) {
                 File themeFolder = ThemeUtils.getThemeFolder(
                         FrontendUtils.getProjectFrontendDir(config), themeName);
-                watchers.add(new ThemeLiveUpdater(themeFolder, context));
+                registerWatcherShutdownCommand(
+                        new ThemeLiveUpdater(themeFolder, context));
             }
         } catch (Exception e) {
             getLogger().error("Failed to start live-reload for theme files", e);
@@ -158,15 +159,16 @@ public class DevModeHandlerManagerImpl implements DevModeHandlerManager {
             devModeHandler.stop();
             devModeHandler = null;
         }
-        for (Closeable watcher : watchers) {
+        for (Command shutdownCommand : shutdownCommands) {
             try {
-                watcher.close();
-            } catch (IOException e) {
-                getLogger().error("Failed to stop watcher "
-                        + watcher.getClass().getName(), e);
+                shutdownCommand.execute();
+            } catch (Exception e) {
+                getLogger().error("Failed to execute shut down command {}",
+                        shutdownCommand.getClass().getName(), e);
             }
         }
-        watchers.clear();
+        shutdownCommands.clear();
+
     }
 
     @Override
@@ -196,14 +198,20 @@ public class DevModeHandlerManagerImpl implements DevModeHandlerManager {
                 new DevModeHandlerAlreadyStartedAttribute());
     }
 
-    @Override
-    public void addWatcher(Closeable closeable) {
-        this.watchers.add(closeable);
+    private void registerWatcherShutdownCommand(Closeable watcher) {
+        registerShutdownCommand(() -> {
+            try {
+                watcher.close();
+            } catch (Exception e) {
+                getLogger().error("Failed to stop watcher {}",
+                        watcher.getClass().getName(), e);
+            }
+        });
     }
 
     @Override
-    public boolean removeWatcher(Closeable closeable) {
-        return this.watchers.remove(closeable);
+    public void registerShutdownCommand(Command command) {
+        shutdownCommands.add(command);
     }
 
     /**


### PR DESCRIPTION
## Description

Sync file watcher should be closed on context shut down so adding watchers to dev tools logical since it handles that 

Fixes # (issue)

## Type of change

- [ ] Bugfix
- [X] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
