### PR TITLE
test: fix URLStreamHandlerFactory reset for Java 17 (2.11)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -632,7 +632,7 @@
             <properties>
                 <maven.compiler.release>8</maven.compiler.release>
                 <!-- needed for running easymock in JDK11+ (easymock#235) -->
-                <surefire.argLine>--add-opens java.base/java.lang=ALL-UNNAMED</surefire.argLine>
+                <surefire.argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED</surefire.argLine>
             </properties>
             <build>
                 <pluginManagement>


### PR DESCRIPTION
Two tests in the codebase need to nullify the factory field of URL class by reflection. With Java 17 this requires java.net module to be opened to the unnamed module.