### PR TITLE
chore: improve class scanning filter

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
@@ -77,12 +77,14 @@ import static com.vaadin.flow.server.frontend.scanner.FrontendClassVisitor.VERSI
 public class FrontendDependencies extends AbstractDependenciesScanner {
 
     //@formatter:off
-    private static final Pattern VISITABLE_CLASS_PATTERN = Pattern.compile("(^$|"
+    private static final Pattern NOT_VISITABLE_CLASS_PATTERN = Pattern.compile("(^$|"
             + ".*(slf4j).*|"
             // #5803
-            + "^(java|sun|oracle|elemental|javax|jakarta|oshi|"
-            + "org\\.(apache|atmosphere|jsoup|jboss|w3c|spring|joda|hibernate|glassfish|hsqldb|osgi|jooq)\\b|"
-            + "com\\.(helger|spring|gwt|lowagie|fasterxml|sun|nimbusds|googlecode)\\b|"
+            + "^(java|sun|oracle|elemental|javax|javafx|jakarta|oshi|cglib|"
+            + "org\\.(apache|antlr|atmosphere|aspectj|jsoup|jboss|w3c|spring|joda|hibernate|glassfish|hsqldb|osgi|jooq|springframework|bouncycastle|snakeyaml|keycloak|flywaydb)\\b|"
+            + "com\\.(helger|spring|gwt|lowagie|fasterxml|sun|nimbusds|googlecode|ibm)\\b|"
+            + "ch\\.quos\\.logback\\b|"
+            + "io\\.(fabric8\\.kubernetes)\\b|"
             + "net\\.(sf|bytebuddy)\\b"
             + ").*|"
             + ".*(Exception)$"
@@ -903,7 +905,7 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
         // common name-spaces that would not have components.
         // We also exclude Feature-Flag classes
         return className != null && !isExperimental(className)
-                && !VISITABLE_CLASS_PATTERN.matcher(className).matches();
+                && !NOT_VISITABLE_CLASS_PATTERN.matcher(className).matches();
     }
 
     private URL getUrl(String className) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
@@ -327,11 +327,11 @@ public class FrontendDependenciesTest {
                 classFinder, true);
 
         Assert.assertTrue(
-                "second package should match fully not as starts with 'spring != springframework'",
-                dependencies.shouldVisit("org.springframework.samples"));
+                "second package should match fully not as starts with 'spring != springseason'",
+                dependencies.shouldVisit("org.springseason.samples"));
         Assert.assertTrue(
-                "second package should match fully not as starts with 'spring != springframework'",
-                dependencies.shouldVisit("org.springframework"));
+                "second package should match fully not as starts with 'spring != springseason'",
+                dependencies.shouldVisit("org.springseason"));
         Assert.assertFalse("should not visit with only 2 packages 'org.spring'",
                 dependencies.shouldVisit("org.spring"));
 


### PR DESCRIPTION
Ignores additional well-known packages when scanning classes to find frontend resources.
