### PR TITLE
fix: reload route configuration upon layout changes

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/hotswap/Hotswapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/hotswap/Hotswapper.java
@@ -39,6 +39,8 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.internal.BrowserLiveReload;
 import com.vaadin.flow.internal.BrowserLiveReloadAccessor;
+import com.vaadin.flow.router.internal.RouteTarget;
+import com.vaadin.flow.server.RouteRegistry;
 import com.vaadin.flow.server.ServiceDestroyEvent;
 import com.vaadin.flow.server.ServiceDestroyListener;
 import com.vaadin.flow.server.ServiceException;
@@ -308,6 +310,19 @@ public class Hotswapper implements ServiceDestroyListener, SessionInitListener,
             // determine the refresh strategy.
             refreshStrategy = computeRefreshStrategyForUITree(ui,
                     changedClasses, targetsChain, route);
+        }
+        // A different layout might have been applied after hotswap
+        if (refreshStrategy == UIRefreshStrategy.SKIP) {
+            RouteRegistry registry = ui.getInternals().getRouter()
+                    .getRegistry();
+            RouteTarget routeTarget = registry
+                    .getNavigationRouteTarget(
+                            ui.getActiveViewLocation().getPath())
+                    .getRouteTarget();
+            if (routeTarget != null && routeTarget.getParentLayouts().stream()
+                    .anyMatch(changedClasses::contains)) {
+                refreshStrategy = UIRefreshStrategy.PUSH_REFRESH_CHAIN;
+            }
         }
 
         // If push is not enabled we can only request a full page refresh

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractRouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractRouteRegistry.java
@@ -35,6 +35,7 @@ import com.vaadin.flow.internal.AnnotationReader;
 import com.vaadin.flow.internal.ReflectTools;
 import com.vaadin.flow.router.BeforeEnterListener;
 import com.vaadin.flow.router.HasErrorParameter;
+import com.vaadin.flow.router.Layout;
 import com.vaadin.flow.router.Menu;
 import com.vaadin.flow.router.MenuData;
 import com.vaadin.flow.router.NotFoundException;
@@ -55,7 +56,6 @@ import com.vaadin.flow.server.auth.MenuAccessControl;
 import com.vaadin.flow.server.auth.NavigationAccessControl;
 import com.vaadin.flow.server.auth.NavigationContext;
 import com.vaadin.flow.server.auth.ViewAccessChecker;
-import com.vaadin.flow.router.Layout;
 import com.vaadin.flow.internal.menu.MenuRegistry;
 import com.vaadin.flow.shared.Registration;
 
@@ -608,6 +608,19 @@ public abstract class AbstractRouteRegistry implements RouteRegistry {
         }
         synchronized (layouts) {
             layouts.put(layout.getAnnotation(Layout.class).value(), layout);
+        }
+    }
+
+    void updateLayout(Class<? extends RouterLayout> layout) {
+        if (layout == null) {
+            return;
+        }
+        synchronized (layouts) {
+            layouts.entrySet()
+                    .removeIf(entry -> layout.equals(entry.getValue()));
+            if (layout.isAnnotationPresent(Layout.class)) {
+                layouts.put(layout.getAnnotation(Layout.class).value(), layout);
+            }
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractRouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractRouteRegistry.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Stream;
@@ -622,6 +623,10 @@ public abstract class AbstractRouteRegistry implements RouteRegistry {
                 layouts.put(layout.getAnnotation(Layout.class).value(), layout);
             }
         }
+    }
+
+    Collection<Class<?>> getLayouts() {
+        return Set.copyOf(layouts.values());
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/RouteUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/RouteUtil.java
@@ -126,7 +126,7 @@ public class RouteUtil {
 
         if (hasRouteAndPathMatches && !route.get().layout().equals(UI.class)) {
             list.addAll(collectRouteParentLayouts(route.get().layout()));
-        } else if (hasRouteAndPathMatches && route.get().autoLayout()
+        } else if (route.get().autoLayout() && hasRouteAndPathMatches
                 && route.get().layout().equals(UI.class)
                 && handledRegistry.hasLayout(path)) {
             list.addAll(

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
@@ -166,8 +166,6 @@ public class TaskGenerateReactFiles
             writeFile(flowTsx, getFileContent(FLOW_TSX));
             writeFile(vaadinReactTsx,
                     getVaadinReactTsContent(routesTsx.exists()));
-            // writeFile(new File(frontendGeneratedFolder, LAYOUTS_JSON),
-            // layoutsContent());
             writeLayoutsJson(
                     options.getClassFinder().getAnnotatedClasses(Layout.class));
             if (fileAvailable(REACT_ADAPTER_TEMPLATE)) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
@@ -18,9 +18,10 @@ package com.vaadin.flow.server.frontend;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
-import java.util.Set;
+import java.util.Collection;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.FileUtils;
@@ -37,6 +38,7 @@ import com.vaadin.flow.server.Version;
 import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
+
 import static com.vaadin.flow.server.frontend.FileIOUtils.compareIgnoringIndentationEOLAndWhiteSpace;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -164,8 +166,10 @@ public class TaskGenerateReactFiles
             writeFile(flowTsx, getFileContent(FLOW_TSX));
             writeFile(vaadinReactTsx,
                     getVaadinReactTsContent(routesTsx.exists()));
-            writeFile(new File(frontendGeneratedFolder, LAYOUTS_JSON),
-                    layoutsContent());
+            // writeFile(new File(frontendGeneratedFolder, LAYOUTS_JSON),
+            // layoutsContent());
+            writeLayoutsJson(
+                    options.getClassFinder().getAnnotatedClasses(Layout.class));
             if (fileAvailable(REACT_ADAPTER_TEMPLATE)) {
                 String reactAdapterContent = getFileContent(
                         REACT_ADAPTER_TEMPLATE);
@@ -201,15 +205,48 @@ public class TaskGenerateReactFiles
         }
     }
 
-    private String layoutsContent() {
+    /**
+     * Writes the `layout.json` file in the frontend generated folder.
+     * <p>
+     * </p>
+     *
+     * @param options
+     *            the task options
+     * @param layoutsClasses
+     *            {@link Layout} annotated classes.
+     */
+    public static void writeLayouts(Options options,
+            Collection<Class<?>> layoutsClasses) {
+        TaskGenerateReactFiles task = new TaskGenerateReactFiles(options);
+        try {
+            task.writeLayoutsJson(layoutsClasses);
+        } catch (ExecutionFailedException e) {
+            if (e.getCause() instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            if (e.getCause() instanceof IOException ioEx) {
+                throw new UncheckedIOException(ioEx);
+            }
+            throw new RuntimeException(e.getCause());
+        }
+    }
+
+    private void writeLayoutsJson(Collection<Class<?>> layoutClasses)
+            throws ExecutionFailedException {
+        writeFile(new File(options.getFrontendGeneratedFolder(), LAYOUTS_JSON),
+                layoutsContent(layoutClasses));
+
+    }
+
+    private String layoutsContent(Collection<Class<?>> layoutClasses) {
         JsonArray availableLayouts = Json.createArray();
-        Set<Class<?>> layoutClasses = options.getClassFinder()
-                .getAnnotatedClasses(Layout.class);
         for (Class<?> layout : layoutClasses) {
-            JsonObject layoutObject = Json.createObject();
-            layoutObject.put("path",
-                    layout.getAnnotation(Layout.class).value());
-            availableLayouts.set(availableLayouts.length(), layoutObject);
+            if (layout.isAnnotationPresent(Layout.class)) {
+                JsonObject layoutObject = Json.createObject();
+                layoutObject.put("path",
+                        layout.getAnnotation(Layout.class).value());
+                availableLayouts.set(availableLayouts.length(), layoutObject);
+            }
         }
         return availableLayouts.toJson();
     }

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/RouteRegistryHotswapperTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/RouteRegistryHotswapperTest.java
@@ -16,6 +16,9 @@
 
 package com.vaadin.flow.router.internal;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -29,10 +32,12 @@ import org.junit.Test;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.router.Layout;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteBaseData;
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.flow.router.RouteData;
+import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.router.RoutesChangedEvent;
 import com.vaadin.flow.router.RoutesChangedListener;
 import com.vaadin.flow.server.MockVaadinServletService;
@@ -42,6 +47,7 @@ import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.startup.ApplicationRouteRegistry;
 import com.vaadin.tests.util.AlwaysLockedVaadinSession;
+import com.vaadin.tests.util.MockDeploymentConfiguration;
 
 public class RouteRegistryHotswapperTest {
 
@@ -194,6 +200,73 @@ public class RouteRegistryHotswapperTest {
                 tracker.removed.isEmpty() && tracker.added.isEmpty());
         Assert.assertEquals(before, after);
 
+    }
+
+    @Test
+    public void onClassLoadEvent_reactEnabled_layoutChanges_layoutJsonUpdated()
+            throws IOException {
+        MockDeploymentConfiguration configuration = (MockDeploymentConfiguration) vaadinService
+                .getDeploymentConfiguration();
+        configuration.setReactEnabled(true);
+        configuration.setProjectFolder(
+                Files.createTempDirectory("temp-project").toFile());
+        Path layoutFile = configuration.getFrontendFolder().toPath()
+                .resolve(Path.of("generated", "layouts.json"));
+        Assert.assertFalse(
+                "Expected layouts.json file not to be present before hotswap",
+                Files.exists(layoutFile));
+
+        @Layout
+        class MyLayout extends Component implements RouterLayout {
+        }
+
+        updater.onClassLoadEvent(vaadinService, Set.of(MyLayout.class), true);
+        Assert.assertTrue("Expected layouts.json file to be written",
+                Files.exists(layoutFile));
+    }
+
+    @Test
+    public void onClassLoadEvent_reactEnabled_notLayoutChanges_layoutJsonNotUpdated()
+            throws IOException {
+        MockDeploymentConfiguration configuration = (MockDeploymentConfiguration) vaadinService
+                .getDeploymentConfiguration();
+        configuration.setReactEnabled(true);
+        configuration.setProjectFolder(
+                Files.createTempDirectory("temp-project").toFile());
+        Path layoutFile = configuration.getFrontendFolder().toPath()
+                .resolve(Path.of("generated", "layouts.json"));
+        Assert.assertFalse(
+                "Expected layouts.json file not to be present before hotswap",
+                Files.exists(layoutFile));
+
+        updater.onClassLoadEvent(vaadinService, Set.of(MyRouteA.class), true);
+        Assert.assertFalse(
+                "Expected layouts.json file not to be present after hotswap",
+                Files.exists(layoutFile));
+    }
+
+    @Test
+    public void onClassLoadEvent_reactDisabled_layoutChanges_layoutJsonNotWritten()
+            throws IOException {
+        MockDeploymentConfiguration configuration = (MockDeploymentConfiguration) vaadinService
+                .getDeploymentConfiguration();
+        configuration.setReactEnabled(false);
+        configuration.setProjectFolder(
+                Files.createTempDirectory("temp-project").toFile());
+        Path layoutFile = configuration.getFrontendFolder().toPath()
+                .resolve(Path.of("generated", "layouts.json"));
+        Assert.assertFalse(
+                "Expected layouts.json file not to be present before hotswap",
+                Files.exists(layoutFile));
+
+        @Layout
+        class MyLayout extends Component implements RouterLayout {
+        }
+
+        updater.onClassLoadEvent(vaadinService, Set.of(MyLayout.class), true);
+        Assert.assertFalse(
+                "Expected layouts.json file not to be present after hotswap",
+                Files.exists(layoutFile));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/RouteRegistryHotswapperTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/RouteRegistryHotswapperTest.java
@@ -105,7 +105,7 @@ public class RouteRegistryHotswapperTest {
 
         Assert.assertEquals(
                 "Expected only changed route to be removed from the registry",
-                appRouteRegistryTracker.removed.size(), 1);
+                1, appRouteRegistryTracker.removed.size());
 
         Assert.assertEquals(Set.of(MyRouteB.class),
                 appRouteRegistryTracker.removed.stream()

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/RouteUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/RouteUtilTest.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.collection.IsIterableContainingInOrder;
@@ -28,16 +29,18 @@ import org.junit.Test;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.internal.ReflectTools;
+import com.vaadin.flow.router.Layout;
 import com.vaadin.flow.router.ParentLayout;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteAlias;
+import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.flow.router.RoutePrefix;
 import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.server.MockVaadinContext;
 import com.vaadin.flow.server.MockVaadinServletService;
 import com.vaadin.flow.server.SessionRouteRegistry;
 import com.vaadin.flow.server.VaadinContext;
-import com.vaadin.flow.router.Layout;
 import com.vaadin.flow.server.startup.ApplicationRouteRegistry;
 import com.vaadin.tests.util.AlwaysLockedVaadinSession;
 
@@ -914,6 +917,159 @@ public class RouteUtilTest {
         // then
         Assert.assertFalse(registry.getConfiguration().hasRoute("a"));
         Assert.assertTrue(registry.getConfiguration().hasRoute("aa"));
+    }
+
+    @Test
+    public void newLayoutAnnotatedComponent_updateRouteRegistry_routeIsUpdated() {
+        MockVaadinServletService service = new MockVaadinServletService() {
+            @Override
+            public VaadinContext getContext() {
+                return new MockVaadinContext();
+            }
+        };
+        ApplicationRouteRegistry registry = ApplicationRouteRegistry
+                .getInstance(service.getContext());
+        registry.update(() -> {
+            RouteConfiguration routeConfiguration = RouteConfiguration
+                    .forRegistry(registry);
+            routeConfiguration.setAnnotatedRoute(AutoLayoutView.class);
+        });
+
+        List<Class<? extends RouterLayout>> parentLayouts = registry
+                .getNavigationRouteTarget("auto").getRouteTarget()
+                .getParentLayouts();
+
+        Assert.assertEquals(
+                "AutoLayoutView should not have layout because no auto layout is registered",
+                0, parentLayouts.size());
+
+        RouteUtil.updateRouteRegistry(registry,
+                Collections.singleton(AutoLayout.class), Collections.emptySet(),
+                Collections.emptySet());
+
+        parentLayouts = registry.getNavigationRouteTarget("auto")
+                .getRouteTarget().getParentLayouts();
+        Assert.assertEquals("AutoLayoutView should now get automatic layout", 1,
+                parentLayouts.size());
+        Assert.assertEquals(
+                "AutoLayoutView layout should be the @Layout annotated RouterLayout",
+                AutoLayout.class, parentLayouts.get(0));
+    }
+
+    @Test
+    public void removeAnnotationsFromLayoutAnnotatedComponent_updateRouteRegistry_routeIsUpdated() {
+
+        MockVaadinServletService service = new MockVaadinServletService() {
+            @Override
+            public VaadinContext getContext() {
+                return new MockVaadinContext();
+            }
+        };
+        class A extends Component implements RouterLayout {
+        }
+        ApplicationRouteRegistry registry = ApplicationRouteRegistry
+                .getInstance(service.getContext());
+        tamperLayouts(registry, layouts -> {
+            layouts.put("/", A.class);
+        });
+        registry.update(() -> {
+            RouteConfiguration.forRegistry(registry)
+                    .setAnnotatedRoute(AutoLayoutView.class);
+        });
+        List<Class<? extends RouterLayout>> parentLayouts = registry
+                .getNavigationRouteTarget("auto").getRouteTarget()
+                .getParentLayouts();
+        Assert.assertEquals(
+                "Route should have layout because auto layout is registered", 1,
+                parentLayouts.size());
+        Assert.assertEquals(
+                "Layout should be the @Layout annotated RouterLayout", A.class,
+                parentLayouts.get(0));
+
+        RouteUtil.updateRouteRegistry(registry, Collections.singleton(A.class),
+                Collections.emptySet(), Collections.emptySet());
+
+        parentLayouts = registry.getNavigationRouteTarget("auto")
+                .getRouteTarget().getParentLayouts();
+        Assert.assertEquals(
+                "Route with no layout should not get automatic layout now", 0,
+                parentLayouts.size());
+    }
+
+    @Test
+    public void layoutAnnotatedComponent_modifiedValue_updateRouteRegistry_routeIsUpdated() {
+
+        MockVaadinServletService service = new MockVaadinServletService() {
+            @Override
+            public VaadinContext getContext() {
+                return new MockVaadinContext();
+            }
+        };
+
+        @Route("hey/view")
+        class View extends Component {
+
+        }
+        ApplicationRouteRegistry registry = ApplicationRouteRegistry
+                .getInstance(service.getContext());
+        tamperLayouts(registry, layouts -> {
+            layouts.put("/hey", AutoLayout.class);
+        });
+        registry.update(() -> {
+            RouteConfiguration routeConfiguration = RouteConfiguration
+                    .forRegistry(registry);
+            routeConfiguration.setAnnotatedRoute(AutoLayoutView.class);
+            routeConfiguration.setAnnotatedRoute(View.class);
+        });
+
+        List<Class<? extends RouterLayout>> parentLayouts = registry
+                .getNavigationRouteTarget("auto").getRouteTarget()
+                .getParentLayouts();
+        Assert.assertEquals(
+                "AutoLayoutView should not have layout because path does not match",
+                0, parentLayouts.size());
+        parentLayouts = registry.getNavigationRouteTarget("hey/view")
+                .getRouteTarget().getParentLayouts();
+        Assert.assertEquals("View should have layout because path matches", 1,
+                parentLayouts.size());
+        Assert.assertEquals(
+                "View layout should be the @Layout annotated RouterLayout",
+                AutoLayout.class, parentLayouts.get(0));
+
+        RouteUtil.updateRouteRegistry(registry,
+                Collections.singleton(AutoLayout.class), Collections.emptySet(),
+                Collections.emptySet());
+
+        parentLayouts = registry.getNavigationRouteTarget("auto")
+                .getRouteTarget().getParentLayouts();
+        Assert.assertEquals("AutoLayoutView should now get automatic layout", 1,
+                parentLayouts.size());
+        Assert.assertEquals(
+                "AutoLayoutView layout should be the @Layout annotated RouterLayout",
+                AutoLayout.class, parentLayouts.get(0));
+
+        parentLayouts = registry.getNavigationRouteTarget("hey/view")
+                .getRouteTarget().getParentLayouts();
+        Assert.assertEquals(
+                "View should still have layout because path matches", 1,
+                parentLayouts.size());
+        Assert.assertEquals(
+                "View layout should be the @Layout annotated RouterLayout",
+                AutoLayout.class, parentLayouts.get(0));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void tamperLayouts(ApplicationRouteRegistry registry,
+            Consumer<Map<String, Class<? extends RouterLayout>>> consumer) {
+        try {
+            Field layoutsField = AbstractRouteRegistry.class
+                    .getDeclaredField("layouts");
+            Map<String, Class<? extends RouterLayout>> layouts = (Map<String, Class<? extends RouterLayout>>) ReflectTools
+                    .getJavaFieldValue(registry, layoutsField);
+            consumer.accept(layouts);
+        } catch (Exception ex) {
+            Assert.fail(ex.getMessage());
+        }
     }
 
     private static void mutableRoutesMap(AbstractRouteRegistry registry) {

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/RouteUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/RouteUtilTest.java
@@ -894,32 +894,6 @@ public class RouteUtilTest {
     }
 
     @Test
-    public void sessionRegistryWithManualRegisteredRouteClass_updateRouteRegistry_routeIsUpdatedInRegistry() {
-        // given
-        @Route("aa")
-        class A extends Component {
-        }
-        MockVaadinServletService service = new MockVaadinServletService() {
-            @Override
-            public VaadinContext getContext() {
-                return new MockVaadinContext();
-            }
-        };
-        ApplicationRouteRegistry registry = ApplicationRouteRegistry
-                .getInstance(service.getContext());
-        registry.setRoute("a", A.class, Collections.emptyList());
-        Assert.assertTrue(registry.getConfiguration().hasRoute("a"));
-
-        // when
-        RouteUtil.updateRouteRegistry(registry, Collections.emptySet(),
-                Collections.singleton(A.class), Collections.emptySet());
-
-        // then
-        Assert.assertFalse(registry.getConfiguration().hasRoute("a"));
-        Assert.assertTrue(registry.getConfiguration().hasRoute("aa"));
-    }
-
-    @Test
     public void newLayoutAnnotatedComponent_updateRouteRegistry_routeIsUpdated() {
         MockVaadinServletService service = new MockVaadinServletService() {
             @Override


### PR DESCRIPTION
## Description

When a [At]Layout annotated class is modified, the changes are not propagated to the route registry after hotswap happens. This change updates Route registry layouts configuration and re-registers routes potentially impacted by the change to apply the new settings. It also checks the route target chain for active UIs in order to trigger a page refresh if the layout changes should be applied.

Fixes #20111

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
