### PR TITLE
test: fix npm base dir for test modules (2.11)

### DIFF
--- a/flow-tests/test-lumo-theme/pom.xml
+++ b/flow-tests/test-lumo-theme/pom.xml
@@ -43,6 +43,14 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <version>${jetty.version}</version>
+                <configuration>
+                    <systemProperties>
+                        <systemProperty>
+                            <key>vaadin.project.basedir</key>
+                            <value>${project.basedir}</value>
+                        </systemProperty>
+                    </systemProperties>
+                </configuration>
                 <executions>
                     <!-- start and stop jetty (running our app) when running
                         integration tests -->
@@ -59,6 +67,27 @@
                         <goals>
                             <goal>stop</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <!--
+                            Ensures that vaadin.project.basedir is removed and not leaking into other modules
+                        -->
+                        <id>unset-vaadin-project-basedir</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>bsh-property</goal>
+                        </goals>
+                        <configuration>
+                            <source><![CDATA[
+                                System.clearProperty("vaadin.project.basedir");
+                            ]]></source>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/flow-tests/test-material-theme/pom.xml
+++ b/flow-tests/test-material-theme/pom.xml
@@ -43,6 +43,14 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <version>${jetty.version}</version>
+                <configuration>
+                    <systemProperties>
+                        <systemProperty>
+                            <key>vaadin.project.basedir</key>
+                            <value>${project.basedir}</value>
+                        </systemProperty>
+                    </systemProperties>
+                </configuration>
                 <executions>
                     <!-- start and stop jetty (running our app) when running
                         integration tests -->
@@ -59,6 +67,27 @@
                         <goals>
                             <goal>stop</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <!--
+                            Ensures that vaadin.project.basedir is removed and not leaking into other modules
+                        -->
+                        <id>unset-vaadin-project-basedir</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>bsh-property</goal>
+                        </goals>
+                        <configuration>
+                            <source><![CDATA[
+                                System.clearProperty("vaadin.project.basedir");
+                            ]]></source>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/flow-tests/test-multi-war/deployment/pom.xml
+++ b/flow-tests/test-multi-war/deployment/pom.xml
@@ -41,7 +41,34 @@
                             <contextPath>/test-war2</contextPath>
                         </contextHandler>
                     </contextHandlers>
+                    <systemProperties>
+                        <systemProperty>
+                            <key>vaadin.project.basedir</key>
+                            <value>${project.basedir}</value>
+                        </systemProperty>
+                    </systemProperties>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <!--
+                            Ensures that vaadin.project.basedir is removed and not leaking into other modules
+                        -->
+                        <id>unset-vaadin-project-basedir</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>bsh-property</goal>
+                        </goals>
+                        <configuration>
+                            <source><![CDATA[
+                                System.clearProperty("vaadin.project.basedir");
+                            ]]></source>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Some test modules do not run prepare-frontend goal, so at runtime the npm folder is computed based on the user.dir system property. This causes the frontend files to be generated in the root project folder and potential failures during subsequent npm builds. This change fixes the test modules setting the vaadin.project.basedir system property to point to the module folder and removing it after tests execution.