### PR TITLE
chore: don't log missing setter message for records

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -1147,7 +1147,7 @@ public class Binder<BEAN> implements Serializable {
             ValueProvider<BEAN, ?> getter = definition.getGetter();
             Setter<BEAN, ?> setter = readOnly ? null
                     : definition.getSetter().orElse(null);
-            if (!readOnly && setter == null) {
+            if (!readOnly && setter == null && !binder.isRecord) {
                 getLogger().info(
                         propertyName + " does not have an accessible setter");
             }


### PR DESCRIPTION
Java records are immutable, so they do not provide setters for their properties. However, Flow Binder fully supports writing records by creating new instances on demand.
This change prevents Binder from logging a useless 'missing setter' log message for records.