### PR TITLE
chore: Update browser details parse log output

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/WebBrowser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/WebBrowser.java
@@ -70,8 +70,7 @@ public class WebBrowser implements Serializable {
             browserDetails = new BrowserDetails(agent) {
                 @Override
                 protected void log(String error, Exception e) {
-                    LoggerFactory.getLogger(BrowserDetails.class).error(error,
-                            e);
+                    LoggerFactory.getLogger(BrowserDetails.class).error(error);
                 }
             };
         }

--- a/flow-server/src/main/java/com/vaadin/flow/shared/BrowserDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/BrowserDetails.java
@@ -463,8 +463,8 @@ public class BrowserDetails implements Serializable {
         try {
             return Integer.parseInt(versionString);
         } catch (Exception e) {
-            log(partName + " version parsing failed for: " + versionString
-                    + "\nWith userAgent: " + userAgent, e);
+            log(partName + " version parsing failed for: \"" + versionString
+                    + "\"\nWith userAgent: " + userAgent, e);
         }
         return -1;
     }


### PR DESCRIPTION
Do not log the exception stack trace
when failing version parse.
Message contains alrready required
information and the result is -1
and the app stays running.

touches #20838
