### PR TITLE
feat: DisabledUpdateMode for ShortcutRegistration

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import com.vaadin.flow.component.internal.UIInternals;
+import com.vaadin.flow.dom.DisabledUpdateMode;
 import com.vaadin.flow.dom.DomListenerRegistration;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableSupplier;
@@ -94,6 +95,8 @@ public class ShortcutRegistration implements Registration, Serializable {
     private ShortcutEventListener eventListener;
 
     private List<Registration> registrations = new ArrayList<>();
+
+    private DisabledUpdateMode mode = DisabledUpdateMode.ONLY_WHEN_ENABLED;
 
     // beforeClientResponse callback
     // needs to be an anonymous class to prevent deserialization issues
@@ -518,6 +521,39 @@ public class ShortcutRegistration implements Registration, Serializable {
     }
 
     /**
+     * Configure whether this listener will be called even in cases when the
+     * component is disabled. Defaults to
+     * {@link DisabledUpdateMode#ONLY_WHEN_ENABLED}.
+     *
+     * @param disabledUpdateMode
+     *            {@link DisabledUpdateMode#ONLY_WHEN_ENABLED} to only fire
+     *            events when the component is enabled,
+     *            {@link DisabledUpdateMode#ALWAYS} to fire events also when the
+     *            component is disabled.
+     *
+     * @return this registration, for chaining
+     */
+    public ShortcutRegistration setDisabledUpdateMode(
+            DisabledUpdateMode disabledUpdateMode) {
+        if (disabledUpdateMode == null) {
+            throw new IllegalArgumentException(
+                    "RPC communication control mode for disabled element must not be null");
+        }
+        mode = disabledUpdateMode;
+        return this;
+    }
+
+    /**
+     * Returns whether this listener will be called even in cases when the
+     * component is disabled.
+     *
+     * @return current disabledUpdateMode for this listener
+     */
+    public DisabledUpdateMode getDisabledUpdateMode() {
+        return mode;
+    }
+
+    /**
      * Used for testing purposes.
      *
      * @return Is there a need to write shortcut changes to the client
@@ -637,8 +673,9 @@ public class ShortcutRegistration implements Registration, Serializable {
     }
 
     private void fireShortcutEvent(Component component) {
-        if (ancestorsOrSelfAreVisible(lifecycleOwner)
-                && lifecycleOwner.getElement().isEnabled()) {
+        if (ancestorsOrSelfAreVisible(lifecycleOwner) && (lifecycleOwner
+                .getElement().isEnabled()
+                || DisabledUpdateMode.ALWAYS.equals(getDisabledUpdateMode()))) {
             invokeShortcutEventListener(component);
         }
     }

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
@@ -33,6 +33,7 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
 import com.vaadin.flow.component.internal.UIInternals;
+import com.vaadin.flow.dom.DisabledUpdateMode;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementFactory;
 import com.vaadin.flow.function.SerializableConsumer;
@@ -504,6 +505,24 @@ public class ShortcutRegistrationTest {
                 .fireEvent(new KeyDownEvent(listenOn[0], Key.KEY_A.toString()));
 
         Assert.assertNull(event.get());
+    }
+
+    @Test
+    public void constructedRegistration_lifecycleOwnerIsDisabledWithDisabledUpdateModeAlways_shortcutEventIsFired() {
+        AtomicReference<ShortcutEvent> event = new AtomicReference<>();
+
+        new ShortcutRegistration(lifecycleOwner, () -> listenOn, event::set,
+                Key.KEY_A).setDisabledUpdateMode(DisabledUpdateMode.ALWAYS);
+
+        Element element = mockLifecycle(true);
+        element.setEnabled(false);
+
+        clientResponse();
+
+        listenOn[0].getEventBus()
+                .fireEvent(new KeyDownEvent(listenOn[0], Key.KEY_A.toString()));
+
+        Assert.assertNotNull(event.get());
     }
 
     @Test

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsView.java
@@ -29,6 +29,7 @@ import com.vaadin.flow.component.html.Input;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.data.value.ValueChangeMode;
+import com.vaadin.flow.dom.DisabledUpdateMode;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 
@@ -85,6 +86,20 @@ public class ShortcutsView extends Div {
                 KeyModifier.CONTROL);
 
         add(disabledButton);
+
+        // DisabledUpdateMode.ALWAYS makes shortcut work when component is
+        // disabled
+        NativeButton disabledButtonWithAlwaysMode = new NativeButton();
+        disabledButtonWithAlwaysMode.setEnabled(false);
+        disabledButtonWithAlwaysMode.addClickListener(event -> {
+            actual.setValue("DISABLED CLICKED");
+        });
+        disabledButtonWithAlwaysMode
+                .addClickShortcut(Key.KEY_P, KeyModifier.SHIFT,
+                        KeyModifier.CONTROL)
+                .setDisabledUpdateMode(DisabledUpdateMode.ALWAYS);
+
+        add(disabledButtonWithAlwaysMode);
 
         // listenOnScopesTheShortcut
         Div subview = new Div();

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ShortcutsIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ShortcutsIT.java
@@ -80,7 +80,7 @@ public class ShortcutsIT extends ChromeBrowserTest {
 
     @Test
     public void shortcutOnlyWorksWhenComponentIsEnabled() {
-        sendKeys(Keys.CONTROL, "U"); // ctrl+shift+u
+        sendKeys(Keys.CONTROL, Keys.SHIFT, "u");
 
         // clicking the button disables it, and clicking again should not have
         // and effect
@@ -89,7 +89,17 @@ public class ShortcutsIT extends ChromeBrowserTest {
         resetActual();
         assertActualEquals(DEFAULT_VALUE);
 
-        sendKeys(Keys.CONTROL, "U"); // ctrl+shift+u
+        sendKeys(Keys.CONTROL, Keys.SHIFT, "u");
+        assertActualEquals(DEFAULT_VALUE);
+    }
+
+    @Test
+    public void shortcutWithDisabledUpdateModeAlwaysWorksWhenComponentIsDisabled() {
+        sendKeys(Keys.CONTROL, Keys.SHIFT, "p");
+
+        assertActualEquals("DISABLED CLICKED");
+
+        resetActual();
         assertActualEquals(DEFAULT_VALUE);
     }
 


### PR DESCRIPTION
Adds `DisabledUpdateMode` support for `ShortcutRegistration`.

Fixes https://github.com/vaadin/flow/issues/20813