### PR TITLE
test: disable shm usage for reload time test

### DIFF
--- a/flow-tests/vaadin-spring-tests/test-plain-spring-boot-reload-time/src/test/java/org/vaadin/example/SpringDevToolsReloadViewIT.java
+++ b/flow-tests/vaadin-spring-tests/test-plain-spring-boot-reload-time/src/test/java/org/vaadin/example/SpringDevToolsReloadViewIT.java
@@ -15,13 +15,22 @@
  */
 package org.vaadin.example;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.vaadin.flow.server.Version;
 import com.vaadin.flow.spring.test.SpringDevToolsReloadUtils;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
+import com.vaadin.testbench.annotations.BrowserConfiguration;
+import com.vaadin.testbench.parallel.Browser;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.logging.Logs;
+import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
 /**
@@ -48,6 +57,25 @@ public class SpringDevToolsReloadViewIT extends ChromeBrowserTest {
         System.out.printf(
                 "##teamcity[buildStatisticValue key='%s,plain-spring-hello-world,spring-boot-devtools-reload-time' value='%s']%n",
                 getVaadinMajorMinorVersion(), result);
+    }
+
+    @BrowserConfiguration
+    public List<DesiredCapabilities> tuneChromeSettings() {
+        List<DesiredCapabilities> list = new ArrayList<>();
+        DesiredCapabilities desiredCapabilities = Browser.CHROME
+                .getDesiredCapabilities();
+        ChromeOptions options = new ChromeOptions();
+        options.addArguments("--disable-dev-shm-usage");
+        list.add(desiredCapabilities.merge(options));
+        return list;
+    }
+
+    @After
+    public void dumpLogs() {
+        Logs logs = driver.manage().logs();
+        logs.getAvailableLogTypes().stream()
+                .flatMap(level -> logs.get(level).getAll().stream())
+                .forEach(System.out::println);
     }
 
     private void triggerReload() {

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/test/java/org/vaadin/example/SpringDevToolsReloadViewIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/test/java/org/vaadin/example/SpringDevToolsReloadViewIT.java
@@ -15,14 +15,23 @@
  */
 package org.vaadin.example;
 
-import com.vaadin.flow.server.Version;
-import com.vaadin.flow.spring.test.SpringDevToolsReloadUtils;
-import com.vaadin.flow.testutil.ChromeBrowserTest;
+import java.util.ArrayList;
+import java.util.List;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.logging.Logs;
+import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import com.vaadin.flow.server.Version;
+import com.vaadin.flow.spring.test.SpringDevToolsReloadUtils;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+import com.vaadin.testbench.annotations.BrowserConfiguration;
+import com.vaadin.testbench.parallel.Browser;
 
 /**
  * Class for testing reload time of "larger" (size is configurable and test is
@@ -35,6 +44,25 @@ public class SpringDevToolsReloadViewIT extends ChromeBrowserTest {
         optionalAssertByReloadThreshold(printTestResultToLog(
                 SpringDevToolsReloadUtils.runAndCalculateAverageResult(5,
                         this::runTestReturnResult)));
+    }
+
+    @BrowserConfiguration
+    public List<DesiredCapabilities> tuneChromeSettings() {
+        List<DesiredCapabilities> list = new ArrayList<>();
+        DesiredCapabilities desiredCapabilities = Browser.CHROME
+                .getDesiredCapabilities();
+        ChromeOptions options = new ChromeOptions();
+        options.addArguments("--disable-dev-shm-usage");
+        list.add(desiredCapabilities.merge(options));
+        return list;
+    }
+
+    @After
+    public void dumpLogs() {
+        Logs logs = driver.manage().logs();
+        logs.getAvailableLogTypes().stream()
+                .flatMap(level -> logs.get(level).getAll().stream())
+                .forEach(System.out::println);
     }
 
     private String runTestReturnResult() {

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-reload-time/src/test/java/org/vaadin/example/SpringDevToolsReloadViewIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-reload-time/src/test/java/org/vaadin/example/SpringDevToolsReloadViewIT.java
@@ -15,18 +15,29 @@
  */
 package org.vaadin.example;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.vaadin.flow.server.Version;
 import com.vaadin.flow.spring.test.SpringDevToolsReloadUtils;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
+import com.vaadin.testbench.annotations.BrowserConfiguration;
+import com.vaadin.testbench.parallel.Browser;
 
+import net.jcip.annotations.NotThreadSafe;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.logging.Logs;
+import org.openqa.selenium.remote.DesiredCapabilities;
 
 /**
  * Class for testing reload time of tiny Vaadin app triggered by spring-boot Dev
  * Tool.
  */
+@NotThreadSafe
 public class SpringDevToolsReloadViewIT extends ChromeBrowserTest {
 
     @Test
@@ -67,6 +78,25 @@ public class SpringDevToolsReloadViewIT extends ChromeBrowserTest {
                 getVaadinMajorMinorVersion(), result);
 
         optionalAssertByReloadThreshold(result);
+    }
+
+    @BrowserConfiguration
+    public List<DesiredCapabilities> tuneChromeSettings() {
+        List<DesiredCapabilities> list = new ArrayList<>();
+        DesiredCapabilities desiredCapabilities = Browser.CHROME
+                .getDesiredCapabilities();
+        ChromeOptions options = new ChromeOptions();
+        options.addArguments("--disable-dev-shm-usage");
+        list.add(desiredCapabilities.merge(options));
+        return list;
+    }
+
+    @After
+    public void dumpLogs() {
+        Logs logs = driver.manage().logs();
+        logs.getAvailableLogTypes().stream()
+                .flatMap(level -> logs.get(level).getAll().stream())
+                .forEach(System.out::println);
     }
 
     private void triggerReload() {


### PR DESCRIPTION
Prevents remote Chrome ERR_INSUFFICIENT_RESOURCES failures for tests loading hundreds of resources concurrently (CSS or JS).