### PR TITLE
fix: reintroduce static methods used by Hilla

### DIFF
--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -180,7 +180,7 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo
      * @return {@code true} to remove created files, {@code false} to keep files
      */
     protected boolean cleanFrontendFiles() {
-        if (isHillaUsed(project, frontendDirectory())) {
+        if (isHillaUsed(frontendDirectory())) {
             /*
              * Override this to not clean generated frontend files after the
              * build. For Hilla, the generated files can still be useful for

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/ConvertPolymerMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/ConvertPolymerMojo.java
@@ -51,7 +51,7 @@ public class ConvertPolymerMojo extends FlowModeAbstractMojo {
 
     @Override
     public void execute() throws MojoFailureException {
-        if (isHillaUsed(project, frontendDirectory())) {
+        if (isHillaUsed(frontendDirectory())) {
             getLog().warn(
                     """
                             The 'convert-polymer' goal is not meant to be used in Hilla projects as polymer templates are not supported.

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -273,13 +273,37 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
     /**
      * Checks if Hilla is available based on the Maven project's classpath.
      *
+     * @return true if Hilla is available, false otherwise
+     */
+    public boolean isHillaAvailable() {
+        return getClassFinder().getResource(
+                "com/vaadin/hilla/EndpointController.class") != null;
+    }
+
+    /**
+     * Checks if Hilla is available based on the Maven project's classpath.
+     *
      * @param mavenProject
      *            Target Maven project
      * @return true if Hilla is available, false otherwise
      */
-    public boolean isHillaAvailable(MavenProject mavenProject) {
-        return getOrCreateClassFinder(mavenProject).getResource(
+    public static boolean isHillaAvailable(MavenProject mavenProject) {
+        return createClassFinder(mavenProject).getResource(
                 "com/vaadin/hilla/EndpointController.class") != null;
+    }
+
+    /**
+     * Checks if Hilla is available and Hilla views are used in the Maven
+     * project based on what is in routes.ts or routes.tsx file.
+     *
+     * @param frontendDirectory
+     *            Target frontend directory.
+     * @return {@code true} if Hilla is available and Hilla views are used,
+     *         {@code false} otherwise
+     */
+    public boolean isHillaUsed(File frontendDirectory) {
+        return isHillaAvailable()
+                && FrontendUtils.isHillaViewsUsed(frontendDirectory);
     }
 
     /**
@@ -293,7 +317,7 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
      * @return {@code true} if Hilla is available and Hilla views are used,
      *         {@code false} otherwise
      */
-    public boolean isHillaUsed(MavenProject mavenProject,
+    public static boolean isHillaUsed(MavenProject mavenProject,
             File frontendDirectory) {
         return isHillaAvailable(mavenProject)
                 && FrontendUtils.isHillaViewsUsed(frontendDirectory);
@@ -326,15 +350,15 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
 
     @Override
     public ClassFinder getClassFinder() {
-        return getOrCreateClassFinder(project);
-    }
-
-    private ClassFinder getOrCreateClassFinder(MavenProject project) {
         if (classFinder == null) {
-            List<String> classpathElements = getClasspathElements(project);
-            classFinder = BuildFrontendUtil.getClassFinder(classpathElements);
+            classFinder = createClassFinder(project);
         }
         return classFinder;
+    }
+
+    private static ClassFinder createClassFinder(MavenProject project) {
+        List<String> classpathElements = getClasspathElements(project);
+        return BuildFrontendUtil.getClassFinder(classpathElements);
     }
 
     @Override
@@ -515,7 +539,7 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
             return frontendHotdeploy;
         }
         File frontendDirectory = BuildFrontendUtil.getFrontendDirectory(this);
-        return isHillaUsed(project, frontendDirectory);
+        return isHillaUsed(frontendDirectory);
     }
 
     @Override


### PR DESCRIPTION
Reintroduces static methods used by Hilla in FlowModeAbstractMojo, preserving the ClassFinder creation improvements for Flow mojos.
