### PR TITLE
chore: Add a shortcut method for reading from record

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -2445,7 +2445,7 @@ public class Binder<BEAN> implements Serializable {
     public void readRecord(BEAN record) {
         if (!isRecord) {
             throw new IllegalArgumentException(
-                    "readRecord methods can't be used with beans, call readBean instead");
+                    "readRecord method can't be used with beans, call readBean instead");
         }
         readBean(record);
     }

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -2399,7 +2399,6 @@ public class Binder<BEAN> implements Serializable {
      * @see #setBean(Object)
      * @see #writeBeanIfValid(Object)
      * @see #writeBean(Object)
-     * @see #writeRecord()
      *
      * @param bean
      *            the bean or record whose property values to read or
@@ -2426,6 +2425,29 @@ public class Binder<BEAN> implements Serializable {
                     BinderValidationStatus.createUnresolvedStatus(this));
             fireStatusChangeEvent(false);
         }
+    }
+
+    /**
+     * Reads the bound property values from the given record to the
+     * corresponding fields.
+     * <p>
+     * The record is not otherwise associated with this binder; in particular
+     * its property values are not bound to the field value changes.
+     *
+     * @see #writeRecord()
+     *
+     * @param record
+     *            the record whose property values to read or {@code null} to
+     *            clear bound fields
+     * @throws IllegalArgumentException
+     *             if the given object's type is not a record
+     */
+    public void readRecord(BEAN record) {
+        if (!isRecord) {
+            throw new IllegalArgumentException(
+                    "readRecord methods can't be used with beans, call readBean instead");
+        }
+        readBean(record);
     }
 
     /**


### PR DESCRIPTION
## Description

Adds a shortcut method that read the record and checks that it's not a bean.

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
