### PR TITLE
fix: Add classpath elements to Surefire plugin

### DIFF
--- a/flow-client/pom.xml
+++ b/flow-client/pom.xml
@@ -192,6 +192,9 @@
                     <excludes>
                         <exclude>**/Gwt*.java</exclude>
                     </excludes>
+                    <additionalClasspathElements>
+                        <additionalClasspathElement>${basedir}/../flow-server/src/main/java</additionalClasspathElement>
+                    </additionalClasspathElements>
                     <enableAssertions>true</enableAssertions>
                 </configuration>
             </plugin>
@@ -228,6 +231,7 @@
                         a separate production build -->
                     <enableAssertions>true</enableAssertions>
                     <failOnError>true</failOnError>
+                    <generateJsInteropExports>true</generateJsInteropExports>
                     <gwtSdkFirstInClasspath></gwtSdkFirstInClasspath>
                     <persistentunitcache>false</persistentunitcache>
                     <webappDirectory>${gwt.module.output}</webappDirectory>


### PR DESCRIPTION
## Description

Maven doesn't use `.classpath` and as such isn't aware that it should use `flow-server` as a source directory. That leads to a whole lot of Project Errors in IntelliJ IDEA if `flow-client` module isn't ignored. This configuration change gets rid of those errors.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
