### PR TITLE
fix: Compliant telemetry

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -149,10 +149,13 @@ public final class Constants implements Serializable {
      */
     public static final boolean DEFAULT_REQUIRE_HOME_NODE_EXECUTABLE = false;
 
+    public static final String TELEMETRY_OPT_OUT_ENV_VARIABLE = "VAADIN_TELEMETRY_OPT_OUT";
+
     /**
      * The default value for whether usage statistics is enabled.
      */
-    public static final boolean DEFAULT_DEVMODE_STATS = true;
+    public static final boolean DEFAULT_DEVMODE_STATS =
+            System.getenv(Constants.TELEMETRY_OPT_OUT_ENV_VARIABLE) == null;
 
     /**
      * Internal parameter which prevent validation for annotations which are

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/stats/DevModeUsageStatistics.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/stats/DevModeUsageStatistics.java
@@ -108,7 +108,7 @@ public class DevModeUsageStatistics {
                 Files.createDirectories(statisticDirPath);
                 Files.writeString(firstSeenPath, Instant.now().toString());
             } catch (IOException ioe) {
-                getLogger().warn("Failed to create statistics first seen file", ioe);
+                getLogger().warn("Failed to create telemetry notice first seen file", ioe);
             }
         }
 


### PR DESCRIPTION
## Description

PoC showcasing how a better way of handling telemetry can be provided.

1. There is now a GLOBAL opt out in the form of the ``VAADIN_TELEMETRY_OPT_OUT`` environment variable
2. When executed for the first time it discloses the telemetry collection to the user (avoids potential violation of [GDPR Art 13](https://gdpr-info.eu/art-13-gdpr/)).

Overall the whole thing is quite similar to how [Dotnet](https://learn.microsoft.com/en-us/dotnet/core/tools/telemetry) handles telemetry.

Please note that there is currently a placeholder for a site with more details about telemetry in place, as this can't be provided by the PR.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.<br/> - I can't verify that because I don't have all tools required for running tests locally installed and they are not in place in the repo.
- [x] I have performed self-review and corrected misspellings.

