### PR TITLE
Refactor MutableTreeRevision

### DIFF
--- a/signals/src/main/java/com/vaadin/signals/impl/MutableTreeRevision.java
+++ b/signals/src/main/java/com/vaadin/signals/impl/MutableTreeRevision.java
@@ -25,12 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
-import java.util.function.Consumer;
-import java.util.function.UnaryOperator;
+import java.util.function.Function;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.DoubleNode;
@@ -49,7 +47,6 @@ import com.vaadin.signals.SignalCommand.ClearOwnerCommand;
 import com.vaadin.signals.SignalCommand.IncrementCommand;
 import com.vaadin.signals.SignalCommand.InsertCommand;
 import com.vaadin.signals.SignalCommand.KeyCondition;
-import com.vaadin.signals.SignalCommand.ConditionCommand;
 import com.vaadin.signals.SignalCommand.LastUpdateCondition;
 import com.vaadin.signals.SignalCommand.PositionCondition;
 import com.vaadin.signals.SignalCommand.PutCommand;
@@ -70,235 +67,215 @@ import com.vaadin.signals.impl.CommandResult.NodeModification;
  */
 public class MutableTreeRevision extends TreeRevision {
     /**
-     * Gathers and collects all state related to applying a single command. With
-     * transactions, previously applied commands might end up rolled back if a
-     * later command in the transaction is rejected. To deal with this, changes
-     * are applied by collecting a set of changes so that later commands are
-     * evaluated against the already collected changes. The same structure also
-     * helps decompose complex single operations into individually evaluated
-     * steps.
+     * Helper for accessing nodes in a consistent way regardless of whether the
+     * nodes are loaded directly from the map in a revision or also checked for
+     * overrides in a result builder.
      */
-    private class TreeManipulator {
+    private static abstract class NodeLookup {
+        protected abstract Node node(Id nodeId);
+
+        protected boolean isChildAt(List<Id> children, int index,
+                Id expectedChild) {
+            assert expectedChild != null;
+
+            if (index < 0 || index >= children.size()) {
+                return false;
+            }
+
+            return isSameNode(children.get(index), expectedChild);
+        }
+
+        protected Data data(Id nodeId) {
+            Node node = node(resolveAlias(nodeId));
+
+            return (Data) node;
+        }
+
+        protected boolean isSameNode(Id a, Id b) {
+            return Objects.equals(resolveAlias(a), resolveAlias(b));
+        }
+
+        protected Id resolveAlias(Id id) {
+            Node node = node(id);
+
+            if (node instanceof Alias alias) {
+                return alias.target();
+            } else {
+                return id;
+            }
+        }
+
+        protected ResolvedData resolveData(Id nodeId) {
+            Id id = resolveAlias(nodeId);
+
+            Node node = node(id);
+            if (node == null) {
+                return null;
+            } else {
+                return new ResolvedData(id, (Data) node);
+            }
+        }
+    }
+
+    private class DirectNodeLookup extends NodeLookup {
+        @Override
+        protected Node node(Id nodeId) {
+            return nodes().get(nodeId);
+        }
+    }
+
+    private record ResolvedData(Id resolvedId, Data data) {
+    }
+
+    /**
+     * Gathers and collects all state related to applying a command that affects
+     * multiple nodes. To help with commands that consist of multiple steps, any
+     * node updates are tracked and subsequent node lookup uses the updates
+     * nodes rather than the originals.
+     */
+    private class ResultBuilder extends NodeLookup {
         private final Map<Id, Node> updatedNodes = new HashMap<>();
         private final Set<Id> detachedNodes = new HashSet<>();
         private final Map<Id, SignalCommand.ScopeOwnerCommand> originalInserts = new HashMap<>();
 
         private final SignalCommand command;
 
-        /**
-         * The operation result is tracked in an instance field to allow helper
-         * methods to optionally set a result while also returning a regular
-         * value.
-         */
-        private CommandResult result;
-
-        /**
-         * Child results are collected for transactions and applied at the end
-         * since the result of earlier operations might change if a later
-         * operation is rejected.
-         */
-        private Map<Id, CommandResult> subCommandResults;
-
-        public TreeManipulator(SignalCommand command) {
+        public ResultBuilder(SignalCommand command) {
             this.command = command;
         }
 
-        private void setResult(CommandResult result) {
-            assert this.result == null;
-            this.result = result;
+        private Reject fail(String reason) {
+            return CommandResult.fail(reason);
         }
 
-        private void fail(String reason) {
-            setResult(CommandResult.fail(reason));
-        }
-
-        private Id resolveAlias(Id nodeId) {
-            Node dataOrAlias = updatedNodes.get(nodeId);
-            if (dataOrAlias == null) {
-                dataOrAlias = nodes().get(nodeId);
+        @Override
+        protected Node node(Id nodeId) {
+            if (detachedNodes.contains(nodeId)) {
+                return null;
             }
 
-            if (dataOrAlias instanceof Alias alias) {
-                return alias.target();
-            } else {
-                return nodeId;
-            }
-        }
-
-        private Optional<Data> data(Id nodeId) {
-            Id id = resolveAlias(nodeId);
-
-            if (detachedNodes.contains(id)) {
-                return Optional.empty();
-            } else if (updatedNodes.containsKey(id)) {
-                return Optional.ofNullable((Data) updatedNodes.get(id));
-            } else {
-                return MutableTreeRevision.this.data(id);
-            }
-        }
-
-        private void useData(Id nodeId, BiConsumer<Data, Id> consumer) {
-            assert result == null;
-
-            Id id = resolveAlias(nodeId);
-            data(id).ifPresentOrElse(node -> consumer.accept(node, id), () -> {
-                fail("Node not found");
-            });
-        }
-
-        private void updateData(Id nodeId, UnaryOperator<Data> updater) {
-            useData(nodeId, (node, id) -> {
-                Data updatedNode = updater.apply(node);
-                if (updatedNode != node) {
-                    updatedNodes.put(id, updatedNode);
-                }
-            });
-        }
-
-        private JsonNode value(Id nodeId) {
-            return data(nodeId).map(Data::value).orElse(null);
-        }
-
-        private void setValue(Id nodeId, JsonNode value) {
-            updateData(nodeId,
-                    node -> new Data(node.parent(), command.commandId(),
-                            node.scopeOwner(), value, node.listChildren(),
-                            node.mapChildren()));
-        }
-
-        private Optional<List<Id>> listChildren(Id parentId) {
-            return data(parentId).map(Data::listChildren);
-        }
-
-        private boolean isChildAt(Id parentId, int index, Id expectedChild) {
-            assert expectedChild != null;
-
-            if (index < 0) {
-                return false;
+            Node node = updatedNodes.get(nodeId);
+            if (node != null) {
+                return node;
             }
 
-            Id idAtIndex = listChildren(parentId).map(children -> {
-                if (index >= children.size()) {
+            return nodes().get(nodeId);
+        }
+
+        private Reject detach(Id nodeId) {
+            ResolvedData resolved = resolveData(nodeId);
+            if (resolved == null) {
+                return fail("Node not found");
+            }
+
+            Data node = resolved.data();
+            Id id = resolved.resolvedId();
+
+            if (id.equals(Id.ZERO)) {
+                return fail("Cannot detach the root");
+            }
+
+            Id parentId = node.parent();
+            if (parentId == null) {
+                return fail("Node is not attached");
+            }
+
+            Data parentData = data(parentId);
+
+            String key = parentData.mapChildren().entrySet().stream()
+                    .filter(entry -> entry.getValue().equals(id)).findAny()
+                    .map(Entry::getKey).orElse(null);
+
+            if (key != null) {
+                updateMapChildren(parentId, map -> {
+                    map.remove(key);
                     return null;
-                }
-                return children.get(index);
-            }).orElse(null);
+                });
+            } else {
+                updateListChildren(parentId, list -> {
+                    list.remove(id);
+                    return null;
+                });
+            }
 
-            return isSameNode(idAtIndex, expectedChild);
+            detachedNodes.add(id);
+            return null;
         }
 
-        private Optional<Id> mapChild(Id nodeId, String key) {
-            return data(nodeId).map(Data::mapChildren)
-                    .map(children -> children.get(key));
-        }
+        private Reject updateMapChildren(Id resolvedParentId,
+                Function<Map<String, Id>, CommandResult.Reject> mapUpdater) {
+            Data node = data(resolvedParentId);
 
-        private boolean isSameNode(Id a, Id b) {
-            return Objects.equals(resolveAlias(a), resolveAlias(b));
-        }
-
-        private boolean detach(Id nodeId) {
-            useData(nodeId, (node, id) -> {
-                if (id.equals(Id.ZERO)) {
-                    fail("Cannot detach the root");
-                    return;
-                }
-
-                Id parentId = node.parent();
-                if (parentId == null) {
-                    fail("Node is not attached");
-                    return;
-                }
-
-                Data parentData = data(parentId).get();
-
-                String key = parentData.mapChildren().entrySet().stream()
-                        .filter(entry -> entry.getValue().equals(id)).findAny()
-                        .map(Entry::getKey).orElse(null);
-
-                if (key != null) {
-                    updatedNodes.put(parentId, updateMapChildren(parentData,
-                            map -> map.remove(key)));
-                } else {
-                    updatedNodes.put(parentId, updateListChildren(parentData,
-                            list -> list.remove(id)));
-                }
-
-                detachedNodes.add(id);
-            });
-
-            // Check if any error was reported
-            return result == null;
-        }
-
-        private Data updateMapChildren(Data node,
-                Consumer<Map<String, Id>> mapUpdater) {
             LinkedHashMap<String, Id> map = new LinkedHashMap<>(
                     node.mapChildren());
-            mapUpdater.accept(map);
-
-            return new Data(node.parent(), command.commandId(),
-                    node.scopeOwner(), node.value(), node.listChildren(),
-                    Collections.unmodifiableMap(map));
-        }
-
-        private Data updateListChildren(Data node,
-                Consumer<List<Id>> listUpdater) {
-            ArrayList<Id> list = new ArrayList<>(node.listChildren());
-            listUpdater.accept(list);
-
-            return new Data(node.parent(), command.commandId(),
-                    node.scopeOwner(), node.value(),
-                    Collections.unmodifiableList(list), node.mapChildren());
-        }
-
-        private void attach(Id parentId, Id childId,
-                BiFunction<Data, Id, Data> attacher) {
-            if (result != null) {
-                return;
+            if (mapUpdater.apply(map) instanceof Reject error) {
+                return error;
             }
 
+            updatedNodes.put(resolvedParentId, new Data(node.parent(),
+                    command.commandId(), node.scopeOwner(), node.value(),
+                    node.listChildren(), Collections.unmodifiableMap(map)));
+
+            return null;
+        }
+
+        private Reject updateListChildren(Id resolvedParentId,
+                Function<List<Id>, CommandResult.Reject> listUpdater) {
+            Data node = data(resolvedParentId);
+
+            ArrayList<Id> list = new ArrayList<>(node.listChildren());
+            if (listUpdater.apply(list) instanceof Reject error) {
+                return error;
+            }
+
+            updatedNodes.put(resolvedParentId, new Data(node.parent(),
+                    command.commandId(), node.scopeOwner(), node.value(),
+                    Collections.unmodifiableList(list), node.mapChildren()));
+            return null;
+        }
+
+        private Reject attach(Id parentId, Id childId,
+                BiFunction<Id, Id, Reject> attacher) {
             Id resolvedParentId = resolveAlias(parentId);
             Id resolvedChildId = resolveAlias(childId);
 
             if (!detachedNodes.contains(resolvedChildId)) {
-                fail("Node is not detached");
-                return;
+                return fail("Node is not detached");
             }
 
             Id ancestor = resolvedParentId;
             while (ancestor != null) {
-                if (ancestor.equals(childId)) {
-                    fail("Cannot attach to own descendant");
-                    return;
+                if (ancestor.equals(resolvedChildId)) {
+                    return fail("Cannot attach to own descendant");
                 }
 
-                ancestor = data(ancestor).map(Data::parent).orElse(null);
+                ancestor = data(ancestor).parent();
             }
 
-            useData(parentId, (node, id) -> {
-                // Mark as detached only after the last error condition check
-                // done by useData
-                detachedNodes.remove(resolvedChildId);
+            detachedNodes.remove(resolvedChildId);
 
-                Data updated = attacher.apply(node, resolvedChildId);
-                if (result == null) {
-                    Data child = data(resolvedChildId).get();
+            if (attacher.apply(resolvedParentId,
+                    resolvedChildId) instanceof Reject error) {
+                return error;
+            }
 
-                    updatedNodes.put(id, updated);
-                    updatedNodes.put(resolvedChildId,
-                            new Data(id, child.lastUpdate(), child.scopeOwner(),
-                                    child.value(), child.listChildren(),
-                                    child.mapChildren()));
-                }
-            });
+            Data child = data(resolvedChildId);
+            updatedNodes.put(resolvedChildId,
+                    new Data(resolvedParentId, child.lastUpdate(),
+                            child.scopeOwner(), child.value(),
+                            child.listChildren(), child.mapChildren()));
+
+            return null;
         }
 
-        private void attachAs(Id parentId, String key, Id childId) {
-            attach(parentId, childId, (parentNode, resolvedChildId) -> {
+        private Reject attachAs(Id parentId, String key, Id childId) {
+            return attach(parentId, childId, (parentNode, resolvedChildId) -> {
                 return updateMapChildren(parentNode, map -> {
                     Id previous = map.putIfAbsent(key, resolvedChildId);
                     if (previous != null) {
-                        fail("Key is in use");
+                        return fail("Key is in use");
+                    } else {
+                        return null;
                     }
                 });
             });
@@ -348,24 +325,27 @@ public class MutableTreeRevision extends TreeRevision {
             }
         }
 
-        private void attachAt(Id parentId, ListPosition position, Id childId) {
-            attach(parentId, childId, (node, resolvedChildId) -> {
-                int insertIndex = findInsertIndex(node.listChildren(),
-                        position);
-                if (insertIndex == -1) {
-                    fail("Insert position not matched");
-                    return null;
-                }
+        private Reject attachAt(Id parentId, ListPosition position,
+                Id childId) {
+            return attach(parentId, childId,
+                    (resolvedParentId, resolvedChildId) -> {
+                        int insertIndex = findInsertIndex(
+                                data(resolvedParentId).listChildren(),
+                                position);
+                        if (insertIndex == -1) {
+                            return fail("Insert position not matched");
+                        }
 
-                return updateListChildren(node,
-                        list -> list.add(insertIndex, resolvedChildId));
-            });
+                        return updateListChildren(resolvedParentId, list -> {
+                            list.add(insertIndex, resolvedChildId);
+                            return null;
+                        });
+                    });
         }
 
-        private void createNode(Id nodeId, JsonNode value, Id scopeOwner) {
-            if (data(nodeId).isPresent()) {
-                fail("Node already exists");
-                return;
+        private Reject createNode(Id nodeId, JsonNode value, Id scopeOwner) {
+            if (node(nodeId) != null) {
+                return fail("Node already exists");
             }
 
             // Mark as detached to make it eligible for attaching
@@ -376,6 +356,7 @@ public class MutableTreeRevision extends TreeRevision {
             if (ownerId().equals(scopeOwner)) {
                 originalInserts.put(nodeId, (ScopeOwnerCommand) command);
             }
+            return null;
         }
 
         private NodeModification createModification(Id id, Node newNode) {
@@ -383,61 +364,7 @@ public class MutableTreeRevision extends TreeRevision {
             return new NodeModification(original, newNode);
         }
 
-        private static Map<Class<? extends SignalCommand>, BiConsumer<TreeManipulator, ? extends SignalCommand>> handlers = new HashMap<>();
-
-        private static <T extends SignalCommand> void addHandler(
-                Class<T> commandType, BiConsumer<TreeManipulator, T> handler) {
-            handlers.put(commandType, handler);
-        }
-
-        private static <T extends ConditionCommand> void addConditionHandler(
-                Class<T> commandType,
-                BiFunction<TreeManipulator, T, CommandResult> handler) {
-            addHandler(commandType, (manipulator, command) -> manipulator
-                    .setResult(handler.apply(manipulator, command)));
-        }
-
-        static {
-            addConditionHandler(ValueCondition.class,
-                    TreeManipulator::handleValueCondition);
-            addConditionHandler(PositionCondition.class,
-                    TreeManipulator::handlePositionCondition);
-            addConditionHandler(KeyCondition.class,
-                    TreeManipulator::handleKeyCondition);
-            addConditionHandler(LastUpdateCondition.class,
-                    TreeManipulator::handleLastUpdateCondition);
-
-            addHandler(AdoptAsCommand.class, TreeManipulator::handleAdoptAs);
-            addHandler(AdoptAtCommand.class, TreeManipulator::handleAdoptAt);
-            addHandler(IncrementCommand.class,
-                    TreeManipulator::handleIncrement);
-            addHandler(ClearCommand.class, TreeManipulator::handleClear);
-            addHandler(RemoveByKeyCommand.class,
-                    TreeManipulator::handleRemoveByKey);
-            addHandler(PutCommand.class, TreeManipulator::handlePut);
-            addHandler(PutIfAbsentCommand.class,
-                    TreeManipulator::handlePutIfAbsent);
-            addHandler(InsertCommand.class, TreeManipulator::handleInsert);
-            addHandler(SetCommand.class, TreeManipulator::handleSet);
-            addHandler(RemoveCommand.class, TreeManipulator::handleRemove);
-            addHandler(ClearOwnerCommand.class,
-                    TreeManipulator::handleClearOwner);
-            addHandler(TransactionCommand.class,
-                    TreeManipulator::handleTransaction);
-            addHandler(SnapshotCommand.class, TreeManipulator::handleSnapshot);
-        }
-
-        public CommandResult handleCommand(SignalCommand command) {
-            @SuppressWarnings("unchecked")
-            BiConsumer<TreeManipulator, SignalCommand> handler = (BiConsumer<TreeManipulator, SignalCommand>) handlers
-                    .get(command.getClass());
-
-            handler.accept(this, command);
-
-            if (result != null) {
-                return result;
-            }
-
+        private CommandResult build() {
             Map<Id, NodeModification> updates = new HashMap<>();
 
             updatedNodes.forEach((id, newNode) -> {
@@ -473,298 +400,6 @@ public class MutableTreeRevision extends TreeRevision {
             }
 
             return new Accept(updates, originalInserts);
-        }
-
-        private CommandResult handleValueCondition(ValueCondition test) {
-            JsonNode value = value(test.targetNodeId());
-            if (value == null) {
-                value = NullNode.getInstance();
-            }
-            JsonNode expectedValue = test.expectedValue();
-
-            if (expectedValue == null) {
-                expectedValue = NullNode.getInstance();
-            }
-
-            return CommandResult.conditional(value.equals(expectedValue),
-                    "Unexpected value");
-        }
-
-        private CommandResult handlePositionCondition(PositionCondition test) {
-            Id nodeId = test.targetNodeId();
-            Id resolvedChild = resolveAlias(test.childId());
-
-            int indexOf = listChildren(nodeId)
-                    .map(list -> list.indexOf(resolvedChild))
-                    .orElseGet(() -> Integer.valueOf(-1));
-
-            if (indexOf == -1) {
-                return CommandResult.fail("Not a child");
-            }
-
-            ListPosition position = test.position();
-
-            Id after = position.after();
-            if (after != null) {
-                if (after.equals(Id.EDGE)) {
-                    if (indexOf != 0) {
-                        return CommandResult.fail("Not the first child");
-                    }
-                } else {
-                    if (!isChildAt(nodeId, indexOf - 1, after)) {
-                        return CommandResult
-                                .fail("Not after the provided child");
-                    }
-                }
-            }
-
-            Id before = position.before();
-            if (before != null) {
-                if (before.equals(Id.EDGE)) {
-                    int childCount = listChildren(nodeId).map(List::size)
-                            .orElse(0);
-                    if (indexOf != childCount - 1) {
-                        return CommandResult.fail("Not the last child");
-                    }
-                } else {
-                    if (!isChildAt(nodeId, indexOf + 1, before)) {
-                        return CommandResult
-                                .fail("Not before the provided child");
-                    }
-                }
-            }
-
-            return CommandResult.ok();
-        }
-
-        private CommandResult handleKeyCondition(KeyCondition keyTest) {
-            Id nodeId = keyTest.targetNodeId();
-            String key = keyTest.key();
-            Id expectedChild = keyTest.expectedChild();
-
-            Id actualChildId = mapChild(nodeId, key).orElse(null);
-            if (expectedChild == null) {
-                return CommandResult.conditional(actualChildId != null,
-                        "Key not present");
-            } else if (Id.ZERO.equals(expectedChild)) {
-                return CommandResult.conditional(actualChildId == null,
-                        "A key is present");
-            } else {
-                return CommandResult.conditional(
-                        isSameNode(actualChildId, expectedChild),
-                        "Unexpected child");
-            }
-        }
-
-        private CommandResult handleLastUpdateCondition(
-                LastUpdateCondition lastUpdateTest) {
-            Id lastUpdate = data(lastUpdateTest.targetNodeId())
-                    .map(Data::lastUpdate).orElse(null);
-
-            return CommandResult.conditional(
-                    Objects.equals(lastUpdate,
-                            lastUpdateTest.expectedLastUpdate()),
-                    "Unexpected last update");
-        }
-
-        private void handleAdoptAs(AdoptAsCommand adoptAs) {
-            Id nodeId = adoptAs.targetNodeId();
-            String key = adoptAs.key();
-            Id childId = adoptAs.childId();
-
-            if (detach(childId)) {
-                attachAs(nodeId, key, childId);
-            }
-        }
-
-        private void handleAdoptAt(AdoptAtCommand adoptAt) {
-            Id nodeId = adoptAt.targetNodeId();
-            ListPosition position = adoptAt.position();
-            Id childId = adoptAt.childId();
-
-            if (detach(childId)) {
-                attachAt(nodeId, position, childId);
-            }
-        }
-
-        private void handleIncrement(IncrementCommand increment) {
-            Id nodeId = increment.targetNodeId();
-            double delta = increment.delta();
-
-            JsonNode oldValue = value(nodeId);
-
-            double newValue;
-            if (oldValue instanceof NumericNode value) {
-                newValue = value.doubleValue() + delta;
-            } else if (oldValue == null || oldValue instanceof NullNode) {
-                newValue = delta;
-            } else {
-                fail("Value is not numeric");
-                return;
-            }
-
-            setValue(nodeId, new DoubleNode(newValue));
-        }
-
-        private void handleClear(ClearCommand clear) {
-            updateData(clear.targetNodeId(), node -> {
-                detachedNodes.addAll(node.listChildren());
-                detachedNodes.addAll(node.mapChildren().values());
-
-                if (detachedNodes.isEmpty()) {
-                    return node;
-                }
-
-                return new Data(node.parent(), command.commandId(),
-                        node.scopeOwner(), node.value(), List.of(), Map.of());
-            });
-        }
-
-        private void handleRemoveByKey(RemoveByKeyCommand removeByKey) {
-            mapChild(removeByKey.targetNodeId(), removeByKey.key())
-                    .ifPresentOrElse(this::detach,
-                            () -> fail("Key not present"));
-        }
-
-        private void handlePut(PutCommand put) {
-            Id commandId = put.commandId();
-            Id nodeId = put.targetNodeId();
-            String key = put.key();
-            JsonNode value = put.value();
-
-            mapChild(nodeId, key).ifPresentOrElse(childId -> {
-                setValue(childId, value);
-            }, () -> {
-                createNode(commandId, value, null);
-                attachAs(nodeId, key, commandId);
-            });
-        }
-
-        private void handlePutIfAbsent(PutIfAbsentCommand putIfAbsent) {
-            Id commandId = putIfAbsent.commandId();
-            Id nodeId = putIfAbsent.targetNodeId();
-            String key = putIfAbsent.key();
-
-            mapChild(nodeId, key).ifPresentOrElse(childId -> {
-                if (data(commandId).isPresent()) {
-                    fail("Node already exists");
-                    return;
-                }
-
-                updatedNodes.put(commandId, new Alias(resolveAlias(childId)));
-            }, () -> {
-                createNode(commandId, putIfAbsent.value(),
-                        putIfAbsent.scopeOwner());
-                attachAs(nodeId, key, commandId);
-            });
-        }
-
-        private void handleInsert(InsertCommand insert) {
-            Id commandId = insert.commandId();
-
-            createNode(commandId, insert.value(), insert.scopeOwner());
-            attachAt(insert.targetNodeId(), insert.position(), commandId);
-        }
-
-        private void handleSet(SetCommand set) {
-            setValue(set.targetNodeId(), set.value());
-        }
-
-        private void handleRemove(RemoveCommand remove) {
-            Id nodeId = remove.targetNodeId();
-            Id expectedParentId = remove.expectedParentId();
-
-            if (expectedParentId != null) {
-                Id parentId = data(nodeId).map(Data::parent).orElse(null);
-
-                if (!isSameNode(expectedParentId, parentId)) {
-                    fail("Not a child");
-                    return;
-                }
-            }
-
-            detach(nodeId);
-        }
-
-        private void handleClearOwner(ClearOwnerCommand clearOwner) {
-            Id ownerId = clearOwner.ownerId();
-
-            // TODO clear originalInserts that have been removed previously?
-            nodes().forEach((id, nodeOrAlias) -> {
-                if (nodeOrAlias instanceof Data node
-                        && ownerId.equals(node.scopeOwner())) {
-                    detach(id);
-                }
-            });
-        }
-
-        private void handleTransaction(TransactionCommand transaction) {
-            List<SignalCommand> commands = transaction.commands();
-
-            MutableTreeRevision scratchpad = new MutableTreeRevision(
-                    MutableTreeRevision.this);
-
-            subCommandResults = new HashMap<Id, CommandResult>();
-
-            Reject firstReject = null;
-            for (SignalCommand command : commands) {
-                scratchpad.apply(command, subCommandResults::put);
-
-                CommandResult childResult = subCommandResults
-                        .get(command.commandId());
-                if (childResult instanceof Reject reject) {
-                    firstReject = reject;
-                    break;
-                }
-            }
-
-            if (firstReject == null) {
-                Map<Id, NodeModification> updates = new HashMap<>();
-                Map<Id, SignalCommand.ScopeOwnerCommand> originalInserts = new HashMap<>();
-
-                // Iterate the command list to preserve order
-                for (SignalCommand command : commands) {
-                    Accept op = (Accept) subCommandResults
-                            .get(command.commandId());
-                    op.updates().forEach((nodeId, modification) -> {
-                        if (updates.containsKey(nodeId)) {
-                            updates.put(nodeId,
-                                    new NodeModification(
-                                            updates.get(nodeId).oldNode(),
-                                            modification.newNode()));
-                        } else {
-                            updates.put(nodeId, modification);
-                        }
-                    });
-
-                    originalInserts.putAll(op.originalInserts());
-                }
-
-                setResult(new Accept(updates, originalInserts));
-            } else {
-                for (SignalCommand command : commands) {
-                    CommandResult originalResult = subCommandResults
-                            .get(command.commandId());
-                    if (originalResult == null
-                            || originalResult instanceof Accept) {
-                        subCommandResults.put(command.commandId(), firstReject);
-                    }
-                }
-
-                setResult(firstReject);
-            }
-        }
-
-        private void handleSnapshot(SnapshotCommand snapshot) {
-            /*
-             * We will have to add support for applying a snapshot to a
-             * non-empty tree if we implement re-synchronization based on
-             * snapshots.
-             */
-            assert updatedNodes.isEmpty();
-            assert detachedNodes.isEmpty();
-
-            updatedNodes.putAll(snapshot.nodes());
         }
     }
 
@@ -823,16 +458,38 @@ public class MutableTreeRevision extends TreeRevision {
      */
     public void apply(SignalCommand command,
             BiConsumer<Id, CommandResult> resultCollector) {
-        CommandResult result = data(command.targetNodeId()).map(data -> {
-            TreeManipulator manipulator = new TreeManipulator(command);
-            var opResult = manipulator.handleCommand(command);
-            if (manipulator.subCommandResults != null
-                    && resultCollector != null) {
-                manipulator.subCommandResults.forEach(resultCollector);
-            }
-            return opResult;
-        }).orElseGet(() -> CommandResult.fail("Node not found"));
+        // Custom logic for transactions that can produce multiple results
+        if (command instanceof TransactionCommand transaction) {
+            Map<Id, CommandResult> results = handleTransaction(transaction);
 
+            applyResult(results.get(transaction.commandId()));
+
+            if (resultCollector != null) {
+                results.forEach(resultCollector);
+            }
+        } else {
+            CommandResult result;
+            if (!nodes().containsKey(command.targetNodeId())) {
+                result = CommandResult.fail("Node not found");
+            } else {
+                @SuppressWarnings("unchecked")
+                var handler = (BiFunction<MutableTreeRevision, SignalCommand, CommandResult>) handlers
+                        .get(command.getClass());
+
+                result = handler.apply(this, command);
+            }
+
+            applyResult(result);
+
+            if (resultCollector != null) {
+                resultCollector.accept(command.commandId(), result);
+            }
+        }
+
+        assert assertValidTree();
+    }
+
+    private void applyResult(CommandResult result) {
         if (result instanceof Accept accept) {
             accept.updates().forEach((nodeId, update) -> {
                 Node newNode = update.newNode();
@@ -847,11 +504,427 @@ public class MutableTreeRevision extends TreeRevision {
 
             originalInserts().putAll(accept.originalInserts());
         }
+    }
 
-        if (resultCollector != null) {
-            resultCollector.accept(command.commandId(), result);
+    private static Map<Class<? extends SignalCommand>, BiFunction<MutableTreeRevision, ? extends SignalCommand, CommandResult>> handlers = new HashMap<>();
+
+    private static <T extends SignalCommand> void addHandler(
+            Class<T> commandType,
+            BiFunction<MutableTreeRevision, T, CommandResult> handler) {
+        handlers.put(commandType, handler);
+    }
+
+    static {
+        addHandler(ValueCondition.class,
+                MutableTreeRevision::handleValueCondition);
+        addHandler(PositionCondition.class,
+                MutableTreeRevision::handlePositionCondition);
+        addHandler(KeyCondition.class, MutableTreeRevision::handleKeyCondition);
+        addHandler(LastUpdateCondition.class,
+                MutableTreeRevision::handleLastUpdateCondition);
+
+        addHandler(AdoptAsCommand.class, MutableTreeRevision::handleAdoptAs);
+        addHandler(AdoptAtCommand.class, MutableTreeRevision::handleAdoptAt);
+        addHandler(IncrementCommand.class,
+                MutableTreeRevision::handleIncrement);
+        addHandler(ClearCommand.class, MutableTreeRevision::handleClear);
+        addHandler(RemoveByKeyCommand.class,
+                MutableTreeRevision::handleRemoveByKey);
+        addHandler(PutCommand.class, MutableTreeRevision::handlePut);
+        addHandler(PutIfAbsentCommand.class,
+                MutableTreeRevision::handlePutIfAbsent);
+        addHandler(InsertCommand.class, MutableTreeRevision::handleInsert);
+        addHandler(SetCommand.class, MutableTreeRevision::handleSet);
+        addHandler(RemoveCommand.class, MutableTreeRevision::handleRemove);
+        addHandler(ClearOwnerCommand.class,
+                MutableTreeRevision::handleClearOwner);
+        addHandler(SnapshotCommand.class, MutableTreeRevision::handleSnapshot);
+    }
+
+    private CommandResult handleValueCondition(ValueCondition test) {
+        JsonNode value = data(test.targetNodeId()).map(Data::value)
+                .orElse(null);
+        if (value == null) {
+            value = NullNode.getInstance();
         }
 
-        assert assertValidTree();
+        JsonNode expectedValue = test.expectedValue();
+        if (expectedValue == null) {
+            expectedValue = NullNode.getInstance();
+        }
+
+        return CommandResult.conditional(value.equals(expectedValue),
+                "Unexpected value");
+    }
+
+    private CommandResult handlePositionCondition(PositionCondition test) {
+        DirectNodeLookup nodeLookup = new DirectNodeLookup();
+
+        List<Id> listChildren = data(test.targetNodeId()).get().listChildren();
+
+        Id resolvedChild = nodeLookup.resolveAlias(test.childId());
+        int indexOf = listChildren.indexOf(resolvedChild);
+
+        if (indexOf == -1) {
+            return CommandResult.fail("Not a child");
+        }
+
+        ListPosition position = test.position();
+
+        Id after = position.after();
+        if (after != null) {
+            if (after.equals(Id.EDGE)) {
+                if (indexOf != 0) {
+                    return CommandResult.fail("Not the first child");
+                }
+            } else {
+                if (!nodeLookup.isChildAt(listChildren, indexOf - 1, after)) {
+                    return CommandResult.fail("Not after the provided child");
+                }
+            }
+        }
+
+        Id before = position.before();
+        if (before != null) {
+            if (before.equals(Id.EDGE)) {
+                int childCount = listChildren.size();
+                if (indexOf != childCount - 1) {
+                    return CommandResult.fail("Not the last child");
+                }
+            } else {
+                if (!nodeLookup.isChildAt(listChildren, indexOf + 1, before)) {
+                    return CommandResult.fail("Not before the provided child");
+                }
+            }
+        }
+
+        return CommandResult.ok();
+    }
+
+    private CommandResult handleKeyCondition(KeyCondition keyTest) {
+        Id nodeId = keyTest.targetNodeId();
+        String key = keyTest.key();
+        Id expectedChild = keyTest.expectedChild();
+
+        Id actualChildId = data(nodeId).get().mapChildren().get(key);
+
+        if (expectedChild == null) {
+            return CommandResult.conditional(actualChildId != null,
+                    "Key not present");
+        } else if (Id.ZERO.equals(expectedChild)) {
+            return CommandResult.conditional(actualChildId == null,
+                    "A key is present");
+        } else {
+            DirectNodeLookup nodeLookup = new DirectNodeLookup();
+
+            return CommandResult.conditional(
+                    nodeLookup.isSameNode(actualChildId, expectedChild),
+                    "Unexpected child");
+        }
+    }
+
+    private CommandResult handleLastUpdateCondition(
+            LastUpdateCondition lastUpdateTest) {
+        Id lastUpdate = data(lastUpdateTest.targetNodeId()).get().lastUpdate();
+
+        return CommandResult.conditional(
+                Objects.equals(lastUpdate, lastUpdateTest.expectedLastUpdate()),
+                "Unexpected last update");
+    }
+
+    private CommandResult handleAdoptAs(AdoptAsCommand adoptAs) {
+        Id nodeId = adoptAs.targetNodeId();
+        Id childId = adoptAs.childId();
+        String key = adoptAs.key();
+
+        var builder = new ResultBuilder(adoptAs);
+
+        if (builder.detach(childId) instanceof Reject error) {
+            return error;
+        }
+
+        if (builder.attachAs(nodeId, key, childId) instanceof Reject error) {
+            return error;
+        }
+
+        return builder.build();
+    }
+
+    private CommandResult handleAdoptAt(AdoptAtCommand adoptAt) {
+        Id nodeId = adoptAt.targetNodeId();
+        Id childId = adoptAt.childId();
+        ListPosition pos = adoptAt.position();
+
+        var builder = new ResultBuilder(adoptAt);
+
+        if (builder.detach(childId) instanceof Reject error) {
+            return error;
+        }
+
+        if (builder.attachAt(nodeId, pos, childId) instanceof Reject error) {
+            return error;
+        }
+
+        return builder.build();
+    }
+
+    private CommandResult handleIncrement(IncrementCommand increment) {
+        DirectNodeLookup nodeLookup = new DirectNodeLookup();
+
+        ResolvedData resolved = nodeLookup
+                .resolveData(increment.targetNodeId());
+
+        double delta = increment.delta();
+
+        JsonNode oldValue = data(increment.targetNodeId()).get().value();
+
+        double newValue;
+        if (oldValue instanceof NumericNode value) {
+            newValue = value.doubleValue() + delta;
+        } else if (oldValue == null || oldValue instanceof NullNode) {
+            newValue = delta;
+        } else {
+            return CommandResult.fail("Value is not numeric");
+        }
+
+        return createValueChange(increment, resolved, new DoubleNode(newValue));
+    }
+
+    private CommandResult handleClear(ClearCommand clear) {
+        var builder = new ResultBuilder(clear);
+
+        ResolvedData resolved = builder.resolveData(clear.targetNodeId());
+
+        Data node = resolved.data;
+
+        builder.detachedNodes.addAll(node.listChildren());
+        builder.detachedNodes.addAll(node.mapChildren().values());
+
+        if (builder.detachedNodes.isEmpty()) {
+            return CommandResult.ok();
+        }
+
+        Data updatedNode = new Data(node.parent(), clear.commandId(),
+                node.scopeOwner(), node.value(), List.of(), Map.of());
+
+        builder.updatedNodes.put(resolved.resolvedId, updatedNode);
+
+        return builder.build();
+    }
+
+    private CommandResult handleRemoveByKey(RemoveByKeyCommand removeByKey) {
+        Id nodeId = removeByKey.targetNodeId();
+        String key = removeByKey.key();
+
+        DirectNodeLookup nodeLookup = new DirectNodeLookup();
+
+        Id childId = nodeLookup.data(nodeId).mapChildren().get(key);
+
+        if (childId == null) {
+            return CommandResult.fail("Key not present");
+        } else {
+            var builder = new ResultBuilder(removeByKey);
+
+            Reject result = builder.detach(childId);
+            assert result == null;
+
+            return builder.build();
+        }
+    }
+
+    private CommandResult handlePut(PutCommand put) {
+        Id commandId = put.commandId();
+        Id nodeId = put.targetNodeId();
+        String key = put.key();
+        JsonNode value = put.value();
+
+        Id childId = data(nodeId).get().mapChildren().get(key);
+        if (childId != null) {
+            DirectNodeLookup nodeLookup = new DirectNodeLookup();
+            return createValueChange(put, nodeLookup.resolveData(childId),
+                    value);
+        } else {
+            var builder = new ResultBuilder(put);
+
+            if (builder.createNode(commandId, value,
+                    null) instanceof Reject error) {
+                return error;
+            }
+
+            if (builder.attachAs(nodeId, key,
+                    commandId) instanceof Reject error) {
+                return error;
+            }
+
+            return builder.build();
+        }
+    }
+
+    private CommandResult handlePutIfAbsent(PutIfAbsentCommand putIfAbsent) {
+        Id commandId = putIfAbsent.commandId();
+        Id nodeId = putIfAbsent.targetNodeId();
+        String key = putIfAbsent.key();
+
+        var builder = new ResultBuilder(putIfAbsent);
+
+        Id childId = builder.data(nodeId).mapChildren().get(key);
+        if (childId != null) {
+            if (builder.node(commandId) != null) {
+                return CommandResult.fail("Node already exists");
+            }
+
+            builder.updatedNodes.put(commandId, new Alias(childId));
+        } else {
+            if (builder.createNode(commandId, putIfAbsent.value(),
+                    putIfAbsent.scopeOwner()) instanceof Reject error) {
+                return error;
+            }
+
+            if (builder.attachAs(nodeId, key,
+                    commandId) instanceof Reject error) {
+                return error;
+            }
+        }
+
+        return builder.build();
+    }
+
+    private CommandResult handleInsert(InsertCommand insert) {
+        Id commandId = insert.commandId();
+
+        var builder = new ResultBuilder(insert);
+
+        if (builder.createNode(commandId, insert.value(),
+                insert.scopeOwner()) instanceof Reject error) {
+            return error;
+        }
+
+        if (builder.attachAt(insert.targetNodeId(), insert.position(),
+                commandId) instanceof Reject error) {
+            return error;
+        }
+
+        return builder.build();
+    }
+
+    private CommandResult handleSet(SetCommand set) {
+        DirectNodeLookup nodeLookup = new DirectNodeLookup();
+
+        ResolvedData resolved = nodeLookup.resolveData(set.targetNodeId());
+
+        return createValueChange(set, resolved, set.value());
+    }
+
+    private CommandResult handleRemove(RemoveCommand remove) {
+        Id nodeId = remove.targetNodeId();
+
+        Id expectedParentId = remove.expectedParentId();
+        if (expectedParentId != null) {
+            DirectNodeLookup nodeLookup = new DirectNodeLookup();
+
+            Id actualParentId = nodeLookup.data(nodeId).parent();
+
+            if (!nodeLookup.isSameNode(expectedParentId, actualParentId)) {
+                return CommandResult.fail("Not a child");
+            }
+        }
+
+        var builder = new ResultBuilder(remove);
+
+        if (builder.detach(nodeId) instanceof Reject error) {
+            return error;
+        }
+
+        return builder.build();
+    }
+
+    private CommandResult handleClearOwner(ClearOwnerCommand clearOwner) {
+        Id ownerId = clearOwner.ownerId();
+
+        var builder = new ResultBuilder(clearOwner);
+
+        nodes().forEach((id, nodeOrAlias) -> {
+            if (nodeOrAlias instanceof Data node
+                    && ownerId.equals(node.scopeOwner())) {
+                Reject result = builder.detach(id);
+                assert result == null;
+            }
+        });
+
+        return builder.build();
+    }
+
+    private Map<Id, CommandResult> handleTransaction(
+            TransactionCommand transaction) {
+        List<SignalCommand> commands = transaction.commands();
+
+        MutableTreeRevision scratchpad = new MutableTreeRevision(this);
+
+        var results = new HashMap<Id, CommandResult>();
+
+        Reject firstReject = null;
+        for (SignalCommand command : commands) {
+            scratchpad.apply(command, results::put);
+
+            CommandResult subResult = results.get(command.commandId());
+            if (subResult instanceof Reject reject) {
+                firstReject = reject;
+                break;
+            }
+        }
+
+        if (firstReject == null) {
+            Map<Id, NodeModification> updates = new HashMap<>();
+            Map<Id, SignalCommand.ScopeOwnerCommand> originalInserts = new HashMap<>();
+
+            // Iterate the command list to preserve order
+            for (SignalCommand command : commands) {
+                Accept op = (Accept) results.get(command.commandId());
+                op.updates().forEach((nodeId, modification) -> {
+                    NodeModification previous = updates.get(nodeId);
+                    if (previous != null) {
+                        updates.put(nodeId, new NodeModification(
+                                previous.oldNode(), modification.newNode()));
+                    } else {
+                        updates.put(nodeId, modification);
+                    }
+                });
+
+                originalInserts.putAll(op.originalInserts());
+            }
+
+            results.put(transaction.commandId(),
+                    new Accept(updates, originalInserts));
+        } else {
+            for (SignalCommand command : commands) {
+                CommandResult originalResult = results.get(command.commandId());
+                if (!(originalResult instanceof Reject)) {
+                    results.put(command.commandId(), firstReject);
+                }
+            }
+
+            results.put(transaction.commandId(), firstReject);
+        }
+
+        return results;
+    }
+
+    private CommandResult handleSnapshot(SnapshotCommand snapshot) {
+        ResultBuilder builder = new ResultBuilder(snapshot);
+
+        builder.updatedNodes.putAll(snapshot.nodes());
+
+        return builder.build();
+    }
+
+    private static CommandResult createValueChange(SignalCommand command,
+            ResolvedData resolved, JsonNode value) {
+        Data oldNode = resolved.data();
+        Data newNode = new Node.Data(oldNode.parent(), command.commandId(),
+                oldNode.scopeOwner(), value, oldNode.listChildren(),
+                oldNode.mapChildren());
+
+        return new Accept(Map.of(resolved.resolvedId(),
+                new NodeModification(oldNode, newNode)), Map.of());
     }
 }


### PR DESCRIPTION
* Rename TreeManipulator to ResultBuilder and use it only for multi-step commands and commands that affect multiple nodes
* Explicitly return a result when handling a command instead of indirectly producing one
* Transactions produce multiple results so they have custom top-level handling instead of following the general pattern
* Handle errors caused by concurrent modifications by returning a Reject result instead of passing the error through an instance field