### PR TITLE
feat: add feature flag for Master Detail Layout

### DIFF
--- a/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
+++ b/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
@@ -95,6 +95,11 @@ public class FeatureFlags implements Serializable {
             "https://github.com/vaadin/web-components/issues/5340", true,
             "com.vaadin.flow.component.card.Card");
 
+    public static final Feature MASTER_DETAIL_LAYOUT_COMPONENT = new Feature(
+            "Master Detail Layout component", "masterDetailLayoutComponent",
+            "https://github.com/vaadin/platform/issues/7173", true,
+            "com.vaadin.flow.component.masterdetaillayout.MasterDetailLayout");
+
     public static final Feature REACT19 = new Feature(
             "React 19 (default in Vaadin 25)", "react19",
             "https://react.dev/blog/2024/12/05/react-19", true, null);
@@ -142,6 +147,7 @@ public class FeatureFlags implements Serializable {
         features.add(new Feature(COPILOT_EXPERIMENTAL));
         features.add(new Feature(DASHBOARD_COMPONENT));
         features.add(new Feature(CARD_COMPONENT));
+        features.add(new Feature(MASTER_DETAIL_LAYOUT_COMPONENT));
         features.add(new Feature(REACT19));
         features.add(new Feature(ACCESSIBLE_DISABLED_BUTTONS));
         features.add(new Feature(LAYOUT_COMPONENT_IMPROVEMENTS));


### PR DESCRIPTION
## Description

Adds a feature flag for the Master Detail Layout component.

Note that we want to release the component as a preview feature in 24.7, so that people can try it out sooner. So let's cherry-pick the flag to that branch as well.

## Type of change

- Feature
