### PR TITLE
fix: update document title for client route

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -71,6 +71,7 @@ import com.vaadin.flow.server.HttpStatusCode;
 import com.vaadin.flow.server.RouteRegistry;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.internal.menu.MenuRegistry;
+import com.vaadin.flow.server.menu.AvailableViewInfo;
 
 /**
  * Base class for navigation handlers that target a navigation state.
@@ -274,7 +275,7 @@ public abstract class AbstractNavigationStateRenderer
                 new AfterNavigationEvent(locationChangeEvent, parameters),
                 afterNavigationHandlers);
 
-        updatePageTitle(event, componentInstance);
+        updatePageTitle(event, componentInstance, route);
 
         return statusCode;
     }
@@ -953,7 +954,7 @@ public abstract class AbstractNavigationStateRenderer
     }
 
     private static void updatePageTitle(NavigationEvent navigationEvent,
-            Component routeTarget) {
+            Component routeTarget, String route) {
 
         Supplier<String> lookForTitleInTarget = () -> lookForTitleInTarget(
                 routeTarget).map(PageTitle::value).orElse("");
@@ -964,7 +965,11 @@ public abstract class AbstractNavigationStateRenderer
                 .filter(HasDynamicTitle.class::isInstance)
                 .map(tc -> ((HasDynamicTitle) tc).getPageTitle())
                 .filter(Objects::nonNull).findFirst()
-                .orElseGet(lookForTitleInTarget);
+                .orElseGet(() -> Optional
+                        .ofNullable(
+                                MenuRegistry.getClientRoutes(true).get(route))
+                        .map(AvailableViewInfo::title)
+                        .orElseGet(lookForTitleInTarget));
 
         navigationEvent.getUI().getPage().setTitle(title);
     }

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
@@ -1044,17 +1044,17 @@ public class NavigationStateRendererTest {
 
     @Test
     public void handle_clientNavigationToFlowLayout_setTitleFromClientRoute() {
-        test("Client", true);
+        testClientNavigationTitle("Client", true);
     }
 
     @Test
     public void handle_clientNavigation_doNotSetTitleFromClientRoute() {
-        test(null, false);
+        testClientNavigationTitle(null, false);
     }
 
-    private void test(String expectedDocumentTitle,
+    private void testClientNavigationTitle(String expectedDocumentTitle,
             boolean clientRouteHasFlowLayout) {
-        UI ui = createTestUIForTitleTests();
+        UI ui = createTestClientNavigationTitleUIForTitleTests();
         try (MockedStatic<MenuRegistry> menuRegistry = Mockito
                 .mockStatic(MenuRegistry.class, Mockito.CALLS_REAL_METHODS)) {
 
@@ -1085,7 +1085,7 @@ public class NavigationStateRendererTest {
         }
     }
 
-    private UI createTestUIForTitleTests() {
+    private UI createTestClientNavigationTitleUIForTitleTests() {
         DeploymentConfiguration configuration = Mockito
                 .mock(DeploymentConfiguration.class);
         MockVaadinServletService service = new MockVaadinServletService(

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
@@ -57,6 +57,7 @@ import com.vaadin.flow.router.AfterNavigationEvent;
 import com.vaadin.flow.router.AfterNavigationObserver;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.BeforeEnterObserver;
+import com.vaadin.flow.router.Layout;
 import com.vaadin.flow.router.Location;
 import com.vaadin.flow.router.NavigationEvent;
 import com.vaadin.flow.router.NavigationState;
@@ -1028,5 +1029,82 @@ public class NavigationStateRendererTest {
 
         Assert.assertTrue(UsageStatistics.getEntries().anyMatch(entry -> entry
                 .getName().equals(Constants.STATISTICS_FLOW_ROUTER)));
+    }
+
+    @Layout
+    @Tag("div")
+    public static class MainLayout extends Component implements RouterLayout {
+        private final Element element = new Element("div");
+
+        @Override
+        public Element getElement() {
+            return element;
+        }
+    }
+
+    @Test
+    public void handle_clientNavigationToFlowLayout_setTitleFromClientRoute() {
+        test("Client", true);
+    }
+
+    @Test
+    public void handle_clientNavigation_doNotSetTitleFromClientRoute() {
+        test(null, false);
+    }
+
+    private void test(String expectedDocumentTitle,
+            boolean clientRouteHasFlowLayout) {
+        UI ui = createTestUIForTitleTests();
+        try (MockedStatic<MenuRegistry> menuRegistry = Mockito
+                .mockStatic(MenuRegistry.class, Mockito.CALLS_REAL_METHODS)) {
+
+            menuRegistry.when(() -> MenuRegistry.getClientRoutes(true))
+                    .thenReturn(Collections.singletonMap("/client-route",
+                            new AvailableViewInfo("Client", null, false,
+                                    "/client-route", false, false, null, null,
+                                    null, clientRouteHasFlowLayout)));
+
+            NavigationEvent event = new NavigationEvent(
+                    new Router(new TestRouteRegistry()),
+                    new Location("client-route"), ui,
+                    NavigationTrigger.UI_NAVIGATE);
+            NavigationStateRenderer renderer = new NavigationStateRenderer(
+                    new NavigationStateBuilder(router)
+                            .withTarget(MainLayout.class)
+                            .withPath("client-route").build());
+
+            renderer.handle(event);
+
+            Assert.assertNotNull(ui.getPage());
+            if (expectedDocumentTitle == null) {
+                Mockito.verify(ui.getPage(), Mockito.never())
+                        .setTitle("Client");
+            } else {
+                Mockito.verify(ui.getPage()).setTitle(expectedDocumentTitle);
+            }
+        }
+    }
+
+    private UI createTestUIForTitleTests() {
+        DeploymentConfiguration configuration = Mockito
+                .mock(DeploymentConfiguration.class);
+        MockVaadinServletService service = new MockVaadinServletService(
+                configuration);
+        AlwaysLockedVaadinSession session = new AlwaysLockedVaadinSession(
+                service) {
+            @Override
+            public DeploymentConfiguration getConfiguration() {
+                return configuration;
+            }
+        };
+        Mockito.when(configuration.isReactEnabled()).thenReturn(false);
+        Page page = Mockito.mock(Page.class);
+        Mockito.when(page.getHistory()).thenReturn(Mockito.mock(History.class));
+        return new MockUI(session) {
+            @Override
+            public Page getPage() {
+                return page;
+            }
+        };
     }
 }


### PR DESCRIPTION
Updates document title for client view with flow layout based on `ViewConfig.title` and when not overridden by server's `HasDynamicTitle`.

RelatedTo: #20107
