### PR TITLE
fix: Allow to override response status codes for downloads

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/ClassDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/ClassDownloadHandler.java
@@ -92,10 +92,10 @@ public class ClassDownloadHandler
                         .getResourceAsStream(resourceName)) {
             TransferProgressListener.transfer(inputStream, outputStream,
                     getTransferContext(downloadEvent), getListeners());
+            responseHandled(true, downloadEvent.getResponse());
         } catch (IOException ioe) {
             // Set status before output is closed (see #8740)
-            downloadEvent.getResponse()
-                    .setStatus(HttpStatusCode.INTERNAL_SERVER_ERROR.getCode());
+            responseHandled(false, downloadEvent.getResponse());
             notifyError(downloadEvent, ioe);
             throw new UncheckedIOException(ioe);
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadHandler.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableFunction;
+import com.vaadin.flow.server.HttpStatusCode;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
 import com.vaadin.flow.server.VaadinSession;
@@ -54,6 +55,29 @@ public interface DownloadHandler extends ElementRequestHandler {
                 owner);
 
         handleDownloadRequest(downloadEvent);
+    }
+
+    /**
+     * Method called by framework when the download is completed, either
+     * successfully or with an error.
+     * <p>
+     * This method sets the http response return codes according to internal
+     * exception handling in the framework.
+     * <p>
+     * If you want custom exception handling and to set the return code,
+     * implement this method and overwrite the default functionality.
+     *
+     * @param success
+     *            if there was no exception thrown for download
+     * @param response
+     *            the response object for the upload request
+     */
+    default void responseHandled(boolean success, VaadinResponse response) {
+        if (success) {
+            response.setStatus(HttpStatusCode.OK.getCode());
+        } else {
+            response.setStatus(HttpStatusCode.INTERNAL_SERVER_ERROR.getCode());
+        }
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/FileDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/FileDownloadHandler.java
@@ -68,9 +68,10 @@ public class FileDownloadHandler
                 FileInputStream inputStream = new FileInputStream(file)) {
             TransferProgressListener.transfer(inputStream, outputStream,
                     getTransferContext(downloadEvent), getListeners());
+            responseHandled(true, response);
         } catch (IOException ioe) {
             // Set status before output is closed (see #8740)
-            response.setStatus(HttpStatusCode.INTERNAL_SERVER_ERROR.getCode());
+            responseHandled(false, response);
             notifyError(downloadEvent, ioe);
             throw new UncheckedIOException(ioe);
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/InputStreamDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/InputStreamDownloadHandler.java
@@ -78,9 +78,10 @@ public class InputStreamDownloadHandler
                 InputStream inputStream = download.getInputStream()) {
             TransferProgressListener.transfer(inputStream, outputStream,
                     getTransferContext(downloadEvent), getListeners());
+            responseHandled(true, response);
         } catch (IOException ioe) {
             // Set status before output is closed (see #8740)
-            response.setStatus(HttpStatusCode.INTERNAL_SERVER_ERROR.getCode());
+            responseHandled(false, response);
             notifyError(downloadEvent, ioe);
             throw new UncheckedIOException(ioe);
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandler.java
@@ -72,10 +72,10 @@ public class ServletResourceDownloadHandler
                             .getServletContext().getResourceAsStream(path)) {
                 TransferProgressListener.transfer(inputStream, outputStream,
                         getTransferContext(downloadEvent), getListeners());
+                responseHandled(true, downloadEvent.getResponse());
             } catch (IOException ioe) {
                 // Set status before output is closed (see #8740)
-                downloadEvent.getResponse().setStatus(
-                        HttpStatusCode.INTERNAL_SERVER_ERROR.getCode());
+                responseHandled(false, downloadEvent.getResponse());
                 notifyError(downloadEvent, ioe);
                 throw new UncheckedIOException(ioe);
             }


### PR DESCRIPTION
This allows to override the response return status code from 200 and 500 to something different by just overriding one method.

In draft because I'm not sure about naming and signature - this may be `getErrorStatusCode()` and `getSuccessStatusCode` instead, or `requestHandled()`.