### PR TITLE
feat: mark full size components with data attribute

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/HasSize.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasSize.java
@@ -341,12 +341,12 @@ public interface HasSize extends HasElement {
      * with a fixed size may shrink to allow the full-size component to take up
      * as much space as possible, or the full-size component may cause the
      * layout to overflow. To improve this, you can enable the
-     * {@code com.vaadin.experimental.layoutImprovements} feature flag to
-     * effectively make full-size components take up the <b>remaining</b> space
-     * in the layout, rather than explicitly using 100% size of the layout. This
-     * applies additional CSS styles that allow the component to shrink below
-     * 100% if there are other components with fixed or relative sizes in the
-     * layout.
+     * {@code com.vaadin.experimental.layoutComponentImprovements} feature flag
+     * to effectively make full-size components take up the <b>remaining</b>
+     * space in the layout, rather than explicitly using 100% size of the
+     * layout. This applies additional CSS styles that allow the component to
+     * shrink below 100% if there are other components with fixed or relative
+     * sizes in the layout.
      */
     default void setSizeFull() {
         setWidth("100%");
@@ -367,12 +367,12 @@ public interface HasSize extends HasElement {
      * with a fixed size may shrink to allow the full-size component to take up
      * as much space as possible, or the full-size component may cause the
      * layout to overflow. To improve this, you can enable the
-     * {@code com.vaadin.experimental.layoutImprovements} feature flag to
-     * effectively make full-size components take up the <b>remaining</b> space
-     * in the layout, rather than explicitly using 100% size of the layout. This
-     * applies additional CSS styles that allow the component to shrink below
-     * 100% if there are other components with fixed or relative sizes in the
-     * layout.
+     * {@code com.vaadin.experimental.layoutComponentImprovements} feature flag
+     * to effectively make full-size components take up the <b>remaining</b>
+     * space in the layout, rather than explicitly using 100% size of the
+     * layout. This applies additional CSS styles that allow the component to
+     * shrink below 100% if there are other components with fixed or relative
+     * sizes in the layout.
      */
     default void setWidthFull() {
         setWidth("100%");
@@ -391,12 +391,12 @@ public interface HasSize extends HasElement {
      * with a fixed size may shrink to allow the full-size component to take up
      * as much space as possible, or the full-size component may cause the
      * layout to overflow. To improve this, you can enable the
-     * {@code com.vaadin.experimental.layoutImprovements} feature flag to
-     * effectively make full-size components take up the <b>remaining</b> space
-     * in the layout, rather than explicitly using 100% size of the layout. This
-     * applies additional CSS styles that allow the component to shrink below
-     * 100% if there are other components with fixed or relative sizes in the
-     * layout.
+     * {@code com.vaadin.experimental.layoutComponentImprovements} feature flag
+     * to effectively make full-size components take up the <b>remaining</b>
+     * space in the layout, rather than explicitly using 100% size of the
+     * layout. This applies additional CSS styles that allow the component to
+     * shrink below 100% if there are other components with fixed or relative
+     * sizes in the layout.
      */
     default void setHeightFull() {
         setHeight("100%");

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasSize.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasSize.java
@@ -47,7 +47,7 @@ public interface HasSize extends HasElement {
      */
     default void setWidth(String width) {
         getElement().getStyle().setWidth(width);
-        getElement().removeAttribute("data-v-width-full");
+        getElement().removeAttribute("data-width-full");
     }
 
     /**
@@ -195,7 +195,7 @@ public interface HasSize extends HasElement {
      */
     default void setHeight(String height) {
         getElement().getStyle().setHeight(height);
-        getElement().removeAttribute("data-v-height-full");
+        getElement().removeAttribute("data-height-full");
     }
 
     /**
@@ -351,8 +351,8 @@ public interface HasSize extends HasElement {
     default void setSizeFull() {
         setWidth("100%");
         setHeight("100%");
-        getElement().setAttribute("data-v-width-full", true);
-        getElement().setAttribute("data-v-height-full", true);
+        getElement().setAttribute("data-width-full", true);
+        getElement().setAttribute("data-height-full", true);
     }
 
     /**
@@ -376,7 +376,7 @@ public interface HasSize extends HasElement {
      */
     default void setWidthFull() {
         setWidth("100%");
-        getElement().setAttribute("data-v-width-full", true);
+        getElement().setAttribute("data-width-full", true);
     }
 
     /**
@@ -400,7 +400,7 @@ public interface HasSize extends HasElement {
      */
     default void setHeightFull() {
         setHeight("100%");
-        getElement().setAttribute("data-v-height-full", true);
+        getElement().setAttribute("data-height-full", true);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasSize.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasSize.java
@@ -349,10 +349,8 @@ public interface HasSize extends HasElement {
      * sizes in the layout.
      */
     default void setSizeFull() {
-        setWidth("100%");
-        setHeight("100%");
-        getElement().setAttribute("data-width-full", true);
-        getElement().setAttribute("data-height-full", true);
+        setWidthFull();
+        setHeightFull();
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasSize.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasSize.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementConstants;
+import com.vaadin.flow.server.Constants;
 
 /**
  * Any component implementing this interface supports setting the size of the
@@ -47,7 +48,7 @@ public interface HasSize extends HasElement {
      */
     default void setWidth(String width) {
         getElement().getStyle().setWidth(width);
-        getElement().removeAttribute("data-width-full");
+        getElement().removeAttribute(Constants.ATTRIBUTE_WIDTH_FULL);
     }
 
     /**
@@ -195,7 +196,7 @@ public interface HasSize extends HasElement {
      */
     default void setHeight(String height) {
         getElement().getStyle().setHeight(height);
-        getElement().removeAttribute("data-height-full");
+        getElement().removeAttribute(Constants.ATTRIBUTE_HEIGHT_FULL);
     }
 
     /**
@@ -374,7 +375,7 @@ public interface HasSize extends HasElement {
      */
     default void setWidthFull() {
         setWidth("100%");
-        getElement().setAttribute("data-width-full", true);
+        getElement().setAttribute(Constants.ATTRIBUTE_WIDTH_FULL, true);
     }
 
     /**
@@ -398,7 +399,7 @@ public interface HasSize extends HasElement {
      */
     default void setHeightFull() {
         setHeight("100%");
-        getElement().setAttribute("data-height-full", true);
+        getElement().setAttribute(Constants.ATTRIBUTE_HEIGHT_FULL, true);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasSize.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasSize.java
@@ -47,6 +47,7 @@ public interface HasSize extends HasElement {
      */
     default void setWidth(String width) {
         getElement().getStyle().setWidth(width);
+        getElement().removeAttribute("data-v-width-full");
     }
 
     /**
@@ -194,6 +195,7 @@ public interface HasSize extends HasElement {
      */
     default void setHeight(String height) {
         getElement().getStyle().setHeight(height);
+        getElement().removeAttribute("data-v-height-full");
     }
 
     /**
@@ -332,20 +334,49 @@ public interface HasSize extends HasElement {
      * This is just a convenience method which delegates its call to the
      * {@link #setWidth(String)} and {@link #setHeight(String)} methods with
      * {@literal "100%"} as the argument value
+     * <p>
+     * When adding full-size components as a child of a Vaadin layout component
+     * that is based on CSS Flexbox, such as HorizontalLayout or VerticalLayout,
+     * this can result in unexpected behavior. For example, other components
+     * with a fixed size may shrink to allow the full-size component to take up
+     * as much space as possible, or the full-size component may cause the
+     * layout to overflow. To improve this, you can enable the
+     * {@code com.vaadin.experimental.layoutImprovements} feature flag to
+     * effectively make full-size components take up the <b>remaining</b> space
+     * in the layout, rather than explicitly using 100% size of the layout. This
+     * applies additional CSS styles that allow the component to shrink below
+     * 100% if there are other components with fixed or relative sizes in the
+     * layout.
      */
     default void setSizeFull() {
         setWidth("100%");
         setHeight("100%");
+        getElement().setAttribute("data-v-width-full", true);
+        getElement().setAttribute("data-v-height-full", true);
     }
 
     /**
      * Sets the width of the component to "100%".
      * <p>
      * This is just a convenience method which delegates its call to the
-     * {@link #setWidth(String)} with {@literal "100%"} as the argument value
+     * {@link #setWidth(String)} with {@literal "100%"} as the argument value.
+     * <p>
+     * When adding full-size components as a child of a Vaadin layout component
+     * that is based on CSS Flexbox, such as HorizontalLayout or VerticalLayout,
+     * this can result in unexpected behavior. For example, other components
+     * with a fixed size may shrink to allow the full-size component to take up
+     * as much space as possible, or the full-size component may cause the
+     * layout to overflow. To improve this, you can enable the
+     * {@code com.vaadin.experimental.layoutImprovements} feature flag to
+     * effectively make full-size components take up the <b>remaining</b> space
+     * in the layout, rather than explicitly using 100% size of the layout. This
+     * applies additional CSS styles that allow the component to shrink below
+     * 100% if there are other components with fixed or relative sizes in the
+     * layout.
      */
     default void setWidthFull() {
         setWidth("100%");
+        getElement().setAttribute("data-v-width-full", true);
     }
 
     /**
@@ -353,9 +384,23 @@ public interface HasSize extends HasElement {
      * <p>
      * This is just a convenience method which delegates its call to the
      * {@link #setHeight(String)} with {@literal "100%"} as the argument value
+     * <p>
+     * When adding full-size components as a child of a Vaadin layout component
+     * that is based on CSS Flexbox, such as HorizontalLayout or VerticalLayout,
+     * this can result in unexpected behavior. For example, other components
+     * with a fixed size may shrink to allow the full-size component to take up
+     * as much space as possible, or the full-size component may cause the
+     * layout to overflow. To improve this, you can enable the
+     * {@code com.vaadin.experimental.layoutImprovements} feature flag to
+     * effectively make full-size components take up the <b>remaining</b> space
+     * in the layout, rather than explicitly using 100% size of the layout. This
+     * applies additional CSS styles that allow the component to shrink below
+     * 100% if there are other components with fixed or relative sizes in the
+     * layout.
      */
     default void setHeightFull() {
         setHeight("100%");
+        getElement().setAttribute("data-v-height-full", true);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -396,6 +396,18 @@ public final class Constants implements Serializable {
      */
     public static final String DISABLE_PREPARE_FRONTEND_CACHE = "disable.prepare.frontend.cache";
 
+    /**
+     * Attribute used by HasSize to mark elements that have been set to full
+     * width.
+     */
+    public static final String ATTRIBUTE_WIDTH_FULL = "data-width-full";
+
+    /**
+     * Attribute used by HasSize to mark elements that have been set to full
+     * height.
+     */
+    public static final String ATTRIBUTE_HEIGHT_FULL = "data-height-full";
+
     private Constants() {
         // prevent instantiation constants class only
     }

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasSizeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasSizeTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component;
 
+import com.vaadin.flow.server.Constants;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -141,10 +142,10 @@ public class HasSizeTest {
         HasSizeComponent component = new HasSizeComponent();
         component.setSizeFull();
 
-        Assert.assertTrue(
-                component.getElement().hasAttribute("data-width-full"));
-        Assert.assertTrue(
-                component.getElement().hasAttribute("data-height-full"));
+        Assert.assertTrue(component.getElement()
+                .hasAttribute(Constants.ATTRIBUTE_WIDTH_FULL));
+        Assert.assertTrue(component.getElement()
+                .hasAttribute(Constants.ATTRIBUTE_HEIGHT_FULL));
     }
 
     @Test
@@ -153,16 +154,16 @@ public class HasSizeTest {
         component.setSizeFull();
 
         component.setWidth("10px");
-        Assert.assertFalse(
-                component.getElement().hasAttribute("data-width-full"));
-        Assert.assertTrue(
-                component.getElement().hasAttribute("data-height-full"));
+        Assert.assertFalse(component.getElement()
+                .hasAttribute(Constants.ATTRIBUTE_WIDTH_FULL));
+        Assert.assertTrue(component.getElement()
+                .hasAttribute(Constants.ATTRIBUTE_HEIGHT_FULL));
 
         component.setHeight("10px");
-        Assert.assertFalse(
-                component.getElement().hasAttribute("data-width-full"));
-        Assert.assertFalse(
-                component.getElement().hasAttribute("data-height-full"));
+        Assert.assertFalse(component.getElement()
+                .hasAttribute(Constants.ATTRIBUTE_WIDTH_FULL));
+        Assert.assertFalse(component.getElement()
+                .hasAttribute(Constants.ATTRIBUTE_HEIGHT_FULL));
     }
 
     @Test
@@ -171,10 +172,10 @@ public class HasSizeTest {
         component.setSizeFull();
         component.setSizeUndefined();
 
-        Assert.assertFalse(
-                component.getElement().hasAttribute("data-width-full"));
-        Assert.assertFalse(
-                component.getElement().hasAttribute("data-height-full"));
+        Assert.assertFalse(component.getElement()
+                .hasAttribute(Constants.ATTRIBUTE_WIDTH_FULL));
+        Assert.assertFalse(component.getElement()
+                .hasAttribute(Constants.ATTRIBUTE_HEIGHT_FULL));
     }
 
     @Test
@@ -190,10 +191,10 @@ public class HasSizeTest {
         HasSizeComponent component = new HasSizeComponent();
         component.setWidthFull();
 
-        Assert.assertTrue(
-                component.getElement().hasAttribute("data-width-full"));
-        Assert.assertFalse(
-                component.getElement().hasAttribute("data-height-full"));
+        Assert.assertTrue(component.getElement()
+                .hasAttribute(Constants.ATTRIBUTE_WIDTH_FULL));
+        Assert.assertFalse(component.getElement()
+                .hasAttribute(Constants.ATTRIBUTE_HEIGHT_FULL));
     }
 
     @Test
@@ -202,10 +203,10 @@ public class HasSizeTest {
         component.setWidthFull();
         component.setWidth("10px");
 
-        Assert.assertFalse(
-                component.getElement().hasAttribute("data-width-full"));
-        Assert.assertFalse(
-                component.getElement().hasAttribute("data-height-full"));
+        Assert.assertFalse(component.getElement()
+                .hasAttribute(Constants.ATTRIBUTE_WIDTH_FULL));
+        Assert.assertFalse(component.getElement()
+                .hasAttribute(Constants.ATTRIBUTE_HEIGHT_FULL));
     }
 
     @Test
@@ -221,10 +222,10 @@ public class HasSizeTest {
         HasSizeComponent component = new HasSizeComponent();
         component.setHeightFull();
 
-        Assert.assertFalse(
-                component.getElement().hasAttribute("data-width-full"));
-        Assert.assertTrue(
-                component.getElement().hasAttribute("data-height-full"));
+        Assert.assertFalse(component.getElement()
+                .hasAttribute(Constants.ATTRIBUTE_WIDTH_FULL));
+        Assert.assertTrue(component.getElement()
+                .hasAttribute(Constants.ATTRIBUTE_HEIGHT_FULL));
     }
 
     @Test
@@ -233,10 +234,10 @@ public class HasSizeTest {
         component.setHeightFull();
         component.setHeight("10px");
 
-        Assert.assertFalse(
-                component.getElement().hasAttribute("data-width-full"));
-        Assert.assertFalse(
-                component.getElement().hasAttribute("data-height-full"));
+        Assert.assertFalse(component.getElement()
+                .hasAttribute(Constants.ATTRIBUTE_WIDTH_FULL));
+        Assert.assertFalse(component.getElement()
+                .hasAttribute(Constants.ATTRIBUTE_HEIGHT_FULL));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasSizeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasSizeTest.java
@@ -142,9 +142,9 @@ public class HasSizeTest {
         component.setSizeFull();
 
         Assert.assertTrue(
-                component.getElement().hasAttribute("data-v-width-full"));
+                component.getElement().hasAttribute("data-width-full"));
         Assert.assertTrue(
-                component.getElement().hasAttribute("data-v-height-full"));
+                component.getElement().hasAttribute("data-height-full"));
     }
 
     @Test
@@ -154,15 +154,15 @@ public class HasSizeTest {
 
         component.setWidth("10px");
         Assert.assertFalse(
-                component.getElement().hasAttribute("data-v-width-full"));
+                component.getElement().hasAttribute("data-width-full"));
         Assert.assertTrue(
-                component.getElement().hasAttribute("data-v-height-full"));
+                component.getElement().hasAttribute("data-height-full"));
 
         component.setHeight("10px");
         Assert.assertFalse(
-                component.getElement().hasAttribute("data-v-width-full"));
+                component.getElement().hasAttribute("data-width-full"));
         Assert.assertFalse(
-                component.getElement().hasAttribute("data-v-height-full"));
+                component.getElement().hasAttribute("data-height-full"));
     }
 
     @Test
@@ -172,9 +172,9 @@ public class HasSizeTest {
         component.setSizeUndefined();
 
         Assert.assertFalse(
-                component.getElement().hasAttribute("data-v-width-full"));
+                component.getElement().hasAttribute("data-width-full"));
         Assert.assertFalse(
-                component.getElement().hasAttribute("data-v-height-full"));
+                component.getElement().hasAttribute("data-height-full"));
     }
 
     @Test
@@ -191,9 +191,9 @@ public class HasSizeTest {
         component.setWidthFull();
 
         Assert.assertTrue(
-                component.getElement().hasAttribute("data-v-width-full"));
+                component.getElement().hasAttribute("data-width-full"));
         Assert.assertFalse(
-                component.getElement().hasAttribute("data-v-height-full"));
+                component.getElement().hasAttribute("data-height-full"));
     }
 
     @Test
@@ -203,9 +203,9 @@ public class HasSizeTest {
         component.setWidth("10px");
 
         Assert.assertFalse(
-                component.getElement().hasAttribute("data-v-width-full"));
+                component.getElement().hasAttribute("data-width-full"));
         Assert.assertFalse(
-                component.getElement().hasAttribute("data-v-height-full"));
+                component.getElement().hasAttribute("data-height-full"));
     }
 
     @Test
@@ -222,9 +222,9 @@ public class HasSizeTest {
         component.setHeightFull();
 
         Assert.assertFalse(
-                component.getElement().hasAttribute("data-v-width-full"));
+                component.getElement().hasAttribute("data-width-full"));
         Assert.assertTrue(
-                component.getElement().hasAttribute("data-v-height-full"));
+                component.getElement().hasAttribute("data-height-full"));
     }
 
     @Test
@@ -234,9 +234,9 @@ public class HasSizeTest {
         component.setHeight("10px");
 
         Assert.assertFalse(
-                component.getElement().hasAttribute("data-v-width-full"));
+                component.getElement().hasAttribute("data-width-full"));
         Assert.assertFalse(
-                component.getElement().hasAttribute("data-v-height-full"));
+                component.getElement().hasAttribute("data-height-full"));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasSizeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasSizeTest.java
@@ -137,6 +137,47 @@ public class HasSizeTest {
     }
 
     @Test
+    public void setSizeFull_addsDataAttribute() {
+        HasSizeComponent component = new HasSizeComponent();
+        component.setSizeFull();
+
+        Assert.assertTrue(
+                component.getElement().hasAttribute("data-v-width-full"));
+        Assert.assertTrue(
+                component.getElement().hasAttribute("data-v-height-full"));
+    }
+
+    @Test
+    public void setSizeFull_setSize_removesDataAttribute() {
+        HasSizeComponent component = new HasSizeComponent();
+        component.setSizeFull();
+
+        component.setWidth("10px");
+        Assert.assertFalse(
+                component.getElement().hasAttribute("data-v-width-full"));
+        Assert.assertTrue(
+                component.getElement().hasAttribute("data-v-height-full"));
+
+        component.setHeight("10px");
+        Assert.assertFalse(
+                component.getElement().hasAttribute("data-v-width-full"));
+        Assert.assertFalse(
+                component.getElement().hasAttribute("data-v-height-full"));
+    }
+
+    @Test
+    public void setSizeFull_setSizeUndefined_removesDataAttribute() {
+        HasSizeComponent component = new HasSizeComponent();
+        component.setSizeFull();
+        component.setSizeUndefined();
+
+        Assert.assertFalse(
+                component.getElement().hasAttribute("data-v-width-full"));
+        Assert.assertFalse(
+                component.getElement().hasAttribute("data-v-height-full"));
+    }
+
+    @Test
     public void setWidthFull() {
         HasSizeComponent component = new HasSizeComponent();
         component.setWidthFull();
@@ -145,11 +186,57 @@ public class HasSizeTest {
     }
 
     @Test
+    public void setWidthFull_addsDataAttribute() {
+        HasSizeComponent component = new HasSizeComponent();
+        component.setWidthFull();
+
+        Assert.assertTrue(
+                component.getElement().hasAttribute("data-v-width-full"));
+        Assert.assertFalse(
+                component.getElement().hasAttribute("data-v-height-full"));
+    }
+
+    @Test
+    public void setWidthFull_setWidth_removesDataAttribute() {
+        HasSizeComponent component = new HasSizeComponent();
+        component.setWidthFull();
+        component.setWidth("10px");
+
+        Assert.assertFalse(
+                component.getElement().hasAttribute("data-v-width-full"));
+        Assert.assertFalse(
+                component.getElement().hasAttribute("data-v-height-full"));
+    }
+
+    @Test
     public void setHeightFull() {
         HasSizeComponent component = new HasSizeComponent();
         component.setHeightFull();
 
         Assert.assertEquals("100%", component.getHeight());
+    }
+
+    @Test
+    public void setHeightFull_addsDataAttribute() {
+        HasSizeComponent component = new HasSizeComponent();
+        component.setHeightFull();
+
+        Assert.assertFalse(
+                component.getElement().hasAttribute("data-v-width-full"));
+        Assert.assertTrue(
+                component.getElement().hasAttribute("data-v-height-full"));
+    }
+
+    @Test
+    public void setHeightFull_setHeight_removesDataAttribute() {
+        HasSizeComponent component = new HasSizeComponent();
+        component.setHeightFull();
+        component.setHeight("10px");
+
+        Assert.assertFalse(
+                component.getElement().hasAttribute("data-v-width-full"));
+        Assert.assertFalse(
+                component.getElement().hasAttribute("data-v-height-full"));
     }
 
     @Test


### PR DESCRIPTION
## Description

Adds data attributes to components that have been configured to use the full size in a layout, by either calling `setWidthFull`, `setHeightFull` or `setSizeFull`. Vaadin components such as `HorizontalLayout` and `VerticalLayout` will include additional styles targeting children with these data attributes, to effectively make these children take up the remaining space in a layout, rather than the full size.

For now, the respective styles will only be added by the Vaadin components if the `com.vaadin.experimental.layoutImprovements` feature flag is enabled (see https://github.com/vaadin/web-components/pull/8552).

Part of https://github.com/vaadin/flow-components/issues/6998

## Type of change

- Feature
