### PR TITLE
Fix flow issue #6349

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -2147,11 +2147,12 @@ public abstract class VaadinService implements Serializable {
         // Dump all current instances, not only the ones dumped by setCurrent
         Map<Class<?>, CurrentInstance> oldInstances = CurrentInstance
                 .getInstances();
-        CurrentInstance.setCurrent(session);
         try {
             while ((pendingAccess = session.getPendingAccessQueue()
                     .poll()) != null) {
                 if (!pendingAccess.isCancelled()) {
+                    CurrentInstance.clearAll();
+                    CurrentInstance.setCurrent(session);
                     pendingAccess.run();
 
                     try {

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinSessionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinSessionTest.java
@@ -29,6 +29,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
@@ -187,6 +189,69 @@ public class VaadinSessionTest {
 
         session.addUI(ui);
 
+    }
+
+    /**
+     * Test for issue #6349
+     */
+    @Test
+    public void testCurrentInstancePollution() throws InterruptedException {
+
+        // Create a sync object
+        final AtomicInteger state = new AtomicInteger();
+
+        // For sleeping while we wait
+        final Runnable napper = () -> {
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                return;
+            }
+        };
+
+        // We need to unlock session before running this test
+        session.unlock();
+        try {
+
+            // Create a thread that holds the session lock until we tell it to
+            // unlock; this will cause VaadinSession.access() to enqueue tasks
+            // instead of running them immediately.
+            Thread thread = new Thread(() -> {
+                session.accessSynchronously(() -> {
+                    state.incrementAndGet();
+                    while (state.get() == 1)
+                        napper.run();
+                });
+            });
+
+            // Start thread and wait for it to grab the lock
+            thread.start();
+            while (state.get() == 0)
+                napper.run();
+
+            // Enqueue two session commands
+            session.access(() -> {
+                UI.setCurrent(ui); // command #1 sets current UI
+                state.incrementAndGet();
+            });
+            final AtomicReference<UI> uiRef = new AtomicReference<>();
+            session.access(() -> {
+                uiRef.set(UI.getCurrent()); // command #2 reads current UI
+                state.incrementAndGet();
+            });
+
+            // Release the session lock, which will run the queue
+            state.incrementAndGet();
+
+            // Wait for enqueued tasks to complete
+            while (state.get() < 4)
+                napper.run();
+
+            // Command #2 should not have seen command #1's UI
+            Assert.assertNull(uiRef.get());
+        } finally {
+            session.lock();
+        }
     }
 
     /**


### PR DESCRIPTION
## Description

Commands enqueued by `VaadinSession.access()` in general have nothing to do with each other. The only thing they have in common is they share the same `VaadinSession` (and, by implication, `VaadinService`).

Therefore, if command №1 invoked `UI.setCurrent()` and command №2 invokes `UI.getCurrent()`, command №2 should read `null`, not the random `UI` from command №1 that it has nothing to do with.

Fixes #6349
 
## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change
  - Except `JarContentsManagerTest.copyFilesFromJar_doNotUpdateFileIfContentIsTheSame` which has nothing to do with this change.
- [X] I have performed self-review and corrected misspellings.
