### PR TITLE
fix: Do not starve the common ForkJoinPool with blocking listener tasks

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/FileWatcher.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/FileWatcher.java
@@ -34,7 +34,8 @@ public class FileWatcher {
 
     private DirectoryWatcher watcher;
 
-    private static ExecutorService executorService = Executors.newCachedThreadPool();
+    private static ExecutorService executorService = Executors
+            .newCachedThreadPool();
 
     /**
      * Creates an instance of the file watcher for the given directory.

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/FileWatcher.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/FileWatcher.java
@@ -18,6 +18,8 @@ package com.vaadin.base.devserver;
 import java.io.File;
 import java.io.IOException;
 import java.util.Objects;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 import io.methvin.watcher.DirectoryWatcher;
 import org.slf4j.Logger;
@@ -31,6 +33,8 @@ import com.vaadin.flow.function.SerializableConsumer;
 public class FileWatcher {
 
     private DirectoryWatcher watcher;
+
+    private Executor executor = Executors.newCachedThreadPool();
 
     /**
      * Creates an instance of the file watcher for the given directory.
@@ -62,7 +66,7 @@ public class FileWatcher {
      * Starts the file watching.
      */
     public void start() {
-        watcher.watchAsync().exceptionally((e) -> {
+        watcher.watchAsync(executor).exceptionally((e) -> {
             getLogger().error("Error starting file watcher", e);
             return null;
         });

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/FileWatcher.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/FileWatcher.java
@@ -18,7 +18,7 @@ package com.vaadin.base.devserver;
 import java.io.File;
 import java.io.IOException;
 import java.util.Objects;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import io.methvin.watcher.DirectoryWatcher;
@@ -34,7 +34,7 @@ public class FileWatcher {
 
     private DirectoryWatcher watcher;
 
-    private Executor executor = Executors.newCachedThreadPool();
+    private static ExecutorService executorService = Executors.newCachedThreadPool();
 
     /**
      * Creates an instance of the file watcher for the given directory.
@@ -66,7 +66,7 @@ public class FileWatcher {
      * Starts the file watching.
      */
     public void start() {
-        watcher.watchAsync(executor).exceptionally((e) -> {
+        watcher.watchAsync(executorService).exceptionally((e) -> {
             getLogger().error("Error starting file watcher", e);
             return null;
         });


### PR DESCRIPTION
Calling watchAsync without any specific executor uses the common ForkJoinPool. This is bad as all the watchers will remain in a blocking state until there is a change and will thus always use up a large part of the ForkJoinPool. If other tasks try to use the common ForkJoinPool, it might run out of concurrent threads and will no longer start any tasks at all
