### PR TITLE
fix: compute unique key for artifact

### DIFF
--- a/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/Reflector.java
+++ b/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/Reflector.java
@@ -223,7 +223,10 @@ public final class Reflector {
         }
 
         Function<Artifact, String> keyMapper = artifact -> artifact.getGroupId()
-                + ":" + artifact.getArtifactId();
+                + ":" + artifact.getArtifactId() + ":" + artifact.getType()
+                + ((artifact.getClassifier() != null)
+                        ? ":" + artifact.getClassifier()
+                        : "");
 
         Map<String, Artifact> projectDependencies = new HashMap<>(project
                 .getArtifacts().stream()

--- a/flow-plugins/flow-maven-plugin/src/it/deps-with-classifier-dups-project/invoker.properties
+++ b/flow-plugins/flow-maven-plugin/src/it/deps-with-classifier-dups-project/invoker.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2000-2024 Vaadin Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+invoker.goals=clean package

--- a/flow-plugins/flow-maven-plugin/src/it/deps-with-classifier-dups-project/pom.xml
+++ b/flow-plugins/flow-maven-plugin/src/it/deps-with-classifier-dups-project/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.vaadin.test.maven</groupId>
+    <artifactId>deps-with-classifier-dups-project</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+
+    <description>
+        Tests that plugin dependency plus classifier do not break build.
+    </description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
+        <maven.test.skip>true</maven.test.skip>
+
+        <flow.version>@project.version@</flow.version>
+        <maven.version>3.9.9</maven.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-server</artifactId>
+            <version>${flow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-client</artifactId>
+            <version>${flow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>2.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.23</version>
+            <classifier>android</classifier>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+            </plugin>
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>flow-maven-plugin</artifactId>
+                <version>${flow.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-frontend</goal>
+                            <goal>build-frontend</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/flow-plugins/flow-maven-plugin/src/it/deps-with-classifier-dups-project/src/main/java/com/vaadin/test/ProjectFlowExtension.java
+++ b/flow-plugins/flow-maven-plugin/src/it/deps-with-classifier-dups-project/src/main/java/com/vaadin/test/ProjectFlowExtension.java
@@ -1,0 +1,20 @@
+package com.vaadin.test;
+
+import java.util.List;
+
+import com.vaadin.flow.server.frontend.Options;
+import com.vaadin.flow.server.frontend.TypeScriptBootstrapModifier;
+import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
+
+/**
+ * Hello world!
+ */
+public class ProjectFlowExtension implements TypeScriptBootstrapModifier {
+
+    @Override
+    public void modify(List<String> bootstrapTypeScript, Options options,
+            FrontendDependenciesScanner frontendDependenciesScanner) {
+        System.out.println("ProjectFlowExtension");
+        bootstrapTypeScript.add("(window as any).testProject=1;");
+    }
+}

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/Reflector.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/Reflector.java
@@ -223,7 +223,10 @@ public final class Reflector {
         }
 
         Function<Artifact, String> keyMapper = artifact -> artifact.getGroupId()
-                + ":" + artifact.getArtifactId();
+                + ":" + artifact.getArtifactId() + ":" + artifact.getType()
+                + ((artifact.getClassifier() != null)
+                        ? ":" + artifact.getClassifier()
+                        : "");
 
         Map<String, Artifact> projectDependencies = new HashMap<>(project
                 .getArtifacts().stream()


### PR DESCRIPTION
Computes a unique key for maven artifacts when collecting dependencies for the Flow maven plugin isolated classloader.

fixes #20555 