### PR TITLE
fix: Layout should be collected as entyrpoint

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
@@ -51,6 +51,7 @@ import com.vaadin.flow.component.page.AppShellConfigurator;
 import com.vaadin.flow.internal.ReflectTools;
 import com.vaadin.flow.router.DefaultRoutePathProvider;
 import com.vaadin.flow.router.HasErrorParameter;
+import com.vaadin.flow.router.Layout;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.internal.DependencyTrigger;
 import com.vaadin.flow.server.LoadDependenciesOnStartup;
@@ -463,6 +464,11 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
         for (Class<?> initListener : getFinder().getSubTypesOf(getFinder()
                 .loadClass(VaadinServiceInitListener.class.getName()))) {
             addInternalEntryPoint(initListener);
+        }
+
+        for (Class<?> layout : getFinder().getAnnotatedClasses(
+                getFinder().loadClass(Layout.class.getName()))) {
+            addInternalEntryPoint(layout);
         }
 
         for (Class<?> appShell : getFinder().getSubTypesOf(

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
@@ -37,8 +37,10 @@ import com.vaadin.flow.component.webcomponent.WebComponent;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.ErrorParameter;
 import com.vaadin.flow.router.HasErrorParameter;
+import com.vaadin.flow.router.Layout;
 import com.vaadin.flow.router.NotFoundException;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.server.UIInitListener;
 import com.vaadin.flow.server.VaadinServiceInitListener;
 import com.vaadin.flow.server.frontend.scanner.samples.ErrorComponent;
@@ -280,6 +282,24 @@ public class FrontendDependenciesTest {
                 "@vaadin/common-frontend/ConnectionIndicator.js");
     }
 
+    @Test // 20074
+    public void layoutClasses_collectedAsEntrypoint() {
+        Mockito.when(classFinder.getAnnotatedClasses(Layout.class))
+                .thenReturn(Collections.singleton(MainLayout.class));
+
+        FrontendDependencies dependencies = new FrontendDependencies(
+                classFinder, false);
+
+        Optional<EntryPointData> layoutEndpointData = dependencies
+                .getEntryPoints().stream().filter(entryPoint -> entryPoint
+                        .getName().equals(MainLayout.class.getName()))
+                .findAny();
+        Assert.assertTrue("MainLayout should be visited",
+                layoutEndpointData.isPresent());
+        DepsTests.assertImports(dependencies.getModules(), "reference.js",
+                "@vaadin/common-frontend/ConnectionIndicator.js");
+    }
+
     @Test // #9861
     public void visitedExporter_previousEntryPointsNotOverridden()
             throws InstantiationException, IllegalAccessException {
@@ -504,4 +524,9 @@ public class FrontendDependenciesTest {
     public static class GrandChildRoute extends ChildRoute {
     }
 
+    @Tag("div")
+    @Layout
+    @JsModule("reference.js")
+    public static class MainLayout extends Component implements RouterLayout {
+    }
 }


### PR DESCRIPTION
Layout annotated classes should be
collected as entrypoints for
production builds.

Fixes #20074
