### PR TITLE
test: refactor FileWatcherTest to clean up resources

### DIFF
--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/FileWatcherTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/FileWatcherTest.java
@@ -3,10 +3,13 @@ package com.vaadin.base.devserver;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -16,43 +19,48 @@ import com.vaadin.flow.server.startup.ApplicationConfiguration;
 
 public class FileWatcherTest {
 
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
     @Test
     public void fileWatcherTriggeredForModification() throws Exception {
         AtomicReference<File> changed = new AtomicReference<>();
 
-        File dir = Files.createTempDirectory("watched").toFile();
+        File dir = temporaryFolder.newFolder("watched");
         FileWatcher watcher = new FileWatcher(file -> {
             changed.set(file);
         }, dir);
 
         watcher.start();
 
-        File newFile = new File(dir, "newFile.txt");
-        newFile.createNewFile();
+        try {
+            File newFile = new File(dir, "newFile.txt");
+            newFile.createNewFile();
 
-        Thread.sleep(50); // The watcher is supposed to be triggered immediately
-        Assert.assertEquals(newFile, changed.get());
+            Thread.sleep(50); // The watcher is supposed to be triggered
+                              // immediately
+            Assert.assertEquals(newFile, changed.get());
+        } finally {
+            watcher.stop();
+        }
     }
 
     @Test
     public void externalDependencyWatcher_setViaParameter_TriggeredForModification()
             throws Exception {
-        File projectFolder = Files.createTempDirectory("projectFolder")
-                .toFile();
-        projectFolder.deleteOnExit();
+        File projectFolder = temporaryFolder.newFolder("projectFolder");
 
         String metaInf = "/src/main/resources/META-INF/";
-        String rootPorjectResourceFrontend = projectFolder.getAbsolutePath()
+        String rootProjectResourceFrontend = projectFolder.getAbsolutePath()
                 + metaInf + "resources/frontend";
         String subProjectLegacyFrontend = projectFolder.getAbsolutePath()
                 + "/fakeproject" + metaInf + "frontend";
 
-        new File(rootPorjectResourceFrontend).mkdirs();
+        new File(rootProjectResourceFrontend).mkdirs();
         new File(subProjectLegacyFrontend).mkdirs();
 
-        File jarFrontendResources = Files
-                .createTempDirectory("jarFrontendResources").toFile();
-        jarFrontendResources.deleteOnExit();
+        File jarFrontendResources = temporaryFolder
+                .newFolder("jarFrontendResources");
 
         VaadinContext vaadinContext = Mockito.mock(VaadinContext.class);
         ApplicationConfiguration config = Mockito
@@ -66,29 +74,29 @@ public class FileWatcherTest {
                 .mockStatic(ApplicationConfiguration.class)) {
             appConfig.when(() -> ApplicationConfiguration.get(Mockito.any()))
                     .thenReturn(config);
-            new ExternalDependencyWatcher(vaadinContext, jarFrontendResources);
+            try (var watcher = new ExternalDependencyWatcher(vaadinContext,
+                    jarFrontendResources)) {
 
-            assertFileCountFound(jarFrontendResources, 0);
+                assertFileCountFound(jarFrontendResources, 0);
 
-            createFile(rootPorjectResourceFrontend + "/somestyles.css");
-            assertFileCountFound(jarFrontendResources, 1);
+                createFile(rootProjectResourceFrontend + "/somestyles.css");
+                assertFileCountFound(jarFrontendResources, 1);
 
-            createFile(subProjectLegacyFrontend + "/somejs.js");
-            assertFileCountFound(jarFrontendResources, 2);
+                createFile(subProjectLegacyFrontend + "/somejs.js");
+                assertFileCountFound(jarFrontendResources, 2);
 
-            Assert.assertEquals("somestyles.css",
-                    jarFrontendResources.listFiles()[0].getName());
-            Assert.assertEquals("somejs.js",
-                    jarFrontendResources.listFiles()[1].getName());
+                Assert.assertEquals("somestyles.css",
+                        jarFrontendResources.listFiles()[0].getName());
+                Assert.assertEquals("somejs.js",
+                        jarFrontendResources.listFiles()[1].getName());
+            }
         }
     }
 
     @Test
     public void externalDependencyWatcher_setAsDefaultForRunnerProjectButNotSubProject_TriggeredForModification()
             throws Exception {
-        File projectFolder = Files.createTempDirectory("projectFolder")
-                .toFile();
-        projectFolder.deleteOnExit();
+        File projectFolder = temporaryFolder.newFolder("projectFolder");
 
         String metaInf = "/src/main/resources/META-INF/";
         String rootPorjectResourceFrontend = projectFolder.getAbsolutePath()
@@ -99,9 +107,8 @@ public class FileWatcherTest {
         new File(rootPorjectResourceFrontend).mkdirs();
         new File(subProjectLegacyFrontend).mkdirs();
 
-        File jarFrontendResources = Files
-                .createTempDirectory("jarFrontendResources").toFile();
-        jarFrontendResources.deleteOnExit();
+        File jarFrontendResources = temporaryFolder
+                .newFolder("jarFrontendResources");
 
         VaadinContext vaadinContext = Mockito.mock(VaadinContext.class);
         ApplicationConfiguration config = Mockito
@@ -115,33 +122,37 @@ public class FileWatcherTest {
                 .mockStatic(ApplicationConfiguration.class)) {
             appConfig.when(() -> ApplicationConfiguration.get(Mockito.any()))
                     .thenReturn(config);
-            new ExternalDependencyWatcher(vaadinContext, jarFrontendResources);
+            try (var watcher = new ExternalDependencyWatcher(vaadinContext,
+                    jarFrontendResources)) {
 
-            assertFileCountFound(jarFrontendResources, 0);
+                assertFileCountFound(jarFrontendResources, 0);
 
-            createFile(rootPorjectResourceFrontend + "/somestyles.css");
-            assertFileCountFound(jarFrontendResources, 1);
+                createFile(rootPorjectResourceFrontend + "/somestyles.css");
+                assertFileCountFound(jarFrontendResources, 1);
 
-            createFile(subProjectLegacyFrontend + "/somejs.js");
-            assertFileCountFound(jarFrontendResources, 1);
+                createFile(subProjectLegacyFrontend + "/somejs.js");
+                assertFileCountFound(jarFrontendResources, 1);
 
-            Assert.assertEquals("somestyles.css",
-                    jarFrontendResources.listFiles()[0].getName());
+                Assert.assertEquals("somestyles.css",
+                        jarFrontendResources.listFiles()[0].getName());
+            }
         }
     }
 
     private void assertFileCountFound(File directory, int count)
             throws InterruptedException {
-        Thread.sleep(100);
+        Thread.sleep(500);
+        File[] files = directory.listFiles();
         Assert.assertEquals(
                 "Wrong amount of copied files found when there should be "
-                        + count + ".",
-                count, directory.listFiles().length);
+                        + count + ". Current files were: "
+                        + Arrays.toString(files),
+                count, files.length);
 
     }
 
     private void createFile(String path) throws IOException {
         File newFile = new File(path);
-        newFile.createNewFile();
+        Files.writeString(newFile.toPath(), "some text");
     }
 }


### PR DESCRIPTION
Stops watchers after test execution and uses JUnit temporary folder rule to ensure temporary directories are deleted.