### PR TITLE
fix: watch active project resources

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/ExternalDependencyWatcher.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/ExternalDependencyWatcher.java
@@ -57,6 +57,9 @@ public class ExternalDependencyWatcher implements Closeable {
                 }
             }
         } else {
+            // Always watch src/main/resources/META-INF from active project
+            hotdeployDependencyFolders.add(projectFolder.getAbsolutePath());
+
             File pomFile = new File(projectFolder, "pom.xml");
             File parentPomFile = MavenUtils
                     .getParentPomOfMultiModuleProject(pomFile);
@@ -78,10 +81,6 @@ public class ExternalDependencyWatcher implements Closeable {
         for (String hotdeployDependencyFolder : hotdeployDependencyFolders) {
             Path moduleFolder = projectFolder.toPath()
                     .resolve(hotdeployDependencyFolder).normalize();
-            if (moduleFolder.equals(projectFolder.toPath())) {
-                // Don't watch the active module
-                continue;
-            }
             Path metaInf = moduleFolder
                     .resolve(Path.of("src", "main", "resources", "META-INF"));
             if (!watchDependencyFolder(metaInf.toFile(),

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/FileWatcherTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/FileWatcherTest.java
@@ -1,11 +1,18 @@
 package com.vaadin.base.devserver;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.server.InitParameters;
+import com.vaadin.flow.server.VaadinContext;
+import com.vaadin.flow.server.startup.ApplicationConfiguration;
 
 public class FileWatcherTest {
 
@@ -25,5 +32,116 @@ public class FileWatcherTest {
 
         Thread.sleep(50); // The watcher is supposed to be triggered immediately
         Assert.assertEquals(newFile, changed.get());
+    }
+
+    @Test
+    public void externalDependencyWatcher_setViaParameter_TriggeredForModification()
+            throws Exception {
+        File projectFolder = Files.createTempDirectory("projectFolder")
+                .toFile();
+        projectFolder.deleteOnExit();
+
+        String metaInf = "/src/main/resources/META-INF/";
+        String rootPorjectResourceFrontend = projectFolder.getAbsolutePath()
+                + metaInf + "resources/frontend";
+        String subProjectLegacyFrontend = projectFolder.getAbsolutePath()
+                + "/fakeProject" + metaInf + "frontend";
+
+        new File(rootPorjectResourceFrontend).mkdirs();
+        new File(subProjectLegacyFrontend).mkdirs();
+
+        File jarFrontendResources = Files
+                .createTempDirectory("jarFrontendResources").toFile();
+        jarFrontendResources.deleteOnExit();
+
+        VaadinContext vaadinContext = Mockito.mock(VaadinContext.class);
+        ApplicationConfiguration config = Mockito
+                .mock(ApplicationConfiguration.class);
+        Mockito.when(config.getStringProperty(
+                InitParameters.FRONTEND_HOTDEPLOY_DEPENDENCIES, null))
+                .thenReturn("./,./fakeproject");
+        Mockito.when(config.getProjectFolder()).thenReturn(projectFolder);
+
+        try (MockedStatic<ApplicationConfiguration> appConfig = Mockito
+                .mockStatic(ApplicationConfiguration.class)) {
+            appConfig.when(() -> ApplicationConfiguration.get(Mockito.any()))
+                    .thenReturn(config);
+            new ExternalDependencyWatcher(vaadinContext, jarFrontendResources);
+
+            assertFileCountFound(jarFrontendResources, 0);
+
+            createFile(rootPorjectResourceFrontend + "/somestyles.css");
+            assertFileCountFound(jarFrontendResources, 1);
+
+            createFile(subProjectLegacyFrontend + "/somejs.js");
+            assertFileCountFound(jarFrontendResources, 2);
+
+            Assert.assertEquals("somestyles.css",
+                    jarFrontendResources.listFiles()[0].getName());
+            Assert.assertEquals("somejs.js",
+                    jarFrontendResources.listFiles()[1].getName());
+        }
+    }
+
+    @Test
+    public void externalDependencyWatcher_setAsDefaultForRunnerProjectButNotSubProject_TriggeredForModification()
+            throws Exception {
+        File projectFolder = Files.createTempDirectory("projectFolder")
+                .toFile();
+        projectFolder.deleteOnExit();
+
+        String metaInf = "/src/main/resources/META-INF/";
+        String rootPorjectResourceFrontend = projectFolder.getAbsolutePath()
+                + metaInf + "resources/frontend";
+        String subProjectLegacyFrontend = projectFolder.getAbsolutePath()
+                + "/fakeProject" + metaInf + "frontend";
+
+        new File(rootPorjectResourceFrontend).mkdirs();
+        new File(subProjectLegacyFrontend).mkdirs();
+
+        File jarFrontendResources = Files
+                .createTempDirectory("jarFrontendResources").toFile();
+        jarFrontendResources.deleteOnExit();
+
+        VaadinContext vaadinContext = Mockito.mock(VaadinContext.class);
+        ApplicationConfiguration config = Mockito
+                .mock(ApplicationConfiguration.class);
+        Mockito.when(config.getStringProperty(
+                InitParameters.FRONTEND_HOTDEPLOY_DEPENDENCIES, null))
+                .thenReturn(null);
+        Mockito.when(config.getProjectFolder()).thenReturn(projectFolder);
+
+        try (MockedStatic<ApplicationConfiguration> appConfig = Mockito
+                .mockStatic(ApplicationConfiguration.class)) {
+            appConfig.when(() -> ApplicationConfiguration.get(Mockito.any()))
+                    .thenReturn(config);
+            new ExternalDependencyWatcher(vaadinContext, jarFrontendResources);
+
+            assertFileCountFound(jarFrontendResources, 0);
+
+            createFile(rootPorjectResourceFrontend + "/somestyles.css");
+            assertFileCountFound(jarFrontendResources, 1);
+
+            createFile(subProjectLegacyFrontend + "/somejs.js");
+            assertFileCountFound(jarFrontendResources, 1);
+
+            Assert.assertEquals("somestyles.css",
+                    jarFrontendResources.listFiles()[0].getName());
+        }
+    }
+
+    private void assertFileCountFound(File directory, int count)
+            throws InterruptedException {
+        Thread.sleep(50);
+        Assert.assertEquals(
+                "Wroug amount of copied files found when there should be "
+                        + count + ".",
+                count, directory.listFiles().length);
+
+    }
+
+    private void createFile(String path) throws IOException {
+        File newFile = new File(path);
+        newFile.createNewFile();
     }
 }

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/FileWatcherTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/FileWatcherTest.java
@@ -132,9 +132,9 @@ public class FileWatcherTest {
 
     private void assertFileCountFound(File directory, int count)
             throws InterruptedException {
-        Thread.sleep(50);
+        Thread.sleep(100);
         Assert.assertEquals(
-                "Wroug amount of copied files found when there should be "
+                "Wrong amount of copied files found when there should be "
                         + count + ".",
                 count, directory.listFiles().length);
 

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/FileWatcherTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/FileWatcherTest.java
@@ -45,7 +45,7 @@ public class FileWatcherTest {
         String rootPorjectResourceFrontend = projectFolder.getAbsolutePath()
                 + metaInf + "resources/frontend";
         String subProjectLegacyFrontend = projectFolder.getAbsolutePath()
-                + "/fakeProject" + metaInf + "frontend";
+                + "/fakeproject" + metaInf + "frontend";
 
         new File(rootPorjectResourceFrontend).mkdirs();
         new File(subProjectLegacyFrontend).mkdirs();
@@ -94,7 +94,7 @@ public class FileWatcherTest {
         String rootPorjectResourceFrontend = projectFolder.getAbsolutePath()
                 + metaInf + "resources/frontend";
         String subProjectLegacyFrontend = projectFolder.getAbsolutePath()
-                + "/fakeProject" + metaInf + "frontend";
+                + "/fakeproject" + metaInf + "frontend";
 
         new File(rootPorjectResourceFrontend).mkdirs();
         new File(subProjectLegacyFrontend).mkdirs();


### PR DESCRIPTION
Watch resources from active project if active project defined in hotdeployDependencyFolders.

If hotdeployDependencyFolders is not set, add active project to watched set of directories.

Fixes https://github.com/vaadin/flow/issues/20992