### PR TITLE
fix: prevent duplicated messages in client queue

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/communication/MessageSender.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/MessageSender.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Timer;
-
 import com.vaadin.client.ConnectionIndicator;
 import com.vaadin.client.Console;
 import com.vaadin.client.Registry;
@@ -208,8 +207,10 @@ public class MessageSender {
      */
     public void send(final JsonObject payload) {
         if (hasQueuedMessages()) {
-            if (messageQueue.stream().noneMatch(
-                    message -> message.toJson().equals(payload.toJson()))) {
+            // The sever sync id is set in the private sendPayload method.
+            // If it is already present on the payload, it means the message has
+            // been already sent and enqueued.
+            if (!payload.hasKey(ApplicationConstants.SERVER_SYNC_ID)) {
                 messageQueue.add(payload);
             }
             return;

--- a/flow-client/src/main/java/com/vaadin/client/communication/MessageSender.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/MessageSender.java
@@ -208,7 +208,10 @@ public class MessageSender {
      */
     public void send(final JsonObject payload) {
         if (hasQueuedMessages()) {
-            messageQueue.add(payload);
+            if (messageQueue.stream().noneMatch(
+                    message -> message.toJson().equals(payload.toJson()))) {
+                messageQueue.add(payload);
+            }
             return;
         }
         messageQueue.add(payload);
@@ -384,8 +387,8 @@ public class MessageSender {
                 if (messageQueue.get(0)
                         .getNumber(ApplicationConstants.CLIENT_TO_SERVER_ID)
                         + 1 == nextExpectedId) {
-                    resetTimer();
                     messageQueue.remove(0);
+                    resetTimer();
                 }
             }
             return;

--- a/flow-test-util/src/main/java/com/vaadin/flow/testutil/AbstractBrowserConsoleTest.java
+++ b/flow-test-util/src/main/java/com/vaadin/flow/testutil/AbstractBrowserConsoleTest.java
@@ -1,14 +1,12 @@
-package com.vaadin.flow.uitest.ui.push;
+package com.vaadin.flow.testutil;
 
 import java.util.List;
-
-import com.vaadin.flow.testutil.ChromeBrowserTest;
 
 public abstract class AbstractBrowserConsoleTest extends ChromeBrowserTest {
 
     @Override
-    protected void open() {
-        super.open();
+    protected void open(String... parameters) {
+        super.open(parameters);
 
         getCommandExecutor().executeScript("window.logs = [];"
                 + "var origConsole = window.console; window.console = {"
@@ -23,10 +21,10 @@ public abstract class AbstractBrowserConsoleTest extends ChromeBrowserTest {
     protected List<?> getBrowserLogs(boolean reset) {
         if (reset) {
             return (List<?>) getCommandExecutor().executeScript(
-                    "var result = window.logs; window.logs=[]; return result;");
+                    "var result = window.logs; window.logs=[]; return result || [];");
         } else {
             return (List<?>) getCommandExecutor()
-                    .executeScript("return window.logs;");
+                    .executeScript("return window.logs || [];");
         }
     }
 

--- a/flow-test-util/src/main/java/com/vaadin/flow/testutil/ChromeBrowserTestWithProxy.java
+++ b/flow-test-util/src/main/java/com/vaadin/flow/testutil/ChromeBrowserTestWithProxy.java
@@ -1,14 +1,12 @@
-package com.vaadin.flow.uitest.ui.push;
+package com.vaadin.flow.testutil;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.After;
-import org.junit.experimental.categories.Category;
 
-import com.vaadin.flow.testcategory.PushTests;
+import com.vaadin.flow.testutil.net.SimpleProxy;
 
-@Category(PushTests.class)
 public abstract class ChromeBrowserTestWithProxy
         extends AbstractBrowserConsoleTest {
 

--- a/flow-test-util/src/main/java/com/vaadin/flow/testutil/net/SimpleProxy.java
+++ b/flow-test-util/src/main/java/com/vaadin/flow/testutil/net/SimpleProxy.java
@@ -1,4 +1,4 @@
-package com.vaadin.flow.uitest.ui.push;
+package com.vaadin.flow.testutil.net;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/faulttolerance/BeforeOutputStreamActionFilter.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/faulttolerance/BeforeOutputStreamActionFilter.java
@@ -1,0 +1,56 @@
+package com.vaadin.flow.uitest.ui.faulttolerance;
+
+import java.io.IOException;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.annotation.WebFilter;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponseWrapper;
+
+import com.vaadin.flow.server.VaadinServletResponse;
+
+@WebFilter(urlPatterns = "/*")
+public class BeforeOutputStreamActionFilter implements Filter {
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response,
+            FilterChain chain) throws IOException, ServletException {
+        response = new BeforeOutputStreamActionResponse(
+                (HttpServletResponse) response);
+        chain.doFilter(request, response);
+    }
+
+    static void beforeGettingOutputStream(Runnable action) {
+        ServletResponse response = VaadinServletResponse.getCurrent()
+                .getResponse();
+        if (response instanceof BeforeOutputStreamActionResponse cast) {
+            cast.beforeGettingOutputStream(action);
+        }
+    }
+
+    public static class BeforeOutputStreamActionResponse
+            extends HttpServletResponseWrapper {
+        private Runnable action;
+
+        BeforeOutputStreamActionResponse(HttpServletResponse response) {
+            super(response);
+        }
+
+        private void beforeGettingOutputStream(Runnable action) {
+            this.action = action;
+        }
+
+        @Override
+        public ServletOutputStream getOutputStream() throws IOException {
+            if (action != null) {
+                action.run();
+                action = null;
+            }
+            return super.getOutputStream();
+        }
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/faulttolerance/NetworkInterruptionView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/faulttolerance/NetworkInterruptionView.java
@@ -1,0 +1,71 @@
+package com.vaadin.flow.uitest.ui.faulttolerance;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.AfterNavigationEvent;
+import com.vaadin.flow.router.AfterNavigationObserver;
+import com.vaadin.flow.router.Route;
+
+@Route("com.vaadin.flow.uitest.ui.faulttolerance.NetworkInterruptionView")
+public class NetworkInterruptionView extends Div
+        implements AfterNavigationObserver {
+
+    public static final String INCREMENT_BUTTON_ID = "incrementCounter";
+    public static final String INCREMENT_STOP_PROXY_BUTTON_ID = "incrementCounterStopProxy";
+    public static final String COUNTER_ID = "counter";
+    private final NativeButton incrementAndStopProxyButton;
+
+    private int clientCounter = 0;
+    private String monitorFile;
+
+    public NetworkInterruptionView() {
+        Span counter = new Span("0");
+        counter.setId(COUNTER_ID);
+        NativeButton incrementButton = new NativeButton("Increment", e -> {
+            clientCounter++;
+            counter.setText(clientCounter + "");
+        });
+        incrementButton.setId(INCREMENT_BUTTON_ID);
+        incrementAndStopProxyButton = new NativeButton("Increment (stop proxy)",
+                e -> {
+                    clientCounter++;
+                    counter.setText(clientCounter + "");
+                    BeforeOutputStreamActionFilter.beforeGettingOutputStream(
+                            this::stopProxyConnection);
+                });
+        incrementAndStopProxyButton.setId(INCREMENT_STOP_PROXY_BUTTON_ID);
+        add(incrementButton, incrementAndStopProxyButton, counter);
+    }
+
+    @Override
+    public void afterNavigation(AfterNavigationEvent event) {
+        monitorFile = event.getLocation().getQueryParameters()
+                .getSingleParameter("proxyMonitorFile").orElse(null);
+        if (monitorFile == null) {
+            remove(incrementAndStopProxyButton);
+        }
+    }
+
+    private void stopProxyConnection() {
+        try {
+            Files.writeString(Paths.get(monitorFile), "stop",
+                    StandardOpenOption.TRUNCATE_EXISTING);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        // wait for proxy disconnection
+        try {
+            Thread.sleep(200);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/faulttolerance/NetworkInterruptionIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/faulttolerance/NetworkInterruptionIT.java
@@ -1,0 +1,145 @@
+package com.vaadin.flow.uitest.ui.faulttolerance;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.component.html.testbench.NativeButtonElement;
+import com.vaadin.flow.component.html.testbench.SpanElement;
+import com.vaadin.flow.testutil.ChromeBrowserTestWithProxy;
+
+public class NetworkInterruptionIT extends ChromeBrowserTestWithProxy {
+
+    private AtomicBoolean stopWatcher = new AtomicBoolean(false);
+
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
+
+    @Override
+    public void setup() throws Exception {
+        super.setup();
+        Path proxyMonitorFile = tempDir.newFile("flow-test-proxy-monitor.txt")
+                .toPath();
+        WatchService watchService = FileSystems.getDefault().newWatchService();
+        tempDir.getRoot().toPath().register(watchService,
+                StandardWatchEventKinds.ENTRY_MODIFY);
+        AtomicBoolean stopWatcher = new AtomicBoolean(false);
+        new Thread(() -> {
+            WatchKey key;
+            try (WatchService ws = watchService) {
+                while (!stopWatcher.get()) {
+                    key = ws.poll(100, TimeUnit.MILLISECONDS);
+                    if (key != null) {
+                        for (WatchEvent<?> event : key.pollEvents()) {
+                            if (event.context() instanceof Path p
+                                    && proxyMonitorFile.equals(tempDir.getRoot()
+                                            .toPath().resolve(p))) {
+                                if (Files.readString(proxyMonitorFile)
+                                        .contains("stop")) {
+                                    disconnectProxy();
+                                }
+                            }
+                        }
+                        key.reset();
+                    }
+                }
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException(e);
+            }
+        }).start();
+        this.stopWatcher = stopWatcher;
+        open("proxyMonitorFile=" + proxyMonitorFile.toAbsolutePath());
+        testBench().disableWaitForVaadin();
+    }
+
+    @After
+    public void stopWatcher() {
+        stopWatcher.set(true);
+    }
+
+    @Test
+    public void networkInterruption_clickIncrementButton_messageQueuedAndResent()
+            throws IOException {
+        disconnectProxy();
+
+        $(NativeButtonElement.class)
+                .id(NetworkInterruptionView.INCREMENT_BUTTON_ID).click();
+        waitForReconnectAttempts();
+        connectProxy();
+
+        waitForLogMessage("Re-established connection to server");
+
+        waitUntil(d -> Integer.parseInt($(SpanElement.class)
+                .id(NetworkInterruptionView.COUNTER_ID).getText()) == 1);
+        ensureNoSystemErrorFromServer();
+    }
+
+    @Test
+    public void networkInterruption_clickIncrementButtonMultipleTime_messagesQueuedAndResent()
+            throws IOException {
+        disconnectProxy();
+
+        NativeButtonElement button = $(NativeButtonElement.class)
+                .id(NetworkInterruptionView.INCREMENT_BUTTON_ID);
+
+        button.click();
+        button.click();
+        button.click();
+        button.click();
+        waitForReconnectAttempts();
+        connectProxy();
+
+        waitForLogMessage("Re-established connection to server");
+
+        waitUntil(d -> Integer.parseInt($(SpanElement.class)
+                .id(NetworkInterruptionView.COUNTER_ID).getText()) == 4);
+        ensureNoSystemErrorFromServer();
+    }
+
+    @Test
+    public void networkInterruption_dropProxyBeforeResponse_serverMessageCachedAndResent()
+            throws Exception {
+        $(NativeButtonElement.class)
+                .id(NetworkInterruptionView.INCREMENT_STOP_PROXY_BUTTON_ID)
+                .click();
+        waitForReconnectAttempts();
+        connectProxy();
+        waitForLogMessage("Re-established connection to server");
+
+        waitUntil(d -> Integer.parseInt($(SpanElement.class)
+                .id(NetworkInterruptionView.COUNTER_ID).getText()) == 1);
+        ensureNoSystemErrorFromServer();
+    }
+
+    private void waitForReconnectAttempts() {
+        waitForLogMessage("Reconnect attempt 2 for XHR");
+    }
+
+    private void ensureNoSystemErrorFromServer() {
+        // Make sure there is no error caused by messages sync lost
+        waitForElementNotPresent(By.cssSelector("div.v-system-error"));
+    }
+
+    private void waitForLogMessage(String expectedMessage) {
+        waitUntil(driver -> getBrowserLogs(true).stream().anyMatch(
+                message -> expectedMessage.equals(message.toString())));
+    }
+
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/push/PushChromeBrowserTestWithProxy.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/push/PushChromeBrowserTestWithProxy.java
@@ -1,0 +1,12 @@
+package com.vaadin.flow.uitest.ui.push;
+
+import org.junit.experimental.categories.Category;
+
+import com.vaadin.flow.testcategory.PushTests;
+import com.vaadin.flow.testutil.ChromeBrowserTestWithProxy;
+
+@Category(PushTests.class)
+public abstract class PushChromeBrowserTestWithProxy
+        extends ChromeBrowserTestWithProxy {
+
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/push/ReconnectTest.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/push/ReconnectTest.java
@@ -3,17 +3,18 @@ package com.vaadin.flow.uitest.ui.push;
 import java.io.IOException;
 
 import org.junit.Test;
+import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
-public abstract class ReconnectTest extends ChromeBrowserTestWithProxy {
+public abstract class ReconnectTest extends PushChromeBrowserTestWithProxy {
 
     @Override
     public void setup() throws Exception {
         super.setup();
 
-        open();
+        open((String[]) null);
 
         startTimer();
         waitUntilServerCounterChanges();
@@ -89,6 +90,12 @@ public abstract class ReconnectTest extends ChromeBrowserTestWithProxy {
                 return false;
             }
         }, 30);
+        ensureNoSystemErrorFromServer();
+    }
+
+    private void ensureNoSystemErrorFromServer() {
+        // Make sure there is no error caused by messages sync lost
+        waitForElementNotPresent(By.cssSelector("div.v-system-error"));
     }
 
     private void waitUntilClientCounterChanges(final int expectedValue) {

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/push/SendMultibyteCharactersTest.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/push/SendMultibyteCharactersTest.java
@@ -10,6 +10,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 
 import com.vaadin.flow.testcategory.PushTests;
+import com.vaadin.flow.testutil.AbstractBrowserConsoleTest;
 import com.vaadin.testbench.TestBenchElement;
 
 @Category(PushTests.class)


### PR DESCRIPTION
Messages sent by the Flow client are queued until the server acknowledges their reception. However, if there's a network fault, the Flow client immediately attempts to resend the message, resulting in duplicates in the queue.

This change ensures that the same message is not added to the queue multiple times.

Fixes #21095