### PR TITLE
Revert "fix: use capture for dragLeave (#20291)"

### DIFF
--- a/flow-dnd/src/main/resources/META-INF/resources/frontend/dndConnector.js
+++ b/flow-dnd/src/main/resources/META-INF/resources/frontend/dndConnector.js
@@ -68,7 +68,7 @@ window.Vaadin.Flow.dndConnector = {
     if (element['__active']) {
       element.addEventListener('dragenter', this.__ondragenterListener, false);
       element.addEventListener('dragover', this.__ondragoverListener, false);
-      element.addEventListener('dragleave', this.__ondragleaveListener, true);
+      element.addEventListener('dragleave', this.__ondragleaveListener, false);
       element.addEventListener('drop', this.__ondropListener, false);
     } else {
       element.removeEventListener('dragenter', this.__ondragenterListener, false);


### PR DESCRIPTION
This reverts commit 17042cebdc0006931b5b835ca6227ba56ee6f946.

Reverting due to regression found in https://github.com/vaadin/flow/issues/20607 and due to no viable fix or workaround for original functionality found.
