### PR TITLE
fix: Clean file-routes if hilla not in use (#21155)

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinBuildFrontendTask.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinBuildFrontendTask.kt
@@ -19,6 +19,7 @@ import com.vaadin.flow.plugin.base.BuildFrontendUtil
 import com.vaadin.flow.server.Constants
 import com.vaadin.flow.server.frontend.BundleValidationUtil
 import com.vaadin.flow.server.frontend.FrontendUtils
+import com.vaadin.flow.server.frontend.Options
 import com.vaadin.flow.server.frontend.TaskCleanFrontendFiles
 import com.vaadin.pro.licensechecker.LicenseChecker
 import org.gradle.api.DefaultTask
@@ -72,9 +73,10 @@ public open class VaadinBuildFrontendTask : DefaultTask() {
         val tokenFile = BuildFrontendUtil.getTokenFile(adapter)
         check(tokenFile.exists()) { "token file $tokenFile doesn't exist!" }
 
-        val cleanTask = TaskCleanFrontendFiles(config.npmFolder.get(),
-                BuildFrontendUtil.getGeneratedFrontendDirectory(adapter), adapter.classFinder
-        )
+        val options = Options(null, adapter.classFinder, config.npmFolder.get())
+            .withFrontendDirectory(config.frontendDirectory.get())
+            .withFrontendGeneratedFolder(config.generatedTsFolder.get())
+        val cleanTask = TaskCleanFrontendFiles(options)
         BuildFrontendUtil.runNodeUpdater(adapter)
 
         if (adapter.generateBundle() && BundleValidationUtil.needsBundleBuild

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -40,6 +40,7 @@ import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.frontend.BundleValidationUtil;
 import com.vaadin.flow.server.frontend.FrontendUtils;
+import com.vaadin.flow.server.frontend.Options;
 import com.vaadin.flow.server.frontend.TaskCleanFrontendFiles;
 import com.vaadin.flow.theme.Theme;
 import com.vaadin.pro.licensechecker.LicenseChecker;
@@ -137,8 +138,10 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo
             throws MojoExecutionException, MojoFailureException {
         long start = System.nanoTime();
 
-        TaskCleanFrontendFiles cleanTask = new TaskCleanFrontendFiles(
-                npmFolder(), frontendDirectory(), getClassFinder());
+        Options options = new Options(null, getClassFinder(), npmFolder())
+                .withFrontendDirectory(frontendDirectory())
+                .withFrontendGeneratedFolder(generatedTsFolder());
+        TaskCleanFrontendFiles cleanTask = new TaskCleanFrontendFiles(options);
         try {
             BuildFrontendUtil.runNodeUpdater(this);
         } catch (ExecutionFailedException | URISyntaxException exception) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -150,9 +150,7 @@ public class NodeTasks implements FallibleCommand {
                 // and no update tasks are executed before it.
                 if (BundleValidationUtil.needsBuild(options,
                         frontendDependencies, Mode.DEVELOPMENT_BUNDLE)) {
-                    commands.add(new TaskCleanFrontendFiles(
-                            options.getNpmFolder(),
-                            options.getFrontendDirectory(), classFinder));
+                    commands.add(new TaskCleanFrontendFiles(options));
                     options.withRunNpmInstall(true);
                     options.withCopyTemplates(true);
                     BundleUtils.copyPackageLockFromBundle(options);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCleanFrontendFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCleanFrontendFiles.java
@@ -56,17 +56,17 @@ public class TaskCleanFrontendFiles implements FallibleCommand {
             FrontendUtils.VITE_GENERATED_CONFIG, FrontendUtils.VITE_CONFIG);
     private Set<File> existingFiles = new HashSet<>();
 
+    private List<String> hillaGenerated = List.of("file-routes.ts",
+            "file-routes.json");
+
     /**
      * Scans the jar files given defined by {@code resourcesToScan}.
      *
-     * @param projectRoot
-     *            project root folder
-     * @param frontendDirectory
-     *            frontend directory
+     * @param options
+     *            options containing file paths and classfinder
      */
-    public TaskCleanFrontendFiles(File projectRoot, File frontendDirectory,
-            ClassFinder classFinder) {
-        this.projectRoot = projectRoot;
+    public TaskCleanFrontendFiles(Options options) {
+        this.projectRoot = options.getNpmFolder();
 
         Arrays.stream(projectRoot
                 .listFiles(file -> generatedFiles.contains(file.getName())))
@@ -74,10 +74,17 @@ public class TaskCleanFrontendFiles implements FallibleCommand {
 
         // If we have an existing package.json or run Hilla, do not remove
         // node_modules
-        if (existingFiles
-                .contains(new File(projectRoot, Constants.PACKAGE_JSON))
-                || FrontendUtils.isHillaUsed(frontendDirectory, classFinder)) {
+        boolean hillaUsed = FrontendUtils.isHillaUsed(
+                options.getFrontendDirectory(), options.getClassFinder());
+        if (existingFiles.contains(
+                new File(projectRoot, Constants.PACKAGE_JSON)) || hillaUsed) {
             existingFiles.add(new File(projectRoot, NODE_MODULES));
+        }
+        // If hilla is not used clean generated hilla files.
+        if (!hillaUsed) {
+            hillaGenerated.forEach(
+                    file -> new File(options.getFrontendGeneratedFolder(), file)
+                            .delete());
         }
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskCleanFrontendFilesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskCleanFrontendFilesTest.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -28,19 +29,23 @@ public class TaskCleanFrontendFilesTest {
     private File projectRoot;
     private File frontendDirectory;
     private ClassFinder classFinder;
+    private Options options;
 
     @Before
     public void init() {
         projectRoot = rootFolder.getRoot();
         frontendDirectory = new File(projectRoot, "target/frontend");
         classFinder = Mockito.mock(ClassFinder.class);
+        options = new Options(null, classFinder, projectRoot)
+                .withFrontendDirectory(frontendDirectory)
+                .withFrontendGeneratedFolder(
+                        new File(frontendDirectory, "generated"));
     }
 
     @Test
     public void createdFileAreRemoved()
             throws IOException, ExecutionFailedException {
-        TaskCleanFrontendFiles clean = new TaskCleanFrontendFiles(projectRoot,
-                frontendDirectory, classFinder);
+        TaskCleanFrontendFiles clean = new TaskCleanFrontendFiles(options);
 
         final Set<String> generatedFiles = Stream
                 .of(FrontendUtils.VITE_CONFIG,
@@ -65,8 +70,7 @@ public class TaskCleanFrontendFilesTest {
                 .collect(Collectors.toSet());
         createFiles(existingfiles);
 
-        TaskCleanFrontendFiles clean = new TaskCleanFrontendFiles(projectRoot,
-                frontendDirectory, classFinder);
+        TaskCleanFrontendFiles clean = new TaskCleanFrontendFiles(options);
 
         final Set<String> generatedFiles = Stream
                 .of(FrontendUtils.VITE_GENERATED_CONFIG,
@@ -84,8 +88,7 @@ public class TaskCleanFrontendFilesTest {
     @Test
     public void nodeModulesFolderIsCleared()
             throws IOException, ExecutionFailedException {
-        TaskCleanFrontendFiles clean = new TaskCleanFrontendFiles(projectRoot,
-                frontendDirectory, classFinder);
+        TaskCleanFrontendFiles clean = new TaskCleanFrontendFiles(options);
 
         final File nodeModules = rootFolder.newFolder("node_modules");
         new File(nodeModules, "file").createNewFile();
@@ -102,8 +105,7 @@ public class TaskCleanFrontendFilesTest {
     public void packageJsonExists_nodeModulesFolderIsKept()
             throws IOException, ExecutionFailedException {
         createFiles(Collections.singleton(Constants.PACKAGE_JSON));
-        TaskCleanFrontendFiles clean = new TaskCleanFrontendFiles(projectRoot,
-                frontendDirectory, classFinder);
+        TaskCleanFrontendFiles clean = new TaskCleanFrontendFiles(options);
 
         final File nodeModules = rootFolder.newFolder("node_modules");
         new File(nodeModules, "file").createNewFile();
@@ -124,8 +126,7 @@ public class TaskCleanFrontendFilesTest {
                 .mockStatic(FrontendUtils.class)) {
             util.when(() -> FrontendUtils.isHillaUsed(Mockito.any(),
                     Mockito.any(ClassFinder.class))).thenReturn(true);
-            clean = new TaskCleanFrontendFiles(projectRoot, frontendDirectory,
-                    classFinder);
+            clean = new TaskCleanFrontendFiles(options);
         }
 
         final File nodeModules = rootFolder.newFolder("node_modules");
@@ -137,6 +138,26 @@ public class TaskCleanFrontendFilesTest {
         clean.execute();
 
         assertFilesExist(Collections.singleton("node_modules"));
+    }
+
+    @Test
+    public void hillaIsNotUsed_fileRoutesExists_fileRoutesClearedEagerly()
+            throws IOException, ExecutionFailedException {
+        TaskCleanFrontendFiles clean;
+        final File nodeModules = rootFolder
+                .newFolder("target/frontend/generated");
+        new File(nodeModules, "file-routes.ts").createNewFile();
+        new File(nodeModules, "file-routes.json").createNewFile();
+
+        try (MockedStatic<FrontendUtils> util = Mockito
+                .mockStatic(FrontendUtils.class)) {
+            util.when(() -> FrontendUtils.isHillaUsed(Mockito.any(),
+                    Mockito.any(ClassFinder.class))).thenReturn(false);
+            new TaskCleanFrontendFiles(options);
+        }
+
+        assertFilesNotExist(Set.of("target/frontend/generated/file-routes.ts",
+                "target/frontend/generated/file-routes.json"));
     }
 
     private void createFiles(Set<String> filesToCreate) throws IOException {


### PR DESCRIPTION
Fixes #21144
