### PR TITLE
fix: prevent serialization to leak CurrentInstances

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/Component.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Component.java
@@ -839,6 +839,7 @@ public abstract class Component
             try {
                 out.defaultWriteObject();
             } finally {
+                CurrentInstance.clearAll();
                 CurrentInstance.restoreInstances(instances);
             }
         } else {
@@ -858,6 +859,7 @@ public abstract class Component
             try {
                 in.defaultReadObject();
             } finally {
+                CurrentInstance.clearAll();
                 CurrentInstance.restoreInstances(instances);
             }
         } else {

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
@@ -1110,6 +1110,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
             resourceRegistry = (StreamResourceRegistry) stream.readObject();
             pendingAccessQueue = new ConcurrentLinkedQueue<>();
         } finally {
+            CurrentInstance.clearAll();
             CurrentInstance.restoreInstances(old);
         }
     }
@@ -1142,6 +1143,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
                 stream.writeObject(new StreamResourceRegistry(this));
             }
         } finally {
+            CurrentInstance.clearAll();
             CurrentInstance.restoreInstances(instanceMap);
         }
     }


### PR DESCRIPTION
During serialization and deserialization of VaadinSession and UI,
CurrentInstances may be set but not present in the original instances map,
causing the added instance to leak outside the scope of the deserialization
hook method.
This fix ensures all instances set by the hooks are wiped out before
restoring the original instances.
