### PR TITLE
Exclude trees without changes from the result collector

### DIFF
--- a/signals/src/test/java/com/vaadin/signals/impl/StagedTransactionTest.java
+++ b/signals/src/test/java/com/vaadin/signals/impl/StagedTransactionTest.java
@@ -483,6 +483,20 @@ public class StagedTransactionTest {
     }
 
     @Test
+    void commit_treeWithoutChanges_resultResolved() {
+        SynchronousSignalTree t1 = new SynchronousSignalTree(false);
+        SynchronousSignalTree t2 = new SynchronousSignalTree(false);
+
+        var operation = Transaction.runInTransaction(() -> {
+            TestUtil.readTransactionRootValue(t1);
+            Transaction.getCurrent().include(t2,
+                    TestUtil.writeRootValueCommand(), null);
+        });
+
+        TestUtil.assertSuccess(operation);
+    }
+
+    @Test
     void treeMixing_multipleSyncAndComputed_allIsFine() {
         SignalTree d1 = new SynchronousSignalTree(false);
         SignalTree d2 = new SynchronousSignalTree(false);


### PR DESCRIPTION
If a tree was only read but not written inside a transaction, then the transaction result was never published. This was because the result collector would wait for a result from the unchanged tree but that tree wasn't involved in the actual two-phase commit procedure and thus never published any result. This is fixed by creating the result collector based on the trees that participate in the two-phase commit.