### PR TITLE
fix: import parent theme lumoImports in dev bundle mode

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/CssBundler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/CssBundler.java
@@ -221,20 +221,27 @@ public class CssBundler {
         boolean potentialAsset = false;
         if (!assetAliases.isEmpty()) {
             Path themeFolderPath = themeFolder.toPath().normalize();
-            Path normalized = themeFolderPath.resolve(potentialFile.toPath())
-                    .normalize();
-            if (normalized.startsWith(themeFolderPath)) {
-                // path is relative to theme folder, check if it matches an
-                // asset
-                String relativePath = themeFolderPath.relativize(normalized)
-                        .toString().replaceAll("\\\\", "/");
-                potentialAsset = assetAliases.stream()
-                        .anyMatch(relativePath::startsWith);
-                if (potentialAsset) {
-                    getLogger().debug(
-                            "Considering '{}' a potential asset of theme '{}'",
-                            relativePath, themeFolder.getName());
+            try {
+                Path normalized = themeFolderPath
+                        .resolve(potentialFile.toPath()).normalize();
+                if (normalized.startsWith(themeFolderPath)) {
+                    // path is relative to theme folder, check if it matches an
+                    // asset
+                    String relativePath = themeFolderPath.relativize(normalized)
+                            .toString().replaceAll("\\\\", "/");
+                    potentialAsset = assetAliases.stream()
+                            .anyMatch(relativePath::startsWith);
+                    if (potentialAsset) {
+                        getLogger().debug(
+                                "Considering '{}' a potential asset of theme '{}'",
+                                relativePath, themeFolder.getName());
+                    }
                 }
+            } catch (IllegalArgumentException e) {
+                getLogger().debug(
+                        "Unresolvable path '{}'. Not considered as a asset of theme '{}'",
+                        potentialFile, themeFolder.getName());
+                return false;
             }
         }
         return potentialAsset;

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
@@ -133,8 +133,8 @@ function writeThemeFiles(themeFolder, themeName, themeProperties, options) {
   }
 
   /* Theme */
+  globalFileContent.push(parentThemeGlobalImport);
   if (useDevServerOrInProductionMode) {
-    globalFileContent.push(parentThemeGlobalImport);
     globalFileContent.push(`import 'themes/${themeName}/${filename}';\n`);
 
     imports.push(`import ${variable} from 'themes/${themeName}/${filename}?inline';\n`);

--- a/flow-tests/test-themes/src/main/frontend/themes/app-theme/theme.json
+++ b/flow-tests/test-themes/src/main/frontend/themes/app-theme/theme.json
@@ -1,5 +1,5 @@
 {
-  "lumoImports": ["typography", "color", "spacing", "badge", "utility"],
+  "lumoImports": ["typography", "color", "spacing", "badge"],
   "parent": "parent-theme",
   "importCss": ["@fortawesome/fontawesome-free/css/all.css"],
   "assets": {

--- a/flow-tests/test-themes/src/main/frontend/themes/parent-theme/theme.json
+++ b/flow-tests/test-themes/src/main/frontend/themes/parent-theme/theme.json
@@ -1,0 +1,3 @@
+{
+  "lumoImports": ["utility"]
+}

--- a/flow-tests/test-themes/src/main/java/com/vaadin/flow/uitest/ui/theme/ThemeView.java
+++ b/flow-tests/test-themes/src/main/java/com/vaadin/flow/uitest/ui/theme/ThemeView.java
@@ -37,7 +37,7 @@ public class ThemeView extends Div {
     public static final String KEYBOARD_ID = "keyboard";
     public static final String LEMON_ID = "lemon";
     public static final String SUN_ID = "sun";
-    public static final String LUMO_BORDER_DIV = "lumo-border-div";
+    public static final String LUMO_BORDER_TOP_DIV = "lumo-border-top-div";
 
     public ThemeView() {
         UI.getCurrent().getPage()
@@ -96,8 +96,8 @@ public class ThemeView extends Div {
         add(new MyComponent().withId(MY_COMPONENT_ID));
 
         Div lumoBorderDiv = new Div("This element has Lumo border style");
-        lumoBorderDiv.addClassName("border");
-        lumoBorderDiv.setId(LUMO_BORDER_DIV);
+        lumoBorderDiv.addClassName("border-t");
+        lumoBorderDiv.setId(LUMO_BORDER_TOP_DIV);
         add(lumoBorderDiv);
     }
 }

--- a/flow-tests/test-themes/src/main/java/com/vaadin/flow/uitest/ui/theme/ThemeView.java
+++ b/flow-tests/test-themes/src/main/java/com/vaadin/flow/uitest/ui/theme/ThemeView.java
@@ -37,6 +37,7 @@ public class ThemeView extends Div {
     public static final String KEYBOARD_ID = "keyboard";
     public static final String LEMON_ID = "lemon";
     public static final String SUN_ID = "sun";
+    public static final String LUMO_BORDER_DIV = "lumo-border-div";
 
     public ThemeView() {
         UI.getCurrent().getPage()
@@ -93,5 +94,10 @@ public class ThemeView extends Div {
 
         add(new Div());
         add(new MyComponent().withId(MY_COMPONENT_ID));
+
+        Div lumoBorderDiv = new Div("This element has Lumo border style");
+        lumoBorderDiv.addClassName("border");
+        lumoBorderDiv.setId(LUMO_BORDER_DIV);
+        add(lumoBorderDiv);
     }
 }

--- a/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
+++ b/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
@@ -39,6 +39,7 @@ import static com.vaadin.flow.uitest.ui.theme.ThemeView.DICE_ID;
 import static com.vaadin.flow.uitest.ui.theme.ThemeView.FONTAWESOME_ID;
 import static com.vaadin.flow.uitest.ui.theme.ThemeView.KEYBOARD_ID;
 import static com.vaadin.flow.uitest.ui.theme.ThemeView.LEMON_ID;
+import static com.vaadin.flow.uitest.ui.theme.ThemeView.LUMO_BORDER_DIV;
 import static com.vaadin.flow.uitest.ui.theme.ThemeView.MY_COMPONENT_ID;
 import static com.vaadin.flow.uitest.ui.theme.ThemeView.OCTOPUSS_ID;
 import static com.vaadin.flow.uitest.ui.theme.ThemeView.SNOWFLAKE_ID;
@@ -269,6 +270,18 @@ public class ThemeIT extends ChromeBrowserTest {
                 "Expecting relative asset URL to be resolved as "
                         + expectedIconsURL + "/sun.svg but was " + imageUrl,
                 imageUrl.matches(String.format(expectedIconsURL, "sun.svg")));
+    }
+
+    /**
+     * Main theme.json does not include utility Lumo import which has border
+     * styling etc. Parent theme.json does include Lumo utility import.
+     */
+    @Test
+    public void parentTheme_lumoStyleAppliedFromParentTheme() {
+        open();
+        WebElement cssNodeLumoBorderDiv = findElement(By.id(LUMO_BORDER_DIV));
+        String border = cssNodeLumoBorderDiv.getCssValue("border");
+        Assert.assertEquals("0.8px solid rgba(26, 57, 96, 0.1)", border);
     }
 
     @Override

--- a/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
+++ b/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
@@ -39,7 +39,7 @@ import static com.vaadin.flow.uitest.ui.theme.ThemeView.DICE_ID;
 import static com.vaadin.flow.uitest.ui.theme.ThemeView.FONTAWESOME_ID;
 import static com.vaadin.flow.uitest.ui.theme.ThemeView.KEYBOARD_ID;
 import static com.vaadin.flow.uitest.ui.theme.ThemeView.LEMON_ID;
-import static com.vaadin.flow.uitest.ui.theme.ThemeView.LUMO_BORDER_DIV;
+import static com.vaadin.flow.uitest.ui.theme.ThemeView.LUMO_BORDER_TOP_DIV;
 import static com.vaadin.flow.uitest.ui.theme.ThemeView.MY_COMPONENT_ID;
 import static com.vaadin.flow.uitest.ui.theme.ThemeView.OCTOPUSS_ID;
 import static com.vaadin.flow.uitest.ui.theme.ThemeView.SNOWFLAKE_ID;
@@ -279,13 +279,11 @@ public class ThemeIT extends ChromeBrowserTest {
     @Test
     public void parentTheme_lumoStyleAppliedFromParentTheme() {
         open();
-        WebElement cssNodeLumoBorderDiv = findElement(By.id(LUMO_BORDER_DIV));
-        // getCssValue doesn't support reliably shorthand properties (e.g.
-        // border).
-        // It's enough to assert only border-top-* properties here.
+        WebElement cssNodeLumoBorderDiv = findElement(
+                By.id(LUMO_BORDER_TOP_DIV));
         Assert.assertEquals("solid",
                 cssNodeLumoBorderDiv.getCssValue("border-top-style"));
-        Assert.assertEquals("0.8px",
+        Assert.assertNotEquals("0px",
                 cssNodeLumoBorderDiv.getCssValue("border-top-width"));
         Assert.assertEquals("rgba(26, 57, 96, 0.1)",
                 cssNodeLumoBorderDiv.getCssValue("border-top-color"));

--- a/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
+++ b/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
@@ -280,8 +280,15 @@ public class ThemeIT extends ChromeBrowserTest {
     public void parentTheme_lumoStyleAppliedFromParentTheme() {
         open();
         WebElement cssNodeLumoBorderDiv = findElement(By.id(LUMO_BORDER_DIV));
-        String border = cssNodeLumoBorderDiv.getCssValue("border");
-        Assert.assertEquals("0.8px solid rgba(26, 57, 96, 0.1)", border);
+        // getCssValue doesn't support reliably shorthand properties (e.g.
+        // border).
+        // It's enough to assert only border-top-* properties here.
+        Assert.assertEquals("solid",
+                cssNodeLumoBorderDiv.getCssValue("border-top-style"));
+        Assert.assertEquals("0.8px",
+                cssNodeLumoBorderDiv.getCssValue("border-top-width"));
+        Assert.assertEquals("rgba(26, 57, 96, 0.1)",
+                cssNodeLumoBorderDiv.getCssValue("border-top-color"));
     }
 
     @Override


### PR DESCRIPTION
Adds missing css imports for parent theme when given in parent theme.json with lumoImports property and running with dev bundle.

Fixes: #19567
