### PR TITLE
fix: Ignore CDI related classes when finding component location

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentTracker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentTracker.java
@@ -52,8 +52,8 @@ public class ComponentTracker {
     private static String[] prefixesToSkip = new String[] {
             "com.vaadin.flow.component.", "com.vaadin.flow.di.",
             "com.vaadin.flow.dom.", "com.vaadin.flow.internal.",
-            "com.vaadin.flow.spring.", "java.", "jdk.",
-            "org.springframework.beans.", };
+            "com.vaadin.flow.spring.", "com.vaadin.cdi.", "java.", "jdk.",
+            "org.springframework.beans.", "org.jboss.weld.", };
 
     /**
      * Represents a location in the source code.


### PR DESCRIPTION
Fixes https://github.com/vaadin/copilot/issues/48
