### PR TITLE
fix: remove modal component on route refresh

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -77,7 +77,6 @@ import com.vaadin.flow.router.internal.AfterNavigationHandler;
 import com.vaadin.flow.router.internal.BeforeEnterHandler;
 import com.vaadin.flow.router.internal.BeforeLeaveHandler;
 import com.vaadin.flow.server.Command;
-import com.vaadin.flow.server.RouteRegistry;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.communication.PushConnection;
@@ -1094,6 +1093,12 @@ public class UIInternals implements Serializable {
     /**
      * Re-navigates to the current route. Also re-instantiates the route target
      * component, and optionally all layouts in the route chain.
+     * <p>
+     * </p>
+     * If modal components are currently defined for the UI, the whole route
+     * chain will be refreshed regardless the {@code refreshRouteChain}
+     * parameter, because otherwise it would not be possible to preserve the
+     * correct modality cardinality and order.
      *
      * @param refreshRouteChain
      *            {@code true} to refresh all layouts in the route chain,
@@ -1105,8 +1110,8 @@ public class UIInternals implements Serializable {
                     + "Unable to refresh the current route.");
         } else {
             getRouter().navigate(ui, locationForRefresh,
-                    NavigationTrigger.PROGRAMMATIC, null, true,
-                    refreshRouteChain);
+                    NavigationTrigger.REFRESH_ROUTE, null, true,
+                    refreshRouteChain || hasModalComponent());
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/hotswap/Hotswapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/hotswap/Hotswapper.java
@@ -349,13 +349,14 @@ public class Hotswapper implements ServiceDestroyListener, SessionInitListener,
                                 .isAssignableFrom(chainItem.getClass())))
                 .distinct().toList();
 
+        UIRefreshStrategy refreshStrategy;
         // A full chain refresh should be triggered if there are modal
         // components, since they could be attached to UI or parent layouts
-        boolean hasModalComponents = ui.hasModalComponent();
-        UIRefreshStrategy refreshStrategy;
-        if (!targetChainChangedItems.isEmpty()) {
-            refreshStrategy = targetChainChangedItems.stream().allMatch(
-                    chainItem -> chainItem == route && !hasModalComponents)
+        if (ui.hasModalComponent()) {
+            refreshStrategy = UIRefreshStrategy.PUSH_REFRESH_CHAIN;
+        } else if (!targetChainChangedItems.isEmpty()) {
+            refreshStrategy = targetChainChangedItems.stream()
+                    .allMatch(chainItem -> chainItem == route)
                             ? UIRefreshStrategy.PUSH_REFRESH_ROUTE
                             : UIRefreshStrategy.PUSH_REFRESH_CHAIN;
         } else {
@@ -365,6 +366,7 @@ public class Hotswapper implements ServiceDestroyListener, SessionInitListener,
             refreshStrategy = computeRefreshStrategyForUITree(ui,
                     changedClasses, targetsChain, route);
         }
+
         // A different layout might have been applied after hotswap
         if (refreshStrategy == UIRefreshStrategy.SKIP) {
             RouteRegistry registry = ui.getInternals().getRouter()

--- a/flow-server/src/main/java/com/vaadin/flow/hotswap/Hotswapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/hotswap/Hotswapper.java
@@ -349,10 +349,13 @@ public class Hotswapper implements ServiceDestroyListener, SessionInitListener,
                                 .isAssignableFrom(chainItem.getClass())))
                 .distinct().toList();
 
+        // A full chain refresh should be triggered if there are modal
+        // components, since they could be attached to UI or parent layouts
+        boolean hasModalComponents = ui.hasModalComponent();
         UIRefreshStrategy refreshStrategy;
         if (!targetChainChangedItems.isEmpty()) {
-            refreshStrategy = targetChainChangedItems.stream()
-                    .allMatch(chainItem -> chainItem == route)
+            refreshStrategy = targetChainChangedItems.stream().allMatch(
+                    chainItem -> chainItem == route && !hasModalComponents)
                             ? UIRefreshStrategy.PUSH_REFRESH_ROUTE
                             : UIRefreshStrategy.PUSH_REFRESH_CHAIN;
         } else {

--- a/flow-server/src/main/java/com/vaadin/flow/router/NavigationTrigger.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/NavigationTrigger.java
@@ -66,5 +66,12 @@ public enum NavigationTrigger {
     /**
      * Navigation is for a reload event on a preserveOnRefresh route.
      */
-    REFRESH
+    REFRESH,
+
+    /**
+     * Navigation was triggered via {@link UI#refreshCurrentRoute(boolean)}.
+     * It's for internal use only.
+     */
+    REFRESH_ROUTE,
+
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/RefreshCurrentRouteView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/RefreshCurrentRouteView.java
@@ -28,6 +28,7 @@ public class RefreshCurrentRouteView extends Div implements BeforeEnterObserver,
     final static String NAVIGATE_ID = "navigate";
     final static String REFRESH_ID = "refresh";
     final static String REFRESH_LAYOUTS_ID = "refreshlayouts";
+    final static String OPEN_MODALS_ID = "openmodals";
 
     private int attach, detach, afterNav, beforeEnter, beforeLeave;
     private final Div id, attachCounter, detachCounter, afterNavCounter,
@@ -58,6 +59,11 @@ public class RefreshCurrentRouteView extends Div implements BeforeEnterObserver,
                 e -> UI.getCurrent().refreshCurrentRoute(true));
         refresh.setId(REFRESH_LAYOUTS_ID);
         add(refresh);
+
+        NativeButton openModals = new NativeButton("Open modal components",
+                e -> openModals());
+        openModals.setId(OPEN_MODALS_ID);
+        add(openModals);
     }
 
     protected String getNavigationTarget() {
@@ -72,6 +78,12 @@ public class RefreshCurrentRouteView extends Div implements BeforeEnterObserver,
         return counter;
     }
 
+    private void openModals() {
+        new Dialog(1).open();
+        new Dialog(2).open();
+        new Dialog(3).open();
+    }
+
     @Override
     protected void onAttach(AttachEvent event) {
         super.onAttach(event);
@@ -81,6 +93,8 @@ public class RefreshCurrentRouteView extends Div implements BeforeEnterObserver,
     @Override
     public void afterNavigation(AfterNavigationEvent event) {
         afterNavCounter.setText(Integer.toString(++afterNav));
+        event.getLocationChangeEvent().getQueryParameter("modal")
+                .ifPresent(unused -> openModals());
     }
 
     @Override
@@ -98,4 +112,38 @@ public class RefreshCurrentRouteView extends Div implements BeforeEnterObserver,
         super.onDetach(event);
         detachCounter.setText(Integer.toString(++detach));
     }
+
+    public static class Dialog extends Div {
+
+        public Dialog(int dialogId) {
+            setId("modal-" + dialogId);
+            add(new Div("modal " + dialogId));
+            NativeButton button = new NativeButton("Refresh route",
+                    ev -> UI.getCurrent().refreshCurrentRoute(false));
+            button.setId("modal-" + dialogId + "-" + REFRESH_ID);
+            add(button);
+
+            button = new NativeButton("Refresh all",
+                    ev -> UI.getCurrent().refreshCurrentRoute(false));
+            button.setId("modal-" + dialogId + "-" + REFRESH_LAYOUTS_ID);
+            add(button);
+
+            button = new NativeButton("Close", ev -> close());
+            button.setId("modal-" + dialogId + "-close");
+            add(button);
+            getStyle().set("position", "fixed").set("inset", "10% 10%")
+                    .setWidth("50%").setHeight("50%")
+                    .setBackgroundColor("green").setBorder("1px solid black")
+                    .setZIndex(dialogId);
+        }
+
+        public void open() {
+            UI.getCurrent().addModal(this);
+        }
+
+        public void close() {
+            UI.getCurrent().remove(this);
+        }
+    }
+
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/RefreshCurrentRouteIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/RefreshCurrentRouteIT.java
@@ -13,6 +13,7 @@ import static com.vaadin.flow.uitest.ui.RefreshCurrentRouteView.BEFORELEAVECOUNT
 import static com.vaadin.flow.uitest.ui.RefreshCurrentRouteView.DETACHCOUNTER_ID;
 import static com.vaadin.flow.uitest.ui.RefreshCurrentRouteView.ID;
 import static com.vaadin.flow.uitest.ui.RefreshCurrentRouteView.NAVIGATE_ID;
+import static com.vaadin.flow.uitest.ui.RefreshCurrentRouteView.OPEN_MODALS_ID;
 import static com.vaadin.flow.uitest.ui.RefreshCurrentRouteView.REFRESH_ID;
 import static com.vaadin.flow.uitest.ui.RefreshCurrentRouteView.REFRESH_LAYOUTS_ID;
 import static com.vaadin.flow.uitest.ui.RefreshCurrentRouteLayout.ROUTER_LAYOUT_ID;
@@ -79,6 +80,40 @@ public class RefreshCurrentRouteIT extends AbstractStreamResourceIT {
 
         // Event counters should equal original values
         assertInitialEventCounters();
+    }
+
+    public void refreshCurrentRoute_modalComponents_newRouteAndLayout() {
+        open("modal=true");
+
+        final String originalId = getString(ID);
+        final String originalLayoutId = getString(ROUTER_LAYOUT_ID);
+
+        assertInitialEventCounters();
+
+        waitForElementPresent(By.id("modal-1"));
+        waitForElementPresent(By.id("modal-2"));
+        waitForElementPresent(By.id("modal-3"));
+        $(NativeButtonElement.class).id("modal-3-refresh").click();
+
+        // UUID should be new since refresh creates new instance
+        Assert.assertNotEquals(getString(ID), originalId);
+        // UUID should be new since new layout instances were requested
+        Assert.assertNotEquals(getString(ROUTER_LAYOUT_ID), originalLayoutId);
+
+        // Event counters should equal original values
+        assertInitialEventCounters();
+
+        waitForElementPresent(By.id("modal-1"));
+        waitForElementPresent(By.id("modal-2"));
+        waitForElementPresent(By.id("modal-3"));
+
+        $(NativeButtonElement.class).id("modal-3-close").click();
+        $(NativeButtonElement.class).id("modal-2-close").click();
+        $(NativeButtonElement.class).id("modal-1-refresh").click();
+
+        waitForElementPresent(By.id("modal-1"));
+        waitForElementPresent(By.id("modal-2"));
+        waitForElementPresent(By.id("modal-3"));
     }
 
     private void assertInitialEventCounters() {


### PR DESCRIPTION
## Description

Modal components attached to the UI were not removed or replaced during self-navigation triggered by a route refresh.
This change updates navigation handler to ensure modal components are removed and adds a new navigation trigger for route refresh to differentiate programmatic navigations (e.g., forward actions).
It also modifies Hotswapper to require a full chain refresh when modal components are present.

Fixes #20473

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
