### PR TITLE
fix: set viewport-fit: cover to enable CSS env() variables in PWAs

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Viewport.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Viewport.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
 /**
  * Defines a viewport tag that will be added to the HTML of the host page of a
  * UI class. If no viewport tag has been defined, a default of
- * <code>width=device-width, initial-scale=1.0</code> is used.
+ * <code>width=device-width, initial-scale=1.0, viewport-fit=cover</code> is used.
  *
  * @author Vaadin Ltd
  * @since 1.0
@@ -42,20 +42,20 @@ public @interface Viewport {
      * <p>
      * Recommended for a Responsive Web Design.
      */
-    String DEFAULT = "width=device-width, initial-scale=1.0";
+    String DEFAULT = "width=device-width, initial-scale=1.0, viewport-fit=cover";
 
     /**
      * Sets the viewport to the height of the device rather than the rendered
      * space.
      */
-    String DEVICE_HEIGHT = "height=device-height, initial-scale=1.0";
+    String DEVICE_HEIGHT = "height=device-height, initial-scale=1.0, viewport-fit=cover";
 
     /**
      * Sets the viewport at the width and height of the device. The device-width
      * and device-height properties are translated to 100vw and 100vh
      * respectively.
      */
-    String DEVICE_DIMENSIONS = "width=device-width, height=device-height, initial-scale=1.0";
+    String DEVICE_DIMENSIONS = "width=device-width, height=device-height, initial-scale=1.0, viewport-fit=cover";
 
     /**
      * Gets the viewport tag content.


### PR DESCRIPTION
## Description

The `env()` variables aren't working in PWAs unless `viewport-fit: cover` is added to the `<meta name="viewport">`, see https://developer.mozilla.org/en-US/docs/Web/CSS/env#usage.

Fixes https://github.com/vaadin/web-components/issues/8449

## Type of change

- [x] Bugfix
