### PR TITLE
fix: Add util method for detecting Hilla auto layout

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/menu/MenuRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/menu/MenuRegistry.java
@@ -90,6 +90,10 @@ public class MenuRegistry {
             }
             return cachedResource;
         }
+
+        private void clear() {
+            cachedResource = null;
+        }
     }
 
     /**
@@ -569,6 +573,16 @@ public class MenuRegistry {
      */
     public static boolean hasClientRoute(String route) {
         return hasClientRoute(route, false);
+    }
+
+    /**
+     * For internal use only.
+     * <p>
+     * Clears file routes cache when running in production.
+     * Only used in tests and should not be needed in projects.
+     */
+    public static void clearFileRoutesCache() {
+        FileRoutesCache.INSTANCE.clear();
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/internal/menu/MenuRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/menu/MenuRegistry.java
@@ -578,8 +578,8 @@ public class MenuRegistry {
     /**
      * For internal use only.
      * <p>
-     * Clears file routes cache when running in production.
-     * Only used in tests and should not be needed in projects.
+     * Clears file routes cache when running in production. Only used in tests
+     * and should not be needed in projects.
      */
     public static void clearFileRoutesCache() {
         FileRoutesCache.INSTANCE.clear();

--- a/flow-server/src/main/java/com/vaadin/flow/internal/menu/MenuRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/menu/MenuRegistry.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -46,10 +45,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.router.BeforeEnterListener;
 import com.vaadin.flow.router.MenuData;
 import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.flow.router.RouteData;
 import com.vaadin.flow.router.RouteParameterData;
@@ -308,9 +307,7 @@ public class MenuRegistry {
 
         Map<String, AvailableViewInfo> configurations = new HashMap<>();
 
-        collectClientMenuItems(configuration,
-                clientViewConfig -> collectClientViews("", clientViewConfig,
-                        configurations));
+        collectClientMenuItems(configuration).forEach(viewInfo -> collectClientViews("", viewInfo, configurations));
 
         if (filterClientViews && !configurations.isEmpty()) {
             filterClientViews(configurations, vaadinRequest);
@@ -320,27 +317,27 @@ public class MenuRegistry {
     }
 
     /**
-     * Determines whether the application contains a Hilla auto layout.
+     * Determines whether the application contains a Hilla automatic main layout.
      * <p>
-     * This method checks if any of the client view configurations in the
-     * {@code file-routes.json} file correspond to a main menu layout, i.e. has
-     * children views.
+     * This method detects only a top-level main layout, when the following conditions are met:
+     * <ul>
+     * <li>only one single root element is present in {@code file-routes.json}</li>
+     * <li>this element has no or blank {@code route} parameter</li>
+     * <li>this element has non-null children array, which may or may not be empty</li>
+     * </ul>
+     * <p>
+     * This method doesn't check nor does it detect the nested layouts, i.e. that are not root entries.
      *
      * @param configuration
      *            the {@link AbstractConfiguration} containing the application
      *            configuration
-     * @return {@code true} if a Hilla auto layout is present in the
+     * @return {@code true} if a Hilla automatic main layout is present in the
      *         configuration, {@code false} otherwise
      */
-    public static boolean hasHillaAutoLayout(
+    public static boolean hasHillaMainLayout(
             AbstractConfiguration configuration) {
-        AtomicBoolean hasHillaAutoLayout = new AtomicBoolean(false);
-        collectClientMenuItems(configuration, clientViewConfig -> {
-            if (!hasHillaAutoLayout.get() && isMainLayout(clientViewConfig)) {
-                hasHillaAutoLayout.compareAndSet(false, true);
-            }
-        });
-        return hasHillaAutoLayout.get();
+        List<AvailableViewInfo> viewInfos = collectClientMenuItems(configuration);
+        return viewInfos.size() == 1 && isMainLayout(viewInfos.iterator().next());
     }
 
     private static boolean isMainLayout(AvailableViewInfo viewInfo) {
@@ -348,35 +345,31 @@ public class MenuRegistry {
                 && viewInfo.children() != null;
     }
 
-    private static void collectClientMenuItems(
-            AbstractConfiguration configuration,
-            SerializableConsumer<AvailableViewInfo> viewInfoConsumer) {
+    private static List<AvailableViewInfo> collectClientMenuItems(
+            AbstractConfiguration configuration) {
         Objects.requireNonNull(configuration);
-        Objects.requireNonNull(viewInfoConsumer);
         URL viewsJsonAsResource = getViewsJsonAsResource(configuration);
-        if (viewsJsonAsResource == null) {
+        if (viewsJsonAsResource != null) {
+            try (InputStream source = viewsJsonAsResource.openStream()) {
+                if (source != null) {
+                    ObjectMapper mapper = new ObjectMapper().configure(
+                            DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
+                            false);
+                    return mapper.readValue(source, new TypeReference<>() {});
+                }
+            } catch (IOException e) {
+                LoggerFactory.getLogger(MenuRegistry.class).warn(
+                        "Failed load {} from {}", FILE_ROUTES_JSON_NAME,
+                        viewsJsonAsResource.getPath(), e);
+            }
+        } else {
             LoggerFactory.getLogger(MenuRegistry.class).debug(
                     "No {} found under {} directory. Skipping client route registration.",
                     FILE_ROUTES_JSON_NAME,
                     configuration.isProductionMode() ? "'META-INF/VAADIN'"
                             : "'frontend/generated'");
-            return;
         }
-
-        try (InputStream source = viewsJsonAsResource.openStream()) {
-            if (source != null) {
-                ObjectMapper mapper = new ObjectMapper().configure(
-                        DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
-                        false);
-                mapper.readValue(source,
-                        new TypeReference<List<AvailableViewInfo>>() {
-                        }).forEach(viewInfoConsumer);
-            }
-        } catch (IOException e) {
-            LoggerFactory.getLogger(MenuRegistry.class).warn(
-                    "Failed load {} from {}", FILE_ROUTES_JSON_NAME,
-                    viewsJsonAsResource.getPath(), e);
-        }
+        return Collections.emptyList();
     }
 
     private static void collectClientViews(String basePath,

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
@@ -53,6 +53,7 @@ import com.vaadin.flow.component.page.AppShellConfigurator;
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.di.ResourceProvider;
 import com.vaadin.flow.internal.UsageStatistics;
+import com.vaadin.flow.internal.menu.MenuRegistry;
 import com.vaadin.flow.router.QueryParameters;
 import com.vaadin.flow.server.AppShellRegistry;
 import com.vaadin.flow.server.BootstrapHandler;
@@ -126,6 +127,8 @@ public class IndexHtmlRequestHandlerTest {
                 .mock(ApplicationConfiguration.class);
         Mockito.when(context.getAttribute(ApplicationConfiguration.class))
                 .thenReturn(applicationConfiguration);
+
+        MenuRegistry.clearFileRoutesCache();
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuConfigurationTest.java
@@ -143,9 +143,9 @@ public class MenuConfigurationTest {
         List<MenuEntry> menuEntries = MenuConfiguration.getMenuEntries();
         Assert.assertEquals(
                 "List of menu items has incorrect size. Excluded menu item like /login is not expected.",
-                4, menuEntries.size());
-        assertOrder(menuEntries,
-                new String[] { "", "/about", "/hilla", "/hilla/sub" });
+                7, menuEntries.size());
+        assertOrder(menuEntries, new String[] { "/", "/about", "/hilla",
+                "/hilla/sub", "/opt_params", "/params", "/wc_params" });
     }
 
     @Test
@@ -166,9 +166,10 @@ public class MenuConfigurationTest {
                 .forEach(routeConfiguration::setAnnotatedRoute);
 
         List<MenuEntry> menuEntries = MenuConfiguration.getMenuEntries();
-        Assert.assertEquals(5, menuEntries.size());
-        assertOrder(menuEntries, new String[] { "", "/home", "/info", "/param",
-                "/param/varargs" });
+        Assert.assertEquals(8, menuEntries.size());
+        assertOrder(menuEntries,
+                new String[] { "/", "/home", "/info", "/opt_params", "/param",
+                        "/param/varargs", "/params", "/wc_params" });
 
         Map<String, MenuEntry> mapMenuItems = menuEntries.stream()
                 .collect(Collectors.toMap(MenuEntry::path, item -> item));
@@ -385,8 +386,8 @@ public class MenuConfigurationTest {
     private void assertClientRoutes(Map<String, MenuEntry> menuOptions,
             boolean authenticated, boolean hasRole, boolean excludeExpected) {
         Assert.assertTrue("Client route '' missing",
-                menuOptions.containsKey(""));
-        Assert.assertEquals("Public", menuOptions.get("").title());
+                menuOptions.containsKey("/"));
+        Assert.assertEquals("Public", menuOptions.get("/").title());
 
         if (authenticated) {
             Assert.assertTrue("Client route 'about' missing",

--- a/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuRegistryTest.java
@@ -377,7 +377,8 @@ public class MenuRegistryTest {
         assertHasHillaMainLayout(nonEmptyRoute, false);
     }
 
-    private void assertHasHillaMainLayout(String fileRoutes, boolean expected) throws IOException {
+    private void assertHasHillaMainLayout(String fileRoutes, boolean expected)
+            throws IOException {
         File generated = tmpDir.newFolder(GENERATED);
         File clientFiles = new File(generated, FILE_ROUTES_JSON_NAME);
         Files.writeString(clientFiles.toPath(), fileRoutes);

--- a/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuRegistryTest.java
@@ -335,35 +335,56 @@ public class MenuRegistryTest {
     }
 
     @Test
-    public void hasHillaAutoLayout_fileRoutesHasLayout_true()
+    public void hasHillaAutoLayout_fileRoutesHasSingleRootLayout_true()
             throws IOException {
         JsonArray fileRoutes = JsonUtil.parse(testClientRouteFile);
         JsonObject layout = fileRoutes.getObject(0);
         JsonArray children = layout.getArray("children");
         Assert.assertNotNull(children);
-        Assert.assertTrue(children.length() > 0);
 
-        File generated = tmpDir.newFolder(GENERATED);
-        File clientFiles = new File(generated, FILE_ROUTES_JSON_NAME);
-        Files.writeString(clientFiles.toPath(), testClientRouteFile);
-
-        boolean hasHillaAutoLayout = MenuRegistry
-                .hasHillaAutoLayout(vaadinService.getDeploymentConfiguration());
-        Assert.assertTrue(hasHillaAutoLayout);
+        assertHasHillaMainLayout(testClientRouteFile, true);
     }
 
     @Test
-    public void hasHillaAutoLayout_fileRoutesHasNoLayout_false()
+    public void hasHillaAutoLayout_fileRoutesHasEmptyChildren_true()
             throws IOException {
-        Assert.assertFalse(noLayoutsRouteFile.contains("\"children\""));
+        JsonArray fileRoutes = JsonUtil.parse(emptyChildren);
+        JsonObject layout = fileRoutes.getObject(0);
+        JsonArray children = layout.getArray("children");
+        Assert.assertNotNull(children);
+        Assert.assertEquals(0, children.length());
 
+        assertHasHillaMainLayout(emptyChildren, true);
+    }
+
+    @Test
+    public void hasHillaAutoLayout_fileRoutesHasSingleRootRoute_false()
+            throws IOException {
+        Assert.assertFalse(singleRoute.contains("\"children\""));
+
+        assertHasHillaMainLayout(singleRoute, false);
+    }
+
+    @Test
+    public void hasHillaAutoLayout_fileRoutesHasMultipleRootRoutes_false()
+            throws IOException {
+        assertHasHillaMainLayout(multipleRootRoutes, false);
+    }
+
+    @Test
+    public void hasHillaAutoLayout_fileRoutesHasNonEmptyRoute_false()
+            throws IOException {
+        assertHasHillaMainLayout(nonEmptyRoute, false);
+    }
+
+    private void assertHasHillaMainLayout(String fileRoutes, boolean expected) throws IOException {
         File generated = tmpDir.newFolder(GENERATED);
         File clientFiles = new File(generated, FILE_ROUTES_JSON_NAME);
-        Files.writeString(clientFiles.toPath(), noLayoutsRouteFile);
+        Files.writeString(clientFiles.toPath(), fileRoutes);
 
-        boolean hasHillaAutoLayout = MenuRegistry
-                .hasHillaAutoLayout(vaadinService.getDeploymentConfiguration());
-        Assert.assertFalse(hasHillaAutoLayout);
+        boolean hasHillaMainLayout = MenuRegistry
+                .hasHillaMainLayout(vaadinService.getDeploymentConfiguration());
+        Assert.assertEquals(expected, hasHillaMainLayout);
     }
 
     private void assertOrder(List<AvailableViewInfo> menuItems,
@@ -719,7 +740,34 @@ public class MenuRegistryTest {
             ]
             """;
 
-    String noLayoutsRouteFile = """
+    String emptyChildren = """
+            [
+              {
+                "route": "",
+                "title": "Main Layout",
+                "children": []
+              }
+            ]
+            """;
+
+    String nonEmptyRoute = """
+            [
+              {
+                "route": "foo",
+                "title": "Main Layout",
+                "children": [
+                  {
+                    "route": "hilla",
+                    "flowLayout": false,
+                    "params": {},
+                    "title": "Hilla view"
+                  }
+                ]
+              }
+            ]
+            """;
+
+    String singleRoute = """
             [
               {
                 "route": "",
@@ -730,6 +778,41 @@ public class MenuRegistryTest {
                 "flowLayout": false,
                 "params": {},
                 "title": "Public"
+              }
+            ]
+            """;
+
+    String multipleRootRoutes = """
+            [
+              {
+                "route": "hilla",
+                "flowLayout": false,
+                "params": {},
+                "children": [
+                  {
+                    "route": "",
+                    "flowLayout": false,
+                    "params": {},
+                    "title": "Layout"
+                  }
+                ]
+              },
+              {
+                "route": "",
+                "flowLayout": false,
+                "params": {},
+                "title": "Layout",
+                "children": [
+                  {
+                    "route": "components",
+                    "menu": {
+                      "title": "React Components"
+                    },
+                    "flowLayout": false,
+                    "params": {},
+                    "title": "Components"
+                  }
+                ]
               }
             ]
             """;

--- a/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuRegistryTest.java
@@ -130,7 +130,7 @@ public class MenuRegistryTest {
         Map<String, AvailableViewInfo> menuItems = new MenuRegistry()
                 .getMenuItems(true);
 
-        Assert.assertEquals(2, menuItems.size());
+        Assert.assertEquals(8, menuItems.size());
         assertClientRoutes(menuItems);
     }
 
@@ -157,7 +157,7 @@ public class MenuRegistryTest {
         Map<String, AvailableViewInfo> menuItems = new MenuRegistry()
                 .getMenuItems(false);
 
-        Assert.assertEquals(5, menuItems.size());
+        Assert.assertEquals(11, menuItems.size());
         // Validate as if logged in as all routes should be available
         assertClientRoutes(menuItems, true, true, false);
     }
@@ -184,7 +184,7 @@ public class MenuRegistryTest {
             Map<String, AvailableViewInfo> menuItems = new MenuRegistry()
                     .getMenuItems(true);
 
-            Assert.assertEquals(2, menuItems.size());
+            Assert.assertEquals(8, menuItems.size());
             assertClientRoutes(menuItems);
         }
     }
@@ -218,7 +218,7 @@ public class MenuRegistryTest {
         Map<String, AvailableViewInfo> menuItems = new MenuRegistry()
                 .getMenuItems(true);
 
-        Assert.assertEquals(4, menuItems.size());
+        Assert.assertEquals(10, menuItems.size());
         assertClientRoutes(menuItems);
         assertServerRoutes(menuItems);
     }
@@ -239,7 +239,7 @@ public class MenuRegistryTest {
         Map<String, AvailableViewInfo> menuItems = MenuRegistry
                 .collectMenuItems();
 
-        Assert.assertEquals(5, menuItems.size());
+        Assert.assertEquals(8, menuItems.size());
         assertClientRoutes(menuItems, false, false, true);
         assertServerRoutes(menuItems);
         assertServerRoutesWithParameters(menuItems, true);
@@ -259,7 +259,7 @@ public class MenuRegistryTest {
         Map<String, AvailableViewInfo> menuItems = new MenuRegistry()
                 .getMenuItems(true);
 
-        Assert.assertEquals(5, menuItems.size());
+        Assert.assertEquals(11, menuItems.size());
         assertClientRoutes(menuItems, true, true, false);
 
         // Verify that getMenuItemsList returns the same data
@@ -267,9 +267,9 @@ public class MenuRegistryTest {
                 .collectMenuItemsList();
         Assert.assertEquals(
                 "List of menu items has incorrect size. Excluded menu item like /login is not expected.",
-                4, menuItemsList.size());
-        assertOrder(menuItemsList,
-                new String[] { "", "/about", "/hilla", "/hilla/sub" });
+                7, menuItemsList.size());
+        assertOrder(menuItemsList, new String[] { "/", "/about", "/hilla",
+                "/hilla/sub", "/opt_params", "/params", "/wc_params" });
     }
 
     @Test
@@ -286,7 +286,7 @@ public class MenuRegistryTest {
         Map<String, AvailableViewInfo> menuItems = new MenuRegistry()
                 .getMenuItems(true);
 
-        Assert.assertEquals(3, menuItems.size());
+        Assert.assertEquals(9, menuItems.size());
         assertClientRoutes(menuItems, true, false, false);
     }
 
@@ -304,14 +304,15 @@ public class MenuRegistryTest {
                 .forEach(routeConfiguration::setAnnotatedRoute);
 
         List<AvailableViewInfo> menuItems = MenuRegistry.collectMenuItemsList();
-        Assert.assertEquals(5, menuItems.size());
-        assertOrder(menuItems, new String[] { "", "/home", "/info", "/param",
-                "/param/varargs" });
+        Assert.assertEquals(8, menuItems.size());
+        assertOrder(menuItems,
+                new String[] { "/", "/home", "/info", "/opt_params", "/param",
+                        "/param/varargs", "/params", "/wc_params" });
         // verifying that data is same as with collectMenuItems
         Map<String, AvailableViewInfo> mapMenuItems = menuItems.stream()
                 .collect(Collectors.toMap(AvailableViewInfo::route,
                         item -> item));
-        assertClientRoutes(mapMenuItems, false, false, true);
+        assertClientRoutes(mapMenuItems, false, false, true, "/");
         assertServerRoutes(mapMenuItems);
         assertServerRoutesWithParameters(mapMenuItems, true);
     }
@@ -343,10 +344,18 @@ public class MenuRegistryTest {
 
     private void assertClientRoutes(Map<String, AvailableViewInfo> menuItems,
             boolean authenticated, boolean hasRole, boolean excludeExpected) {
-        Assert.assertTrue("Client route '' missing", menuItems.containsKey(""));
-        Assert.assertEquals("Public", menuItems.get("").title());
+        assertClientRoutes(menuItems, authenticated, hasRole, excludeExpected,
+                "");
+    }
+
+    private void assertClientRoutes(Map<String, AvailableViewInfo> menuItems,
+            boolean authenticated, boolean hasRole, boolean excludeExpected,
+            String expectedRootPath) {
+        Assert.assertTrue("Client route '" + expectedRootPath + "' missing",
+                menuItems.containsKey(expectedRootPath));
+        Assert.assertEquals("Public", menuItems.get(expectedRootPath).title());
         Assert.assertNotNull("Public should contain default menu data",
-                menuItems.get("").menu());
+                menuItems.get(expectedRootPath).menu());
 
         if (authenticated) {
             Assert.assertTrue("Client route 'about' missing",
@@ -573,6 +582,52 @@ public class MenuRegistryTest {
                         "route": "sub",
                         "params": {},
                         "title": "Hilla Sub"
+                      }
+                    ]
+                  },
+                  {
+                    "route": "wc_params/:param?",
+                    "loginRequired": false,
+                    "params": {
+                       ":param": "*"
+                    },
+                    "title": "wc_params path is included in menu"
+                  },
+                  {
+                    "route": "opt_params/:param?",
+                    "loginRequired": false,
+                    "params": {
+                       ":param": "opt"
+                    },
+                    "title": "opt_params path is included in menu"
+                  },
+                  {
+                    "route": "req_params/:param",
+                    "loginRequired": false,
+                    "params": {
+                       ":param": "req"
+                    },
+                    "title": "req_params path is excluded from menu"
+                  },
+                  {
+                    "route": "params",
+                    "loginRequired": false,
+                    "title": "params path is shown in menu",
+                    "children": [
+                      {
+                        "route": ":param",
+                        "loginRequired": false,
+                        "params": {
+                           ":param": "req"
+                        },
+                        "title": "params/:param path is excluded from menu",
+                        "children": [
+                          {
+                            "route": "sub",
+                            "loginRequired": false,
+                            "title": "params/:param/sub path is excluded from menu"
+                          }
+                        ]
                       }
                     ]
                   },


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Adds a new util method that detects layout entries in `file-routes.json`.

Related-to https://github.com/vaadin/hilla/issues/2825

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
