### PR TITLE
fix: prevent hot-reload failure caused by prepare-frontend task

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
@@ -15,20 +15,22 @@
  */
 package com.vaadin.gradle
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.vaadin.flow.internal.JacksonUtils
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import kotlin.io.path.div
+import kotlin.io.path.writeText
 import kotlin.test.assertContains
 import kotlin.test.expect
+import com.vaadin.flow.internal.JacksonUtils
 import com.vaadin.flow.internal.StringUtil
 import com.vaadin.flow.server.InitParameters
 import com.vaadin.flow.server.frontend.FrontendUtils
+import com.fasterxml.jackson.databind.JsonNode
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Before
 import org.junit.Test
-import java.nio.file.Files
-import java.nio.file.StandardCopyOption
 
 
 /**
@@ -567,6 +569,114 @@ class VaadinSmokeTest : AbstractGradleTest() {
         val result2 = testProject.build("--configuration-cache", "vaadinPrepareFrontend", "-Dvaadin.eagerServerLoad=true", checkTasksSuccessful = false)
         result2.expectTaskOutcome("vaadinPrepareFrontend", TaskOutcome.SUCCESS)
         assertContains(result.output, "Calculating task graph as no cached configuration is available for tasks: vaadinPrepareFrontend")
+    }
+
+    // When Hilla is detected, frontend hot deploy should be automatically
+    // enabled and as a consequence prepare frontend task should create react
+    // related files
+    @Test
+    fun vaadinPrepareFrontend_hillaAvailable_frontendHotDeployEnabled() {
+        // Setup a project local maven repo to simulate the presence of Hilla
+        val fakeHillaVersion = "0.0.0.localtest";
+        val projectLocalMavenRepo = testProject.newFolder("libs").absoluteFile
+        val hillaEndpointFolder =
+            projectLocalMavenRepo.toPath() / "com" / "vaadin" / "hilla-endpoint" / fakeHillaVersion
+        Files.createDirectories(hillaEndpointFolder)
+
+        // hilla-endpoint-stub.jar contains only stub for com.vaadin.hilla.EndpointController.class
+        val hillaEndpointJar =
+            hillaEndpointFolder / "hilla-endpoint-${fakeHillaVersion}.jar"
+        Files.copy(
+            File(javaClass.classLoader.getResource("hilla-endpoint-stub.jar").path).toPath(),
+            hillaEndpointJar, StandardCopyOption.REPLACE_EXISTING
+        )
+        val hillaEndpointPom =
+            hillaEndpointFolder / "hilla-endpoint-${fakeHillaVersion}.pom"
+        hillaEndpointPom.writeText(
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+                xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.vaadin</groupId>
+                <artifactId>hilla-endpoint</artifactId>
+                <version>${fakeHillaVersion}</version>
+                <name>Fake Hilla Endpoint</name>
+            </project>
+            """.trimIndent()
+        )
+        enableHilla()
+
+        testProject.buildFile.writeText(
+            """
+            plugins {
+                id 'war'
+                id 'com.vaadin'
+            }
+            repositories {
+                maven {
+                    url = '${projectLocalMavenRepo.toURI().toURL()}'
+                }
+                mavenLocal()
+                mavenCentral()
+                maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
+                flatDir {
+                   dirs("libs")
+                }
+            }
+            dependencies {
+                implementation("com.vaadin:flow:$flowVersion")
+                implementation("com.vaadin:hilla-endpoint:${fakeHillaVersion}")
+                providedCompile("jakarta.servlet:jakarta.servlet-api:6.0.0")
+                implementation("org.slf4j:slf4j-simple:$slf4jVersion")
+            }
+            vaadin {
+            }
+        """.trimIndent()
+        )
+
+        val flowTsx = File(
+            testProject.dir,
+            FrontendUtils.DEFAULT_PROJECT_FRONTEND_GENERATED_DIR + "flow/Flow.tsx"
+        )
+        val vaadinReactTsx = File(
+            testProject.dir,
+            FrontendUtils.DEFAULT_PROJECT_FRONTEND_GENERATED_DIR + "vaadin-react.tsx"
+        )
+
+        testProject.build("vaadinPrepareFrontend")
+        expect(
+            true,
+            "Expected Flow.tsx to be created when Hilla is available"
+        ) { flowTsx.exists() }
+        expect(
+            true,
+            "Expected vaadin-react.tsx to be created when Hilla is available"
+        ) { vaadinReactTsx.exists() }
+    }
+
+    // When Hilla is not available, frontend hot deploy should not be enabled
+    // by default and react related files should not be created
+    @Test
+    fun vaadinPrepareFrontend_hillaNotAvailable_frontendHotDeployNotEnabled() {
+        val flowTsx = File(
+            testProject.dir,
+            FrontendUtils.DEFAULT_PROJECT_FRONTEND_GENERATED_DIR + "flow/Flow.tsx"
+        )
+        val vaadinReactTsx = File(
+            testProject.dir,
+            FrontendUtils.DEFAULT_PROJECT_FRONTEND_GENERATED_DIR + "vaadin-react.tsx"
+        )
+
+        testProject.build("vaadinPrepareFrontend")
+        expect(
+            false,
+            "Expected Flow.tsx not to be created when Hilla is not available"
+        ) { flowTsx.exists() }
+        expect(
+            false,
+            "Expected vaadin-react.tsx not to be created when Hilla is not available"
+        ) { vaadinReactTsx.exists() }
     }
 
     private fun enableHilla() {

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
@@ -507,10 +507,14 @@ public class PluginEffectiveConfiguration(
 
     public val frontendHotdeploy: Provider<Boolean> =
         extension.frontendHotdeploy
-            .convention(effectiveFrontendDirectory.map { frontendDirectory ->
-                hillaAvailable.get() &&
-                        FrontendUtils.isHillaViewsUsed(frontendDirectory)
-            })
+            .convention(
+                effectiveFrontendDirectory.zip(
+                    hillaAvailable
+                ) { frontendDirectory, hasHilla ->
+                    hasHilla &&
+                            FrontendUtils.isHillaViewsUsed(frontendDirectory)
+                }
+            )
             .overrideWithSystemPropertyFlag(
                 project,
                 InitParameters.FRONTEND_HOTDEPLOY

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRemoveOldFrontendGeneratedFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRemoveOldFrontendGeneratedFiles.java
@@ -125,12 +125,12 @@ public class TaskRemoveOldFrontendGeneratedFiles implements FallibleCommand {
     }
 
     private Predicate<Path> isKnownUnhandledFile() {
-        Path flowGeneratedImports = FrontendUtils
-                .getFlowGeneratedImports(frontendFolder).toPath()
-                .toAbsolutePath();
-        Path flowGeneratedWebComponentImports = FrontendUtils
+        Path flowGeneratedImports = normalizePath(
+                FrontendUtils.getFlowGeneratedImports(frontendFolder).toPath()
+                        .toAbsolutePath());
+        Path flowGeneratedWebComponentImports = normalizePath(FrontendUtils
                 .getFlowGeneratedWebComponentsImports(frontendFolder).toPath()
-                .toAbsolutePath();
+                .toAbsolutePath());
         Set<Path> knownFiles = new HashSet<>();
         knownFiles.add(flowGeneratedImports);
         knownFiles.add(flowGeneratedWebComponentImports);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRemoveOldFrontendGeneratedFilesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRemoveOldFrontendGeneratedFilesTest.java
@@ -151,7 +151,16 @@ public class TaskRemoveOldFrontendGeneratedFilesTest {
 
     @Test
     public void execute_knownFiles_notDeleted() throws Exception {
-        Set<File> knownFiles = Set.of(new File(generatedFolder, "routes.tsx"),
+        Set<File> knownFiles = Set.of(generatedFolder.toPath()
+                .resolve(Path.of("flow", "generated-flow-imports.js")).toFile(),
+                generatedFolder.toPath()
+                        .resolve(Path.of("flow", "generated-flow-imports.d.ts"))
+                        .toFile(),
+                generatedFolder.toPath()
+                        .resolve(Path.of("flow",
+                                "generated-flow-webcomponent-imports.js"))
+                        .toFile(),
+                new File(generatedFolder, "routes.tsx"),
                 new File(generatedFolder, "routes.ts"), generatedFolder.toPath()
                         .resolve(Path.of("flow", "Flow.tsx")).toFile(),
                 new File(generatedFolder, "file-routes.ts"));


### PR DESCRIPTION
If the prepare-frontend task is invoked while the Vaadin application is running, it may happen that some generated files are mistakenly removed, causing the frontend compilation to fail and sometimes an infinite reload loop.

This happens, for example, in Hilla projects based on Gradle and IntelliJ IDEA: when the IDE compiles a class, it runs Gradle, and the vaadinPrepareFrontend task is executed. Some generated files are then deleted for two reasons:

1. Hilla is not detected because the check is done during the Gradle configuration phase, and it uses the plugin class loader, which does not have references to the project dependencies.
2. The TaskRemoveOldFrontendGeneratedFiles is executed, but it fails to compare non-normalized paths.

This change fixes the two issues by detecting Hilla from the project dependencies and normalizing paths before comparison.

Fixes #20831
Fixes #19748