### PR TITLE
feat: Add setSrc(AbstractStreamResource)

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
@@ -20,6 +20,8 @@ import com.vaadin.flow.component.HtmlComponent;
 import com.vaadin.flow.component.PropertyDescriptor;
 import com.vaadin.flow.component.PropertyDescriptors;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.server.AbstractStreamResource;
+import com.vaadin.flow.server.StreamResource;
 
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -142,6 +144,19 @@ public class IFrame extends HtmlComponent implements HasAriaLabel {
      */
     public void setSrc(String src) {
         set(srcDescriptor, src);
+    }
+
+    /**
+     * Sets the source of the iframe with a source URL with the URL of the given
+     * {@link StreamResource}.
+     *
+     * @see #setSrc(String)
+     *
+     * @param src
+     *            the resource value, not null
+     */
+    public void setSrc(AbstractStreamResource src) {
+        getElement().setAttribute("src", src);
     }
 
     /**

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/IFrameView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/IFrameView.java
@@ -15,10 +15,13 @@
  */
 package com.vaadin.flow.uitest.ui;
 
+import java.io.ByteArrayInputStream;
+
 import com.vaadin.flow.component.html.IFrame;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.StreamResource;
 import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 
 /**
@@ -43,6 +46,7 @@ public class IFrameView extends AbstractDivView {
 
     public IFrame frame = new IFrame();
     public NativeButton button;
+    public IFrame frameResource = new IFrame();
 
     public IFrameView() {
         content = "A";
@@ -56,10 +60,17 @@ public class IFrameView extends AbstractDivView {
         frame.setId("frame1");
         button = new NativeButton("Reload", event -> handleButtonClick());
         button.setId("Reload");
-
         button.addClickListener(event -> handleButtonClick());
-        add(frame, button);
 
+        StreamResource dynamicResource = new StreamResource("dynamic-resource",
+                () -> new ByteArrayInputStream(
+                        "<html><body><span id=\"content\">Dynamic</span></body></html>"
+                                .getBytes()));
+        dynamicResource.setContentType("text/html");
+        frameResource.setSrc(dynamicResource);
+        frameResource.setId("frame2");
+
+        add(frame, button, frameResource);
     }
 
     public void handleButtonClick() {

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/IFrameIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/IFrameIT.java
@@ -25,4 +25,13 @@ public class IFrameIT extends ChromeBrowserTest {
         waitUntil(webDriver -> "B"
                 .equals(findElement(By.id("Friday")).getText()));
     }
+
+    @Test
+    public void testIFrameWithDynamicResource() {
+        open();
+
+        waitForElementPresent(By.id("frame2"));
+        getDriver().switchTo().frame("frame2");
+        Assert.assertEquals("Dynamic", findElement(By.id("content")).getText());
+    }
 }


### PR DESCRIPTION
Setting resource should happen via underlying element API to avoid timing issues. This convenience API is easier to find.