### PR TITLE
fix: prevent file watcher threads from slowing down JVM shutdown (#21365) (CP: 24.6)

### DIFF
--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
@@ -85,6 +85,7 @@ public abstract class ClassesSerializableTest extends ClassFinder {
                 "com\\.vaadin\\.base\\.devserver\\.DevToolsMessageHandler",
                 "com\\.vaadin\\.base\\.devserver\\.ExternalDependencyWatcher",
                 "com\\.vaadin\\.base\\.devserver\\.FileWatcher",
+                "com\\.vaadin\\.base\\.devserver\\.NamedDaemonThreadFactory",
                 "com\\.vaadin\\.base\\.devserver\\.IdeIntegration",
                 "com\\.vaadin\\.base\\.devserver\\.OpenInCurrentIde.*",
                 "com\\.vaadin\\.base\\.devserver\\.RestartMonitor",

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/FileWatcher.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/FileWatcher.java
@@ -34,8 +34,9 @@ public class FileWatcher {
 
     private DirectoryWatcher watcher;
 
-    private static ExecutorService executorService = Executors
-            .newCachedThreadPool();
+    private static final ExecutorService executorService = Executors
+            .newCachedThreadPool(
+                    new NamedDaemonThreadFactory("vaadin-file-watcher"));
 
     /**
      * Creates an instance of the file watcher for the given directory.

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/NamedDaemonThreadFactory.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/NamedDaemonThreadFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.base.devserver;
+
+import java.util.Objects;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A factory for creating daemon threads with custom naming conventions, used to
+ * generate threads with a predefined naming pattern.
+ * <p>
+ * </p>
+ * This class implements the {@link ThreadFactory} interface to provide a
+ * mechanism for instantiating threads that are configured with specific
+ * attributes such as name prefix, thread priority, and daemon status.
+ */
+public class NamedDaemonThreadFactory implements ThreadFactory {
+    private final AtomicInteger threadNumber = new AtomicInteger(1);
+
+    private final String namePrefix;
+
+    /**
+     * Constructs a new {@code NamedDaemonThreadFactory} with the specified name
+     * prefix for the threads created by this factory.
+     *
+     * @param namePrefix
+     *            the prefix to be used for naming threads created by this
+     *            factory, not {@literal null}.
+     */
+    public NamedDaemonThreadFactory(String namePrefix) {
+        this.namePrefix = Objects.requireNonNull(namePrefix,
+                "namePrefix must not be null");
+    }
+
+    @Override
+    public Thread newThread(Runnable runnable) {
+        String threadName = namePrefix + "-" + threadNumber.getAndIncrement();
+        Thread thread = new Thread(runnable, threadName);
+        thread.setDaemon(true);
+        thread.setPriority(Thread.NORM_PRIORITY);
+        return thread;
+    }
+}


### PR DESCRIPTION
FileWatcher was using an executor that creates non-daemon threads to watch for file changes. This caused a delay in JVM shutdown, as it would wait at least 60 seconds for all threads in the executor pool to be evicted.

This change provides a custom thread factory that creates daemon threads for the executor to prevent JVM shutdown delays.