### PR TITLE
fix: prevent possible error on embedded component disconnect

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/webcomponent/webcomponent-script-template.js
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/webcomponent/webcomponent-script-template.js
@@ -125,7 +125,7 @@ _ThemeImport_class _TagCamel_ extends HTMLElement {
     return Object.values(clients).find(client => client.exportedWebComponents && client.exportedWebComponents.indexOf('_TagDash_') != -1)
   }
   disconnectedCallback() {
-    this.$server.disconnected();
+    this.$server && this.$server.disconnected();
 
     console.debug("disconnected", this);
   }


### PR DESCRIPTION
## Description

This fixes the following error which sometimes occurs when switching between docs pages with Java examples:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'disconnected')
    at ContextMenuPresentationWc.disconnectedCallback (:8000/vaadin/VAADIN/generated/flow/web-components/context-menu-presentation-wc.js:131:18)
    at removeChild (chunk-UXDD7MME.js:8456:26)
```

I'm not sure how to test this but it makes sense to check for object being defined before calling its methods anyway.

## Type of change

- Bugfix