### PR TITLE
chore: add toString method to PushMessage

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/AtmospherePushConnection.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/AtmospherePushConnection.java
@@ -466,6 +466,11 @@ public class AtmospherePushConnection
         boolean alreadySeen(int lastSeenOnClient) {
             return serverSyncId <= lastSeenOnClient;
         }
+
+        @Override
+        public String toString() {
+            return "PushMessage " + serverSyncId + ", body: " + message;
+        }
     }
 
     /**


### PR DESCRIPTION
Adds toString to PushMessage, so the content of the message can be visible on Atmosphere TRACE logs for debugging purposes.