### PR TITLE
fix: fix setReadonly when using binder with records

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -1659,7 +1659,7 @@ public class Binder<BEAN> implements Serializable {
 
         @Override
         public void setReadOnly(boolean readOnly) {
-            if (setter == null && !readOnly) {
+            if (!binder.isRecord && this.setter == null && !readOnly) {
                 throw new IllegalStateException(
                         "Binding with a null setter has to be read-only");
             }
@@ -3535,7 +3535,8 @@ public class Binder<BEAN> implements Serializable {
      *            to set them to read-write
      */
     public void setReadOnly(boolean readOnly) {
-        getBindings().stream().filter(binding -> binding.getSetter() != null)
+        getBindings().stream()
+                .filter(binding -> isRecord || binding.getSetter() != null)
                 .forEach(field -> field.setReadOnly(readOnly));
     }
 

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -1304,6 +1304,23 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
     }
 
     @Test
+    public void setReadonly_record_allFieldsAreReadonly() {
+        Binder<TestRecord> binder = new Binder<>(TestRecord.class);
+        binder.forField(nameField).bind("name");
+        binder.forField(ageField).bind("age");
+
+        binder.getBinding("name").ifPresent(b -> b.setReadOnly(true));
+        binder.setReadOnly(true);
+        assertTrue("Name field should be readonly", nameField.isReadOnly());
+        assertTrue("Age field should be readonly", ageField.isReadOnly());
+
+        binder.setReadOnly(false);
+        assertFalse("Name field should not be readonly",
+                nameField.isReadOnly());
+        assertFalse("Age field should not be readonly", ageField.isReadOnly());
+    }
+
+    @Test
     public void isValidTest_bound_binder() {
         binder.forField(nameField)
                 .withValidator(Validator.from(


### PR DESCRIPTION
## Description

When Binder is used with record, calling setReadonly method does not have any effect because the logic only considers bindings with a proper setter. This change fixes the setReadonly logic to take care of all bindings when Binder is using a record.

Fixes #20854

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
