### PR TITLE
Revert "Sends beacon request in beforeunload event in Firefox (#20198)"

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
@@ -116,16 +116,9 @@ public class ApplicationConnection {
             registry.getMessageHandler().handleMessage(initialUidl);
         }
 
-        if (BrowserInfo.get().isFirefox()) {
-            // Sends in beforeunload in FF (don't support beacon in pagehide)
-            Browser.getWindow().addEventListener("beforeunload", e -> {
-                registry.getMessageSender().sendUnloadBeacon();
-            });
-        } else {
-            Browser.getWindow().addEventListener("pagehide", e -> {
-                registry.getMessageSender().sendUnloadBeacon();
-            });
-        }
+        Browser.getWindow().addEventListener("pagehide", e -> {
+            registry.getMessageSender().sendUnloadBeacon();
+        });
 
         Browser.getWindow().addEventListener("pageshow", e -> {
             // Currently only Safari gets here, sometimes when going back/foward


### PR DESCRIPTION
This reverts commit e554b456891e6cdc112fda9e02872b4d6de639a9.