### PR TITLE
fix: force page reload only for redefined classes

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/hotswap/Hotswapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/hotswap/Hotswapper.java
@@ -277,7 +277,8 @@ public class Hotswapper implements ServiceDestroyListener, SessionInitListener,
             }
         }
         forceBrowserReload = forceBrowserReload
-                || getForceReloadHolder(vaadinService).shouldReloadPage();
+                || (getForceReloadHolder(vaadinService).shouldReloadPage()
+                        && redefined);
 
         boolean uiTreeNeedsRefresh = false;
         EnumMap<UIRefreshStrategy, List<UI>> refreshActions = null;

--- a/flow-server/src/test/java/com/vaadin/flow/hotswap/HotswapperTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/hotswap/HotswapperTest.java
@@ -944,7 +944,7 @@ public class HotswapperTest {
     }
 
     @Test
-    public void onHotswap_pushDisabled_forcePageReload_fullReloadTriggered()
+    public void onHotswap_pushDisabled_forcePageReload_redefinedClass_fullReloadTriggered()
             throws ServiceException {
         VaadinSession session = createMockVaadinSession();
         hotswapper.sessionInit(new SessionInitEvent(service, session, null));
@@ -957,6 +957,22 @@ public class HotswapperTest {
         ui.assertNotRefreshed();
         Mockito.verify(liveReload, never()).refresh(anyBoolean());
         Mockito.verify(liveReload).reload();
+    }
+
+    @Test
+    public void onHotswap_pushDisabled_forcePageReload_loadedClass_notReload()
+            throws ServiceException {
+        VaadinSession session = createMockVaadinSession();
+        hotswapper.sessionInit(new SessionInitEvent(service, session, null));
+
+        RefreshTestingUI ui = initUIAndNavigateTo(session, MyRoute.class);
+
+        Hotswapper.forcePageReload(service, true);
+        hotswapper.onHotswap(new String[] { MyRoute.class.getName() }, false);
+
+        ui.assertNotRefreshed();
+        Mockito.verify(liveReload, never()).refresh(anyBoolean());
+        Mockito.verify(liveReload, never()).reload();
     }
 
     @Test
@@ -986,7 +1002,7 @@ public class HotswapperTest {
     }
 
     @Test
-    public void onHotswap_pushEnabled_forcePageReload_fullReloadTriggered()
+    public void onHotswap_pushEnabled_forcePageReload_redefinedClass_fullReloadTriggered()
             throws ServiceException {
         VaadinSession session = createMockVaadinSession();
         hotswapper.sessionInit(new SessionInitEvent(service, session, null));
@@ -1000,6 +1016,23 @@ public class HotswapperTest {
         ui.assertNotRefreshed();
         Mockito.verify(liveReload, never()).refresh(anyBoolean());
         Mockito.verify(liveReload).reload();
+    }
+
+    @Test
+    public void onHotswap_pushEnabled_forcePageReload_loadedClass_fullReloadTriggered()
+            throws ServiceException {
+        VaadinSession session = createMockVaadinSession();
+        hotswapper.sessionInit(new SessionInitEvent(service, session, null));
+
+        RefreshTestingUI ui = initUIAndNavigateTo(session, MyRoute.class);
+        ui.enablePush();
+
+        Hotswapper.forcePageReload(service, true);
+        hotswapper.onHotswap(new String[] { MyRoute.class.getName() }, false);
+
+        ui.assertNotRefreshed();
+        Mockito.verify(liveReload, never()).refresh(anyBoolean());
+        Mockito.verify(liveReload, never()).reload();
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/hotswap/HotswapperTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/hotswap/HotswapperTest.java
@@ -1019,7 +1019,7 @@ public class HotswapperTest {
     }
 
     @Test
-    public void onHotswap_pushEnabled_forcePageReload_loadedClass_fullReloadTriggered()
+    public void onHotswap_pushEnabled_forcePageReload_loadedClass_noReload()
             throws ServiceException {
         VaadinSession session = createMockVaadinSession();
         hotswapper.sessionInit(new SessionInitEvent(service, session, null));


### PR DESCRIPTION
When Hotswapper force page reload is active, trigger page reload only for redefined classes, not when they are loaded for the first time.

Fixes #21273