### PR TITLE
chore: Set DAU cookie secure if the request is secure

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/dau/FlowDauIntegration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/dau/FlowDauIntegration.java
@@ -51,6 +51,7 @@ public final class FlowDauIntegration {
                 + Instant.now().toEpochMilli();
         Cookie cookie = new Cookie(DAU_COOKIE_NAME, cookieValue);
         cookie.setHttpOnly(true);
+        cookie.setSecure(request.isSecure());
         cookie.setMaxAge(DAU_COOKIE_MAX_AGE_IN_SECONDS);
         cookie.setPath("/");
         return cookie;

--- a/flow-server/src/test/java/com/vaadin/flow/server/dau/FlowDauIntegrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/dau/FlowDauIntegrationTest.java
@@ -1,0 +1,50 @@
+package com.vaadin.flow.server.dau;
+
+import jakarta.servlet.http.Cookie;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.internal.hilla.EndpointRequestUtil;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.pro.licensechecker.LocalSubscriptionKey;
+import com.vaadin.pro.licensechecker.SubscriptionKey;
+import com.vaadin.pro.licensechecker.dau.DauIntegration;
+
+import static org.junit.Assert.*;
+
+public class FlowDauIntegrationTest {
+
+    @Test
+    public void generateNewCookie_setsUpExpectedParameters() {
+        try (MockedStatic<DauIntegration> key = Mockito
+                .mockStatic(DauIntegration.class)) {
+            key.when(DauIntegration::newTrackingHash).thenReturn("hash");
+            VaadinRequest request = Mockito.mock(VaadinRequest.class);
+            Mockito.when(request.isSecure()).thenReturn(true);
+            Cookie cookie = FlowDauIntegration.generateNewCookie(request);
+            String[] hashAndTime = cookie.getValue().split("\\$");
+            Assert.assertEquals("hash", hashAndTime[0]);
+            Assert.assertFalse(hashAndTime[1].isBlank());
+            Assert.assertEquals(DAUUtils.DAU_COOKIE_NAME, cookie.getName());
+            Assert.assertTrue(cookie.isHttpOnly());
+            Assert.assertTrue(cookie.getSecure());
+            Assert.assertEquals(DAUUtils.DAU_COOKIE_MAX_AGE_IN_SECONDS,
+                    cookie.getMaxAge());
+            Assert.assertEquals("/", cookie.getPath());
+        }
+    }
+
+    @Test
+    public void generateNewCookie_notSecureRequest_cookieNotSecure() {
+        try (MockedStatic<DauIntegration> key = Mockito
+                .mockStatic(DauIntegration.class)) {
+            key.when(DauIntegration::newTrackingHash).thenReturn("hash");
+            VaadinRequest request = Mockito.mock(VaadinRequest.class);
+            Mockito.when(request.isSecure()).thenReturn(false);
+            Cookie cookie = FlowDauIntegration.generateNewCookie(request);
+            Assert.assertFalse(cookie.getSecure());
+        }
+    }
+}


### PR DESCRIPTION
## Description

Set the DAU cookie as secure, if the http request is secure. Same as for JWT cookie.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
