### PR TITLE
feat: HMR for translation files

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/hotswap/Hotswapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/hotswap/Hotswapper.java
@@ -185,11 +185,16 @@ public class Hotswapper implements ServiceDestroyListener, SessionInitListener,
             liveReload.sendHmrEvent("translations-update", Json.createObject());
 
             // Trigger any potential Flow translation updates
-            List<UI> uis = new ArrayList<>();
             EnumMap<UIRefreshStrategy, List<UI>> refreshActions = new EnumMap<>(
                     UIRefreshStrategy.class);
-            forEachActiveUI(ui -> uis.add(ui));
-            refreshActions.put(UIRefreshStrategy.REFRESH, uis);
+            forEachActiveUI(ui -> {
+                UIRefreshStrategy strategy = ui.getPushConfiguration()
+                        .getPushMode().isEnabled()
+                                ? UIRefreshStrategy.PUSH_REFRESH_CHAIN
+                                : UIRefreshStrategy.REFRESH;
+                refreshActions.computeIfAbsent(strategy, k -> new ArrayList<>())
+                        .add(ui);
+            });
             triggerClientUpdate(refreshActions, false);
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/hotswap/Hotswapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/hotswap/Hotswapper.java
@@ -53,7 +53,6 @@ import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
 
 import elemental.json.Json;
-import elemental.json.JsonObject;
 
 /**
  * Entry point for application classes hot reloads.
@@ -180,6 +179,11 @@ public class Hotswapper implements ServiceDestroyListener, SessionInitListener,
             // Clear resource bundle cache so that translations (and other
             // resources) are reloaded
             ResourceBundle.clearCache();
+            // Trigger UI refresh
+            EnumMap<UIRefreshStrategy, List<UI>> refreshStrategy = new EnumMap<>(
+                    UIRefreshStrategy.class);
+            refreshStrategy.put(UIRefreshStrategy.REFRESH, List.of());
+            triggerClientUpdate(refreshStrategy, false);
             // Trigger any potential Hilla translation updates
             liveReload.sendHmrEvent("translations-update", Json.createObject());
         }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReload.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReload.java
@@ -120,7 +120,7 @@ public interface BrowserLiveReload extends FragmentedMessageHolder {
 
     /**
      * Send a client side HMR event.
-     * 
+     *
      * @param event
      *            the event name
      * @param eventData

--- a/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReload.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReload.java
@@ -17,8 +17,9 @@ package com.vaadin.flow.internal;
 
 import org.atmosphere.cpr.AtmosphereResource;
 
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.server.communication.FragmentedMessageHolder;
+
+import elemental.json.JsonObject;
 
 /**
  * Provides a way to reload browser tabs via web socket connection passed as a
@@ -116,5 +117,15 @@ public interface BrowserLiveReload extends FragmentedMessageHolder {
      *            the received message
      */
     void onMessage(AtmosphereResource resource, String msg);
+
+    /**
+     * Send a client side HMR event.
+     * 
+     * @param event
+     *            the event name
+     * @param eventData
+     *            the event data
+     */
+    void sendHmrEvent(String event, JsonObject eventData);
 
 }

--- a/vaadin-dev-server/package.json
+++ b/vaadin-dev-server/package.json
@@ -15,7 +15,7 @@
     "@web/dev-server-esbuild": "^0.3.3",
     "prettier": "^2.8.4",
     "tslib": "^2.5.3",
-    "vite": "^4.1.4"
+    "vite": "^5.4.8"
   },
   "dependencies": {
     "construct-style-sheets-polyfill": "^3.1.0",

--- a/vaadin-dev-server/src/main/frontend/vaadin-dev-tools.ts
+++ b/vaadin-dev-server/src/main/frontend/vaadin-dev-tools.ts
@@ -77,6 +77,10 @@ type DevToolsConf = {
   liveReloadPort: number;
   token?: string;
 };
+
+// @ts-ignore
+const hmrClient: any = import.meta.hot ? import.meta.hot.hmrClient : undefined;
+
 @customElement('vaadin-dev-tools')
 export class VaadinDevTools extends LitElement {
   unhandledMessages: ServerMessage[] = [];
@@ -711,10 +715,20 @@ export class VaadinDevTools extends LitElement {
   }
   handleFrontendMessage(message: ServerMessage) {
     if (message.command === 'featureFlags') {
-    } else if (handleLicenseMessage(message)) {
+    } else if (handleLicenseMessage(message) || this.handleHmrMessage(message)) {
     } else {
       this.unhandledMessages.push(message);
     }
+  }
+
+  handleHmrMessage(message: ServerMessage): boolean {
+    if (message.command !== 'hmr') {
+      return false;
+    }
+    if (hmrClient) {
+      hmrClient.notifyListeners(message.data.event, message.data.eventData);
+    }
+    return true;
   }
 
   getDedicatedWebSocketUrl(): string | undefined {

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DebugWindowConnection.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DebugWindowConnection.java
@@ -381,4 +381,15 @@ public class DebugWindowConnection implements BrowserLiveReload {
         resources.put(ref, new FragmentedMessage());
     }
 
+    @Override
+    public void sendHmrEvent(String event, JsonObject eventData) {
+        JsonObject msg = Json.createObject();
+        msg.put("command", "hmr");
+        JsonObject data = Json.createObject();
+        msg.put("data", data);
+        data.put("event", event);
+        data.put("eventData", eventData);
+        broadcast(msg);
+    }
+
 }

--- a/vaadin-dev-server/vite.config.js
+++ b/vaadin-dev-server/vite.config.js
@@ -2,8 +2,6 @@ import { fileURLToPath } from 'url';
 import { defineConfig } from 'vite';
 import typescript from '@rollup/plugin-typescript';
 
-const { execSync } = require('child_process');
-
 export default defineConfig({
   build: {
     // Write output to resources to include it in Maven package
@@ -27,5 +25,7 @@ export default defineConfig({
         /^@vaadin.*/,
       ]
     }
-  }
+  },
+  // Preserve import.meta.hot in the built file so it can be replaced in the application instead
+  define: { 'import.meta.hot': 'import.meta.hot' }
 });


### PR DESCRIPTION
Clears resource bundle cache on translation resource redeployment
Fires a HMR event to the browser when translations are reloaded
    
Limitation: Only supports DefaultI18NHandler where the paths are known. If you have a custom I18N handler, you might need a custom HMR supporting HotswapListener.
    
For #20118
Requires https://github.com/vaadin/hilla/pull/2795 to fully fix the issue
