### PR TITLE
chore: Add convenience list and count without Filter

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/data/CountService.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/data/CountService.java
@@ -10,12 +10,21 @@ import com.vaadin.flow.spring.data.filter.Filter;
 public interface CountService {
 
     /**
+     * Counts the number of items, without any filtering.
+     *
+     * @return the number of items in the service
+     */
+    default long count() {
+        return count(null);
+    }
+
+    /**
      * Counts the number of items that match the given filter.
      *
      * @param filter
      *            the filter, or {@code null} to use no filter
      * @return the number of items in the service that match the filter
      */
-    public long count(@Nullable Filter filter);
+    long count(@Nullable Filter filter);
 
 }

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/data/ListService.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/data/ListService.java
@@ -15,6 +15,18 @@ import com.vaadin.flow.spring.data.filter.Filter;
  */
 public interface ListService<T> {
     /**
+     * Lists objects of the given type using the paging and sorting
+     * options provided in the parameters.
+     *
+     * @param pageable
+     *            contains information about paging and sorting
+     * @return a list of objects or an empty list if no objects were found
+     */
+    default List<T> list(Pageable pageable) {
+        return list(pageable, null);
+    }
+
+    /**
      * Lists objects of the given type using the paging, sorting and filtering
      * options provided in the parameters.
      *

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/data/ListService.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/data/ListService.java
@@ -15,8 +15,8 @@ import com.vaadin.flow.spring.data.filter.Filter;
  */
 public interface ListService<T> {
     /**
-     * Lists objects of the given type using the paging and sorting
-     * options provided in the parameters.
+     * Lists objects of the given type using the paging and sorting options
+     * provided in the parameters.
      *
      * @param pageable
      *            contains information about paging and sorting


### PR DESCRIPTION
Using a default implementation does not put any extra burden on the interface implementor
