### PR TITLE
Fix for duplicate maven-jar entries in POM.XML

### DIFF
--- a/flow-tests/test-express-build/frontend-add-on/pom.xml
+++ b/flow-tests/test-express-build/frontend-add-on/pom.xml
@@ -75,6 +75,12 @@
                             <Vaadin-Package-Version>1</Vaadin-Package-Version>
                         </manifestEntries>
                     </archive>
+                    <!-- Generated file that shouldn't be included in add-ons -->
+                    <excludes>
+                        <exclude>
+                            META-INF/VAADIN/config/flow-build-info.json
+                        </exclude>
+                    </excludes>
                 </configuration>
             </plugin>
 
@@ -112,19 +118,6 @@
                 <configuration>
                     <quiet>true</quiet>
                     <doclint>none</doclint>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>3.4.2</version>
-                <configuration>
-                    <!-- Generated file that shouldn't be included in add-ons -->
-                    <excludes>
-                        <exclude>
-                            META-INF/VAADIN/config/flow-build-info.json
-                        </exclude>
-                    </excludes>
                 </configuration>
             </plugin>
         </plugins>

--- a/flow-tests/test-express-build/java-add-on/pom.xml
+++ b/flow-tests/test-express-build/java-add-on/pom.xml
@@ -70,6 +70,12 @@
                             <Vaadin-Package-Version>1</Vaadin-Package-Version>
                         </manifestEntries>
                     </archive>
+                    <!-- Generated file that shouldn't be included in add-ons -->
+                    <excludes>
+                        <exclude>
+                            META-INF/VAADIN/config/flow-build-info.json
+                        </exclude>
+                    </excludes>
                 </configuration>
             </plugin>
 
@@ -107,19 +113,6 @@
                 <configuration>
                     <quiet>true</quiet>
                     <doclint>none</doclint>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>3.4.2</version>
-                <configuration>
-                    <!-- Generated file that shouldn't be included in add-ons -->
-                    <excludes>
-                        <exclude>
-                            META-INF/VAADIN/config/flow-build-info.json
-                        </exclude>
-                    </excludes>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Removed duplicate maven-jar and merged the configuration options