### PR TITLE
fix: prevent resending message when request is in progress

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/communication/DefaultConnectionStateHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/DefaultConnectionStateHandler.java
@@ -228,7 +228,7 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
         // do not need to start a new one
         if (reconnectAttempt == 1) {
             // Try once immediately
-            Console.warn("Immediate reconnect attempt for " + payload);
+            Console.debug("Immediate reconnect attempt for " + payload);
             doReconnect(payload);
         } else {
             scheduledReconnect = new Timer() {
@@ -238,7 +238,7 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
                         scheduledReconnect.cancel();
                     }
                     scheduledReconnect = null;
-                    Console.warn("Scheduled reconnect attempt "
+                    Console.debug("Scheduled reconnect attempt "
                             + reconnectAttempt + " for " + payload);
                     doReconnect(payload);
                 }

--- a/flow-client/src/main/java/com/vaadin/client/communication/DefaultConnectionStateHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/DefaultConnectionStateHandler.java
@@ -22,8 +22,8 @@ import com.google.gwt.regexp.shared.RegExp;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.xhr.client.XMLHttpRequest;
 
-import com.vaadin.client.Console;
 import com.vaadin.client.ConnectionIndicator;
+import com.vaadin.client.Console;
 import com.vaadin.client.Registry;
 import com.vaadin.client.UILifecycle;
 import com.vaadin.client.UILifecycle.UIState;
@@ -228,12 +228,18 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
         // do not need to start a new one
         if (reconnectAttempt == 1) {
             // Try once immediately
+            Console.warn("Immediate reconnect attempt for " + payload);
             doReconnect(payload);
         } else {
             scheduledReconnect = new Timer() {
                 @Override
                 public void run() {
+                    if (scheduledReconnect != null) {
+                        scheduledReconnect.cancel();
+                    }
                     scheduledReconnect = null;
+                    Console.warn("Scheduled reconnect attempt "
+                            + reconnectAttempt + " for " + payload);
                     doReconnect(payload);
                 }
             };
@@ -259,11 +265,13 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
             return;
         }
         if (payload != null) {
-            Console.debug("Re-sending last message to the server...");
-            registry.getMessageSender().send(payload);
+            Console.debug("Trying to re-establish server connection (UIDL)...");
+            registry.getRequestResponseTracker()
+                    .fireEvent(new ReconnectionAttemptEvent(reconnectAttempt));
         } else {
             // Use heartbeat
-            Console.debug("Trying to re-establish server connection...");
+            Console.debug(
+                    "Trying to re-establish server connection (heartbeat)...");
             registry.getHeartbeat().send();
         }
     }
@@ -448,6 +456,10 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
 
         reconnectionCause = null;
         reconnectAttempt = 0;
+        if (scheduledReconnect != null) {
+            scheduledReconnect.cancel();
+            scheduledReconnect = null;
+        }
         ConnectionIndicator.setState(ConnectionIndicator.CONNECTED);
 
         Console.debug("Re-established connection to server");

--- a/flow-client/src/main/java/com/vaadin/client/communication/MessageSender.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/MessageSender.java
@@ -229,10 +229,12 @@ public class MessageSender {
             // been already sent and enqueued.
             if (!payload.hasKey(ApplicationConstants.SERVER_SYNC_ID)) {
                 messageQueue.add(payload);
-                Console.log(
-                        "Message not sent because other messages are pending. Added to the queue.");
+                Console.debug(
+                        "Message not sent because other messages are pending. Added to the queue: "
+                                + payload.toJson());
             } else {
-                Console.log("Message not sent because already queued");
+                Console.debug("Message not sent because already queued: "
+                        + payload.toJson());
             }
             return;
         }

--- a/flow-client/src/main/java/com/vaadin/client/communication/MessageSender.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/MessageSender.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Timer;
+
 import com.vaadin.client.ConnectionIndicator;
 import com.vaadin.client.Console;
 import com.vaadin.client.Registry;
@@ -83,6 +84,17 @@ public class MessageSender {
     public MessageSender(Registry registry) {
         this.registry = registry;
         this.pushConnectionFactory = GWT.create(PushConnectionFactory.class);
+        this.registry.getRequestResponseTracker()
+                .addReconnectionAttemptHandler(ev -> {
+                    Console.debug(
+                            "Re-sending queued messages to the server (attempt "
+                                    + ev.getAttempt() + ") ...");
+                    // Try to reconnect by sending queued messages.
+                    // Stops the resend timer, since it will anyway not make any
+                    // request during reconnection process.
+                    resetTimer();
+                    doSendInvocationsToServer();
+                });
     }
 
     /**
@@ -128,7 +140,12 @@ public class MessageSender {
             registry.getRequestResponseTracker().startRequest();
             sendPayload(payload);
             return;
-        } else if (hasQueuedMessages() && resendMessageTimer == null) {
+        } else if (hasQueuedMessages()) {
+            Console.debug("Sending queued messages to server");
+            if (resendMessageTimer != null) {
+                // Stopping resend timer and re-send immediately
+                resetTimer();
+            }
             sendPayload(messageQueue.get(0));
             return;
         }
@@ -212,6 +229,10 @@ public class MessageSender {
             // been already sent and enqueued.
             if (!payload.hasKey(ApplicationConstants.SERVER_SYNC_ID)) {
                 messageQueue.add(payload);
+                Console.log(
+                        "Message not sent because other messages are pending. Added to the queue.");
+            } else {
+                Console.log("Message not sent because already queued");
             }
             return;
         }
@@ -255,7 +276,6 @@ public class MessageSender {
         } else {
             Console.debug("send XHR");
             registry.getXhrConnection().send(payload);
-
             resetTimer();
             // resend last payload if response hasn't come in.
             resendMessageTimer = new Timer() {
@@ -264,11 +284,16 @@ public class MessageSender {
                     resendMessageTimer
                             .schedule(registry.getApplicationConfiguration()
                                     .getMaxMessageSuspendTimeout() + 500);
+                    // Avoid re-sending the message if a request is still in
+                    // progress.
+                    // If the response to the message has not yet been processed
+                    // the reconnection attempt listener takes care of resending
+                    // the queued message.
                     if (!registry.getRequestResponseTracker()
                             .hasActiveRequest()) {
                         registry.getRequestResponseTracker().startRequest();
+                        registry.getXhrConnection().send(payload);
                     }
-                    registry.getXhrConnection().send(payload);
                 }
             };
             resendMessageTimer.schedule(registry.getApplicationConfiguration()

--- a/flow-client/src/main/java/com/vaadin/client/communication/ReconnectionAttemptEvent.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/ReconnectionAttemptEvent.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.client.communication;
+
+import com.google.web.bindery.event.shared.Event;
+
+import com.google.gwt.event.shared.EventHandler;
+
+/**
+ * Event fired when a reconnection attempt is requested.
+ *
+ * @author Vaadin Ltd
+ * @since 1.0
+ */
+public class ReconnectionAttemptEvent
+        extends Event<ReconnectionAttemptEvent.Handler> {
+
+    /**
+     * Handler for {@link ReconnectionAttemptEvent}s.
+     */
+    @FunctionalInterface
+    public interface Handler extends EventHandler {
+        /**
+         * Called when handling of a reconnection attempt starts.
+         *
+         * @param event
+         *            the event object
+         */
+        void onReconnectionAttempt(ReconnectionAttemptEvent event);
+    }
+
+    private static Type<Handler> type = null;
+
+    private final int attempt;
+
+    /**
+     * Creates an event object.
+     */
+    public ReconnectionAttemptEvent(int attempt) {
+        this.attempt = attempt;
+    }
+
+    /**
+     * Gets the number of the current reconnection attempt.
+     *
+     * @return the number of the current reconnection attempt.
+     */
+    public int getAttempt() {
+        return attempt;
+    }
+
+    /**
+     * Gets the type of the event after ensuring the type has been created.
+     *
+     * @return the type for the event
+     */
+    public static Type<Handler> getType() {
+        if (type == null) {
+            type = new Type<>();
+        }
+        return type;
+    }
+
+    @Override
+    public Type<Handler> getAssociatedType() {
+        return type;
+    }
+
+    @Override
+    protected void dispatch(Handler handler) {
+        handler.onReconnectionAttempt(this);
+    }
+
+}

--- a/flow-client/src/main/java/com/vaadin/client/communication/ReconnectionAttemptEvent.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/ReconnectionAttemptEvent.java
@@ -23,7 +23,7 @@ import com.google.gwt.event.shared.EventHandler;
  * Event fired when a reconnection attempt is requested.
  *
  * @author Vaadin Ltd
- * @since 1.0
+ * @since 24.7
  */
 public class ReconnectionAttemptEvent
         extends Event<ReconnectionAttemptEvent.Handler> {

--- a/flow-client/src/main/java/com/vaadin/client/communication/RequestResponseTracker.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/RequestResponseTracker.java
@@ -15,14 +15,15 @@
  */
 package com.vaadin.client.communication;
 
-import com.google.gwt.core.client.Scheduler;
 import com.google.web.bindery.event.shared.Event;
 import com.google.web.bindery.event.shared.EventBus;
 import com.google.web.bindery.event.shared.HandlerRegistration;
 
-import com.vaadin.client.communication.MessageSender.ResynchronizationState;
+import com.google.gwt.core.client.Scheduler;
+
 import com.vaadin.client.ConnectionIndicator;
 import com.vaadin.client.Registry;
+import com.vaadin.client.communication.MessageSender.ResynchronizationState;
 import com.vaadin.client.gwt.com.google.web.bindery.event.shared.SimpleEventBus;
 
 /**
@@ -172,6 +173,18 @@ public class RequestResponseTracker {
             ResponseHandlingEndedEvent.Handler handler) {
         return eventBus.addHandler(ResponseHandlingEndedEvent.getType(),
                 handler);
+    }
+
+    /**
+     * Adds a handler for {@link ReconnectionAttemptEvent}s.
+     *
+     * @param handler
+     *            the handler to add
+     * @return a registration object which can be used to remove the handler
+     */
+    public HandlerRegistration addReconnectionAttemptHandler(
+            ReconnectionAttemptEvent.Handler handler) {
+        return eventBus.addHandler(ReconnectionAttemptEvent.getType(), handler);
     }
 
 }

--- a/flow-tests/test-client-queue/src/main/java/com/vaadin/flow/misc/ui/SlowResponseView.java
+++ b/flow-tests/test-client-queue/src/main/java/com/vaadin/flow/misc/ui/SlowResponseView.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.misc.ui;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.Route;
+
+@Route("slow-response")
+public class SlowResponseView extends Div {
+
+    public static final String SLOW_ADD = "slowAdd";
+    public static final String ADD = "add";
+    public static final String ADDED_PREDICATE = "added_";
+
+    private int elements = 0;
+
+    public SlowResponseView() {
+        int messageTimeoutMillis = UI.getCurrent().getSession().getService()
+                .getDeploymentConfiguration().getMaxMessageSuspendTimeout();
+        add(new Span("Max message suspend timeout: " + messageTimeoutMillis));
+        NativeButton slowAddElement = new NativeButton(
+                "Add element (slow response)", event -> {
+                    slowAddElement(messageTimeoutMillis + 1000);
+                });
+        slowAddElement.setId(SLOW_ADD);
+
+        NativeButton addElement = new NativeButton("Add element", event -> {
+            addElement();
+        });
+        addElement.setId(ADD);
+
+        add(slowAddElement, addElement);
+    }
+
+    private void addElement() {
+        Div addedElement = new Div("Added element");
+        addedElement.setId(ADDED_PREDICATE + elements++);
+        add(addedElement);
+    }
+
+    private void slowAddElement(long delayMillis) {
+        try {
+            Thread.sleep(delayMillis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+        addElement();
+    }
+}

--- a/flow-tests/test-client-queue/src/test/java/com/vaadin/flow/misc/ui/SlowResponseIT.java
+++ b/flow-tests/test-client-queue/src/test/java/com/vaadin/flow/misc/ui/SlowResponseIT.java
@@ -1,0 +1,111 @@
+package com.vaadin.flow.misc.ui;
+
+import java.util.function.Predicate;
+import java.util.logging.Level;
+import java.util.regex.Pattern;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.TimeoutException;
+
+import com.vaadin.flow.component.html.testbench.DivElement;
+import com.vaadin.flow.component.html.testbench.NativeButtonElement;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+import static com.vaadin.flow.misc.ui.SlowResponseView.ADD;
+import static com.vaadin.flow.misc.ui.SlowResponseView.ADDED_PREDICATE;
+import static com.vaadin.flow.misc.ui.SlowResponseView.SLOW_ADD;
+
+public class SlowResponseIT extends ChromeBrowserTest {
+
+    private static final Predicate<String> DUPLICATE_RESPONSE_LOG_MESSAGE_PREDICATE = Pattern
+            .compile(
+                    ".*Received message with server id \\d but have already seen \\d. Ignoring it.*")
+            .asMatchPredicate();
+
+    @Override
+    protected String getTestPath() {
+        return "/slow-response";
+    }
+
+    @Test
+    public void slowResponseForRequest_clientDontResendsRequest_serverAnswersCorrectly() {
+        open();
+
+        try {
+            waitUntil(driver -> $(NativeButtonElement.class).withId(SLOW_ADD)
+                    .exists());
+        } catch (TimeoutException te) {
+            Assert.fail("Expected 'slow add element' button wasn't found");
+        }
+        // Add element normally
+        $(NativeButtonElement.class).id(ADD).click();
+        Assert.assertTrue(
+                $(DivElement.class).id(ADDED_PREDICATE + 0).isDisplayed());
+
+        // Request null response for next add
+        $(NativeButtonElement.class).id(SLOW_ADD).click();
+
+        $(NativeButtonElement.class).id(ADD).click();
+
+        try {
+            waitUntil(driver -> $(DivElement.class).withId(ADDED_PREDICATE + 1)
+                    .exists());
+        } catch (TimeoutException te) {
+            Assert.fail(
+                    "New element was not added though client should re-send request.");
+        }
+
+        Assert.assertTrue(
+                "Slow response click message sent multiple times and got duplicate response",
+                getLogEntries(Level.WARNING).stream().noneMatch(
+                        logEntry -> DUPLICATE_RESPONSE_LOG_MESSAGE_PREDICATE
+                                .test(logEntry.getMessage())));
+    }
+
+    @Test
+    public void clickWhileRequestPending_clientQueuesRequests_messagesSentCorrectly() {
+        open();
+
+        try {
+            waitUntil(driver -> $(NativeButtonElement.class).withId(SLOW_ADD)
+                    .exists());
+        } catch (TimeoutException te) {
+            Assert.fail("Expected 'slow add element' button wasn't found");
+        }
+
+        // Add element normally
+        $(NativeButtonElement.class).id(ADD).click();
+        Assert.assertTrue(
+                $(DivElement.class).id(ADDED_PREDICATE + 0).isDisplayed());
+
+        // Request null response for next add
+        $(NativeButtonElement.class).id(SLOW_ADD).click();
+
+        $(NativeButtonElement.class).id(ADD).click();
+        $(NativeButtonElement.class).id(ADD).click();
+
+        try {
+            waitUntil(driver -> $(DivElement.class).withId(ADDED_PREDICATE + 1)
+                    .exists());
+        } catch (TimeoutException te) {
+            Assert.fail(
+                    "New element was not added though client should re-send request.");
+        }
+
+        try {
+            waitUntil(driver -> $(DivElement.class).withId(ADDED_PREDICATE + 2)
+                    .exists());
+        } catch (TimeoutException te) {
+            Assert.fail(
+                    "Second new element was not added though client should queue request.");
+        }
+
+        Assert.assertTrue(
+                "Slow response click message sent multiple times and got duplicate response",
+                getLogEntries(Level.WARNING).stream().noneMatch(
+                        logEntry -> DUPLICATE_RESPONSE_LOG_MESSAGE_PREDICATE
+                                .test(logEntry.getMessage())));
+
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/faulttolerance/NetworkInterruptionIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/faulttolerance/NetworkInterruptionIT.java
@@ -129,7 +129,7 @@ public class NetworkInterruptionIT extends ChromeBrowserTestWithProxy {
     }
 
     private void waitForReconnectAttempts() {
-        waitForLogMessage("Reconnect attempt 2 for XHR");
+        waitForLogMessage("Reconnect attempt 4 for XHR");
     }
 
     private void ensureNoSystemErrorFromServer() {


### PR DESCRIPTION
When a request takes longer to respond than the configured `maxMessageSuspendTimeout`, the Flow client still attempts to resend the last message to the server, causing inconsistencies with the connection state indicator in subsequent requests.

This change prevents messages from being resent while a request is in progress. It also updates the reconnection mechanism to properly attempt an HTTP request instead of merely re-adding the unsent message to the client queue.

Fixes #21188