### PR TITLE
fix: Add React Router future flags for flow auto-generated routes file

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/routes-flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/routes-flow.tsx
@@ -12,7 +12,21 @@ import { serverSideRoutes } from 'Frontend/generated/flow/Flow';
 function build() {
     const routes = [...serverSideRoutes] as RouteObject[];
     return {
-        router: createBrowserRouter([...routes], { basename: new URL(document.baseURI).pathname }),
+        router: createBrowserRouter([...routes], {
+            basename: new URL(document.baseURI).pathname,
+            future: {
+                // eslint-disable-next-line camelcase
+                v7_fetcherPersist: true,
+                // eslint-disable-next-line camelcase
+                v7_normalizeFormMethod: true,
+                // eslint-disable-next-line camelcase
+                v7_partialHydration: true,
+                // eslint-disable-next-line camelcase
+                v7_relativeSplatPath: true,
+                // eslint-disable-next-line camelcase
+                v7_skipActionErrorRevalidation: true,
+            },
+        }),
         routes
     };
 }


### PR DESCRIPTION
Adds missing future flags for a Flow only configuration.

Fixes https://github.com/vaadin/flow/issues/20527