### PR TITLE
chore: Use custom react transform in development mode

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
@@ -112,6 +112,9 @@ public class TaskGenerateReactFiles
     private static final String LAYOUTS_JSON = "layouts.json";
     static final String FLOW_FLOW_TSX = "flow/" + FLOW_TSX;
     static final String FLOW_REACT_ADAPTER_TSX = "flow/" + REACT_ADAPTER_TSX;
+    static final String JSX_TRANSFORM_INDEX = "jsx-dev-transform/index.ts";
+    static final String JSX_TRANSFORM_RUNTIME = "jsx-dev-transform/jsx-runtime.ts";
+    static final String JSX_TRANSFORM_DEV_RUNTIME = "jsx-dev-transform/jsx-dev-runtime.ts";
     private static final String ROUTES_JS_IMPORT_PATH_TOKEN = "%routesJsImportPath%";
 
     // matches setting the server-side routes from Flow.tsx:
@@ -164,6 +167,14 @@ public class TaskGenerateReactFiles
                 frontendGeneratedFolder, FrontendUtils.ROUTES_TSX);
         try {
             writeFile(flowTsx, getFileContent(FLOW_TSX));
+            writeFile(new File(frontendGeneratedFolder, JSX_TRANSFORM_INDEX),
+                    getFileContent(JSX_TRANSFORM_INDEX));
+            writeFile(
+                    new File(frontendGeneratedFolder,
+                            JSX_TRANSFORM_DEV_RUNTIME),
+                    getFileContent(JSX_TRANSFORM_DEV_RUNTIME));
+            writeFile(new File(frontendGeneratedFolder, JSX_TRANSFORM_RUNTIME),
+                    getFileContent(JSX_TRANSFORM_RUNTIME));
             writeFile(vaadinReactTsx,
                     getVaadinReactTsContent(routesTsx.exists()));
             writeLayoutsJson(
@@ -262,6 +273,12 @@ public class TaskGenerateReactFiles
                     frontendGeneratedFolder, FrontendUtils.ROUTES_TSX);
             File layoutsJson = new File(frontendGeneratedFolder, LAYOUTS_JSON);
             FileUtils.deleteQuietly(flowTsx);
+            FileUtils.deleteQuietly(
+                    new File(frontendGeneratedFolder, JSX_TRANSFORM_INDEX));
+            FileUtils.deleteQuietly(new File(frontendGeneratedFolder,
+                    JSX_TRANSFORM_DEV_RUNTIME));
+            FileUtils.deleteQuietly(
+                    new File(frontendGeneratedFolder, JSX_TRANSFORM_RUNTIME));
             FileUtils.deleteQuietly(layoutsJson);
             FileUtils.deleteQuietly(vaadinReactTsx);
             FileUtils.deleteQuietly(reactAdapterTsx);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRemoveOldFrontendGeneratedFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRemoveOldFrontendGeneratedFiles.java
@@ -138,6 +138,15 @@ public class TaskRemoveOldFrontendGeneratedFiles implements FallibleCommand {
                 .resolveSibling(FrontendUtils.IMPORTS_D_TS_NAME));
         knownFiles.add(normalizePath(frontendGeneratedFolder.resolve(
                 new File(TaskGenerateReactFiles.FLOW_FLOW_TSX).toPath())));
+        knownFiles.add(normalizePath(frontendGeneratedFolder.resolve(
+                new File(TaskGenerateReactFiles.JSX_TRANSFORM_DEV_RUNTIME)
+                        .toPath())));
+        knownFiles.add(normalizePath(frontendGeneratedFolder
+                .resolve(new File(TaskGenerateReactFiles.JSX_TRANSFORM_RUNTIME)
+                        .toPath())));
+        knownFiles.add(normalizePath(frontendGeneratedFolder
+                .resolve(new File(TaskGenerateReactFiles.JSX_TRANSFORM_INDEX)
+                        .toPath())));
         knownFiles.add(normalizePath(
                 frontendGeneratedFolder.resolve(FrontendUtils.ROUTES_TSX)));
         knownFiles.add(normalizePath(

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/jsx-dev-transform/index.ts
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/jsx-dev-transform/index.ts
@@ -1,0 +1,3 @@
+import { createElement as reactCreateElement } from "react";
+
+export const createElement = reactCreateElement;

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/jsx-dev-transform/jsx-dev-runtime.ts
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/jsx-dev-transform/jsx-dev-runtime.ts
@@ -1,0 +1,29 @@
+import { JSXSource, Fragment as reactFragment, jsxDEV as reactJsxDEV } from 'react/jsx-dev-runtime';
+
+export const Fragment = reactFragment;
+
+export function jsxDEV(
+  type: React.ElementType,
+  props: unknown,
+  key: React.Key | undefined,
+  isStatic: boolean,
+  source?: JSXSource,
+  self?: unknown
+): React.ReactElement {
+  const realFreeze = Object.freeze;
+  try {
+    (Object as any).freeze = undefined; // prevent React from freezing the element
+
+    const reactElement: any = reactJsxDEV(type, props, key, isStatic, source, self);
+    if (source && !reactElement._source) {
+      // When running with React 19, put the source information on the _debugInfo array, 
+      // which will be transferred to the fiber node by React
+      reactElement._debugInfo ??= [];
+      reactElement._debugInfo.source = source;
+    }
+    realFreeze(reactElement);
+    return reactElement;
+  } finally {
+    (Object as any).freeze = realFreeze;
+  }
+}

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/jsx-dev-transform/jsx-runtime.ts
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/jsx-dev-transform/jsx-runtime.ts
@@ -1,0 +1,13 @@
+import {
+  Fragment as reactFragment,
+  jsx as reactJsx,
+  jsxs as reactJsxs,
+} from "react/jsx-runtime";
+
+export const Fragment = reactFragment;
+export const jsx = reactJsx;
+export const jsxs = reactJsxs;
+
+throw new Error(
+  "Do not use this transform for production builds. It is only meant for development."
+);

--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -781,7 +781,16 @@ export const vaadinConfig: UserConfigFn = (env) => {
         babel: {
           // We need to use babel to provide the source information for it to be correct
           // (otherwise Babel will slightly rewrite the source file and esbuild generate source info for the modified file)
-          presets: [['@babel/preset-react', { runtime: 'automatic', development: !productionMode }]],
+          presets: [
+            [
+              '@babel/preset-react',
+              {
+                runtime: 'automatic',
+                importSource: productionMode ? 'react' : 'Frontend/generated/jsx-dev-transform',
+                development: !productionMode
+              }
+            ]
+          ],
           // React writes the source location for where components are used, this writes for where they are defined
           plugins: [
             !productionMode && addFunctionComponentSourceLocationBabel(),

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateReactFilesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateReactFilesTest.java
@@ -90,6 +90,16 @@ public class TaskGenerateReactFilesTest {
                         + "layouts.json",
                 new File(new File(frontend, FrontendUtils.GENERATED),
                         "layouts.json").exists());
+        assertGeneratedFileExists("jsx-dev-transform/index.ts");
+        assertGeneratedFileExists("jsx-dev-transform/jsx-runtime.ts");
+        assertGeneratedFileExists("jsx-dev-transform/jsx-dev-runtime.ts");
+    }
+
+    private void assertGeneratedFileExists(String filename) {
+        Assert.assertTrue(
+                "Missing ./frontend/" + FrontendUtils.GENERATED + filename,
+                new File(new File(frontend, FrontendUtils.GENERATED), filename)
+                        .exists());
     }
 
     @Test
@@ -423,6 +433,16 @@ public class TaskGenerateReactFilesTest {
         Assert.assertFalse(
                 "./frontend/routes.tsx.flowBackup should not be created with default content",
                 new File(frontend, "routes.tsx.flowBackup").exists());
+        assertGeneratedFileRemoved("jsx-dev-transform/index.ts");
+        assertGeneratedFileRemoved("jsx-dev-transform/jsx-dev-runtime.ts");
+        assertGeneratedFileRemoved("jsx-dev-transform/jsx-runtime.ts");
+    }
+
+    private void assertGeneratedFileRemoved(String filename) {
+        Assert.assertFalse(
+                "./frontend/generated/" + filename
+                        + " should be removed when react is disabled",
+                new File(frontendGenerated, filename).exists());
     }
 
     @Test


### PR DESCRIPTION
Needed for Copilot to get source information as React 19 drops _debugSource from fiber nodes
