### PR TITLE
fix: add nodeVersion in gradle plugin settings

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/PrepareFrontendInputProperties.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/PrepareFrontendInputProperties.kt
@@ -174,6 +174,7 @@ internal class PrepareFrontendInputProperties(private val config: PluginEffectiv
         settings.isForceAlternativeNode = config.requireHomeNodeExec.get()
         settings.isUseGlobalPnpm = config.useGlobalPnpm.get()
         settings.isAutoUpdate = config.nodeAutoUpdate.get()
+        settings.nodeVersion = config.nodeVersion.get()
         FrontendTools(settings)
     }
 }


### PR DESCRIPTION
## Description

Prior to this fix, the settings declared in Gradle were not being passed to the plugin. For example, changing the nodeVersion in build.gradle did not update the actual nodeVersion used.

Fixes [# (issue)](https://github.com/vaadin/flow/issues/20058)

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

There are no existed tests for this part of code. You can review code execution flow for review this changes. 
