### PR TITLE
fix: support client route parameters in auto layout path matching

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/menu/MenuRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/menu/MenuRegistry.java
@@ -528,16 +528,6 @@ public class MenuRegistry {
         return false;
     }
 
-    private static boolean hasOptionalOrVarargsParameter(
-            AvailableViewInfo viewInfo) {
-        final Map<String, RouteParamType> routeParameters = viewInfo
-                .routeParameters();
-        return routeParameters != null && !routeParameters.isEmpty()
-                && routeParameters.values().stream().anyMatch(
-                        paramType -> paramType == RouteParamType.OPTIONAL
-                                || paramType == RouteParamType.WILDCARD);
-    }
-
     /**
      * Check view against authentication state.
      * <p>

--- a/flow-server/src/main/java/com/vaadin/flow/internal/menu/MenuRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/menu/MenuRegistry.java
@@ -677,7 +677,7 @@ public class MenuRegistry {
             // - routes with required parameters
             // - routes with exclude=true
             // Remove following without including nested ones:
-            // - routes with direct children with optional or varargs parameter
+            // - routes with direct children with route parameter
             if (viewInfo.menu().isExclude() || hasRequiredParameter(viewInfo)) {
                 menuRoutes.remove(path);
                 if (viewInfo.children() != null) {

--- a/flow-server/src/main/java/com/vaadin/flow/internal/menu/MenuRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/menu/MenuRegistry.java
@@ -667,25 +667,18 @@ public class MenuRegistry {
             // - routes with required parameters
             // - routes with exclude=true
             // Remove following without including nested ones:
-            // - routes with direct children with route parameter
+            // - routes with undefined title and icon
             if (viewInfo.menu().isExclude() || hasRequiredParameter(viewInfo)) {
                 menuRoutes.remove(path);
                 if (viewInfo.children() != null) {
                     removeChildren(menuRoutes, viewInfo, path);
                 }
-            } else if (childrenHasRouteParameter(viewInfo.children())) {
-                menuRoutes.remove(path);
+            } else if (viewInfo.menu().getIcon() == null) {
+                if (viewInfo.menu().title() == null
+                        && viewInfo.title() == null) {
+                    menuRoutes.remove(path);
+                }
             }
         }
-    }
-
-    private static boolean childrenHasRouteParameter(
-            List<AvailableViewInfo> children) {
-        if (children == null || children.isEmpty()) {
-            return false;
-        }
-        return children.stream()
-                .anyMatch(viewInfo -> viewInfo.routeParameters() != null
-                        && !viewInfo.routeParameters().isEmpty());
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/ClientTarget.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/ClientTarget.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.router.internal;
+
+import com.vaadin.flow.component.Component;
+
+/**
+ * Client route target stores the target template.
+ * <p>
+ * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 24.5
+ */
+public class ClientTarget extends RouteTarget {
+    private final String template;
+
+    /**
+     * Create a new Client route target holder with the given route template.
+     *
+     * @param template
+     *            route template
+     */
+    public ClientTarget(String template) {
+        super(Component.class);
+        this.template = template;
+    }
+
+    /**
+     * Get the route template.
+     *
+     * @return route template
+     */
+    String getTemplate() {
+        return template;
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/DefaultRouteResolver.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/DefaultRouteResolver.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.router.internal;
 
 import java.util.Collections;
+import java.util.Optional;
 
 import org.slf4j.LoggerFactory;
 
@@ -47,10 +48,14 @@ public class DefaultRouteResolver implements RouteResolver {
                 .getNavigationRouteTarget(path);
 
         if (!navigationResult.hasTarget()) {
-            if (MenuRegistry.hasClientRoute(path)) {
+            Optional<String> clientNavigationTargetPath = RouteUtil
+                    .getClientNavigationRouteTargetTemplate(path);
+            if (clientNavigationTargetPath.isPresent()) {
+                String clientPath = clientNavigationTargetPath.get();
                 AvailableViewInfo viewInfo = MenuRegistry.getClientRoutes(false)
-                        .get(path.isEmpty() ? path
-                                : path.startsWith("/") ? path : "/" + path);
+                        .get(clientPath.isEmpty() ? clientPath
+                                : clientPath.startsWith("/") ? clientPath
+                                        : "/" + clientPath);
                 if (viewInfo != null && viewInfo.flowLayout()) {
 
                     Class<? extends Component> layout = (Class<? extends Component>) registry

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/RouteTarget.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/RouteTarget.java
@@ -42,8 +42,6 @@ public class RouteTarget implements Serializable {
     private final boolean annotatedRoute;
     private final boolean registeredAtStartup;
 
-    private String template;
-
     /**
      * Create a new Route target holder with the given target registered.
      *
@@ -74,23 +72,6 @@ public class RouteTarget implements Serializable {
      */
     public RouteTarget(Class<? extends Component> target) {
         this(target, null);
-    }
-
-    /**
-     * Create a new Route target holder with the given target registered and
-     * route template and empty parent layouts.
-     *
-     * @param target
-     *            navigation target
-     * @param parents
-     *            parent layout chain
-     * @param template
-     *            route template
-     */
-    RouteTarget(Class<? extends Component> target,
-            List<Class<? extends RouterLayout>> parents, String template) {
-        this(target, parents);
-        this.template = template;
     }
 
     /**
@@ -145,12 +126,4 @@ public class RouteTarget implements Serializable {
         return registeredAtStartup;
     }
 
-    /**
-     * Get the route template.
-     *
-     * @return route template
-     */
-    String getTemplate() {
-        return template;
-    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/RouteTarget.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/RouteTarget.java
@@ -42,6 +42,8 @@ public class RouteTarget implements Serializable {
     private final boolean annotatedRoute;
     private final boolean registeredAtStartup;
 
+    private String template;
+
     /**
      * Create a new Route target holder with the given target registered.
      *
@@ -72,6 +74,23 @@ public class RouteTarget implements Serializable {
      */
     public RouteTarget(Class<? extends Component> target) {
         this(target, null);
+    }
+
+    /**
+     * Create a new Route target holder with the given target registered and
+     * route template and empty parent layouts.
+     *
+     * @param target
+     *            navigation target
+     * @param parents
+     *            parent layout chain
+     * @param template
+     *            route template
+     */
+    RouteTarget(Class<? extends Component> target,
+            List<Class<? extends RouterLayout>> parents, String template) {
+        this(target, parents);
+        this.template = template;
     }
 
     /**
@@ -126,4 +145,12 @@ public class RouteTarget implements Serializable {
         return registeredAtStartup;
     }
 
+    /**
+     * Get the route template.
+     *
+     * @return route template
+     */
+    String getTemplate() {
+        return template;
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/RouteUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/RouteUtil.java
@@ -52,6 +52,7 @@ import com.vaadin.flow.router.RoutePathProvider;
 import com.vaadin.flow.router.RoutePrefix;
 import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.server.AbstractConfiguration;
+import com.vaadin.flow.server.AmbiguousRouteConfigurationException;
 import com.vaadin.flow.server.InvalidRouteConfigurationException;
 import com.vaadin.flow.server.RouteRegistry;
 import com.vaadin.flow.server.SessionRouteRegistry;
@@ -725,5 +726,36 @@ public class RouteUtil {
                 .filter(HasDynamicTitle.class::isInstance)
                 .map(element -> ((HasDynamicTitle) element).getPageTitle())
                 .filter(Objects::nonNull).findFirst();
+    }
+
+    /**
+     * Search for a client route using given navigation url and return target
+     * template.
+     *
+     * @param url
+     *            the navigation url used to search a route target.
+     *
+     * @return a {@link Optional} containing the template of the client route
+     *         target or an empty {@link Optional}.
+     */
+    public static Optional<String> getClientNavigationRouteTargetTemplate(
+            String url) {
+        if (url == null) {
+            return Optional.empty();
+        }
+        RouteModel routeModel = RouteModel.create(true);
+        MenuRegistry.getClientRoutes(false).forEach((key, value) -> {
+            try {
+                routeModel.addRoute(key,
+                        new RouteTarget(Component.class, null, key));
+            } catch (AmbiguousRouteConfigurationException tolerate) {
+                // tolerate ambiguous routes. First added route wins and
+                // declares returned template.
+            }
+        });
+        url = url.isEmpty() ? url : url.startsWith("/") ? url : "/" + url;
+        return Optional.ofNullable(routeModel.getNavigationRouteTarget(url))
+                .map(NavigationRouteTarget::getRouteTarget)
+                .map(RouteTarget::getTemplate);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/RouteUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/RouteUtil.java
@@ -746,8 +746,7 @@ public class RouteUtil {
         RouteModel routeModel = RouteModel.create(true);
         MenuRegistry.getClientRoutes(false).forEach((key, value) -> {
             try {
-                routeModel.addRoute(key,
-                        new RouteTarget(Component.class, null, key));
+                routeModel.addRoute(key, new ClientTarget(key));
             } catch (AmbiguousRouteConfigurationException tolerate) {
                 // tolerate ambiguous routes. First added route wins and
                 // declares returned template.
@@ -756,6 +755,6 @@ public class RouteUtil {
         url = url.isEmpty() ? url : url.startsWith("/") ? url : "/" + url;
         return Optional.ofNullable(routeModel.getNavigationRouteTarget(url))
                 .map(NavigationRouteTarget::getRouteTarget)
-                .map(RouteTarget::getTemplate);
+                .map(ClientTarget.class::cast).map(ClientTarget::getTemplate);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/menu/MenuConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/menu/MenuConfiguration.java
@@ -167,7 +167,7 @@ public final class MenuConfiguration {
                     .filter(menuEntry -> PathUtil.trimPath(menuEntry.getKey())
                             .equals(activeLocation))
                     .map(Map.Entry::getValue).map(AvailableViewInfo::title)
-                    .findFirst();
+                    .filter(Objects::nonNull).findFirst();
         }
         return Optional.empty();
     }

--- a/flow-server/src/test/java/com/vaadin/flow/router/DefaultRouteResolverTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/DefaultRouteResolverTest.java
@@ -18,6 +18,8 @@ package com.vaadin.flow.router;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -136,8 +138,6 @@ public class DefaultRouteResolverTest extends RoutingTestBase {
 
         try (MockedStatic<MenuRegistry> menuRegistry = Mockito
                 .mockStatic(MenuRegistry.class)) {
-            menuRegistry.when(() -> MenuRegistry.hasClientRoute(path))
-                    .thenReturn(true);
             menuRegistry.when(() -> MenuRegistry.getClientRoutes(false))
                     .thenReturn(Collections.singletonMap("/route",
                             new AvailableViewInfo("", null, false, "/route",
@@ -150,6 +150,142 @@ public class DefaultRouteResolverTest extends RoutingTestBase {
     }
 
     @Test
+    public void clientRouteRequest_withRouteParameters_getDefinedLayout() {
+        router.getRegistry().setLayout(DefaultLayout.class);
+
+        try (MockedStatic<MenuRegistry> menuRegistry = Mockito
+                .mockStatic(MenuRegistry.class)) {
+            menuRegistry.when(() -> MenuRegistry.getClientRoutes(false))
+            // @formatter:off
+                    .thenReturn(buildClientRoutes(
+                            "/route/:param",
+                            "/opt_route/:param?",
+                            "/wildcard_route/:param*",
+                            "/one/:param/two/:param2",
+                            "/foo/:param?/bar/:param2?"));
+            Stream.of(
+                    "route/1",
+                            "/route/abc",
+                            "/opt_route",
+                            "/opt_route/",
+                            "/opt_route/1",
+                            "/wildcard_route",
+                            "wildcard_route",
+                            "wildcard_route/",
+                            "wildcard_route/1",
+                            "/wildcard_route/1/2",
+                            "one/1/two/2",
+                            "foo/bar",
+                            "foo/a/bar",
+                            "foo/bar/b",
+                            "foo/a/bar/b")
+                    // @formatter:on
+                    .forEach(path -> {
+                        String msg = String.format(
+                                "Layout should be returned for path '%s' a non server route when matching @Layout exists",
+                                path);
+                        var state = resolveNavigationState(path);
+                        Assert.assertNotNull(msg, state);
+                        Assert.assertEquals(msg, DefaultLayout.class,
+                                resolveNavigationState(path).getRouteTarget()
+                                        .getTarget());
+                    });
+        }
+    }
+
+    @Test
+    public void clientRouteRequest_withRouteParameters_noLayout() {
+        router.getRegistry().setLayout(DefaultLayout.class);
+
+        try (MockedStatic<MenuRegistry> menuRegistry = Mockito
+                .mockStatic(MenuRegistry.class)) {
+            menuRegistry.when(() -> MenuRegistry.getClientRoutes(false))
+            // @formatter:off
+                    .thenReturn(buildClientRoutes(
+                            "/route/:param",
+                            "/opt_route/:param?",
+                            "/wildcard_route/:param*",
+                            "/one/:param/two/:param2",
+                            "/foo/:param?/bar/:param2?"));
+            // @formatter:off
+            Stream.of(
+                            "route",
+                            "/route/abc/def",
+                            "/unknown_route",
+                            "/opt_route/1/2",
+                            "/",
+                            "",
+                            "one/1/two/2/3",
+                            "one/two/2",
+                            "one/two/",
+                            "foo",
+                            "foo/foo/foo/bar/bar/")
+                    // @formatter:on
+                    .forEach(path -> {
+                        Assert.assertNull(String.format(
+                                "Layout should not be returned for a non server route '%s' when matching @Layout doesn't exist",
+                                path), resolveNavigationState(path));
+                    });
+        }
+    }
+
+    /**
+     * Ambiguous routes should be resolved by the order they were added to the
+     * RouteModel. First added wins. Ambiguous route is detected by
+     * AmbiguousRouteConfigurationException.
+     */
+    @Test
+    public void clientRouteRequest_withRouteParameters_ambiguousRoutesFirstAddedWins() {
+        router.getRegistry().setLayout(DefaultLayout.class);
+
+        try (MockedStatic<MenuRegistry> menuRegistry = Mockito
+                .mockStatic(MenuRegistry.class)) {
+            menuRegistry.when(() -> MenuRegistry.getClientRoutes(false))
+            // @formatter:off
+                    .thenReturn(buildClientRoutes(
+                            "/route",
+                            "/route/:param?",
+                            "/foo",
+                            "/foo/:param*"));
+            // @formatter:off
+            Stream.of(
+                    "route",
+                            "foo",
+                            "foo/1"
+                            )
+                    // @formatter:on
+                    .forEach(path -> {
+                        String msg = String.format(
+                                "Layout should be returned for path '%s' a non server route when matching @Layout exists",
+                                path);
+                        var state = resolveNavigationState(path);
+                        Assert.assertNotNull(msg, state);
+                        Assert.assertEquals(msg, DefaultLayout.class,
+                                resolveNavigationState(path).getRouteTarget()
+                                        .getTarget());
+                    });
+            Stream.of("route/1").forEach(path -> {
+                Assert.assertNull(String.format(
+                        "Layout should not be returned for a non server route '%s' when matching @Layout doesn't exist",
+                        path), resolveNavigationState(path));
+            });
+        }
+    }
+
+    private Map<String, AvailableViewInfo> buildClientRoutes(String... routes) {
+        Map<String, AvailableViewInfo> clientRoutes = new LinkedHashMap<>();
+        for (String route : routes) {
+            clientRoutes.put(route, createAvailableViewInfo(route));
+        }
+        return clientRoutes;
+    }
+
+    private AvailableViewInfo createAvailableViewInfo(String route) {
+        return new AvailableViewInfo("", null, false, route, false, false, null,
+                null, null, true);
+    }
+
+    @Test
     public void clientRouteRequest_noLayoutForPath_Throws() {
         expectedEx.expect(NotFoundException.class);
         expectedEx.expectMessage("No layout for client path 'route'");
@@ -158,8 +294,6 @@ public class DefaultRouteResolverTest extends RoutingTestBase {
 
         try (MockedStatic<MenuRegistry> menuRegistry = Mockito
                 .mockStatic(MenuRegistry.class)) {
-            menuRegistry.when(() -> MenuRegistry.hasClientRoute(path))
-                    .thenReturn(true);
             menuRegistry.when(() -> MenuRegistry.getClientRoutes(false))
                     .thenReturn(Collections.singletonMap("/route",
                             new AvailableViewInfo("", null, false, "/route",

--- a/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuConfigurationTest.java
@@ -144,8 +144,10 @@ public class MenuConfigurationTest {
         Assert.assertEquals(
                 "List of menu items has incorrect size. Excluded menu item like /login is not expected.",
                 7, menuEntries.size());
-        assertOrder(menuEntries, new String[] { "/", "/about", "/hilla",
-                "/hilla/sub", "/opt_params", "/params", "/wc_params" });
+        assertOrder(menuEntries,
+                new String[] { "/", "/about", "/hilla", "/hilla/sub",
+                        "/opt_params", "/params_with_opt_children",
+                        "/wc_params" });
     }
 
     @Test
@@ -169,7 +171,8 @@ public class MenuConfigurationTest {
         Assert.assertEquals(8, menuEntries.size());
         assertOrder(menuEntries,
                 new String[] { "/", "/home", "/info", "/opt_params", "/param",
-                        "/param/varargs", "/params", "/wc_params" });
+                        "/param/varargs", "/params_with_opt_children",
+                        "/wc_params" });
 
         Map<String, MenuEntry> mapMenuItems = menuEntries.stream()
                 .collect(Collectors.toMap(MenuEntry::path, item -> item));

--- a/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuRegistryTest.java
@@ -714,7 +714,6 @@ public class MenuRegistryTest {
                   {
                     "route": "params_with_opt_children",
                     "loginRequired": false,
-                    "title": "params_with_opt_children path is not included in menu",
                     "children": [
                         {
                             "route": ":param?",
@@ -737,7 +736,7 @@ public class MenuRegistryTest {
                   {
                     "route": "params",
                     "loginRequired": false,
-                    "title": "params path is shown in menu",
+                    "title": null,
                     "children": [
                       {
                         "route": ":param",

--- a/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuRegistryTest.java
@@ -189,7 +189,7 @@ public class MenuRegistryTest {
 
         Map<String, AvailableViewInfo> menuItems = new MenuRegistry()
                 .getMenuItems(false);
-        Assert.assertEquals(13, menuItems.size());
+        Assert.assertEquals(15, menuItems.size());
 
         RouteUtil.checkForClientRouteCollisions(vaadinService,
                 routeConfiguration.getAvailableRoutes());

--- a/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuRegistryTest.java
@@ -143,7 +143,7 @@ public class MenuRegistryTest {
         Map<String, AvailableViewInfo> menuItems = new MenuRegistry()
                 .getMenuItems(true);
 
-        Assert.assertEquals(8, menuItems.size());
+        Assert.assertEquals(10, menuItems.size());
         assertClientRoutes(menuItems);
     }
 
@@ -170,7 +170,7 @@ public class MenuRegistryTest {
         Map<String, AvailableViewInfo> menuItems = new MenuRegistry()
                 .getMenuItems(false);
 
-        Assert.assertEquals(11, menuItems.size());
+        Assert.assertEquals(13, menuItems.size());
         // Validate as if logged in as all routes should be available
         assertClientRoutes(menuItems, true, true, false);
     }
@@ -231,7 +231,7 @@ public class MenuRegistryTest {
             Map<String, AvailableViewInfo> menuItems = new MenuRegistry()
                     .getMenuItems(true);
 
-            Assert.assertEquals(8, menuItems.size());
+            Assert.assertEquals(10, menuItems.size());
             assertClientRoutes(menuItems);
         }
     }
@@ -265,7 +265,7 @@ public class MenuRegistryTest {
         Map<String, AvailableViewInfo> menuItems = new MenuRegistry()
                 .getMenuItems(true);
 
-        Assert.assertEquals(10, menuItems.size());
+        Assert.assertEquals(12, menuItems.size());
         assertClientRoutes(menuItems);
         assertServerRoutes(menuItems);
     }
@@ -306,7 +306,7 @@ public class MenuRegistryTest {
         Map<String, AvailableViewInfo> menuItems = new MenuRegistry()
                 .getMenuItems(true);
 
-        Assert.assertEquals(11, menuItems.size());
+        Assert.assertEquals(13, menuItems.size());
         assertClientRoutes(menuItems, true, true, false);
 
         // Verify that getMenuItemsList returns the same data
@@ -315,8 +315,10 @@ public class MenuRegistryTest {
         Assert.assertEquals(
                 "List of menu items has incorrect size. Excluded menu item like /login is not expected.",
                 7, menuItemsList.size());
-        assertOrder(menuItemsList, new String[] { "/", "/about", "/hilla",
-                "/hilla/sub", "/opt_params", "/params", "/wc_params" });
+        assertOrder(menuItemsList,
+                new String[] { "/", "/about", "/hilla", "/hilla/sub",
+                        "/opt_params", "/params_with_opt_children",
+                        "/wc_params" });
     }
 
     @Test
@@ -333,7 +335,7 @@ public class MenuRegistryTest {
         Map<String, AvailableViewInfo> menuItems = new MenuRegistry()
                 .getMenuItems(true);
 
-        Assert.assertEquals(9, menuItems.size());
+        Assert.assertEquals(11, menuItems.size());
         assertClientRoutes(menuItems, true, false, false);
     }
 
@@ -354,7 +356,8 @@ public class MenuRegistryTest {
         Assert.assertEquals(8, menuItems.size());
         assertOrder(menuItems,
                 new String[] { "/", "/home", "/info", "/opt_params", "/param",
-                        "/param/varargs", "/params", "/wc_params" });
+                        "/param/varargs", "/params_with_opt_children",
+                        "/wc_params" });
         // verifying that data is same as with collectMenuItems
         Map<String, AvailableViewInfo> mapMenuItems = menuItems.stream()
                 .collect(Collectors.toMap(AvailableViewInfo::route,
@@ -707,6 +710,21 @@ public class MenuRegistryTest {
                        ":param": "opt"
                     },
                     "title": "opt_params path is included in menu"
+                  },
+                  {
+                    "route": "params_with_opt_children",
+                    "loginRequired": false,
+                    "title": "params_with_opt_children path is not included in menu",
+                    "children": [
+                        {
+                            "route": ":param?",
+                            "loginRequired": false,
+                            "params": {
+                               ":param": "opt"
+                            },
+                            "title": "params_with_opt_children/:param? path is included in menu"
+                        }
+                    ]
                   },
                   {
                     "route": "req_params/:param",


### PR DESCRIPTION
Improves navigation path matching with client route templates. Adds support for matching with route parameters to find automatic Flow main layout for client routes.

Fixes: #20268
