### PR TITLE
Add support for VaadinWebSecurity customization via bean injection

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -24,6 +24,7 @@ import javax.crypto.SecretKey;
 
 import java.io.IOException;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -125,6 +126,9 @@ public abstract class VaadinWebSecurity {
 
     private NavigationAccessControl accessControl;
 
+    @Autowired(required = false)
+    private List<VaadinWebSecurityCustomizer> webSecurityCustomizers;
+
     @PostConstruct
     void afterPropertiesSet() {
         accessControl = accessControlProvider.getIfAvailable();
@@ -145,6 +149,10 @@ public abstract class VaadinWebSecurity {
      */
     @Bean(name = "VaadinSecurityFilterChainBean")
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        if (webSecurityCustomizers != null) {
+            webSecurityCustomizers
+                    .forEach(customizer -> customizer.customize(http));
+        }
         configure(http);
         http.logout(cfg -> {
             cfg.invalidateHttpSession(true);

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -127,7 +127,7 @@ public abstract class VaadinWebSecurity {
     private NavigationAccessControl accessControl;
 
     @Autowired(required = false)
-    private List<VaadinWebSecurityCustomizer> webSecurityCustomizers;
+    private List<VaadinWebSecurityCustomizer> securityCustomizers;
 
     @PostConstruct
     void afterPropertiesSet() {
@@ -149,9 +149,10 @@ public abstract class VaadinWebSecurity {
      */
     @Bean(name = "VaadinSecurityFilterChainBean")
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        if (webSecurityCustomizers != null) {
-            webSecurityCustomizers
-                    .forEach(customizer -> customizer.customize(http));
+        if (securityCustomizers != null) {
+            for (VaadinWebSecurityCustomizer customizer : securityCustomizers) {
+                customizer.customize(this, http);
+            }
         }
         configure(http);
         http.logout(cfg -> {
@@ -392,7 +393,7 @@ public abstract class VaadinWebSecurity {
      * @throws Exception
      *             if something goes wrong
      */
-    protected void setLoginView(HttpSecurity http, String hillaLoginViewPath)
+    public void setLoginView(HttpSecurity http, String hillaLoginViewPath)
             throws Exception {
         setLoginView(http, hillaLoginViewPath, getDefaultLogoutUrl());
     }
@@ -418,7 +419,7 @@ public abstract class VaadinWebSecurity {
      * @throws Exception
      *             if something goes wrong
      */
-    protected void setLoginView(HttpSecurity http, String hillaLoginViewPath,
+    public void setLoginView(HttpSecurity http, String hillaLoginViewPath,
             String logoutSuccessUrl) throws Exception {
         String completeHillaLoginViewPath = applyUrlMapping(hillaLoginViewPath);
         http.formLogin(formLogin -> {
@@ -445,7 +446,7 @@ public abstract class VaadinWebSecurity {
      * @throws Exception
      *             if something goes wrong
      */
-    protected void setLoginView(HttpSecurity http,
+    public void setLoginView(HttpSecurity http,
             Class<? extends Component> flowLoginView) throws Exception {
         setLoginView(http, flowLoginView, getDefaultLogoutUrl());
     }
@@ -463,7 +464,7 @@ public abstract class VaadinWebSecurity {
      * @throws Exception
      *             if something goes wrong
      */
-    protected void setLoginView(HttpSecurity http,
+    public void setLoginView(HttpSecurity http,
             Class<? extends Component> flowLoginView, String logoutSuccessUrl)
             throws Exception {
         Optional<Route> route = AnnotationReader.getAnnotationFor(flowLoginView,
@@ -523,7 +524,7 @@ public abstract class VaadinWebSecurity {
      *             Re-throws the possible exceptions while activating
      *             OAuth2LoginConfigurer
      */
-    protected void setOAuth2LoginPage(HttpSecurity http, String oauth2LoginPage)
+    public void setOAuth2LoginPage(HttpSecurity http, String oauth2LoginPage)
             throws Exception {
         setOAuth2LoginPage(http, oauth2LoginPage, "{baseUrl}");
     }
@@ -553,7 +554,7 @@ public abstract class VaadinWebSecurity {
      *             Re-throws the possible exceptions while activating
      *             OAuth2LoginConfigurer
      */
-    protected void setOAuth2LoginPage(HttpSecurity http, String oauth2LoginPage,
+    public void setOAuth2LoginPage(HttpSecurity http, String oauth2LoginPage,
             String postLogoutRedirectUri) throws Exception {
         http.oauth2Login(cfg -> cfg.loginPage(oauth2LoginPage).successHandler(
                 getVaadinSavedRequestAwareAuthenticationSuccessHandler(http))

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurityCustomizer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurityCustomizer.java
@@ -38,7 +38,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
  * public class MyCustomizer implements VaadinWebSecurityCustomizer {
  *
  *     &#64;Override
- *     public void customize(HttpSecurity http) {
+ *     public void customize(VaadinWebSecurity conf, HttpSecurity http) {
  *         http.addFilter(MyCustomFilter.class);
  *     }
  * }
@@ -49,13 +49,16 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 public interface VaadinWebSecurityCustomizer extends Serializable {
 
     /**
-     * Customizes the provided {@link HttpSecurity} instance with specific
-     * security configurations for integrating Vaadin applications with Spring
-     * Security. This method enables implementations to adjust or enhance the
-     * default security setup as needed.
+     * Customizes the provided {@link VaadinWebSecurity} and
+     * {@link HttpSecurity} instances with specific security configurations for
+     * integrating Vaadin applications with Spring Security. This method enables
+     * implementations to adjust or enhance the default security setup as
+     * needed.
      *
+     * @param conf
+     *            the {@link VaadinWebSecurity} instance to be customized
      * @param http
      *            the {@link HttpSecurity} instance to be customized
      */
-    void customize(HttpSecurity http);
+    void customize(VaadinWebSecurity conf, HttpSecurity http) throws Exception;
 }

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurityCustomizer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurityCustomizer.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.spring.security;
+
+import java.io.Serializable;
+
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+
+/**
+ * Functional interface for customizing the Spring Security {@link HttpSecurity}
+ * instance specifically for use with Vaadin applications.
+ * <p>
+ * Implementations of this interface can provide additional configuration or
+ * adjustments to the security setup that integrates Vaadin with Spring
+ * Security.
+ * <p>
+ * Beans implementing this interface will be automatically discovered and
+ * applied to the filter chain.
+ * <p>
+ * For example:
+ *
+ * <pre>
+ * <code>
+ * &#64;Component
+ * public class MyCustomizer implements VaadinWebSecurityCustomizer {
+ *
+ *     &#64;Override
+ *     public void customize(HttpSecurity http) {
+ *         http.addFilter(MyCustomFilter.class);
+ *     }
+ * }
+ * </code>
+ * </pre>
+ */
+@FunctionalInterface
+public interface VaadinWebSecurityCustomizer extends Serializable {
+
+    /**
+     * Customizes the provided {@link HttpSecurity} instance with specific
+     * security configurations for integrating Vaadin applications with Spring
+     * Security. This method enables implementations to adjust or enhance the
+     * default security setup as needed.
+     *
+     * @param http
+     *            the {@link HttpSecurity} instance to be customized
+     */
+    void customize(HttpSecurity http);
+}

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/VaadinWebSecurityTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/VaadinWebSecurityTest.java
@@ -130,13 +130,13 @@ public class VaadinWebSecurityTest {
                 new AuthenticationManagerBuilder(postProcessor),
                 Map.of(ApplicationContext.class, appCtx));
         Filter customFilter = mock(Filter.class);
-        VaadinWebSecurityCustomizer customizer = http -> {
+        VaadinWebSecurityCustomizer customizer = (conf, http) -> {
             http.addFilterBefore(customFilter, AuthenticationFilter.class);
         };
         VaadinWebSecurity testConfig = new VaadinWebSecurity() {
         };
         mockVaadinWebSecurityInjection(testConfig);
-        ReflectionTestUtils.setField(testConfig, "webSecurityCustomizers",
+        ReflectionTestUtils.setField(testConfig, "securityCustomizers",
                 Collections.singletonList(customizer));
 
         SecurityFilterChain filterChain = testConfig.filterChain(httpSecurity);


### PR DESCRIPTION
Introduced `VaadinWebSecurityCustomizer` interface to allow customizations of `HttpSecurity` for Vaadin-related security configurations. Implementations of this interface are automatically detected and applied to the security filter chain. Added tests to ensure the customizers are properly applied.

Closes #21356 
