### PR TITLE
fix: Close opened input stream.

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/PwaRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PwaRegistry.java
@@ -403,7 +403,9 @@ public class PwaRegistry implements Serializable {
         URLConnection logoResource = logo != null ? logo.openConnection()
                 : BootstrapHandler.class.getResource("default-logo.png")
                         .openConnection();
-        return ImageIO.read(logoResource.getInputStream());
+        try (InputStream inputStream = logoResource.getInputStream()) {
+            return ImageIO.read(inputStream);
+        }
     }
 
     /**


### PR DESCRIPTION
ImageIO.read does not close
the input stream.
Close it after use.

Fixes #9364
