### PR TITLE
chore!: Change supported Node from 18 to 20

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -117,9 +117,9 @@ public class FrontendTools {
     private static final FrontendVersion WHITESPACE_ACCEPTING_NPM_VERSION = new FrontendVersion(
             7, 0);
 
-    private static final int SUPPORTED_NODE_MAJOR_VERSION = 18;
-    private static final int SUPPORTED_NODE_MINOR_VERSION = 12;
-    private static final int SUPPORTED_NPM_MAJOR_VERSION = 8;
+    private static final int SUPPORTED_NODE_MAJOR_VERSION = 20;
+    private static final int SUPPORTED_NODE_MINOR_VERSION = 0;
+    private static final int SUPPORTED_NPM_MAJOR_VERSION = 9;
     private static final int SUPPORTED_NPM_MINOR_VERSION = 6;
 
     static final FrontendVersion SUPPORTED_NODE_VERSION = new FrontendVersion(

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -69,7 +69,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @Category(SlowTests.class)
 public class FrontendToolsTest {
 
-    private static final String SUPPORTED_NODE_BUT_OLDER_THAN_AUTOINSTALLED = "18.12.0";
+    private static final String SUPPORTED_NODE_BUT_OLDER_THAN_AUTOINSTALLED = "20.0.0";
 
     public static final String DEFAULT_NODE = FrontendUtils.isWindows()
             ? "node\\node.exe"

--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/FrontendStubs.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/FrontendStubs.java
@@ -254,8 +254,8 @@ public class FrontendStubs {
      */
     public static class ToolStubBuilder {
 
-        private static final String DEFAULT_NPM_VERSION = "8.6.0";
-        private static final String DEFAULT_NODE_VERSION = "18.12.0";
+        private static final String DEFAULT_NPM_VERSION = "10.9.0";
+        private static final String DEFAULT_NODE_VERSION = "22.12.0";
 
         private String version;
         private String cacheDir;


### PR DESCRIPTION
Node 20 is the active LTS version for Node.

Node 18 will be end of life soon and new libraries like React 19 support Node 20+
