### PR TITLE
chore: Add JSpecify as a flow-server dependency

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -27,6 +27,11 @@
             <artifactId>throw-if-servlet3</artifactId>
             <version>1.0.2</version>
         </dependency>
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <version>1.0.0</version>
+        </dependency>
 
         <!-- DefaultApplicationConfigurationFactory is declared as an OSGi
             service -->

--- a/vaadin-spring/pom.xml
+++ b/vaadin-spring/pom.xml
@@ -43,12 +43,6 @@
             <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jspecify</groupId>
-            <artifactId>jspecify</artifactId>
-            <version>1.0.0</version>
-        </dependency>
-
 
         <dependency>
             <groupId>com.vaadin</groupId>


### PR DESCRIPTION
This is so it can be used in projects without further imports, and we can use it new new start.vaadin.com projects
