### PR TITLE
fix: correct route path for MenuEntry

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuConfigurationTest.java
@@ -143,9 +143,9 @@ public class MenuConfigurationTest {
         List<MenuEntry> menuEntries = MenuConfiguration.getMenuEntries();
         Assert.assertEquals(
                 "List of menu items has incorrect size. Excluded menu item like /login is not expected.",
-                4, menuEntries.size());
-        assertOrder(menuEntries,
-                new String[] { "", "/about", "/hilla", "/hilla/sub" });
+                7, menuEntries.size());
+        assertOrder(menuEntries, new String[] { "/", "/about", "/hilla",
+                "/hilla/sub", "/opt_params", "/params", "/wc_params" });
     }
 
     @Test
@@ -166,9 +166,10 @@ public class MenuConfigurationTest {
                 .forEach(routeConfiguration::setAnnotatedRoute);
 
         List<MenuEntry> menuEntries = MenuConfiguration.getMenuEntries();
-        Assert.assertEquals(5, menuEntries.size());
-        assertOrder(menuEntries, new String[] { "", "/home", "/info", "/param",
-                "/param/varargs" });
+        Assert.assertEquals(8, menuEntries.size());
+        assertOrder(menuEntries,
+                new String[] { "/", "/home", "/info", "/opt_params", "/param",
+                        "/param/varargs", "/params", "/wc_params" });
 
         Map<String, MenuEntry> mapMenuItems = menuEntries.stream()
                 .collect(Collectors.toMap(MenuEntry::path, item -> item));
@@ -385,8 +386,8 @@ public class MenuConfigurationTest {
     private void assertClientRoutes(Map<String, MenuEntry> menuOptions,
             boolean authenticated, boolean hasRole) {
         Assert.assertTrue("Client route '' missing",
-                menuOptions.containsKey(""));
-        Assert.assertEquals("Public", menuOptions.get("").title());
+                menuOptions.containsKey("/"));
+        Assert.assertEquals("Public", menuOptions.get("/").title());
 
         if (authenticated) {
             Assert.assertTrue("Client route 'about' missing",

--- a/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuRegistryTest.java
@@ -130,7 +130,7 @@ public class MenuRegistryTest {
         Map<String, AvailableViewInfo> menuItems = new MenuRegistry()
                 .getMenuItems(true);
 
-        Assert.assertEquals(2, menuItems.size());
+        Assert.assertEquals(8, menuItems.size());
         assertClientRoutes(menuItems);
     }
 
@@ -157,7 +157,7 @@ public class MenuRegistryTest {
         Map<String, AvailableViewInfo> menuItems = new MenuRegistry()
                 .getMenuItems(false);
 
-        Assert.assertEquals(5, menuItems.size());
+        Assert.assertEquals(11, menuItems.size());
         // Validate as if logged in as all routes should be available
         assertClientRoutes(menuItems, true, true, false);
     }
@@ -184,7 +184,7 @@ public class MenuRegistryTest {
             Map<String, AvailableViewInfo> menuItems = new MenuRegistry()
                     .getMenuItems(true);
 
-            Assert.assertEquals(2, menuItems.size());
+            Assert.assertEquals(8, menuItems.size());
             assertClientRoutes(menuItems);
         }
     }
@@ -218,7 +218,7 @@ public class MenuRegistryTest {
         Map<String, AvailableViewInfo> menuItems = new MenuRegistry()
                 .getMenuItems(true);
 
-        Assert.assertEquals(4, menuItems.size());
+        Assert.assertEquals(10, menuItems.size());
         assertClientRoutes(menuItems);
         assertServerRoutes(menuItems);
     }
@@ -239,7 +239,7 @@ public class MenuRegistryTest {
         Map<String, AvailableViewInfo> menuItems = MenuRegistry
                 .collectMenuItems();
 
-        Assert.assertEquals(5, menuItems.size());
+        Assert.assertEquals(8, menuItems.size());
         assertClientRoutes(menuItems, false, false, true);
         assertServerRoutes(menuItems);
         assertServerRoutesWithParameters(menuItems, true);
@@ -259,7 +259,7 @@ public class MenuRegistryTest {
         Map<String, AvailableViewInfo> menuItems = new MenuRegistry()
                 .getMenuItems(true);
 
-        Assert.assertEquals(5, menuItems.size());
+        Assert.assertEquals(11, menuItems.size());
         assertClientRoutes(menuItems, true, true, false);
 
         // Verify that getMenuItemsList returns the same data
@@ -267,9 +267,9 @@ public class MenuRegistryTest {
                 .collectMenuItemsList();
         Assert.assertEquals(
                 "List of menu items has incorrect size. Excluded menu item like /login is not expected.",
-                4, menuItemsList.size());
-        assertOrder(menuItemsList,
-                new String[] { "", "/about", "/hilla", "/hilla/sub" });
+                7, menuItemsList.size());
+        assertOrder(menuItemsList, new String[] { "/", "/about", "/hilla",
+                "/hilla/sub", "/opt_params", "/params", "/wc_params" });
     }
 
     @Test
@@ -286,7 +286,7 @@ public class MenuRegistryTest {
         Map<String, AvailableViewInfo> menuItems = new MenuRegistry()
                 .getMenuItems(true);
 
-        Assert.assertEquals(3, menuItems.size());
+        Assert.assertEquals(9, menuItems.size());
         assertClientRoutes(menuItems, true, false, false);
     }
 
@@ -304,14 +304,15 @@ public class MenuRegistryTest {
                 .forEach(routeConfiguration::setAnnotatedRoute);
 
         List<AvailableViewInfo> menuItems = MenuRegistry.collectMenuItemsList();
-        Assert.assertEquals(5, menuItems.size());
-        assertOrder(menuItems, new String[] { "", "/home", "/info", "/param",
-                "/param/varargs" });
+        Assert.assertEquals(8, menuItems.size());
+        assertOrder(menuItems,
+                new String[] { "/", "/home", "/info", "/opt_params", "/param",
+                        "/param/varargs", "/params", "/wc_params" });
         // verifying that data is same as with collectMenuItems
         Map<String, AvailableViewInfo> mapMenuItems = menuItems.stream()
                 .collect(Collectors.toMap(AvailableViewInfo::route,
                         item -> item));
-        assertClientRoutes(mapMenuItems, false, false, true);
+        assertClientRoutes(mapMenuItems, false, false, true, "/");
         assertServerRoutes(mapMenuItems);
         assertServerRoutesWithParameters(mapMenuItems, true);
     }
@@ -343,10 +344,18 @@ public class MenuRegistryTest {
 
     private void assertClientRoutes(Map<String, AvailableViewInfo> menuItems,
             boolean authenticated, boolean hasRole, boolean excludeExpected) {
-        Assert.assertTrue("Client route '' missing", menuItems.containsKey(""));
-        Assert.assertEquals("Public", menuItems.get("").title());
+        assertClientRoutes(menuItems, authenticated, hasRole, excludeExpected,
+                "");
+    }
+
+    private void assertClientRoutes(Map<String, AvailableViewInfo> menuItems,
+            boolean authenticated, boolean hasRole, boolean excludeExpected,
+            String expectedRootPath) {
+        Assert.assertTrue("Client route '" + expectedRootPath + "' missing",
+                menuItems.containsKey(expectedRootPath));
+        Assert.assertEquals("Public", menuItems.get(expectedRootPath).title());
         Assert.assertNotNull("Public should contain default menu data",
-                menuItems.get("").menu());
+                menuItems.get(expectedRootPath).menu());
 
         if (authenticated) {
             Assert.assertTrue("Client route 'about' missing",
@@ -573,6 +582,52 @@ public class MenuRegistryTest {
                         "route": "sub",
                         "params": {},
                         "title": "Hilla Sub"
+                      }
+                    ]
+                  },
+                  {
+                    "route": "wc_params/:param?",
+                    "loginRequired": false,
+                    "params": {
+                       ":param": "*"
+                    },
+                    "title": "wc_params path is included in menu"
+                  },
+                  {
+                    "route": "opt_params/:param?",
+                    "loginRequired": false,
+                    "params": {
+                       ":param": "opt"
+                    },
+                    "title": "opt_params path is included in menu"
+                  },
+                  {
+                    "route": "req_params/:param",
+                    "loginRequired": false,
+                    "params": {
+                       ":param": "req"
+                    },
+                    "title": "req_params path is excluded from menu"
+                  },
+                  {
+                    "route": "params",
+                    "loginRequired": false,
+                    "title": "params path is shown in menu",
+                    "children": [
+                      {
+                        "route": ":param",
+                        "loginRequired": false,
+                        "params": {
+                           ":param": "req"
+                        },
+                        "title": "params/:param path is excluded from menu",
+                        "children": [
+                          {
+                            "route": "sub",
+                            "loginRequired": false,
+                            "title": "params/:param/sub path is excluded from menu"
+                          }
+                        ]
                       }
                     ]
                   },


### PR DESCRIPTION
MenuEntry should not have route parameters included in the path for client routes. It should omit route path in same way as with Hilla automatic menu. Menu should not include nested routes for excluded menu item or for route with required parameter.
