### PR TITLE
feat: execute Hilla tasks whenever Hilla is available

### DIFF
--- a/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
+++ b/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
@@ -35,6 +35,7 @@ import org.mockito.Mockito;
 
 import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.internal.hilla.EndpointRequestUtil;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.InitParameters;
@@ -151,10 +152,10 @@ public class BuildFrontendUtilTest {
                 .when(endpointGeneratorTaskFactory)
                 .createTaskGenerateEndpoint(Mockito.any());
 
-        try (MockedStatic<FrontendUtils> util = Mockito
-                .mockStatic(FrontendUtils.class, Mockito.CALLS_REAL_METHODS)) {
-            util.when(() -> FrontendUtils.isHillaUsed(Mockito.any(),
-                    Mockito.any())).thenReturn(true);
+        try (MockedStatic<EndpointRequestUtil> util = Mockito.mockStatic(
+                EndpointRequestUtil.class, Mockito.CALLS_REAL_METHODS)) {
+            util.when(() -> EndpointRequestUtil.isHillaAvailable(Mockito.any()))
+                    .thenReturn(true);
             BuildFrontendUtil.runNodeUpdater(adapter);
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.internal.UsageStatistics;
+import com.vaadin.flow.internal.hilla.EndpointRequestUtil;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.Mode;
@@ -315,8 +316,7 @@ public class NodeTasks implements FallibleCommand {
     }
 
     private void addEndpointServicesTasks(Options options) {
-        if (!FrontendUtils.isHillaUsed(options.getFrontendDirectory(),
-                options.getClassFinder())) {
+        if (!EndpointRequestUtil.isHillaAvailable(options.getClassFinder())) {
             return;
         }
         Lookup lookup = options.getLookup();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksHillaTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksHillaTest.java
@@ -31,6 +31,7 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.internal.hilla.EndpointRequestUtil;
 import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder.DefaultClassFinder;
@@ -117,10 +118,10 @@ public class NodeTasksHillaTest {
         Mockito.doReturn(endpointGeneratorTaskFactory).when(options.getLookup())
                 .lookup(EndpointGeneratorTaskFactory.class);
 
-        try (MockedStatic<FrontendUtils> util = Mockito
-                .mockStatic(FrontendUtils.class, Mockito.CALLS_REAL_METHODS)) {
-            util.when(() -> FrontendUtils.isHillaUsed(Mockito.any(),
-                    Mockito.any())).thenReturn(true);
+        try (MockedStatic<EndpointRequestUtil> util = Mockito.mockStatic(
+                EndpointRequestUtil.class, Mockito.CALLS_REAL_METHODS)) {
+            util.when(() -> EndpointRequestUtil.isHillaAvailable(Mockito.any()))
+                    .thenReturn(true);
 
             new NodeTasks(options).execute();
         }

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/DevModeEndpointTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/DevModeEndpointTest.java
@@ -22,6 +22,7 @@ import com.vaadin.base.devserver.startup.AbstractDevModeTest;
 import com.vaadin.base.devserver.startup.DevModeStartupListener;
 import com.vaadin.flow.di.ResourceProvider;
 import com.vaadin.flow.internal.DevModeHandlerManager;
+import com.vaadin.flow.internal.hilla.EndpointRequestUtil;
 import com.vaadin.flow.server.VaadinServlet;
 import com.vaadin.flow.server.VaadinServletContext;
 import com.vaadin.flow.server.frontend.EndpointGeneratorTaskFactory;
@@ -107,10 +108,10 @@ public class DevModeEndpointTest extends AbstractDevModeTest {
                 .toFile();
 
         Assert.assertFalse(generatedOpenApiJson.exists());
-        try (MockedStatic<FrontendUtils> util = Mockito
-                .mockStatic(FrontendUtils.class, Mockito.CALLS_REAL_METHODS)) {
-            util.when(() -> FrontendUtils.isHillaUsed(Mockito.any(),
-                    Mockito.any())).thenReturn(true);
+        try (MockedStatic<EndpointRequestUtil> util = Mockito.mockStatic(
+                EndpointRequestUtil.class, Mockito.CALLS_REAL_METHODS)) {
+            util.when(() -> EndpointRequestUtil.isHillaAvailable(Mockito.any()))
+                    .thenReturn(true);
             devModeStartupListener.onStartup(classes, servletContext);
             handler = getDevModeHandler();
             waitForDevServer();
@@ -139,10 +140,10 @@ public class DevModeEndpointTest extends AbstractDevModeTest {
 
         assertFalse(ts1.exists());
         assertFalse(ts2.exists());
-        try (MockedStatic<FrontendUtils> util = Mockito
-                .mockStatic(FrontendUtils.class, Mockito.CALLS_REAL_METHODS)) {
-            util.when(() -> FrontendUtils.isHillaUsed(Mockito.any(),
-                    Mockito.any())).thenReturn(true);
+        try (MockedStatic<EndpointRequestUtil> util = Mockito.mockStatic(
+                EndpointRequestUtil.class, Mockito.CALLS_REAL_METHODS)) {
+            util.when(() -> EndpointRequestUtil.isHillaAvailable(Mockito.any()))
+                    .thenReturn(true);
             devModeStartupListener.onStartup(classes, servletContext);
             handler = getDevModeHandler();
             waitForDevServer();

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/DevModeInitializerTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/DevModeInitializerTest.java
@@ -36,6 +36,7 @@ import java.util.function.Function;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.page.AppShellConfigurator;
 import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.internal.hilla.EndpointRequestUtil;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.LoadDependenciesOnStartup;
@@ -352,10 +353,10 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
                     javaSourceFolder.getRoot().getAbsolutePath());
 
             Assert.assertFalse(generatedOpenApiJson.exists());
-            try (MockedStatic<FrontendUtils> util = Mockito.mockStatic(
-                    FrontendUtils.class, Mockito.CALLS_REAL_METHODS)) {
-                util.when(() -> FrontendUtils.isHillaUsed(Mockito.any(),
-                        Mockito.any())).thenReturn(true);
+            try (MockedStatic<EndpointRequestUtil> util = Mockito.mockStatic(
+                    EndpointRequestUtil.class, Mockito.CALLS_REAL_METHODS)) {
+                util.when(() -> EndpointRequestUtil
+                        .isHillaAvailable(Mockito.any())).thenReturn(true);
                 devModeStartupListener.onStartup(classes, servletContext);
                 handler = getDevModeHandler();
                 waitForDevServer();
@@ -420,10 +421,10 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
             System.setProperty("vaadin." + CONNECT_JAVA_SOURCE_FOLDER_TOKEN,
                     javaSourceFolder.getRoot().getAbsolutePath());
 
-            try (MockedStatic<FrontendUtils> util = Mockito.mockStatic(
-                    FrontendUtils.class, Mockito.CALLS_REAL_METHODS)) {
-                util.when(() -> FrontendUtils.isHillaUsed(Mockito.any(),
-                        Mockito.any())).thenReturn(true);
+            try (MockedStatic<EndpointRequestUtil> util = Mockito.mockStatic(
+                    EndpointRequestUtil.class, Mockito.CALLS_REAL_METHODS)) {
+                util.when(() -> EndpointRequestUtil
+                        .isHillaAvailable(Mockito.any())).thenReturn(true);
                 devModeStartupListener.onStartup(classes, servletContext);
                 handler = getDevModeHandler();
                 waitForDevServer();


### PR DESCRIPTION
Execute Hilla tasks (`TaskGenerateOpenAPI` and `TaskGenerateEndpoint`) whenever Hilla is available on the classpath. These tasks should determine the required actions themselves, instead of Flow trying to do it.

Fixes https://github.com/vaadin/flow/issues/20289
Fixes https://github.com/vaadin/flow/issues/18800