### PR TITLE
test: menu registry test in production mode

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuRegistryTest.java
@@ -144,7 +144,7 @@ public class MenuRegistryTest {
         File clientFiles = new File(generated, FILE_ROUTES_JSON_NAME);
         Files.writeString(clientFiles.toPath(), testClientRouteFile);
 
-        Map<String, AvailableViewInfo> menuItems = new MenuRegistry()
+        Map<String, AvailableViewInfo> menuItems = MenuRegistry
                 .getMenuItems(true);
 
         Assert.assertEquals(10, menuItems.size());
@@ -158,7 +158,7 @@ public class MenuRegistryTest {
         File clientFiles = new File(generated, FILE_ROUTES_JSON_NAME);
         Files.writeString(clientFiles.toPath(), nestedLoginRequiredRouteFile);
 
-        Map<String, AvailableViewInfo> menuItems = new MenuRegistry()
+        Map<String, AvailableViewInfo> menuItems = MenuRegistry
                 .getMenuItems(true);
 
         Assert.assertEquals(0, menuItems.size());
@@ -171,7 +171,7 @@ public class MenuRegistryTest {
         File clientFiles = new File(generated, FILE_ROUTES_JSON_NAME);
         Files.writeString(clientFiles.toPath(), testClientRouteFile);
 
-        Map<String, AvailableViewInfo> menuItems = new MenuRegistry()
+        Map<String, AvailableViewInfo> menuItems = MenuRegistry
                 .getMenuItems(false);
 
         Assert.assertEquals(13, menuItems.size());
@@ -191,7 +191,7 @@ public class MenuRegistryTest {
         Arrays.asList(MyRoute.class, MyInfo.class)
                 .forEach(routeConfiguration::setAnnotatedRoute);
 
-        Map<String, AvailableViewInfo> menuItems = new MenuRegistry()
+        Map<String, AvailableViewInfo> menuItems = MenuRegistry
                 .getMenuItems(false);
         Assert.assertEquals(15, menuItems.size());
 
@@ -218,6 +218,8 @@ public class MenuRegistryTest {
             throws IOException {
         Mockito.when(deploymentConfiguration.isProductionMode())
                 .thenReturn(true);
+        // Clear any production mode execution route contents
+        MenuRegistry.clearFileRoutesCache();
 
         tmpDir.newFolder("META-INF", "VAADIN");
         File clientFiles = new File(tmpDir.getRoot(),
@@ -232,11 +234,14 @@ public class MenuRegistryTest {
             menuRegistry.when(() -> MenuRegistry.getClassLoader())
                     .thenReturn(mockClassLoader);
 
-            Map<String, AvailableViewInfo> menuItems = new MenuRegistry()
+            Map<String, AvailableViewInfo> menuItems = MenuRegistry
                     .getMenuItems(true);
 
             Assert.assertEquals(10, menuItems.size());
             assertClientRoutes(menuItems);
+        } finally {
+            // Clear our routes from production mode cache
+            MenuRegistry.clearFileRoutesCache();
         }
     }
 
@@ -247,7 +252,7 @@ public class MenuRegistryTest {
         Arrays.asList(MyRoute.class, MyInfo.class)
                 .forEach(routeConfiguration::setAnnotatedRoute);
 
-        Map<String, AvailableViewInfo> menuItems = new MenuRegistry()
+        Map<String, AvailableViewInfo> menuItems = MenuRegistry
                 .getMenuItems(true);
 
         Assert.assertEquals(2, menuItems.size());
@@ -266,7 +271,7 @@ public class MenuRegistryTest {
         Arrays.asList(MyRoute.class, MyInfo.class)
                 .forEach(routeConfiguration::setAnnotatedRoute);
 
-        Map<String, AvailableViewInfo> menuItems = new MenuRegistry()
+        Map<String, AvailableViewInfo> menuItems = MenuRegistry
                 .getMenuItems(true);
 
         Assert.assertEquals(12, menuItems.size());
@@ -307,7 +312,7 @@ public class MenuRegistryTest {
         File clientFiles = new File(generated, FILE_ROUTES_JSON_NAME);
         Files.writeString(clientFiles.toPath(), testClientRouteFile);
 
-        Map<String, AvailableViewInfo> menuItems = new MenuRegistry()
+        Map<String, AvailableViewInfo> menuItems = MenuRegistry
                 .getMenuItems(true);
 
         Assert.assertEquals(13, menuItems.size());
@@ -336,7 +341,7 @@ public class MenuRegistryTest {
         File clientFiles = new File(generated, FILE_ROUTES_JSON_NAME);
         Files.writeString(clientFiles.toPath(), testClientRouteFile);
 
-        Map<String, AvailableViewInfo> menuItems = new MenuRegistry()
+        Map<String, AvailableViewInfo> menuItems = MenuRegistry
                 .getMenuItems(true);
 
         Assert.assertEquals(11, menuItems.size());

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/FileWatcherTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/FileWatcherTest.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Assert;
@@ -85,10 +86,14 @@ public class FileWatcherTest {
                 createFile(subProjectLegacyFrontend + "/somejs.js");
                 assertFileCountFound(jarFrontendResources, 2);
 
-                Assert.assertEquals("somestyles.css",
-                        jarFrontendResources.listFiles()[0].getName());
-                Assert.assertEquals("somejs.js",
-                        jarFrontendResources.listFiles()[1].getName());
+                // Map files as listFiles makes no promises on ordering
+                List<String> frontendFiles = Arrays
+                        .stream(jarFrontendResources.listFiles())
+                        .map(File::getName).toList();
+                Assert.assertTrue("No 'somestyles.css' file found",
+                        frontendFiles.contains("somestyles.css"));
+                Assert.assertTrue("No 'somejs.js' file found",
+                        frontendFiles.contains("somejs.js"));
             }
         }
     }

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketConnectionTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketConnectionTest.java
@@ -147,7 +147,7 @@ public class ViteWebsocketConnectionTest {
     }
 
     @SuppressWarnings("unchecked")
-    @Test(timeout = 3500)
+    @Test(timeout = 5000)
     public void close_clientWebsocketClose_dontBlockIndefinitely()
             throws ExecutionException, InterruptedException,
             NoSuchFieldException, InvocationTargetException,


### PR DESCRIPTION
Clear the menuregistry cache for
production mode execution as it
caches client routes.

Use the now static getMenuItems as
static without creating an instance.
