### PR TITLE
fix: delay session expiration handling to prevent canceling ongoing navigation (#19983) (CP: 2.11)

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
@@ -418,9 +418,14 @@ public class MessageHandler {
                     if (nextResponseSessionExpiredHandler != null) {
                         nextResponseSessionExpiredHandler.execute();
                     } else if (uiState != UIState.TERMINATED) {
-                        registry.getSystemErrorHandler()
-                                .handleSessionExpiredError(null);
                         registry.getUILifecycle().setState(UIState.TERMINATED);
+                        // Delay the session expiration handling to prevent
+                        // canceling potential ongoing page redirect/reload
+                        Scheduler.get().scheduleFixedDelay(() -> {
+                            registry.getSystemErrorHandler()
+                                    .handleSessionExpiredError(null);
+                            return false;
+                        }, 250);
                     }
                 } else if (meta.containsKey("appError")
                         && uiState != UIState.TERMINATED) {

--- a/flow-client/src/test-gwt/java/com/vaadin/client/GwtMessageHandlerTest.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/GwtMessageHandlerTest.java
@@ -152,12 +152,13 @@ public class GwtMessageHandlerTest extends ClientEngineTestBase {
 
         @Override
         public void handleUnrecoverableError(String caption, String message,
-                                             String details, String url, String querySelector) {
+                String details, String url, String querySelector) {
             unrecoverableErrorHandled = true;
         }
     }
 
-    private static class TestApplicationConfiguration extends ApplicationConfiguration {
+    private static class TestApplicationConfiguration
+            extends ApplicationConfiguration {
         @Override
         public String getApplicationId() {
             return "test-application-id";
@@ -223,8 +224,7 @@ public class GwtMessageHandlerTest extends ClientEngineTestBase {
             assertEquals(ResourceLoader.class.getName(),
                     eventsOrder.sources.get(0));
             // the second one is applying changes to StatTree
-            assertEquals(StateTree.class.getName(),
-                    eventsOrder.sources.get(1));
+            assertEquals(StateTree.class.getName(), eventsOrder.sources.get(1));
         });
     }
 
@@ -301,11 +301,13 @@ public class GwtMessageHandlerTest extends ClientEngineTestBase {
 
         doAssert(() -> {
             // then: no session expire and unrecoverable error handling expected
-            assertFalse("Session Expired Message handling is not expected " +
-                        "when the page is being redirected",
+            assertFalse(
+                    "Session Expired Message handling is not expected "
+                            + "when the page is being redirected",
                     getSystemErrorHandler().sessionExpiredMessageHandled);
-            assertFalse("Unrecoverable Error Message handling was not " +
-                        "expected when the page is being redirected",
+            assertFalse(
+                    "Unrecoverable Error Message handling was not "
+                            + "expected when the page is being redirected",
                     getSystemErrorHandler().unrecoverableErrorHandled);
             assertEquals(UILifecycle.UIState.TERMINATED,
                     getUILifecycle().getState());
@@ -333,11 +335,13 @@ public class GwtMessageHandlerTest extends ClientEngineTestBase {
 
         doAssert(() -> {
             // then: no session expire and unrecoverable error handling expected
-            assertFalse("Session Expired Message handling is not expected " +
-                        "when the page is being redirected",
+            assertFalse(
+                    "Session Expired Message handling is not expected "
+                            + "when the page is being redirected",
                     getSystemErrorHandler().sessionExpiredMessageHandled);
-            assertFalse("Unrecoverable Error Message handling was not " +
-                        "expected when the page is being redirected",
+            assertFalse(
+                    "Unrecoverable Error Message handling was not "
+                            + "expected when the page is being redirected",
                     getSystemErrorHandler().unrecoverableErrorHandled);
             assertEquals(UILifecycle.UIState.TERMINATED,
                     getUILifecycle().getState());
@@ -369,7 +373,7 @@ public class GwtMessageHandlerTest extends ClientEngineTestBase {
                     getSystemErrorHandler().unrecoverableErrorHandled);
             assertEquals(UILifecycle.UIState.TERMINATED,
                     getUILifecycle().getState());
-        });
+        }, 300);
     }
 
     public void testHandleJSON_unrecoverableErrorAndUIRunning_unrecoverableErrorMessageShown() {
@@ -416,8 +420,7 @@ public class GwtMessageHandlerTest extends ClientEngineTestBase {
         doAssert(assertions, 100);
     }
 
-    private void doAssert(Runnable assertions,
-                          int assertDelayInMillis) {
+    private void doAssert(Runnable assertions, int assertDelayInMillis) {
         delayTestFinish(500);
         new Timer() {
             @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
@@ -284,6 +284,14 @@ public class ServerRpcHandler implements Serializable {
                 getLogger().info(
                         "Ignoring old duplicate message from the client. Expected: "
                                 + expectedId + ", got: " + requestId);
+            } else if (rpcRequest.isUnloadBeaconRequest()) {
+                getLogger().debug(
+                        "Ignoring unexpected message id from the client on UNLOAD request. "
+                                + "This could happen for example during login process, if concurrent requests "
+                                + "are sent to the server and one of those changes the session identifier, "
+                                + "causing an UIDL request to be rejected because of session expiration. "
+                                + "Expected sync id: {}, got {}.",
+                        expectedId, requestId);
             } else {
                 /*
                  * If the reason for ending up here is intermittent, then we

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/InternalErrorIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/InternalErrorIT.java
@@ -82,6 +82,8 @@ public class InternalErrorIT extends ChromeBrowserTest {
         // Just click on any button to make a request after killing the session
         clickButton(CLOSE_SESSION);
 
+        waitUntil(d -> isSessionExpiredNotificationPresent());
+
         Assert.assertTrue("After enabling the 'Session Expired' notification, "
                 + "the page should not be refreshed "
                 + "after killing the session", isMessageUpdated());

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/RouterSessionExpirationIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/RouterSessionExpirationIT.java
@@ -22,21 +22,23 @@ public class RouterSessionExpirationIT extends ChromeBrowserTest {
     }
 
     @Test
-    public void navigationAfterSessionExpired() {
+    public void should_HaveANewSessionId_when_NavigationAfterSessionExpired() {
         openUrl("/new-router-session/NormalView");
 
         navigateToAnotherView();
         String sessionId = getSessionId();
         navigateToFirstView();
         Assert.assertEquals(sessionId, getSessionId());
+
         navigateToSesssionExpireView();
         // expired session causes page reload, after the page reload there will
         // be a new session
-        Assert.assertNotEquals(sessionId, getSessionId());
-        sessionId = getSessionId();
-        navigateToFirstView();
+        waitUntil(d -> !sessionId.equals(getSessionId()));
+
+        String newSessionId = getSessionId();
+        navigateToAnotherView();
         // session is preserved
-        Assert.assertEquals(sessionId, getSessionId());
+        Assert.assertEquals(newSessionId, getSessionId());
     }
 
     @Test
@@ -66,7 +68,7 @@ public class RouterSessionExpirationIT extends ChromeBrowserTest {
     }
 
     private void navigateToSesssionExpireView() {
-        navigateTo("ViewWhichInvalidatesSession");
+        findElement(By.linkText("ViewWhichInvalidatesSession")).click();
     }
 
     private void navigateToInternalErrorView() {
@@ -76,8 +78,12 @@ public class RouterSessionExpirationIT extends ChromeBrowserTest {
 
     private void navigateTo(String linkText) {
         findElement(By.linkText(linkText)).click();
+        assertTextAvailableInView(linkText);
+
+    }
+
+    private void assertTextAvailableInView(String linkText) {
         Assert.assertNotNull(
                 findElement(By.xpath("//strong[text()='" + linkText + "']")));
-
     }
 }


### PR DESCRIPTION
Attempts to fix the synchronization issue related to the usage of the Login reported in #12640. The Login component sends the UIDL request for the login event to the server and concurrently submits the form. If processing the form submission performs a session ID change and a request redirect, the UIDL requests might fail with a session expiration response. The Flow client then can cancel the first redirect because it reloads the page due to the session expiration. Lastly, the beacon request hits again a valid session, but a resynchronization is triggered because the previous UIDL request was rejected.

This change delays a bit the session expiration handling on Flow client, to allow a potential redirect to complete without being cancelled. However, the client application is immediately set in TERMINATED state.