### PR TITLE
feat: opt-out web components from package.json

### DIFF
--- a/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
+++ b/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
@@ -171,8 +171,8 @@ public class BuildDevBundleMojo extends AbstractMojo
     @Parameter(defaultValue = "${project.basedir}/src/main/" + FRONTEND)
     private File frontendDirectory;
 
-    @Parameter(property = InitParameters.INCLUDE_WEB_COMPONENT_NPM_PACKAGES, defaultValue = "true")
-    private boolean includeWebComponentNpmPackages;
+    @Parameter(property = InitParameters.NPM_EXCLUDE_WEB_COMPONENTS, defaultValue = "false")
+    private boolean npmExcludeWebComponents;
 
     @Override
     public void execute() throws MojoFailureException {
@@ -474,7 +474,7 @@ public class BuildDevBundleMojo extends AbstractMojo
     }
 
     @Override
-    public boolean isIncludeWebComponentNpmPackages() {
-        return includeWebComponentNpmPackages;
+    public boolean isNpmExcludeWebComponents() {
+        return npmExcludeWebComponents;
     }
 }

--- a/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
+++ b/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
@@ -171,6 +171,9 @@ public class BuildDevBundleMojo extends AbstractMojo
     @Parameter(defaultValue = "${project.basedir}/src/main/" + FRONTEND)
     private File frontendDirectory;
 
+    @Parameter(property = InitParameters.INCLUDE_WEB_COMPONENT_NPM_PACKAGES, defaultValue = "true")
+    private boolean includeWebComponentNpmPackages;
+
     @Override
     public void execute() throws MojoFailureException {
         long start = System.nanoTime();
@@ -468,5 +471,10 @@ public class BuildDevBundleMojo extends AbstractMojo
     public boolean checkRuntimeDependency(String groupId, String artifactId,
             Consumer<String> missingDependencyMessageConsumer) {
         return false;
+    }
+
+    @Override
+    public boolean isIncludeWebComponentNpmPackages() {
+        return includeWebComponentNpmPackages;
     }
 }

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
@@ -218,7 +218,7 @@ internal class GradlePluginAdapter(
 
     override fun applicationIdentifier(): String = config.applicationIdentifier.get()
 
-    override fun isIncludeWebComponentNpmPackages(): Boolean = config.includeWebComponentNpmPackages.get()
+    override fun isNpmExcludeWebComponents(): Boolean = config.npmExcludeWebComponents.get()
 
     override fun checkRuntimeDependency(
         groupId: String,

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
@@ -218,7 +218,7 @@ internal class GradlePluginAdapter(
 
     override fun applicationIdentifier(): String = config.applicationIdentifier.get()
 
-    override fun includeWebComponentNpmPackages(): Boolean = config.includeWebComponentNpmPackages.get()
+    override fun isIncludeWebComponentNpmPackages(): Boolean = config.includeWebComponentNpmPackages.get()
 
     override fun checkRuntimeDependency(
         groupId: String,

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
@@ -218,6 +218,8 @@ internal class GradlePluginAdapter(
 
     override fun applicationIdentifier(): String = config.applicationIdentifier.get()
 
+    override fun includeWebComponentNpmPackages(): Boolean = config.includeWebComponentNpmPackages.get()
+
     override fun checkRuntimeDependency(
         groupId: String,
         artifactId: String,

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/PrepareFrontendInputProperties.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/PrepareFrontendInputProperties.kt
@@ -143,6 +143,9 @@ internal class PrepareFrontendInputProperties(private val config: PluginEffectiv
     public fun getApplicationIdentifier(): Provider<String> = config.applicationIdentifier
 
     @Input
+    public fun getIncludeWebComponentNpmPackages(): Provider<Boolean> = config.includeWebComponentNpmPackages
+
+    @Input
     @Optional
     public fun getNodeExecutablePath(): Provider<String> = tools
         .mapOrNull { it.nodeBinary }

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/PrepareFrontendInputProperties.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/PrepareFrontendInputProperties.kt
@@ -143,7 +143,7 @@ internal class PrepareFrontendInputProperties(private val config: PluginEffectiv
     public fun getApplicationIdentifier(): Provider<String> = config.applicationIdentifier
 
     @Input
-    public fun getIncludeWebComponentNpmPackages(): Provider<Boolean> = config.includeWebComponentNpmPackages
+    public fun getNpmExcludeWebComponents(): Provider<Boolean> = config.npmExcludeWebComponents
 
     @Input
     @Optional

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
@@ -282,6 +282,8 @@ public abstract class VaadinFlowPluginExtension @Inject constructor(private val 
 
     public abstract val applicationIdentifier: Property<String>
 
+    public abstract val includeWebComponentNpmPackages: Property<Boolean>
+
     public fun filterClasspath(@DelegatesTo(value = ClasspathFilter::class, strategy = Closure.DELEGATE_FIRST) block: Closure<*>) {
         block.delegate = classpathFilter
         block.resolveStrategy = Closure.DELEGATE_FIRST
@@ -439,6 +441,9 @@ public class PluginEffectiveConfiguration(
             ))
         .overrideWithSystemProperty("vaadin.${InitParameters.APPLICATION_IDENTIFIER}")
 
+    public val includeWebComponentNpmPackages: Provider<Boolean> = extension
+            .includeWebComponentNpmPackages.convention(true)
+
     /**
      * Finds the value of a boolean property. It searches in gradle and system properties.
      *
@@ -499,7 +504,8 @@ public class PluginEffectiveConfiguration(
             "alwaysExecutePrepareFrontend=${alwaysExecutePrepareFrontend.get()}, " +
             "frontendHotdeploy=${frontendHotdeploy.get()}," +
             "reactEnable=${reactEnable.get()}," +
-            "cleanFrontendFiles=${cleanFrontendFiles.get()}" +
+            "cleanFrontendFiles=${cleanFrontendFiles.get()}," +
+            "includeWebComponentNpmPackages=${includeWebComponentNpmPackages.get()}" +
             ")"
     public companion object {
         public fun get(project: Project): PluginEffectiveConfiguration =

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
@@ -282,7 +282,7 @@ public abstract class VaadinFlowPluginExtension @Inject constructor(private val 
 
     public abstract val applicationIdentifier: Property<String>
 
-    public abstract val includeWebComponentNpmPackages: Property<Boolean>
+    public abstract val npmExcludeWebComponents: Property<Boolean>
 
     public fun filterClasspath(@DelegatesTo(value = ClasspathFilter::class, strategy = Closure.DELEGATE_FIRST) block: Closure<*>) {
         block.delegate = classpathFilter
@@ -441,8 +441,8 @@ public class PluginEffectiveConfiguration(
             ))
         .overrideWithSystemProperty("vaadin.${InitParameters.APPLICATION_IDENTIFIER}")
 
-    public val includeWebComponentNpmPackages: Provider<Boolean> = extension
-            .includeWebComponentNpmPackages.convention(true)
+    public val npmExcludeWebComponents: Provider<Boolean> = extension
+            .npmExcludeWebComponents.convention(false)
 
     /**
      * Finds the value of a boolean property. It searches in gradle and system properties.
@@ -505,7 +505,7 @@ public class PluginEffectiveConfiguration(
             "frontendHotdeploy=${frontendHotdeploy.get()}," +
             "reactEnable=${reactEnable.get()}," +
             "cleanFrontendFiles=${cleanFrontendFiles.get()}," +
-            "includeWebComponentNpmPackages=${includeWebComponentNpmPackages.get()}" +
+            "npmExcludeWebComponents=${npmExcludeWebComponents.get()}" +
             ")"
     public companion object {
         public fun get(project: Project): PluginEffectiveConfiguration =

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -234,8 +234,8 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
     @Parameter(property = InitParameters.REACT_ENABLE, defaultValue = "${null}")
     private Boolean reactEnable;
 
-    @Parameter(property = InitParameters.INCLUDE_WEB_COMPONENT_NPM_PACKAGES, defaultValue = "true")
-    private boolean includeWebComponentNpmPackages;
+    @Parameter(property = InitParameters.NPM_EXCLUDE_WEB_COMPONENTS, defaultValue = "false")
+    private boolean npmExcludeWebComponents;
 
     /**
      * Identifier for the application.
@@ -575,7 +575,7 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
     }
 
     @Override
-    public boolean isIncludeWebComponentNpmPackages() {
-        return includeWebComponentNpmPackages;
+    public boolean isNpmExcludeWebComponents() {
+        return npmExcludeWebComponents;
     }
 }

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -234,6 +234,9 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
     @Parameter(property = InitParameters.REACT_ENABLE, defaultValue = "${null}")
     private Boolean reactEnable;
 
+    @Parameter(property = InitParameters.INCLUDE_WEB_COMPONENT_NPM_PACKAGES, defaultValue = "true")
+    private boolean includeWebComponentNpmPackages;
+
     /**
      * Identifier for the application.
      * <p>
@@ -569,5 +572,10 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
         return "app-" + StringUtil.getHash(
                 project.getGroupId() + ":" + project.getArtifactId(),
                 StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public boolean isIncludeWebComponentNpmPackages() {
+        return includeWebComponentNpmPackages;
     }
 }

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/GenerateNpmBOMMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/GenerateNpmBOMMojo.java
@@ -177,8 +177,8 @@ public class GenerateNpmBOMMojo extends FlowModeAbstractMojo {
                         .setJavaResourceFolder(javaResourceFolder())
                         .withProductionMode(productionMode)
                         .withReact(isReactEnabled())
-                        .withIncludeWebComponentNpmPackages(
-                                isIncludeWebComponentNpmPackages());
+                        .withNpmExcludeWebComponents(
+                                isNpmExcludeWebComponents());
                 new NodeTasks(options).execute();
                 logInfo("SBOM generation created node_modules and all needed metadata. "
                         + "If you don't need it, please run mvn vaadin:clean-frontend");

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/GenerateNpmBOMMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/GenerateNpmBOMMojo.java
@@ -176,7 +176,9 @@ public class GenerateNpmBOMMojo extends FlowModeAbstractMojo {
                         .withHomeNodeExecRequired(requireHomeNodeExec())
                         .setJavaResourceFolder(javaResourceFolder())
                         .withProductionMode(productionMode)
-                        .withReact(isReactEnabled());
+                        .withReact(isReactEnabled())
+                        .withIncludeWebComponentNpmPackages(
+                                isIncludeWebComponentNpmPackages());
                 new NodeTasks(options).execute();
                 logInfo("SBOM generation created node_modules and all needed metadata. "
                         + "If you don't need it, please run mvn vaadin:clean-frontend");

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -166,7 +166,8 @@ public class BuildFrontendUtil {
                 .withHomeNodeExecRequired(adapter.requireHomeNodeExec())
                 .setJavaResourceFolder(adapter.javaResourceFolder())
                 .withProductionMode(false).withReact(adapter.isReactEnabled())
-                .withIncludeWebComponentNpmPackages(adapter.isIncludeWebComponentNpmPackages());
+                .withIncludeWebComponentNpmPackages(
+                        adapter.isIncludeWebComponentNpmPackages());
 
         // Copy jar artifact contents in TaskCopyFrontendFiles
         options.copyResources(adapter.getJarFiles());
@@ -341,7 +342,8 @@ public class BuildFrontendUtil {
                     .withCiBuild(adapter.ciBuild())
                     .withForceProductionBuild(adapter.forceProductionBuild())
                     .withReact(adapter.isReactEnabled())
-                    .withIncludeWebComponentNpmPackages(adapter.isIncludeWebComponentNpmPackages());
+                    .withIncludeWebComponentNpmPackages(
+                            adapter.isIncludeWebComponentNpmPackages());
             new NodeTasks(options).execute();
         } catch (ExecutionFailedException exception) {
             throw exception;
@@ -408,7 +410,8 @@ public class BuildFrontendUtil {
                     .skipDevBundleBuild(adapter.skipDevBundleBuild())
                     .withCompressBundle(adapter.compressBundle())
                     .withReact(adapter.isReactEnabled())
-                    .withIncludeWebComponentNpmPackages(adapter.isIncludeWebComponentNpmPackages());
+                    .withIncludeWebComponentNpmPackages(
+                            adapter.isIncludeWebComponentNpmPackages());
             new NodeTasks(options).execute();
         } catch (ExecutionFailedException exception) {
             throw exception;

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -762,6 +762,7 @@ public class BuildFrontendUtil {
             buildInfo.remove(Constants.CONNECT_OPEN_API_FILE_TOKEN);
             buildInfo.remove(Constants.PROJECT_FRONTEND_GENERATED_DIR_TOKEN);
             buildInfo.remove(InitParameters.BUILD_FOLDER);
+            buildInfo.remove(InitParameters.NPM_EXCLUDE_WEB_COMPONENTS);
             // Premium features flag is always true, because Vaadin CI server
             // uses Enterprise sub, thus it's always true.
             // Thus, resets the premium feature flag and DAU flag before asking

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -166,8 +166,8 @@ public class BuildFrontendUtil {
                 .withHomeNodeExecRequired(adapter.requireHomeNodeExec())
                 .setJavaResourceFolder(adapter.javaResourceFolder())
                 .withProductionMode(false).withReact(adapter.isReactEnabled())
-                .withIncludeWebComponentNpmPackages(
-                        adapter.isIncludeWebComponentNpmPackages());
+                .withNpmExcludeWebComponents(
+                        adapter.isNpmExcludeWebComponents());
 
         // Copy jar artifact contents in TaskCopyFrontendFiles
         options.copyResources(adapter.getJarFiles());
@@ -342,8 +342,8 @@ public class BuildFrontendUtil {
                     .withCiBuild(adapter.ciBuild())
                     .withForceProductionBuild(adapter.forceProductionBuild())
                     .withReact(adapter.isReactEnabled())
-                    .withIncludeWebComponentNpmPackages(
-                            adapter.isIncludeWebComponentNpmPackages());
+                    .withNpmExcludeWebComponents(
+                            adapter.isNpmExcludeWebComponents());
             new NodeTasks(options).execute();
         } catch (ExecutionFailedException exception) {
             throw exception;
@@ -410,8 +410,8 @@ public class BuildFrontendUtil {
                     .skipDevBundleBuild(adapter.skipDevBundleBuild())
                     .withCompressBundle(adapter.compressBundle())
                     .withReact(adapter.isReactEnabled())
-                    .withIncludeWebComponentNpmPackages(
-                            adapter.isIncludeWebComponentNpmPackages());
+                    .withNpmExcludeWebComponents(
+                            adapter.isNpmExcludeWebComponents());
             new NodeTasks(options).execute();
         } catch (ExecutionFailedException exception) {
             throw exception;

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -165,7 +165,8 @@ public class BuildFrontendUtil {
                 .setNodeAutoUpdate(adapter.nodeAutoUpdate())
                 .withHomeNodeExecRequired(adapter.requireHomeNodeExec())
                 .setJavaResourceFolder(adapter.javaResourceFolder())
-                .withProductionMode(false).withReact(adapter.isReactEnabled());
+                .withProductionMode(false).withReact(adapter.isReactEnabled())
+                .withIncludeWebComponentNpmPackages(adapter.isIncludeWebComponentNpmPackages());
 
         // Copy jar artifact contents in TaskCopyFrontendFiles
         options.copyResources(adapter.getJarFiles());
@@ -339,7 +340,8 @@ public class BuildFrontendUtil {
                     .withPostinstallPackages(adapter.postinstallPackages())
                     .withCiBuild(adapter.ciBuild())
                     .withForceProductionBuild(adapter.forceProductionBuild())
-                    .withReact(adapter.isReactEnabled());
+                    .withReact(adapter.isReactEnabled())
+                    .withIncludeWebComponentNpmPackages(adapter.isIncludeWebComponentNpmPackages());
             new NodeTasks(options).execute();
         } catch (ExecutionFailedException exception) {
             throw exception;
@@ -405,7 +407,8 @@ public class BuildFrontendUtil {
                     .withBundleBuild(true)
                     .skipDevBundleBuild(adapter.skipDevBundleBuild())
                     .withCompressBundle(adapter.compressBundle())
-                    .withReact(adapter.isReactEnabled());
+                    .withReact(adapter.isReactEnabled())
+                    .withIncludeWebComponentNpmPackages(adapter.isIncludeWebComponentNpmPackages());
             new NodeTasks(options).execute();
         } catch (ExecutionFailedException exception) {
             throw exception;

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -77,6 +77,7 @@ import static com.vaadin.flow.server.InitParameters.APPLICATION_IDENTIFIER;
 import static com.vaadin.flow.server.InitParameters.FRONTEND_HOTDEPLOY;
 import static com.vaadin.flow.server.InitParameters.NODE_DOWNLOAD_ROOT;
 import static com.vaadin.flow.server.InitParameters.NODE_VERSION;
+import static com.vaadin.flow.server.InitParameters.NPM_EXCLUDE_WEB_COMPONENTS;
 import static com.vaadin.flow.server.InitParameters.REACT_ENABLE;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_INITIAL_UIDL;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE;
@@ -265,6 +266,10 @@ public class BuildFrontendUtil {
         }
 
         buildInfo.put(REACT_ENABLE, adapter.isReactEnabled());
+        if (adapter.isNpmExcludeWebComponents()) {
+            buildInfo.put(NPM_EXCLUDE_WEB_COMPONENTS,
+                    adapter.isNpmExcludeWebComponents());
+        }
 
         try {
             FileUtils.forceMkdir(token.getParentFile());

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBase.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBase.java
@@ -343,5 +343,5 @@ public interface PluginAdapterBase {
      *
      * @return {@code true} to include web component npm packages.
      */
-    boolean isIncludeWebComponentNpmPackages();
+    boolean isNpmExcludeWebComponents();
 }

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBase.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBase.java
@@ -337,4 +337,11 @@ public interface PluginAdapterBase {
      *         {@literal blank}.
      */
     String applicationIdentifier();
+
+    /**
+     * Whether to include web component npm packages in packages.json.
+     *
+     * @return {@code true} to include web component npm packages.
+     */
+    boolean isIncludeWebComponentNpmPackages();
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -285,4 +285,9 @@ public class InitParameters implements Serializable {
      */
     public static final String APPLICATION_IDENTIFIER = "applicationIdentifier";
 
+    /**
+     * Configuration name for including npm packages for web components.
+     */
+    public static final String INCLUDE_WEB_COMPONENT_NPM_PACKAGES = "include.web.component.npm.packages";
+
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -286,8 +286,8 @@ public class InitParameters implements Serializable {
     public static final String APPLICATION_IDENTIFIER = "applicationIdentifier";
 
     /**
-     * Configuration name for including npm packages for web components.
+     * Configuration name for excluding npm packages for web components.
      */
-    public static final String INCLUDE_WEB_COMPONENT_NPM_PACKAGES = "include.web.component.npm.packages";
+    public static final String NPM_EXCLUDE_WEB_COMPONENTS = "npm.excludeWebComponents";
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleValidationUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleValidationUtil.java
@@ -317,7 +317,7 @@ public final class BundleValidationUtil {
                     options.getClassFinder(),
                     options.isReactEnabled()
                             && FrontendUtils.isReactModuleAvailable(options),
-                    options.isIncludeWebComponentNpmPackages())
+                    options.isNpmExcludeWebComponents())
                     .exclude(applicationDependencies);
 
             // Add application dependencies

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleValidationUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleValidationUtil.java
@@ -316,7 +316,8 @@ public final class BundleValidationUtil {
             Map<String, String> filteredApplicationDependencies = new ExclusionFilter(
                     options.getClassFinder(),
                     options.isReactEnabled()
-                            && FrontendUtils.isReactModuleAvailable(options))
+                            && FrontendUtils.isReactModuleAvailable(options),
+                    options.isIncludeWebComponentNpmPackages())
                     .exclude(applicationDependencies);
 
             // Add application dependencies

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/ExclusionFilter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/ExclusionFilter.java
@@ -43,7 +43,7 @@ public class ExclusionFilter implements Serializable {
 
     private final boolean reactEnabled;
 
-    private final boolean includeWebComponentNpmPackages;
+    private final boolean excludeWebComponentNpmPackages;
 
     /**
      * Create a new exclusion filter.
@@ -54,7 +54,7 @@ public class ExclusionFilter implements Serializable {
      *            whether React is enabled
      */
     public ExclusionFilter(ClassFinder finder, boolean reactEnabled) {
-        this(finder, reactEnabled, true);
+        this(finder, reactEnabled, false);
     }
 
     /**
@@ -64,14 +64,14 @@ public class ExclusionFilter implements Serializable {
      *            the class finder to use
      * @param reactEnabled
      *            whether React is enabled
-     * @param includeWebComponentNpmPackages
-     *            whether to include web component npm packages
+     * @param excludeWebComponentNpmPackages
+     *            whether to exclude web component npm packages
      */
     public ExclusionFilter(ClassFinder finder, boolean reactEnabled,
-            boolean includeWebComponentNpmPackages) {
+            boolean excludeWebComponentNpmPackages) {
         this.finder = finder;
         this.reactEnabled = reactEnabled;
-        this.includeWebComponentNpmPackages = includeWebComponentNpmPackages;
+        this.excludeWebComponentNpmPackages = excludeWebComponentNpmPackages;
     }
 
     /**
@@ -113,7 +113,7 @@ public class ExclusionFilter implements Serializable {
             VersionsJsonConverter convert = new VersionsJsonConverter(
                     Json.parse(
                             IOUtils.toString(content, StandardCharsets.UTF_8)),
-                    reactEnabled, includeWebComponentNpmPackages);
+                    reactEnabled, excludeWebComponentNpmPackages);
             return convert.getExclusions();
         }
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/ExclusionFilter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/ExclusionFilter.java
@@ -110,27 +110,11 @@ public class ExclusionFilter implements Serializable {
 
     private Set<String> getExclusions(URL versionsResource) throws IOException {
         try (InputStream content = versionsResource.openStream()) {
-            if (!includeWebComponentNpmPackages) {
-                // Full list of web component dependencies is a union of all
-                // 'react' mode dependencies and dependencies of exclusion
-                // lists for react dependencies.
-                VersionsJsonConverter convert = new VersionsJsonConverter(
-                        Json.parse(IOUtils.toString(content,
-                                StandardCharsets.UTF_8)),
-                        true, true);
-                convert.getExclusions().addAll(convert.getDependenciesForMode(
-                        VersionsJsonConverter.MODE_REACT));
-                // always exclude @vaadin/bundles
-                convert.getExclusions()
-                        .add(VersionsJsonConverter.VAADIN_BUNDLES);
-                return convert.getExclusions();
-            } else {
-                VersionsJsonConverter convert = new VersionsJsonConverter(
-                        Json.parse(IOUtils.toString(content,
-                                StandardCharsets.UTF_8)),
-                        reactEnabled, true);
-                return convert.getExclusions();
-            }
+            VersionsJsonConverter convert = new VersionsJsonConverter(
+                    Json.parse(
+                            IOUtils.toString(content, StandardCharsets.UTF_8)),
+                    reactEnabled, includeWebComponentNpmPackages);
+            return convert.getExclusions();
         }
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/ExclusionFilter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/ExclusionFilter.java
@@ -52,6 +52,18 @@ public class ExclusionFilter implements Serializable {
      *            the class finder to use
      * @param reactEnabled
      *            whether React is enabled
+     */
+    public ExclusionFilter(ClassFinder finder, boolean reactEnabled) {
+        this(finder, reactEnabled, true);
+    }
+
+    /**
+     * Create a new exclusion filter.
+     *
+     * @param finder
+     *            the class finder to use
+     * @param reactEnabled
+     *            whether React is enabled
      * @param includeWebComponentNpmPackages
      *            whether to include web component npm packages
      */

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/ExclusionFilter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/ExclusionFilter.java
@@ -111,9 +111,9 @@ public class ExclusionFilter implements Serializable {
     private Set<String> getExclusions(URL versionsResource) throws IOException {
         try (InputStream content = versionsResource.openStream()) {
             if (!includeWebComponentNpmPackages) {
-                // By default get excluded dependencies for react mode, plus
-                // include all react mode dependencies to get a full list of web
-                // component dependencies for both lit and react mode.
+                // Full list of web component dependencies is a union of all
+                // 'react' mode dependencies and dependencies of exclusion
+                // lists for react dependencies.
                 VersionsJsonConverter convert = new VersionsJsonConverter(
                         Json.parse(IOUtils.toString(content,
                                 StandardCharsets.UTF_8)),

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -178,7 +178,7 @@ public abstract class NodeUpdater implements FallibleCommand {
                             IOUtils.toString(content, StandardCharsets.UTF_8)),
                     options.isReactEnabled()
                             && FrontendUtils.isReactModuleAvailable(options),
-                    options.isIncludeWebComponentNpmPackages());
+                    options.isNpmExcludeWebComponents());
             versionsJson = convert.getConvertedJson();
             versionsJson = new VersionsJsonFilter(getPackageJson(),
                     DEPENDENCIES)
@@ -618,7 +618,7 @@ public abstract class NodeUpdater implements FallibleCommand {
             if (options.isReactEnabled()) {
                 dependencies.putAll(readDependenciesIfAvailable(
                         "hilla/components/react", packageJsonKey));
-                if (!options.isIncludeWebComponentNpmPackages()) {
+                if (options.isNpmExcludeWebComponents()) {
                     // remove dependencies that depends on web components
                     dependencies.remove("@vaadin/hilla-react-crud");
                 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -177,7 +177,8 @@ public abstract class NodeUpdater implements FallibleCommand {
                     Json.parse(
                             IOUtils.toString(content, StandardCharsets.UTF_8)),
                     options.isReactEnabled()
-                            && FrontendUtils.isReactModuleAvailable(options));
+                            && FrontendUtils.isReactModuleAvailable(options),
+                    options.isIncludeWebComponentNpmPackages());
             versionsJson = convert.getConvertedJson();
             versionsJson = new VersionsJsonFilter(getPackageJson(),
                     DEPENDENCIES)
@@ -617,6 +618,10 @@ public abstract class NodeUpdater implements FallibleCommand {
             if (options.isReactEnabled()) {
                 dependencies.putAll(readDependenciesIfAvailable(
                         "hilla/components/react", packageJsonKey));
+                if (!options.isIncludeWebComponentNpmPackages()) {
+                    // remove dependencies that depends on web components
+                    dependencies.remove("@vaadin/hilla-react-crud");
+                }
             } else {
                 dependencies.putAll(readDependenciesIfAvailable(
                         "hilla/components/lit", packageJsonKey));

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/Options.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/Options.java
@@ -125,6 +125,8 @@ public class Options implements Serializable {
 
     private boolean reactEnable = true;
 
+    private boolean includeWebComponentNpmPackages = true;
+
     /**
      * Removes generated files from a previous execution that are no more
      * created.
@@ -966,5 +968,26 @@ public class Options implements Serializable {
      */
     public boolean isCleanOldGeneratedFiles() {
         return cleanOldGeneratedFiles;
+    }
+
+    /**
+     * Sets whether to include web component npm packages in packages.json.
+     *
+     * @return this builder
+     */
+    public boolean isIncludeWebComponentNpmPackages() {
+        return includeWebComponentNpmPackages;
+    }
+
+    /**
+     * Sets whether to include web component npm packages in packages.json.
+     *
+     * @param include
+     *            whether to include web component npm packages
+     * @return this builder
+     */
+    public Options withIncludeWebComponentNpmPackages(boolean include) {
+        this.includeWebComponentNpmPackages = include;
+        return this;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/Options.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/Options.java
@@ -125,7 +125,7 @@ public class Options implements Serializable {
 
     private boolean reactEnable = true;
 
-    private boolean includeWebComponentNpmPackages = true;
+    private boolean npmExcludeWebComponents = false;
 
     /**
      * Removes generated files from a previous execution that are no more
@@ -971,23 +971,23 @@ public class Options implements Serializable {
     }
 
     /**
-     * Sets whether to include web component npm packages in packages.json.
+     * Sets whether to exclude web component npm packages in packages.json.
      *
      * @return this builder
      */
-    public boolean isIncludeWebComponentNpmPackages() {
-        return includeWebComponentNpmPackages;
+    public boolean isNpmExcludeWebComponents() {
+        return npmExcludeWebComponents;
     }
 
     /**
-     * Sets whether to include web component npm packages in packages.json.
+     * Sets whether to exclude web component npm packages in packages.json.
      *
-     * @param include
-     *            whether to include web component npm packages
+     * @param exclude
+     *            whether to exclude web component npm packages
      * @return this builder
      */
-    public Options withIncludeWebComponentNpmPackages(boolean include) {
-        this.includeWebComponentNpmPackages = include;
+    public Options withNpmExcludeWebComponents(boolean exclude) {
+        this.npmExcludeWebComponents = exclude;
         return this;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -218,7 +218,7 @@ public class TaskUpdatePackages extends NodeUpdater {
                 finder,
                 options.isReactEnabled()
                         && FrontendUtils.isReactModuleAvailable(options),
-                options.isIncludeWebComponentNpmPackages())
+                options.isNpmExcludeWebComponents())
                 .exclude(applicationDependencies);
 
         // Add application dependencies

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -217,7 +217,8 @@ public class TaskUpdatePackages extends NodeUpdater {
         Map<String, String> filteredApplicationDependencies = new ExclusionFilter(
                 finder,
                 options.isReactEnabled()
-                        && FrontendUtils.isReactModuleAvailable(options))
+                        && FrontendUtils.isReactModuleAvailable(options),
+                options.isIncludeWebComponentNpmPackages())
                 .exclude(applicationDependencies);
 
         // Add application dependencies

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonConverter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonConverter.java
@@ -164,8 +164,10 @@ class VersionsJsonConverter {
         if (!isIncludedByMode(mode)) {
             if (excludeWebComponents) {
                 // collecting exclusions also from non-included dependencies
-                // with a mode (lit/react), when web components are not wanted.
-                exclusions.add(npmName);
+                // with a mode (react), when web components are not wanted.
+                if (MODE_REACT.equalsIgnoreCase(mode)) {
+                    exclusions.add(npmName);
+                }
                 collectExclusions(obj);
             }
             return;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonConverter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonConverter.java
@@ -75,7 +75,7 @@ class VersionsJsonConverter {
 
     private boolean reactEnabled;
 
-    private boolean includeWebComponents;
+    private boolean excludeWebComponents;
 
     private Set<String> exclusions;
 
@@ -84,9 +84,9 @@ class VersionsJsonConverter {
     }
 
     VersionsJsonConverter(JsonObject platformVersions, boolean reactEnabled,
-            boolean includeWebComponents) {
+            boolean excludeWebComponents) {
         this.reactEnabled = reactEnabled;
-        this.includeWebComponents = includeWebComponents;
+        this.excludeWebComponents = excludeWebComponents;
         exclusions = new HashSet<>();
         convertedObject = Json.createObject();
 
@@ -139,7 +139,7 @@ class VersionsJsonConverter {
     private boolean isIncludedByMode(String mode) {
         if (mode == null || mode.isBlank() || MODE_ALL.equalsIgnoreCase(mode)) {
             return true;
-        } else if (!includeWebComponents) {
+        } else if (excludeWebComponents) {
             return false;
         } else if (reactEnabled) {
             return MODE_REACT.equalsIgnoreCase(mode);
@@ -157,12 +157,12 @@ class VersionsJsonConverter {
         if (Objects.equals(npmName, VAADIN_CORE_NPM_PACKAGE)) {
             return;
         }
-        if (!includeWebComponents && Objects.equals(npmName, VAADIN_BUNDLES)) {
+        if (excludeWebComponents && Objects.equals(npmName, VAADIN_BUNDLES)) {
             exclusions.add(npmName);
             return;
         }
         if (!isIncludedByMode(mode)) {
-            if (!includeWebComponents) {
+            if (excludeWebComponents) {
                 // collecting exclusions also from non-included dependencies
                 // with a mode (lit/react), when web components are not wanted.
                 exclusions.add(npmName);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonConverter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonConverter.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.IntStream;
 
@@ -186,7 +187,9 @@ class VersionsJsonConverter {
                     + "Please report a bug in https://github.com/vaadin/platform/issues/new");
         }
         convertedObject.put(npmName, version);
-        dependenciesForModes.getOrDefault(mode, new HashSet<>()).add(npmName);
+        dependenciesForModes.compute(mode,
+                (key, value) -> (value == null) ? new HashSet<>() : value);
+        dependenciesForModes.get(mode).add(npmName);
 
         if (obj.hasKey(EXCLUSIONS)) {
             JsonArray array = obj.getArray(EXCLUSIONS);

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractConfigurationFactory.java
@@ -52,6 +52,7 @@ import static com.vaadin.flow.server.InitParameters.BUILD_FOLDER;
 import static com.vaadin.flow.server.InitParameters.FRONTEND_HOTDEPLOY;
 import static com.vaadin.flow.server.InitParameters.NODE_DOWNLOAD_ROOT;
 import static com.vaadin.flow.server.InitParameters.NODE_VERSION;
+import static com.vaadin.flow.server.InitParameters.NPM_EXCLUDE_WEB_COMPONENTS;
 import static com.vaadin.flow.server.InitParameters.REACT_ENABLE;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_ENABLE_DEV_SERVER;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_INITIAL_UIDL;
@@ -185,6 +186,11 @@ public class AbstractConfigurationFactory implements Serializable {
         if (buildInfo.hasKey(PREMIUM_FEATURES)) {
             params.put(PREMIUM_FEATURES,
                     String.valueOf(buildInfo.getBoolean(PREMIUM_FEATURES)));
+        }
+
+        if (buildInfo.hasKey(NPM_EXCLUDE_WEB_COMPONENTS)) {
+            params.put(NPM_EXCLUDE_WEB_COMPONENTS, String
+                    .valueOf(buildInfo.getBoolean(NPM_EXCLUDE_WEB_COMPONENTS)));
         }
 
         setDevModePropertiesUsingTokenData(params, buildInfo);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -483,7 +483,7 @@ public class NodeUpdaterTest {
     @Test
     public void testGetPlatformPinnedDependencies_reactAvailable_excludeWebComponents()
             throws IOException, ClassNotFoundException {
-        options.withIncludeWebComponentNpmPackages(false);
+        options.withNpmExcludeWebComponents(true);
         generateTestDataForReactComponents();
 
         JsonObject pinnedVersions = nodeUpdater.getPlatformPinnedDependencies();
@@ -499,7 +499,7 @@ public class NodeUpdaterTest {
     public void testGetPlatformPinnedDependencies_reactDisabled_excludeWebComponents()
             throws IOException, ClassNotFoundException {
         options.withReact(false);
-        options.withIncludeWebComponentNpmPackages(false);
+        options.withNpmExcludeWebComponents(true);
         generateTestDataForReactComponents();
 
         JsonObject pinnedVersions = nodeUpdater.getPlatformPinnedDependencies();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -484,21 +484,15 @@ public class NodeUpdaterTest {
     public void testGetPlatformPinnedDependencies_reactAvailable_excludeWebComponents()
             throws IOException, ClassNotFoundException {
         options.withIncludeWebComponentNpmPackages(false);
-        try {
-            generateTestDataForReactComponents();
+        generateTestDataForReactComponents();
 
-            JsonObject pinnedVersions = nodeUpdater
-                    .getPlatformPinnedDependencies();
+        JsonObject pinnedVersions = nodeUpdater.getPlatformPinnedDependencies();
 
-            // @vaadin/button doesn't have 'mode' set, so it should be included
-            Assert.assertTrue(pinnedVersions.hasKey("@vaadin/button"));
-            Assert.assertFalse(
-                    pinnedVersions.hasKey("@vaadin/react-components"));
-            Assert.assertFalse(
-                    pinnedVersions.hasKey("@vaadin/react-components-pro"));
-        } finally {
-            options.withIncludeWebComponentNpmPackages(true);
-        }
+        // @vaadin/button doesn't have 'mode' set, so it should be included
+        Assert.assertTrue(pinnedVersions.hasKey("@vaadin/button"));
+        Assert.assertFalse(pinnedVersions.hasKey("@vaadin/react-components"));
+        Assert.assertFalse(
+                pinnedVersions.hasKey("@vaadin/react-components-pro"));
     }
 
     @Test
@@ -506,22 +500,15 @@ public class NodeUpdaterTest {
             throws IOException, ClassNotFoundException {
         options.withReact(false);
         options.withIncludeWebComponentNpmPackages(false);
-        try {
-            generateTestDataForReactComponents();
+        generateTestDataForReactComponents();
 
-            JsonObject pinnedVersions = nodeUpdater
-                    .getPlatformPinnedDependencies();
+        JsonObject pinnedVersions = nodeUpdater.getPlatformPinnedDependencies();
 
-            // @vaadin/button doesn't have 'mode' set, so it should be included
-            Assert.assertTrue(pinnedVersions.hasKey("@vaadin/button"));
-            Assert.assertFalse(
-                    pinnedVersions.hasKey("@vaadin/react-components"));
-            Assert.assertFalse(
-                    pinnedVersions.hasKey("@vaadin/react-components-pro"));
-        } finally {
-            options.withReact(true);
-            options.withIncludeWebComponentNpmPackages(true);
-        }
+        // @vaadin/button doesn't have 'mode' set, so it should be included
+        Assert.assertTrue(pinnedVersions.hasKey("@vaadin/button"));
+        Assert.assertFalse(pinnedVersions.hasKey("@vaadin/react-components"));
+        Assert.assertFalse(
+                pinnedVersions.hasKey("@vaadin/react-components-pro"));
     }
 
     private void generateTestDataForReactComponents()

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -470,6 +470,62 @@ public class NodeUpdaterTest {
     @Test
     public void testGetPlatformPinnedDependencies_reactAvailable_containsReactComponents()
             throws IOException, ClassNotFoundException {
+        generateTestDataForReactComponents();
+
+        JsonObject pinnedVersions = nodeUpdater.getPlatformPinnedDependencies();
+
+        Assert.assertTrue(pinnedVersions.hasKey("@vaadin/button"));
+        Assert.assertTrue(pinnedVersions.hasKey("@vaadin/react-components"));
+        Assert.assertTrue(
+                pinnedVersions.hasKey("@vaadin/react-components-pro"));
+    }
+
+    @Test
+    public void testGetPlatformPinnedDependencies_reactAvailable_excludeWebComponents()
+            throws IOException, ClassNotFoundException {
+        options.withIncludeWebComponentNpmPackages(false);
+        try {
+            generateTestDataForReactComponents();
+
+            JsonObject pinnedVersions = nodeUpdater
+                    .getPlatformPinnedDependencies();
+
+            // @vaadin/button doesn't have 'mode' set, so it should be included
+            Assert.assertTrue(pinnedVersions.hasKey("@vaadin/button"));
+            Assert.assertFalse(
+                    pinnedVersions.hasKey("@vaadin/react-components"));
+            Assert.assertFalse(
+                    pinnedVersions.hasKey("@vaadin/react-components-pro"));
+        } finally {
+            options.withIncludeWebComponentNpmPackages(true);
+        }
+    }
+
+    @Test
+    public void testGetPlatformPinnedDependencies_reactDisabled_excludeWebComponents()
+            throws IOException, ClassNotFoundException {
+        options.withReact(false);
+        options.withIncludeWebComponentNpmPackages(false);
+        try {
+            generateTestDataForReactComponents();
+
+            JsonObject pinnedVersions = nodeUpdater
+                    .getPlatformPinnedDependencies();
+
+            // @vaadin/button doesn't have 'mode' set, so it should be included
+            Assert.assertTrue(pinnedVersions.hasKey("@vaadin/button"));
+            Assert.assertFalse(
+                    pinnedVersions.hasKey("@vaadin/react-components"));
+            Assert.assertFalse(
+                    pinnedVersions.hasKey("@vaadin/react-components-pro"));
+        } finally {
+            options.withReact(true);
+            options.withIncludeWebComponentNpmPackages(true);
+        }
+    }
+
+    private void generateTestDataForReactComponents()
+            throws IOException, ClassNotFoundException {
         File coreVersionsFile = File.createTempFile("vaadin-core-versions",
                 ".json", temporaryFolder.newFolder());
         File vaadinVersionsFile = File.createTempFile("vaadin-versions",
@@ -514,13 +570,6 @@ public class NodeUpdaterTest {
         Class clazz = FeatureFlags.class; // actual class doesn't matter
         Mockito.doReturn(clazz).when(finder).loadClass(
                 "com.vaadin.flow.component.react.ReactAdapterComponent");
-
-        JsonObject pinnedVersions = nodeUpdater.getPlatformPinnedDependencies();
-
-        Assert.assertTrue(pinnedVersions.hasKey("@vaadin/button"));
-        Assert.assertTrue(pinnedVersions.hasKey("@vaadin/react-components"));
-        Assert.assertTrue(
-                pinnedVersions.hasKey("@vaadin/react-components-pro"));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
@@ -23,6 +23,8 @@ import static com.vaadin.flow.server.frontend.NodeUpdater.DEV_DEPENDENCIES;
 import static com.vaadin.flow.server.frontend.NodeUpdater.OVERRIDES;
 import static com.vaadin.flow.server.frontend.NodeUpdater.VAADIN_DEP_KEY;
 import static com.vaadin.flow.server.frontend.VersionsJsonConverter.VAADIN_CORE_NPM_PACKAGE;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import java.io.File;
 import java.io.IOException;
@@ -50,7 +52,6 @@ import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
@@ -846,6 +847,163 @@ public class TaskUpdatePackagesNpmTest {
                 && newPackageJson.getObject("vaadin").getObject("dependencies")
                         .hasKey(REACT_COMPONENTS));
 
+    }
+
+    @Test
+    public void webComponentsExcluded_reactDisabled_noExclusionsInVersions()
+            throws IOException {
+        createVaadinVersionsJson(PLATFORM_DIALOG_VERSION,
+                PLATFORM_ELEMENT_MIXIN_VERSION, PLATFORM_OVERLAY_VERSION);
+        Options options = new MockOptions(finder, npmFolder)
+                .withBuildDirectory(TARGET).withEnablePnpm(false)
+                .withBundleBuild(true).withReact(false)
+                .withIncludeWebComponentNpmPackages(false);
+        // with scanned application dependencies
+        execTaskUpdatePackages(createApplicationDependencies(), options);
+        JsonObject pkgJson = getOrCreatePackageJson();
+
+        assertTrue(hasInDependencies(pkgJson, VAADIN_DIALOG));
+        assertTrue(hasInVaadinDependencies(pkgJson, VAADIN_DIALOG));
+        assertTrue(hasInDependencies(pkgJson, VAADIN_OVERLAY));
+        assertTrue(hasInVaadinDependencies(pkgJson, VAADIN_OVERLAY));
+        assertFalse(hasInDependencies(pkgJson, REACT_COMPONENTS));
+        assertFalse(hasInVaadinDependencies(pkgJson, REACT_COMPONENTS));
+
+        // without scanned application dependencies
+        execTaskUpdatePackages(new HashMap<>(), options);
+        pkgJson = getOrCreatePackageJson();
+
+        assertFalse(hasInDependencies(pkgJson, VAADIN_DIALOG));
+        assertFalse(hasInVaadinDependencies(pkgJson, VAADIN_DIALOG));
+        assertTrue(hasInDependencies(pkgJson, VAADIN_OVERLAY));
+        assertTrue(hasInVaadinDependencies(pkgJson, VAADIN_OVERLAY));
+        assertFalse(hasInDependencies(pkgJson, REACT_COMPONENTS));
+        assertFalse(hasInVaadinDependencies(pkgJson, REACT_COMPONENTS));
+    }
+
+    @Test
+    public void webComponentsExcluded_reactDisabled_exclusionsInVersions_noWebComponentsIncluded()
+            throws IOException {
+        createVaadinVersionsJson(PLATFORM_DIALOG_VERSION,
+                PLATFORM_ELEMENT_MIXIN_VERSION, PLATFORM_OVERLAY_VERSION,
+                Set.of(VAADIN_DIALOG));
+        Options options = new MockOptions(finder, npmFolder)
+                .withBuildDirectory(TARGET).withEnablePnpm(false)
+                .withBundleBuild(true).withReact(false)
+                .withIncludeWebComponentNpmPackages(false);
+
+        // with scanned application dependencies
+        execTaskUpdatePackages(createApplicationDependencies(), options);
+        JsonObject pkgJson = getOrCreatePackageJson();
+
+        assertFalse(hasInDependencies(pkgJson, VAADIN_DIALOG));
+        assertFalse(hasInVaadinDependencies(pkgJson, VAADIN_DIALOG));
+        assertTrue(hasInDependencies(pkgJson, VAADIN_OVERLAY));
+        assertTrue(hasInVaadinDependencies(pkgJson, VAADIN_OVERLAY));
+        assertFalse(hasInDependencies(pkgJson, REACT_COMPONENTS));
+        assertFalse(hasInVaadinDependencies(pkgJson, REACT_COMPONENTS));
+
+        // without scanned application dependencies
+        execTaskUpdatePackages(new HashMap<>(), options);
+        pkgJson = getOrCreatePackageJson();
+
+        assertFalse(hasInDependencies(pkgJson, VAADIN_DIALOG));
+        assertFalse(hasInVaadinDependencies(pkgJson, VAADIN_DIALOG));
+        assertTrue(hasInDependencies(pkgJson, VAADIN_OVERLAY));
+        assertTrue(hasInVaadinDependencies(pkgJson, VAADIN_OVERLAY));
+        assertFalse(hasInDependencies(pkgJson, REACT_COMPONENTS));
+        assertFalse(hasInVaadinDependencies(pkgJson, REACT_COMPONENTS));
+    }
+
+    @Test
+    public void webComponentsExcluded_reactEnabled_noExclusionsInVersions()
+            throws IOException {
+        createVaadinVersionsJson(PLATFORM_DIALOG_VERSION,
+                PLATFORM_ELEMENT_MIXIN_VERSION, PLATFORM_OVERLAY_VERSION);
+        Options options = new MockOptions(finder, npmFolder)
+                .withBuildDirectory(TARGET).withEnablePnpm(false)
+                .withBundleBuild(true).withReact(true)
+                .withIncludeWebComponentNpmPackages(false);
+
+        // with scanned application dependencies
+        execTaskUpdatePackages(createApplicationDependencies(), options);
+        JsonObject pkgJson = getOrCreatePackageJson();
+
+        assertTrue(hasInDependencies(pkgJson, VAADIN_DIALOG));
+        assertTrue(hasInVaadinDependencies(pkgJson, VAADIN_DIALOG));
+        assertTrue(hasInDependencies(pkgJson, VAADIN_OVERLAY));
+        assertTrue(hasInVaadinDependencies(pkgJson, VAADIN_OVERLAY));
+        assertFalse(hasInDependencies(pkgJson, REACT_COMPONENTS));
+        assertFalse(hasInVaadinDependencies(pkgJson, REACT_COMPONENTS));
+
+        // without scanned application dependencies
+        execTaskUpdatePackages(new HashMap<>(), options);
+        pkgJson = getOrCreatePackageJson();
+
+        assertFalse(hasInDependencies(pkgJson, VAADIN_DIALOG));
+        assertFalse(hasInVaadinDependencies(pkgJson, VAADIN_DIALOG));
+        assertTrue(hasInDependencies(pkgJson, VAADIN_OVERLAY));
+        assertTrue(hasInVaadinDependencies(pkgJson, VAADIN_OVERLAY));
+        assertFalse(hasInDependencies(pkgJson, REACT_COMPONENTS));
+        assertFalse(hasInVaadinDependencies(pkgJson, REACT_COMPONENTS));
+    }
+
+    @Test
+    public void webComponentsExcluded_reactEnabled_exclusionsInVersions_noWebComponentsIncluded()
+            throws IOException {
+        createVaadinVersionsJson(PLATFORM_DIALOG_VERSION,
+                PLATFORM_ELEMENT_MIXIN_VERSION, PLATFORM_OVERLAY_VERSION,
+                Set.of(VAADIN_DIALOG));
+        Options options = new MockOptions(finder, npmFolder)
+                .withBuildDirectory(TARGET).withEnablePnpm(false)
+                .withBundleBuild(true).withReact(true)
+                .withIncludeWebComponentNpmPackages(false);
+
+        // with scanned application dependencies
+        execTaskUpdatePackages(createApplicationDependencies(), options);
+        JsonObject pkgJson = getOrCreatePackageJson();
+
+        assertFalse(hasInDependencies(pkgJson, VAADIN_DIALOG));
+        assertFalse(hasInVaadinDependencies(pkgJson, VAADIN_DIALOG));
+        assertTrue(hasInDependencies(pkgJson, VAADIN_OVERLAY));
+        assertTrue(hasInVaadinDependencies(pkgJson, VAADIN_OVERLAY));
+        assertFalse(hasInDependencies(pkgJson, REACT_COMPONENTS));
+        assertFalse(hasInVaadinDependencies(pkgJson, REACT_COMPONENTS));
+
+        // without scanned application dependencies
+        execTaskUpdatePackages(new HashMap<>(), options);
+        pkgJson = getOrCreatePackageJson();
+
+        assertFalse(hasInDependencies(pkgJson, VAADIN_DIALOG));
+        assertFalse(hasInVaadinDependencies(pkgJson, VAADIN_DIALOG));
+        assertTrue(hasInDependencies(pkgJson, VAADIN_OVERLAY));
+        assertTrue(hasInVaadinDependencies(pkgJson, VAADIN_OVERLAY));
+        assertFalse(hasInDependencies(pkgJson, REACT_COMPONENTS));
+        assertFalse(hasInVaadinDependencies(pkgJson, REACT_COMPONENTS));
+    }
+
+    private void execTaskUpdatePackages(
+            Map<String, String> scannedApplicationDependencies,
+            Options options) {
+        final FrontendDependencies frontendDependenciesScanner = Mockito
+                .mock(FrontendDependencies.class);
+        Mockito.when(frontendDependenciesScanner.getPackages())
+                .thenReturn(scannedApplicationDependencies);
+        final TaskUpdatePackages task = new TaskUpdatePackages(
+                frontendDependenciesScanner, options) {
+        };
+        task.execute();
+    }
+
+    private boolean hasInDependencies(JsonObject newPackageJson, String key) {
+        return newPackageJson.hasKey("dependencies")
+                && newPackageJson.getObject("dependencies").hasKey(key);
+    }
+
+    private boolean hasInVaadinDependencies(JsonObject newPackageJson,
+            String key) {
+        return newPackageJson.hasKey("vaadin") && newPackageJson
+                .getObject("vaadin").getObject("dependencies").hasKey(key);
     }
 
     private void createBasicVaadinVersionsJson() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
@@ -862,8 +862,8 @@ public class TaskUpdatePackagesNpmTest {
         execTaskUpdatePackages(createApplicationDependencies(), options);
         JsonObject pkgJson = getOrCreatePackageJson();
 
-        assertFalse(hasInDependencies(pkgJson, VAADIN_DIALOG));
-        assertFalse(hasInVaadinDependencies(pkgJson, VAADIN_DIALOG));
+        assertTrue(hasInDependencies(pkgJson, VAADIN_DIALOG));
+        assertTrue(hasInVaadinDependencies(pkgJson, VAADIN_DIALOG));
         assertTrue(hasInDependencies(pkgJson, VAADIN_OVERLAY));
         assertTrue(hasInVaadinDependencies(pkgJson, VAADIN_OVERLAY));
         assertFalse(hasInDependencies(pkgJson, REACT_COMPONENTS));
@@ -929,8 +929,8 @@ public class TaskUpdatePackagesNpmTest {
         execTaskUpdatePackages(createApplicationDependencies(), options);
         JsonObject pkgJson = getOrCreatePackageJson();
 
-        assertFalse(hasInDependencies(pkgJson, VAADIN_DIALOG));
-        assertFalse(hasInVaadinDependencies(pkgJson, VAADIN_DIALOG));
+        assertTrue(hasInDependencies(pkgJson, VAADIN_DIALOG));
+        assertTrue(hasInVaadinDependencies(pkgJson, VAADIN_DIALOG));
         assertTrue(hasInDependencies(pkgJson, VAADIN_OVERLAY));
         assertTrue(hasInVaadinDependencies(pkgJson, VAADIN_OVERLAY));
         assertFalse(hasInDependencies(pkgJson, REACT_COMPONENTS));

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
@@ -857,7 +857,7 @@ public class TaskUpdatePackagesNpmTest {
         Options options = new MockOptions(finder, npmFolder)
                 .withBuildDirectory(TARGET).withEnablePnpm(false)
                 .withBundleBuild(true).withReact(false)
-                .withIncludeWebComponentNpmPackages(false);
+                .withNpmExcludeWebComponents(true);
         // with scanned application dependencies
         execTaskUpdatePackages(createApplicationDependencies(), options);
         JsonObject pkgJson = getOrCreatePackageJson();
@@ -890,7 +890,7 @@ public class TaskUpdatePackagesNpmTest {
         Options options = new MockOptions(finder, npmFolder)
                 .withBuildDirectory(TARGET).withEnablePnpm(false)
                 .withBundleBuild(true).withReact(false)
-                .withIncludeWebComponentNpmPackages(false);
+                .withNpmExcludeWebComponents(true);
 
         // with scanned application dependencies
         execTaskUpdatePackages(createApplicationDependencies(), options);
@@ -923,7 +923,7 @@ public class TaskUpdatePackagesNpmTest {
         Options options = new MockOptions(finder, npmFolder)
                 .withBuildDirectory(TARGET).withEnablePnpm(false)
                 .withBundleBuild(true).withReact(true)
-                .withIncludeWebComponentNpmPackages(false);
+                .withNpmExcludeWebComponents(true);
 
         // with scanned application dependencies
         execTaskUpdatePackages(createApplicationDependencies(), options);
@@ -957,7 +957,7 @@ public class TaskUpdatePackagesNpmTest {
         Options options = new MockOptions(finder, npmFolder)
                 .withBuildDirectory(TARGET).withEnablePnpm(false)
                 .withBundleBuild(true).withReact(true)
-                .withIncludeWebComponentNpmPackages(false);
+                .withNpmExcludeWebComponents(true);
 
         // with scanned application dependencies
         execTaskUpdatePackages(createApplicationDependencies(), options);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
@@ -862,8 +862,8 @@ public class TaskUpdatePackagesNpmTest {
         execTaskUpdatePackages(createApplicationDependencies(), options);
         JsonObject pkgJson = getOrCreatePackageJson();
 
-        assertTrue(hasInDependencies(pkgJson, VAADIN_DIALOG));
-        assertTrue(hasInVaadinDependencies(pkgJson, VAADIN_DIALOG));
+        assertFalse(hasInDependencies(pkgJson, VAADIN_DIALOG));
+        assertFalse(hasInVaadinDependencies(pkgJson, VAADIN_DIALOG));
         assertTrue(hasInDependencies(pkgJson, VAADIN_OVERLAY));
         assertTrue(hasInVaadinDependencies(pkgJson, VAADIN_OVERLAY));
         assertFalse(hasInDependencies(pkgJson, REACT_COMPONENTS));
@@ -929,8 +929,8 @@ public class TaskUpdatePackagesNpmTest {
         execTaskUpdatePackages(createApplicationDependencies(), options);
         JsonObject pkgJson = getOrCreatePackageJson();
 
-        assertTrue(hasInDependencies(pkgJson, VAADIN_DIALOG));
-        assertTrue(hasInVaadinDependencies(pkgJson, VAADIN_DIALOG));
+        assertFalse(hasInDependencies(pkgJson, VAADIN_DIALOG));
+        assertFalse(hasInVaadinDependencies(pkgJson, VAADIN_DIALOG));
         assertTrue(hasInDependencies(pkgJson, VAADIN_OVERLAY));
         assertTrue(hasInVaadinDependencies(pkgJson, VAADIN_OVERLAY));
         assertFalse(hasInDependencies(pkgJson, REACT_COMPONENTS));

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/VersionsJsonConverterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/VersionsJsonConverterTest.java
@@ -64,7 +64,7 @@ public class VersionsJsonConverterTest {
         // @formatter:on
 
         VersionsJsonConverter convert = new VersionsJsonConverter(
-                Json.parse(json), false, true);
+                Json.parse(json), false, false);
         JsonObject convertedJson = convert.getConvertedJson();
         Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-progress-bar"));
         Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-upload"));
@@ -278,7 +278,7 @@ public class VersionsJsonConverterTest {
 
         // react enabled
         VersionsJsonConverter convert = new VersionsJsonConverter(
-                Json.parse(json), true, true);
+                Json.parse(json), true, false);
         JsonObject convertedJson = convert.getConvertedJson();
         Assert.assertFalse(convertedJson.hasKey("@vaadin/vaadin-progress-bar"));
         Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-upload"));
@@ -296,7 +296,7 @@ public class VersionsJsonConverterTest {
         Assert.assertFalse(convertedJson.hasKey("react-components-pro"));
 
         // react enabled, exclude web components
-        convert = new VersionsJsonConverter(Json.parse(json), true, false);
+        convert = new VersionsJsonConverter(Json.parse(json), true, true);
         convertedJson = convert.getConvertedJson();
         Assert.assertFalse(convertedJson.hasKey("@vaadin/vaadin-progress-bar"));
         Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-upload"));
@@ -315,7 +315,7 @@ public class VersionsJsonConverterTest {
         Assert.assertFalse(convertedJson.hasKey("react-components-pro"));
 
         // react disabled
-        convert = new VersionsJsonConverter(Json.parse(json), false, true);
+        convert = new VersionsJsonConverter(Json.parse(json), false, false);
         convertedJson = convert.getConvertedJson();
         Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-progress-bar"));
         Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-upload"));
@@ -333,7 +333,7 @@ public class VersionsJsonConverterTest {
         Assert.assertFalse(convertedJson.hasKey("react-components"));
 
         // react disabled, exclude web components
-        convert = new VersionsJsonConverter(Json.parse(json), false, false);
+        convert = new VersionsJsonConverter(Json.parse(json), false, true);
         convertedJson = convert.getConvertedJson();
         Assert.assertFalse(convertedJson.hasKey("@vaadin/vaadin-progress-bar"));
         Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-upload"));
@@ -408,7 +408,7 @@ public class VersionsJsonConverterTest {
 
         // react enabled
         VersionsJsonConverter convert = new VersionsJsonConverter(
-                Json.parse(json), true, true);
+                Json.parse(json), true, false);
         JsonObject convertedJson = convert.getConvertedJson();
         Assert.assertFalse(convertedJson.hasKey("@vaadin/vaadin-progress-bar"));
         Assert.assertFalse(convertedJson.hasKey("@vaadin/vaadin-upload"));
@@ -427,7 +427,7 @@ public class VersionsJsonConverterTest {
         Assert.assertFalse(convertedJson.hasKey("react-components-pro"));
 
         // react disabled
-        convert = new VersionsJsonConverter(Json.parse(json), false, true);
+        convert = new VersionsJsonConverter(Json.parse(json), false, false);
         convertedJson = convert.getConvertedJson();
         Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-progress-bar"));
         Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-upload"));

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/VersionsJsonConverterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/VersionsJsonConverterTest.java
@@ -64,7 +64,7 @@ public class VersionsJsonConverterTest {
         // @formatter:on
 
         VersionsJsonConverter convert = new VersionsJsonConverter(
-                Json.parse(json), false);
+                Json.parse(json), false, true);
         JsonObject convertedJson = convert.getConvertedJson();
         Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-progress-bar"));
         Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-upload"));
@@ -127,7 +127,7 @@ public class VersionsJsonConverterTest {
                 """.formatted(VAADIN_CORE_NPM_PACKAGE);
 
         VersionsJsonConverter convert = new VersionsJsonConverter(
-                Json.parse(json), true);
+                Json.parse(json), true, true);
         JsonObject convertedJson = convert.getConvertedJson();
         Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-progress-bar"));
         Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-upload"));
@@ -202,7 +202,7 @@ public class VersionsJsonConverterTest {
                 """.formatted(VAADIN_CORE_NPM_PACKAGE);
 
         VersionsJsonConverter convert = new VersionsJsonConverter(
-                Json.parse(json), false);
+                Json.parse(json), false, true);
         JsonObject convertedJson = convert.getConvertedJson();
         Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-progress-bar"));
         Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-upload"));
@@ -278,7 +278,7 @@ public class VersionsJsonConverterTest {
 
         // react enabled
         VersionsJsonConverter convert = new VersionsJsonConverter(
-                Json.parse(json), true);
+                Json.parse(json), true, true);
         JsonObject convertedJson = convert.getConvertedJson();
         Assert.assertFalse(convertedJson.hasKey("@vaadin/vaadin-progress-bar"));
         Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-upload"));
@@ -295,10 +295,47 @@ public class VersionsJsonConverterTest {
         Assert.assertFalse(convertedJson.hasKey("react-components"));
         Assert.assertFalse(convertedJson.hasKey("react-components-pro"));
 
+        // react enabled, exclude web components
+        convert = new VersionsJsonConverter(Json.parse(json), true, false);
+        convertedJson = convert.getConvertedJson();
+        Assert.assertFalse(convertedJson.hasKey("@vaadin/vaadin-progress-bar"));
+        Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-upload"));
+        Assert.assertTrue(convertedJson.hasKey("@polymer/iron-list"));
+        Assert.assertFalse(
+                convertedJson.hasKey("@vaadin/react-components-pro"));
+        Assert.assertFalse(convertedJson.hasKey("@vaadin/react-components"));
+
+        Assert.assertFalse(convertedJson.hasKey("flow"));
+        Assert.assertFalse(convertedJson.hasKey("core"));
+        Assert.assertFalse(convertedJson.hasKey(VAADIN_CORE_NPM_PACKAGE));
+        Assert.assertFalse(convertedJson.hasKey("platform"));
+        Assert.assertFalse(convertedJson.hasKey("react"));
+        Assert.assertFalse(convertedJson.hasKey("react-pro"));
+        Assert.assertFalse(convertedJson.hasKey("react-components"));
+        Assert.assertFalse(convertedJson.hasKey("react-components-pro"));
+
         // react disabled
-        convert = new VersionsJsonConverter(Json.parse(json), false);
+        convert = new VersionsJsonConverter(Json.parse(json), false, true);
         convertedJson = convert.getConvertedJson();
         Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-progress-bar"));
+        Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-upload"));
+        Assert.assertTrue(convertedJson.hasKey("@polymer/iron-list"));
+        Assert.assertFalse(
+                convertedJson.hasKey("@vaadin/react-components-pro"));
+        Assert.assertFalse(convertedJson.hasKey("@vaadin/react-components"));
+
+        Assert.assertFalse(convertedJson.hasKey("flow"));
+        Assert.assertFalse(convertedJson.hasKey("core"));
+        Assert.assertFalse(convertedJson.hasKey(VAADIN_CORE_NPM_PACKAGE));
+        Assert.assertFalse(convertedJson.hasKey("platform"));
+        Assert.assertFalse(convertedJson.hasKey("react"));
+        Assert.assertFalse(convertedJson.hasKey("react-pro"));
+        Assert.assertFalse(convertedJson.hasKey("react-components"));
+
+        // react disabled, exclude web components
+        convert = new VersionsJsonConverter(Json.parse(json), false, false);
+        convertedJson = convert.getConvertedJson();
+        Assert.assertFalse(convertedJson.hasKey("@vaadin/vaadin-progress-bar"));
         Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-upload"));
         Assert.assertTrue(convertedJson.hasKey("@polymer/iron-list"));
         Assert.assertFalse(
@@ -371,7 +408,7 @@ public class VersionsJsonConverterTest {
 
         // react enabled
         VersionsJsonConverter convert = new VersionsJsonConverter(
-                Json.parse(json), true);
+                Json.parse(json), true, true);
         JsonObject convertedJson = convert.getConvertedJson();
         Assert.assertFalse(convertedJson.hasKey("@vaadin/vaadin-progress-bar"));
         Assert.assertFalse(convertedJson.hasKey("@vaadin/vaadin-upload"));
@@ -390,7 +427,7 @@ public class VersionsJsonConverterTest {
         Assert.assertFalse(convertedJson.hasKey("react-components-pro"));
 
         // react disabled
-        convert = new VersionsJsonConverter(Json.parse(json), false);
+        convert = new VersionsJsonConverter(Json.parse(json), false, true);
         convertedJson = convert.getConvertedJson();
         Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-progress-bar"));
         Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-upload"));

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
@@ -81,6 +81,7 @@ import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 import static com.vaadin.flow.server.Constants.PROJECT_FRONTEND_GENERATED_DIR_TOKEN;
 import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
 import static com.vaadin.flow.server.Constants.VAADIN_WEBAPP_RESOURCES;
+import static com.vaadin.flow.server.InitParameters.INCLUDE_WEB_COMPONENT_NPM_PACKAGES;
 import static com.vaadin.flow.server.InitParameters.REACT_ENABLE;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE;
 import static com.vaadin.flow.server.frontend.FrontendUtils.GENERATED;
@@ -270,6 +271,8 @@ public class DevModeInitializer implements Serializable {
         boolean reactEnable = config.getBooleanProperty(REACT_ENABLE,
                 FrontendUtils
                         .isReactRouterRequired(options.getFrontendDirectory()));
+        boolean includeWebComponentNpmPackages = config
+                .getBooleanProperty(INCLUDE_WEB_COMPONENT_NPM_PACKAGES, true);
         options.enablePackagesUpdate(true)
                 .useByteCodeScanner(useByteCodeScanner)
                 .withFrontendGeneratedFolder(frontendGeneratedFolder)
@@ -289,7 +292,8 @@ public class DevModeInitializer implements Serializable {
                 .withFrontendHotdeploy(
                         mode == Mode.DEVELOPMENT_FRONTEND_LIVERELOAD)
                 .withBundleBuild(mode == Mode.DEVELOPMENT_BUNDLE)
-                .withReact(reactEnable);
+                .withReact(reactEnable).withIncludeWebComponentNpmPackages(
+                        includeWebComponentNpmPackages);
 
         NodeTasks tasks = new NodeTasks(options);
 

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
@@ -81,7 +81,7 @@ import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 import static com.vaadin.flow.server.Constants.PROJECT_FRONTEND_GENERATED_DIR_TOKEN;
 import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
 import static com.vaadin.flow.server.Constants.VAADIN_WEBAPP_RESOURCES;
-import static com.vaadin.flow.server.InitParameters.INCLUDE_WEB_COMPONENT_NPM_PACKAGES;
+import static com.vaadin.flow.server.InitParameters.NPM_EXCLUDE_WEB_COMPONENTS;
 import static com.vaadin.flow.server.InitParameters.REACT_ENABLE;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE;
 import static com.vaadin.flow.server.frontend.FrontendUtils.GENERATED;
@@ -271,8 +271,8 @@ public class DevModeInitializer implements Serializable {
         boolean reactEnable = config.getBooleanProperty(REACT_ENABLE,
                 FrontendUtils
                         .isReactRouterRequired(options.getFrontendDirectory()));
-        boolean includeWebComponentNpmPackages = config
-                .getBooleanProperty(INCLUDE_WEB_COMPONENT_NPM_PACKAGES, true);
+        boolean npmExcludeWebComponents = config
+                .getBooleanProperty(NPM_EXCLUDE_WEB_COMPONENTS, false);
         options.enablePackagesUpdate(true)
                 .useByteCodeScanner(useByteCodeScanner)
                 .withFrontendGeneratedFolder(frontendGeneratedFolder)
@@ -292,8 +292,8 @@ public class DevModeInitializer implements Serializable {
                 .withFrontendHotdeploy(
                         mode == Mode.DEVELOPMENT_FRONTEND_LIVERELOAD)
                 .withBundleBuild(mode == Mode.DEVELOPMENT_BUNDLE)
-                .withReact(reactEnable).withIncludeWebComponentNpmPackages(
-                        includeWebComponentNpmPackages);
+                .withReact(reactEnable)
+                .withNpmExcludeWebComponents(npmExcludeWebComponents);
 
         NodeTasks tasks = new NodeTasks(options);
 


### PR DESCRIPTION
Adds new property `npm.excludeWebComponents` (or `npmExcludeWebComponents` in Maven configurations). By default, it's `false` and everything works as before. `true` will exclude all web component dependencies from `package.json` for development mode (Vite/dev bundle) and production bundle build. Excluded dependencies are all Vaadin core components (e.g. button, grid, login, etc.) and commercial components (e.g. charts, rich-text-editor, etc.), but not lumo/material themes.

RelatedTo: #19948
