### PR TITLE
chore: Log the correct id

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
@@ -341,7 +341,7 @@ public class ServerRpcHandler implements Serializable {
                                 + "This could happen for example during login process, if concurrent requests "
                                 + "are sent to the server and one of those changes the session identifier, "
                                 + "causing an UIDL request to be rejected because of session expiration. "
-                                + "Expected sync id: {}, got {}.",
+                                + "Expected client id: {}, got {}.",
                         expectedId, requestId);
             } else {
                 /*
@@ -357,12 +357,12 @@ public class ServerRpcHandler implements Serializable {
                  */
                 String messageDetails = getMessageDetails(rpcRequest);
                 getLogger().debug("Unexpected message id from the client."
-                        + " Expected sync id: " + expectedId + ", got "
+                        + " Expected client id: " + expectedId + ", got "
                         + requestId + ". Message start: " + messageDetails);
                 throw new UnsupportedOperationException(
                         "Unexpected message id from the client."
-                                + " Expected sync id: " + expectedId + ", got "
-                                + requestId
+                                + " Expected client id: " + expectedId
+                                + ", got " + requestId
                                 + ". more details logged on DEBUG level.");
             }
         } else {


### PR DESCRIPTION
Log the correct expected id.
the expected and checked id
is the clientId not the syncId
