### PR TITLE
fix: handle logout from a background thread 

### DIFF
--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/MainView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/MainView.java
@@ -1,9 +1,14 @@
 package com.vaadin.flow.spring.flowsecurity.views;
 
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.security.concurrent.DelegatingSecurityContextExecutor;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.applayout.AppLayout;
 import com.vaadin.flow.component.applayout.DrawerToggle;
 import com.vaadin.flow.component.avatar.Avatar;
@@ -96,6 +101,18 @@ public class MainView extends AppLayout {
                 securityUtils.logout();
             });
             layout.add(logout);
+
+            Button logoutFromServer = new Button("Logout from server");
+            logoutFromServer.setId("logout-server");
+            logoutFromServer.addClickListener(e -> {
+                UI ui = UI.getCurrent();
+                Runnable action = ui.accessLater(() -> securityUtils.logout(),
+                        null);
+                CompletableFuture.runAsync(action,
+                        new DelegatingSecurityContextExecutor(CompletableFuture
+                                .delayedExecutor(1, TimeUnit.SECONDS)));
+            });
+            layout.add(logoutFromServer);
 
             Anchor logoutWithUrl = new Anchor("doLogout", "Logout with URL");
             logoutWithUrl.getElement().setAttribute("router-ignore", true);

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AppViewIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AppViewIT.java
@@ -309,6 +309,16 @@ public class AppViewIT extends AbstractIT {
     }
 
     @Test
+    public void logout_server_initiated_redirects_to_logout() {
+        open(LOGIN_PATH);
+        loginAdmin();
+        navigateTo("admin");
+        assertAdminPageShown(ADMIN_FULLNAME);
+        getMainView().$(ButtonElement.class).id("logout-server").click();
+        assertRootPageShown();
+    }
+
+    @Test
     public void client_menu_routes_correct_for_anonymous() {
         navigateToClientMenuList();
         assertMenuListContains("PublicView");

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/UIAccessContextIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/UIAccessContextIT.java
@@ -15,15 +15,15 @@
  */
 package com.vaadin.flow.spring.flowsecurity;
 
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.WebDriver;
+
 import com.vaadin.flow.component.button.testbench.ButtonElement;
 import com.vaadin.flow.component.login.testbench.LoginFormElement;
 import com.vaadin.flow.component.login.testbench.LoginOverlayElement;
 import com.vaadin.testbench.HasElementQuery;
 import com.vaadin.testbench.TestBenchElement;
-
-import org.junit.Assert;
-import org.junit.Test;
-import org.openqa.selenium.WebDriver;
 
 public class UIAccessContextIT extends AbstractIT {
 
@@ -37,14 +37,15 @@ public class UIAccessContextIT extends AbstractIT {
             super.setup();
             open("private");
             loginUser();
-            TestBenchElement balance = $("span").id("balanceText");
+            TestBenchElement balance = waitUntil(
+                    d -> $("span").id("balanceText"));
             Assert.assertEquals(expectedUserBalance, balance.getText());
 
             open("private", adminBrowser);
             HasElementQuery adminContext = () -> adminBrowser;
             loginAdmin(adminContext);
-            TestBenchElement adminBalance = adminContext.$("span")
-                    .id("balanceText");
+            TestBenchElement adminBalance = waitUntil(
+                    d -> adminContext.$("span").id("balanceText"));
             Assert.assertEquals(expectedAdminBalance, adminBalance.getText());
 
             ButtonElement sendRefresh = $(ButtonElement.class)
@@ -70,6 +71,10 @@ public class UIAccessContextIT extends AbstractIT {
         form.getUsernameField().setValue("emma");
         form.getPasswordField().setValue("emma");
         form.submit();
+        waitUntilNot(driver -> ((WebDriver) adminContext.getContext())
+                .getCurrentUrl().contains("my/login/page"));
+        waitUntilNot(
+                driver -> adminContext.$(LoginOverlayElement.class).exists());
     }
 
 }


### PR DESCRIPTION
## Description

Allows AuthenticationContext.logout feature to be used from a background thread,
handling the missing request by forcing the client to make an additional request.
Applies the same logic used to support logout when using PUSH with websocket
transport.

References #11026

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
