### PR TITLE
chore!: upgrade minimum supported Gradle version to 8.7

### DIFF
--- a/flow-plugins/flow-gradle-plugin/README.md
+++ b/flow-plugins/flow-gradle-plugin/README.md
@@ -4,7 +4,7 @@ This is the official Vaadin Gradle Plugin for Vaadin 19 and newer.
 The implementation is based on `flow-plugin-base` which is also used by the Vaadin Maven plugin.
 
 Prerequisites:
-* Java 8 or higher
+* Java 17 or higher
 * node.js and npm. Vaadin will now automatically install node.js and npm, but you can also install those locally:
   * Windows/Mac: [node.js Download site](https://nodejs.org/en/download/)
   * Linux: Use package manager e.g. `sudo apt install npm`
@@ -23,7 +23,7 @@ You need to add the following lines to your `build.gradle` file
 
 ```
 plugins {
-    id 'com.vaadin' version '0.8.0'
+    id 'com.vaadin'
 }
 ```
 
@@ -32,16 +32,17 @@ plugins {
 Please follow this chart to learn which Plugin version to use with particular Vaadin version.
 Vaadin recommends using the latest Vaadin LTS (Long-Term Support) version.
 
-| Vaadin Gradle Plugin version | Supports |
-|------------------------------|----------|
-| -                            | Vaadin 13 and lower are unsupported |
-| 0.6.0 and lower              | Vaadin 14.1.x LTS and lower |
-| 0.7.0                        | Vaadin 14.2.x LTS |
+| Vaadin Gradle Plugin version | Supports                                       |
+|------------------------------|------------------------------------------------|
+| -                            | Vaadin 13 and lower are unsupported            |
+| 0.6.0 and lower              | Vaadin 14.1.x LTS and lower                    |
+| 0.7.0                        | Vaadin 14.2.x LTS                              |
 | 0.14.3.7                     | All other Vaadin 14 LTS versions (recommended) |
-| -                            | Vaadin 15 and 16 are unsupported |
-| 0.17.0.1                     | Vaadin 17 and higher |
-| 0.20.0.0.alpha3              | experimental support for Vaadin 19 and 20 |
-| 20.0.0                       | Vaadin 20 and higher |
+| -                            | Vaadin 15 and 16 are unsupported               |
+| 0.17.0.1                     | Vaadin 17 and higher                           |
+| 0.20.0.0.alpha3              | experimental support for Vaadin 19 and 20      |
+| 20.0.0                       | Vaadin 20 and higher                           |
+| 24.0.0                       | Vaadin 24 and higher                           |
 
 ## Tasks
 

--- a/flow-plugins/flow-gradle-plugin/build.gradle
+++ b/flow-plugins/flow-gradle-plugin/build.gradle
@@ -183,7 +183,7 @@ publishing {
  *
  **********************************************************************************************************************/
 wrapper {
-    gradleVersion = '8.5'
+    gradleVersion = '8.7'
     distributionType = Wrapper.DistributionType.ALL
 }
 

--- a/flow-plugins/flow-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/flow-plugins/flow-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/TestUtils.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/TestUtils.kt
@@ -213,7 +213,7 @@ object OsUtils {
  * Used to test the plugin. Contains helpful utility methods to manipulate folders
  * and files in the project.
  */
-class TestProject(val gradleVersion: String = if(JavaVersion.current().majorVersion.toInt() >= 20) "8.3" else VaadinPlugin.GRADLE_MINIMUM_SUPPORTED_VERSION) {
+class TestProject(val gradleVersion: String = VaadinPlugin.GRADLE_MINIMUM_SUPPORTED_VERSION) {
     /**
      * The project root dir.
      */

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
@@ -464,26 +464,36 @@ class VaadinSmokeTest : AbstractGradleTest() {
             setup()
         }
 
-        for (supportedVersion in arrayOf(VaadinPlugin.GRADLE_MINIMUM_SUPPORTED_VERSION, "8.5", "8.6") ) {
+        for (supportedVersion in arrayOf(VaadinPlugin.GRADLE_MINIMUM_SUPPORTED_VERSION, "8.8", "8.10") ) {
                 setupProjectForGradleVersion(supportedVersion)
                 val result = testProject.build("vaadinClean")
                 result.expectTaskSucceded("vaadinClean")
         }
 
-        for (unsupportedVersion in arrayOf("8.3")) {
+        for (unsupportedVersion in arrayOf("8.3", "8.4", "8.5", "8.6")) {
             setupProjectForGradleVersion(unsupportedVersion)
             val result = testProject.buildAndFail("vaadinClean")
-            assertContains(
-                result.output,
-                "requires Gradle ${VaadinPlugin.GRADLE_MINIMUM_SUPPORTED_VERSION} or later",
-                true,
-                "Expecting plugin execution to fail for version ${unsupportedVersion} " +
-                        "as it is lower than the supported one (${VaadinPlugin.GRADLE_MINIMUM_SUPPORTED_VERSION})"
-            )
-            assertContains(
-                result.output,
-                "current version is ${unsupportedVersion}"
-            )
+            if (result.output.contains("Unsupported class file major version")) {
+                assertContains(
+                    result.output,
+                    Regex("Failed to process the entry 'META-INF/versions/(\\d+)/com/fasterxml/jackson/"),
+                    "Expecting plugin execution to fail for version ${unsupportedVersion} " +
+                            "as it is lower than the supported one (${VaadinPlugin.GRADLE_MINIMUM_SUPPORTED_VERSION}) " +
+                            "and it is incompatible with Jackson library used by Flow"
+                )
+            } else {
+                assertContains(
+                    result.output,
+                    "requires Gradle ${VaadinPlugin.GRADLE_MINIMUM_SUPPORTED_VERSION} or later",
+                    true,
+                    "Expecting plugin execution to fail for version ${unsupportedVersion} " +
+                            "as it is lower than the supported one (${VaadinPlugin.GRADLE_MINIMUM_SUPPORTED_VERSION})"
+                )
+                assertContains(
+                    result.output,
+                    "current version is ${unsupportedVersion}"
+                )
+            }
         }
     }
 

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinPlugin.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinPlugin.kt
@@ -28,7 +28,7 @@ import org.gradle.util.GradleVersion
  */
 public class VaadinPlugin : Plugin<Project> {
     public companion object {
-        public const val GRADLE_MINIMUM_SUPPORTED_VERSION: String = "8.4"
+        public const val GRADLE_MINIMUM_SUPPORTED_VERSION: String = "8.7"
     }
 
     override fun apply(project: Project) {


### PR DESCRIPTION
Jackson 2.18 is incompatible with Gradle 8.4 because it contains classes compiled with Java 22.
This change bumps Gradle minimum supported version to 8.7 that supports Java 22.