### PR TITLE
fix: Preserve handler type when chaining listener methods

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/TransferProgressListener.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/TransferProgressListener.java
@@ -33,10 +33,10 @@ import com.vaadin.flow.server.streams.TransferContext;
  * Implementations of this interface can be used to monitor the progress of file
  * transfers, such as downloads or uploads.
  * <p>
- * It uses {@link com.vaadin.flow.component.UI#access} to send UI changes from
- * progress listeners when the download or upload request is being handled.
- * Thus, it needs {@link com.vaadin.flow.component.page.Push} to be enabled in
- * the application.
+ * It uses {@link com.vaadin.flow.component.UI#access(Command)} to send UI
+ * changes from progress listeners when the download or upload request is being
+ * handled. Thus, it needs {@link com.vaadin.flow.component.page.Push} to be
+ * enabled in the application.
  *
  * @since 24.8
  */
@@ -61,11 +61,12 @@ public interface TransferProgressListener extends Serializable {
      * Called when the data transfer is started.
      * <p>
      * The call of this method is wrapped by the
-     * {@link com.vaadin.flow.component.UI#access} to send UI changes defined
-     * here when the download or upload request is being handled. Thus, no need
-     * to call {@link com.vaadin.flow.component.UI#access} in the implementation
-     * of this method. This needs {@link com.vaadin.flow.component.page.Push} to
-     * be enabled in the application to properly send the UI changes to client.
+     * {@link com.vaadin.flow.component.UI#access(Command)} to send UI changes
+     * defined here when the download or upload request is being handled. Thus,
+     * no need to call {@link com.vaadin.flow.component.UI#access(Command)} in
+     * the implementation of this method. This needs
+     * {@link com.vaadin.flow.component.page.Push} to be enabled in the
+     * application to properly send the UI changes to client.
      *
      * @param context
      *            the context of the transfer
@@ -78,11 +79,12 @@ public interface TransferProgressListener extends Serializable {
      * Called periodically during the transfer to report progress.
      * <p>
      * The call of this method is wrapped by the
-     * {@link com.vaadin.flow.component.UI#access} to send UI changes defined
-     * here when the download or upload request is being handled. Thus, no need
-     * to call {@link com.vaadin.flow.component.UI#access} in the implementation
-     * of this method. This needs {@link com.vaadin.flow.component.page.Push} to
-     * be enabled in the application to properly send the UI changes to client.
+     * {@link com.vaadin.flow.component.UI#access(Command)} to send UI changes
+     * defined here when the download or upload request is being handled. Thus,
+     * no need to call {@link com.vaadin.flow.component.UI#access(Command)} in
+     * the implementation of this method. This needs
+     * {@link com.vaadin.flow.component.page.Push} to be enabled in the
+     * application to properly send the UI changes to client.
      *
      * @param context
      *            the context of the transfer
@@ -102,11 +104,12 @@ public interface TransferProgressListener extends Serializable {
      * Called when the transfer is failed.
      * <p>
      * The call of this method is wrapped by the
-     * {@link com.vaadin.flow.component.UI#access} to send UI changes defined
-     * here when the download or upload request is being handled. Thus, no need
-     * to call {@link com.vaadin.flow.component.UI#access} in the implementation
-     * of this method. This needs {@link com.vaadin.flow.component.page.Push} to
-     * be enabled in the application to properly send the UI changes to client.
+     * {@link com.vaadin.flow.component.UI#access(Command)} to send UI changes
+     * defined here when the download or upload request is being handled. Thus,
+     * no need to call {@link com.vaadin.flow.component.UI#access(Command)} in
+     * the implementation of this method. This needs
+     * {@link com.vaadin.flow.component.page.Push} to be enabled in the
+     * application to properly send the UI changes to client.
      *
      * @param context
      *            the context of the transfer
@@ -121,11 +124,12 @@ public interface TransferProgressListener extends Serializable {
      * Called when the transfer is started.
      * <p>
      * The call of this method is wrapped by the
-     * {@link com.vaadin.flow.component.UI#access} to send UI changes defined
-     * here when the download or upload request is being handled. Thus, no need
-     * to call {@link com.vaadin.flow.component.UI#access} in the implementation
-     * of this method. This needs {@link com.vaadin.flow.component.page.Push} to
-     * be enabled in the application to properly send the UI changes to client.
+     * {@link com.vaadin.flow.component.UI#access(Command)} to send UI changes
+     * defined here when the download or upload request is being handled. Thus,
+     * no need to call {@link com.vaadin.flow.component.UI#access(Command)} in
+     * the implementation of this method. This needs
+     * {@link com.vaadin.flow.component.page.Push} to be enabled in the
+     * application to properly send the UI changes to client.
      *
      * @param context
      *            the context of the transfer

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/AbstractDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/AbstractDownloadHandler.java
@@ -22,10 +22,13 @@ import com.vaadin.flow.server.DownloadEvent;
 /**
  * Abstract class for common methods used in pre-made download handlers.
  *
+ * @param <R>
+ *            the type of the subclass implementing this abstract class
  * @since 24.8
  */
-public abstract class AbstractDownloadHandler extends
-        TransferProgressAwareHandler<DownloadEvent> implements DownloadHandler {
+public abstract class AbstractDownloadHandler<R extends AbstractDownloadHandler>
+        extends TransferProgressAwareHandler<DownloadEvent, R>
+        implements DownloadHandler {
 
     @Override
     protected TransferContext getTransferContext(DownloadEvent transferEvent) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/ClassDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/ClassDownloadHandler.java
@@ -36,7 +36,8 @@ import com.vaadin.flow.server.TransferProgressListener;
  *
  * @since 24.8
  */
-public class ClassDownloadHandler extends AbstractDownloadHandler {
+public class ClassDownloadHandler
+        extends AbstractDownloadHandler<ClassDownloadHandler> {
 
     private final Class<?> clazz;
     private final String resourceName;

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/FileDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/FileDownloadHandler.java
@@ -33,7 +33,8 @@ import com.vaadin.flow.server.VaadinResponse;
  *
  * @since 24.8
  */
-public class FileDownloadHandler extends AbstractDownloadHandler {
+public class FileDownloadHandler
+        extends AbstractDownloadHandler<FileDownloadHandler> {
 
     private final File file;
     private final String name;

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/InputStreamDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/InputStreamDownloadHandler.java
@@ -32,7 +32,8 @@ import com.vaadin.flow.server.VaadinResponse;
  *
  * @since 24.8
  */
-public class InputStreamDownloadHandler extends AbstractDownloadHandler {
+public class InputStreamDownloadHandler
+        extends AbstractDownloadHandler<InputStreamDownloadHandler> {
 
     private final SerializableFunction<DownloadEvent, DownloadResponse> handler;
     private final String name;

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandler.java
@@ -35,7 +35,8 @@ import com.vaadin.flow.server.VaadinServletService;
  *
  * @since 24.8
  */
-public class ServletResourceDownloadHandler extends AbstractDownloadHandler {
+public class ServletResourceDownloadHandler
+        extends AbstractDownloadHandler<ServletResourceDownloadHandler> {
 
     private final String path;
     private final String name;

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/TransferProgressAwareHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/TransferProgressAwareHandler.java
@@ -41,8 +41,12 @@ import elemental.json.JsonValue;
  * @param <T>
  *            type of transfer event, e.g.
  *            {@link com.vaadin.flow.server.DownloadHandler}
+ * @param <R>
+ *            type of the subclass implementing this abstract class, needed for
+ *            revealing a proper type when you chain the methods
  */
-public abstract class TransferProgressAwareHandler<T> implements Serializable {
+public abstract class TransferProgressAwareHandler<T, R extends TransferProgressAwareHandler>
+        implements Serializable {
 
     private List<TransferProgressListener> listeners;
 
@@ -103,8 +107,7 @@ public abstract class TransferProgressAwareHandler<T> implements Serializable {
      * @param <R>
      *            the type of this transfer progress aware handler
      */
-    public <R extends TransferProgressAwareHandler<T>> R whenStart(
-            SerializableRunnable startHandler) {
+    public R whenStart(SerializableRunnable startHandler) {
         Objects.requireNonNull(startHandler, "Start handler cannot be null");
         addTransferProgressListenerInternal(new TransferProgressListener() {
             @Override
@@ -136,8 +139,7 @@ public abstract class TransferProgressAwareHandler<T> implements Serializable {
      * @param <R>
      *            the type of this transfer progress aware handler
      */
-    public <R extends TransferProgressAwareHandler<T>> R onProgress(
-            SerializableBiConsumer<Long, Long> progressHandler,
+    public R onProgress(SerializableBiConsumer<Long, Long> progressHandler,
             long progressIntervalInBytes) {
         Objects.requireNonNull(progressHandler,
                 "Progress handler cannot be null");
@@ -179,8 +181,7 @@ public abstract class TransferProgressAwareHandler<T> implements Serializable {
      * @param <R>
      *            the type of this transfer progress aware handler
      */
-    public <R extends TransferProgressAwareHandler<T>> R onProgress(
-            SerializableBiConsumer<Long, Long> progressHandler) {
+    public R onProgress(SerializableBiConsumer<Long, Long> progressHandler) {
         return onProgress(progressHandler,
                 TransferProgressListener.DEFAULT_PROGRESS_REPORT_INTERVAL_IN_BYTES);
     }
@@ -204,7 +205,7 @@ public abstract class TransferProgressAwareHandler<T> implements Serializable {
      * @param <R>
      *            the type of this transfer progress aware handler
      */
-    public <R extends TransferProgressAwareHandler<T>> R whenComplete(
+    public R whenComplete(
             SerializableConsumer<Boolean> completeOrTerminateHandler) {
         Objects.requireNonNull(completeOrTerminateHandler,
                 "Complete or terminate handler cannot be null");

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/TransferProgressAwareHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/TransferProgressAwareHandler.java
@@ -70,10 +70,10 @@ public abstract class TransferProgressAwareHandler<T, R extends TransferProgress
      * </ul>
      * <p>
      * The calls of the given listener's methods are wrapped by the
-     * {@link com.vaadin.flow.component.UI#access} to send UI changes defined
-     * here when the download or upload request is being handled. Thus, no need
-     * to call {@link com.vaadin.flow.component.UI#access} in the implementation
-     * of the given listener. This needs
+     * {@link com.vaadin.flow.component.UI#access(Command)} to send UI changes
+     * defined here when the download or upload request is being handled. Thus,
+     * no need to call {@link com.vaadin.flow.component.UI#access(Command)} in
+     * the implementation of the given listener. This needs
      * {@link com.vaadin.flow.component.page.Push} to be enabled in the
      * application to properly send the UI changes to client.
      *
@@ -94,18 +94,16 @@ public abstract class TransferProgressAwareHandler<T, R extends TransferProgress
      * Adds a listener to be notified when the transfer starts.
      * <p>
      * The call of the given callback is wrapped by the
-     * {@link com.vaadin.flow.component.UI#access} to send UI changes defined
-     * here when the download or upload request is being handled. Thus, no need
-     * to call {@link com.vaadin.flow.component.UI#access} in the implementation
-     * of the given handler. This needs
+     * {@link com.vaadin.flow.component.UI#access(Command)} to send UI changes
+     * defined here when the download or upload request is being handled. Thus,
+     * no need to call {@link com.vaadin.flow.component.UI#access(Command)} in
+     * the implementation of the given handler. This needs
      * {@link com.vaadin.flow.component.page.Push} to be enabled in the
      * application to properly send the UI changes to client.
      *
      * @param startHandler
      *            the handler to be called when the transfer starts
      * @return this instance for method chaining
-     * @param <R>
-     *            the type of this transfer progress aware handler
      */
     public R whenStart(SerializableRunnable startHandler) {
         Objects.requireNonNull(startHandler, "Start handler cannot be null");
@@ -124,10 +122,10 @@ public abstract class TransferProgressAwareHandler<T, R extends TransferProgress
      * Adds a listener to be notified of transfer progress.
      * <p>
      * The call of the given callback is wrapped by the
-     * {@link com.vaadin.flow.component.UI#access} to send UI changes defined
-     * here when the download or upload request is being handled. Thus, no need
-     * to call {@link com.vaadin.flow.component.UI#access} in the implementation
-     * of the given handler. This needs
+     * {@link com.vaadin.flow.component.UI#access(Command)} to send UI changes
+     * defined here when the download or upload request is being handled. Thus,
+     * no need to call {@link com.vaadin.flow.component.UI#access(Command)} in
+     * the implementation of the given handler. This needs
      * {@link com.vaadin.flow.component.page.Push} to be enabled in the
      * application to properly send the UI changes to client.
      *
@@ -136,8 +134,6 @@ public abstract class TransferProgressAwareHandler<T, R extends TransferProgress
      * @param progressIntervalInBytes
      *            the interval in bytes for reporting progress
      * @return this instance for method chaining
-     * @param <R>
-     *            the type of this transfer progress aware handler
      */
     public R onProgress(SerializableBiConsumer<Long, Long> progressHandler,
             long progressIntervalInBytes) {
@@ -168,18 +164,16 @@ public abstract class TransferProgressAwareHandler<T, R extends TransferProgress
      * the second is the total number of bytes.
      * <p>
      * The call of the given callback is wrapped by the
-     * {@link com.vaadin.flow.component.UI#access} to send UI changes defined
-     * here when the download or upload request is being handled. Thus, no need
-     * to call {@link com.vaadin.flow.component.UI#access} in the implementation
-     * of the given handler. This needs
+     * {@link com.vaadin.flow.component.UI#access(Command)} to send UI changes
+     * defined here when the download or upload request is being handled. Thus,
+     * no need to call {@link com.vaadin.flow.component.UI#access(Command)} in
+     * the implementation of the given handler. This needs
      * {@link com.vaadin.flow.component.page.Push} to be enabled in the
      * application to properly send the UI changes to client.
      *
      * @param progressHandler
      *            the handler to be called with the current and total bytes
      * @return this instance for method chaining
-     * @param <R>
-     *            the type of this transfer progress aware handler
      */
     public R onProgress(SerializableBiConsumer<Long, Long> progressHandler) {
         return onProgress(progressHandler,
@@ -192,18 +186,16 @@ public abstract class TransferProgressAwareHandler<T, R extends TransferProgress
      * whether the transfer was completed successfully (true) or not (false).
      * <p>
      * The call of the given callback is wrapped by the
-     * {@link com.vaadin.flow.component.UI#access} to send UI changes defined
-     * here when the download or upload request is being handled. Thus, no need
-     * to call {@link com.vaadin.flow.component.UI#access} in the implementation
-     * of the given handler. This needs
+     * {@link com.vaadin.flow.component.UI#access(Command)} to send UI changes
+     * defined here when the download or upload request is being handled. Thus,
+     * no need to call {@link com.vaadin.flow.component.UI#access(Command)} in
+     * the implementation of the given handler. This needs
      * {@link com.vaadin.flow.component.page.Push} to be enabled in the
      * application to properly send the UI changes to client.
      *
      * @param completeOrTerminateHandler
      *            the handler to be called when the transfer is completed
      * @return this instance for method chaining
-     * @param <R>
-     *            the type of this transfer progress aware handler
      */
     public R whenComplete(
             SerializableConsumer<Boolean> completeOrTerminateHandler) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/AbstractDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/AbstractDownloadHandlerTest.java
@@ -50,7 +50,7 @@ public class AbstractDownloadHandlerTest {
     private static final long TRANSFERRED_BYTES = 42L;
     private static final IOException EXCEPTION = new IOException("Test error");
 
-    private AbstractDownloadHandler handler;
+    private AbstractDownloadHandler<?> handler;
     private TransferContext mockContext;
     private TransferProgressListener listener;
 
@@ -84,7 +84,7 @@ public class AbstractDownloadHandlerTest {
         downloadEvent = new DownloadEvent(request, response, session,
                 "download", "application/octet-stream", owner);
 
-        handler = new AbstractDownloadHandler() {
+        handler = new AbstractDownloadHandler<>() {
             @Override
             public void handleDownloadRequest(DownloadEvent event) {
             }
@@ -162,7 +162,7 @@ public class AbstractDownloadHandlerTest {
     public void customHandlerWithShorthandCompleteListener_noErrorInTransfer_success_errorInTransfer_failure()
             throws IOException {
         AtomicBoolean successAtomic = new AtomicBoolean(false);
-        AbstractDownloadHandler customHandler = new AbstractDownloadHandler() {
+        AbstractDownloadHandler customHandler = new AbstractDownloadHandler<>() {
             @Override
             public void handleDownloadRequest(DownloadEvent event) {
                 ByteArrayInputStream inputStream = new ByteArrayInputStream(


### PR DESCRIPTION
This allows to type
```java
DownloadHandler.forFile(new File("image.png"))
       .whenComplete(success -> {});
```

and get the proper type after you ask "Introduce local variable" in IDE:

```java
FileDownloadHandler fileDownloadHandler =
                DownloadHandler.forFile(new File("image.png"))
                        .whenComplete(success -> {});
```

Without it, the IDE create a variable of type `TransferProgressAwareHandler` that you cannot pass to component.

Related-to https://github.com/vaadin/flow/pull/21343

