### PR TITLE
test: run npm production tests before development mode (23.5)

### DIFF
--- a/flow-tests/test-frontend/pom.xml
+++ b/flow-tests/test-frontend/pom.xml
@@ -43,13 +43,13 @@
                 <module>vite-pwa-production</module>
                 <module>vite-embedded</module>
                 <module>vite-embedded/pom-production.xml</module>
+                <module>vite-embedded-webcomponent-resync</module>
                 <!-- npm and pnpm dev mode and prod mode -->
                 <!-- run production build before dev build as dev build has npm i in thread -->
-                <module>vite-embedded-webcomponent-resync</module>
-                <module>test-npm</module>
                 <module>test-npm/pom-production.xml</module>
-                <module>test-pnpm</module>
+                <module>test-npm/pom.xml</module>
                 <module>test-pnpm/pom-production.xml</module>
+                <module>test-pnpm/pom.xml</module>
             </modules>
         </profile>
     </profiles>


### PR DESCRIPTION
If the dev and prod mode test modules are defined in the same folder, the production mode can fail if executed after development mode. This happens because the dev mode npm install background process may still be running when Maven executes the frontend build for prod mode, causing conflicts in the node_modules folder.

This change swaps the execution order of the modules to ensure that prod mode is executed before dev mode.