### PR TITLE
chore: upgrade frontend-maven-plugin version

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -74,7 +74,7 @@ public class FrontendTools {
 
     public static final String DEFAULT_PNPM_VERSION = "8.6.11";
 
-    public static final String INSTALL_NODE_LOCALLY = "%n  $ mvn com.github.eirslett:frontend-maven-plugin:1.10.0:install-node-and-npm "
+    public static final String INSTALL_NODE_LOCALLY = "%n  $ mvn com.github.eirslett:frontend-maven-plugin:1.15.1:install-node-and-npm "
             + "-DnodeVersion=\"" + DEFAULT_NODE_VERSION + "\" ";
 
     public static final String NPM_BIN_PATH = FrontendUtils.isWindows()


### PR DESCRIPTION
seems 1.10.0 is from 2020.. so let us use something newer