### PR TITLE
fix: Store layout packages

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/ReloadCache.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/ReloadCache.java
@@ -29,6 +29,7 @@ class ReloadCache implements Serializable {
     static Set<String> skippedResources = new HashSet<>();
     static Set<String> dynamicWhiteList;
     static Set<String> routePackages;
+    static Set<String> layoutPackages;
     static Set<String> jarClassNames = new HashSet<>();
     static Set<Class<?>> jarClasses = new HashSet<>();
 }

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -327,7 +327,7 @@ public class VaadinServletContextInitializer
                 getLogger().debug("There are no discovered routes yet. "
                         + "Start to collect all routes from the classpath...");
                 try {
-                    Collection<String> routePackages = null;
+                    Collection<String> routePackages;
                     if (devModeCachingEnabled
                             && ReloadCache.routePackages != null) {
                         routePackages = ReloadCache.routePackages;
@@ -356,11 +356,27 @@ public class VaadinServletContextInitializer
                             "There are {} navigation targets after filtering route classes: {}",
                             navigationTargets.size(), navigationTargets);
 
+                    Collection<String> layoutPackages;
+                    if (devModeCachingEnabled
+                            && ReloadCache.layoutPackages != null) {
+                        layoutPackages = ReloadCache.layoutPackages;
+                    } else {
+                        layoutPackages = getDefaultPackages();
+                    }
+
                     Set<Class<?>> layoutClasses = findByAnnotation(
-                            routePackages, Layout.class)
+                            layoutPackages, Layout.class)
                             .collect(Collectors.toSet());
+
+                    if (devModeCachingEnabled) {
+                        ReloadCache.layoutPackages = layoutClasses.stream()
+                                .map(Class::getPackageName)
+                                .collect(Collectors.toSet());
+                    }
+
                     RouteRegistryInitializer
                             .validateLayoutAnnotations(layoutClasses);
+
                     // Collect all layouts to use with Hilla as a main layout
                     layoutClasses.stream().filter(
                             clazz -> RouterLayout.class.isAssignableFrom(clazz))


### PR DESCRIPTION
Store layout packages
in development mode reload
cache as layouts may not be
in same packages as routes.

Fixes #20066
