### PR TITLE
fix: Output file JSON without a leading space before colon

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/JacksonUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JacksonUtils.java
@@ -34,6 +34,9 @@ import java.util.stream.Stream;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.core.util.Separators;
+import com.fasterxml.jackson.core.util.Separators.Spacing;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -488,5 +491,23 @@ public final class JacksonUtils {
      */
     public static ObjectNode writeValue(Object object) {
         return objectMapper.valueToTree(object);
+    }
+
+    /**
+     * Converts the given node into JSON suitable for writing into a file such
+     * as {@literal package.json}.
+     *
+     * @param node
+     *            the node to convert
+     * @return the JSON string
+     * @throws JsonProcessingException
+     *             if the node cannot be converted
+     */
+    public static String toFileJson(JsonNode node)
+            throws JsonProcessingException {
+        DefaultPrettyPrinter filePrinter = new DefaultPrettyPrinter(
+                Separators.createDefaultInstance()
+                        .withObjectFieldValueSpacing(Spacing.AFTER));
+        return objectMapper.writer().with(filePrinter).writeValueAsString(node);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -521,7 +521,7 @@ public abstract class NodeUpdater implements FallibleCommand {
 
     String writePackageFile(JsonNode json, File packageFile)
             throws IOException {
-        String content = json.toPrettyString() + "\n";
+        String content = JacksonUtils.toFileJson(json);
         if (packageFile.exists() || options.isFrontendHotdeploy()
                 || options.isBundleBuild()) {
             log().debug("writing file {}.", packageFile.getAbsolutePath());

--- a/flow-server/src/test/java/com/vaadin/flow/internal/JacksonUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/JacksonUtilsTest.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.stream.DoubleStream;
 import java.util.stream.Stream;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -39,7 +40,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class JacksonUtilsTest {
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = JacksonUtils.getMapper();
 
     @Test
     public void testEquals() {
@@ -470,6 +471,19 @@ public class JacksonUtilsTest {
         Assert.assertEquals("Foo", person.name);
         Assert.assertEquals(30.5, person.age, 0.0);
         Assert.assertTrue(person.canSwim);
+    }
+
+    @Test
+    public void toFileJson() throws JsonProcessingException {
+        ObjectNode json = JacksonUtils.beanToJson(new ParentBean());
+        Assert.assertEquals("""
+                {
+                  "parentValue": "parent",
+                  "child": {
+                    "childValue": "child"
+                  }
+                }""", JacksonUtils.toFileJson(json));
+
     }
 
 }


### PR DESCRIPTION
This is compatible with the old elemental json version and with how browsers output indented json
