### PR TITLE
chore: Wrap each enum on a separate line when there are many of them

### DIFF
--- a/eclipse/VaadinJavaConventions.xml
+++ b/eclipse/VaadinJavaConventions.xml
@@ -248,7 +248,7 @@
 <setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="48"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_block" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>

--- a/flow-data/src/test/java/com/vaadin/flow/tests/data/bean/Country.java
+++ b/flow-data/src/test/java/com/vaadin/flow/tests/data/bean/Country.java
@@ -2,8 +2,12 @@ package com.vaadin.flow.tests.data.bean;
 
 public enum Country {
 
-    FINLAND("Finland"), SWEDEN("Sweden"), USA("USA"), RUSSIA(
-            "Russia"), NETHERLANDS("Netherlands"), SOUTH_AFRICA("South Africa");
+    FINLAND("Finland"),
+    SWEDEN("Sweden"),
+    USA("USA"),
+    RUSSIA("Russia"),
+    NETHERLANDS("Netherlands"),
+    SOUTH_AFRICA("South Africa");
 
     private final String name;
 

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
@@ -83,18 +83,21 @@ public class IFrame extends HtmlComponent implements HasAriaLabel {
      * Sandbox types.
      */
     public enum SandboxType {
-        RESTRICT_ALL(""), ALLOW_FORMS("allow-forms"), ALLOW_MODALS(
-                "allow-modals"), ALLOW_ORIENTATION_LOCK(
-                        "allow-orientation-lock"), ALLOW_POINTER_LOCK(
-                                "allow-pointer-lock"), ALLOW_POPUPS(
-                                        "allow-popups"), ALLOW_POPUPS_TO_ESCAPE_SANDBOX(
-                                                "allow-popups-to-escape-sandbox"), ALLOW_PRESENTATION(
-                                                        "allow-presentation"), ALLOW_SAME_ORIGIN(
-                                                                "allow-same-origin"), ALLOW_SCRIPTS(
-                                                                        "allow-scripts"), ALLOW_STORAGE_ACCESS_BY_USER_ACTIVATION(
-                                                                                "allow-storage-access-by-user-activation"), ALLOW_TOP_NAVIGATION(
-                                                                                        "allow-top-navigation"), ALLOW_TOP_NAVIGATION_BY_USER_ACTIVATION(
-                                                                                                "allow-top-navigation-by-user-activation");
+        RESTRICT_ALL(""),
+        ALLOW_FORMS("allow-forms"),
+        ALLOW_MODALS("allow-modals"),
+        ALLOW_ORIENTATION_LOCK("allow-orientation-lock"),
+        ALLOW_POINTER_LOCK("allow-pointer-lock"),
+        ALLOW_POPUPS("allow-popups"),
+        ALLOW_POPUPS_TO_ESCAPE_SANDBOX("allow-popups-to-escape-sandbox"),
+        ALLOW_PRESENTATION("allow-presentation"),
+        ALLOW_SAME_ORIGIN("allow-same-origin"),
+        ALLOW_SCRIPTS("allow-scripts"),
+        ALLOW_STORAGE_ACCESS_BY_USER_ACTIVATION(
+                "allow-storage-access-by-user-activation"),
+        ALLOW_TOP_NAVIGATION("allow-top-navigation"),
+        ALLOW_TOP_NAVIGATION_BY_USER_ACTIVATION(
+                "allow-top-navigation-by-user-activation");
 
         private final String value;
 

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Style.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Style.java
@@ -267,7 +267,29 @@ public interface Style extends Serializable {
     }
 
     public enum Display {
-        INLINE, BLOCK, CONTENTS, FLEX, GRID, INLINE_BLOCK, INLINE_FLEX, INLINE_GRID, INLINE_TABLE, LIST_ITEM, RUN_IN, TABLE, TABLE_CAPTION, TABLE_COLUMN_GROUP, TABLE_HEADER_GROUP, TABLE_FOOTER_GROUP, TABLE_ROW_GROUP, TABLE_CELL, TABLE_COLUMN, TABLE_ROW, NONE, INITIAL, INHERIT
+        INLINE,
+        BLOCK,
+        CONTENTS,
+        FLEX,
+        GRID,
+        INLINE_BLOCK,
+        INLINE_FLEX,
+        INLINE_GRID,
+        INLINE_TABLE,
+        LIST_ITEM,
+        RUN_IN,
+        TABLE,
+        TABLE_CAPTION,
+        TABLE_COLUMN_GROUP,
+        TABLE_HEADER_GROUP,
+        TABLE_FOOTER_GROUP,
+        TABLE_ROW_GROUP,
+        TABLE_CELL,
+        TABLE_COLUMN,
+        TABLE_ROW,
+        NONE,
+        INITIAL,
+        INHERIT
     }
 
     /**
@@ -837,7 +859,19 @@ public interface Style extends Serializable {
      * Css values for the <code>align-items</code> property.
      */
     public enum AlignItems {
-        NORMAL, STRETCH, CENTER, UNSAFE, SAFE, START, END, FLEX_START, FLEX_END, SELF_START, SELF_END, BASELINE, INITIAL;
+        NORMAL,
+        STRETCH,
+        CENTER,
+        UNSAFE,
+        SAFE,
+        START,
+        END,
+        FLEX_START,
+        FLEX_END,
+        SELF_START,
+        SELF_END,
+        BASELINE,
+        INITIAL;
     }
 
     /**
@@ -856,7 +890,20 @@ public interface Style extends Serializable {
      * Css values for the <code>align-self</code> property.
      */
     public enum AlignSelf {
-        AUTO, NORMAL, STRETCH, UNSAFE, SAFE, CENTER, START, END, FLEX_START, FLEX_END, SELF_START, SELF_END, BASELINE, INITIAL;
+        AUTO,
+        NORMAL,
+        STRETCH,
+        UNSAFE,
+        SAFE,
+        CENTER,
+        START,
+        END,
+        FLEX_START,
+        FLEX_END,
+        SELF_START,
+        SELF_END,
+        BASELINE,
+        INITIAL;
     }
 
     /**
@@ -918,7 +965,21 @@ public interface Style extends Serializable {
      * Css values for the <code>justify-content</code> property.
      */
     public enum JustifyContent {
-        CENTER, START, END, FLEX_START, FLEX_END, LEFT, RIGHT, NORMAL, SPACE_BETWEEN, SPACE_AROUND, SPACE_EVENLY, STRETCH, SAFE, UNSAFE, INITIAL
+        CENTER,
+        START,
+        END,
+        FLEX_START,
+        FLEX_END,
+        LEFT,
+        RIGHT,
+        NORMAL,
+        SPACE_BETWEEN,
+        SPACE_AROUND,
+        SPACE_EVENLY,
+        STRETCH,
+        SAFE,
+        UNSAFE,
+        INITIAL
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StringUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StringUtil.java
@@ -36,7 +36,11 @@ public final class StringUtil {
      * Comment parser state enumeration.
      */
     private enum State {
-        NORMAL, IN_LINE_COMMENT, IN_BLOCK_COMMENT, IN_STRING, IN_STRING_APOSTROPHE
+        NORMAL,
+        IN_LINE_COMMENT,
+        IN_BLOCK_COMMENT,
+        IN_STRING,
+        IN_STRING_APOSTROPHE
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/Mode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Mode.java
@@ -21,9 +21,10 @@ package com.vaadin.flow.server;
  * One of production, development using livereload or development using bundle
  */
 public enum Mode {
-    PRODUCTION_CUSTOM("production", true), PRODUCTION_PRECOMPILED_BUNDLE(
-            "production", true), DEVELOPMENT_FRONTEND_LIVERELOAD("development",
-                    false), DEVELOPMENT_BUNDLE("development", false);
+    PRODUCTION_CUSTOM("production", true),
+    PRODUCTION_PRECOMPILED_BUNDLE("production", true),
+    DEVELOPMENT_FRONTEND_LIVERELOAD("development", false),
+    DEVELOPMENT_BUNDLE("development", false);
 
     private final String name;
     private final boolean production;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -137,8 +137,10 @@ public class FrontendTools {
             1, 0, 6); // Bun 1.0.6 is the first version with "overrides" support
 
     private enum BuildTool {
-        NPM("npm", "npm-cli.js"), NPX("npx", "npx-cli.js"), PNPM("pnpm",
-                null), BUN("bun", null);
+        NPM("npm", "npm-cli.js"),
+        NPX("npx", "npx-cli.js"),
+        PNPM("pnpm", null),
+        BUN("bun", null);
 
         private final String name;
         private final String script;


### PR DESCRIPTION
If some projects use the formatting file directly from https://github.com/vaadin/flow/blob/main/eclipse/VaadinJavaConventions.xml then the formatting of those projects will change slightly