### PR TITLE
fix: support serialization of Vaadin scoped beans

### DIFF
--- a/flow-server/src/test/java/com/vaadin/tests/server/SerializationTest.java
+++ b/flow-server/src/test/java/com/vaadin/tests/server/SerializationTest.java
@@ -5,19 +5,29 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serial;
 import java.io.Serializable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.RequestHandler;
 import com.vaadin.flow.server.StreamRegistration;
 import com.vaadin.flow.server.StreamResource;
 import com.vaadin.flow.server.VaadinContext;
 import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinResponse;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServletService;
 import com.vaadin.flow.server.VaadinSession;
@@ -28,6 +38,30 @@ import com.vaadin.tests.util.MockUI;
 import static org.mockito.Mockito.withSettings;
 
 public class SerializationTest {
+
+    Runnable cleaner;
+
+    @Before
+    public void enabledSerializationDebugInfo() {
+        String extendedDebugInfo = System
+                .getProperty("sun.io.serialization.extendedDebugInfo");
+        System.setProperty("sun.io.serialization.extendedDebugInfo", "true");
+        cleaner = () -> {
+            if (extendedDebugInfo != null) {
+                System.setProperty("sun.io.serialization.extendedDebugInfo",
+                        extendedDebugInfo);
+            } else {
+                System.clearProperty("sun.io.serialization.extendedDebugInfo");
+            }
+        };
+    }
+
+    @After
+    public void restore() {
+        if (cleaner != null) {
+            cleaner.run();
+        }
+    }
 
     @Test
     public void testSerializeVaadinSession_accessQueueIsRecreated()
@@ -123,8 +157,119 @@ public class SerializationTest {
         Assert.assertNull(againSerializedAndDeserializedSession.getService());
     }
 
+    @Test
+    // Covers serialization of UI scoped beans, e.g. in Kubernetes Kit
+    // https://github.com/vaadin/flow/issues/19967
+    // https://github.com/vaadin/kubernetes-kit/issues/140
+    public void serializeUI_currentUI_availableDuringSerialization()
+            throws Exception {
+        VaadinSession deserializeSession = serializeAndDeserializeWithUI(true,
+                true, ui -> ui.add(new MyComponent()));
+        MyComponent deserializedComponent = deserializeSession.getUIs()
+                .iterator().next().getChildren()
+                .filter(MyComponent.class::isInstance)
+                .map(MyComponent.class::cast).findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "Custom component has not been deserialized"));
+
+        deserializedComponent.checker.assertInstancesAvailable();
+    }
+
+    @Test
+    // Covers serialization of UI scoped beans, e.g. in Kubernetes Kit
+    // https://github.com/vaadin/flow/issues/19967
+    // https://github.com/vaadin/kubernetes-kit/issues/140
+    public void serializeUI_currentVaadinSession_availableDuringSerialization()
+            throws Exception {
+        VaadinSession deserializeSession = serializeAndDeserializeWithUI(true,
+                true,
+                ui -> ui.getSession().addRequestHandler(new MyListener()));
+
+        MyListener deserializedListener = deserializeSession
+                .getRequestHandlers().stream()
+                .filter(MyListener.class::isInstance)
+                .map(MyListener.class::cast).findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "Session request listener has not been deserialized"));
+
+        deserializedListener.checker.assertSessionAvailable();
+    }
+
+    private static class SerializationInstancesChecker implements Serializable {
+        private boolean uiAvailableOnRead = false;
+        private boolean sessionAvailableOnRead = false;
+        private boolean uiAvailableOnWrite = false;
+        private boolean sessionAvailableOnWrite = false;
+
+        @Serial
+        private void writeObject(ObjectOutputStream out) throws IOException {
+            uiAvailableOnWrite = UI.getCurrent() != null;
+            sessionAvailableOnWrite = VaadinSession.getCurrent() != null;
+            out.defaultWriteObject();
+        }
+
+        @Serial
+        private void readObject(ObjectInputStream in)
+                throws IOException, ClassNotFoundException {
+            in.defaultReadObject();
+            uiAvailableOnRead = UI.getCurrent() != null;
+            sessionAvailableOnRead = VaadinSession.getCurrent() != null;
+        }
+
+        void assertInstancesAvailable() {
+            assertUIAvailable();
+            assertSessionAvailable();
+        }
+
+        void assertUIAvailable() {
+            Assert.assertTrue(
+                    "Expecting serialization hook to be called with UI thread local set",
+                    uiAvailableOnWrite);
+            Assert.assertTrue(
+                    "Expecting deserialization hook to be called with UI thread local set",
+                    uiAvailableOnRead);
+        }
+
+        void assertSessionAvailable() {
+            Assert.assertTrue(
+                    "Expecting serialization hook to be called with VaadinSession thread local set",
+                    sessionAvailableOnWrite);
+            Assert.assertTrue(
+                    "Expecting deserialization hook to be called with VaadinSession thread local set",
+                    sessionAvailableOnRead);
+        }
+
+    }
+
+    @Tag("my-component")
+    private static class MyComponent extends Component {
+
+        private final SerializationInstancesChecker checker = new SerializationInstancesChecker();
+
+    }
+
+    private static class MyListener implements RequestHandler {
+
+        private final SerializationInstancesChecker checker = new SerializationInstancesChecker();
+
+        @Override
+        public boolean handleRequest(VaadinSession session,
+                VaadinRequest request, VaadinResponse response)
+                throws IOException {
+            return false;
+        }
+    }
+
     private static VaadinSession serializeAndDeserializeWithUI(
-            boolean serializeUI) throws IOException, ClassNotFoundException {
+            boolean serializeUI) throws Exception {
+        return serializeAndDeserializeWithUI(serializeUI, false, ui -> {
+        });
+    }
+
+    private static VaadinSession serializeAndDeserializeWithUI(
+            boolean serializeUI, boolean background, Consumer<UI> uiConsumer)
+            throws Exception {
+
         VaadinService vaadinService = new MockVaadinService(false, serializeUI);
         VaadinSession session = new VaadinSession(vaadinService);
         // This is done only for test purpose to init the session lock,
@@ -136,13 +281,25 @@ public class SerializationTest {
         MockUI ui = new MockUI(session);
         ui.doInit(null, 42);
         session.addUI(ui);
+        uiConsumer.accept(ui);
 
-        session = serializeAndDeserialize(session);
+        VaadinSession deserializedSession;
+        if (background) {
+            deserializedSession = CompletableFuture.supplyAsync(() -> {
+                try {
+                    return serializeAndDeserialize(session);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }).get();
+        } else {
+            deserializedSession = serializeAndDeserialize(session);
+        }
         // This is done only for test purpose to refresh the session lock,
         // should be called by Flow internally as soon as the session has
         // been retrieved from http session.
-        session.refreshTransients(null, vaadinService);
-        return session;
+        deserializedSession.refreshTransients(null, vaadinService);
+        return deserializedSession;
     }
 
     private static <S extends Serializable> S serializeAndDeserialize(S s)

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/scopes/BeanStore.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/scopes/BeanStore.java
@@ -149,11 +149,11 @@ class BeanStore implements Serializable {
         if (session.hasLock()) {
             return supplier.get();
         } else {
-            session.lock();
+            session.getLockInstance().lock();
             try {
                 return supplier.get();
             } finally {
-                session.unlock();
+                session.getLockInstance().unlock();
             }
         }
     }

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/scopes/VaadinSessionScope.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/scopes/VaadinSessionScope.java
@@ -19,7 +19,6 @@ import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 
 import com.vaadin.flow.server.VaadinSession;
-import com.vaadin.flow.shared.Registration;
 
 /**
  * Implementation of Spring's
@@ -67,7 +66,7 @@ public class VaadinSessionScope extends AbstractScope {
     @Override
     protected BeanStore getBeanStore() {
         final VaadinSession session = getVaadinSession();
-        session.lock();
+        session.getLockInstance().lock();
         try {
             BeanStore beanStore = session.getAttribute(BeanStore.class);
             if (beanStore == null) {
@@ -76,7 +75,7 @@ public class VaadinSessionScope extends AbstractScope {
             }
             return beanStore;
         } finally {
-            session.unlock();
+            session.getLockInstance().unlock();
         }
     }
 

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/scopes/VaadinUIScope.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/scopes/VaadinUIScope.java
@@ -108,7 +108,7 @@ public class VaadinUIScope extends AbstractScope {
     @Override
     protected BeanStore getBeanStore() {
         final VaadinSession session = getVaadinSession();
-        session.lock();
+        session.getLockInstance().lock();
         try {
             UIStoreWrapper wrapper = session.getAttribute(UIStoreWrapper.class);
             if (wrapper == null) {
@@ -117,7 +117,7 @@ public class VaadinUIScope extends AbstractScope {
             }
             return wrapper.getBeanStore(getUI());
         } finally {
-            session.unlock();
+            session.getLockInstance().unlock();
         }
     }
 

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringClassesSerializableTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringClassesSerializableTest.java
@@ -97,6 +97,7 @@ public class SpringClassesSerializableTest extends ClassesSerializableTest {
                 "com\\.vaadin\\.flow\\.spring\\.springnative\\.VaadinBeanFactoryInitializationAotProcessor",
                 "com\\.vaadin\\.flow\\.spring\\.springnative\\.VaadinBeanFactoryInitializationAotProcessor\\$Marker",
                 "com\\.vaadin\\.flow\\.spring\\.springnative\\.VaadinHintsRegistrar",
+                "com\\.vaadin\\.flow\\.spring\\.scopes\\.VaadinRouteScope(\\$.*)?",
                 "com\\.vaadin\\.flow\\.spring\\.scopes\\.VaadinSessionScope",
                 "com\\.vaadin\\.flow\\.spring\\.scopes\\.AbstractScope",
                 "com\\.vaadin\\.flow\\.spring\\.scopes\\.VaadinUIScope",

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/scopes/AbstractScopeTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/scopes/AbstractScopeTest.java
@@ -180,6 +180,8 @@ public abstract class AbstractScopeTest {
         when(session.getConfiguration()).thenReturn(config);
 
         VaadinSession.setCurrent(session);
+        ReentrantLock lock = new ReentrantLock();
+        when(session.getLockInstance()).thenReturn(lock);
         when(session.hasLock()).thenReturn(true);
 
         // keep a reference to the session so that it cannot be GCed.

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/scopes/VaadinRouteScopeTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/scopes/VaadinRouteScopeTest.java
@@ -25,6 +25,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.ObjectFactory;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.web.context.WebApplicationContext;
 
 import com.vaadin.flow.component.Component;
@@ -57,7 +58,10 @@ public class VaadinRouteScopeTest extends AbstractUIScopedTest {
 
     @Override
     protected VaadinRouteScope getScope() {
-        return new VaadinRouteScope();
+        VaadinRouteScope scope = new VaadinRouteScope();
+        scope.postProcessBeanFactory(
+                Mockito.mock(ConfigurableListableBeanFactory.class));
+        return scope;
     }
 
     @Test
@@ -148,7 +152,8 @@ public class VaadinRouteScopeTest extends AbstractUIScopedTest {
         AtomicInteger count = new AtomicInteger();
         scope.registerDestructionCallback("foo", () -> count.getAndIncrement());
 
-        scope.uiInit(new UIInitEvent(ui, ui.getSession().getService()));
+        new VaadinRouteScope.NavigationListenerRegistrar()
+                .uiInit(new UIInitEvent(ui, ui.getSession().getService()));
 
         navigateTo(ui, new NavigationTarget());
 
@@ -195,7 +200,8 @@ public class VaadinRouteScopeTest extends AbstractUIScopedTest {
         AtomicInteger count = new AtomicInteger();
         scope.registerDestructionCallback("foo", () -> count.getAndIncrement());
 
-        scope.uiInit(new UIInitEvent(ui, ui.getSession().getService()));
+        new VaadinRouteScope.NavigationListenerRegistrar()
+                .uiInit(new UIInitEvent(ui, ui.getSession().getService()));
 
         navigateTo(ui, new NavigationTarget());
 
@@ -243,7 +249,8 @@ public class VaadinRouteScopeTest extends AbstractUIScopedTest {
         VaadinRouteScope scope = getScope();
         scope.getBeanStore();
 
-        scope.uiInit(new UIInitEvent(ui, ui.getSession().getService()));
+        new VaadinRouteScope.NavigationListenerRegistrar()
+                .uiInit(new UIInitEvent(ui, ui.getSession().getService()));
         return scope;
     }
 


### PR DESCRIPTION
## Description

Makes sure that VaadinSession and UI thread locals are available during both serialization and deserialization, to allow other libraries to perform inspection and injection of Vaadin scoped beans.

Also refactors VaadinRouteScope to be independent from VaadinService when fetching RouteScopeOwner annotation for the bean, and replaces VaadinSession.unlock() calls with direct access to the lock instance to prevent unwanted push during bean lookup.

Fixes #19967
Part of vaadin/kubernetes-kit#140

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
