### PR TITLE
chore: make GHA work again on 23.5 branch

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ failure() || success() }}
         with:
-          name: tests-output
+          name: tests-output-unit-${{ matrix.current }}
           path: tests-report-*.tgz
   it-tests:
     needs: build
@@ -219,7 +219,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ failure() || success() }}
         with:
-          name: tests-output
+          name: tests-output-it-${{ matrix.current }}
           path: tests-report-*.tgz
   test-results:
     permissions:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           tar cf workspace.tar -C ~/ $(cd ~/ && echo .m2/repository/com/vaadin/*/999.99-SNAPSHOT)
           tar rf workspace.tar $(find . -d -name target)
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: saved-workspace
           path: workspace.tar
@@ -100,7 +100,7 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         if: ${{ github.run_attempt == 1 }}
         with:
           name: saved-workspace
@@ -133,7 +133,7 @@ jobs:
       - name: Package test-report files
         if: ${{ failure() || success() }}
         run: find . -name surefire-reports -o -name failsafe-reports -o -name error-screenshots -o -name "mvn-*.out" | tar -czf tests-report-unit-${{matrix.current}}.tgz -T -
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ failure() || success() }}
         with:
           name: tests-output
@@ -175,7 +175,7 @@ jobs:
       - uses: browser-actions/setup-chrome@latest
         with:
           chrome-version: stable
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         if: ${{ github.run_attempt == 1 }}
         with:
           name: saved-workspace
@@ -216,7 +216,7 @@ jobs:
       - name: Package test-report files
         if: ${{ failure() || success() }}
         run: find . -name surefire-reports -o -name failsafe-reports -o -name error-screenshots -o -name "mvn-*.out" | tar -czf tests-report-it-${{matrix.current}}.tgz -T -
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ failure() || success() }}
         with:
           name: tests-output
@@ -233,7 +233,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: tests-output
       - name: extract downloaded files

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -230,6 +230,11 @@ jobs:
     needs: [unit-tests, it-tests]
     runs-on: ubuntu-22.04
     steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: tests-output
+          pattern: tests-output-*
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/flow-test-util/src/main/java/com/vaadin/flow/testutil/DevToolsWrapper.java
+++ b/flow-test-util/src/main/java/com/vaadin/flow/testutil/DevToolsWrapper.java
@@ -21,7 +21,7 @@ import org.openqa.selenium.devtools.SeleniumCdpConnection;
 import org.openqa.selenium.devtools.idealized.Domains;
 import org.openqa.selenium.devtools.idealized.target.model.SessionID;
 import org.openqa.selenium.devtools.idealized.target.model.TargetID;
-import org.openqa.selenium.devtools.v120.network.Network;
+import org.openqa.selenium.devtools.v132.network.Network;
 import org.openqa.selenium.remote.Augmenter;
 import org.openqa.selenium.remote.RemoteWebDriver;
 

--- a/flow-test-util/src/main/java/com/vaadin/flow/testutil/DevToolsWrapper.java
+++ b/flow-test-util/src/main/java/com/vaadin/flow/testutil/DevToolsWrapper.java
@@ -46,6 +46,7 @@ public class DevToolsWrapper {
         sendToAllTargets(Network.enable(Optional.empty(), Optional.empty(),
                 Optional.empty()));
         sendToAllTargets(Network.emulateNetworkConditions(isEnabled, -1, -1, -1,
+                Optional.empty(), Optional.empty(), Optional.empty(),
                 Optional.empty()));
     }
 

--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -80,19 +80,6 @@
             <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
-        <!-- To be removed after TestBench 8.2.7 release -->
-        <dependency>
-            <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-devtools-v127</artifactId>
-            <version>4.25.0</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.seleniumhq.selenium</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -414,23 +414,6 @@
             </properties>
         </profile>
         <profile>
-            <!-- To be removed after chrome used by CI gets upgraded to 128 or later -->
-            <id>ci-devtools</id>
-            <activation>
-                <property>
-                    <name>teamcity.build.id</name>
-                </property>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>org.seleniumhq.selenium</groupId>
-                    <artifactId>selenium-devtools-v127</artifactId>
-                    <version>4.25.0</version>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
             <id>deepClean</id>
             <build>
                 <plugins>

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AbstractIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AbstractIT.java
@@ -95,12 +95,14 @@ public abstract class AbstractIT extends AbstractSpringTest {
     }
 
     protected void assertRootPageShown() {
+        waitForClientRouter();
         waitUntil(drive -> $("h1").attribute("id", "header").exists());
         String headerText = $("h1").id("header").getText();
         Assert.assertEquals(ROOT_PAGE_HEADER_TEXT, headerText);
     }
 
     protected void assertAnotherPublicPageShown() {
+        waitForClientRouter();
         waitUntil(drive -> $("h1").attribute("id", "header").exists());
         String headerText = $("h1").id("header").getText();
         Assert.assertEquals(ANOTHER_PUBLIC_PAGE_HEADER_TEXT, headerText);
@@ -123,7 +125,7 @@ public abstract class AbstractIT extends AbstractSpringTest {
     }
 
     protected void assertPathShown(String path) {
-
+        waitForClientRouter();
         waitUntil(driver -> {
             String url = driver.getCurrentUrl();
             if (!url.startsWith(getRootURL())) {
@@ -136,8 +138,15 @@ public abstract class AbstractIT extends AbstractSpringTest {
     }
 
     protected void assertResourceShown(String path) {
-        waitUntil(driver -> driver.getCurrentUrl()
-                .equals(getRootURL() + "/" + path));
+        waitUntil(driver -> {
+            // HttpSessionRequestCache uses request parameter "continue",
+            // see HttpSessionRequestCache::setMatchingRequestParameterName
+            String url = driver.getCurrentUrl();
+            if (url.endsWith("continue")) {
+                url = url.substring(0, url.length() - 9);
+            }
+            return url.equals(getRootURL() + "/" + path);
+        });
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <maven.resources.plugin.version>3.0.2</maven.resources.plugin.version>
         <maven.clean.plugin.version>3.2.0</maven.clean.plugin.version>
         <maven.exec.plugin.version>1.6.0</maven.exec.plugin.version>
-        <testbench.version>8.2.6</testbench.version>
+        <testbench.version>8.2.7</testbench.version>
         <jetty.version>10.0.13</jetty.version>
         <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>
 


### PR DESCRIPTION
- Some actions are deprecated and prevent the workflow execution.
- bump TB version
- fix selenium import and remove not needed dependency 
- fix tests