### PR TITLE
refactor: use Vite official API for building sw.js

### DIFF
--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -117,8 +117,7 @@ function injectManifestToSWPlugin(): rollup.Plugin {
   };
 }
 
-function buildSWPlugin(opts: { devMode: boolean }): PluginOption {
-  const { devMode } = opts;
+function buildSWPlugin(): PluginOption {
   let buildConfig: InlineConfig;
 
   return {
@@ -149,20 +148,19 @@ function buildSWPlugin(opts: { devMode: boolean }): PluginOption {
             },
           },
         },
-        plugins: [
-          !devMode && injectManifestToSWPlugin(),
-          !devMode && brotli()
-        ]
       };
     },
     async buildStart() {
-      if (devMode) {
+      if (buildConfig.mode === 'development') {
         await build(buildConfig);
       }
     },
     async closeBundle() {
-      if (!devMode) {
-        await build(buildConfig);
+      if (buildConfig.mode !== 'development') {
+        await build({
+          ...buildConfig,
+          plugins: [injectManifestToSWPlugin(), brotli()]
+        });
       }
     },
   };
@@ -727,7 +725,7 @@ export const vaadinConfig: UserConfigFn = (env) => {
       productionMode && brotli(),
       devMode && vaadinBundlesPlugin(),
       devMode && showRecompileReason(),
-      settings.offlineEnabled && buildSWPlugin({ devMode }),
+      settings.offlineEnabled && buildSWPlugin(),
       !devMode && statsExtracterPlugin(),
       !productionMode && preserveUsageStats(),
       themePlugin({ devMode }),

--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -106,7 +106,7 @@ function injectManifestToSWPlugin(): rollup.Plugin {
         const { manifestEntries } = await getManifest({
           globDirectory: buildOutputFolder,
           globPatterns: ['**/*'],
-          globIgnores: ['**/*.br', 'pwa-icons/**'],
+          globIgnores: ['**/*.br', 'pwa-icons/**', 'sw.js'],
           manifestTransforms: [rewriteManifestIndexHtmlUrl],
           maximumFileSizeToCacheInBytes: 100 * 1024 * 1024 // 100mb,
         });

--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -145,6 +145,7 @@ function buildSWPlugin(): PluginOption {
             },
             output: {
               entryFileNames: 'sw.js',
+              inlineDynamicImports: true,
             },
           },
         },

--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -106,7 +106,7 @@ function injectManifestToSWPlugin(): rollup.Plugin {
         const { manifestEntries } = await getManifest({
           globDirectory: buildOutputFolder,
           globPatterns: ['**/*'],
-          globIgnores: ['**/*.br', 'pwa-icons/**'],
+          globIgnores: ['**/*.br', 'pwa-icons/**', 'sw.js'],
           manifestTransforms: [rewriteManifestIndexHtmlUrl],
           maximumFileSizeToCacheInBytes: 100 * 1024 * 1024 // 100mb,
         });
@@ -140,15 +140,10 @@ function buildSWPlugin(opts: { devMode: boolean }): PluginOption {
           sourcemap: viteConfig.command === 'serve' || viteConfig.build.sourcemap,
           emptyOutDir: false,
           modulePreload: false,
-          lib: {
-            entry: settings.clientServiceWorkerSource,
-            name: 'sw',
-            // Note the build.minify option does not minify whitespaces
-            // when using the 'es' format in lib mode. That's why we use
-            // the 'umd' format here.
-            formats: ['umd'],
-          },
           rollupOptions: {
+            input: {
+              sw: settings.clientServiceWorkerSource
+            },
             output: {
               entryFileNames: 'sw.js',
             },

--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -145,6 +145,7 @@ function buildSWPlugin(opts: { devMode: boolean }): PluginOption {
               sw: settings.clientServiceWorkerSource
             },
             output: {
+              exports: 'none',
               entryFileNames: 'sw.js',
               inlineDynamicImports: true,
             },

--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -20,14 +20,14 @@ import {
   mergeConfig,
   OutputOptions,
   PluginOption,
-  ResolvedConfig,
-  UserConfigFn
+  build,
+  UserConfigFn,
+  ResolvedConfig
 } from 'vite';
 import { getManifest, type ManifestTransform } from 'workbox-build';
 
 import * as rollup from 'rollup';
 import brotli from 'rollup-plugin-brotli';
-import replace from '@rollup/plugin-replace';
 import checker from 'vite-plugin-checker';
 import postcssLit from '#buildFolder#/plugins/rollup-plugin-postcss-lit-custom/rollup-plugin-postcss-lit.js';
 
@@ -118,87 +118,46 @@ function injectManifestToSWPlugin(): rollup.Plugin {
 }
 
 function buildSWPlugin(opts: { devMode: boolean }): PluginOption {
-  let config: ResolvedConfig;
-  const devMode = opts.devMode;
-
-  const swObj: { code?: string, map?: rollup.SourceMap | null } = {};
-
-  async function build(action: 'generate' | 'write', additionalPlugins: rollup.Plugin[] = []) {
-    const includedPluginNames = [
-      'vite:esbuild',
-      'rollup-plugin-dynamic-import-variables',
-      'vite:esbuild-transpile',
-      'vite:terser'
-    ];
-    const plugins: rollup.Plugin[] = config.plugins.filter((p) => {
-      return includedPluginNames.includes(p.name);
-    });
-    const resolver = config.createResolver();
-    const resolvePlugin: rollup.Plugin = {
-      name: 'resolver',
-      resolveId(source, importer, _options) {
-        return resolver(source, importer);
-      }
-    };
-    plugins.unshift(resolvePlugin); // Put resolve first
-    plugins.push(
-      replace({
-        values: {
-          'process.env.NODE_ENV': JSON.stringify(config.mode),
-          ...config.define
-        },
-        preventAssignment: true
-      })
-    );
-    if (additionalPlugins) {
-      plugins.push(...additionalPlugins);
-    }
-    const bundle = await rollup.rollup({
-      input: path.resolve(settings.clientServiceWorkerSource),
-      plugins
-    });
-
-    try {
-      return await bundle[action]({
-        file: path.resolve(buildOutputFolder, 'sw.js'),
-        format: 'es',
-        exports: 'none',
-        sourcemap: config.command === 'serve' || config.build.sourcemap,
-        inlineDynamicImports: true
-      });
-    } finally {
-      await bundle.close();
-    }
-  }
+  const { devMode } = opts;
+  let viteConfig: ResolvedConfig;
 
   return {
     name: 'vaadin:build-sw',
     enforce: 'post',
     async configResolved(resolvedConfig) {
-      config = resolvedConfig;
+      viteConfig = resolvedConfig;
     },
     async buildStart() {
-      if (devMode) {
-        const { output } = await build('generate');
-        swObj.code = output[0].code;
-        swObj.map = output[0].map;
-      }
+      await build({
+        base: viteConfig.base,
+        root: viteConfig.root,
+        mode: viteConfig.mode,
+        resolve: viteConfig.resolve,
+        define: {
+          ...viteConfig.define,
+          'process.env.NODE_ENV': JSON.stringify(viteConfig.mode),
+        },
+        build: {
+          ...viteConfig.build,
+          sourcemap: viteConfig.command === 'serve' || viteConfig.build.sourcemap,
+          modulePreload: false,
+          lib: {
+            entry: settings.clientServiceWorkerSource,
+            name: 'sw',
+            formats: ['umd'],
+          },
+          rollupOptions: {
+            output: {
+              entryFileNames: 'sw.js',
+            },
+          },
+        },
+        plugins: [
+          !devMode && injectManifestToSWPlugin(),
+          !devMode && brotli()
+        ]
+      });
     },
-    async load(id) {
-      if (id.endsWith('sw.js')) {
-        return '';
-      }
-    },
-    async transform(_code, id) {
-      if (id.endsWith('sw.js')) {
-        return swObj;
-      }
-    },
-    async closeBundle() {
-      if (!devMode) {
-        await build('write', [injectManifestToSWPlugin(), brotli()]);
-      }
-    }
   };
 }
 

--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -106,7 +106,7 @@ function injectManifestToSWPlugin(): rollup.Plugin {
         const { manifestEntries } = await getManifest({
           globDirectory: buildOutputFolder,
           globPatterns: ['**/*'],
-          globIgnores: ['**/*.br', 'pwa-icons/**', 'sw.js'],
+          globIgnores: ['**/*.br', 'pwa-icons/**'],
           manifestTransforms: [rewriteManifestIndexHtmlUrl],
           maximumFileSizeToCacheInBytes: 100 * 1024 * 1024 // 100mb,
         });
@@ -127,7 +127,7 @@ function buildSWPlugin(opts: { devMode: boolean }): PluginOption {
     async configResolved(resolvedConfig) {
       viteConfig = resolvedConfig;
     },
-    async buildStart() {
+    async closeBundle() {
       await build({
         base: viteConfig.base,
         root: viteConfig.root,

--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -138,17 +138,21 @@ function buildSWPlugin(opts: { devMode: boolean }): PluginOption {
           'process.env.NODE_ENV': JSON.stringify(viteConfig.mode),
         },
         build: {
-          ...viteConfig.build,
+          minify: viteConfig.build.minify,
+          outDir: viteConfig.build.outDir,
           sourcemap: viteConfig.command === 'serve' || viteConfig.build.sourcemap,
           modulePreload: false,
           lib: {
             entry: settings.clientServiceWorkerSource,
             name: 'sw',
+            // Note the build.minify option does not minify whitespaces
+            // when using the 'es' format in lib mode. That's why we use
+            // the 'umd' format here.
             formats: ['umd'],
           },
           rollupOptions: {
             output: {
-              entryFileNames: 'sw.js',
+              entryChunkNames: 'sw.js',
             },
           },
         },

--- a/flow-tests/test-pwa/src/test/java/com/vaadin/flow/pwatest/ui/PwaTestIT.java
+++ b/flow-tests/test-pwa/src/test/java/com/vaadin/flow/pwatest/ui/PwaTestIT.java
@@ -129,7 +129,7 @@ public class PwaTestIT extends ChromeDeviceTest {
         Assert.assertTrue(
                 "Expected sw-runtime-resources-precache.js to be imported, but was not",
                 serviceWorkerJS.contains(
-                        "importScripts(\"sw-runtime-resources-precache.js\");"));
+                        "importScripts(\"sw-runtime-resources-precache.js\")"));
 
         serviceWorkerUrl = getRootURL() + "/sw-runtime-resources-precache.js";
         serviceWorkerJS = readStringFromUrl(serviceWorkerUrl);


### PR DESCRIPTION
## Description

Updates the service worker plugin to use the Vite official API for building `sw.js`.

Fixes https://github.com/vaadin/flow/issues/20808

## Type of change

- [x] Bugfix
