### PR TITLE
chore: use github variable for concurrency group

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -11,6 +11,8 @@ concurrency:
   group: ${{ github.head_ref }} || ${{ github.ref_name }}
   cancel-in-progress: true
 env:
+  HEAD_REF: ${{ github.head_ref }}
+  REF_NAME: ${{ github.ref_name }}
   HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 jobs:
   build:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -8,11 +8,9 @@ on:
 permissions:
   contents: read
 concurrency:
-  group: $HEAD_REF || $REF_NAME
+  group: ${{ github.head_ref }} || ${{ github.ref_name }}
   cancel-in-progress: true
 env:
-  HEAD_REF: ${{ github.head_ref }}
-  REF_NAME: ${{ github.ref_name }}
   HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 jobs:
   build:


### PR DESCRIPTION
seems the environment variable is not working for concurrency group..