### PR TITLE
fix: always fetch reactEnabled from service

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -2056,7 +2056,8 @@ public class UI extends Component
         } catch (Exception exception) {
             handleExceptionNavigation(location, exception);
         } finally {
-            if (getInternals().getSession().getConfiguration().isReactEnabled()
+            if (getInternals().getSession().getService()
+                    .getDeploymentConfiguration().isReactEnabled()
                     && getInternals().getContinueNavigationAction() != null) {
                 getInternals().clearLastHandledNavigation();
             } else {

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptNavigationStateRenderer.java
@@ -101,8 +101,8 @@ public class JavaScriptNavigationStateRenderer extends NavigationStateRenderer {
 
     @Override
     protected boolean shouldPushHistoryState(NavigationEvent event) {
-        if (event.getUI().getInternals().getSession().getConfiguration()
-                .isReactEnabled()) {
+        if (event.getUI().getInternals().getSession().getService()
+                .getDeploymentConfiguration().isReactEnabled()) {
             return super.shouldPushHistoryState(event);
         }
         if (NavigationTrigger.CLIENT_SIDE.equals(event.getTrigger())

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -858,7 +858,8 @@ public class UIInternals implements Serializable {
             }
             previous = current;
         }
-        if (getSession().getConfiguration().isReactEnabled()
+        if (getSession().getService().getDeploymentConfiguration()
+                .isReactEnabled()
                 && getRouter().getRegistry()
                         .getNavigationTarget(viewLocation.getPath()).isEmpty()
                 && target instanceof RouterLayout) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/History.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/History.java
@@ -227,7 +227,8 @@ public class History implements Serializable {
                 location);
         // Second parameter is title which is currently ignored according to
         // https://developer.mozilla.org/en-US/docs/Web/API/History_API
-        if (ui.getSession().getConfiguration().isReactEnabled()) {
+        if (ui.getSession().getService().getDeploymentConfiguration()
+                .isReactEnabled()) {
             ui.getPage().executeJs(
                     "window.dispatchEvent(new CustomEvent('vaadin-navigate', { detail: { state: $0, url: $1, replace: false, callback: $2 } }));",
                     state, pathWithQueryParameters, callback);
@@ -314,7 +315,8 @@ public class History implements Serializable {
                 location);
         // Second parameter is title which is currently ignored according to
         // https://developer.mozilla.org/en-US/docs/Web/API/History_API
-        if (ui.getSession().getConfiguration().isReactEnabled()) {
+        if (ui.getSession().getService().getDeploymentConfiguration()
+                .isReactEnabled()) {
             ui.getPage().executeJs(
                     "window.dispatchEvent(new CustomEvent('vaadin-navigate', { detail: { state: $0, url: $1, replace: true, callback: $2 } }));",
                     state, pathWithQueryParameters, callback);

--- a/flow-server/src/main/java/com/vaadin/flow/router/BeforeLeaveEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/BeforeLeaveEvent.java
@@ -88,7 +88,8 @@ public class BeforeLeaveEvent extends BeforeEvent {
                 // If the server updates the url also we will get 2 history
                 // changes instead of 1.
                 if (NavigationTrigger.ROUTER_LINK.equals(event.getTrigger())
-                        && !event.getUI().getSession().getConfiguration()
+                        && !event.getUI().getSession().getService()
+                                .getDeploymentConfiguration()
                                 .isReactEnabled()) {
                     event = new NavigationEvent(event.getSource(),
                             event.getLocation(), event.getUI(),

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -296,8 +296,8 @@ public abstract class AbstractNavigationStateRenderer
             }
 
             ui.getInternals().setLastHandledNavigation(event.getLocation());
-        } else if (ui.getInternals().getSession().getConfiguration()
-                .isReactEnabled()) {
+        } else if (ui.getInternals().getSession().getService()
+                .getDeploymentConfiguration().isReactEnabled()) {
             if (shouldPushHistoryState(event)) {
                 pushHistoryState(event);
             }

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
@@ -48,6 +48,7 @@ import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.VaadinSessionState;
 import com.vaadin.flow.server.menu.MenuRegistry;
+import com.vaadin.tests.util.MockDeploymentConfiguration;
 
 public class JavaScriptBootstrapUITest {
 
@@ -419,7 +420,8 @@ public class JavaScriptBootstrapUITest {
                 .mock(DeploymentConfiguration.class);
         Mockito.when(internals.getSession()).thenReturn(session);
         Mockito.when(session.getConfiguration()).thenReturn(configuration);
-        Mockito.when(configuration.isReactEnabled()).thenReturn(false);
+        ((MockDeploymentConfiguration) session.getService()
+                .getDeploymentConfiguration()).setReactEnabled(false);
 
         Mockito.when(internals.hasLastHandledLocation()).thenReturn(true);
         Location lastLocation = new Location("clean");

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/HistoryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/HistoryTest.java
@@ -25,6 +25,7 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
 
 import elemental.json.Json;
@@ -67,6 +68,7 @@ public class HistoryTest {
     private TestPage page = new TestPage(ui);
     private History history;
 
+    private VaadinService service = Mockito.mock(VaadinService.class);
     private VaadinSession session = Mockito.mock(VaadinSession.class);
     private DeploymentConfiguration configuration;
 
@@ -80,6 +82,10 @@ public class HistoryTest {
     public void setup() {
         history = new History(ui);
         configuration = Mockito.mock(DeploymentConfiguration.class);
+
+        Mockito.when(session.getService()).thenReturn(service);
+        Mockito.when(service.getDeploymentConfiguration())
+                .thenReturn(configuration);
         Mockito.when(session.getConfiguration()).thenReturn(configuration);
         Mockito.when(configuration.isReactEnabled()).thenReturn(false);
     }

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
@@ -64,6 +64,7 @@ import com.vaadin.flow.server.InvalidRouteConfigurationException;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.startup.ApplicationRouteRegistry;
 import com.vaadin.flow.shared.Registration;
+import com.vaadin.tests.util.MockDeploymentConfiguration;
 
 import elemental.json.Json;
 import elemental.json.JsonObject;
@@ -2934,6 +2935,9 @@ public class RouterTest extends RoutingTestBase {
     @Test
     public void ui_navigate_should_only_have_one_history_marking_on_loop()
             throws InvalidRouteConfigurationException {
+        ((MockDeploymentConfiguration) ui.getSession().getService()
+                .getDeploymentConfiguration()).setReactEnabled(false);
+
         setNavigationTargets(LoopByUINavigate.class);
 
         ui.navigate("loop");

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
@@ -848,7 +848,8 @@ public class NavigationStateRendererTest {
     public void handle_variousInputs_checkPushStateShouldBeCalledOrNot() {
         // given a service with instantiator
         MockVaadinServletService service = createMockServiceWithInstantiator();
-
+        ((MockDeploymentConfiguration) service.getDeploymentConfiguration())
+                .setReactEnabled(false);
         // given a locked session
         MockVaadinSession session = new AlwaysLockedVaadinSession(service);
         MockDeploymentConfiguration configuration = new MockDeploymentConfiguration();

--- a/flow-tests/test-react-router/src/main/java/com/vaadin/flow/StateView.java
+++ b/flow-tests/test-react-router/src/main/java/com/vaadin/flow/StateView.java
@@ -29,7 +29,7 @@ public class StateView extends Div {
     @Override
     protected void onAttach(AttachEvent attachEvent) {
         Span enabled = new Span("React enabled: " + getUI().get().getSession()
-                .getConfiguration().isReactEnabled());
+                .getService().getDeploymentConfiguration().isReactEnabled());
         enabled.setId(ENABLED_SPAN);
 
         File baseDir = attachEvent.getSession().getConfiguration()

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PopStateHandlerView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PopStateHandlerView.java
@@ -30,7 +30,8 @@ public class PopStateHandlerView extends RouterLinkView {
         Element button = ElementFactory.createButton(target).setAttribute("id",
                 target);
         String historyPush = "window.history.pushState(null, null, event.target.textContent)";
-        if (VaadinSession.getCurrent().getConfiguration().isReactEnabled()) {
+        if (VaadinSession.getCurrent().getService().getDeploymentConfiguration()
+                .isReactEnabled()) {
             historyPush = "window.dispatchEvent(new CustomEvent('vaadin-navigate', { detail: {  url: event.target.textContent, replace: false } }))";
         }
         button.addEventListener("click", e -> {


### PR DESCRIPTION
`reactEnabled` value might have been stored in session store so we can't trust that - this patch makes Flow always fetch it from `VaadinService`

Most likely fixes https://github.com/vaadin/flow/issues/20077