### PR TITLE
fix: Do not try to refresh app while it is initializing

### DIFF
--- a/vaadin-dev-server/src/main/frontend/vaadin-dev-tools.ts
+++ b/vaadin-dev-server/src/main/frontend/vaadin-dev-tools.ts
@@ -660,6 +660,8 @@ export class VaadinDevTools extends LitElement {
                 client.sendEventMessage(1, "ui-refresh", {
                   fullRefresh: strategy === 'full-refresh'
                })
+              } else {
+                console.warn("Ignoring ui-refresh event for application ",id);
               }
             });
       } else {

--- a/vaadin-dev-server/src/main/frontend/vaadin-dev-tools.ts
+++ b/vaadin-dev-server/src/main/frontend/vaadin-dev-tools.ts
@@ -656,9 +656,11 @@ export class VaadinDevTools extends LitElement {
             .filter((key) => key !== 'TypeScript')
             .map((id) => anyVaadin.Flow.clients[id])
             .forEach((client) => {
-              client.sendEventMessage(1, "ui-refresh", {
-                fullRefresh: strategy === 'full-refresh'
-              })
+              if (client.sendEventMessage) {
+                client.sendEventMessage(1, "ui-refresh", {
+                  fullRefresh: strategy === 'full-refresh'
+               })
+              }
             });
       } else {
         const lastReload = window.sessionStorage.getItem(VaadinDevTools.TRIGGERED_COUNT_KEY_IN_SESSION_STORAGE);


### PR DESCRIPTION
When the app is bootstrapping, it only contains
`initializing`, `isActive` and `productionMode`. We should not call `sendEventMessage` at this point or might cause `Uncaught TypeError: l.sendEventMessage is not a function`. 

This is unlikely to happen in many real world scenarios but happens in Copilot tests
