### PR TITLE
fix: fix class and resource loading in maven plugin (#20465) (CP: 24.5)

### DIFF
--- a/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
+++ b/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
@@ -17,26 +17,39 @@ package com.vaadin.flow.plugin.maven;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.classworlds.realm.NoSuchRealmException;
 
 import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.JsModule;
@@ -52,7 +65,9 @@ import com.vaadin.flow.server.frontend.FrontendUtils;
 import com.vaadin.flow.server.frontend.installer.NodeInstaller;
 import com.vaadin.flow.server.frontend.installer.Platform;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
+import com.vaadin.flow.server.scanner.ReflectionsClassFinder;
 import com.vaadin.flow.theme.Theme;
+import com.vaadin.flow.utils.FlowFileUtils;
 
 import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
 import static com.vaadin.flow.server.Constants.VAADIN_WEBAPP_RESOURCES;
@@ -130,6 +145,9 @@ public class BuildDevBundleMojo extends AbstractMojo
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     MavenProject project;
 
+    @Parameter(defaultValue = "${mojoExecution}")
+    MojoExecution mojoExecution;
+
     /**
      * The folder where `package.json` file is located. Default is project root
      * dir.
@@ -171,8 +189,33 @@ public class BuildDevBundleMojo extends AbstractMojo
     @Parameter(defaultValue = "${project.basedir}/src/main/" + FRONTEND)
     private File frontendDirectory;
 
+    static final String CLASSFINDER_FIELD_NAME = "classFinder";
+
+    private ClassFinder classFinder;
+
     @Override
-    public void execute() throws MojoFailureException {
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        PluginDescriptor pluginDescriptor = mojoExecution.getMojoDescriptor()
+                .getPluginDescriptor();
+        checkFlowCompatibility(pluginDescriptor);
+
+        Reflector reflector = getOrCreateReflector();
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread()
+                .setContextClassLoader(reflector.getIsolatedClassLoader());
+        try {
+            org.apache.maven.plugin.Mojo task = reflector.createMojo(this);
+            findExecuteMethod(task.getClass()).invoke(task);
+        } catch (MojoExecutionException | MojoFailureException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new MojoFailureException(e.getMessage(), e);
+        } finally {
+            Thread.currentThread().setContextClassLoader(tccl);
+        }
+    }
+
+    public void executeInternal() throws MojoFailureException {
         long start = System.nanoTime();
 
         try {
@@ -239,7 +282,9 @@ public class BuildDevBundleMojo extends AbstractMojo
      * @param project
      *            a given MavenProject
      * @return List of ClasspathElements
+     * @deprecated will be removed without replacement.
      */
+    @Deprecated(forRemoval = true)
     public static List<String> getClasspathElements(MavenProject project) {
 
         try {
@@ -282,11 +327,13 @@ public class BuildDevBundleMojo extends AbstractMojo
 
     @Override
     public ClassFinder getClassFinder() {
-
-        List<String> classpathElements = getClasspathElements(project);
-
-        return BuildFrontendUtil.getClassFinder(classpathElements);
-
+        if (classFinder == null) {
+            URLClassLoader classLoader = getOrCreateReflector()
+                    .getIsolatedClassLoader();
+            classFinder = new ReflectionsClassFinder(classLoader,
+                    classLoader.getURLs());
+        }
+        return classFinder;
     }
 
     @Override
@@ -469,4 +516,126 @@ public class BuildDevBundleMojo extends AbstractMojo
             Consumer<String> missingDependencyMessageConsumer) {
         return false;
     }
+
+    private static URLClassLoader createIsolatedClassLoader(
+            MavenProject project, MojoExecution mojoExecution) {
+        List<URL> urls = new ArrayList<>();
+        String outputDirectory = project.getBuild().getOutputDirectory();
+        if (outputDirectory != null) {
+            urls.add(FlowFileUtils.convertToUrl(new File(outputDirectory)));
+        }
+
+        Function<Artifact, String> keyMapper = artifact -> artifact.getGroupId()
+                + ":" + artifact.getArtifactId();
+
+        Map<String, Artifact> projectDependencies = new HashMap<>(project
+                .getArtifacts().stream()
+                .filter(artifact -> artifact.getFile() != null
+                        && artifact.getArtifactHandler().isAddedToClasspath()
+                        && (Artifact.SCOPE_COMPILE.equals(artifact.getScope())
+                                || Artifact.SCOPE_RUNTIME
+                                        .equals(artifact.getScope())
+                                || Artifact.SCOPE_SYSTEM
+                                        .equals(artifact.getScope())
+                                || (Artifact.SCOPE_PROVIDED
+                                        .equals(artifact.getScope())
+                                        && artifact.getFile().getPath().matches(
+                                                INCLUDE_FROM_COMPILE_DEPS_REGEX))))
+                .collect(Collectors.toMap(keyMapper, Function.identity())));
+        if (mojoExecution != null) {
+            mojoExecution.getMojoDescriptor().getPluginDescriptor()
+                    .getArtifacts().stream()
+                    .filter(artifact -> !projectDependencies
+                            .containsKey(keyMapper.apply(artifact)))
+                    .forEach(artifact -> projectDependencies
+                            .put(keyMapper.apply(artifact), artifact));
+        }
+
+        projectDependencies.values().stream()
+                .map(artifact -> FlowFileUtils.convertToUrl(artifact.getFile()))
+                .forEach(urls::add);
+        ClassLoader mavenApiClassLoader;
+        if (mojoExecution != null) {
+            ClassRealm pluginClassRealm = mojoExecution.getMojoDescriptor()
+                    .getPluginDescriptor().getClassRealm();
+            try {
+                mavenApiClassLoader = pluginClassRealm.getWorld()
+                        .getRealm("maven.api");
+            } catch (NoSuchRealmException e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            mavenApiClassLoader = org.apache.maven.plugin.Mojo.class
+                    .getClassLoader();
+            if (mavenApiClassLoader instanceof ClassRealm classRealm) {
+                try {
+                    mavenApiClassLoader = classRealm.getWorld()
+                            .getRealm("maven.api");
+                } catch (NoSuchRealmException e) {
+                    // Should never happen. In case, ignore the error and use
+                    // class loader from the Maven class
+                }
+            }
+        }
+        return new URLClassLoader(urls.toArray(URL[]::new),
+                mavenApiClassLoader);
+    }
+
+    private void checkFlowCompatibility(PluginDescriptor pluginDescriptor) {
+        Predicate<Artifact> isFlowServer = artifact -> "com.vaadin"
+                .equals(artifact.getGroupId())
+                && "flow-server".equals(artifact.getArtifactId());
+        String projectFlowVersion = project.getArtifacts().stream()
+                .filter(isFlowServer).map(Artifact::getVersion).findFirst()
+                .orElse(null);
+        String pluginFlowVersion = pluginDescriptor.getArtifacts().stream()
+                .filter(isFlowServer).map(Artifact::getVersion).findFirst()
+                .orElse(null);
+        if (!Objects.equals(projectFlowVersion, pluginFlowVersion)) {
+            getLog().warn(
+                    "Vaadin Flow used in project does not match the version expected by the Vaadin plugin. "
+                            + "Flow version for project is "
+                            + projectFlowVersion
+                            + ", Vaadin plugin is built for Flow version "
+                            + pluginFlowVersion + ".");
+        }
+    }
+
+    private Reflector getOrCreateReflector() {
+        Map<String, Object> pluginContext = getPluginContext();
+        String pluginKey = mojoExecution.getPlugin().getKey();
+        String reflectorKey = Reflector.class.getName() + "-" + pluginKey + "-"
+                + mojoExecution.getLifecyclePhase();
+        if (pluginContext != null && pluginContext.containsKey(reflectorKey)) {
+            getLog().debug("Using cached Reflector for plugin " + pluginKey
+                    + " and phase " + mojoExecution.getLifecyclePhase());
+            return Reflector.adapt(pluginContext.get(reflectorKey));
+        }
+        Reflector reflector = Reflector.of(project, mojoExecution);
+        if (pluginContext != null) {
+            pluginContext.put(reflectorKey, reflector);
+            getLog().debug("Cached Reflector for plugin " + pluginKey
+                    + " and phase " + mojoExecution.getLifecyclePhase());
+        }
+        return reflector;
+    }
+
+    private Method findExecuteMethod(Class<?> taskClass)
+            throws NoSuchMethodException {
+
+        while (taskClass != null && taskClass != Object.class) {
+            try {
+                Method executeInternal = taskClass
+                        .getDeclaredMethod("executeInternal");
+                executeInternal.setAccessible(true);
+                return executeInternal;
+            } catch (NoSuchMethodException e) {
+                // ignore
+            }
+            taskClass = taskClass.getSuperclass();
+        }
+        throw new NoSuchMethodException(
+                "Method executeInternal not found in " + getClass().getName());
+    }
+
 }

--- a/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/Reflector.java
+++ b/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/Reflector.java
@@ -1,0 +1,397 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.plugin.maven;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.Mojo;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.classworlds.realm.NoSuchRealmException;
+
+import com.vaadin.flow.internal.ReflectTools;
+import com.vaadin.flow.server.frontend.scanner.ClassFinder;
+import com.vaadin.flow.server.scanner.ReflectionsClassFinder;
+import com.vaadin.flow.utils.FlowFileUtils;
+
+/**
+ * Helper class to deal with classloading of Flow plugin mojos.
+ */
+public final class Reflector {
+
+    public static final String INCLUDE_FROM_COMPILE_DEPS_REGEX = ".*(/|\\\\)(portlet-api|javax\\.servlet-api)-.+jar$";
+
+    private final URLClassLoader isolatedClassLoader;
+    private Object classFinder;
+
+    /**
+     * Creates a new reflector instance for the given classloader.
+     *
+     * @param isolatedClassLoader
+     *            class loader to be used to create mojo instances.
+     */
+    public Reflector(URLClassLoader isolatedClassLoader) {
+        this.isolatedClassLoader = isolatedClassLoader;
+    }
+
+    private Reflector(URLClassLoader isolatedClassLoader, Object classFinder) {
+        this.isolatedClassLoader = isolatedClassLoader;
+        this.classFinder = classFinder;
+    }
+
+    /**
+     * Gets a {@link Reflector} instance usable with the caller class loader.
+     * <p>
+     * </p>
+     * Reflector instances are cached in Maven plugin context, but instances
+     * might be associated to the plugin class loader, thus not working with
+     * classes loaded by the isolated class loader. This method returns the
+     * input object if it is compatible with the class loader, otherwise it
+     * creates a copy referencing the same isolated class loader and
+     * {@link ClassFinder}.
+     *
+     * @param reflector
+     *            the {@link Reflector} instance.
+     * @return a {@link Reflector} instance compatible with the current class
+     *         loader.
+     * @throws IllegalArgumentException
+     *             if the input object is not a {@link Reflector} instance or if
+     *             it is not possible to make a copy for it due to class
+     *             definition incompatibilities.
+     */
+    static Reflector adapt(Object reflector) {
+        if (reflector instanceof Reflector sameClassLoader) {
+            return sameClassLoader;
+        } else if (Reflector.class.getName()
+                .equals(reflector.getClass().getName())) {
+            Class<?> reflectorClass = reflector.getClass();
+            try {
+                URLClassLoader classLoader = (URLClassLoader) ReflectTools
+                        .getJavaFieldValue(reflector,
+                                findField(reflectorClass,
+                                        "isolatedClassLoader"),
+                                URLClassLoader.class);
+                Object classFinder = ReflectTools.getJavaFieldValue(reflector,
+                        findField(reflectorClass, "classFinder"));
+                return new Reflector(classLoader, classFinder);
+            } catch (Exception e) {
+                throw new IllegalArgumentException(
+                        "Object of type " + reflector.getClass().getName()
+                                + " is not a compatible Reflector",
+                        e);
+            }
+        }
+        throw new IllegalArgumentException(
+                "Object of type " + reflector.getClass().getName()
+                        + " is not a compatible Reflector");
+    }
+
+    /**
+     * Gets the isolated class loader.
+     *
+     * @return the isolated class loader.
+     */
+    public URLClassLoader getIsolatedClassLoader() {
+        return isolatedClassLoader;
+    }
+
+    /**
+     * Loads the class with the given name from the isolated classloader.
+     *
+     * @param className
+     *            the name of the class to load.
+     * @return the class object.
+     * @throws ClassNotFoundException
+     *             if the class was not found.
+     */
+    public Class<?> loadClass(String className) throws ClassNotFoundException {
+        return isolatedClassLoader.loadClass(className);
+    }
+
+    /**
+     * Get a resource from the classpath of the isolated class loader.
+     *
+     * @param name
+     *            class literal
+     * @return the resource
+     */
+    public URL getResource(String name) {
+        return isolatedClassLoader.getResource(name);
+    }
+
+    /**
+     * Creates a copy of the given Flow mojo, loading classes the isolated
+     * classloader.
+     * <p>
+     * </p>
+     * Loads the given mojo class from the isolated class loader and then
+     * creates a new instance for it and fills all field copying values from the
+     * original mojo. The input mojo must have a public no-args constructor.
+     * Mojo fields must reference types that can be safely loaded be the
+     * isolated class loader, such as JDK or Maven core API. It also creates and
+     * injects a {@link ClassFinder}, based on the isolated class loader.
+     *
+     * @param sourceMojo
+     *            The mojo for which to create the instance from the isolated
+     *            class loader.
+     * @return an instance of the mojo loaded from the isolated class loader.
+     * @throws Exception
+     *             if the mojo instance cannot be created.
+     */
+    public Mojo createMojo(BuildDevBundleMojo sourceMojo) throws Exception {
+        Class<?> targetMojoClass = loadClass(sourceMojo.getClass().getName());
+        Object targetMojo = targetMojoClass.getConstructor().newInstance();
+        copyFields(sourceMojo, targetMojo);
+        Field classFinderField = findField(targetMojoClass,
+                BuildDevBundleMojo.CLASSFINDER_FIELD_NAME);
+        ReflectTools.setJavaFieldValue(targetMojo, classFinderField,
+                getOrCreateClassFinder());
+        return (Mojo) targetMojo;
+    }
+
+    /**
+     * Gets a new {@link Reflector} instance for the current Mojo execution.
+     * <p>
+     * </p>
+     * An isolated class loader is created based on project and plugin
+     * dependencies, with the first ones having precedence over the seconds. The
+     * maven.api class realm is used as parent classloader, allowing usage of
+     * Maven core classes in the mojo.
+     *
+     * @param project
+     *            the maven project.
+     * @param mojoExecution
+     *            the current mojo execution.
+     * @return a Reflector instance for the current maven execution.
+     */
+    public static Reflector of(MavenProject project,
+            MojoExecution mojoExecution) {
+        URLClassLoader classLoader = createIsolatedClassLoader(project,
+                mojoExecution);
+        return new Reflector(classLoader);
+    }
+
+    private synchronized Object getOrCreateClassFinder() throws Exception {
+        if (classFinder == null) {
+            Class<?> classFinderImplClass = loadClass(
+                    ReflectionsClassFinder.class.getName());
+            classFinder = classFinderImplClass
+                    .getConstructor(ClassLoader.class, URL[].class).newInstance(
+                            isolatedClassLoader, isolatedClassLoader.getURLs());
+        }
+        return classFinder;
+    }
+
+    private static URLClassLoader createIsolatedClassLoader(
+            MavenProject project, MojoExecution mojoExecution) {
+        List<URL> urls = new ArrayList<>();
+        String outputDirectory = project.getBuild().getOutputDirectory();
+        if (outputDirectory != null) {
+            urls.add(FlowFileUtils.convertToUrl(new File(outputDirectory)));
+        }
+
+        Function<Artifact, String> keyMapper = artifact -> artifact.getGroupId()
+                + ":" + artifact.getArtifactId();
+
+        Map<String, Artifact> projectDependencies = new HashMap<>(project
+                .getArtifacts().stream()
+                .filter(artifact -> artifact.getFile() != null
+                        && artifact.getArtifactHandler().isAddedToClasspath()
+                        && (Artifact.SCOPE_COMPILE.equals(artifact.getScope())
+                                || Artifact.SCOPE_RUNTIME
+                                        .equals(artifact.getScope())
+                                || Artifact.SCOPE_SYSTEM
+                                        .equals(artifact.getScope())
+                                || (Artifact.SCOPE_PROVIDED
+                                        .equals(artifact.getScope())
+                                        && artifact.getFile().getPath().matches(
+                                                INCLUDE_FROM_COMPILE_DEPS_REGEX))))
+                .collect(Collectors.toMap(keyMapper, Function.identity())));
+        if (mojoExecution != null) {
+            mojoExecution.getMojoDescriptor().getPluginDescriptor()
+                    .getArtifacts().stream()
+                    .filter(artifact -> !projectDependencies
+                            .containsKey(keyMapper.apply(artifact)))
+                    .forEach(artifact -> projectDependencies
+                            .put(keyMapper.apply(artifact), artifact));
+        }
+
+        projectDependencies.values().stream()
+                .map(artifact -> FlowFileUtils.convertToUrl(artifact.getFile()))
+                .forEach(urls::add);
+        ClassLoader mavenApiClassLoader;
+        if (mojoExecution != null) {
+            ClassRealm pluginClassRealm = mojoExecution.getMojoDescriptor()
+                    .getPluginDescriptor().getClassRealm();
+            try {
+                mavenApiClassLoader = pluginClassRealm.getWorld()
+                        .getRealm("maven.api");
+            } catch (NoSuchRealmException e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            mavenApiClassLoader = Mojo.class.getClassLoader();
+            if (mavenApiClassLoader instanceof ClassRealm classRealm) {
+                try {
+                    mavenApiClassLoader = classRealm.getWorld()
+                            .getRealm("maven.api");
+                } catch (NoSuchRealmException e) {
+                    // Should never happen. In case, ignore the error and use
+                    // class loader from the Maven class
+                }
+            }
+        }
+        return new CombinedClassLoader(urls.toArray(new URL[0]),
+                mavenApiClassLoader);
+    }
+
+    // Tries to load class from the give class loader and fallbacks
+    // to Platform class loader in case of failure.
+    private static class CombinedClassLoader extends URLClassLoader {
+        private final ClassLoader delegate;
+
+        private CombinedClassLoader(URL[] urls, ClassLoader delegate) {
+            super(urls, null);
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            try {
+                return super.loadClass(name);
+            } catch (ClassNotFoundException e) {
+                // ignore and continue with delegate class loader
+            }
+            if (delegate != null) {
+                try {
+                    return delegate.loadClass(name);
+                } catch (ClassNotFoundException e) {
+                    // ignore and continue with platform class loader
+                }
+            }
+            return ClassLoader.getPlatformClassLoader().loadClass(name);
+        }
+
+        @Override
+        public URL getResource(String name) {
+            URL url = super.getResource(name);
+            if (url == null && delegate != null) {
+                url = delegate.getResource(name);
+            }
+            if (url == null) {
+                url = ClassLoader.getPlatformClassLoader().getResource(name);
+            }
+            return url;
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            Enumeration<URL> resources = super.getResources(name);
+            if (!resources.hasMoreElements() && delegate != null) {
+                resources = delegate.getResources(name);
+            }
+            if (!resources.hasMoreElements()) {
+                resources = ClassLoader.getPlatformClassLoader()
+                        .getResources(name);
+            }
+            return resources;
+        }
+    }
+
+    private void copyFields(BuildDevBundleMojo sourceMojo, Object targetMojo)
+            throws IllegalAccessException, NoSuchFieldException {
+        Class<?> sourceClass = sourceMojo.getClass();
+        Class<?> targetClass = targetMojo.getClass();
+        while (sourceClass != null && sourceClass != Object.class) {
+            for (Field sourceField : sourceClass.getDeclaredFields()) {
+                copyField(sourceMojo, targetMojo, sourceField, targetClass);
+            }
+            targetClass = targetClass.getSuperclass();
+            sourceClass = sourceClass.getSuperclass();
+        }
+    }
+
+    private static void copyField(BuildDevBundleMojo sourceMojo,
+            Object targetMojo, Field sourceField, Class<?> targetClass)
+            throws IllegalAccessException, NoSuchFieldException {
+        if (Modifier.isStatic(sourceField.getModifiers())) {
+            return;
+        }
+        sourceField.setAccessible(true);
+        Object value = sourceField.get(sourceMojo);
+        if (value == null) {
+            return;
+        }
+        Field targetField;
+        try {
+            targetField = targetClass.getDeclaredField(sourceField.getName());
+        } catch (NoSuchFieldException ex) {
+            // Should never happen, since the class definition should be
+            // the same
+            String message = "Field " + sourceField.getName() + " defined in "
+                    + sourceField.getDeclaringClass().getName()
+                    + " is missing in " + targetClass.getName();
+            sourceMojo.logError(message, ex);
+            throw ex;
+        }
+
+        Class<?> targetFieldType = targetField.getType();
+        if (!targetFieldType.isAssignableFrom(sourceField.getType())) {
+            String message = "Field " + targetFieldType.getName() + " in class "
+                    + targetClass.getName() + " of type "
+                    + targetFieldType.getName()
+                    + " is loaded from different class loaders."
+                    + " Source class loader: "
+                    + sourceField.getType().getClassLoader()
+                    + ", Target class loader: "
+                    + targetFieldType.getClassLoader()
+                    + ". This is likely a bug in the Vaadin Maven plugin."
+                    + " Please, report the error on the issue tracker.";
+            sourceMojo.logError(message);
+            throw new NoSuchFieldException(message);
+        }
+        targetField.setAccessible(true);
+        targetField.set(targetMojo, value);
+    }
+
+    private static Field findField(Class<?> clazz, String fieldName)
+            throws NoSuchFieldException {
+        while (clazz != null && !clazz.equals(Object.class)) {
+            try {
+                return clazz.getDeclaredField(fieldName);
+            } catch (NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(fieldName);
+    }
+
+}

--- a/flow-plugins/flow-maven-plugin/pom.xml
+++ b/flow-plugins/flow-maven-plugin/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.vaadin</groupId>
@@ -106,6 +106,35 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-invoker-plugin</artifactId>
+                <version>3.6.1</version>
+                <configuration>
+                    <skipInstallation>${skipTests}</skipInstallation>
+                    <skipInvocation>${skipTests}</skipInvocation>
+                    <localRepositoryPath>target/local-repo</localRepositoryPath>
+                    <extraArtifacts>
+                        <artifact>com.vaadin:flow-client:${project.version}</artifact>
+                    </extraArtifacts>
+                    <streamLogsOnFailures>true</streamLogsOnFailures>
+                    <settingsFile>src/it/settings.xml</settingsFile>
+                    <postBuildHookScript>verify</postBuildHookScript>
+                    <addTestClassPath>true</addTestClassPath>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>integration-test</id>
+                        <goals>
+                            <goal>install</goal>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
 
     </build>
 </project>

--- a/flow-plugins/flow-maven-plugin/src/it/.gitignore
+++ b/flow-plugins/flow-maven-plugin/src/it/.gitignore
@@ -1,0 +1,7 @@
+**/src/main/bundles
+**/src/main/frontend/generated
+**/src/main/frontend/index.html
+**/package*.json
+**/tsconfig.json
+**/types.d.ts
+**/vite.*.ts

--- a/flow-plugins/flow-maven-plugin/src/it/appshellconfiguration-external-annotations/invoker.properties
+++ b/flow-plugins/flow-maven-plugin/src/it/appshellconfiguration-external-annotations/invoker.properties
@@ -1,0 +1,18 @@
+#
+# Copyright 2000-2024 Vaadin Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+invoker.goals=clean package
+invoker.profiles.1=prepare-frontend-after-compile
+invoker.profiles.2=build-frontend-full-dep-scan

--- a/flow-plugins/flow-maven-plugin/src/it/appshellconfiguration-external-annotations/pom.xml
+++ b/flow-plugins/flow-maven-plugin/src/it/appshellconfiguration-external-annotations/pom.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.vaadin.test.maven</groupId>
+    <artifactId>classfinder-lookup</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+
+    <description><![CDATA[
+        Tests that prepare-frontend does not fail when both plugin and ClassFinder loads
+        transitive classes from different classloaders.
+        In this test the plugin loads classes from spring-data-commons (RepositoryFactoryBeanSupport)
+        that implements ApplicationEventPublisherAware that is however in spring-context artifact.
+        Since spring-context is referenced only by the project, by default the plugin class loader
+        would not able to find ApplicationEventPublisherAware when loading RepositoryFactoryBeanSupport,
+        causing a ClassNotFoundException exception.
+        Usually this error happens when prepare-fronted is called after compilation, or when build-frontend is
+        configured with optimizeBundle=false, causing FullDependenciesScanner to be used.
+        Flow maven plugin must make sure that class loading works fine combining plugin and project dependencies.
+    ]]></description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
+        <maven.test.skip>true</maven.test.skip>
+
+        <flow.version>@project.version@</flow.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-server</artifactId>
+            <version>${flow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-client</artifactId>
+            <version>${flow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-jpa</artifactId>
+            <version>3.3.4</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+            </plugin>
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>flow-maven-plugin</artifactId>
+                <version>${flow.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.springframework.data</groupId>
+                        <artifactId>spring-data-commons</artifactId>
+                        <version>3.3.4</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>prepare-frontend-after-compile</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.vaadin</groupId>
+                        <artifactId>flow-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>prepare-frontend</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>build-frontend-full-dep-scan</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.vaadin</groupId>
+                        <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <optimizeBundle>false</optimizeBundle>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>prepare-frontend</goal>
+                                    <goal>build-frontend</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/flow-plugins/flow-maven-plugin/src/it/appshellconfiguration-external-annotations/src/main/java/com/vaadin/test/AppConfig.java
+++ b/flow-plugins/flow-maven-plugin/src/it/appshellconfiguration-external-annotations/src/main/java/com/vaadin/test/AppConfig.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package com.vaadin.test;
+
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.component.page.AppShellConfigurator;
+
+@NpmPackage(value = "react-error-boundary", version = "4.0.13")
+@EnableJpaRepositories
+public class AppConfig implements AppShellConfigurator {
+
+}

--- a/flow-plugins/flow-maven-plugin/src/it/classfinder-lookup/invoker.properties
+++ b/flow-plugins/flow-maven-plugin/src/it/classfinder-lookup/invoker.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2000-2024 Vaadin Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+invoker.goals=clean package

--- a/flow-plugins/flow-maven-plugin/src/it/classfinder-lookup/pom.xml
+++ b/flow-plugins/flow-maven-plugin/src/it/classfinder-lookup/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.vaadin.test.maven</groupId>
+    <artifactId>classfinder-lookup</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+
+    <description>
+        Tests that there are no class loading issues for components loaded by Lookup backed by ClassFinder
+    </description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
+        <maven.test.skip>true</maven.test.skip>
+
+        <flow.version>@project.version@</flow.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-server</artifactId>
+            <version>${flow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-client</artifactId>
+            <version>${flow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin.test</groupId>
+            <artifactId>flow-addon</artifactId>
+            <version>1.0.0</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/../flow-addon/target/flow-addon-1.0.0.jar</systemPath>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+            </plugin>
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>flow-maven-plugin</artifactId>
+                <version>${flow.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-frontend</goal>
+                            <goal>build-frontend</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/flow-plugins/flow-maven-plugin/src/it/classfinder-lookup/src/main/java/com/vaadin/test/ProjectFlowExtension.java
+++ b/flow-plugins/flow-maven-plugin/src/it/classfinder-lookup/src/main/java/com/vaadin/test/ProjectFlowExtension.java
@@ -1,0 +1,21 @@
+package com.vaadin.test;
+
+import java.util.List;
+
+import com.vaadin.flow.server.frontend.Options;
+import com.vaadin.flow.server.frontend.TypeScriptBootstrapModifier;
+import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
+
+/**
+ * Hello world!
+ */
+public class ProjectFlowExtension implements TypeScriptBootstrapModifier {
+
+    @Override
+    public void modify(List<String> bootstrapTypeScript, Options options,
+            FrontendDependenciesScanner frontendDependenciesScanner) {
+        bootstrapTypeScript.add("""
+                (window as any).testProject=1;
+                """);
+    }
+}

--- a/flow-plugins/flow-maven-plugin/src/it/classfinder-lookup/verify.bsh
+++ b/flow-plugins/flow-maven-plugin/src/it/classfinder-lookup/verify.bsh
@@ -1,0 +1,14 @@
+import java.nio.file.*;
+
+vaadinTs = basedir.toPath().resolve("src/main/frontend/generated/vaadin.ts");
+if ( !Files.exists(vaadinTs, new LinkOption[0]) )
+{
+    throw new RuntimeException("vaadin.ts file not generated");
+}
+lines = Files.readAllLines(vaadinTs);
+if (!lines.contains("(window as any).testProject=1;")) {
+    throw new RuntimeException("vaadin.ts does note contain lines added by project TypeScriptBootstrapModifier");
+}
+if (!lines.contains("(window as any).testAddOn=1;")) {
+    throw new RuntimeException("vaadin.ts does note contain lines added by project dependency TypeScriptBootstrapModifier");
+}

--- a/flow-plugins/flow-maven-plugin/src/it/flow-addon/invoker.properties
+++ b/flow-plugins/flow-maven-plugin/src/it/flow-addon/invoker.properties
@@ -1,0 +1,23 @@
+#
+# Copyright 2000-2024 Vaadin Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+# High ordinal number to be executed first
+invoker.ordinal = 100
+# Not invoking clean to make sure JAR from both executions are preserved
+invoker.goals=package
+invoker.profiles.1=
+invoker.profiles.2=fake-flow-resources
+invoker.profiles.3=fake-flow-plugin-resources

--- a/flow-plugins/flow-maven-plugin/src/it/flow-addon/pom.xml
+++ b/flow-plugins/flow-maven-plugin/src/it/flow-addon/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.vaadin.test</groupId>
+    <artifactId>flow-addon</artifactId>
+    <version>1.0.0</version>
+
+    <name>flow-addon</name>
+    <description>
+        Test project to build the JAR file for other tests.
+        Run 'mvn package' on this module and then copy the JAR
+        where needed.
+    </description>
+
+    <properties>
+        <vaadin.version>@project.version@</vaadin.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
+        <maven.test.skip>true</maven.test.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-server</artifactId>
+            <version>${vaadin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.11</version>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>fake-flow-resources</id>
+            <build>
+                <finalName>fake-resources-${project.version}</finalName>
+                <resources>
+                    <resource>
+                        <directory>${project.basedir}/src/main/fake-resources</directory>
+                    </resource>
+                </resources>
+            </build>
+        </profile>
+        <profile>
+            <id>fake-flow-plugin-resources</id>
+            <build>
+                <finalName>fake-resources-plugin-${project.version}</finalName>
+                <resources>
+                    <resource>
+                        <directory>${project.basedir}/src/main/fake-plugin-resources</directory>
+                    </resource>
+                </resources>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/flow-plugins/flow-maven-plugin/src/it/flow-addon/src/main/fake-plugin-resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-plugins/flow-maven-plugin/src/it/flow-addon/src/main/fake-plugin-resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+// Resource loaded from plugin dependency
+export const serverSideRoutes = []

--- a/flow-plugins/flow-maven-plugin/src/it/flow-addon/src/main/fake-resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-plugins/flow-maven-plugin/src/it/flow-addon/src/main/fake-resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+// Resource loaded from project dependency
+export const serverSideRoutes = []

--- a/flow-plugins/flow-maven-plugin/src/it/flow-addon/src/main/java/com/vaadin/test/Addon.java
+++ b/flow-plugins/flow-maven-plugin/src/it/flow-addon/src/main/java/com/vaadin/test/Addon.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package com.vaadin.test;
+
+import java.util.List;
+
+import com.vaadin.flow.server.frontend.Options;
+import com.vaadin.flow.server.frontend.TypeScriptBootstrapModifier;
+import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
+
+public class Addon implements TypeScriptBootstrapModifier {
+
+    @Override
+    public void modify(List<String> bootstrapTypeScript, Options options,
+            FrontendDependenciesScanner frontendDependenciesScanner) {
+        bootstrapTypeScript.add("""
+                (window as any).testAddOn=1;
+                """);
+    }
+}

--- a/flow-plugins/flow-maven-plugin/src/it/resources-from-project/invoker.properties
+++ b/flow-plugins/flow-maven-plugin/src/it/resources-from-project/invoker.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2000-2024 Vaadin Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+invoker.goals=clean package

--- a/flow-plugins/flow-maven-plugin/src/it/resources-from-project/pom.xml
+++ b/flow-plugins/flow-maven-plugin/src/it/resources-from-project/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.vaadin.test.maven</groupId>
+    <artifactId>resources-from-project</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+
+    <description>
+        Tests that plugin dependencies do not override resources from project artifacts.
+    </description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
+        <maven.test.skip>true</maven.test.skip>
+
+        <flow.version>@project.version@</flow.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-server</artifactId>
+            <version>${flow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-client</artifactId>
+            <version>${flow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin.test</groupId>
+            <artifactId>fake-flow-resources</artifactId>
+            <version>1.0.0</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/../flow-addon/target/fake-resources-1.0.0.jar</systemPath>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+            </plugin>
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>flow-maven-plugin</artifactId>
+                <version>${flow.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-frontend</goal>
+                            <goal>build-frontend</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.vaadin.test</groupId>
+                        <artifactId>fake-flow-resources</artifactId>
+                        <version>1.0.0</version>
+                        <scope>system</scope>
+                        <systemPath>${project.basedir}/../flow-addon/target/fake-resources-plugin-1.0.0.jar</systemPath>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/flow-plugins/flow-maven-plugin/src/it/resources-from-project/src/main/java/com/vaadin/test/ProjectFlowExtension.java
+++ b/flow-plugins/flow-maven-plugin/src/it/resources-from-project/src/main/java/com/vaadin/test/ProjectFlowExtension.java
@@ -1,0 +1,20 @@
+package com.vaadin.test;
+
+import java.util.List;
+
+import com.vaadin.flow.server.frontend.Options;
+import com.vaadin.flow.server.frontend.TypeScriptBootstrapModifier;
+import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
+
+/**
+ * Hello world!
+ */
+public class ProjectFlowExtension implements TypeScriptBootstrapModifier {
+
+    @Override
+    public void modify(List<String> bootstrapTypeScript, Options options,
+            FrontendDependenciesScanner frontendDependenciesScanner) {
+        System.out.println("ProjectFlowExtension");
+        bootstrapTypeScript.add("(window as any).testProject=1;");
+    }
+}

--- a/flow-plugins/flow-maven-plugin/src/it/resources-from-project/verify.bsh
+++ b/flow-plugins/flow-maven-plugin/src/it/resources-from-project/verify.bsh
@@ -1,0 +1,12 @@
+import java.nio.file.*;
+
+flowTsx = basedir.toPath().resolve("src/main/frontend/generated/flow/Flow.tsx");
+if ( !Files.exists(flowTsx, new LinkOption[0]) )
+{
+    throw new RuntimeException("Flow.tsx file not generated");
+}
+
+lines = Files.readAllLines(flowTsx);
+if (lines.contains("// Resource loaded from plugin dependency")) {
+    throw new RuntimeException("Flow.tsx has been extracted from plugin classloader");
+}

--- a/flow-plugins/flow-maven-plugin/src/it/settings.xml
+++ b/flow-plugins/flow-maven-plugin/src/it/settings.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright 2000-2024 Vaadin Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+
+<settings>
+    <profiles>
+        <profile>
+            <id>it-repo</id>
+            <repositories>
+                <repository>
+                    <id>local.central</id>
+                    <url>@localRepositoryUrl@</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>local.central</id>
+                    <url>@localRepositoryUrl@</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
+    <activeProfiles>
+        <activeProfile>it-repo</activeProfile>
+    </activeProfiles>
+</settings>

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -133,7 +133,8 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo
     private boolean cleanFrontendFiles;
 
     @Override
-    public void execute() throws MojoExecutionException, MojoFailureException {
+    protected void executeInternal()
+            throws MojoExecutionException, MojoFailureException {
         long start = System.nanoTime();
 
         TaskCleanFrontendFiles cleanTask = new TaskCleanFrontendFiles(

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/CleanFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/CleanFrontendMojo.java
@@ -40,7 +40,7 @@ import com.vaadin.flow.plugin.base.CleanOptions;
 public class CleanFrontendMojo extends FlowModeAbstractMojo {
 
     @Override
-    public void execute() throws MojoFailureException {
+    protected void executeInternal() throws MojoFailureException {
         try {
             CleanFrontendUtil.runCleaning(this, new CleanOptions());
         } catch (CleanFrontendException e) {

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/ConvertPolymerMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/ConvertPolymerMojo.java
@@ -50,7 +50,7 @@ public class ConvertPolymerMojo extends FlowModeAbstractMojo {
     private boolean disableOptionalChaining;
 
     @Override
-    public void execute() throws MojoFailureException {
+    protected void executeInternal() throws MojoFailureException {
         if (isHillaUsed(frontendDirectory())) {
             getLog().warn(
                     """

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -15,23 +15,37 @@
  */
 package com.vaadin.flow.plugin.maven;
 
+import javax.inject.Inject;
+
 import java.io.File;
+import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.Mojo;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.build.BuildContext;
 
 import com.vaadin.flow.internal.StringUtil;
 import com.vaadin.flow.plugin.base.BuildFrontendUtil;
@@ -43,6 +57,7 @@ import com.vaadin.flow.server.frontend.FrontendUtils;
 import com.vaadin.flow.server.frontend.installer.NodeInstaller;
 import com.vaadin.flow.server.frontend.installer.Platform;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
+import com.vaadin.flow.server.scanner.ReflectionsClassFinder;
 
 import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
 import static com.vaadin.flow.server.Constants.VAADIN_WEBAPP_RESOURCES;
@@ -171,6 +186,9 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     MavenProject project;
 
+    @Parameter(defaultValue = "${mojoExecution}")
+    MojoExecution mojoExecution;
+
     /**
      * The folder where `package.json` file is located. Default is project root
      * dir.
@@ -242,7 +260,68 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
     @Parameter(property = InitParameters.APPLICATION_IDENTIFIER)
     private String applicationIdentifier;
 
+    static final String CLASSFINDER_FIELD_NAME = "classFinder";
     private ClassFinder classFinder;
+
+    private Consumer<File> buildContextRefresher;
+
+    @Inject
+    void setBuildContext(BuildContext buildContext) {
+        buildContextRefresher = buildContext::refresh;
+    }
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        PluginDescriptor pluginDescriptor = mojoExecution.getMojoDescriptor()
+                .getPluginDescriptor();
+        checkFlowCompatibility(pluginDescriptor);
+
+        Reflector reflector = getOrCreateReflector();
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread()
+                .setContextClassLoader(reflector.getIsolatedClassLoader());
+        try {
+            Mojo task = reflector.createMojo(this);
+            findExecuteMethod(task.getClass()).invoke(task);
+        } catch (MojoExecutionException | MojoFailureException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new MojoFailureException(e.getMessage(), e);
+        } finally {
+            Thread.currentThread().setContextClassLoader(tccl);
+        }
+    }
+
+    /**
+     * Perform whatever build-process behavior this <code>Mojo</code>
+     * implements.<br>
+     * This is the main trigger for the <code>Mojo</code> inside the
+     * <code>Maven</code> system, and allows the <code>Mojo</code> to
+     * communicate errors.
+     *
+     * @throws MojoExecutionException
+     *             if an unexpected problem occurs. Throwing this exception
+     *             causes a "BUILD ERROR" message to be displayed.
+     * @throws MojoFailureException
+     *             if an expected problem (such as a compilation failure)
+     *             occurs. Throwing this exception causes a "BUILD FAILURE"
+     *             message to be displayed.
+     */
+    protected abstract void executeInternal()
+            throws MojoExecutionException, MojoFailureException;
+
+    /**
+     * Indicates that the file or folder content has been modified during the
+     * build.
+     *
+     * @param file
+     *            a {@link java.io.File} object.
+     */
+    protected void triggerRefresh(File file) {
+        if (buildContextRefresher != null) {
+            buildContextRefresher.accept(file);
+        }
+    }
 
     /**
      * Generates a List of ClasspathElements (Run and CompileTime) from a
@@ -251,7 +330,9 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
      * @param project
      *            a given MavenProject
      * @return List of ClasspathElements
+     * @deprecated will be removed without replacement.
      */
+    @Deprecated(forRemoval = true)
     public static List<String> getClasspathElements(MavenProject project) {
 
         try {
@@ -276,7 +357,7 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
      * @return true if Hilla is available, false otherwise
      */
     public boolean isHillaAvailable() {
-        return getClassFinder().getResource(
+        return getOrCreateReflector().getResource(
                 "com/vaadin/hilla/EndpointController.class") != null;
     }
 
@@ -288,7 +369,7 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
      * @return true if Hilla is available, false otherwise
      */
     public static boolean isHillaAvailable(MavenProject mavenProject) {
-        return createClassFinder(mavenProject).getResource(
+        return Reflector.of(mavenProject, null).getResource(
                 "com/vaadin/hilla/EndpointController.class") != null;
     }
 
@@ -351,14 +432,12 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
     @Override
     public ClassFinder getClassFinder() {
         if (classFinder == null) {
-            classFinder = createClassFinder(project);
+            URLClassLoader classLoader = getOrCreateReflector()
+                    .getIsolatedClassLoader();
+            classFinder = new ReflectionsClassFinder(classLoader,
+                    classLoader.getURLs());
         }
         return classFinder;
-    }
-
-    private static ClassFinder createClassFinder(MavenProject project) {
-        List<String> classpathElements = getClasspathElements(project);
-        return BuildFrontendUtil.getClassFinder(classpathElements);
     }
 
     @Override
@@ -569,5 +648,62 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
         return "app-" + StringUtil.getHash(
                 project.getGroupId() + ":" + project.getArtifactId(),
                 StandardCharsets.UTF_8);
+    }
+
+    private void checkFlowCompatibility(PluginDescriptor pluginDescriptor) {
+        Predicate<Artifact> isFlowServer = artifact -> "com.vaadin"
+                .equals(artifact.getGroupId())
+                && "flow-server".equals(artifact.getArtifactId());
+        String projectFlowVersion = project.getArtifacts().stream()
+                .filter(isFlowServer).map(Artifact::getVersion).findFirst()
+                .orElse(null);
+        String pluginFlowVersion = pluginDescriptor.getArtifacts().stream()
+                .filter(isFlowServer).map(Artifact::getVersion).findFirst()
+                .orElse(null);
+        if (!Objects.equals(projectFlowVersion, pluginFlowVersion)) {
+            getLog().warn(
+                    "Vaadin Flow used in project does not match the version expected by the Vaadin plugin. "
+                            + "Flow version for project is "
+                            + projectFlowVersion
+                            + ", Vaadin plugin is built for Flow version "
+                            + pluginFlowVersion + ".");
+        }
+    }
+
+    private Method findExecuteMethod(Class<?> taskClass)
+            throws NoSuchMethodException {
+
+        while (taskClass != null && taskClass != Object.class) {
+            try {
+                Method executeInternal = taskClass
+                        .getDeclaredMethod("executeInternal");
+                executeInternal.setAccessible(true);
+                return executeInternal;
+            } catch (NoSuchMethodException e) {
+                // ignore
+            }
+            taskClass = taskClass.getSuperclass();
+        }
+        throw new NoSuchMethodException(
+                "Method executeInternal not found in " + getClass().getName());
+    }
+
+    private Reflector getOrCreateReflector() {
+        Map<String, Object> pluginContext = getPluginContext();
+        String pluginKey = mojoExecution.getPlugin().getKey();
+        String reflectorKey = Reflector.class.getName() + "-" + pluginKey + "-"
+                + mojoExecution.getLifecyclePhase();
+        if (pluginContext != null && pluginContext.containsKey(reflectorKey)) {
+            getLog().debug("Using cached Reflector for plugin " + pluginKey
+                    + " and phase " + mojoExecution.getLifecyclePhase());
+            return Reflector.adapt(pluginContext.get(reflectorKey));
+        }
+        Reflector reflector = Reflector.of(project, mojoExecution);
+        if (pluginContext != null) {
+            pluginContext.put(reflectorKey, reflector);
+            getLog().debug("Cached Reflector for plugin " + pluginKey
+                    + " and phase " + mojoExecution.getLifecyclePhase());
+        }
+        return reflector;
     }
 }

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/GenerateNpmBOMMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/GenerateNpmBOMMojo.java
@@ -138,7 +138,8 @@ public class GenerateNpmBOMMojo extends FlowModeAbstractMojo {
     private String specVersion;
 
     @Override
-    public void execute() throws MojoExecutionException, MojoFailureException {
+    protected void executeInternal()
+            throws MojoExecutionException, MojoFailureException {
         InvocationRequestBuilder requestBuilder = new InvocationRequestBuilder();
         InvocationRequest request = requestBuilder.groupId(GROUP)
                 .artifactId(ARTIFACT).version(VERSION).goal(GOAL)

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
@@ -16,16 +16,12 @@
 package com.vaadin.flow.plugin.maven;
 
 import java.io.File;
-import java.io.IOException;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
-import org.codehaus.plexus.build.BuildContext;
 
 import com.vaadin.flow.plugin.base.BuildFrontendUtil;
 
@@ -41,11 +37,9 @@ import com.vaadin.flow.plugin.base.BuildFrontendUtil;
 @Mojo(name = "prepare-frontend", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, defaultPhase = LifecyclePhase.PROCESS_RESOURCES)
 public class PrepareFrontendMojo extends FlowModeAbstractMojo {
 
-    @Component
-    private BuildContext buildContext; // m2eclipse integration
-
     @Override
-    public void execute() throws MojoExecutionException, MojoFailureException {
+    protected void executeInternal()
+            throws MojoExecutionException, MojoFailureException {
         if (productionMode != null) {
             logWarn("The <productionMode>" + productionMode
                     + "</productionMode> Maven parameter no longer has any effect and can be removed. Production mode is automatically enabled when you run the build-frontend target.");
@@ -56,9 +50,7 @@ public class PrepareFrontendMojo extends FlowModeAbstractMojo {
 
         // Inform m2eclipse that the directory containing the token file has
         // been updated in order to trigger server re-deployment (#6103)
-        if (buildContext != null) {
-            buildContext.refresh(tokenFile.getParentFile());
-        }
+        triggerRefresh(tokenFile.getParentFile());
 
         try {
             BuildFrontendUtil.prepareFrontend(this);

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/Reflector.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/Reflector.java
@@ -1,0 +1,397 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.plugin.maven;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.Mojo;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.classworlds.realm.NoSuchRealmException;
+
+import com.vaadin.flow.internal.ReflectTools;
+import com.vaadin.flow.server.frontend.scanner.ClassFinder;
+import com.vaadin.flow.server.scanner.ReflectionsClassFinder;
+import com.vaadin.flow.utils.FlowFileUtils;
+
+/**
+ * Helper class to deal with classloading of Flow plugin mojos.
+ */
+public final class Reflector {
+
+    public static final String INCLUDE_FROM_COMPILE_DEPS_REGEX = ".*(/|\\\\)(portlet-api|javax\\.servlet-api)-.+jar$";
+
+    private final URLClassLoader isolatedClassLoader;
+    private Object classFinder;
+
+    /**
+     * Creates a new reflector instance for the given classloader.
+     *
+     * @param isolatedClassLoader
+     *            class loader to be used to create mojo instances.
+     */
+    public Reflector(URLClassLoader isolatedClassLoader) {
+        this.isolatedClassLoader = isolatedClassLoader;
+    }
+
+    private Reflector(URLClassLoader isolatedClassLoader, Object classFinder) {
+        this.isolatedClassLoader = isolatedClassLoader;
+        this.classFinder = classFinder;
+    }
+
+    /**
+     * Gets a {@link Reflector} instance usable with the caller class loader.
+     * <p>
+     * </p>
+     * Reflector instances are cached in Maven plugin context, but instances
+     * might be associated to the plugin class loader, thus not working with
+     * classes loaded by the isolated class loader. This method returns the
+     * input object if it is compatible with the class loader, otherwise it
+     * creates a copy referencing the same isolated class loader and
+     * {@link ClassFinder}.
+     *
+     * @param reflector
+     *            the {@link Reflector} instance.
+     * @return a {@link Reflector} instance compatible with the current class
+     *         loader.
+     * @throws IllegalArgumentException
+     *             if the input object is not a {@link Reflector} instance or if
+     *             it is not possible to make a copy for it due to class
+     *             definition incompatibilities.
+     */
+    static Reflector adapt(Object reflector) {
+        if (reflector instanceof Reflector sameClassLoader) {
+            return sameClassLoader;
+        } else if (Reflector.class.getName()
+                .equals(reflector.getClass().getName())) {
+            Class<?> reflectorClass = reflector.getClass();
+            try {
+                URLClassLoader classLoader = (URLClassLoader) ReflectTools
+                        .getJavaFieldValue(reflector,
+                                findField(reflectorClass,
+                                        "isolatedClassLoader"),
+                                URLClassLoader.class);
+                Object classFinder = ReflectTools.getJavaFieldValue(reflector,
+                        findField(reflectorClass, "classFinder"));
+                return new Reflector(classLoader, classFinder);
+            } catch (Exception e) {
+                throw new IllegalArgumentException(
+                        "Object of type " + reflector.getClass().getName()
+                                + " is not a compatible Reflector",
+                        e);
+            }
+        }
+        throw new IllegalArgumentException(
+                "Object of type " + reflector.getClass().getName()
+                        + " is not a compatible Reflector");
+    }
+
+    /**
+     * Gets the isolated class loader.
+     *
+     * @return the isolated class loader.
+     */
+    public URLClassLoader getIsolatedClassLoader() {
+        return isolatedClassLoader;
+    }
+
+    /**
+     * Loads the class with the given name from the isolated classloader.
+     *
+     * @param className
+     *            the name of the class to load.
+     * @return the class object.
+     * @throws ClassNotFoundException
+     *             if the class was not found.
+     */
+    public Class<?> loadClass(String className) throws ClassNotFoundException {
+        return isolatedClassLoader.loadClass(className);
+    }
+
+    /**
+     * Get a resource from the classpath of the isolated class loader.
+     *
+     * @param name
+     *            class literal
+     * @return the resource
+     */
+    public URL getResource(String name) {
+        return isolatedClassLoader.getResource(name);
+    }
+
+    /**
+     * Creates a copy of the given Flow mojo, loading classes the isolated
+     * classloader.
+     * <p>
+     * </p>
+     * Loads the given mojo class from the isolated class loader and then
+     * creates a new instance for it and fills all field copying values from the
+     * original mojo. The input mojo must have a public no-args constructor.
+     * Mojo fields must reference types that can be safely loaded be the
+     * isolated class loader, such as JDK or Maven core API. It also creates and
+     * injects a {@link ClassFinder}, based on the isolated class loader.
+     *
+     * @param sourceMojo
+     *            The mojo for which to create the instance from the isolated
+     *            class loader.
+     * @return an instance of the mojo loaded from the isolated class loader.
+     * @throws Exception
+     *             if the mojo instance cannot be created.
+     */
+    public Mojo createMojo(FlowModeAbstractMojo sourceMojo) throws Exception {
+        Class<?> targetMojoClass = loadClass(sourceMojo.getClass().getName());
+        Object targetMojo = targetMojoClass.getConstructor().newInstance();
+        copyFields(sourceMojo, targetMojo);
+        Field classFinderField = findField(targetMojoClass,
+                FlowModeAbstractMojo.CLASSFINDER_FIELD_NAME);
+        ReflectTools.setJavaFieldValue(targetMojo, classFinderField,
+                getOrCreateClassFinder());
+        return (Mojo) targetMojo;
+    }
+
+    /**
+     * Gets a new {@link Reflector} instance for the current Mojo execution.
+     * <p>
+     * </p>
+     * An isolated class loader is created based on project and plugin
+     * dependencies, with the first ones having precedence over the seconds. The
+     * maven.api class realm is used as parent classloader, allowing usage of
+     * Maven core classes in the mojo.
+     *
+     * @param project
+     *            the maven project.
+     * @param mojoExecution
+     *            the current mojo execution.
+     * @return a Reflector instance for the current maven execution.
+     */
+    public static Reflector of(MavenProject project,
+            MojoExecution mojoExecution) {
+        URLClassLoader classLoader = createIsolatedClassLoader(project,
+                mojoExecution);
+        return new Reflector(classLoader);
+    }
+
+    private synchronized Object getOrCreateClassFinder() throws Exception {
+        if (classFinder == null) {
+            Class<?> classFinderImplClass = loadClass(
+                    ReflectionsClassFinder.class.getName());
+            classFinder = classFinderImplClass
+                    .getConstructor(ClassLoader.class, URL[].class).newInstance(
+                            isolatedClassLoader, isolatedClassLoader.getURLs());
+        }
+        return classFinder;
+    }
+
+    private static URLClassLoader createIsolatedClassLoader(
+            MavenProject project, MojoExecution mojoExecution) {
+        List<URL> urls = new ArrayList<>();
+        String outputDirectory = project.getBuild().getOutputDirectory();
+        if (outputDirectory != null) {
+            urls.add(FlowFileUtils.convertToUrl(new File(outputDirectory)));
+        }
+
+        Function<Artifact, String> keyMapper = artifact -> artifact.getGroupId()
+                + ":" + artifact.getArtifactId();
+
+        Map<String, Artifact> projectDependencies = new HashMap<>(project
+                .getArtifacts().stream()
+                .filter(artifact -> artifact.getFile() != null
+                        && artifact.getArtifactHandler().isAddedToClasspath()
+                        && (Artifact.SCOPE_COMPILE.equals(artifact.getScope())
+                                || Artifact.SCOPE_RUNTIME
+                                        .equals(artifact.getScope())
+                                || Artifact.SCOPE_SYSTEM
+                                        .equals(artifact.getScope())
+                                || (Artifact.SCOPE_PROVIDED
+                                        .equals(artifact.getScope())
+                                        && artifact.getFile().getPath().matches(
+                                                INCLUDE_FROM_COMPILE_DEPS_REGEX))))
+                .collect(Collectors.toMap(keyMapper, Function.identity())));
+        if (mojoExecution != null) {
+            mojoExecution.getMojoDescriptor().getPluginDescriptor()
+                    .getArtifacts().stream()
+                    .filter(artifact -> !projectDependencies
+                            .containsKey(keyMapper.apply(artifact)))
+                    .forEach(artifact -> projectDependencies
+                            .put(keyMapper.apply(artifact), artifact));
+        }
+
+        projectDependencies.values().stream()
+                .map(artifact -> FlowFileUtils.convertToUrl(artifact.getFile()))
+                .forEach(urls::add);
+        ClassLoader mavenApiClassLoader;
+        if (mojoExecution != null) {
+            ClassRealm pluginClassRealm = mojoExecution.getMojoDescriptor()
+                    .getPluginDescriptor().getClassRealm();
+            try {
+                mavenApiClassLoader = pluginClassRealm.getWorld()
+                        .getRealm("maven.api");
+            } catch (NoSuchRealmException e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            mavenApiClassLoader = Mojo.class.getClassLoader();
+            if (mavenApiClassLoader instanceof ClassRealm classRealm) {
+                try {
+                    mavenApiClassLoader = classRealm.getWorld()
+                            .getRealm("maven.api");
+                } catch (NoSuchRealmException e) {
+                    // Should never happen. In case, ignore the error and use
+                    // class loader from the Maven class
+                }
+            }
+        }
+        return new CombinedClassLoader(urls.toArray(new URL[0]),
+                mavenApiClassLoader);
+    }
+
+    // Tries to load class from the give class loader and fallbacks
+    // to Platform class loader in case of failure.
+    private static class CombinedClassLoader extends URLClassLoader {
+        private final ClassLoader delegate;
+
+        private CombinedClassLoader(URL[] urls, ClassLoader delegate) {
+            super(urls, null);
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            try {
+                return super.loadClass(name);
+            } catch (ClassNotFoundException e) {
+                // ignore and continue with delegate class loader
+            }
+            if (delegate != null) {
+                try {
+                    return delegate.loadClass(name);
+                } catch (ClassNotFoundException e) {
+                    // ignore and continue with platform class loader
+                }
+            }
+            return ClassLoader.getPlatformClassLoader().loadClass(name);
+        }
+
+        @Override
+        public URL getResource(String name) {
+            URL url = super.getResource(name);
+            if (url == null && delegate != null) {
+                url = delegate.getResource(name);
+            }
+            if (url == null) {
+                url = ClassLoader.getPlatformClassLoader().getResource(name);
+            }
+            return url;
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            Enumeration<URL> resources = super.getResources(name);
+            if (!resources.hasMoreElements() && delegate != null) {
+                resources = delegate.getResources(name);
+            }
+            if (!resources.hasMoreElements()) {
+                resources = ClassLoader.getPlatformClassLoader()
+                        .getResources(name);
+            }
+            return resources;
+        }
+    }
+
+    private void copyFields(FlowModeAbstractMojo sourceMojo, Object targetMojo)
+            throws IllegalAccessException, NoSuchFieldException {
+        Class<?> sourceClass = sourceMojo.getClass();
+        Class<?> targetClass = targetMojo.getClass();
+        while (sourceClass != null && sourceClass != Object.class) {
+            for (Field sourceField : sourceClass.getDeclaredFields()) {
+                copyField(sourceMojo, targetMojo, sourceField, targetClass);
+            }
+            targetClass = targetClass.getSuperclass();
+            sourceClass = sourceClass.getSuperclass();
+        }
+    }
+
+    private static void copyField(FlowModeAbstractMojo sourceMojo,
+            Object targetMojo, Field sourceField, Class<?> targetClass)
+            throws IllegalAccessException, NoSuchFieldException {
+        if (Modifier.isStatic(sourceField.getModifiers())) {
+            return;
+        }
+        sourceField.setAccessible(true);
+        Object value = sourceField.get(sourceMojo);
+        if (value == null) {
+            return;
+        }
+        Field targetField;
+        try {
+            targetField = targetClass.getDeclaredField(sourceField.getName());
+        } catch (NoSuchFieldException ex) {
+            // Should never happen, since the class definition should be
+            // the same
+            String message = "Field " + sourceField.getName() + " defined in "
+                    + sourceField.getDeclaringClass().getName()
+                    + " is missing in " + targetClass.getName();
+            sourceMojo.logError(message, ex);
+            throw ex;
+        }
+
+        Class<?> targetFieldType = targetField.getType();
+        if (!targetFieldType.isAssignableFrom(sourceField.getType())) {
+            String message = "Field " + targetFieldType.getName() + " in class "
+                    + targetClass.getName() + " of type "
+                    + targetFieldType.getName()
+                    + " is loaded from different class loaders."
+                    + " Source class loader: "
+                    + sourceField.getType().getClassLoader()
+                    + ", Target class loader: "
+                    + targetFieldType.getClassLoader()
+                    + ". This is likely a bug in the Vaadin Maven plugin."
+                    + " Please, report the error on the issue tracker.";
+            sourceMojo.logError(message);
+            throw new NoSuchFieldException(message);
+        }
+        targetField.setAccessible(true);
+        targetField.set(targetMojo, value);
+    }
+
+    private static Field findField(Class<?> clazz, String fieldName)
+            throws NoSuchFieldException {
+        while (clazz != null && !clazz.equals(Object.class)) {
+            try {
+                return clazz.getDeclaredField(fieldName);
+            } catch (NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(fieldName);
+    }
+
+}

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
@@ -29,10 +29,35 @@ import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.model.Build;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.ReflectionUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
 
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.internal.StringUtil;
@@ -44,25 +69,10 @@ import com.vaadin.flow.server.frontend.FrontendTools;
 import com.vaadin.flow.server.frontend.FrontendUtils;
 import com.vaadin.flow.server.frontend.installer.NodeInstaller;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
+
 import elemental.json.Json;
 import elemental.json.JsonObject;
 import elemental.json.impl.JsonUtil;
-import org.apache.maven.model.Build;
-import org.apache.maven.plugin.AbstractMojo;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.util.FileUtils;
-import org.codehaus.plexus.util.ReflectionUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.mockito.Mockito;
-
-import static java.io.File.pathSeparator;
 
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 import static com.vaadin.flow.server.Constants.TARGET;
@@ -79,8 +89,7 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
 import static com.vaadin.flow.server.frontend.FrontendUtils.TOKEN_FILE;
 import static com.vaadin.flow.server.frontend.FrontendUtils.VITE_CONFIG;
 import static com.vaadin.flow.server.frontend.FrontendUtils.VITE_GENERATED_CONFIG;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static java.io.File.pathSeparator;
 
 public class BuildFrontendMojoTest {
     public static final String TEST_PROJECT_RESOURCE_JS = "test_project_resource.js";
@@ -221,16 +230,48 @@ public class BuildFrontendMojoTest {
 
     static void setProject(AbstractMojo mojo, File baseFolder)
             throws Exception {
-        Build buildMock = mock(Build.class);
-        when(buildMock.getFinalName()).thenReturn("finalName");
-        MavenProject project = mock(MavenProject.class);
-        Mockito.when(project.getGroupId()).thenReturn("com.vaadin.testing");
-        Mockito.when(project.getArtifactId()).thenReturn("my-application");
-        when(project.getBasedir()).thenReturn(baseFolder);
-        when(project.getBuild()).thenReturn(buildMock);
-        when(project.getRuntimeClasspathElements())
-                .thenReturn(getClassPath(baseFolder.toPath()));
+        mojo.setPluginContext(new HashMap<>());
+
+        MavenProject project = new MavenProject();
+        project.setGroupId("com.vaadin.testing");
+        project.setArtifactId("my-application");
+        project.setFile(baseFolder.toPath().resolve("pom.xml").toFile());
+        project.setBuild(new Build());
+        project.getBuild().setFinalName("finalName");
+
+        List<String> classPath = getClassPath(baseFolder.toPath()).stream()
+                // Exclude maven jars so classes will be loaded by them fake
+                // maven.api realm that will be the same for the test class
+                // and the mojo execution
+                .filter(path -> !path.matches(".*([\\\\/])maven-.*\\.jar"))
+                .toList();
+        AtomicInteger dependencyCounter = new AtomicInteger();
+        project.setArtifacts(classPath.stream().map(path -> {
+            DefaultArtifactHandler artifactHandler = new DefaultArtifactHandler();
+            artifactHandler.setAddedToClasspath(true);
+            DefaultArtifact artifact = new DefaultArtifact("com.vaadin.testing",
+                    "dep-" + dependencyCounter.incrementAndGet(), "1.0",
+                    "compile", "jar", null, artifactHandler);
+            artifact.setFile(new File(path));
+            return artifact;
+        }).collect(Collectors.toSet()));
         ReflectionUtils.setVariableValueInObject(mojo, "project", project);
+
+        ClassWorld classWorld = new ClassWorld();
+        ClassRealm mavenApiRealm = classWorld.newRealm("maven.api", null);
+        mavenApiRealm.importFrom(MavenProject.class.getClassLoader(), "");
+        ClassRealm pluginClassRealm = classWorld.newRealm("flow-plugin", null);
+
+        PluginDescriptor pluginDescriptor = new PluginDescriptor();
+        pluginDescriptor.setArtifacts(List.of());
+        pluginDescriptor.setClassRealm(pluginClassRealm);
+        pluginDescriptor.setPlugin(new Plugin());
+        pluginDescriptor.setClassRealm(pluginClassRealm);
+        MojoDescriptor mojoDescriptor = new MojoDescriptor();
+        mojoDescriptor.setPluginDescriptor(pluginDescriptor);
+        MojoExecution mojoExecution = new MojoExecution(mojoDescriptor);
+        ReflectionUtils.setVariableValueInObject(mojo, "mojoExecution",
+                mojoExecution);
     }
 
     @Test

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/CleanFrontendMojoTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/CleanFrontendMojoTest.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
 
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.FileUtils;
@@ -112,7 +113,8 @@ public class CleanFrontendMojoTest {
     }
 
     @Test
-    public void should_removeNodeModulesFolder() throws MojoFailureException {
+    public void should_removeNodeModulesFolder()
+            throws MojoFailureException, MojoExecutionException {
         final File nodeModules = new File(projectBase, NODE_MODULES);
         Assert.assertTrue("Failed to create 'node_modules'",
                 nodeModules.mkdirs());
@@ -123,7 +125,7 @@ public class CleanFrontendMojoTest {
 
     @Test
     public void should_notRemoveNodeModulesFolder_hilla()
-            throws MojoFailureException, IOException {
+            throws MojoFailureException, IOException, MojoExecutionException {
         enableHilla();
         final File nodeModules = new File(projectBase, NODE_MODULES);
         Assert.assertTrue("Failed to create 'node_modules'",
@@ -135,7 +137,7 @@ public class CleanFrontendMojoTest {
 
     @Test
     public void should_removeCompressedDevBundle()
-            throws MojoFailureException, IOException {
+            throws MojoFailureException, IOException, MojoExecutionException {
         final File devBundleDir = new File(projectBase,
                 Constants.BUNDLE_LOCATION);
         final File devBundle = new File(projectBase,
@@ -150,7 +152,8 @@ public class CleanFrontendMojoTest {
     }
 
     @Test
-    public void should_removeOldDevBundle() throws MojoFailureException {
+    public void should_removeOldDevBundle()
+            throws MojoFailureException, MojoExecutionException {
         final File devBundleDir = new File(projectBase, "src/main/dev-bundle/");
         Assert.assertTrue("Failed to create 'dev-bundle' folder",
                 devBundleDir.mkdirs());
@@ -161,7 +164,7 @@ public class CleanFrontendMojoTest {
 
     @Test
     public void should_removeFrontendGeneratedFolder()
-            throws MojoFailureException, IOException {
+            throws MojoFailureException, IOException, MojoExecutionException {
         Assert.assertTrue("Failed to create 'frontend/generated'",
                 frontendGenerated.mkdirs());
         FileUtils.fileWrite(new File(frontendGenerated, "my_theme.js"),
@@ -175,7 +178,8 @@ public class CleanFrontendMojoTest {
 
     @Test
     public void should_removeGeneratedFolderForCustomFrontendFolder()
-            throws MojoFailureException, IOException, IllegalAccessException {
+            throws MojoFailureException, IOException, IllegalAccessException,
+            MojoExecutionException {
 
         File customFrontendFolder = new File(projectBase, "src/main/frontend");
         File customFrontendGenerated = new File(customFrontendFolder,
@@ -199,7 +203,7 @@ public class CleanFrontendMojoTest {
 
     @Test
     public void should_removeNpmPackageLockFile()
-            throws MojoFailureException, IOException {
+            throws MojoFailureException, IOException, MojoExecutionException {
         final File packageLock = new File(projectBase, "package-lock.json");
         FileUtils.fileWrite(packageLock, "{ \"fake\": \"lock\"}");
 
@@ -210,7 +214,7 @@ public class CleanFrontendMojoTest {
 
     @Test
     public void should_notRemoveNpmPackageLockFile_hilla()
-            throws MojoFailureException, IOException {
+            throws MojoFailureException, IOException, MojoExecutionException {
         enableHilla();
         final File packageLock = new File(projectBase, "package-lock.json");
         FileUtils.fileWrite(packageLock, "{ \"fake\": \"lock\"}");
@@ -222,7 +226,7 @@ public class CleanFrontendMojoTest {
 
     @Test
     public void should_removePnpmFile()
-            throws MojoFailureException, IOException {
+            throws MojoFailureException, IOException, MojoExecutionException {
         final File pnpmFile = new File(projectBase, ".pnpmfile.cjs");
         FileUtils.fileWrite(pnpmFile, "{ \"fake\": \"pnpmfile\"}");
 
@@ -232,7 +236,7 @@ public class CleanFrontendMojoTest {
 
     @Test
     public void should_removePnpmPackageLockFile()
-            throws MojoFailureException, IOException {
+            throws MojoFailureException, IOException, MojoExecutionException {
         final File pnpmLock = new File(projectBase, "pnpm-lock.yaml");
         FileUtils.fileWrite(pnpmLock, "lockVersion: -1");
         mojo.execute();
@@ -241,7 +245,7 @@ public class CleanFrontendMojoTest {
 
     @Test
     public void should_cleanPackageJson_removeVaadinAndHashObjects()
-            throws MojoFailureException, IOException {
+            throws MojoFailureException, IOException, MojoExecutionException {
         JsonObject json = createInitialPackageJson();
         FileUtils.fileWrite(packageJson, json.toJson());
         mojo.execute();
@@ -257,7 +261,7 @@ public class CleanFrontendMojoTest {
 
     @Test
     public void should_cleanPackageJson_removeVaadinDependenciesInOverrides()
-            throws MojoFailureException, IOException {
+            throws MojoFailureException, IOException, MojoExecutionException {
         JsonObject json = createInitialPackageJson(true);
         FileUtils.fileWrite(packageJson, json.toJson());
 
@@ -272,7 +276,7 @@ public class CleanFrontendMojoTest {
 
     @Test
     public void should_keepUserDependencies_whenPackageJsonEdited()
-            throws MojoFailureException, IOException {
+            throws MojoFailureException, IOException, MojoExecutionException {
         JsonObject json = createInitialPackageJson();
         json.put("dependencies", Json.createObject());
         json.getObject("dependencies").put("foo", "bar");

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/GenerateNpmBOMMojoTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/GenerateNpmBOMMojoTest.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.ReflectionUtils;
 import org.junit.Assert;
@@ -23,6 +22,7 @@ import com.vaadin.flow.server.frontend.EndpointGeneratorTaskFactory;
 import com.vaadin.flow.server.frontend.FrontendTools;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 
+import static com.vaadin.flow.plugin.maven.BuildFrontendMojoTest.setProject;
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
@@ -47,9 +47,7 @@ public class GenerateNpmBOMMojoTest {
     public void setUp() throws Exception {
         this.mojo = Mockito.spy(new GenerateNpmBOMMojo());
 
-        MavenProject project = Mockito.mock(MavenProject.class);
         File projectBase = temporaryFolder.getRoot();
-        Mockito.when(project.getBasedir()).thenReturn(projectBase);
         File frontendDirectory = new File(projectBase, DEFAULT_FRONTEND_DIR);
         resourceOutputDirectory = new File(projectBase,
                 VAADIN_SERVLET_RESOURCES);
@@ -84,7 +82,6 @@ public class GenerateNpmBOMMojoTest {
         ReflectionUtils.setVariableValueInObject(mojo, "packageManifest",
                 manifestFilePath);
         ReflectionUtils.setVariableValueInObject(mojo, "specVersion", "1.4");
-        ReflectionUtils.setVariableValueInObject(mojo, "project", project);
         ReflectionUtils.setVariableValueInObject(mojo, "frontendDirectory",
                 frontendDirectory);
         ReflectionUtils.setVariableValueInObject(mojo, "projectBasedir",
@@ -96,8 +93,9 @@ public class GenerateNpmBOMMojoTest {
         ReflectionUtils.setVariableValueInObject(mojo, "npmFolder",
                 projectBase);
         ReflectionUtils.setVariableValueInObject(mojo, "productionMode", false);
-        Mockito.when(mojo.getJarFiles()).thenReturn(
-                Set.of(jarResourcesSource.getParentFile().getParentFile()));
+        Mockito.doReturn(
+                Set.of(jarResourcesSource.getParentFile().getParentFile()))
+                .when(mojo).getJarFiles();
 
         FileUtils.fileWrite(manifestFilePath, "UTF-8",
                 TestUtils.getInitialPackageJson().toJson());
@@ -109,6 +107,10 @@ public class GenerateNpmBOMMojoTest {
                     .lookup(ClassFinder.class);
             return lookup;
         }).when(mojo).createLookup(Mockito.any(ClassFinder.class));
+
+        setProject(mojo, projectBase);
+        // Prevent unwanted resources to be present on classpath
+        mojo.project.setArtifacts(Set.of());
     }
 
     @Test

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
@@ -74,7 +74,6 @@ public class PrepareFrontendMojoTest {
     private File defaultJavaSource;
     private File defaultJavaResource;
     private File generatedTsFolder;
-    private MavenProject project;
 
     @Before
     public void setup() throws Exception {
@@ -83,18 +82,6 @@ public class PrepareFrontendMojoTest {
 
         tokenFile = new File(temporaryFolder.getRoot(),
                 VAADIN_SERVLET_RESOURCES + TOKEN_FILE);
-
-        project = Mockito.mock(MavenProject.class);
-
-        List<String> packages = Arrays
-                .stream(System.getProperty("java.class.path")
-                        .split(File.pathSeparatorChar + ""))
-                .collect(Collectors.toList());
-        Mockito.when(project.getRuntimeClasspathElements())
-                .thenReturn(packages);
-        Mockito.when(project.getCompileClasspathElements())
-                .thenReturn(Collections.emptyList());
-        Mockito.when(project.getBasedir()).thenReturn(projectBase);
 
         packageJson = new File(projectBase, PACKAGE_JSON).getAbsolutePath();
         webpackOutputDirectory = new File(projectBase, VAADIN_WEBAPP_RESOURCES);
@@ -271,8 +258,8 @@ public class PrepareFrontendMojoTest {
     public void jarPackaging_copyProjectFrontendResources()
             throws MojoExecutionException, MojoFailureException,
             IllegalAccessException {
-        Mockito.when(project.getPackaging()).thenReturn("jar");
-
+        mojo.project.setPackaging("jar");
+        MavenProject project = Mockito.spy(mojo.project);
         ReflectionUtils.setVariableValueInObject(mojo, "project", project);
 
         mojo.execute();

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/ReflectorTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/ReflectorTest.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.plugin.maven;
+
+import javax.inject.Inject;
+
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.model.Build;
+import org.apache.maven.plugin.Mojo;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.utils.FlowFileUtils;
+
+import static com.vaadin.flow.plugin.maven.BuildFrontendMojoTest.getClassPath;
+import static com.vaadin.flow.utils.FlowFileUtils.convertToUrl;
+
+public class ReflectorTest {
+
+    Reflector reflector;
+
+    @Before
+    public void setUp() {
+        ClassLoader systemClassLoader = ClassLoader.getSystemClassLoader();
+        URLClassLoader urlClassLoader = new URLClassLoader(
+                getClassPath(Path.of(".")).stream().distinct().map(File::new)
+                        .map(FlowFileUtils::convertToUrl).toArray(URL[]::new),
+                ClassLoader.getPlatformClassLoader()) {
+            @Override
+            protected Class<?> findClass(String name)
+                    throws ClassNotFoundException {
+                // For test purposes, make maven API are loaded from shared
+                // class loader
+                if (!name.startsWith("com.vaadin.flow.plugin.maven.")) {
+                    return systemClassLoader.loadClass(name);
+                }
+                return super.findClass(name);
+            }
+        };
+        reflector = new Reflector(urlClassLoader);
+    }
+
+    @Test
+    public void createMojo_createInstanceAndCopyFields() throws Exception {
+        MyMojo source = new MyMojo();
+        source.fillFields();
+        Mojo target = reflector.createMojo(source);
+        MatcherAssert.assertThat("foo field", target,
+                Matchers.hasProperty("foo", Matchers.equalTo(source.foo)));
+        MatcherAssert.assertThat("bar field", target,
+                Matchers.hasProperty("bar", Matchers.equalTo(source.bar)));
+        MatcherAssert.assertThat("notAnnotated field", target,
+                Matchers.hasProperty("notAnnotated",
+                        Matchers.equalTo(source.notAnnotated)));
+        MatcherAssert.assertThat("mojoExecution field", target,
+                Matchers.hasProperty("mojoExecution",
+                        Matchers.equalTo(source.mojoExecution)));
+        MatcherAssert.assertThat("maven project field", target, Matchers
+                .hasProperty("project", Matchers.equalTo(source.project)));
+        MatcherAssert.assertThat("classFinder field", target,
+                Matchers.hasProperty("classFinder", Matchers.notNullValue()));
+    }
+
+    @Test
+    public void createMojo_subclass_createInstanceAndCopyFields()
+            throws Exception {
+        SubClassMojo source = new SubClassMojo();
+        source.fillFields();
+        Mojo target = reflector.createMojo(source);
+        MatcherAssert.assertThat("foo field", target,
+                Matchers.hasProperty("foo", Matchers.equalTo(source.foo)));
+        MatcherAssert.assertThat("bar field", target,
+                Matchers.hasProperty("bar", Matchers.equalTo(source.bar)));
+        MatcherAssert.assertThat("childProperty field", target,
+                Matchers.hasProperty("childProperty",
+                        Matchers.equalTo(source.childProperty)));
+        MatcherAssert.assertThat("notAnnotated field", target,
+                Matchers.hasProperty("notAnnotated",
+                        Matchers.equalTo(source.notAnnotated)));
+        MatcherAssert.assertThat("mojoExecution field", target,
+                Matchers.hasProperty("mojoExecution",
+                        Matchers.equalTo(source.mojoExecution)));
+        MatcherAssert.assertThat("maven project field", target, Matchers
+                .hasProperty("project", Matchers.equalTo(source.project)));
+        MatcherAssert.assertThat("classFinder field", target,
+                Matchers.hasProperty("classFinder", Matchers.notNullValue()));
+    }
+
+    @Test
+    public void createMojo_incompatibleFields_fails() {
+        IncompatibleFieldsMojo source = new IncompatibleFieldsMojo();
+        source.fillFields();
+        NoSuchFieldException exception = Assert.assertThrows(
+                NoSuchFieldException.class, () -> reflector.createMojo(source));
+        Assert.assertTrue(
+                "Expected exception to be thrown because of class loader mismatch",
+                exception.getMessage()
+                        .contains("loaded from different class loaders"));
+    }
+
+    @Test
+    public void reflector_fromProject_getsIsolatedClassLoader()
+            throws Exception {
+        String outputDirectory = "/my/project/target";
+
+        MavenProject project = new MavenProject();
+        project.setGroupId("com.vaadin.test");
+        project.setArtifactId("reflector-tests");
+        project.setBuild(new Build());
+        project.getBuild().setOutputDirectory(outputDirectory);
+        project.setArtifacts(Set.of(
+                createArtifact("com.vaadin.test", "compile", "1.0", "compile",
+                        true),
+                createArtifact("com.vaadin.test", "provided", "1.0", "provided",
+                        true),
+                createArtifact("com.vaadin.test", "test", "1.0", "test", true),
+                createArtifact("com.vaadin.test", "system", "1.0", "system",
+                        true),
+                createArtifact("com.vaadin.test", "not-classpath", "1.0",
+                        "compile", false)));
+
+        MojoExecution mojoExecution = new MojoExecution(new MojoDescriptor());
+        PluginDescriptor pluginDescriptor = new PluginDescriptor();
+        mojoExecution.getMojoDescriptor().setPluginDescriptor(pluginDescriptor);
+        pluginDescriptor.setGroupId("com.vaadin.test");
+        pluginDescriptor.setArtifactId("test-plugin");
+        pluginDescriptor.setArtifacts(List.of(
+                createArtifact("com.vaadin.test", "plugin", "1.0", "compile",
+                        true),
+                createArtifact("com.vaadin.test", "compile", "2.0", "compile",
+                        true)));
+        ClassWorld classWorld = new ClassWorld("maven.api", null);
+        classWorld.getRealm("maven.api")
+                .addURL(Path
+                        .of("src", "test", "resources",
+                                "jar-without-frontend-resources.jar")
+                        .toUri().toURL());
+        // .addURL(new URL("file:///some/flat/maven-repo/maven-api.jar"));
+        pluginDescriptor.setClassRealm(classWorld.newRealm("maven-plugin"));
+
+        Reflector execReflector = Reflector.of(project, mojoExecution);
+
+        URLClassLoader isolatedClassLoader = execReflector
+                .getIsolatedClassLoader();
+
+        Set<URL> urlSet = Set.of(isolatedClassLoader.getURLs());
+        Assert.assertEquals(4, urlSet.size());
+        Assert.assertTrue(
+                urlSet.contains(convertToUrl(new File(outputDirectory))));
+        Assert.assertTrue(urlSet.contains(convertToUrl(new File(
+                "/some/flat/maven-repo/com.vaadin.test-compile-1.0.jar"))));
+        Assert.assertTrue(urlSet.contains(convertToUrl(new File(
+                "/some/flat/maven-repo/com.vaadin.test-system-1.0.jar"))));
+        Assert.assertTrue(urlSet.contains(convertToUrl(new File(
+                "/some/flat/maven-repo/com.vaadin.test-plugin-1.0.jar"))));
+
+        // from platform class loader
+        Assert.assertNotNull(
+                isolatedClassLoader.loadClass("java.net.http.HttpClient"));
+        // from maven.api class loader
+        Assert.assertNotNull(
+                isolatedClassLoader.getResource("org/json/CookieList.class"));
+        Assert.assertNotNull(
+                isolatedClassLoader.loadClass("org.json.CookieList"));
+    }
+
+    private Artifact createArtifact(String groupId, String artifactId,
+            String version, String scope, boolean addedToClasspath) {
+        DefaultArtifactHandler artifactHandler = new DefaultArtifactHandler();
+        artifactHandler.setAddedToClasspath(addedToClasspath);
+        DefaultArtifact artifact = new DefaultArtifact(groupId, artifactId,
+                version, scope, "jar", null, artifactHandler);
+        artifact.setFile(
+                new File(String.format("/some/flat/maven-repo/%s-%s-%s.jar",
+                        groupId, artifactId, version)));
+        return artifact;
+    }
+
+    public static class MyMojo extends FlowModeAbstractMojo {
+
+        @Parameter
+        String foo;
+
+        @Parameter
+        Boolean bar;
+
+        String notAnnotated = "NOT ANNOTATED";
+
+        public MyMojo() {
+            project = new MavenProject();
+            project.setGroupId("com.vaadin.test");
+            project.setArtifactId("reflector-tests");
+        }
+
+        void fillFields() {
+            mojoExecution = new MojoExecution(new MojoDescriptor());
+            project = new MavenProject();
+            foo = "foo";
+            bar = true;
+        }
+
+        protected void executeInternal() {
+
+        }
+
+        public String getFoo() {
+            return foo;
+        }
+
+        public Boolean getBar() {
+            return bar;
+        }
+
+        public String getNotAnnotated() {
+            return notAnnotated;
+        }
+
+        public MojoExecution getMojoExecution() {
+            return mojoExecution;
+        }
+
+        public MavenProject getProject() {
+            return project;
+        }
+
+    }
+
+    public static class SubClassMojo extends MyMojo {
+
+        @Parameter
+        private String childProperty;
+
+        @Override
+        void fillFields() {
+            super.fillFields();
+            childProperty = "CHILD";
+        }
+
+        public String getChildProperty() {
+            return childProperty;
+        }
+    }
+
+    public static class FakeMavenComponent {
+    }
+
+    public static class IncompatibleFieldsMojo extends MyMojo {
+
+        @Inject
+        private FakeMavenComponent buildContext;
+
+        @Override
+        void fillFields() {
+            super.fillFields();
+            buildContext = new FakeMavenComponent();
+        }
+
+        public FakeMavenComponent getBuildContext() {
+            return buildContext;
+        }
+    }
+
+}

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/server/scanner/ReflectionsClassFinder.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/server/scanner/ReflectionsClassFinder.java
@@ -56,8 +56,12 @@ public class ReflectionsClassFinder implements ClassFinder {
      *            the list of urls for finding classes.
      */
     public ReflectionsClassFinder(URL... urls) {
-        classLoader = new URLClassLoader(urls,
-                Thread.currentThread().getContextClassLoader());
+        this(new URLClassLoader(urls,
+                Thread.currentThread().getContextClassLoader()), urls);
+    }
+
+    public ReflectionsClassFinder(ClassLoader classLoader, URL... urls) {
+        this.classLoader = classLoader;
         ConfigurationBuilder configurationBuilder = new ConfigurationBuilder()
                 .addClassLoaders(classLoader).setExpandSuperTypes(false)
                 .addUrls(urls);


### PR DESCRIPTION
Run Flow mojos using an isolated class loader that includes both project and plugin dependencies, with project dependencies taking precedence. This ensures that classes are always loaded from the same class loader at runtime, preventing errors where a class might be loaded by the plugin's class loader while one of its parent classes is only available in the project’s class loader (see #19616).

Additionally, this approach prevents the retrieval of resources from plugin dependencies when the same artifact is defined within the project (see #19009).

This refactoring also introduces caching for ClassFinder instances per execution phase, allowing multiple goals configured for the same phase to reuse the same ClassFinder. It also removes the need to instantiate a ClassFinder solely for Hilla class checks, reducing the number of scans performed during the build.

Fixes #19616
Fixes #19009
Fixes #20385