### PR TITLE
fix: reduce concurrent PWA icons generation tasks

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -22,6 +22,7 @@ import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -340,8 +341,14 @@ public class NodeTasks implements FallibleCommand {
             sortCommands(commands);
             GeneratedFilesSupport generatedFilesSupport = new GeneratedFilesSupport();
             for (FallibleCommand command : commands) {
+                long startTime = System.nanoTime();
                 command.setGeneratedFileSupport(generatedFilesSupport);
                 command.execute();
+                Duration durationInNs = Duration
+                        .ofNanos(System.nanoTime() - startTime);
+                getLogger().debug("Task [ {} ] completed in {} ms",
+                        command.getClass().getSimpleName(),
+                        durationInNs.toMillis());
             }
         } finally {
             releaseLock();


### PR DESCRIPTION
Submitting multiple asynchronous jobs to generate PWA icons at build time can cause OutOfMemory errors with Gradle.
This change introduces a fixed thread pool executor so that fewer icon generations are processed concurrently, allowing the JVM to clean up memory for already generated images.

Fixes #20842