### PR TITLE
Add VaadinUser for accessing common user attributes.

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/AuthenticationContext.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/AuthenticationContext.java
@@ -97,6 +97,18 @@ public class AuthenticationContext {
     }
 
     /**
+     * Gets an {@link Optional} with an instance of the current user if it has
+     * been authenticated, or empty if the user is not authenticated.
+     *
+     * @return an {@link Optional} with the current authenticated user, or empty
+     *         if none available
+     */
+    public Optional<VaadinUser> getAuthenticatedUser() {
+        return getAuthentication()
+                .map(VaadinUserFactory::createVaadinUser);
+    }
+
+    /**
      * Gets an {@link Optional} containing the authenticated principal name, or
      * an empty optional if the user is not authenticated.
      *

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/OidcVaadinUser.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/OidcVaadinUser.java
@@ -1,0 +1,90 @@
+package com.vaadin.flow.spring.security;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.oidc.StandardClaimAccessor;
+
+import java.time.ZoneId;
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * Implementation of {@link VaadinUser} that assumes the authenticated principal implements
+ * {@link StandardClaimAccessor}.
+ */
+final class OidcVaadinUser implements VaadinUser {
+
+    private final String userId;
+    private final String email;
+    private final String fullName;
+    private final String pictureUrl;
+    private final String profileUrl;
+    private final ZoneId timeZone;
+    private final Locale locale;
+
+    /**
+     * Creates a new {@code OidcVaadinUser}.
+     *
+     * @param authentication the authentication object to use for extracting the user information.
+     * @throws ClassCastException if the authentication principal is not an instance of {@link StandardClaimAccessor}.
+     */
+    OidcVaadinUser(Authentication authentication) {
+        var claimAccessor = (StandardClaimAccessor) authentication.getPrincipal();
+        var subject = claimAccessor.getSubject();
+
+        userId = subject != null ? subject : authentication.getName();
+        email = claimAccessor.getEmail();
+        fullName = claimAccessor.getFullName();
+        pictureUrl = claimAccessor.getPicture();
+        profileUrl = claimAccessor.getProfile();
+        timeZone = parseZoneId(claimAccessor.getZoneInfo());
+        locale = parseLocale(claimAccessor.getLocale());
+    }
+
+    private static @Nullable ZoneId parseZoneId(@Nullable String zoneInfo) {
+        try {
+            return zoneInfo == null ? null : ZoneId.of(zoneInfo);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static @Nullable Locale parseLocale(@Nullable String locale) {
+        return locale == null ? null : Locale.forLanguageTag(locale);
+    }
+
+    @Override
+    public String getUserId() {
+        return userId;
+    }
+
+    @Override
+    public Optional<String> getEmail() {
+        return Optional.ofNullable(email);
+    }
+
+    @Override
+    public Optional<String> getFullName() {
+        return Optional.ofNullable(fullName);
+    }
+
+    @Override
+    public Optional<String> getPictureUrl() {
+        return Optional.ofNullable(pictureUrl);
+    }
+
+    @Override
+    public Optional<String> getProfileUrl() {
+        return Optional.ofNullable(profileUrl);
+    }
+
+    @Override
+    public Optional<ZoneId> getTimeZone() {
+        return Optional.ofNullable(timeZone);
+    }
+
+    @Override
+    public Optional<Locale> getLocale() {
+        return Optional.ofNullable(locale);
+    }
+}

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinUser.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinUser.java
@@ -1,0 +1,76 @@
+package com.vaadin.flow.spring.security;
+
+import java.io.Serializable;
+import java.time.ZoneId;
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * Interface for accessing information about the current user. To provide a custom implementation, create a new
+ * {@link org.springframework.security.core.userdetails.UserDetailsService} that return objects that implement both
+ * the {@link org.springframework.security.core.userdetails.UserDetails} and this interface.
+ */
+public interface VaadinUser extends Serializable {
+
+    /**
+     * Returns the ID of the user. This can be a username, a UUID or some other identifier that uniquely identifies the
+     * user. It can be used for things like audit logging, but should typically not be displayed to the user.
+     *
+     * @return the user ID (never {@code null}).
+     */
+    String getUserId();
+
+    /**
+     * Returns the email address of the user if available.
+     *
+     * @return the user's email address, or an empty {@code Optional} if not available.
+     */
+    default Optional<String> getEmail() {
+        return Optional.empty();
+    }
+
+    /**
+     * Returns the user's full name if available.
+     *
+     * @return the user's full name, or an empty {@code Optional} if not available.
+     */
+    default Optional<String> getFullName() {
+        return Optional.empty();
+    }
+
+    /**
+     * Returns the URL of the user's profile picture if available.
+     *
+     * @return the user's profile picture URL, or an empty {@code Optional} if not available.
+     */
+    default Optional<String> getPictureUrl() {
+        return Optional.empty();
+    }
+
+    /**
+     * Returns the URL of the user's profile page if available.
+     *
+     * @return the user's profile page URL, or an empty {@code Optional} if not available.
+     */
+    default Optional<String> getProfileUrl() {
+        return Optional.empty();
+    }
+
+    /**
+     * Returns the user's timezone if available.
+     *
+     * @return the user's timezone, or an empty {@code Optional} if not available.
+     */
+    default Optional<ZoneId> getTimeZone() {
+        return Optional.empty();
+    }
+
+    /**
+     * Returns the user's locale if available.
+     *
+     * @return the user's locale, or an empty {@code Optional} if not available.
+     */
+    default Optional<Locale> getLocale() {
+        return Optional.empty();
+    }
+}

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinUserFactory.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinUserFactory.java
@@ -1,0 +1,44 @@
+package com.vaadin.flow.spring.security;
+
+import org.springframework.security.core.Authentication;
+
+final class VaadinUserFactory {
+
+    private VaadinUserFactory() {
+    }
+
+    static VaadinUser createVaadinUser(Authentication authentication) {
+        var principal = authentication.getPrincipal();
+        if (principal instanceof VaadinUser vaadinPrincipal) {
+            return vaadinPrincipal;
+        } else if (isOidcPrincipal(principal)) {
+            return new OidcVaadinUser(authentication);
+        } else {
+            return new BasicVaadinUser(authentication.getName());
+        }
+    }
+
+    private static boolean isOidcPrincipal(Object principal) {
+        // Not all Vaadin applications have the OIDC dependency on their classpath.
+        try {
+            var claimAccessorClass = Class.forName("org.springframework.security.oauth2.core.oidc.StandardClaimAccessor");
+            return claimAccessorClass.isInstance(principal);
+        } catch (ClassNotFoundException ex) {
+            return false;
+        }
+    }
+
+    private static class BasicVaadinUser implements VaadinUser {
+
+        private final String userId;
+
+        public BasicVaadinUser(String userId) {
+            this.userId = userId;
+        }
+
+        @Override
+        public String getUserId() {
+            return userId;
+        }
+    }
+}


### PR DESCRIPTION
## Description

The Walking Skeleton comes with a parent layout that is intended to be production ready. It also contains a user menu that shows the name of the current user, an avatar, a link to the profile page, and a logout item. It is currently a mock, but we'd like it to be fully implemented.

Because security can be implemented in many different ways, we don't want the parent layout to worry about it. `AuthenticationContext` is a good start, but it only gives the principal name. When using OIDC, such as via Control Center, this is an UUID. This PR aims to extend the API of `AuthenticationContext` with additional user information, such as email, full name, profile image, profile page, time zone, and locale.

This is done by introducing a new `VaadinUser` interface. 

If the principal is an OIDC principal, there is a built-in implementation of this interface that extracts the necessary claims from the token. 

If the principal implements the interface, it is returned directly. You can achieve this by e.g. creating your own `UserDetailsService` and have it return objects that also implement `VaadinUser`.

There is also a fallback implementation for principals that don't fit these criteria.

With this API in place, the Walking Skeleton can contain a working user menu that works both with Control Center, and with a custom security configuration.

This PR is marked as a draft because it does not contain any tests yet, and the JavaDocs could be improved. Before proceeding, I want to discuss whether this is the right way to go.

Fixes # (issue)

## Type of change

- [ ] Bugfix
- [x] Feature

