### PR TITLE
chore: Preserve method signature to avoid compile errors

### DIFF
--- a/flow-react/src/main/resources/META-INF/resources/frontend/ReactRouterOutletElement.tsx
+++ b/flow-react/src/main/resources/META-INF/resources/frontend/ReactRouterOutletElement.tsx
@@ -3,8 +3,8 @@ import { ReactAdapterElement } from "Frontend/generated/flow/ReactAdapter.js";
 import React from "react";
 
 class ReactRouterOutletElement extends ReactAdapterElement {
-  connectedCallback() {
-    super.connectedCallback();
+  public async connectedCallback() {
+    await super.connectedCallback();
     this.style.display = 'contents';
   }
 


### PR DESCRIPTION
Should fix compile errors like:
```
[ERROR] src/main/frontend/generated/jar-resources/ReactRouterOutletElement.tsx(6,3): error TS2416: Property 'connectedCallback' in type 'ReactRouterOutletElement' is not assignable to the same property in base type 'ReactAdapterElement'.
```