### PR TITLE
Sends beacon request in beforeunload event in Firefox

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
@@ -116,9 +116,16 @@ public class ApplicationConnection {
             registry.getMessageHandler().handleMessage(initialUidl);
         }
 
-        Browser.getWindow().addEventListener("pagehide", e -> {
-            registry.getMessageSender().sendUnloadBeacon();
-        });
+        if (BrowserInfo.get().isFirefox()) {
+            // Sends in beforeunload in FF (don't support beacon in pagehide)
+            Browser.getWindow().addEventListener("beforeunload", e -> {
+                registry.getMessageSender().sendUnloadBeacon();
+            });
+        } else {
+            Browser.getWindow().addEventListener("pagehide", e -> {
+                registry.getMessageSender().sendUnloadBeacon();
+            });
+        }
 
         Browser.getWindow().addEventListener("pageshow", e -> {
             // Currently only Safari gets here, sometimes when going back/foward


### PR DESCRIPTION
Firefox has a bug/feature that it don't send the beacon in pagehide event.

Fixes #19305

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
