### PR TITLE
fix: prevent hot-reload failure caused by prepare-frontend task (#21174)(CP:24.6)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRemoveOldFrontendGeneratedFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRemoveOldFrontendGeneratedFiles.java
@@ -125,12 +125,12 @@ public class TaskRemoveOldFrontendGeneratedFiles implements FallibleCommand {
     }
 
     private Predicate<Path> isKnownUnhandledFile() {
-        Path flowGeneratedImports = FrontendUtils
-                .getFlowGeneratedImports(frontendFolder).toPath()
-                .toAbsolutePath();
-        Path flowGeneratedWebComponentImports = FrontendUtils
+        Path flowGeneratedImports = normalizePath(
+                FrontendUtils.getFlowGeneratedImports(frontendFolder).toPath()
+                        .toAbsolutePath());
+        Path flowGeneratedWebComponentImports = normalizePath(FrontendUtils
                 .getFlowGeneratedWebComponentsImports(frontendFolder).toPath()
-                .toAbsolutePath();
+                .toAbsolutePath());
         Set<Path> knownFiles = new HashSet<>();
         knownFiles.add(flowGeneratedImports);
         knownFiles.add(flowGeneratedWebComponentImports);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRemoveOldFrontendGeneratedFilesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRemoveOldFrontendGeneratedFilesTest.java
@@ -151,7 +151,16 @@ public class TaskRemoveOldFrontendGeneratedFilesTest {
 
     @Test
     public void execute_knownFiles_notDeleted() throws Exception {
-        Set<File> knownFiles = Set.of(new File(generatedFolder, "routes.tsx"),
+        Set<File> knownFiles = Set.of(generatedFolder.toPath()
+                .resolve(Path.of("flow", "generated-flow-imports.js")).toFile(),
+                generatedFolder.toPath()
+                        .resolve(Path.of("flow", "generated-flow-imports.d.ts"))
+                        .toFile(),
+                generatedFolder.toPath()
+                        .resolve(Path.of("flow",
+                                "generated-flow-webcomponent-imports.js"))
+                        .toFile(),
+                new File(generatedFolder, "routes.tsx"),
                 new File(generatedFolder, "routes.ts"), generatedFolder.toPath()
                         .resolve(Path.of("flow", "Flow.tsx")).toFile(),
                 new File(generatedFolder, "file-routes.ts"));


### PR DESCRIPTION
If the prepare-frontend task is invoked while the Vaadin application is running, it may happen that some generated files are mistakenly removed, causing the frontend compilation to fail and sometimes an infinite reload loop.

This happens, for example, in Hilla projects based on Gradle and IntelliJ IDEA: when the IDE compiles a class, it runs Gradle, and the vaadinPrepareFrontend task is executed. Some generated files are then deleted for two reasons:

Hilla is not detected because the check is done during the Gradle configuration phase, and it uses the plugin class loader, which does not have references to the project dependencies. The TaskRemoveOldFrontendGeneratedFiles is executed, but it fails to compare non-normalized paths. This change fixes the two issues by detecting Hilla from the project dependencies and normalizing paths before comparison.

Fixes #20831
Fixes #19748

(cherry picked from commit 5fe0e3b4564757bf8e093d91866680b32dc93b09)
