### PR TITLE
chore: Run npm install with --legacy-peer-deps for React 19

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 
+import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.internal.Pair;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.ExecutionFailedException;
@@ -267,6 +268,9 @@ public class TaskRunNpmInstall implements FallibleCommand {
         }
 
         npmInstallCommand.add("--ignore-scripts");
+        if (options.getFeatureFlags().isEnabled(FeatureFlags.REACT19)) {
+            npmInstallCommand.add(" --legacy-peer-deps");
+        }
 
         if (options.isCiBuild()) {
             if (options.isEnablePnpm() || options.isEnableBun()) {


### PR DESCRIPTION
Needed until there is a new Lit release
