### PR TITLE
feat: add defaultAutoResponsiveFormLayout feature flag

### DIFF
--- a/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
+++ b/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
@@ -109,6 +109,12 @@ public class FeatureFlags implements Serializable {
             "https://github.com/vaadin/flow-components/issues/6998", true,
             null);
 
+    public static final Feature DEFAULT_AUTO_RESPONSIVE_FORM_LAYOUT = new Feature(
+        "Form Layout auto-responsive mode enabled by default",
+        "defaultAutoResponsiveFormLayout",
+        "https://github.com/vaadin/platform/issues/7172", true,
+        null);
+
     private List<Feature> features = new ArrayList<>();
 
     File propertiesFolder = null;
@@ -140,6 +146,7 @@ public class FeatureFlags implements Serializable {
         features.add(new Feature(REACT19));
         features.add(new Feature(ACCESSIBLE_DISABLED_BUTTONS));
         features.add(new Feature(LAYOUT_COMPONENT_IMPROVEMENTS));
+        features.add(new Feature(DEFAULT_AUTO_RESPONSIVE_FORM_LAYOUT));
         loadProperties();
     }
 

--- a/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
+++ b/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
@@ -110,10 +110,9 @@ public class FeatureFlags implements Serializable {
             null);
 
     public static final Feature DEFAULT_AUTO_RESPONSIVE_FORM_LAYOUT = new Feature(
-        "Form Layout auto-responsive mode enabled by default",
-        "defaultAutoResponsiveFormLayout",
-        "https://github.com/vaadin/platform/issues/7172", true,
-        null);
+            "Form Layout auto-responsive mode enabled by default",
+            "defaultAutoResponsiveFormLayout",
+            "https://github.com/vaadin/platform/issues/7172", true, null);
 
     private List<Feature> features = new ArrayList<>();
 


### PR DESCRIPTION
## Description

The PR introduces a new feature flag, `defaultAutoResponsiveFormLayout`, which enables auto-responsive mode for all form layouts by default.

Part of https://github.com/vaadin/flow-components/issues/7164

## Type of change

- [x] Feature
