### PR TITLE
fix: vaadin/router added with react-router

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonConverter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonConverter.java
@@ -70,6 +70,7 @@ class VersionsJsonConverter {
      * Mode value for dependency for all modes.
      */
     public static final String MODE_ALL = "all"; // same as empty string
+    private static final Object VAADIN_ROUTER = "@vaadin/router";
 
     private final JsonObject convertedObject;
 
@@ -158,6 +159,10 @@ class VersionsJsonConverter {
             return;
         }
         if (excludeWebComponents && Objects.equals(npmName, VAADIN_BUNDLES)) {
+            exclusions.add(npmName);
+            return;
+        }
+        if (reactEnabled && Objects.equals(npmName, VAADIN_ROUTER)) {
             exclusions.add(npmName);
             return;
         }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/VersionsJsonConverterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/VersionsJsonConverterTest.java
@@ -229,6 +229,41 @@ public class VersionsJsonConverterTest {
     }
 
     @Test
+    public void reactRouterUsed_noVaadinRouterAdded() {
+        String json = """
+                {
+                  "core": {
+                    "flow": {
+                      "javaVersion": "3.0.0.alpha17"
+                    },
+                  },
+                  "vaadin-router": {
+                    "npmName": "@vaadin/router",
+                    "jsVersion": "2.0.0"
+                  },
+                  "react": {
+                    "react-components": {
+                      "jsVersion": "24.4.0-alpha7",
+                      "npmName": "@vaadin/react-components",
+                      "mode": "react"
+                    }
+                  },
+                  "platform": "foo"
+                }
+                """.formatted(VAADIN_CORE_NPM_PACKAGE);
+
+        VersionsJsonConverter convert = new VersionsJsonConverter(
+                Json.parse(json), true, false);
+        JsonObject convertedJson = convert.getConvertedJson();
+
+        Assert.assertFalse(
+                "Found @vaadin/router even though it should not be in use.",
+                convertedJson.hasKey("@vaadin/router"));
+        Assert.assertTrue("Missing react-components",
+                convertedJson.hasKey("@vaadin/react-components"));
+    }
+
+    @Test
     public void testModeProperty() {
         String json = """
                 {


### PR DESCRIPTION
Exclude vaadin/router when runing
in react mode.
Without exclusion vaadin/router
gets added from the vaadin-core.json
package in platform.

Fixes #20496
