### PR TITLE
chore: Opt-in for v7_startTransition of React Router

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/index-react.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/index-react.tsx
@@ -16,7 +16,7 @@ import { RouterProvider } from 'react-router-dom';
 import { router } from '%routesJsImportPath%';
 
 function App() {
-    return <RouterProvider router={router} />;
+    return <RouterProvider router={router} future={{ v7_startTransition: true }} />;
 }
 
 const outlet = document.getElementById('outlet')!;


### PR DESCRIPTION
Preparations for React Router v7, opts-in a new feature to avoid warnings in console.

Related-to https://github.com/vaadin/flow/issues/20527