### PR TITLE
fix: fix role checking when using websocket push (#20679) (CP: 24.4)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/NavigationAccessControl.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/NavigationAccessControl.java
@@ -454,7 +454,7 @@ public class NavigationAccessControl implements BeforeEnterListener {
         Objects.requireNonNull(vaadinService);
         return new NavigationContext(vaadinService.getRouter(),
                 navigationTarget, new Location(path), RouteParameters.empty(),
-                vaadinRequest.getUserPrincipal(),
-                getRolesChecker(vaadinRequest), false);
+                getPrincipal(vaadinRequest), getRolesChecker(vaadinRequest),
+                false);
     }
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-websocket/src/test/java/com/vaadin/flow/spring/flowsecuritywebsocket/AppViewIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-websocket/src/test/java/com/vaadin/flow/spring/flowsecuritywebsocket/AppViewIT.java
@@ -14,7 +14,17 @@ public class AppViewIT extends com.vaadin.flow.spring.flowsecurity.AppViewIT {
             session expiration handler to redirect to the timeout page instead
             of the logout view, because the logout process is still ongoing.
             """)
-    public void logout_via_doLogin_redirects_to_logout() {
-        super.logout_via_doLogin_redirects_to_logout();
+    public void logout_via_doLogoutURL_redirects_to_logout() {
+        super.logout_via_doLogoutURL_redirects_to_logout();
+    }
+
+    @Test
+    public void websocket_roles_checked_correctly_during_navigation() {
+        open("admin");
+        loginAdmin();
+        navigateTo("");
+        assertRootPageShown();
+        navigateTo("admin");
+        assertAdminPageShown(ADMIN_FULLNAME);
     }
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/PublicView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/views/PublicView.java
@@ -1,5 +1,8 @@
 package com.vaadin.flow.spring.flowsecurity.views;
 
+import org.springframework.security.concurrent.DelegatingSecurityContextRunnable;
+import org.springframework.security.core.context.SecurityContextHolder;
+
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.H1;
@@ -36,7 +39,7 @@ public class PublicView extends FlexLayout {
         Button backgroundNavigation = new Button(
                 "Navigate to admin view in 1 second", e -> {
                     UI ui = e.getSource().getUI().get();
-                    new Thread(() -> {
+                    Runnable navigateToAdmin = () -> {
                         try {
                             Thread.sleep(1000);
                         } catch (InterruptedException e1) {
@@ -44,8 +47,11 @@ public class PublicView extends FlexLayout {
                         ui.access(() -> {
                             ui.navigate(AdminView.class);
                         });
-
-                    }).start();
+                    };
+                    Runnable wrappedRunnable = new DelegatingSecurityContextRunnable(
+                            navigateToAdmin,
+                            SecurityContextHolder.getContext());
+                    new Thread(wrappedRunnable).start();
                 });
         backgroundNavigation.setId(BACKGROUND_NAVIGATION_ID);
         add(backgroundNavigation);


### PR DESCRIPTION
When using PUSH with websocket transport, the atmosphere wrapped request can be a no-op implementation whose isUserInRole method alwasy returns false, causing, for example, wrong access checking during navigation. This change falls back to Spring Securty for role checking when PUSH transport is websocket.
It also fixes some tests in order to propagate the Spring Security context when starting Thread that perform UI operations.

References psi#123
Part of #11026