### PR TITLE
fix(flow-server): enable top-level await for service worker

### DIFF
--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -141,6 +141,7 @@ function buildSWPlugin(opts: { devMode: boolean }): PluginOption {
           write: !devMode,
           minify: viteConfig.build.minify,
           outDir: viteConfig.build.outDir,
+          target,
           sourcemap: viteConfig.command === 'serve' || viteConfig.build.sourcemap,
           emptyOutDir: false,
           modulePreload: false,


### PR DESCRIPTION
Vite / Rollup defaults are old. While #21276 adjusted the target for the dependencies optimizer, this change applies the same target also for the `sw.js` entrypoint build.
