### PR TITLE
feat: Add a helper method for menu's page title

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/menu/MenuConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/menu/MenuConfiguration.java
@@ -19,7 +19,9 @@ package com.vaadin.flow.server.menu;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.internal.menu.MenuRegistry;
 
 /**
@@ -53,6 +55,34 @@ public final class MenuConfiguration {
     public static List<MenuEntry> getMenuEntries(Locale locale) {
         return MenuRegistry.collectMenuItemsList(locale).stream()
                 .map(MenuConfiguration::createMenuEntry).toList();
+    }
+
+    /**
+     * Get the optional page title of the currently shown view that is rendered
+     * in the main layout and menu is used for navigation. Returns an empty page
+     * title, when navigating in other way rather than menu.
+     *
+     * @return page title, if navigation with menu, empty optional if navigating
+     *         in other way.
+     */
+    public static Optional<String> getPageTitle() {
+        UI ui = UI.getCurrent();
+        if (ui != null) {
+            String path = ui.getInternals().getActiveViewLocation().getPath();
+            if (path.startsWith("/")) {
+                path = path.substring(1);
+            }
+            String finalPath = path;
+            return MenuRegistry.collectMenuItemsList().stream()
+                    .filter(menuItem -> {
+                        String route = menuItem.route();
+                        if (route.startsWith("/")) {
+                            route = route.substring(1);
+                        }
+                        return route.equals(finalPath);
+                    }).map(AvailableViewInfo::title).findFirst();
+        }
+        return Optional.empty();
     }
 
     private static MenuEntry createMenuEntry(AvailableViewInfo viewInfo) {


### PR DESCRIPTION
## Description

Adds a new static helper method that gives a page title for views shown using menu.

Fixes https://github.com/vaadin/flow/issues/20158

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
