### PR TITLE
feat: add Vite variable for determining service worker build context

### DIFF
--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -145,6 +145,7 @@ function buildSWPlugin(opts: { devMode: boolean }): PluginOption {
       replace({
         values: {
           'process.env.NODE_ENV': JSON.stringify(config.mode),
+          'process.env.VITE_SW_CONTEXT': true,
           ...config.define
         },
         preventAssignment: true


### PR DESCRIPTION
Hilla needs to dynamically import modules/libraries for the service workers, so there is some property to determine if the build is for SW or base.  

Fixes https://github.com/vaadin/hilla/issues/2867
