### PR TITLE
fix: validate downloaded node

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/MessageDigestUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/MessageDigestUtil.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.internal;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -73,6 +74,22 @@ public class MessageDigestUtil {
      */
     public static byte[] sha256(String string, byte[] salt, Charset charset) {
         return getSha256(salt).digest(string.getBytes(charset));
+    }
+
+    public static String sha256Hex(byte[] content) {
+        return sha256Hex(content, null);
+    }
+
+    public static String sha256Hex(byte[] content, byte[] salt) {
+        byte[] digest = getSha256(salt).digest(content);
+        final StringBuilder hexString = new StringBuilder();
+        for (int i = 0; i < digest.length; i++) {
+            final String hex = Integer.toHexString(0xff & digest[i]);
+            if (hex.length() == 1)
+                hexString.append('0');
+            hexString.append(hex);
+        }
+        return hexString.toString();
     }
 
     private static MessageDigest getSha256(byte[] salt) {

--- a/flow-server/src/main/java/com/vaadin/flow/internal/MessageDigestUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/MessageDigestUtil.java
@@ -76,10 +76,27 @@ public class MessageDigestUtil {
         return getSha256(salt).digest(string.getBytes(charset));
     }
 
+    /**
+     * Calculates the SHA-256 hash of the given byte array.
+     *
+     * @param content
+     *            the byte array to hash
+     *
+     * @return sha256 hash string
+     */
     public static String sha256Hex(byte[] content) {
         return sha256Hex(content, null);
     }
 
+    /**
+     * Calculates the SHA-256 hash of the given byte array with the given salt.
+     *
+     * @param content
+     *            the byte array to hash
+     * @param salt
+     *            salt to be added to the calculation
+     * @return sha256 hash string
+     */
     public static String sha256Hex(byte[] content, byte[] salt) {
         byte[] digest = getSha256(salt).digest(content);
         final StringBuilder hexString = new StringBuilder();

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
@@ -584,10 +584,7 @@ public class NodeInstaller {
                 fileDownloader.download(shaSumsURL, shaSums, userName, password,
                         null);
             } catch (DownloadException e) {
-                if (System.getProperties()
-                        .containsKey("vaadin.acceptMissingSHA")
-                        && Boolean.parseBoolean(System
-                                .getProperty("vaadin.acceptMissingSHA"))) {
+                if (Boolean.getBoolean(ACCEPT_MISSING_SHA)) {
                     getLogger().warn(
                             "Could not verify SHA256 sum of downloaded node in {}. Accepting missing sha verification as per set system property.",
                             archive);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
@@ -613,6 +613,8 @@ public class NodeInstaller {
                             .trim())
                     .findFirst().orElse("-1");
 
+            shaSums.delete();
+
             if (!archiveSHA256.equals(archiveTargetSHA256)) {
                 getLogger().error("Expected SHA256 [{}], got [{}]",
                         archiveTargetSHA256, archiveSHA256);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
@@ -67,7 +67,7 @@ public class NodeInstaller {
     private static final int MAX_DOWNLOAD_ATTEMPS = 5;
 
     private static final int DOWNLOAD_ATTEMPT_DELAY = 5;
-    public static final String ACCEPT_MISSING_SHA = "vaadin.acceptMissingSHA";
+    public static final String ACCEPT_MISSING_SHA = "vaadin.node.download.acceptMissingSHA";
 
     private final Object lock = new Object();
 
@@ -547,7 +547,8 @@ public class NodeInstaller {
                         Thread.currentThread().interrupt();
                     }
                 } catch (VerificationException ve) {
-                    getLogger().warn("SHA256 verification failed.");
+                    getLogger().warn(
+                            "SHA256 verification of downloaded node archive failed.");
                     if (i == MAX_DOWNLOAD_ATTEMPS - 1) {
                         removeArchiveFile(destination);
                         throw new DownloadException(
@@ -586,12 +587,12 @@ public class NodeInstaller {
             } catch (DownloadException e) {
                 if (Boolean.getBoolean(ACCEPT_MISSING_SHA)) {
                     getLogger().warn(
-                            "Could not verify SHA256 sum of downloaded node in {}. Accepting missing sha verification as per set system property.",
-                            archive);
+                            "Could not verify SHA256 sum of downloaded node in {}. Accepting missing checksum verification as set in '{}' system property.",
+                            archive, ACCEPT_MISSING_SHA);
                     return;
                 } else {
                     getLogger().info(
-                            "Download failed. If download failure of {} persists, use system property '{}' to skip verification or download node manually.",
+                            "Download of {} failed. If failure persists, use system property '{}' to skip verification or download node manually.",
                             SHA_SUMS_FILE, ACCEPT_MISSING_SHA);
                     throw e;
                 }
@@ -613,7 +614,8 @@ public class NodeInstaller {
             shaSums.delete();
 
             if (!archiveSHA256.equals(archiveTargetSHA256)) {
-                getLogger().error("Expected SHA256 [{}], got [{}]",
+                getLogger().error(
+                        "Expected SHA256 [{}] for downloaded node archive, got [{}]",
                         archiveTargetSHA256, archiveSHA256);
                 throw new VerificationException(
                         "SHA256 sums did not match for downloaded node");

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/ProxyConfig.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/ProxyConfig.java
@@ -70,8 +70,9 @@ public class ProxyConfig {
                 + "development-mode/node-js#proxy-settings-for-downloading-"
                 + "frontend-toolchain for information on proxy configuration.";
         if (proxies.isEmpty()) {
-            getLogger().info("No proxies configured. "
-                    + "If you are behind a proxy server, " + docLink);
+            getLogger().debug(
+                    "No proxies configured. If you are behind a proxy server, {}",
+                    docLink);
             return null;
         }
         final URI uri = URI.create(requestUrl);
@@ -80,9 +81,8 @@ public class ProxyConfig {
                 return proxy;
             }
         }
-        getLogger().info(
-                "Could not find matching proxy for host: {}" + " - " + docLink,
-                uri.getHost());
+        getLogger().info("Could not find matching proxy for host: {} - {}",
+                uri.getHost(), docLink);
         return null;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/VerificationException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/VerificationException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2000-2024 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.frontend.installer;
+
+/**
+ * Exception indicating a failure during file download.
+ * <p>
+ * Derived from eirslett/frontend-maven-plugin
+ * <p>
+ * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since
+ */
+public final class VerificationException extends Exception {
+
+    /**
+     * Exceptioon with message.
+     *
+     * @param message
+     *            exception message
+     */
+    public VerificationException(String message) {
+        super(message);
+    }
+
+    /**
+     * Exceptioon with message and cause.
+     *
+     * @param message
+     *            exception message
+     * @param cause
+     *            cause for exception
+     */
+    VerificationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/VerificationException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/VerificationException.java
@@ -16,9 +16,7 @@
 package com.vaadin.flow.server.frontend.installer;
 
 /**
- * Exception indicating a failure during file download.
- * <p>
- * Derived from eirslett/frontend-maven-plugin
+ * Exception indicating a failure during downloaded archive verification.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -182,6 +182,9 @@ public class FrontendToolsTest {
     @Test
     public void nodeIsBeingLocated_unsupportedNodeInstalled_defaultNodeVersionInstalledToAlternativeDirectory()
             throws FrontendUtils.UnknownVersionException, IOException {
+        Assume.assumeFalse(
+                "Skipping test on windows until a fake node.exe that isn't caught by Window defender can be created.",
+                FrontendUtils.isWindows());
         // Unsupported node version
         FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo
                 .builder(FrontendStubs.Tool.NODE).withVersion("8.9.3").build();
@@ -204,6 +207,9 @@ public class FrontendToolsTest {
     @Test
     public void nodeIsBeingLocated_unsupportedNodeInstalled_fallbackToNodeInstalledToAlternativeDirectory()
             throws IOException, FrontendUtils.UnknownVersionException {
+        Assume.assumeFalse(
+                "Skipping test on windows until a fake node.exe that isn't caught by Window defender can be created.",
+                FrontendUtils.isWindows());
         // Unsupported node version
         FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo
                 .builder(FrontendStubs.Tool.NODE).withVersion("8.9.3").build();
@@ -730,6 +736,8 @@ public class FrontendToolsTest {
 
     @Test
     public void getSuitablePnpm_useGlobalPnpm_noPnpmInstalled_throws() {
+        Assume.assumeFalse("Skipping test on windows.",
+                FrontendUtils.isWindows());
         Optional<File> pnpm = frontendToolsLocator.tryLocateTool("pnpm");
         Assume.assumeFalse("Skip this test once globally installed pnpm is "
                 + "discovered", pnpm.isPresent());


### PR DESCRIPTION
Validate downloaded node
against the provided
sha256 hash.

Fixes #20661
