### PR TITLE
fix: always create AvailableViewInfo.menu

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractRouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractRouteRegistry.java
@@ -323,7 +323,8 @@ public abstract class AbstractRouteRegistry implements RouteRegistry {
                                 : menu.title(),
                         (Objects.equals(menu.order(), Double.MIN_VALUE)) ? null
                                 : menu.order(),
-                        excludeFromMenu, menu.icon()))
+                        excludeFromMenu,
+                        (menu.icon().isBlank() ? null : menu.icon())))
                 .orElse(null);
 
         RouteData route = new RouteData(parentLayouts, template, parameters,

--- a/flow-server/src/main/java/com/vaadin/flow/server/menu/MenuRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/menu/MenuRegistry.java
@@ -343,11 +343,24 @@ public class MenuRegistry {
                 : viewConfig.route().startsWith("/")
                         ? basePath + viewConfig.route()
                         : basePath + '/' + viewConfig.route();
+        if (viewConfig.menu() == null) {
+            // create MenuData anyway to avoid need for null checking
+            viewConfig = copyAvailableViewInfo(viewConfig,
+                    new MenuData(viewConfig.title(), null, false, null));
+        }
         configurations.put(path, viewConfig);
         if (viewConfig.children() != null) {
             viewConfig.children().forEach(
                     child -> collectClientViews(path, child, configurations));
         }
+    }
+
+    private static AvailableViewInfo copyAvailableViewInfo(
+            AvailableViewInfo source, MenuData newMenuData) {
+        return new AvailableViewInfo(source.title(), source.rolesAllowed(),
+                source.loginRequired(), source.route(), source.lazy(),
+                source.register(), newMenuData, source.children(),
+                source.routeParameters(), source.flowLayout());
     }
 
     public static final String FILE_ROUTES_JSON_NAME = "file-routes.json";

--- a/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuRegistryTest.java
@@ -344,7 +344,7 @@ public class MenuRegistryTest {
             boolean authenticated, boolean hasRole, boolean excludeExpected) {
         Assert.assertTrue("Client route '' missing", menuItems.containsKey(""));
         Assert.assertEquals("Public", menuItems.get("").title());
-        Assert.assertNull("Public doesn't contain specific menu data",
+        Assert.assertNotNull("Public should contain default menu data",
                 menuItems.get("").menu());
 
         if (authenticated) {
@@ -353,7 +353,7 @@ public class MenuRegistryTest {
             Assert.assertEquals("About", menuItems.get("/about").title());
             Assert.assertTrue("Login should be required",
                     menuItems.get("/about").loginRequired());
-            Assert.assertNull("About doesn't contain specific menu data",
+            Assert.assertNotNull("About should contain default menu data",
                     menuItems.get("/about").menu());
 
             if (hasRole) {
@@ -365,7 +365,7 @@ public class MenuRegistryTest {
                 Assert.assertArrayEquals("Faulty roles fo hilla",
                         new String[] { "ROLE_USER" },
                         menuItems.get("/hilla").rolesAllowed());
-                Assert.assertNull("Hilla doesn't contain specific menu data",
+                Assert.assertNotNull("Hilla should contain default menu data",
                         menuItems.get("/hilla").menu());
 
                 Assert.assertTrue("Client child route 'hilla/sub' missing",


### PR DESCRIPTION
Create always MenuData in `AvailableViewInfo.menu` to avoid need for extra null checking in automatic menu in Hilla. This change affects only code that reads available client routes from Hilla generated json file.

Fixes: #20109