### PR TITLE
fix: Do not lock the session while transferring content

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/TransferProgressListener.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/TransferProgressListener.java
@@ -185,8 +185,7 @@ public interface TransferProgressListener extends Serializable {
                 listeners.size());
         byte[] buffer = new byte[DEFAULT_BUFFER_SIZE];
         int read;
-        while ((read = read(transferContext.session(), inputStream,
-                buffer)) >= 0) {
+        while ((read = inputStream.read(buffer, 0, DEFAULT_BUFFER_SIZE)) >= 0) {
             outputStream.write(buffer, 0, read);
             if (transferred < Long.MAX_VALUE) {
                 try {
@@ -213,30 +212,5 @@ public interface TransferProgressListener extends Serializable {
         listeners.forEach(listener -> listener.onComplete(transferContext,
                 finalTransferred));
         return transferred;
-    }
-
-    /**
-     * Read buffer amount of bytes from the input stream.
-     *
-     * @param session
-     *            vaadin session in use
-     * @param source
-     *            input stream source
-     * @param buffer
-     *            byte buffer to read into
-     * @return amount of bytes read into buffer
-     * @throws IOException
-     *             If the first byte cannot be read for any reason other than
-     *             the end of the file, if the input stream has been closed, or
-     *             if some other I/O error occurs.
-     */
-    static int read(VaadinSession session, InputStream source, byte[] buffer)
-            throws IOException {
-        session.lock();
-        try {
-            return source.read(buffer, 0, DEFAULT_BUFFER_SIZE);
-        } finally {
-            session.unlock();
-        }
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/AbstractDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/AbstractDownloadHandlerTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -154,6 +155,21 @@ public class AbstractDownloadHandlerTest {
         });
         Mockito.verify(completeHandler).accept(true);
         Mockito.verify(completeHandler).accept(false);
+    }
+
+    @Test
+    public void transferProgressListener_transfer_sessionNotLocked()
+            throws IOException {
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(
+                "Hello".getBytes(StandardCharsets.UTF_8));
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        TransferContext context = Mockito.mock(TransferContext.class);
+        Mockito.when(context.session()).thenReturn(session);
+        OutputStream outputStream = Mockito.mock(OutputStream.class);
+        Collection<TransferProgressListener> listeners = new ArrayList<>();
+        TransferProgressListener.transfer(inputStream, outputStream, context,
+                listeners);
+        Mockito.verify(session, Mockito.times(0)).lock();
     }
 
     @Test


### PR DESCRIPTION
For common cases let's not lock the session for data transfer and assume that this locking can be done in a custom handler, if required.