### PR TITLE
fix: fix UI refresh event name

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/hotswap/Hotswapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/hotswap/Hotswapper.java
@@ -514,7 +514,7 @@ public class Hotswapper implements ServiceDestroyListener, SessionInitListener,
         ui.getPage().executeJs(
                 """
                         const $wnd = window;
-                        window.addEventListener('vaadin-ui-refresh', (ev) => {
+                        window.addEventListener('vaadin-refresh-ui', (ev) => {
                             const senderFn = $wnd.Vaadin?.Flow?.clients[$0]?.sendEventMessage;
                             if (senderFn) {
                                 senderFn(1, "ui-refresh", ev.detail);

--- a/flow-server/src/test/java/com/vaadin/flow/hotswap/HotswapperTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/hotswap/HotswapperTest.java
@@ -16,6 +16,7 @@
 
 package com.vaadin.flow.hotswap;
 
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.HashSet;
@@ -58,6 +59,7 @@ import com.vaadin.flow.server.SessionDestroyEvent;
 import com.vaadin.flow.server.SessionDestroyListener;
 import com.vaadin.flow.server.SessionInitEvent;
 import com.vaadin.flow.server.SessionInitListener;
+import com.vaadin.flow.server.UIInitEvent;
 import com.vaadin.flow.server.UIInitListener;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinService;
@@ -1048,6 +1050,24 @@ public class HotswapperTest {
                 uiInitInstalled.get());
     }
 
+    @Test
+    public void uiInit_registersUIRefreshClientSideEvent() {
+        VaadinSession session = createMockVaadinSession();
+        RefreshTestingUI ui = initUIAndNavigateTo(session, MyRoute.class,
+                MyLayoutWithChild.class);
+
+        try {
+            session.lock();
+            UIInitEvent event = new UIInitEvent(ui, service);
+            hotswapper.uiInit(event);
+            Assert.assertTrue(
+                    "Expected Hotswapper to register client side refresh event listener ",
+                    ui.refreshUIClientListenerRegistered);
+        } finally {
+            session.unlock();
+        }
+    }
+
     private void assertOnHotswapCompleteInvoked(VaadinHotswapper hotswapper,
             HotswapCompleteEvent event) {
         var eventArgumentCaptor = ArgumentCaptor
@@ -1156,9 +1176,15 @@ public class HotswapperTest {
 
     private static class RefreshTestingUI extends MockUI {
 
-        private static final Pattern UI_REFRESH_EVENT = Pattern.compile(
-                ".*new CustomEvent\\(\"vaadin-refresh-ui\",\\s*\\{\\s*detail:\\s*\\{\\s*fullRefresh:\\s*(true|false)\\s*}\\s*}\\).*");
+        private static final String REFRESH_EVENT_NAME = "vaadin-refresh-ui";
+
+        private static final Pattern FIRE_UI_REFRESH_EVENT = Pattern
+                .compile(".*new CustomEvent\\(\"" + REFRESH_EVENT_NAME
+                        + "\",\\s*\\{\\s*detail:\\s*\\{\\s*fullRefresh:\\s*(true|false)\\s*}\\s*}\\).*");
+        private static final String ADD_CLIENT_UI_REFRESH_LISTENER = "window.addEventListener('"
+                + REFRESH_EVENT_NAME + "',";
         private Boolean refreshRouteChainRequested;
+        private boolean refreshUIClientListenerRegistered;
 
         private final Page pageSpy;
 
@@ -1168,13 +1194,18 @@ public class HotswapperTest {
             // Intercept javascript executions to check if the custom ui refresh
             // event dispatch has been registered.
             Mockito.doAnswer(i -> {
-                Matcher matcher = UI_REFRESH_EVENT.matcher(i.getArgument(0));
+                String expression = i.getArgument(0);
+                Matcher matcher = FIRE_UI_REFRESH_EVENT.matcher(expression);
                 if (matcher.matches()) {
                     refreshRouteChainRequested = Boolean
                             .parseBoolean(matcher.group(1));
+                } else if (expression
+                        .contains(ADD_CLIENT_UI_REFRESH_LISTENER)) {
+                    refreshUIClientListenerRegistered = true;
                 }
                 return null;
-            }).when(pageSpy).executeJs(Mockito.anyString());
+            }).when(pageSpy).executeJs(Mockito.anyString(),
+                    Mockito.any(Serializable[].class));
         }
 
         @Override


### PR DESCRIPTION
The  name used to register the event listener for hotswap refresh and the name used to fire the event are different. This change fixes the name in the listener.

Fixes #20843
