### PR TITLE
chore: use custom thread pool for vaadin-dev-server tasks

### DIFF
--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
@@ -79,6 +79,7 @@ public abstract class ClassesSerializableTest extends ClassFinder {
                 "com\\.vaadin\\.base\\.devserver\\.DebugWindowConnection",
                 "com\\.vaadin\\.base\\.devserver\\.DebugWindowConnection\\$DevToolsInterfaceImpl",
                 "com\\.vaadin\\.base\\.devserver\\.DevModeHandlerManagerImpl",
+                "com\\.vaadin\\.base\\.devserver\\.DevModeHandlerManagerImpl\\$InternalThreadFactory",
                 "com\\.vaadin\\.base\\.devserver\\.DevServerWatchDog",
                 "com\\.vaadin\\.base\\.devserver\\.DevServerWatchDog\\$WatchDogServer",
                 "com\\.vaadin\\.base\\.devserver\\.DevToolsInterface",

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerManagerImpl.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerManagerImpl.java
@@ -15,18 +15,20 @@
  */
 package com.vaadin.base.devserver;
 
-import com.vaadin.flow.server.Command;
 import jakarta.servlet.annotation.HandlesTypes;
 
 import java.io.Closeable;
 import java.io.File;
-import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,6 +37,7 @@ import com.vaadin.base.devserver.startup.DevModeInitializer;
 import com.vaadin.base.devserver.startup.DevModeStartupListener;
 import com.vaadin.flow.internal.DevModeHandler;
 import com.vaadin.flow.internal.DevModeHandlerManager;
+import com.vaadin.flow.server.Command;
 import com.vaadin.flow.server.Mode;
 import com.vaadin.flow.server.VaadinContext;
 import com.vaadin.flow.server.frontend.FrontendUtils;
@@ -68,6 +71,7 @@ public class DevModeHandlerManagerImpl implements DevModeHandlerManager {
     private DevModeHandler devModeHandler;
     private BrowserLauncher browserLauncher;
     private final Set<Command> shutdownCommands = new HashSet<>();
+    private ExecutorService executorService;
 
     private String applicationUrl;
     private boolean fullyStarted = false;
@@ -96,8 +100,11 @@ public class DevModeHandlerManagerImpl implements DevModeHandlerManager {
     @Override
     public void initDevModeHandler(Set<Class<?>> classes, VaadinContext context)
             throws VaadinInitializerException {
-        setDevModeHandler(
-                DevModeInitializer.initDevModeHandler(classes, context));
+        shutdownExecutorService();
+        executorService = Executors.newFixedThreadPool(4,
+                new InternalThreadFactory());
+        setDevModeHandler(DevModeInitializer.initDevModeHandler(classes,
+                context, executorService));
         CompletableFuture.runAsync(() -> {
             DevModeHandler devModeHandler = getDevModeHandler();
             if (devModeHandler instanceof AbstractDevServerRunner) {
@@ -111,9 +118,15 @@ public class DevModeHandlerManagerImpl implements DevModeHandlerManager {
             startWatchingThemeFolder(context, config);
             watchExternalDependencies(context, config);
             setFullyStarted(true);
-        });
+        }, executorService);
         setDevModeStarted(context);
         this.browserLauncher = new BrowserLauncher(context);
+    }
+
+    private void shutdownExecutorService() {
+        if (executorService != null) {
+            executorService.shutdownNow();
+        }
     }
 
     private void watchExternalDependencies(VaadinContext context,
@@ -159,6 +172,7 @@ public class DevModeHandlerManagerImpl implements DevModeHandlerManager {
             devModeHandler.stop();
             devModeHandler = null;
         }
+        shutdownExecutorService();
         for (Command shutdownCommand : shutdownCommands) {
             try {
                 shutdownCommand.execute();
@@ -230,5 +244,19 @@ public class DevModeHandlerManagerImpl implements DevModeHandlerManager {
 
     private static Logger getLogger() {
         return LoggerFactory.getLogger(DevModeHandlerManagerImpl.class);
+    }
+
+    private static class InternalThreadFactory implements ThreadFactory {
+        private final AtomicInteger threadNumber = new AtomicInteger(1);
+
+        @Override
+        public Thread newThread(Runnable runnable) {
+            String threadName = "vaadin-dev-server-"
+                    + threadNumber.getAndIncrement();
+            Thread thread = new Thread(runnable, threadName);
+            thread.setDaemon(true);
+            thread.setPriority(Thread.NORM_PRIORITY);
+            return thread;
+        }
     }
 }

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerManagerImpl.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerManagerImpl.java
@@ -126,6 +126,7 @@ public class DevModeHandlerManagerImpl implements DevModeHandlerManager {
     private void shutdownExecutorService() {
         if (executorService != null) {
             executorService.shutdownNow();
+            executorService = null;
         }
     }
 


### PR DESCRIPTION
Vaadin dev-server executes long-running tasks (e.g. npm install) using the common ForkJoin pool. This can cause a slow startup or even timeouts when the pool size is small.
Using a dedicated executor for dev-server tasks should prevent the above issues.

Fixes #20793