### PR TITLE
chore: Revert "[test PR]chore: test Spring boot 3.4 (#20008)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <failOnMissingWebXml>false</failOnMissingWebXml>
 
         <!-- Dependencies -->
-        <spring.boot.version>3.4.0-M3</spring.boot.version>
+        <spring.boot.version>3.3.4</spring.boot.version>
         <gwt.version>2.9.0</gwt.version>
         <hibernate.validator.version>8.0.1.Final</hibernate.validator.version>
         <slf4j.version>2.0.16</slf4j.version>
@@ -172,14 +172,6 @@
                 <enabled>false</enabled>
             </snapshots>
         </repository>
-        <repository> 
-            <id>repository.spring.milestone</id> 
-            <name>Spring Milestone Repository</name> 
-            <url>https://repo.spring.io/milestone</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
     </repositories>
 
     <pluginRepositories>
@@ -195,14 +187,6 @@
         <pluginRepository>
             <id>${flow.release.repo.id}</id>
             <url>${flow.release.repo.url}</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </pluginRepository>
-        <pluginRepository> 
-            <id>repository.spring.milestone</id> 
-            <name>Spring Milestone Repository</name> 
-            <url>https://repo.spring.io/milestone</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -21,6 +21,7 @@ import jakarta.servlet.ServletContextEvent;
 import jakarta.servlet.ServletContextListener;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.HandlesTypes;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
@@ -64,7 +65,6 @@ import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.di.LookupInitializer;
 import com.vaadin.flow.internal.DevModeHandlerManager;
 import com.vaadin.flow.router.HasErrorParameter;
-import com.vaadin.flow.router.Layout;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteAlias;
 import com.vaadin.flow.router.RouteConfiguration;
@@ -75,6 +75,7 @@ import com.vaadin.flow.server.InvalidRouteLayoutConfigurationException;
 import com.vaadin.flow.server.RouteRegistry;
 import com.vaadin.flow.server.VaadinServletContext;
 import com.vaadin.flow.server.communication.IndexHtmlRequestHandler;
+import com.vaadin.flow.router.Layout;
 import com.vaadin.flow.server.startup.AbstractRouteRegistryInitializer;
 import com.vaadin.flow.server.startup.AnnotationValidator;
 import com.vaadin.flow.server.startup.ApplicationConfiguration;
@@ -1085,7 +1086,7 @@ public class VaadinServletContextInitializer
                             AtomicBoolean parentIsAllowedByPackageProperties = new AtomicBoolean(
                                     true);
                             if (parents.stream()
-                                    .allMatch(parent -> shouldPathBeScanned(
+                                    .anyMatch(parent -> shouldPathBeScanned(
                                             path.substring(parent.length()),
                                             parent,
                                             parentIsAllowedByPackageProperties))) {

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/stateless/JwtStatelessAuthenticationTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/stateless/JwtStatelessAuthenticationTest.java
@@ -80,7 +80,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ExtendWith(SpringExtension.class)
 @WebAppConfiguration
 @WebMvcTest
-@ContextConfiguration(classes = { SpringBootAutoConfiguration.class,
+@ContextConfiguration(classes = { SecurityAutoConfiguration.class,
+        SpringBootAutoConfiguration.class,
         SpringSecurityAutoConfiguration.class,
         JwtStatelessAuthenticationTest.WorkaroundConfig.class,
         JwtStatelessAuthenticationTest.SecurityConfig.class })


### PR DESCRIPTION
This reverts commit ca3c3e7da1f9c7e8cba5ad4ed7b07bfc4bc860a4.

using sb unstable released version causes too much  effort for other projects.
the original PR was meant to test the new version..
we can upgrade sb 3.4 after it reaches final 