### PR TITLE
fix: menu page header path check

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/menu/MenuConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/menu/MenuConfiguration.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.server.menu;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -154,12 +155,12 @@ public final class MenuConfiguration {
             String activeLocation = PathUtil.trimPath(
                     ui.getInternals().getActiveViewLocation().getPath());
 
-            List<AvailableViewInfo> menuItems = MenuRegistry.getMenuItems(false)
-                    .values().stream().toList();
+            Map<String, AvailableViewInfo> menuItems = MenuRegistry.getMenuItems(
+                    false);
 
-            return menuItems.stream()
-                    .filter(menuItem -> PathUtil.trimPath(menuItem.route())
-                            .equals(activeLocation))
+            return menuItems.entrySet().stream()
+                    .filter(menuEntry -> PathUtil.trimPath(menuEntry.getKey())
+                            .equals(activeLocation)).map(Map.Entry::getValue)
                     .map(AvailableViewInfo::title).findFirst();
         }
         return Optional.empty();

--- a/flow-server/src/main/java/com/vaadin/flow/server/menu/MenuConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/menu/MenuConfiguration.java
@@ -155,13 +155,14 @@ public final class MenuConfiguration {
             String activeLocation = PathUtil.trimPath(
                     ui.getInternals().getActiveViewLocation().getPath());
 
-            Map<String, AvailableViewInfo> menuItems = MenuRegistry.getMenuItems(
-                    false);
+            Map<String, AvailableViewInfo> menuItems = MenuRegistry
+                    .getMenuItems(false);
 
             return menuItems.entrySet().stream()
                     .filter(menuEntry -> PathUtil.trimPath(menuEntry.getKey())
-                            .equals(activeLocation)).map(Map.Entry::getValue)
-                    .map(AvailableViewInfo::title).findFirst();
+                            .equals(activeLocation))
+                    .map(Map.Entry::getValue).map(AvailableViewInfo::title)
+                    .findFirst();
         }
         return Optional.empty();
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuConfigurationTest.java
@@ -355,6 +355,12 @@ public class MenuConfigurationTest {
             // from ViewConfig.title, when flow layout is false
             Assert.assertEquals("Hilla", header.get());
 
+            Mockito.when(location.getPath()).thenReturn("/flow/hello");
+            header = MenuConfiguration.getPageHeader();
+            Assert.assertTrue(header.isPresent());
+            // from ViewConfig.title, when flow layout is false
+            Assert.assertEquals("Hello", header.get());
+
             Mockito.when(uiInternals.getActiveRouterTargetsChain())
                     .thenReturn(List.of(new RouteOrLayoutWithDynamicTitle()));
             header = MenuConfiguration.getPageHeader();
@@ -522,6 +528,19 @@ public class MenuConfigurationTest {
                     "route": "hilla",
                     "title": "Hilla",
                     "flowLayout": false
+                  }
+                ]
+              },
+              {
+                "route": "flow",
+                "params": {},
+                "children": [
+                  {
+                    "route": "hello",
+                    "menu": {
+                      "title": "Hello For Flow Layout"
+                    },
+                    "title": "Hello"
                   }
                 ]
               }


### PR DESCRIPTION
Fix the menu page header to
check the actual full path for the
view and not the view path.
For client entries the
AvailableViewInfo.path is only
the "route" for the file and
not the whole path from parents.
