### PR TITLE
fix: fix ServletFileUpload header encoding (#20480) (CP: 24.4)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
@@ -630,11 +630,22 @@ public class StreamReceiverHandler implements Serializable {
 
     protected FileItemInputIterator getItemIterator(VaadinRequest request)
             throws FileUploadException, IOException {
+        JakartaServletFileUpload upload = createServletFileUpload(request);
+        return upload.getItemIterator((HttpServletRequest) request);
+    }
+
+    // protected for testing purposes only
+    protected JakartaServletFileUpload createServletFileUpload(VaadinRequest request) {
         JakartaServletFileUpload upload = new JakartaServletFileUpload();
         upload.setSizeMax(requestSizeMax);
         upload.setFileSizeMax(fileSizeMax);
         upload.setFileCountMax(fileCountMax);
-        return upload.getItemIterator((HttpServletRequest) request);
+        if (request.getCharacterEncoding() == null) {
+            // Request body's file upload headers are expected to be encoded in
+            // UTF-8 if not explicitly set otherwise in the request.
+            upload.setHeaderCharset(StandardCharsets.UTF_8);
+        }
+        return upload;
     }
 
     public void setRequestSizeMax(long requestSizeMax) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
@@ -635,7 +635,8 @@ public class StreamReceiverHandler implements Serializable {
     }
 
     // protected for testing purposes only
-    protected JakartaServletFileUpload createServletFileUpload(VaadinRequest request) {
+    protected JakartaServletFileUpload createServletFileUpload(
+            VaadinRequest request) {
         JakartaServletFileUpload upload = new JakartaServletFileUpload();
         upload.setSizeMax(requestSizeMax);
         upload.setFileSizeMax(fileSizeMax);

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/StreamReceiverHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/StreamReceiverHandlerTest.java
@@ -10,13 +10,14 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import org.apache.commons.fileupload.servlet.ServletFileUpload;
+import org.apache.commons.fileupload2.jakarta.JakartaServletFileUpload;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -300,23 +301,23 @@ public class StreamReceiverHandlerTest {
 
     @Test
     public void createServletFileUpload_useUTF8HeaderCharacterEncodingWhenRequestCharEncodingIsNotSet() {
-        ServletFileUpload servletFileUpload = handler
+        JakartaServletFileUpload servletFileUpload = handler
                 .createServletFileUpload(request);
         Assert.assertNotNull(servletFileUpload);
         Assert.assertEquals(
                 "Header encoding should be UTF-8 when request character encoding is null",
-                "UTF-8", servletFileUpload.getHeaderEncoding());
+                StandardCharsets.UTF_8, servletFileUpload.getHeaderCharset());
     }
 
     @Test
     public void createServletFileUpload_dontSetHeaderCharEncodingWhenRequestCharEncodingIsSet() {
         requestCharacterEncoding = "ASCII";
-        ServletFileUpload servletFileUpload = handler
+        JakartaServletFileUpload servletFileUpload = handler
                 .createServletFileUpload(request);
         Assert.assertNotNull(servletFileUpload);
         Assert.assertNull(
                 "Header encoding should not be set by Flow when request character encoding is set",
-                servletFileUpload.getHeaderEncoding());
+                servletFileUpload.getHeaderCharset());
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/StreamReceiverHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/StreamReceiverHandlerTest.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -87,6 +88,7 @@ public class StreamReceiverHandlerTest {
     private List<Part> parts;
 
     private boolean isGetContentLengthLongCalled;
+    private String requestCharacterEncoding;
 
     @Before
     public void setup() throws Exception {
@@ -180,6 +182,11 @@ public class StreamReceiverHandlerTest {
             public long getContentLengthLong() {
                 isGetContentLengthLongCalled = true;
                 return 0;
+            }
+
+            @Override
+            public String getCharacterEncoding() {
+                return requestCharacterEncoding;
             }
         };
     }
@@ -289,6 +296,27 @@ public class StreamReceiverHandlerTest {
         Mockito.verify(response)
                 .setStatus(HttpStatusCode.INTERNAL_SERVER_ERROR.getCode());
         Assert.assertTrue(isGetContentLengthLongCalled);
+    }
+
+    @Test
+    public void createServletFileUpload_useUTF8HeaderCharacterEncodingWhenRequestCharEncodingIsNotSet() {
+        ServletFileUpload servletFileUpload = handler
+                .createServletFileUpload(request);
+        Assert.assertNotNull(servletFileUpload);
+        Assert.assertEquals(
+                "Header encoding should be UTF-8 when request character encoding is null",
+                "UTF-8", servletFileUpload.getHeaderEncoding());
+    }
+
+    @Test
+    public void createServletFileUpload_dontSetHeaderCharEncodingWhenRequestCharEncodingIsSet() {
+        requestCharacterEncoding = "ASCII";
+        ServletFileUpload servletFileUpload = handler
+                .createServletFileUpload(request);
+        Assert.assertNotNull(servletFileUpload);
+        Assert.assertNull(
+                "Header encoding should not be set by Flow when request character encoding is set",
+                servletFileUpload.getHeaderEncoding());
     }
 
     @Test


### PR DESCRIPTION
This change will set JakartaServletFileUpload's header charset to UTF-8 in StreamReceiverHandler when request character encoding is null. This ensures that system's default character encoding is not applied when parsing filename of the uploaded file, unless request's character encoding is set otherwise.
Only for setups without multipart config for servlet.

Fixes: https://github.com/vaadin/flow/issues/20417