### PR TITLE
fix: extra delay on full page reload

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
@@ -349,6 +349,14 @@ public class ServerRpcHandler implements Serializable {
                 getLogger().debug(
                         "Eager UI close ignored for @PreserveOnRefresh view");
             } else {
+                PushConnection pushConnection = ui.getInternals()
+                        .getPushConnection();
+                if (pushConnection != null) {
+                    // Disconnect push before closing ui to not generate
+                    // empty request that blocks close as client is already
+                    // closed at this time.
+                    pushConnection.disconnect();
+                }
                 ui.close();
                 getLogger().debug("UI closed with a beacon request");
             }


### PR DESCRIPTION
Fix 1s delay on init request
when reloading full page.

We now close the push channel
if open for beacon close request
before ui.close so we do not get a
pending empty message that blocks
push channel close.

Fixes #21158

