### PR TITLE
fix: catch exceptions from detach calls

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
@@ -48,6 +48,7 @@ import com.vaadin.flow.internal.nodefeature.VirtualChildrenList;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.Router;
 import com.vaadin.flow.server.Attributes;
+import com.vaadin.flow.server.ErrorEvent;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.shared.Registration;
@@ -338,7 +339,12 @@ public class ComponentUtil {
         }
 
         DetachEvent detachEvent = new DetachEvent(component);
-        component.onDetach(detachEvent);
+        try {
+            component.onDetach(detachEvent);
+        } catch (RuntimeException e) {
+            VaadinSession.getCurrent().getErrorHandler()
+                    .error(new ErrorEvent(e));
+        }
         fireEvent(component, detachEvent);
 
         // inform component about onEnabledState if parent and child states

--- a/flow-server/src/main/java/com/vaadin/flow/component/DetachNotifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/DetachNotifier.java
@@ -17,6 +17,8 @@ package com.vaadin.flow.component;
 
 import java.io.Serializable;
 
+import com.vaadin.flow.server.ErrorEvent;
+import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.shared.Registration;
 
 /**
@@ -38,7 +40,14 @@ public interface DetachNotifier extends Serializable {
             ComponentEventListener<DetachEvent> listener) {
         if (this instanceof Component) {
             return ComponentUtil.addListener((Component) this,
-                    DetachEvent.class, listener);
+                    DetachEvent.class, event -> {
+                        try {
+                            listener.onComponentEvent(event);
+                        } catch (RuntimeException e) {
+                            VaadinSession.getCurrent().getErrorHandler()
+                                    .error(new ErrorEvent(e));
+                        }
+                    });
         } else {
             throw new IllegalStateException(String.format(
                     "The class '%s' doesn't extend '%s'. "


### PR DESCRIPTION
Wraps detach listener calls and onDetach calls into try-catch blocks so all
possible exceptions are handled by session ErrorHandler, and they will not
interrupt running the remaining detach handlers.

Fixes https://github.com/vaadin/flow/issues/20577