### PR TITLE
feat: resend payload of reoccuring client request

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -215,6 +215,8 @@ public class UIInternals implements Serializable {
 
     private byte[] lastProcessedMessageHash = null;
 
+    private String lastRequestResponse = "for(;;);[{}]";
+
     private String contextRootRelativePath;
 
     private String appId;
@@ -303,6 +305,25 @@ public class UIInternals implements Serializable {
             byte[] lastProcessedMessageHash) {
         this.lastProcessedClientToServerId = lastProcessedClientToServerId;
         this.lastProcessedMessageHash = lastProcessedMessageHash;
+    }
+
+    /**
+     * Sets the response created for the last UIDL request.
+     *
+     * @param lastRequestResponse
+     *            The request that was sent for the last UIDL request.
+     */
+    public void setLastRequestResponse(String lastRequestResponse) {
+        this.lastRequestResponse = lastRequestResponse;
+    }
+
+    /**
+     * Returns the response created for the last UIDL request.
+     *
+     * @return The request that was sent for the last UIDL request.
+     */
+    public String getLastRequestResponse() {
+        return lastRequestResponse;
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -215,7 +215,7 @@ public class UIInternals implements Serializable {
 
     private byte[] lastProcessedMessageHash = null;
 
-    private String lastRequestResponse = "for(;;);[{}]";
+    private String lastRequestResponse;
 
     private String contextRootRelativePath;
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
@@ -237,14 +237,14 @@ public class ServerRpcHandler implements Serializable {
     }
 
     /**
-     * Exception thrown then the client side re-sent the same request.
+     * Exception thrown when the client side re-sends the same request.
      */
-    public static class ResendPayloadException extends RuntimeException {
+    public static class ClientResentPayloadException extends RuntimeException {
 
         /**
          * Default constructor for the exception.
          */
-        public ResendPayloadException() {
+        public ClientResentPayloadException() {
             super();
         }
     }
@@ -334,7 +334,7 @@ public class ServerRpcHandler implements Serializable {
                         "Received old duplicate message from the client. Expected: "
                                 + expectedId + ", got: " + requestId
                                 + ". Resending previous response.");
-                throw new ResendPayloadException();
+                throw new ClientResentPayloadException();
             } else if (rpcRequest.isUnloadBeaconRequest()) {
                 getLogger().debug(
                         "Ignoring unexpected message id from the client on UNLOAD request. "

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
@@ -237,6 +237,19 @@ public class ServerRpcHandler implements Serializable {
     }
 
     /**
+     * Exception thrown then the client side re-sent the same request.
+     */
+    public static class ResendPayloadException extends RuntimeException {
+
+        /**
+         * Default constructor for the exception.
+         */
+        public ResendPayloadException() {
+            super();
+        }
+    }
+
+    /**
      * Reads JSON containing zero or more serialized RPC calls (including legacy
      * variable changes) and executes the calls.
      *
@@ -317,9 +330,11 @@ public class ServerRpcHandler implements Serializable {
                  * situation is most likely triggered by a timeout or such
                  * causing a message to be resent.
                  */
-                getLogger().info(
-                        "Ignoring old duplicate message from the client. Expected: "
-                                + expectedId + ", got: " + requestId);
+                getLogger().debug(
+                        "Received old duplicate message from the client. Expected: "
+                                + expectedId + ", got: " + requestId
+                                + ". Resending previous response.");
+                throw new ResendPayloadException();
             } else if (rpcRequest.isUnloadBeaconRequest()) {
                 getLogger().debug(
                         "Ignoring unexpected message id from the client on UNLOAD request. "

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlRequestHandler.java
@@ -39,6 +39,7 @@ import com.vaadin.flow.server.VaadinResponse;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.communication.ServerRpcHandler.InvalidUIDLSecurityKeyException;
+import com.vaadin.flow.server.communication.ServerRpcHandler.ResendPayloadException;
 import com.vaadin.flow.server.communication.ServerRpcHandler.ResynchronizationRequiredException;
 import com.vaadin.flow.server.dau.DAUUtils;
 import com.vaadin.flow.server.dau.DauEnforcementException;
@@ -134,8 +135,10 @@ public class UidlRequestHandler extends SynchronizedRequestHandler
         StringWriter stringWriter = new StringWriter();
 
         try {
-            getRpcHandler(session).handleRpc(uI, requestBody, request);
+            getRpcHandler().handleRpc(uI, requestBody, request);
             writeUidl(uI, stringWriter, false);
+        } catch (ResendPayloadException e) {
+            stringWriter.write(uI.getInternals().getLastRequestResponse());
         } catch (JsonException e) {
             getLogger().error("Error writing JSON to response", e);
             // Refresh on client side
@@ -176,6 +179,7 @@ public class UidlRequestHandler extends SynchronizedRequestHandler
 
         // some dirt to prevent cross site scripting
         String responseString = "for(;;);[" + uidl.toJson() + "]";
+        ui.getInternals().setLastRequestResponse(responseString);
         writer.write(responseString);
     }
 
@@ -208,7 +212,7 @@ public class UidlRequestHandler extends SynchronizedRequestHandler
         return true;
     }
 
-    private ServerRpcHandler getRpcHandler(VaadinSession session) {
+    private ServerRpcHandler getRpcHandler() {
         ServerRpcHandler handler = rpcHandler.get();
         if (handler == null) {
             rpcHandler.compareAndSet(null, createRpcHandler());

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlRequestHandler.java
@@ -39,7 +39,7 @@ import com.vaadin.flow.server.VaadinResponse;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.communication.ServerRpcHandler.InvalidUIDLSecurityKeyException;
-import com.vaadin.flow.server.communication.ServerRpcHandler.ResendPayloadException;
+import com.vaadin.flow.server.communication.ServerRpcHandler.ClientResentPayloadException;
 import com.vaadin.flow.server.communication.ServerRpcHandler.ResynchronizationRequiredException;
 import com.vaadin.flow.server.dau.DAUUtils;
 import com.vaadin.flow.server.dau.DauEnforcementException;
@@ -137,7 +137,7 @@ public class UidlRequestHandler extends SynchronizedRequestHandler
         try {
             getRpcHandler().handleRpc(uI, requestBody, request);
             writeUidl(uI, stringWriter, false);
-        } catch (ResendPayloadException e) {
+        } catch (ClientResentPayloadException e) {
             stringWriter.write(uI.getInternals().getLastRequestResponse());
         } catch (JsonException e) {
             getLogger().error("Error writing JSON to response", e);

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/ServerRpcHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/ServerRpcHandlerTest.java
@@ -1,7 +1,6 @@
 package com.vaadin.flow.server.communication;
 
 import java.io.IOException;
-import java.io.Reader;
 import java.io.StringReader;
 
 import org.junit.Assert;
@@ -99,7 +98,7 @@ public class ServerRpcHandlerTest {
         Mockito.verify(dependencyList).clearPendingSendToClient();
     }
 
-    @Test(expected = ServerRpcHandler.ResendPayloadException.class)
+    @Test(expected = ServerRpcHandler.ClientResentPayloadException.class)
     public void handleRpc_duplicateMessage_throwsResendPayload()
             throws InvalidUIDLSecurityKeyException {
         String msg = "{\"" + ApplicationConstants.CLIENT_TO_SERVER_ID + "\":1}";

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/ServerRpcHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/ServerRpcHandlerTest.java
@@ -99,9 +99,9 @@ public class ServerRpcHandlerTest {
         Mockito.verify(dependencyList).clearPendingSendToClient();
     }
 
-    @Test
-    public void handleRpc_duplicateMessage_doNotThrow()
-            throws InvalidUIDLSecurityKeyException, IOException {
+    @Test(expected = ServerRpcHandler.ResendPayloadException.class)
+    public void handleRpc_duplicateMessage_throwsResendPayload()
+            throws InvalidUIDLSecurityKeyException {
         String msg = "{\"" + ApplicationConstants.CLIENT_TO_SERVER_ID + "\":1}";
         ServerRpcHandler handler = new ServerRpcHandler();
 


### PR DESCRIPTION
If the client request contains
the previous id and exactly the
same message content respond with
the same payload as previously.

Closes #20506
