### PR TITLE
fix: prevent blocking when closing ViteWebSocketConnection

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketConnection.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketConnection.java
@@ -158,7 +158,7 @@ public class ViteWebsocketConnection implements Listener {
                 }
             }
         } else {
-            // Websocket client has not
+            // Websocket client connection has not been established
             clientWebsocket.cancel(true);
         }
     }


### PR DESCRIPTION
## Description

This change prevents ViteWebSocketConnection to waiting indefinitely on close, waiting at most 500 milliseconds for the client websocket close request to complete.

Fixes #20445

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
