### PR TITLE
chore: deprecate StreamResource api

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
@@ -105,6 +105,8 @@ public class Anchor extends HtmlContainer
      *            the resource value, not null
      * @param text
      *            the text content to set
+     *
+     * @deprecated use {@link #Anchor(DownloadHandler, String)} instead
      */
     public Anchor(AbstractStreamResource href, String text) {
         setHref(href);
@@ -133,7 +135,7 @@ public class Anchor extends HtmlContainer
      * Creates an anchor component with the given href and components as
      * children of this component.
      *
-     * @see #setHref(AbstractStreamResource)
+     * @see #setHref(DownloadHandler)
      * @see #add(Component...)
      *
      * @param href
@@ -156,7 +158,7 @@ public class Anchor extends HtmlContainer
      * instead of setting it to an empty string.
      *
      * @see #removeHref()
-     * @see #setHref(AbstractStreamResource)
+     * @see #setHref(DownloadHandler)
      *
      * @param href
      *            the href to set
@@ -186,6 +188,7 @@ public class Anchor extends HtmlContainer
      *
      * @param href
      *            the resource value, not null
+     * @deprecated use {@link #setHref(DownloadHandler)} instead
      */
     public void setHref(AbstractStreamResource href) {
         this.href = href;

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
@@ -108,6 +108,7 @@ public class Anchor extends HtmlContainer
      *
      * @deprecated use {@link #Anchor(DownloadHandler, String)} instead
      */
+    @Deprecated(since = "24.8")
     public Anchor(AbstractStreamResource href, String text) {
         setHref(href);
         setText(text);
@@ -190,6 +191,7 @@ public class Anchor extends HtmlContainer
      *            the resource value, not null
      * @deprecated use {@link #setHref(DownloadHandler)} instead
      */
+    @Deprecated(since = "24.8")
     public void setHref(AbstractStreamResource href) {
         this.href = href;
         setRouterIgnore(true);

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
@@ -108,7 +108,7 @@ public class Anchor extends HtmlContainer
      *
      * @deprecated use {@link #Anchor(DownloadHandler, String)} instead
      */
-    @Deprecated(since = "24.8")
+    @Deprecated(since = "24.8", forRemoval = true)
     public Anchor(AbstractStreamResource href, String text) {
         setHref(href);
         setText(text);
@@ -191,7 +191,7 @@ public class Anchor extends HtmlContainer
      *            the resource value, not null
      * @deprecated use {@link #setHref(DownloadHandler)} instead
      */
-    @Deprecated(since = "24.8")
+    @Deprecated(since = "24.8", forRemoval = true)
     public void setHref(AbstractStreamResource href) {
         this.href = href;
         setRouterIgnore(true);

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/HtmlObject.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/HtmlObject.java
@@ -106,6 +106,7 @@ public class HtmlObject extends HtmlContainer implements
      *            a type attribute value
      * @deprecated use {@link #HtmlObject(DownloadHandler,String)} instead
      */
+    @Deprecated(since = "24.8")
     public HtmlObject(AbstractStreamResource data, String type) {
         setData(data);
         setType(type);
@@ -129,6 +130,7 @@ public class HtmlObject extends HtmlContainer implements
      * @deprecated use {@link #HtmlObject(DownloadHandler,String, Param...)}
      *             instead
      */
+    @Deprecated(since = "24.8")
     public HtmlObject(AbstractStreamResource data, String type,
             Param... params) {
         setData(data);
@@ -241,8 +243,8 @@ public class HtmlObject extends HtmlContainer implements
      * @param data
      *            the resource value, not {@code null}
      * @deprecated use {@link #HtmlObject(DownloadHandler)} instead
-     *
      */
+    @Deprecated(since = "24.8")
     public HtmlObject(AbstractStreamResource data) {
         setData(data);
     }
@@ -260,6 +262,7 @@ public class HtmlObject extends HtmlContainer implements
      *            parameter components
      * @deprecated use {@link #HtmlObject(DownloadHandler,Param...)} instead
      */
+    @Deprecated(since = "24.8")
     public HtmlObject(AbstractStreamResource data, Param... params) {
         setData(data);
         add(params);
@@ -282,6 +285,7 @@ public class HtmlObject extends HtmlContainer implements
      *            a "data" attribute value,, not {@code null}
      * @deprecated use {@link #setData(DownloadHandler)} instead
      */
+    @Deprecated(since = "24.8")
     public void setData(AbstractStreamResource data) {
         getElement().setAttribute("data", data);
     }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/HtmlObject.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/HtmlObject.java
@@ -106,7 +106,7 @@ public class HtmlObject extends HtmlContainer implements
      *            a type attribute value
      * @deprecated use {@link #HtmlObject(DownloadHandler,String)} instead
      */
-    @Deprecated(since = "24.8")
+    @Deprecated(since = "24.8", forRemoval = true)
     public HtmlObject(AbstractStreamResource data, String type) {
         setData(data);
         setType(type);
@@ -130,7 +130,7 @@ public class HtmlObject extends HtmlContainer implements
      * @deprecated use {@link #HtmlObject(DownloadHandler,String, Param...)}
      *             instead
      */
-    @Deprecated(since = "24.8")
+    @Deprecated(since = "24.8", forRemoval = true)
     public HtmlObject(AbstractStreamResource data, String type,
             Param... params) {
         setData(data);
@@ -189,7 +189,8 @@ public class HtmlObject extends HtmlContainer implements
      *
      *
      * @param data
-     *            a data attribute value
+     *            a handler that defines the data to be set to this object
+     *            component
      * @param params
      *            parameter components
      */
@@ -209,7 +210,8 @@ public class HtmlObject extends HtmlContainer implements
      *
      *
      * @param data
-     *            a data attribute value
+     *            a handler that defines the data to be set to this object
+     *            component
      */
     public HtmlObject(DownloadHandler data) {
         setData(new StreamResourceRegistry.ElementStreamResource(data,
@@ -244,7 +246,7 @@ public class HtmlObject extends HtmlContainer implements
      *            the resource value, not {@code null}
      * @deprecated use {@link #HtmlObject(DownloadHandler)} instead
      */
-    @Deprecated(since = "24.8")
+    @Deprecated(since = "24.8", forRemoval = true)
     public HtmlObject(AbstractStreamResource data) {
         setData(data);
     }
@@ -262,7 +264,7 @@ public class HtmlObject extends HtmlContainer implements
      *            parameter components
      * @deprecated use {@link #HtmlObject(DownloadHandler,Param...)} instead
      */
-    @Deprecated(since = "24.8")
+    @Deprecated(since = "24.8", forRemoval = true)
     public HtmlObject(AbstractStreamResource data, Param... params) {
         setData(data);
         add(params);
@@ -285,7 +287,7 @@ public class HtmlObject extends HtmlContainer implements
      *            a "data" attribute value,, not {@code null}
      * @deprecated use {@link #setData(DownloadHandler)} instead
      */
-    @Deprecated(since = "24.8")
+    @Deprecated(since = "24.8", forRemoval = true)
     public void setData(AbstractStreamResource data) {
         getElement().setAttribute("data", data);
     }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/HtmlObject.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/HtmlObject.java
@@ -104,6 +104,7 @@ public class HtmlObject extends HtmlContainer implements
      *            the resource value, not null
      * @param type
      *            a type attribute value
+     * @deprecated use {@link #HtmlObject(DownloadHandler,String)} instead
      */
     public HtmlObject(AbstractStreamResource data, String type) {
         setData(data);
@@ -125,6 +126,8 @@ public class HtmlObject extends HtmlContainer implements
      *            a type attribute value
      * @param params
      *            parameter components
+     * @deprecated use {@link #HtmlObject(DownloadHandler,String, Param...)}
+     *             instead
      */
     public HtmlObject(AbstractStreamResource data, String type,
             Param... params) {
@@ -138,7 +141,7 @@ public class HtmlObject extends HtmlContainer implements
      * {@link DownloadHandler} callback for providing an object data and type
      * value.
      *
-     * @see #setData(AbstractStreamResource)
+     * @see #setData(DownloadHandler)
      * @see #setType(String)
      *
      * @param data
@@ -175,6 +178,43 @@ public class HtmlObject extends HtmlContainer implements
     }
 
     /**
+     * Creates a new <code>&lt;object&gt;</code> component with given data
+     * resource, type value and "param" components.
+     *
+     * @see #setData(String)
+     * @see #setType(String)
+     * @see #add(Component...)
+     *
+     *
+     * @param data
+     *            a data attribute value
+     * @param params
+     *            parameter components
+     */
+    public HtmlObject(DownloadHandler data, Param... params) {
+        setData(new StreamResourceRegistry.ElementStreamResource(data,
+                this.getElement()));
+        add(params);
+    }
+
+    /**
+     * Creates a new <code>&lt;object&gt;</code> component with given data
+     * resource, type value and "param" components.
+     *
+     * @see #setData(String)
+     * @see #setType(String)
+     * @see #add(Component...)
+     *
+     *
+     * @param data
+     *            a data attribute value
+     */
+    public HtmlObject(DownloadHandler data) {
+        setData(new StreamResourceRegistry.ElementStreamResource(data,
+                this.getElement()));
+    }
+
+    /**
      * Creates a new <code>&lt;object&gt;</code> component with given data and
      * "param" components.
      *
@@ -200,6 +240,8 @@ public class HtmlObject extends HtmlContainer implements
      *
      * @param data
      *            the resource value, not {@code null}
+     * @deprecated use {@link #HtmlObject(DownloadHandler)} instead
+     *
      */
     public HtmlObject(AbstractStreamResource data) {
         setData(data);
@@ -216,6 +258,7 @@ public class HtmlObject extends HtmlContainer implements
      *            the resource value, not {@code null}
      * @param params
      *            parameter components
+     * @deprecated use {@link #HtmlObject(DownloadHandler,Param...)} instead
      */
     public HtmlObject(AbstractStreamResource data, Param... params) {
         setData(data);
@@ -237,6 +280,7 @@ public class HtmlObject extends HtmlContainer implements
      *
      * @param data
      *            a "data" attribute value,, not {@code null}
+     * @deprecated use {@link #setData(DownloadHandler)} instead
      */
     public void setData(AbstractStreamResource data) {
         getElement().setAttribute("data", data);
@@ -261,7 +305,7 @@ public class HtmlObject extends HtmlContainer implements
      * @return the "data" attribute value
      *
      * @see #setData(String)
-     * @see #setData(AbstractStreamResource)
+     * @see #setData(DownloadHandler)
      */
     public String getData() {
         return get(dataDescriptor);

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
@@ -170,6 +170,7 @@ public class IFrame extends HtmlComponent implements HasAriaLabel {
      *            the resource value, not null
      * @deprecated use {@link #setSrc(DownloadHandler)} instead
      */
+    @Deprecated(since = "24.8")
     public void setSrc(AbstractStreamResource src) {
         getElement().setAttribute("src", src);
     }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
@@ -170,7 +170,7 @@ public class IFrame extends HtmlComponent implements HasAriaLabel {
      *            the resource value, not null
      * @deprecated use {@link #setSrc(DownloadHandler)} instead
      */
-    @Deprecated(since = "24.8")
+    @Deprecated(since = "24.8", forRemoval = true)
     public void setSrc(AbstractStreamResource src) {
         getElement().setAttribute("src", src);
     }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
@@ -168,6 +168,7 @@ public class IFrame extends HtmlComponent implements HasAriaLabel {
      *
      * @param src
      *            the resource value, not null
+     * @deprecated use {@link #setSrc(DownloadHandler)} instead
      */
     public void setSrc(AbstractStreamResource src) {
         getElement().setAttribute("src", src);

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
@@ -83,6 +83,7 @@ public class Image extends HtmlContainer
      * @see #setAlt(String)
      * @deprecated use {@link #Image(DownloadHandler, String)} instead
      */
+    @Deprecated(since = "24.8")
     public Image(AbstractStreamResource src, String alt) {
         setSrc(src);
         setAlt(alt);
@@ -135,6 +136,7 @@ public class Image extends HtmlContainer
      *            the resource value, not null
      * @deprecated use {@link #setSrc(DownloadHandler)} instead
      */
+    @Deprecated(since = "24.8")
     public void setSrc(AbstractStreamResource src) {
         getElement().setAttribute("src", src);
     }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
@@ -83,7 +83,7 @@ public class Image extends HtmlContainer
      * @see #setAlt(String)
      * @deprecated use {@link #Image(DownloadHandler, String)} instead
      */
-    @Deprecated(since = "24.8")
+    @Deprecated(since = "24.8", forRemoval = true)
     public Image(AbstractStreamResource src, String alt) {
         setSrc(src);
         setAlt(alt);

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
@@ -136,7 +136,7 @@ public class Image extends HtmlContainer
      *            the resource value, not null
      * @deprecated use {@link #setSrc(DownloadHandler)} instead
      */
-    @Deprecated(since = "24.8")
+    @Deprecated(since = "24.8", forRemoval = true)
     public void setSrc(AbstractStreamResource src) {
         getElement().setAttribute("src", src);
     }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
@@ -81,6 +81,7 @@ public class Image extends HtmlContainer
      *
      * @see #setSrc(AbstractStreamResource)
      * @see #setAlt(String)
+     * @deprecated use {@link #Image(DownloadHandler, String)} instead
      */
     public Image(AbstractStreamResource src, String alt) {
         setSrc(src);
@@ -100,7 +101,7 @@ public class Image extends HtmlContainer
      * @param alt
      *            the alternate text
      *
-     * @see #setSrc(AbstractStreamResource)
+     * @see #setSrc(DownloadHandler)
      * @see #setAlt(String)
      */
     public Image(DownloadHandler downloadHandler, String alt) {
@@ -132,6 +133,7 @@ public class Image extends HtmlContainer
      *
      * @param src
      *            the resource value, not null
+     * @deprecated use {@link #setSrc(DownloadHandler)} instead
      */
     public void setSrc(AbstractStreamResource src) {
         getElement().setAttribute("src", src);

--- a/flow-server/src/main/java/com/vaadin/flow/server/StreamReceiver.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StreamReceiver.java
@@ -27,6 +27,7 @@ import com.vaadin.flow.internal.StateNode;
  * @author Vaadin Ltd
  * @since 1.0
  *
+ * @deprecated use {@link com.vaadin.flow.server.streams.UploadHandler} instead
  */
 public class StreamReceiver extends AbstractStreamResource {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/StreamReceiver.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StreamReceiver.java
@@ -29,6 +29,7 @@ import com.vaadin.flow.internal.StateNode;
  *
  * @deprecated use {@link com.vaadin.flow.server.streams.UploadHandler} instead
  */
+@Deprecated(since = "24.8", forRemoval = true)
 public class StreamReceiver extends AbstractStreamResource {
 
     private StateNode node;

--- a/flow-server/src/main/java/com/vaadin/flow/server/StreamResource.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StreamResource.java
@@ -46,6 +46,7 @@ import com.vaadin.flow.function.ContentTypeResolver;
  * @deprecated use {@link com.vaadin.flow.server.streams.DownloadHandler}
  *             instead
  */
+@Deprecated(since = "24.8", forRemoval = true)
 public class StreamResource extends AbstractStreamResource {
 
     private static final String DEFAULT_CONTENT_TYPE = "application/octet-stream";

--- a/flow-server/src/main/java/com/vaadin/flow/server/StreamResource.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StreamResource.java
@@ -42,6 +42,9 @@ import com.vaadin.flow.function.ContentTypeResolver;
  *
  * @author Vaadin Ltd
  * @since 1.0
+ *
+ * @deprecated use {@link com.vaadin.flow.server.streams.DownloadHandler}
+ *             instead
  */
 public class StreamResource extends AbstractStreamResource {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/StreamVariable.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StreamVariable.java
@@ -34,6 +34,7 @@ import java.io.Serializable;
  *
  * @deprecated use {@link com.vaadin.flow.server.streams.UploadHandler} instead
  */
+@Deprecated(since = "24.8", forRemoval = true)
 public interface StreamVariable extends Serializable {
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/StreamVariable.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StreamVariable.java
@@ -31,6 +31,8 @@ import java.io.Serializable;
  *
  * @author Vaadin Ltd
  * @since 1.0.
+ *
+ * @deprecated use {@link com.vaadin.flow.server.streams.UploadHandler} instead
  */
 public interface StreamVariable extends Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/TransferProgressAwareHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/TransferProgressAwareHandler.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import com.vaadin.flow.function.SerializableBiConsumer;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableRunnable;
+import com.vaadin.flow.server.Command;
 import com.vaadin.flow.shared.Registration;
 
 /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/TransferProgressListener.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/TransferProgressListener.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import com.vaadin.flow.server.Command;
 import com.vaadin.flow.server.VaadinSession;
 
 /**


### PR DESCRIPTION
Mark StreamResource api as deprecated
and point to Upload-/DownloadHandler
instead.

part of #21414
