### PR TITLE
chore: fix javadoc links after refactor

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/TransferProgressListener.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/TransferProgressListener.java
@@ -34,10 +34,11 @@ import com.vaadin.flow.server.VaadinSession;
  * Implementations of this interface can be used to monitor the progress of file
  * transfers, such as downloads or uploads.
  * <p>
- * It uses {@link com.vaadin.flow.component.UI#access(Command)} to send UI
- * changes from progress listeners when the download or upload request is being
- * handled. Thus, it needs {@link com.vaadin.flow.component.page.Push} to be
- * enabled in the application.
+ * It uses
+ * {@link com.vaadin.flow.component.UI#access(com.vaadin.flow.server.Command)}
+ * to send UI changes from progress listeners when the download or upload
+ * request is being handled. Thus, it needs
+ * {@link com.vaadin.flow.component.page.Push} to be enabled in the application.
  *
  * @since 24.8
  */
@@ -62,10 +63,11 @@ public interface TransferProgressListener extends Serializable {
      * Called when the data transfer is started.
      * <p>
      * The call of this method is wrapped by the
-     * {@link com.vaadin.flow.component.UI#access(Command)} to send UI changes
-     * defined here when the download or upload request is being handled. Thus,
-     * no need to call {@link com.vaadin.flow.component.UI#access(Command)} in
-     * the implementation of this method. This needs
+     * {@link com.vaadin.flow.component.UI#access(com.vaadin.flow.server.Command)}
+     * to send UI changes defined here when the download or upload request is
+     * being handled. Thus, no need to call
+     * {@link com.vaadin.flow.component.UI#access(com.vaadin.flow.server.Command)}
+     * in the implementation of this method. This needs
      * {@link com.vaadin.flow.component.page.Push} to be enabled in the
      * application to properly send the UI changes to client.
      *
@@ -80,10 +82,11 @@ public interface TransferProgressListener extends Serializable {
      * Called periodically during the transfer to report progress.
      * <p>
      * The call of this method is wrapped by the
-     * {@link com.vaadin.flow.component.UI#access(Command)} to send UI changes
-     * defined here when the download or upload request is being handled. Thus,
-     * no need to call {@link com.vaadin.flow.component.UI#access(Command)} in
-     * the implementation of this method. This needs
+     * {@link com.vaadin.flow.component.UI#access(com.vaadin.flow.server.Command)}
+     * to send UI changes defined here when the download or upload request is
+     * being handled. Thus, no need to call
+     * {@link com.vaadin.flow.component.UI#access(com.vaadin.flow.server.Command)}
+     * in the implementation of this method. This needs
      * {@link com.vaadin.flow.component.page.Push} to be enabled in the
      * application to properly send the UI changes to client.
      *
@@ -105,10 +108,11 @@ public interface TransferProgressListener extends Serializable {
      * Called when the transfer is failed.
      * <p>
      * The call of this method is wrapped by the
-     * {@link com.vaadin.flow.component.UI#access(Command)} to send UI changes
-     * defined here when the download or upload request is being handled. Thus,
-     * no need to call {@link com.vaadin.flow.component.UI#access(Command)} in
-     * the implementation of this method. This needs
+     * {@link com.vaadin.flow.component.UI#access(com.vaadin.flow.server.Command)}
+     * to send UI changes defined here when the download or upload request is
+     * being handled. Thus, no need to call
+     * {@link com.vaadin.flow.component.UI#access(com.vaadin.flow.server.Command)}
+     * in the implementation of this method. This needs
      * {@link com.vaadin.flow.component.page.Push} to be enabled in the
      * application to properly send the UI changes to client.
      *
@@ -125,10 +129,11 @@ public interface TransferProgressListener extends Serializable {
      * Called when the transfer is started.
      * <p>
      * The call of this method is wrapped by the
-     * {@link com.vaadin.flow.component.UI#access(Command)} to send UI changes
-     * defined here when the download or upload request is being handled. Thus,
-     * no need to call {@link com.vaadin.flow.component.UI#access(Command)} in
-     * the implementation of this method. This needs
+     * {@link com.vaadin.flow.component.UI#access(com.vaadin.flow.server.Command)}
+     * to send UI changes defined here when the download or upload request is
+     * being handled. Thus, no need to call
+     * {@link com.vaadin.flow.component.UI#access(com.vaadin.flow.server.Command)}
+     * in the implementation of this method. This needs
      * {@link com.vaadin.flow.component.page.Push} to be enabled in the
      * application to properly send the UI changes to client.
      *


### PR DESCRIPTION
Fix javadoc links after
file move.
