### PR TITLE
chore: allow running gradle plugin tests with JDK greater that 17

### DIFF
--- a/flow-plugins/flow-gradle-plugin/build.gradle
+++ b/flow-plugins/flow-gradle-plugin/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 /***********************************************************************************************************************
  *
  * Plugins
@@ -196,14 +198,9 @@ functionalTest {
 }
 
 kotlin {
-    jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
     }
     explicitApi()
 }
 
-compileKotlin {
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-}

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
@@ -238,7 +238,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
 
     private fun doTestSpringProjectProductionMode(compressedExtension: String = "*.br") {
 
-        val springBootVersion = "3.0.0"
+        val springBootVersion = "3.3.4"
 
         testProject.settingsFile.writeText(
             """
@@ -569,7 +569,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
             """
             plugins {
                 id 'java'
-                id 'org.springframework.boot' version '3.0.0'
+                id 'org.springframework.boot' version '3.3.4'
                 id 'io.spring.dependency-management' version '1.0.11.RELEASE'
                 id("com.vaadin")
             }


### PR DESCRIPTION
Currently, running gradle plugin tests with a JDK greater than 17, and not having 17 installed on the system, fails because kotlin is configured to use a JDK 17 toolchain. This change replaces the toolchain setting for kotlin, pinning insted the jvmTarget compiler configuration to 17.

This is an alternative way to fix #17574.