### PR TITLE
feat: scan Maven "provided" scoped dependencies

### DIFF
--- a/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/Reflector.java
+++ b/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/Reflector.java
@@ -33,6 +33,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.resolver.filter.ScopeArtifactFilter;
 import org.apache.maven.plugin.Mojo;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
@@ -57,6 +58,8 @@ public final class Reflector {
     private static final Set<String> REQUIRED_PLUGIN_DEPENDENCIES = Set.of(
             "org.reflections:reflections:jar",
             "org.zeroturnaround:zt-exec:jar");
+    private static final ScopeArtifactFilter PRODUCTION_SCOPE_FILTER = new ScopeArtifactFilter(
+            Artifact.SCOPE_COMPILE_PLUS_RUNTIME);
 
     private final URLClassLoader isolatedClassLoader;
     private List<String> dependenciesIncompatibility;
@@ -269,15 +272,7 @@ public final class Reflector {
                         .contains(artifact.getGroupId()))
                 .filter(artifact -> artifact.getFile() != null
                         && artifact.getArtifactHandler().isAddedToClasspath()
-                        && (Artifact.SCOPE_COMPILE.equals(artifact.getScope())
-                                || Artifact.SCOPE_RUNTIME
-                                        .equals(artifact.getScope())
-                                || Artifact.SCOPE_SYSTEM
-                                        .equals(artifact.getScope())
-                                || (Artifact.SCOPE_PROVIDED
-                                        .equals(artifact.getScope())
-                                        && artifact.getFile().getPath().matches(
-                                                INCLUDE_FROM_COMPILE_DEPS_REGEX))))
+                        && PRODUCTION_SCOPE_FILTER.include(artifact))
                 .collect(Collectors.toMap(keyMapper, Function.identity())));
 
         if (mojoExecution != null) {

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/Reflector.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/Reflector.java
@@ -41,6 +41,7 @@ import java.util.stream.Collectors;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.resolver.filter.ScopeArtifactFilter;
 import org.apache.maven.plugin.Mojo;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
@@ -70,6 +71,8 @@ public final class Reflector {
     private static final Set<String> REQUIRED_PLUGIN_DEPENDENCIES = Set.of(
             "org.reflections:reflections:jar",
             "org.zeroturnaround:zt-exec:jar");
+    private static final ScopeArtifactFilter PRODUCTION_SCOPE_FILTER = new ScopeArtifactFilter(
+            Artifact.SCOPE_COMPILE_PLUS_RUNTIME);
     private static final Logger log = LoggerFactory.getLogger(Reflector.class);
 
     private final URLClassLoader isolatedClassLoader;
@@ -413,16 +416,10 @@ public final class Reflector {
                 filteredUrls.toArray(new URL[0]), mavenApiClassLoader);
     }
 
-    // TODO: include also provided scope
     private static boolean isProductionDependency(Artifact artifact) {
         return artifact.getFile() != null
                 && artifact.getArtifactHandler().isAddedToClasspath()
-                && (Artifact.SCOPE_COMPILE.equals(artifact.getScope())
-                        || Artifact.SCOPE_RUNTIME.equals(artifact.getScope())
-                        || Artifact.SCOPE_SYSTEM.equals(artifact.getScope())
-                        || (Artifact.SCOPE_PROVIDED.equals(artifact.getScope())
-                                && artifact.getFile().getPath().matches(
-                                        INCLUDE_FROM_COMPILE_DEPS_REGEX)));
+                && PRODUCTION_SCOPE_FILTER.include(artifact);
     }
 
     /**

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/ReflectorTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/ReflectorTest.java
@@ -199,10 +199,12 @@ public class ReflectorTest {
 
         Set<String> urlSet = Arrays.stream(isolatedClassLoader.getURLs())
                 .map(URL::toExternalForm).collect(Collectors.toSet());
-        Assert.assertEquals(4, urlSet.size());
+        Assert.assertEquals(5, urlSet.size());
         Assert.assertTrue(urlSet.contains(toURLExternalForm(outputDirectory)));
         Assert.assertTrue(urlSet.contains(
                 toURLExternalForm("com.vaadin.test-compile-1.0.jar")));
+        Assert.assertTrue(urlSet.contains(
+                toURLExternalForm("com.vaadin.test-provided-1.0.jar")));
         Assert.assertTrue(urlSet
                 .contains(toURLExternalForm("com.vaadin.test-system-1.0.jar")));
         Assert.assertTrue(urlSet


### PR DESCRIPTION
Adds the "provided" scope to the list of Maven dependency scopes considered during class scanning by the Flow maven plugin.

Fixes #21192