### PR TITLE
fix: enforce plugin-required dependencies and log incompatibilities

### DIFF
--- a/flow-plugins/flow-maven-plugin/src/it/offending-dependency-project/invoker.properties
+++ b/flow-plugins/flow-maven-plugin/src/it/offending-dependency-project/invoker.properties
@@ -1,0 +1,18 @@
+#
+# Copyright 2000-2024 Vaadin Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+invoker.goals=clean package
+invoker.buildResult=failure

--- a/flow-plugins/flow-maven-plugin/src/it/offending-dependency-project/pom.xml
+++ b/flow-plugins/flow-maven-plugin/src/it/offending-dependency-project/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.vaadin.test.maven</groupId>
+    <artifactId>offending-dependency-project</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+
+    <description>
+        Tests that project dependencies does not override plugin required dependency.
+    </description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
+        <maven.test.skip>true</maven.test.skip>
+
+        <flow.version>@project.version@</flow.version>
+        <maven.version>3.9.9</maven.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-server</artifactId>
+            <version>${flow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-client</artifactId>
+            <version>${flow.version}</version>
+        </dependency>
+        <!-- commons-io 2.6 is incompatible with Flow plugin -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.6</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+            </plugin>
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>flow-maven-plugin</artifactId>
+                <version>${flow.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-frontend</goal>
+                            <goal>build-frontend</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/flow-plugins/flow-maven-plugin/src/it/offending-dependency-project/src/main/java/com/vaadin/test/ProjectFlowExtension.java
+++ b/flow-plugins/flow-maven-plugin/src/it/offending-dependency-project/src/main/java/com/vaadin/test/ProjectFlowExtension.java
@@ -1,0 +1,20 @@
+package com.vaadin.test;
+
+import java.util.List;
+
+import com.vaadin.flow.server.frontend.Options;
+import com.vaadin.flow.server.frontend.TypeScriptBootstrapModifier;
+import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
+
+/**
+ * Hello world!
+ */
+public class ProjectFlowExtension implements TypeScriptBootstrapModifier {
+
+    @Override
+    public void modify(List<String> bootstrapTypeScript, Options options,
+            FrontendDependenciesScanner frontendDependenciesScanner) {
+        System.out.println("ProjectFlowExtension");
+        bootstrapTypeScript.add("(window as any).testProject=1;");
+    }
+}

--- a/flow-plugins/flow-maven-plugin/src/it/offending-dependency-project/verify.bsh
+++ b/flow-plugins/flow-maven-plugin/src/it/offending-dependency-project/verify.bsh
@@ -1,0 +1,15 @@
+import java.nio.file.*;
+
+flowTsx = basedir.toPath().resolve("build.log");
+if ( !Files.exists(flowTsx, new LinkOption[0]) )
+{
+    throw new RuntimeException("build.log not found");
+}
+
+lines = Files.readString(flowTsx);
+if (
+    !lines.contains("Found dependencies defined with different versions in project and Vaadin maven plugin") &&
+    !lines.matches("^commons-io:commons-io.*\\[2\\.6\\],.*")
+    ) {
+    throw new RuntimeException("Offending commons-io 2.6 dependency not detected");
+}

--- a/flow-plugins/flow-maven-plugin/src/it/plugin-pinned-deps-project/invoker.properties
+++ b/flow-plugins/flow-maven-plugin/src/it/plugin-pinned-deps-project/invoker.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2000-2024 Vaadin Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+invoker.goals=clean package

--- a/flow-plugins/flow-maven-plugin/src/it/plugin-pinned-deps-project/pom.xml
+++ b/flow-plugins/flow-maven-plugin/src/it/plugin-pinned-deps-project/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.vaadin.test.maven</groupId>
+    <artifactId>plugin-pinned-deps-project</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+
+    <description>
+        Tests that project dependencies does not override plugin required dependency.
+    </description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
+        <maven.test.skip>true</maven.test.skip>
+
+        <flow.version>@project.version@</flow.version>
+        <maven.version>3.9.9</maven.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-server</artifactId>
+            <version>${flow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-client</artifactId>
+            <version>${flow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+            <version>0.9.10</version>
+        </dependency>
+        <dependency>
+            <groupId>org.zeroturnaround</groupId>
+            <artifactId>zt-exec</artifactId>
+            <version>1.4</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+            </plugin>
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>flow-maven-plugin</artifactId>
+                <version>${flow.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-frontend</goal>
+                            <goal>build-frontend</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/flow-plugins/flow-maven-plugin/src/it/plugin-pinned-deps-project/src/main/java/com/vaadin/test/ProjectFlowExtension.java
+++ b/flow-plugins/flow-maven-plugin/src/it/plugin-pinned-deps-project/src/main/java/com/vaadin/test/ProjectFlowExtension.java
@@ -1,0 +1,20 @@
+package com.vaadin.test;
+
+import java.util.List;
+
+import com.vaadin.flow.server.frontend.Options;
+import com.vaadin.flow.server.frontend.TypeScriptBootstrapModifier;
+import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
+
+/**
+ * Hello world!
+ */
+public class ProjectFlowExtension implements TypeScriptBootstrapModifier {
+
+    @Override
+    public void modify(List<String> bootstrapTypeScript, Options options,
+            FrontendDependenciesScanner frontendDependenciesScanner) {
+        System.out.println("ProjectFlowExtension");
+        bootstrapTypeScript.add("(window as any).testProject=1;");
+    }
+}

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.plugin.maven;
 import javax.inject.Inject;
 
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -52,6 +53,7 @@ import com.vaadin.flow.internal.StringUtil;
 import com.vaadin.flow.plugin.base.BuildFrontendUtil;
 import com.vaadin.flow.plugin.base.PluginAdapterBase;
 import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.frontend.FrontendTools;
 import com.vaadin.flow.server.frontend.FrontendUtils;
@@ -305,13 +307,35 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
         try {
             Mojo task = reflector.createMojo(this);
             findExecuteMethod(task.getClass()).invoke(task);
+            reflector.logIncompatibilities(getLog()::debug);
         } catch (MojoExecutionException | MojoFailureException e) {
+            logTroubleshootingHints(reflector, e);
             throw e;
         } catch (Exception e) {
+            logTroubleshootingHints(reflector, e);
             throw new MojoFailureException(e.getMessage(), e);
         } finally {
             Thread.currentThread().setContextClassLoader(tccl);
         }
+    }
+
+    private void logTroubleshootingHints(Reflector reflector, Throwable ex) {
+        reflector.logIncompatibilities(getLog()::warn);
+        if (ex instanceof InvocationTargetException) {
+            ex = ex.getCause();
+        }
+        StringBuilder errorMessage = new StringBuilder(ex.getMessage());
+        Throwable cause = ex.getCause();
+        while (cause != null) {
+            if (cause.getMessage() != null) {
+                errorMessage.append(" ").append(cause.getMessage());
+            }
+            cause = cause.getCause();
+        }
+        getLog().error(
+                "The build process encountered an error: " + errorMessage);
+        logError(
+                "To diagnose the issue, please re-run Maven with the -X option to enable detailed debug logging and identify the root cause.");
     }
 
     /**
@@ -691,10 +715,10 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
                 .equals(artifact.getGroupId())
                 && "flow-server".equals(artifact.getArtifactId());
         String projectFlowVersion = project.getArtifacts().stream()
-                .filter(isFlowServer).map(Artifact::getVersion).findFirst()
+                .filter(isFlowServer).map(Artifact::getBaseVersion).findFirst()
                 .orElse(null);
         String pluginFlowVersion = pluginDescriptor.getArtifacts().stream()
-                .filter(isFlowServer).map(Artifact::getVersion).findFirst()
+                .filter(isFlowServer).map(Artifact::getBaseVersion).findFirst()
                 .orElse(null);
         if (!Objects.equals(projectFlowVersion, pluginFlowVersion)) {
             getLog().warn(

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
@@ -178,6 +178,16 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
             long ms = (System.nanoTime() - start) / 1000000;
             log().info("Visited {} classes. Took {} ms.", visitedClasses.size(),
                     ms);
+        } catch (IllegalArgumentException ex) {
+            StackTraceElement[] stackTrace = ex.getStackTrace();
+            if (ex.getMessage() != null
+                    && ex.getMessage().startsWith("Unsupported api ")
+                    && stackTrace.length > 0 && stackTrace[0].getClassName()
+                            .equals("org.objectweb.asm.ClassVisitor")) {
+                log().error(
+                        "Invalid asm library version. Please make sure that the project does not override org.ow2.asm:asm dependency defined by Vaadin with an incompatible version.");
+            }
+            throw ex;
         } catch (ClassNotFoundException | InstantiationException
                 | IllegalAccessException | IOException e) {
             throw new IllegalStateException(


### PR DESCRIPTION
## Description

The Flow Maven Plugin uses a class loader that combines project and plugin dependencies to ensure class scanning happens on runtime artifacts. However, plugin execution may fail if the project defines dependency versions incompatible with those used by the plugin.

This change enforces the use of plugin-defined versions for certain dependencies not directly used by Flow at runtime. Additionally, it logs potential incompatibilities for other dependencies if the build fails.

Fixes vaadin/mpr-demo#23

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
