### PR TITLE
fix: flush logic

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
@@ -741,14 +741,17 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
                     .getPreviousDomValue();
 
             // Check for if User has modified DOM value during round-trip.
-            // Preserve the modified value.
-            boolean updatedDuringRoundTrip = previousDomValue.isPresent()
-                    && !WidgetUtil.equals(domValue, previousDomValue.get());
+            // Preserve the modified value, if it has been changed by the user
+            // and has not been changed on the server.
+            boolean updateToTreeValue = previousDomValue
+                    .map(o -> !WidgetUtil.equals(domValue, o)
+                            && !WidgetUtil.equals(treeValue, o))
+                    .orElse(true);
 
             // We compare with the current property to avoid setting properties
             // which are updated on the client side, e.g. when synchronizing
             // properties to the server (won't work for readonly properties).
-            if (!updatedDuringRoundTrip && (WidgetUtil.isUndefined(domValue)
+            if (updateToTreeValue && (WidgetUtil.isUndefined(domValue)
                     || !WidgetUtil.equals(domValue, treeValue))) {
                 Reactive.runWithComputation(null,
                         () -> WidgetUtil.setJsProperty(element, name,

--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
@@ -740,13 +740,11 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
             Optional<Object> previousDomValue = mapProperty
                     .getPreviousDomValue();
 
-            // Check for if User has modified DOM value during round-trip.
-            // Preserve the modified value, if it has been changed by the user
-            // and has not been changed on the server.
+            // User might have modified DOM value during server round-trip.
+            // That is why we only want to update to the tree value if the tree
+            // value is different from the pre-server-round-trip DOM value.
             boolean updateToTreeValue = previousDomValue
-                    .map(o -> !WidgetUtil.equals(domValue, o)
-                            && !WidgetUtil.equals(treeValue, o))
-                    .orElse(true);
+                    .map(o -> !WidgetUtil.equals(treeValue, o)).orElse(true);
 
             // We compare with the current property to avoid setting properties
             // which are updated on the client side, e.g. when synchronizing

--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
@@ -737,10 +737,13 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
         if (mapProperty.hasValue()) {
             Object treeValue = mapProperty.getValue();
             Object domValue = WidgetUtil.getJsProperty(element, name);
-            Object preServerRoundTripDomValue = mapProperty.getPreviousDomValue();
+            Object preServerRoundTripDomValue = mapProperty
+                    .getPreviousDomValue();
 
-            if (mapProperty.isPreviousDomValueSet() && !WidgetUtil.equals(domValue, preServerRoundTripDomValue)) {
-                // User has modified DOM value during round-trip. Preserve the modified value.
+            if (mapProperty.isPreviousDomValueSet() && !WidgetUtil
+                    .equals(domValue, preServerRoundTripDomValue)) {
+                // User has modified DOM value during round-trip. Preserve the
+                // modified value.
                 return;
             }
 

--- a/flow-client/src/main/java/com/vaadin/client/flow/nodefeature/MapProperty.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/nodefeature/MapProperty.java
@@ -17,6 +17,7 @@ package com.vaadin.client.flow.nodefeature;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import com.vaadin.client.flow.StateNode;
 import com.vaadin.client.flow.StateTree;
@@ -65,8 +66,7 @@ public class MapProperty implements ReactiveValue {
     private boolean hasValue = false;
 
     private final boolean forceValueUpdate;
-    private Object previousDomValue;
-    private boolean previousDomValueSet;
+    private Optional<Object> previousDomValue;
 
     /**
      * Creates a new property.
@@ -336,21 +336,33 @@ public class MapProperty implements ReactiveValue {
         return NO_OP;
     }
 
+    /**
+     * Stores previous DOM value of this property for detection of value
+     * modification by the user during the server round-trip.
+     *
+     * @param previousDomValue
+     *            DOM value of property prior to server round-trip start. Can be
+     *            <code>null</code>;
+     */
     public void setPreviousDomValue(Object previousDomValue) {
-        this.previousDomValue = previousDomValue;
-        previousDomValueSet = true;
+        this.previousDomValue = Optional.ofNullable(previousDomValue);
     }
 
-    public Object getPreviousDomValue() {
+    /**
+     * Returns previous DOM value of this property for detection of value
+     * modification by the user during the server round-trip.
+     *
+     * @return Optional of previous DOM value. Empty optional is returned if
+     *         previous value has not been stored.
+     */
+    public Optional<Object> getPreviousDomValue() {
         return previousDomValue;
     }
 
-    public boolean isPreviousDomValueSet() {
-        return previousDomValueSet;
-    }
-
+    /**
+     * Clears the previous DOM value of this property.
+     */
     public void clearPreviousDomValue() {
-        this.previousDomValue = null;
-        previousDomValueSet = false;
+        this.previousDomValue = Optional.empty();
     }
 }

--- a/flow-client/src/main/java/com/vaadin/client/flow/nodefeature/MapProperty.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/nodefeature/MapProperty.java
@@ -65,6 +65,8 @@ public class MapProperty implements ReactiveValue {
     private boolean hasValue = false;
 
     private final boolean forceValueUpdate;
+    private Object previousDomValue;
+    private boolean previousDomValueSet;
 
     /**
      * Creates a new property.
@@ -332,5 +334,23 @@ public class MapProperty implements ReactiveValue {
             }
         }
         return NO_OP;
+    }
+
+    public void setPreviousDomValue(Object previousDomValue) {
+        this.previousDomValue = previousDomValue;
+        previousDomValueSet = true;
+    }
+
+    public Object getPreviousDomValue() {
+        return previousDomValue;
+    }
+
+    public boolean isPreviousDomValueSet() {
+        return previousDomValueSet;
+    }
+
+    public void clearPreviousDomValue() {
+        this.previousDomValue = null;
+        previousDomValueSet = false;
     }
 }

--- a/flow-client/src/main/java/com/vaadin/client/flow/nodefeature/MapProperty.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/nodefeature/MapProperty.java
@@ -66,7 +66,7 @@ public class MapProperty implements ReactiveValue {
     private boolean hasValue = false;
 
     private final boolean forceValueUpdate;
-    private Optional<Object> previousDomValue;
+    private Optional<Object> previousDomValue = Optional.empty();
 
     /**
      * Creates a new property.

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ClientSideValueChangeView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ClientSideValueChangeView.java
@@ -15,21 +15,13 @@
  */
 package com.vaadin.flow.uitest.ui;
 
-import com.vaadin.flow.component.Text;
-import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Input;
-import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Span;
-import com.vaadin.flow.dom.Style;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 
 @Route(value = "com.vaadin.flow.uitest.ui.ClientSideValueChangeView", layout = ViewTestLayout.class)
 public class ClientSideValueChangeView extends AbstractDivView {
-
-    public static final String TEXT = "This is the basic component view text component with some tags: <b><html></body>";
-    public static final String BUTTON_TEXT = "Click me";
-    public static final String DIV_TEXT = "Hello world";
 
     @Override
     protected void onShow() {
@@ -48,6 +40,23 @@ public class ClientSideValueChangeView extends AbstractDivView {
         });
 
         add(input);
+
+        Input input2 = new Input();
+        input2.setId("inputfieldserversetsvalue");
+
+        input2.addValueChangeListener(e -> {
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException ex) {
+                throw new RuntimeException(ex);
+            }
+            input2.setValue("fromserver");
+            Span span = new Span("done");
+            span.setId("statusserversetsvalue");
+            add(span);
+        });
+
+        add(input2);
     }
 
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ClientSideValueChangeView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ClientSideValueChangeView.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Input;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.dom.Style;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+@Route(value = "com.vaadin.flow.uitest.ui.ClientSideValueChangeView", layout = ViewTestLayout.class)
+public class ClientSideValueChangeView extends AbstractDivView {
+
+    public static final String TEXT = "This is the basic component view text component with some tags: <b><html></body>";
+    public static final String BUTTON_TEXT = "Click me";
+    public static final String DIV_TEXT = "Hello world";
+
+    @Override
+    protected void onShow() {
+        Input input = new Input();
+        input.setId("inputfield");
+
+        input.addValueChangeListener(e -> {
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException ex) {
+                throw new RuntimeException(ex);
+            }
+            Span span = new Span("done");
+            span.setId("status");
+            add(span);
+        });
+
+        add(input);
+    }
+
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ClientSideValueChangeIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ClientSideValueChangeIT.java
@@ -42,4 +42,24 @@ public class ClientSideValueChangeIT extends ChromeBrowserTest {
                 "abc123",
                 $(InputTextElement.class).id("inputfield").getValue());
     }
+
+    @Test
+    public void clientSideValueEntryDuringRoundTrip_serverChangesValue_serverValueShouldBeUsed() {
+        open();
+
+        getCommandExecutor().disableWaitForVaadin();
+
+        InputTextElement input = $(InputTextElement.class)
+                .id("inputfieldserversetsvalue");
+        input.setValue("abc");
+        input.sendKeys("123");
+
+        waitUntil(ExpectedConditions
+                .presenceOfElementLocated(By.id("statusserversetsvalue")));
+
+        Assert.assertEquals(
+                "Value set by server during round-trip was unexpectedly overridden",
+                "fromserver", $(InputTextElement.class)
+                        .id("inputfieldserversetsvalue").getValue());
+    }
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ClientSideValueChangeIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ClientSideValueChangeIT.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import com.vaadin.flow.component.html.testbench.InputTextElement;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class ClientSideValueChangeIT extends ChromeBrowserTest {
+
+    @Test
+    public void clientSideValueEntryDuringRoundTrip_enteredValueShouldNotBeOverridden() {
+        open();
+
+        getCommandExecutor().disableWaitForVaadin();
+
+        InputTextElement input = $(InputTextElement.class).id("inputfield");
+        input.setValue("abc");
+        input.sendKeys("123");
+
+        waitUntil(ExpectedConditions.presenceOfElementLocated(By.id("status")));
+
+        Assert.assertEquals(
+                "User input during round-trip was unexpectedly overridden",
+                "abc123",
+                $(InputTextElement.class).id("inputfield").getValue());
+    }
+}


### PR DESCRIPTION
Changes client side value binding logic so that if the user modifies the value during server round-trip, the value earlier sent to the server no longer overwrites user's changes once the round-trip finishes. Instead, user's changes are preserved.

Fixes https://github.com/vaadin/flow/issues/20365