### PR TITLE
test: disable selenium-devtools workaround (24.6)

### DIFF
--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -439,12 +439,14 @@
                 </property>
             </activation>
             <dependencies>
+                <!--
                 <dependency>
                     <groupId>org.seleniumhq.selenium</groupId>
                     <artifactId>selenium-devtools-v127</artifactId>
                     <version>4.25.0</version>
                     <scope>test</scope>
                 </dependency>
+                -->
             </dependencies>
         </profile>
         <profile>


### PR DESCRIPTION
Selenium and Testbench have been updated to a new version supported by CI. The workaround must be removed to prevent build failures.