### PR TITLE
feat: ComponentTracker file location of Kotlin files

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentTracker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentTracker.java
@@ -127,7 +127,13 @@ public class ComponentTracker {
          */
         public File findJavaFile(AbstractConfiguration configuration) {
             String cls = className();
-            String filenameNoExt = filename().replace(".java", "");
+            int indexOfExt = filename().lastIndexOf(".");
+            String ext = filename().substring(indexOfExt);
+            if (!ext.equals(".java") && !ext.equals(".kt")) {
+                return null;
+            }
+
+            String filenameNoExt = filename().substring(0, indexOfExt);
 
             if (!cls.endsWith(filenameNoExt)) {
                 // Check for inner class
@@ -141,8 +147,12 @@ public class ComponentTracker {
             }
 
             File src = configuration.getJavaSourceFolder();
+            if (ext.equals(".kt") && src.getPath().endsWith("/java")) {
+                src = new File(src.getPath().substring(0,
+                        src.getPath().lastIndexOf("/java")) + "/kotlin");
+            }
             File javaFile = new File(src,
-                    cls.replace(".", File.separator) + ".java");
+                    cls.replace(".", File.separator) + ext);
             return javaFile;
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentTracker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentTracker.java
@@ -119,13 +119,13 @@ public class ComponentTracker {
         }
 
         /**
-         * Finds the Java file this location refers to.
+         * Finds the source file this location refers to.
          *
          * @param configuration
          *            the application configuration
-         * @return the Java file the location refers to, or {@code null}
+         * @return the source file the location refers to, or {@code null}
          */
-        public File findJavaFile(AbstractConfiguration configuration) {
+        public File findSourceFile(AbstractConfiguration configuration) {
             String cls = className();
             int indexOfExt = filename().lastIndexOf(".");
             String ext = filename().substring(indexOfExt);
@@ -154,6 +154,19 @@ public class ComponentTracker {
             File javaFile = new File(src,
                     cls.replace(".", File.separator) + ext);
             return javaFile;
+        }
+
+        /**
+         * Finds the Java file this location refers to.
+         *
+         * @param configuration
+         *            the application configuration
+         * @return the Java file the location refers to, or {@code null}
+         * @deprecated use findSourceFile
+         */
+        @Deprecated
+        public File findJavaFile(AbstractConfiguration configuration) {
+            return findSourceFile(configuration);
         }
 
         @Override

--- a/flow-server/src/test/java/com/vaadin/flow/ComponentTrackerLocationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/ComponentTrackerLocationTest.java
@@ -121,4 +121,23 @@ public class ComponentTrackerLocationTest {
         Assert.assertEquals(expectedFile, javaFile);
     }
 
+    @Test
+    public void findKotlinFile_simpleClass() {
+        File defaultJavaSrcDir = new File("src/main/java");
+        File kotlinExpectedSrcDir = new File("src/main/kotlin");
+        AbstractConfiguration configuration = Mockito
+                .mock(AbstractConfiguration.class);
+        Mockito.when(configuration.getJavaSourceFolder())
+                .thenReturn(defaultJavaSrcDir);
+
+        ComponentTracker.Location location = new ComponentTracker.Location(
+                "com.example.app.MyClass", "MyClass.kt", "whoCares", 99);
+        File expectedFile = kotlinExpectedSrcDir.toPath()
+                .resolve(Path.of("com", "example", "app", "MyClass.kt"))
+                .toFile();
+
+        File javaFile = location.findJavaFile(configuration);
+        Assert.assertEquals(expectedFile, javaFile);
+    }
+
 }

--- a/flow-server/src/test/java/com/vaadin/flow/ComponentTrackerLocationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/ComponentTrackerLocationTest.java
@@ -42,7 +42,7 @@ public class ComponentTrackerLocationTest {
                 .resolve(Path.of("com", "example", "app", "MyClass.java"))
                 .toFile();
 
-        File javaFile = location.findJavaFile(configuration);
+        File javaFile = location.findSourceFile(configuration);
         Assert.assertEquals(expectedFile, javaFile);
     }
 
@@ -60,7 +60,7 @@ public class ComponentTrackerLocationTest {
                 .resolve(Path.of("com", "exa$mple", "app", "MyClass.java"))
                 .toFile();
 
-        File javaFile = location.findJavaFile(configuration);
+        File javaFile = location.findSourceFile(configuration);
         Assert.assertEquals(expectedFile, javaFile);
     }
 
@@ -79,7 +79,7 @@ public class ComponentTrackerLocationTest {
                 Path.of("com", "example", "app", "MyClass$NotInner.java"))
                 .toFile();
 
-        File javaFile = location.findJavaFile(configuration);
+        File javaFile = location.findSourceFile(configuration);
         Assert.assertEquals(expectedFile, javaFile);
     }
 
@@ -98,7 +98,7 @@ public class ComponentTrackerLocationTest {
                 .resolve(Path.of("com", "example", "app", "MyClass.java"))
                 .toFile();
 
-        File javaFile = location.findJavaFile(configuration);
+        File javaFile = location.findSourceFile(configuration);
         Assert.assertEquals(expectedFile, javaFile);
     }
 
@@ -117,7 +117,7 @@ public class ComponentTrackerLocationTest {
                 .resolve(Path.of("com", "example", "app", "MyClass.java"))
                 .toFile();
 
-        File javaFile = location.findJavaFile(configuration);
+        File javaFile = location.findSourceFile(configuration);
         Assert.assertEquals(expectedFile, javaFile);
     }
 
@@ -136,7 +136,7 @@ public class ComponentTrackerLocationTest {
                 .resolve(Path.of("com", "example", "app", "MyClass.kt"))
                 .toFile();
 
-        File javaFile = location.findJavaFile(configuration);
+        File javaFile = location.findSourceFile(configuration);
         Assert.assertEquals(expectedFile, javaFile);
     }
 


### PR DESCRIPTION
## Description

Checks if Java file is de facto Kotlin file and uses proper source directory

Fixes https://github.com/vaadin/copilot/issues/30

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
