### PR TITLE
fix: Update default npm version

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -70,7 +70,7 @@ public class FrontendTools {
     /**
      * This is the version shipped with the default Node version.
      */
-    public static final String DEFAULT_NPM_VERSION = "10.8.2";
+    public static final String DEFAULT_NPM_VERSION = "10.9.0";
 
     public static final String DEFAULT_PNPM_VERSION = "8.6.11";
 


### PR DESCRIPTION
Update default npm version
to match the version used
by node 22.10.0
