### PR TITLE
fix: remove tokenFile after production build

### DIFF
--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -778,6 +778,7 @@ public class BuildFrontendUtil {
 
             FileUtils.write(tokenFile, JsonUtil.stringify(buildInfo, 2) + "\n",
                     StandardCharsets.UTF_8.name());
+            tokenFile.deleteOnExit();
         } catch (IOException e) {
             adapter.logWarn("Unable to read token file", e);
         }


### PR DESCRIPTION
Clean the token file after
production build/execution
to not make ide app execution
run app in production mode.

Closes #20294
