### PR TITLE
chore: remove exclude from MenuEntry

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/menu/MenuConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/menu/MenuConfiguration.java
@@ -57,15 +57,15 @@ public final class MenuConfiguration {
 
     private static MenuEntry createMenuEntry(AvailableViewInfo viewInfo) {
         if (viewInfo.menu() == null) {
-            return new MenuEntry(viewInfo.route(), viewInfo.title(), null,
-                    false, null, null);
+            return new MenuEntry(viewInfo.route(), viewInfo.title(), null, null,
+                    null);
         }
         return new MenuEntry(viewInfo.route(),
                 (viewInfo.menu().title() != null
                         && !viewInfo.menu().title().isBlank()
                                 ? viewInfo.menu().title()
                                 : viewInfo.title()),
-                viewInfo.menu().order(), viewInfo.menu().exclude(),
-                viewInfo.menu().icon(), viewInfo.menu().menuClass());
+                viewInfo.menu().order(), viewInfo.menu().icon(),
+                viewInfo.menu().menuClass());
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/menu/MenuEntry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/menu/MenuEntry.java
@@ -29,8 +29,6 @@ import com.vaadin.flow.component.Component;
  *            the title to display
  * @param order
  *            the order in the menu or null for default order
- * @param exclude
- *            whether to exclude the menu entry
  * @param icon
  *            Icon to use in the menu or null for no icon. Value can go inside a
  *            {@code <vaadin-icon>} element's {@code icon} attribute which
@@ -43,5 +41,5 @@ import com.vaadin.flow.component.Component;
  *            Hilla/TypeScript client views.
  */
 public record MenuEntry(String path, String title, Double order,
-                        boolean exclude, String icon, Class<? extends Component> menuClass) implements Serializable  {
+                        String icon, Class<? extends Component> menuClass) implements Serializable  {
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuConfigurationTest.java
@@ -156,7 +156,7 @@ public class MenuConfigurationTest {
 
         Map<String, MenuEntry> mapMenuItems = menuEntries.stream()
                 .collect(Collectors.toMap(MenuEntry::path, item -> item));
-        assertClientRoutes(mapMenuItems, false, false, true);
+        assertClientRoutes(mapMenuItems, false, false);
         assertServerRoutes(mapMenuItems);
         assertServerRoutesWithParameters(mapMenuItems, true);
     }
@@ -188,7 +188,7 @@ public class MenuConfigurationTest {
     }
 
     private void assertClientRoutes(Map<String, MenuEntry> menuOptions,
-            boolean authenticated, boolean hasRole, boolean excludeExpected) {
+            boolean authenticated, boolean hasRole) {
         Assert.assertTrue("Client route '' missing",
                 menuOptions.containsKey(""));
         Assert.assertEquals("Public", menuOptions.get("").title());
@@ -221,17 +221,8 @@ public class MenuConfigurationTest {
                     menuOptions.containsKey("/hilla"));
         }
 
-        if (excludeExpected) {
-            Assert.assertFalse("Client route 'login' should be excluded",
-                    menuOptions.containsKey("/login"));
-        } else {
-            Assert.assertTrue("Client route 'login' missing",
-                    menuOptions.containsKey("/login"));
-            Assert.assertEquals("Login", menuOptions.get("/login").title());
-            Assert.assertNull(menuOptions.get("/login").title());
-            Assert.assertTrue("Login view should be excluded",
-                    menuOptions.get("/login").exclude());
-        }
+        Assert.assertFalse("Client route 'login' should be excluded",
+                menuOptions.containsKey("/login"));
     }
 
     private void assertServerRoutes(Map<String, MenuEntry> menuItems) {
@@ -257,32 +248,14 @@ public class MenuConfigurationTest {
             Assert.assertFalse(
                     "Server route '/param/:param1' should be excluded",
                     menuItems.containsKey("/param/:param1"));
-        } else {
-            Assert.assertTrue("Server route '/param/:param' missing",
-                    menuItems.containsKey("/param/:param"));
-            Assert.assertTrue(
-                    "Server route '/param/:param' should be excluded from menu",
-                    menuItems.get("/param/:param").exclude());
-
-            Assert.assertTrue("Server route '/param/:param1' missing",
-                    menuItems.containsKey("/param/:param1"));
-            Assert.assertTrue(
-                    "Server route '/param/:param1' should be excluded from menu",
-                    menuItems.get("/param/:param1").exclude());
         }
 
         Assert.assertTrue(
                 "Server route with optional parameters '/param' missing",
                 menuItems.containsKey("/param"));
-        Assert.assertFalse(
-                "Server route '/param' should be included in the menu",
-                menuItems.get("/param").exclude());
 
         Assert.assertTrue(
                 "Server route with optional parameters '/param/varargs' missing",
                 menuItems.containsKey("/param/varargs"));
-        Assert.assertFalse(
-                "Server route '/param/varargs' should be included in the menu",
-                menuItems.get("/param/varargs").exclude());
     }
 }


### PR DESCRIPTION
`MenuEntry#exclude` is always false with `MenuConfiguration`.