### PR TITLE
Update read revision before applying changes

### DIFF
--- a/signals/src/main/java/com/vaadin/signals/impl/Transaction.java
+++ b/signals/src/main/java/com/vaadin/signals/impl/Transaction.java
@@ -94,9 +94,11 @@ public abstract class Transaction {
         @Override
         public void include(SignalTree tree, SignalCommand command,
                 Consumer<CommandResult> resultHandler, boolean applyToTree) {
-            super.include(tree, command, resultHandler, applyToTree);
-
+            // Update the read revision first so that change observers can read
+            // the updated value
             getOrCreateReadRevision(tree).apply(command, null);
+
+            super.include(tree, command, resultHandler, applyToTree);
 
             // Let an outer transaction update its own read revision
             outer.include(tree, command, null, false);


### PR DESCRIPTION
The logic that determines whether a computed signal or effect should be run again is triggered from a change observer. If the value used by that change observer was already captured in the read transaction, then the old value would be used instead of the new one when the value is changed which would mean that the change remains undetected.