### PR TITLE
fix: fix role checking when using websocket push (#20679) (CP: 24.5)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/NavigationAccessControl.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/NavigationAccessControl.java
@@ -454,7 +454,7 @@ public class NavigationAccessControl implements BeforeEnterListener {
         Objects.requireNonNull(vaadinService);
         return new NavigationContext(vaadinService.getRouter(),
                 navigationTarget, new Location(path), RouteParameters.empty(),
-                vaadinRequest.getUserPrincipal(),
-                getRolesChecker(vaadinRequest), false);
+                getPrincipal(vaadinRequest), getRolesChecker(vaadinRequest),
+                false);
     }
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-websocket/src/test/java/com/vaadin/flow/spring/flowsecuritywebsocket/AppViewIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-websocket/src/test/java/com/vaadin/flow/spring/flowsecuritywebsocket/AppViewIT.java
@@ -14,7 +14,17 @@ public class AppViewIT extends com.vaadin.flow.spring.flowsecurity.AppViewIT {
             session expiration handler to redirect to the timeout page instead
             of the logout view, because the logout process is still ongoing.
             """)
-    public void logout_via_doLogin_redirects_to_logout() {
-        super.logout_via_doLogin_redirects_to_logout();
+    public void logout_via_doLogoutURL_redirects_to_logout() {
+        super.logout_via_doLogoutURL_redirects_to_logout();
+    }
+
+    @Test
+    public void websocket_roles_checked_correctly_during_navigation() {
+        open("admin");
+        loginAdmin();
+        navigateTo("");
+        assertRootPageShown();
+        navigateTo("admin");
+        assertAdminPageShown(ADMIN_FULLNAME);
     }
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/PublicView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/PublicView.java
@@ -1,5 +1,8 @@
 package com.vaadin.flow.spring.flowsecurity.views;
 
+import org.springframework.security.concurrent.DelegatingSecurityContextRunnable;
+import org.springframework.security.core.context.SecurityContextHolder;
+
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.H1;
@@ -36,7 +39,7 @@ public class PublicView extends FlexLayout {
         Button backgroundNavigation = new Button(
                 "Navigate to admin view in 1 second", e -> {
                     UI ui = e.getSource().getUI().get();
-                    new Thread(() -> {
+                    Runnable navigateToAdmin = () -> {
                         try {
                             Thread.sleep(1000);
                         } catch (InterruptedException e1) {
@@ -44,8 +47,11 @@ public class PublicView extends FlexLayout {
                         ui.access(() -> {
                             ui.navigate(AdminView.class);
                         });
-
-                    }).start();
+                    };
+                    Runnable wrappedRunnable = new DelegatingSecurityContextRunnable(
+                            navigateToAdmin,
+                            SecurityContextHolder.getContext());
+                    new Thread(wrappedRunnable).start();
                 });
         backgroundNavigation.setId(BACKGROUND_NAVIGATION_ID);
         add(backgroundNavigation);

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/SecurityUtil.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/SecurityUtil.java
@@ -18,9 +18,16 @@ package com.vaadin.flow.spring.security;
 
 import java.security.Principal;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.springframework.security.concurrent.DelegatingSecurityContextRunnable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextImpl;
+
 import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.server.HandlerHelper;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.spring.AuthenticationUtil;
@@ -42,7 +49,9 @@ class SecurityUtil {
      *         if no user is currently logged in
      */
     static Principal getPrincipal(VaadinRequest request) {
-        if (request == null) {
+        boolean isWebsocketPush = isWebsocketPush(request);
+        if (request == null
+                || (isWebsocketPush && request.getUserPrincipal() == null)) {
             return AuthenticationUtil.getSecurityHolderAuthentication();
         }
         return request.getUserPrincipal();
@@ -58,15 +67,40 @@ class SecurityUtil {
      *         the user is included in that role
      */
     static Predicate<String> getRolesChecker(VaadinRequest request) {
-        if (request == null) {
-            return Optional.ofNullable(VaadinService.getCurrent())
+        boolean isWebsocketPush = isWebsocketPush(request);
+
+        // Role checks on PUSH request works out of the box only happen if
+        // transport is not WEBSOCKET.
+        // For websocket PUSH, HttServletRequest#isUserInRole method in
+        // Atmosphere HTTP request wrapper always returns, so we need to
+        // fall back to Spring Security.
+        if (request == null || isWebsocketPush) {
+            AtomicReference<Function<String, Boolean>> roleCheckerHolder = new AtomicReference<>();
+            Runnable roleCheckerLookup = () -> roleCheckerHolder.set(Optional
+                    .ofNullable(request).map(VaadinRequest::getService)
+                    .or(() -> Optional.ofNullable(VaadinService.getCurrent()))
                     .map(service -> service.getContext()
                             .getAttribute(Lookup.class))
                     .map(lookup -> lookup.lookup(VaadinRolePrefixHolder.class))
                     .map(VaadinRolePrefixHolder::getRolePrefix)
                     .map(AuthenticationUtil::getSecurityHolderRoleChecker)
                     .orElseGet(
-                            AuthenticationUtil::getSecurityHolderRoleChecker)::apply;
+                            AuthenticationUtil::getSecurityHolderRoleChecker));
+
+            Authentication authentication = AuthenticationUtil
+                    .getSecurityHolderAuthentication();
+            // Spring Security context holder might not have been initialized
+            // for thread handling websocket message. If so, create a temporary
+            // security context based on the handshake request principal.
+            if (authentication == null && isWebsocketPush && request
+                    .getUserPrincipal() instanceof Authentication requestAuthentication) {
+                roleCheckerLookup = new DelegatingSecurityContextRunnable(
+                        roleCheckerLookup,
+                        new SecurityContextImpl(requestAuthentication));
+            }
+
+            roleCheckerLookup.run();
+            return roleCheckerHolder.get()::apply;
         }
 
         // Update active role prefix if it's not set yet.
@@ -77,6 +111,14 @@ class SecurityUtil {
                         prefixHolder -> prefixHolder.resetRolePrefix(request));
 
         return request::isUserInRole;
+    }
+
+    private static boolean isWebsocketPush(VaadinRequest request) {
+        return request != null
+                && HandlerHelper.isRequestType(request,
+                        HandlerHelper.RequestType.PUSH)
+                && "websocket"
+                        .equals(request.getHeader("X-Atmosphere-Transport"));
     }
 
 }


### PR DESCRIPTION
When using PUSH with websocket transport, the atmosphere wrapped request can be a no-op implementation whose isUserInRole method alwasy returns false, causing, for example, wrong access checking during navigation. This change falls back to Spring Securty for role checking when PUSH transport is websocket.
It also fixes some tests in order to propagate the Spring Security context when starting Thread that perform UI operations.

References psi#123
Part of #11026
