### PR TITLE
chore: upgrade vaadin-parent to 2.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-parent</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2</version>
     </parent>
 
     <modules>


### PR DESCRIPTION
 updated the flatten-maven-plugin to keep <scm> when publishing

