### PR TITLE
test: set Jetty stop timeout (2.11)

### DIFF
--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -201,6 +201,9 @@
                         <stopPort>${server.stop.port}</stopPort>
                         <stopKey>foo</stopKey>
                         <stopWait>5</stopWait>
+                        <server>
+                            <stopTimeout>4</stopTimeout>
+                        </server>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
Set the Jetty stop timeout to a value less than the Jetty plugin's stop wait time. This change prevents the ShutdownManager from being blocked while waiting for Jetty to stop, avoiding an inconsistent state when subsequent Maven modules are executed.
