### PR TITLE
revert: chore(deps): bump io.smallrye:jandex-maven-plugin from 3.2.7 to 3.3.0 (#21247)

### DIFF
--- a/flow-jandex/pom.xml
+++ b/flow-jandex/pom.xml
@@ -101,7 +101,7 @@
             <plugin>
                 <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.2.7</version>
                 <executions>
                     <execution>
                         <id>make-index</id>


### PR DESCRIPTION
This reverts commit afecf4038e05f2d15ff82143f8a6020e675450ae.

Jandex index 3.3.0 is incompatible with Quarkus 3.15, currently used by vaadin-quarkus

