### PR TITLE
feat: generate PWA icons at build time

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -186,6 +186,11 @@ public final class Constants implements Serializable {
     public static final String VAADIN_WEBAPP = "webapp/";
 
     /**
+     * The generated PWA icons folder.
+     */
+    public static final String VAADIN_PWA_ICONS = "pwa-icons/";
+
+    /**
      * The path to meta-inf/VAADIN/ where static resources are put on the
      * servlet.
      */

--- a/flow-server/src/main/java/com/vaadin/flow/server/PwaIcon.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PwaIcon.java
@@ -16,12 +16,14 @@
 package com.vaadin.flow.server;
 
 import javax.imageio.ImageIO;
+
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.Image;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.io.UncheckedIOException;
@@ -97,6 +99,15 @@ public class PwaIcon implements Serializable {
         }
 
         setRelativeName();
+    }
+
+    protected PwaIcon(PwaIcon icon) {
+        this.width = icon.width;
+        this.height = icon.height;
+        this.baseName = icon.baseName;
+        this.domain = icon.domain;
+        this.shouldBeCached = icon.shouldBeCached;
+        this.attributes.putAll(icon.attributes);
     }
 
     /**
@@ -236,6 +247,25 @@ public class PwaIcon implements Serializable {
         }
     }
 
+    void setImage(InputStream image) throws IOException {
+        if (image != null) {
+            data = image.readAllBytes();
+            fileHash = Arrays.hashCode(data);
+            setRelativeName();
+        }
+    }
+
+    /**
+     * Gets if the icon can be written on a stream or not.
+     *
+     * @return {@literal true} if the icon can be written, otherwise
+     *         {@literal false}.
+     * @see #write(OutputStream)
+     */
+    boolean isAvailable() {
+        return data != null || registry.getBaseImage() != null;
+    }
+
     /**
      * Writes the icon image to output stream.
      *
@@ -246,7 +276,7 @@ public class PwaIcon implements Serializable {
         if (data == null) {
             // New image with wanted size
             // Store byte array and hashcode of image (GeneratedImage)
-            setImage(drawIconImage(registry.getBaseImage()));
+            setImage(drawIconImage(getBaseImage()));
         }
         try {
             outputStream.write(data);
@@ -255,6 +285,11 @@ public class PwaIcon implements Serializable {
                     "Failed to store the icon image into the stream provided",
                     ioe);
         }
+    }
+
+    // visible for test
+    protected BufferedImage getBaseImage() {
+        return registry.getBaseImage();
     }
 
     private BufferedImage drawIconImage(BufferedImage baseImage) {
@@ -296,4 +331,5 @@ public class PwaIcon implements Serializable {
         graphics.dispose();
         return bimage;
     }
+
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/PwaRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PwaRegistry.java
@@ -15,12 +15,10 @@
  */
 package com.vaadin.flow.server;
 
-import javax.imageio.ImageIO;
 import jakarta.servlet.ServletContext;
 
-import java.awt.Color;
-import java.awt.Graphics2D;
-import java.awt.Image;
+import javax.imageio.ImageIO;
+
 import java.awt.image.BufferedImage;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -29,21 +27,21 @@ import java.io.InputStreamReader;
 import java.io.Serializable;
 import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.di.ResourceProvider;
 import com.vaadin.flow.server.communication.PwaHandler;
 import com.vaadin.flow.server.startup.ApplicationConfiguration;
 import com.vaadin.flow.server.startup.ApplicationRouteRegistry;
@@ -85,6 +83,7 @@ public class PwaRegistry implements Serializable {
     private List<PwaIcon> icons = new ArrayList<>();
     private final PwaConfiguration pwaConfiguration;
 
+    private URL baseImageUrl;
     private BufferedImage baseImage;
 
     /**
@@ -113,7 +112,21 @@ public class PwaRegistry implements Serializable {
         initializeResources(servletContext);
     }
 
+    // Lazy load base image to prevent using AWT api unless icon
+    // generation is required at runtime.
+    // baseImageUrl is computed during registry initialization and used on to
+    // load the image.
     BufferedImage getBaseImage() {
+        if (baseImage == null && baseImageUrl != null) {
+            try {
+                baseImage = getBaseImage(baseImageUrl);
+            } catch (IOException ex) {
+                getLogger().error("Image is not found or can't be loaded: {}",
+                        baseImageUrl);
+            } finally {
+                baseImageUrl = null;
+            }
+        }
         return baseImage;
     }
 
@@ -124,24 +137,19 @@ public class PwaRegistry implements Serializable {
         }
         long start = System.currentTimeMillis();
 
+        // Load base logo from servlet context if available
+        // fall back to local image if unavailable
         URL logo = getResourceUrl(servletContext,
                 pwaConfiguration.relIconPath());
+        baseImageUrl = logo != null ? logo
+                : BootstrapHandler.class.getResource("default-logo.png");
 
         URL offlinePage = pwaConfiguration.isOfflinePathEnabled()
                 ? getResourceUrl(servletContext,
                         pwaConfiguration.relOfflinePath())
                 : null;
 
-        // Load base logo from servlet context if available
-        // fall back to local image if unavailable
-        baseImage = getBaseImage(logo);
-
-        if (baseImage == null) {
-            getLogger().error("Image is not found or can't be loaded: " + logo);
-        } else {
-            // initialize icons
-            icons = initializeIcons();
-        }
+        icons = initializeIcons(servletContext);
 
         // Load offline page as string, from servlet context if
         // available, fall back to default page
@@ -175,12 +183,41 @@ public class PwaRegistry implements Serializable {
         return resourceUrl;
     }
 
-    private List<PwaIcon> initializeIcons() {
+    private List<PwaIcon> initializeIcons(ServletContext servletContext) {
+        Optional<ResourceProvider> optionalResourceProvider = Optional
+                .ofNullable(new VaadinServletContext(servletContext)
+                        .getAttribute(Lookup.class))
+                .map(lookup -> lookup.lookup(ResourceProvider.class));
         for (PwaIcon icon : getIconTemplates(pwaConfiguration.getIconPath())) {
             icon.setRegistry(this);
-            icons.add(icon);
+            // Try to find a pre-generated image
+            String iconPath = Constants.VAADIN_WEBAPP_RESOURCES
+                    + Constants.VAADIN_PWA_ICONS
+                    + icon.getRelHref().substring(1);
+            optionalResourceProvider.ifPresent(
+                    provider -> tryLoadGeneratedIcon(provider, icon, iconPath));
+            if (icon.isAvailable()) {
+                icons.add(icon);
+            }
         }
         return icons;
+    }
+
+    private static void tryLoadGeneratedIcon(ResourceProvider resourceProvider,
+            PwaIcon icon, String iconPath) {
+        URL iconResource = resourceProvider.getApplicationResource(iconPath);
+        if (iconResource != null) {
+            try (InputStream data = iconResource.openStream()) {
+                icon.setImage(data);
+                getLogger().trace("Loading generated PWA image from {}",
+                        iconPath);
+            } catch (IOException ex) {
+                // Ignore, icon will be generated at runtime
+                getLogger().debug(
+                        "Cannot load generated PWA image from {}. Icon will be regenerated at runtime.",
+                        iconPath, ex);
+            }
+        }
     }
 
     /**
@@ -443,7 +480,14 @@ public class PwaRegistry implements Serializable {
         return pwaConfiguration;
     }
 
-    static List<PwaIcon> getIconTemplates(String baseName) {
+    /**
+     * Gets all PWA icon variants for the give base icon.
+     *
+     * @param baseName
+     *            path of the base icon.
+     * @return list of PWA icons variants.
+     */
+    public static List<PwaIcon> getIconTemplates(String baseName) {
         List<PwaIcon> icons = new ArrayList<>();
         // Basic manifest icons for android support
         icons.add(

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -35,7 +35,6 @@ import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.server.Constants;
@@ -80,6 +79,7 @@ public class NodeTasks implements FallibleCommand {
             TaskGenerateEndpoint.class,
             TaskCopyFrontendFiles.class,
             TaskCopyLocalFrontendFiles.class,
+            TaskGeneratePWAIcons.class,
             TaskUpdateSettingsFile.class,
             TaskUpdateVite.class,
             TaskUpdateImports.class,
@@ -258,6 +258,9 @@ public class NodeTasks implements FallibleCommand {
             pwa = frontendDependencies.getPwaConfiguration();
         } else {
             pwa = new PwaConfiguration();
+        }
+        if (options.isProductionMode() && pwa.isEnabled()) {
+            commands.add(new TaskGeneratePWAIcons(options, pwa));
         }
         commands.add(new TaskUpdateSettingsFile(options, themeName, pwa));
         if (options.isFrontendHotdeploy() || options.isBundleBuild()) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGeneratePWAIcons.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGeneratePWAIcons.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.server.frontend;
+
+import javax.imageio.ImageIO;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.vaadin.flow.server.BootstrapHandler;
+import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.ExecutionFailedException;
+import com.vaadin.flow.server.PwaConfiguration;
+import com.vaadin.flow.server.PwaIcon;
+import com.vaadin.flow.server.PwaRegistry;
+import com.vaadin.flow.server.frontend.scanner.ClassFinder;
+
+/**
+ * Generates necessary PWA icons.
+ * <p>
+ * For internal use only. May be renamed or removed in a future release.
+ */
+public class TaskGeneratePWAIcons implements FallibleCommand {
+
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(TaskGeneratePWAIcons.class);
+    private static final String HEADLESS_PROPERTY = "java.awt.headless";
+
+    private final Path generatedIconsPath;
+    private final PwaConfiguration pwaConfiguration;
+    private final ClassFinder classFinder;
+
+    public TaskGeneratePWAIcons(Options options,
+            PwaConfiguration pwaConfiguration) {
+        this.pwaConfiguration = pwaConfiguration;
+        generatedIconsPath = options.getWebappResourcesDirectory().toPath()
+                .resolve(Constants.VAADIN_PWA_ICONS);
+        this.classFinder = options.getClassFinder();
+    }
+
+    @Override
+    public void execute() throws ExecutionFailedException {
+        if (!pwaConfiguration.isEnabled()) {
+            return;
+        }
+        URL iconURL = findIcon(pwaConfiguration);
+        if (iconURL == null) {
+            LOGGER.warn(
+                    "Skipping PWA icons generation because icon '{}' cannot be found in classpath",
+                    pwaConfiguration.getIconPath());
+            return;
+        }
+
+        String headless = System.getProperty(HEADLESS_PROPERTY);
+        if (headless == null) {
+            // set headless mode if the property is not explicitly set
+            System.setProperty(HEADLESS_PROPERTY, Boolean.TRUE.toString());
+        }
+
+        LOGGER.debug("Generating PWA icons from '{}'",
+                pwaConfiguration.getIconPath());
+
+        try {
+            BufferedImage baseImage = loadBaseImage(iconURL);
+            createGeneratedIconsFolder();
+
+            CompletableFuture<?>[] iconsGenerators = PwaRegistry
+                    .getIconTemplates(pwaConfiguration.getIconPath()).stream()
+                    .map(icon -> new InternalPwaIcon(icon, baseImage))
+                    .map(this::generateIcon).toArray(CompletableFuture[]::new);
+
+            try {
+                CompletableFuture.allOf(iconsGenerators).join();
+            } catch (CompletionException ex) {
+                Throwable cause = ex.getCause();
+                if (cause instanceof UncheckedIOException uncheckedIOException) {
+                    throw new ExecutionFailedException(
+                            "PWA icons generation failed",
+                            uncheckedIOException.getCause());
+                }
+                throw new ExecutionFailedException(
+                        "PWA icons generation failed", cause);
+            } catch (CancellationException ex) {
+                throw new ExecutionFailedException(
+                        "PWA icons generation failed", ex);
+            }
+        } finally {
+            if (headless == null) {
+                System.clearProperty(HEADLESS_PROPERTY);
+            } else if (!headless.equals(Boolean.TRUE.toString())) {
+                System.setProperty(HEADLESS_PROPERTY, headless);
+            }
+        }
+        LOGGER.info("PWA icons generated");
+    }
+
+    private void createGeneratedIconsFolder() throws ExecutionFailedException {
+        try {
+            Path generatedPath = generatedIconsPath
+                    .resolve(Path.of(pwaConfiguration.getIconPath().replace('/',
+                            File.separatorChar)))
+                    .getParent();
+            Files.createDirectories(generatedPath);
+        } catch (IOException e) {
+            throw new ExecutionFailedException(
+                    "Cannot create PWA generated icons folder "
+                            + generatedIconsPath,
+                    e);
+        }
+    }
+
+    private static BufferedImage loadBaseImage(URL iconURL)
+            throws ExecutionFailedException {
+        BufferedImage baseImage;
+        try (InputStream inputStream = iconURL.openStream()) {
+            baseImage = ImageIO.read(inputStream);
+        } catch (IOException e) {
+            throw new ExecutionFailedException(
+                    "Cannot load PWA icon from " + iconURL, e);
+        }
+        if (baseImage == null) {
+            throw new ExecutionFailedException(
+                    "Cannot load PWA icon from " + iconURL);
+        }
+        return baseImage;
+    }
+
+    private URL findIcon(PwaConfiguration pwaConfiguration) {
+        URL iconURL = classFinder.getResource(pwaConfiguration.getIconPath());
+        if (iconURL == null) {
+            iconURL = classFinder.getResource(
+                    "META-INF/resources/" + pwaConfiguration.getIconPath());
+        }
+        if (iconURL == null) {
+            iconURL = BootstrapHandler.class.getResource("default-logo.png");
+            if (iconURL == null) {
+                LOGGER.warn(
+                        "PWA icon '{}' cannot be found in classpath, fallback to default icon.",
+                        pwaConfiguration.getIconPath());
+            }
+        }
+        return iconURL;
+    }
+
+    private CompletableFuture<?> generateIcon(InternalPwaIcon icon) {
+        Path iconPath = generatedIconsPath.resolve(icon.getRelHref()
+                .substring(1).replace('/', File.separatorChar));
+        return CompletableFuture.runAsync(() -> {
+            try (OutputStream os = Files.newOutputStream(iconPath)) {
+                icon.write(os);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        });
+    }
+
+    private BufferedImage getBaseImage(URL logo) throws IOException {
+        URLConnection logoResource = logo != null ? logo.openConnection()
+                : BootstrapHandler.class.getResource("default-logo.png")
+                        .openConnection();
+        return ImageIO.read(logoResource.getInputStream());
+    }
+
+    private static class InternalPwaIcon extends PwaIcon {
+        private final BufferedImage baseImage;
+
+        public InternalPwaIcon(PwaIcon icon, BufferedImage baseImage) {
+            super(icon);
+            this.baseImage = baseImage;
+        }
+
+        @Override
+        protected BufferedImage getBaseImage() {
+            return baseImage;
+        }
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/PwaHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/PwaHandlerTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.server.communication;
 
+import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -132,6 +133,7 @@ public class PwaHandlerTest {
         PwaIcon icon = ctor.newInstance(size, size,
                 PwaConfiguration.DEFAULT_ICON);
         icon.setRegistry(registry);
+        icon.setImage(new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB));
         return icon;
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGeneratePWAIconsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGeneratePWAIconsTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.server.frontend;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.ExecutionFailedException;
+import com.vaadin.flow.server.PwaConfiguration;
+import com.vaadin.flow.server.frontend.scanner.ClassFinder;
+import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
+
+public class TaskGeneratePWAIconsTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    private final TestPwaConfiguration pwaConfiguration = new TestPwaConfiguration();
+    private TaskGeneratePWAIcons task;
+    private Path resourcesDirectory;
+    private Path iconsOutDirectory;
+
+    @Before
+    public void setUp() throws Exception {
+        // creating non-existing folder to make sure the execute() creates
+        // the folder if missing
+        File projectDirectory = temporaryFolder.newFolder("my-project");
+        resourcesDirectory = temporaryFolder
+                .newFolder("my-project", "out", "classes").toPath();
+        Files.createDirectories(resourcesDirectory);
+        Path resourceOutDirectory = projectDirectory.toPath()
+                .resolve(Path.of("out", "VAADIN"));
+        Path wabappResourceOutDirectory = resourceOutDirectory
+                .resolve("wabapp");
+        iconsOutDirectory = wabappResourceOutDirectory
+                .resolve(Constants.VAADIN_PWA_ICONS);
+
+        FrontendDependenciesScanner scanner = Mockito
+                .mock(FrontendDependenciesScanner.class);
+        Mockito.when(scanner.getPwaConfiguration()).then(i -> pwaConfiguration);
+
+        URLClassLoader classFinderClassLoader = new URLClassLoader(
+                new URL[] { resourcesDirectory.toUri().toURL() }, null);
+        ClassFinder classFinder = new ClassFinder.DefaultClassFinder(
+                classFinderClassLoader);
+        Options options = new Options(Mockito.mock(Lookup.class), classFinder,
+                projectDirectory)
+                .withBuildResultFolders(wabappResourceOutDirectory.toFile(),
+                        resourceOutDirectory.toFile());
+        task = new TaskGeneratePWAIcons(options, pwaConfiguration);
+    }
+
+    @Test
+    public void execute_PWA_disabled_iconsNotGenerated()
+            throws ExecutionFailedException {
+        pwaConfiguration.enabled = false;
+        task.execute();
+        Assert.assertFalse("PWA icons should not have been generated",
+                Files.exists(iconsOutDirectory));
+    }
+
+    @Test
+    public void execute_PWA_iconInClassPath_generateIcons()
+            throws ExecutionFailedException, IOException {
+        createBaseIcon(resourcesDirectory);
+        task.execute();
+        assertIconsGenerated();
+    }
+
+    @Test
+    public void execute_PWA_iconInMetaInfResourcesFolder_generateIcons()
+            throws ExecutionFailedException, IOException {
+        createBaseIcon(
+                resourcesDirectory.resolve(Path.of("META-INF", "resources")));
+        task.execute();
+        assertIconsGenerated();
+    }
+
+    @Test
+    public void execute_PWA_baseIconNotFound_generateIconsFromDefaultLogo()
+            throws ExecutionFailedException, IOException {
+        task.execute();
+        assertIconsGenerated();
+    }
+
+    @Test
+    public void execute_PWA_invalidBaseIconNotFound_throws()
+            throws IOException {
+        createBaseIcon(
+                resourcesDirectory.resolve(Path.of("META-INF", "resources")),
+                new ByteArrayInputStream("NOT AN IMAGE".getBytes()));
+        ExecutionFailedException exception = Assert
+                .assertThrows(ExecutionFailedException.class, task::execute);
+        Assert.assertTrue(
+                exception.getMessage().contains("Cannot load PWA icon"));
+        Assert.assertTrue(exception.getCause() instanceof IOException);
+        Assert.assertFalse("PWA icons should not have been generated",
+                Files.exists(iconsOutDirectory));
+    }
+
+    private void createBaseIcon(Path resourcesFolder) throws IOException {
+        createBaseIcon(resourcesFolder, getClass()
+                .getResourceAsStream("/META-INF/resources/icons/icon.png"));
+    }
+
+    private void createBaseIcon(Path resourcesFolder, InputStream data)
+            throws IOException {
+        Path baseIcon = resourcesFolder.resolve(resourcesFolder)
+                .resolve(pwaConfiguration.getIconPath().replace('/',
+                        File.separatorChar));
+        Files.createDirectories(baseIcon.getParent());
+        Files.copy(data, baseIcon);
+    }
+
+    private void assertIconsGenerated() throws IOException {
+        String iconPath = pwaConfiguration.getIconPath();
+        Path generatedIconsPath = iconsOutDirectory
+                .resolve(iconPath.replace('/', File.separatorChar)).getParent();
+        Assert.assertTrue("PWA icons folder should have been generated",
+                Files.exists(generatedIconsPath));
+        String iconName = iconPath.substring(iconPath.lastIndexOf("/") + 1,
+                iconPath.lastIndexOf("."));
+        String iconExt = iconPath.substring(iconPath.lastIndexOf(".") + 1);
+        Predicate<String> iconNamePattern = Pattern
+                .compile(iconName + "-\\d+x\\d+\\." + iconExt).asPredicate();
+        List<String> generatedIcons = Files.list(generatedIconsPath)
+                .map(p -> p.getFileName().toString()).toList();
+        Assert.assertFalse("Expected PWA icons to be generated",
+                generatedIcons.isEmpty());
+        Assert.assertTrue(
+                "Generated icons have invalid names: " + generatedIcons,
+                generatedIcons.stream().allMatch(iconNamePattern));
+
+    }
+
+    private static class TestPwaConfiguration extends PwaConfiguration {
+        private Boolean enabled;
+
+        public TestPwaConfiguration() {
+            super(true, DEFAULT_NAME, "Flow PWA", "", DEFAULT_BACKGROUND_COLOR,
+                    DEFAULT_THEME_COLOR, "custom/icons/logo.png", DEFAULT_PATH,
+                    DEFAULT_OFFLINE_PATH, DEFAULT_DISPLAY, DEFAULT_START_URL,
+                    new String[] {}, false);
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return enabled != null ? enabled : super.isEnabled();
+        }
+
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGeneratePWAIconsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGeneratePWAIconsTest.java
@@ -124,7 +124,6 @@ public class TaskGeneratePWAIconsTest {
                 .assertThrows(ExecutionFailedException.class, task::execute);
         Assert.assertTrue(
                 exception.getMessage().contains("Cannot load PWA icon"));
-        Assert.assertTrue(exception.getCause() instanceof IOException);
         Assert.assertFalse("PWA icons should not have been generated",
                 Files.exists(iconsOutDirectory));
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGeneratePWAIconsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGeneratePWAIconsTest.java
@@ -157,9 +157,10 @@ public class TaskGeneratePWAIconsTest {
                 .map(p -> p.getFileName().toString()).toList();
         Assert.assertFalse("Expected PWA icons to be generated",
                 generatedIcons.isEmpty());
-        Assert.assertTrue(
-                "Generated icons have invalid names: " + generatedIcons,
-                generatedIcons.stream().allMatch(iconNamePattern));
+        List<String> invalidIcons = generatedIcons.stream()
+                .filter(iconNamePattern.negate()).toList();
+        Assert.assertTrue("Generated icons have invalid names: " + invalidIcons,
+                invalidIcons.isEmpty());
 
     }
 


### PR DESCRIPTION
## Description

Generates PWA icons during the production build, preventing the need to use AWT APIs at runtime and making first requests to the application faster. Also prevents potential issues caused by loading AWT native library in native images.
If the base icon cannot be found at build time, Flow will attempt to generate the icons at runtime, exactly how it does before this change.

Fixes #19497

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
