### PR TITLE
fix!: Add setter helpers to DownloadEvent and new method for inline

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/AbstractDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/AbstractDownloadHandler.java
@@ -32,7 +32,7 @@ public abstract class AbstractDownloadHandler<R extends AbstractDownloadHandler>
         implements DownloadHandler {
 
     // Content-Disposition: attachment by default
-    private boolean attachment = true;
+    private boolean inline = false;
 
     @Override
     protected TransferContext getTransferContext(DownloadEvent transferEvent) {
@@ -56,7 +56,7 @@ public abstract class AbstractDownloadHandler<R extends AbstractDownloadHandler>
      * @return this instance for method chaining
      */
     public R inline() {
-        attachment = false;
+        inline = true;
         return (R) this;
     }
 
@@ -64,10 +64,10 @@ public abstract class AbstractDownloadHandler<R extends AbstractDownloadHandler>
      * Returns if the download content to be displayed inside the Web page or
      * downloaded as a file.
      *
-     * @return true if the content is to be downloaded as a file, false if it is
-     *         to be displayed inline
+     * @return true if the content is to be displayed inline, false if it is to
+     *         be downloaded as a file
      */
-    protected boolean isAttachment() {
-        return attachment;
+    public boolean isInline() {
+        return inline;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/AbstractDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/AbstractDownloadHandler.java
@@ -31,6 +31,9 @@ public abstract class AbstractDownloadHandler<R extends AbstractDownloadHandler>
         extends TransferProgressAwareHandler<DownloadEvent, R>
         implements DownloadHandler {
 
+    // Content-Disposition: attachment by default
+    private boolean attachment = true;
+
     @Override
     protected TransferContext getTransferContext(DownloadEvent transferEvent) {
         return new TransferContext(transferEvent.getRequest(),
@@ -42,5 +45,29 @@ public abstract class AbstractDownloadHandler<R extends AbstractDownloadHandler>
     protected String getContentType(String fileName, VaadinResponse response) {
         return Optional.ofNullable(response.getService().getMimeType(fileName))
                 .orElse("application/octet-stream");
+    }
+
+    /**
+     * Sets this download content to be displayed inside the Web page, or as the
+     * Web page, e.g. as an image or inside an iframe.
+     * <p>
+     * Sets the 'Content-Disposition' attribute to 'inline'.
+     *
+     * @return this instance for method chaining
+     */
+    public R inline() {
+        attachment = false;
+        return (R) this;
+    }
+
+    /**
+     * Returns if the download content to be displayed inside the Web page or
+     * downloaded as a file.
+     *
+     * @return true if the content is to be downloaded as a file, false if it is
+     *         to be displayed inline
+     */
+    protected boolean isAttachment() {
+        return attachment;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/AbstractDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/AbstractDownloadHandler.java
@@ -16,6 +16,10 @@
 
 package com.vaadin.flow.server.streams;
 
+import java.util.Optional;
+
+import com.vaadin.flow.server.VaadinResponse;
+
 /**
  * Abstract class for common methods used in pre-made download handlers.
  *
@@ -31,6 +35,12 @@ public abstract class AbstractDownloadHandler<R extends AbstractDownloadHandler>
     protected TransferContext getTransferContext(DownloadEvent transferEvent) {
         return new TransferContext(transferEvent.getRequest(),
                 transferEvent.getResponse(), transferEvent.getSession(),
-                transferEvent.getFileName(), transferEvent.owningElement(), -1);
+                transferEvent.getFileName(), transferEvent.getOwningElement(),
+                -1);
+    }
+
+    protected String getContentType(String fileName, VaadinResponse response) {
+        return Optional.ofNullable(response.getService().getMimeType(fileName))
+                .orElse("application/octet-stream");
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/ClassDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/ClassDownloadHandler.java
@@ -90,6 +90,9 @@ public class ClassDownloadHandler
         try (OutputStream outputStream = downloadEvent.getOutputStream();
                 InputStream inputStream = clazz
                         .getResourceAsStream(resourceName)) {
+            downloadEvent.setContentType(getContentType(getUrlPostfix(),
+                    downloadEvent.getResponse()));
+            downloadEvent.setFileName(getUrlPostfix());
             TransferProgressListener.transfer(inputStream, outputStream,
                     getTransferContext(downloadEvent), getListeners());
         } catch (IOException ioe) {
@@ -99,9 +102,6 @@ public class ClassDownloadHandler
             notifyError(downloadEvent, ioe);
             throw new UncheckedIOException(ioe);
         }
-
-        downloadEvent.getResponse()
-                .setContentType(downloadEvent.getContentType());
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/ClassDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/ClassDownloadHandler.java
@@ -100,7 +100,7 @@ public class ClassDownloadHandler
             String resourceName = getUrlPostfix();
             downloadEvent.setContentType(
                     getContentType(resourceName, downloadEvent.getResponse()));
-            if (isAttachment()) {
+            if (!isInline()) {
                 downloadEvent.setFileName(resourceName);
             }
             TransferProgressListener.transfer(inputStream, outputStream,

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/ClassDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/ClassDownloadHandler.java
@@ -44,6 +44,10 @@ public class ClassDownloadHandler
     /**
      * Create a class resource download handler with the resource name as the
      * url postfix (file name).
+     * <p>
+     * The downloaded file name and download URL postfix will be set to
+     * <code>resourceName</code>. If you want to use a different file name, use
+     * {@link #ClassDownloadHandler(Class, String, String)} instead.
      *
      * @param clazz
      *            class to use for getting resource
@@ -57,6 +61,9 @@ public class ClassDownloadHandler
     /**
      * Create a class resource download handler with the given file name as the
      * url postfix.
+     * <p>
+     * The downloaded file name and download URL postfix will be set to
+     * <code>fileName</code>.
      *
      * @param clazz
      *            class to use for getting resource
@@ -90,9 +97,12 @@ public class ClassDownloadHandler
         try (OutputStream outputStream = downloadEvent.getOutputStream();
                 InputStream inputStream = clazz
                         .getResourceAsStream(resourceName)) {
-            downloadEvent.setContentType(getContentType(getUrlPostfix(),
-                    downloadEvent.getResponse()));
-            downloadEvent.setFileName(getUrlPostfix());
+            String resourceName = getUrlPostfix();
+            downloadEvent.setContentType(
+                    getContentType(resourceName, downloadEvent.getResponse()));
+            if (isAttachment()) {
+                downloadEvent.setFileName(resourceName);
+            }
             TransferProgressListener.transfer(inputStream, outputStream,
                     getTransferContext(downloadEvent), getListeners());
         } catch (IOException ioe) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadEvent.java
@@ -141,7 +141,7 @@ public class DownloadEvent {
     public void setFileName(String fileName) {
         fileName = fileName != null ? fileName : "";
         response.setHeader("Content-Disposition",
-                "attachment;filename=\"" + fileName + "\"");
+                "attachment; filename=\"" + fileName + "\"");
         this.fileName = fileName;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadEvent.java
@@ -139,6 +139,7 @@ public class DownloadEvent {
      *            the name to be assigned to the file
      */
     public void setFileName(String fileName) {
+        fileName = fileName != null ? fileName : "";
         response.setHeader("Content-Disposition",
                 "attachment;filename=\"" + fileName + "\"");
         this.fileName = fileName;

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadEvent.java
@@ -140,8 +140,12 @@ public class DownloadEvent {
      */
     public void setFileName(String fileName) {
         fileName = fileName != null ? fileName : "";
-        response.setHeader("Content-Disposition",
-                "attachment; filename=\"" + fileName + "\"");
+        if (fileName.isEmpty()) {
+            response.setHeader("Content-Disposition", "attachment");
+        } else {
+            response.setHeader("Content-Disposition",
+                    "attachment; filename=\"" + fileName + "\"");
+        }
         this.fileName = fileName;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadEvent.java
@@ -32,13 +32,31 @@ import com.vaadin.flow.server.VaadinResponse;
 import com.vaadin.flow.server.VaadinSession;
 
 /**
- * Class containing data on requested client download.
+ * Class containing meta-data for handling the requested client download.
+ * <p>
+ * It gives direct access to the underlying request, response and session as
+ * well as various helpers specifically for handling downloads.
+ *
  *
  * @since 24.8
  */
-public record DownloadEvent(VaadinRequest request, VaadinResponse response,
-        VaadinSession session, String fileName, String contentType,
-        Element owningElement) {
+public class DownloadEvent {
+
+    private VaadinRequest request;
+    private VaadinResponse response;
+    private VaadinSession session;
+    private Element owningElement;
+    private String fileName;
+    private String contentType;
+    private long contentLength;
+
+    public DownloadEvent(VaadinRequest request, VaadinResponse response,
+            VaadinSession session, Element owningElement) {
+        this.request = request;
+        this.response = response;
+        this.session = session;
+        this.owningElement = owningElement;
+    }
 
     /**
      * Returns a <code>OutputStream</code> for writing binary data in the
@@ -111,21 +129,49 @@ public record DownloadEvent(VaadinRequest request, VaadinResponse response,
     }
 
     /**
-     * Get the set file name.
+     * Sets the name of the file to be downloaded. This method utilizes the HTTP
+     * Content-Disposition header to specify the name of the file to be
+     * downloaded.
+     * <p>
+     * To be called before the response is committed.
      *
-     * @return file name
+     * @param fileName
+     *            the name to be assigned to the file
      */
-    public String getFileName() {
-        return fileName == null ? "" : fileName;
+    public void setFileName(String fileName) {
+        response.setHeader("Content-Disposition",
+                "attachment;filename=" + fileName);
+        this.fileName = fileName;
     }
 
     /**
-     * Get the content type for the data to download.
+     * Sets the content type for the current download. This methods utilizes the
+     * HTTP Content-Type header to specify the type of content being sent to the
+     * client.
+     * <p>
+     * To be called before the response is committed.
      *
-     * @return set content type
+     * @param contentType
+     *            the MIME type to set as the content type
      */
-    public String getContentType() {
-        return contentType;
+    public void setContentType(String contentType) {
+        response.setContentType(contentType);
+        this.contentType = contentType;
+    }
+
+    /**
+     * Sets the length of the content body in the response. This method utilizes
+     * the HTTP Content-Length header to specify the length of the content being
+     * sent to the client.
+     * <p>
+     * To be called before the response is committed.
+     *
+     * @param contentLength
+     *            the length of the response content in bytes
+     */
+    public void setContentLength(long contentLength) {
+        response.setContentLength(Math.toIntExact(contentLength));
+        this.contentLength = contentLength;
     }
 
     /**
@@ -147,13 +193,27 @@ public record DownloadEvent(VaadinRequest request, VaadinResponse response,
     }
 
     /**
-     * Get the UI instance for this request.
+     * Get the current UI instance for this request that can be used to make
+     * asynchronnous UI updates with
+     * {@link UI#access(com.vaadin.flow.server.Command)}.
      *
-     * @return Current UI
+     * @return Current UI instance
      */
     public UI getUI() {
         Optional<Component> component = owningElement.getComponent();
         return component.map(value -> value.getUI().orElseGet(UI::getCurrent))
                 .orElseGet(UI::getCurrent);
+    }
+
+    String getFileName() {
+        return fileName;
+    }
+
+    String getContentType() {
+        return contentType;
+    }
+
+    long getContentLength() {
+        return contentLength;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadEvent.java
@@ -140,7 +140,7 @@ public class DownloadEvent {
      */
     public void setFileName(String fileName) {
         response.setHeader("Content-Disposition",
-                "attachment;filename=" + fileName);
+                "attachment;filename=\"" + fileName + "\"");
         this.fileName = fileName;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadHandler.java
@@ -45,13 +45,8 @@ public interface DownloadHandler extends ElementRequestHandler {
 
     default void handleRequest(VaadinRequest request, VaadinResponse response,
             VaadinSession session, Element owner) {
-        String fileName = getUrlPostfix() == null ? "" : getUrlPostfix();
-
         DownloadEvent downloadEvent = new DownloadEvent(request, response,
-                session, fileName,
-                Optional.ofNullable(response.getService().getMimeType(fileName))
-                        .orElse("application/octet-stream"),
-                owner);
+                session, owner);
 
         handleDownloadRequest(downloadEvent);
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/FileDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/FileDownloadHandler.java
@@ -75,7 +75,7 @@ public class FileDownloadHandler
         try (OutputStream outputStream = downloadEvent.getOutputStream();
                 FileInputStream inputStream = new FileInputStream(file)) {
             String resourceName = getUrlPostfix();
-            if (isAttachment()) {
+            if (!isInline()) {
                 downloadEvent.setFileName(resourceName);
             }
             downloadEvent

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/FileDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/FileDownloadHandler.java
@@ -40,7 +40,11 @@ public class FileDownloadHandler
 
     /**
      * Create a download handler for given file. Url postfix will be used as
-     * {@code file.getName()}
+     * {@code file.getName()}.
+     * <p>
+     * The downloaded file name and download URL postfix will be set to
+     * <code>file.getName()</code>. If you want to use a different file name,
+     * use {@link #FileDownloadHandler(File, String)} instead.
      *
      * @param file
      *            file to download
@@ -51,6 +55,9 @@ public class FileDownloadHandler
 
     /**
      * Create a download handler for given file.
+     * <p>
+     * The downloaded file name and download URL postfix will be set to
+     * <code>name</code>.
      *
      * @param file
      *            file to download
@@ -67,9 +74,12 @@ public class FileDownloadHandler
         VaadinResponse response = downloadEvent.getResponse();
         try (OutputStream outputStream = downloadEvent.getOutputStream();
                 FileInputStream inputStream = new FileInputStream(file)) {
-            downloadEvent.setFileName(file.getName());
+            String resourceName = getUrlPostfix();
+            if (isAttachment()) {
+                downloadEvent.setFileName(resourceName);
+            }
             downloadEvent
-                    .setContentType(getContentType(file.getName(), response));
+                    .setContentType(getContentType(resourceName, response));
             downloadEvent.setContentLength(file.length());
             TransferProgressListener.transfer(inputStream, outputStream,
                     getTransferContext(downloadEvent), getListeners());
@@ -93,7 +103,7 @@ public class FileDownloadHandler
     protected TransferContext getTransferContext(DownloadEvent transferEvent) {
         return new TransferContext(transferEvent.getRequest(),
                 transferEvent.getResponse(), transferEvent.getSession(),
-                file.getName(), transferEvent.getOwningElement(),
+                getUrlPostfix(), transferEvent.getOwningElement(),
                 file.length());
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/FileDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/FileDownloadHandler.java
@@ -21,6 +21,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
+import java.util.Optional;
 
 import com.vaadin.flow.server.HttpStatusCode;
 import com.vaadin.flow.server.VaadinResponse;
@@ -66,6 +67,10 @@ public class FileDownloadHandler
         VaadinResponse response = downloadEvent.getResponse();
         try (OutputStream outputStream = downloadEvent.getOutputStream();
                 FileInputStream inputStream = new FileInputStream(file)) {
+            downloadEvent.setFileName(file.getName());
+            downloadEvent
+                    .setContentType(getContentType(file.getName(), response));
+            downloadEvent.setContentLength(file.length());
             TransferProgressListener.transfer(inputStream, outputStream,
                     getTransferContext(downloadEvent), getListeners());
         } catch (IOException ioe) {
@@ -74,8 +79,6 @@ public class FileDownloadHandler
             notifyError(downloadEvent, ioe);
             throw new UncheckedIOException(ioe);
         }
-        response.setContentType(downloadEvent.getContentType());
-        response.setContentLength(Math.toIntExact(file.length()));
     }
 
     @Override
@@ -89,8 +92,8 @@ public class FileDownloadHandler
     @Override
     protected TransferContext getTransferContext(DownloadEvent transferEvent) {
         return new TransferContext(transferEvent.getRequest(),
-                transferEvent.getResponse(), transferEvent.session(),
-                transferEvent.fileName(), transferEvent.owningElement(),
+                transferEvent.getResponse(), transferEvent.getSession(),
+                file.getName(), transferEvent.getOwningElement(),
                 file.length());
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/InputStreamDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/InputStreamDownloadHandler.java
@@ -70,17 +70,17 @@ public class InputStreamDownloadHandler
 
     @Override
     public void handleDownloadRequest(DownloadEvent downloadEvent) {
-        String resourceName = getUrlPostfix();
-        downloadEvent.setContentType(
-                getContentType(resourceName, downloadEvent.getResponse()));
-        if (!isInline()) {
-            downloadEvent.setFileName(resourceName);
-        }
         DownloadResponse download = handler.apply(downloadEvent);
         VaadinResponse response = downloadEvent.getResponse();
         if (download.hasError()) {
             response.setStatus(download.getError());
             return;
+        }
+
+        String downloadName = download.getFileName();
+        downloadEvent.setContentType(getContentType(downloadName, response));
+        if (!isInline()) {
+            downloadEvent.setFileName(downloadName);
         }
 
         try (OutputStream outputStream = downloadEvent.getOutputStream();

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/InputStreamDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/InputStreamDownloadHandler.java
@@ -49,8 +49,11 @@ public class InputStreamDownloadHandler
     }
 
     /**
-     * Create a input stream download handler for given event -> response
+     * Create an input stream download handler for given event -> response
      * function.
+     * <p>
+     * The downloaded file name and download URL postfix will be set to
+     * <code>name</code>.
      *
      * @param handler
      *            serializable function for handling download
@@ -67,8 +70,12 @@ public class InputStreamDownloadHandler
 
     @Override
     public void handleDownloadRequest(DownloadEvent downloadEvent) {
+        String resourceName = getUrlPostfix();
         downloadEvent.setContentType(
-                getContentType(name, downloadEvent.getResponse()));
+                getContentType(resourceName, downloadEvent.getResponse()));
+        if (isAttachment()) {
+            downloadEvent.setFileName(resourceName);
+        }
         DownloadResponse download = handler.apply(downloadEvent);
         VaadinResponse response = downloadEvent.getResponse();
         if (download.hasError()) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/InputStreamDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/InputStreamDownloadHandler.java
@@ -73,7 +73,7 @@ public class InputStreamDownloadHandler
         String resourceName = getUrlPostfix();
         downloadEvent.setContentType(
                 getContentType(resourceName, downloadEvent.getResponse()));
-        if (isAttachment()) {
+        if (!isInline()) {
             downloadEvent.setFileName(resourceName);
         }
         DownloadResponse download = handler.apply(downloadEvent);

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/InputStreamDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/InputStreamDownloadHandler.java
@@ -67,6 +67,8 @@ public class InputStreamDownloadHandler
 
     @Override
     public void handleDownloadRequest(DownloadEvent downloadEvent) {
+        downloadEvent.setContentType(
+                getContentType(name, downloadEvent.getResponse()));
         DownloadResponse download = handler.apply(downloadEvent);
         VaadinResponse response = downloadEvent.getResponse();
         if (download.hasError()) {
@@ -84,11 +86,6 @@ public class InputStreamDownloadHandler
             notifyError(downloadEvent, ioe);
             throw new UncheckedIOException(ioe);
         }
-
-        response.setContentType(download.getContentType());
-        response.setContentLength(download.getSize());
-        response.setHeader("Content-Disposition",
-                "attachment;filename=" + download.getFileName());
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandler.java
@@ -42,7 +42,11 @@ public class ServletResourceDownloadHandler
 
     /**
      * Create download handler for servlet resource. Uses url postfix as file
-     * name from path
+     * name from path.
+     * <p>
+     * The downloaded file name and download URL postfix will be set to the file
+     * name from <code>path</code>. If you want to use a different file name,
+     * use {@link #ServletResourceDownloadHandler(String, String)} instead.
      *
      * @param path
      *            path of servlet resource
@@ -53,6 +57,9 @@ public class ServletResourceDownloadHandler
 
     /**
      * Create download handler for servlet resource.
+     * <p>
+     * The downloaded file name and download URL postfix will be set to
+     * <code>name</code>.
      *
      * @param path
      *            path of servlet resource
@@ -75,7 +82,9 @@ public class ServletResourceDownloadHandler
                 String resourceName = getUrlPostfix();
                 downloadEvent
                         .setContentType(getContentType(resourceName, response));
-                downloadEvent.setFileName(resourceName);
+                if (isAttachment()) {
+                    downloadEvent.setFileName(resourceName);
+                }
                 TransferProgressListener.transfer(inputStream, outputStream,
                         getTransferContext(downloadEvent), getListeners());
             } catch (IOException ioe) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandler.java
@@ -82,7 +82,7 @@ public class ServletResourceDownloadHandler
                 String resourceName = getUrlPostfix();
                 downloadEvent
                         .setContentType(getContentType(resourceName, response));
-                if (isAttachment()) {
+                if (!isInline()) {
                     downloadEvent.setFileName(resourceName);
                 }
                 TransferProgressListener.transfer(inputStream, outputStream,

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/AbstractDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/AbstractDownloadHandlerTest.java
@@ -79,8 +79,7 @@ public class AbstractDownloadHandlerTest {
                 .thenReturn(Optional.of(componentOwner));
         Mockito.when(componentOwner.getUI()).thenReturn(Optional.of(ui));
 
-        downloadEvent = new DownloadEvent(request, response, session,
-                "download", "application/octet-stream", owner);
+        downloadEvent = new DownloadEvent(request, response, session, owner);
 
         handler = new AbstractDownloadHandler<>() {
             @Override

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/AbstractDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/AbstractDownloadHandlerTest.java
@@ -209,4 +209,15 @@ public class AbstractDownloadHandlerTest {
         customHandler.handleDownloadRequest(downloadEvent);
         Assert.assertFalse(successAtomic.get());
     }
+
+    @Test
+    public void inline_attachmentUsedByDefault() {
+        Assert.assertFalse(handler.isInline());
+    }
+
+    @Test
+    public void inline_inlinedWhenExplicitlyCalled() {
+        handler.inline();
+        Assert.assertTrue(handler.isInline());
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/ClassDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/ClassDownloadHandlerTest.java
@@ -35,6 +35,7 @@ import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.server.Command;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
+import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
 
 public class ClassDownloadHandlerTest {
@@ -43,6 +44,7 @@ public class ClassDownloadHandlerTest {
     private VaadinRequest request;
     private VaadinResponse response;
     private VaadinSession session;
+    private VaadinService service;
     private DownloadEvent downloadEvent;
     private OutputStream outputStream;
     private Element owner;
@@ -52,6 +54,7 @@ public class ClassDownloadHandlerTest {
         request = Mockito.mock(VaadinRequest.class);
         response = Mockito.mock(VaadinResponse.class);
         session = Mockito.mock(VaadinSession.class);
+        service = Mockito.mock(VaadinService.class);
 
         UI ui = Mockito.mock(UI.class);
         // run the command immediately
@@ -70,6 +73,9 @@ public class ClassDownloadHandlerTest {
         downloadEvent = new DownloadEvent(request, response, session, owner);
         outputStream = new ByteArrayOutputStream();
         Mockito.when(response.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(response.getService()).thenReturn(service);
+        Mockito.when(service.getMimeType(Mockito.anyString()))
+                .thenReturn("application/octet-stream");
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/ClassDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/ClassDownloadHandlerTest.java
@@ -67,8 +67,7 @@ public class ClassDownloadHandlerTest {
                 .thenReturn(Optional.of(componentOwner));
         Mockito.when(componentOwner.getUI()).thenReturn(Optional.of(ui));
 
-        downloadEvent = new DownloadEvent(request, response, session,
-                "download", "application/octet-stream", owner);
+        downloadEvent = new DownloadEvent(request, response, session, owner);
         outputStream = new ByteArrayOutputStream();
         Mockito.when(response.getOutputStream()).thenReturn(outputStream);
     }
@@ -131,7 +130,7 @@ public class ClassDownloadHandlerTest {
         DownloadEvent event = Mockito.mock(DownloadEvent.class);
         Mockito.when(event.getSession()).thenReturn(session);
         Mockito.when(event.getResponse()).thenReturn(response);
-        Mockito.when(event.owningElement()).thenReturn(owner);
+        Mockito.when(event.getOwningElement()).thenReturn(owner);
         OutputStream outputStreamMock = Mockito.mock(OutputStream.class);
         Mockito.doThrow(new IOException("I/O exception")).when(outputStreamMock)
                 .write(Mockito.any(byte[].class), Mockito.anyInt(),

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/ClassDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/ClassDownloadHandlerTest.java
@@ -179,4 +179,46 @@ public class ClassDownloadHandlerTest {
         }
         Assert.assertEquals(List.of("onStart", "onError"), invocations);
     }
+
+    @Test
+    public void inline_setFileNameInvokedByDefault() throws IOException {
+        DownloadHandler handler = DownloadHandler.forClassResource(
+                this.getClass(), PATH_TO_FILE, "my-download.pdf");
+
+        DownloadEvent event = Mockito.mock(DownloadEvent.class);
+        Mockito.when(event.getSession()).thenReturn(session);
+        Mockito.when(event.getResponse()).thenReturn(response);
+        Mockito.when(event.getOwningElement()).thenReturn(owner);
+        Mockito.when(event.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(response.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(response.getService()).thenReturn(service);
+        Mockito.when(service.getMimeType(Mockito.anyString()))
+                .thenReturn("application/pdf");
+
+        handler.handleDownloadRequest(event);
+
+        Mockito.verify(event).setFileName("my-download.pdf");
+        Mockito.verify(event).setContentType("application/pdf");
+    }
+
+    @Test
+    public void attachment_doesNotSetFileNameWhenInlined() throws IOException {
+        DownloadHandler handler = DownloadHandler.forClassResource(
+                this.getClass(), PATH_TO_FILE, "my-download.pdf").inline();
+
+        DownloadEvent event = Mockito.mock(DownloadEvent.class);
+        Mockito.when(event.getSession()).thenReturn(session);
+        Mockito.when(event.getResponse()).thenReturn(response);
+        Mockito.when(event.getOwningElement()).thenReturn(owner);
+        Mockito.when(event.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(response.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(response.getService()).thenReturn(service);
+        Mockito.when(service.getMimeType(Mockito.anyString()))
+                .thenReturn("application/pdf");
+
+        handler.handleDownloadRequest(event);
+
+        Mockito.verify(event, Mockito.times(0)).setFileName("my-download.pdf");
+        Mockito.verify(event).setContentType("application/pdf");
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/DownloadEventTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/DownloadEventTest.java
@@ -1,0 +1,60 @@
+package com.vaadin.flow.server.streams;
+
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinResponse;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
+
+import static org.junit.Assert.*;
+
+public class DownloadEventTest {
+    private VaadinRequest request;
+    private VaadinResponse response;
+    private VaadinSession session;
+    private VaadinService service;
+
+    @Before
+    public void setUp() throws IOException {
+        request = Mockito.mock(VaadinRequest.class);
+        response = Mockito.mock(VaadinResponse.class);
+        session = Mockito.mock(VaadinSession.class);
+        service = Mockito.mock(VaadinService.class);
+    }
+
+    @Test
+    public void setFileName_setsContentDispositionToResponse() {
+        DownloadEvent downloadEvent = new DownloadEvent(request, response,
+                session, null);
+        String fileName = "test.txt";
+        downloadEvent.setFileName(fileName);
+
+        Mockito.verify(response).setHeader("Content-Disposition",
+                "attachment; filename=\"" + fileName + "\"");
+    }
+
+    @Test
+    public void setContentType_setsContentTypeToResponse() {
+        DownloadEvent downloadEvent = new DownloadEvent(request, response,
+                session, null);
+        String contentType = "application/pdf";
+        downloadEvent.setContentType(contentType);
+
+        Mockito.verify(response).setContentType(contentType);
+    }
+
+    @Test
+    public void setContentLenght_setsContentLengthToResponse() {
+        DownloadEvent downloadEvent = new DownloadEvent(request, response,
+                session, null);
+        int contentLength = 1024;
+        downloadEvent.setContentLength(contentLength);
+
+        Mockito.verify(response).setContentLengthLong(contentLength);
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/DownloadEventTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/DownloadEventTest.java
@@ -28,14 +28,30 @@ public class DownloadEventTest {
     }
 
     @Test
-    public void setFileName_setsContentDispositionToResponse() {
+    public void setFileName_nonEmptyFileName_setsContentDispositionFilenameQuotedToResponse() {
         DownloadEvent downloadEvent = new DownloadEvent(request, response,
                 session, null);
         String fileName = "test.txt";
         downloadEvent.setFileName(fileName);
-
         Mockito.verify(response).setHeader("Content-Disposition",
                 "attachment; filename=\"" + fileName + "\"");
+    }
+
+    @Test
+    public void setFileName_emptyFileName_setsContentDispositionToResponse() {
+        DownloadEvent downloadEvent = new DownloadEvent(request, response,
+                session, null);
+        String fileName = "";
+        downloadEvent.setFileName(fileName);
+        Mockito.verify(response).setHeader("Content-Disposition", "attachment");
+    }
+
+    @Test
+    public void setFileName_nullFileName_setsContentDispositionToResponse() {
+        DownloadEvent downloadEvent = new DownloadEvent(request, response,
+                session, null);
+        downloadEvent.setFileName(null);
+        Mockito.verify(response).setHeader("Content-Disposition", "attachment");
     }
 
     @Test
@@ -44,7 +60,6 @@ public class DownloadEventTest {
                 session, null);
         String contentType = "application/pdf";
         downloadEvent.setContentType(contentType);
-
         Mockito.verify(response).setContentType(contentType);
     }
 
@@ -54,7 +69,6 @@ public class DownloadEventTest {
                 session, null);
         int contentLength = 1024;
         downloadEvent.setContentLength(contentLength);
-
         Mockito.verify(response).setContentLengthLong(contentLength);
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/FileDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/FileDownloadHandlerTest.java
@@ -37,6 +37,7 @@ import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.server.Command;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
+import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
 
 public class FileDownloadHandlerTest {
@@ -46,6 +47,7 @@ public class FileDownloadHandlerTest {
     private VaadinRequest request;
     private VaadinResponse response;
     private VaadinSession session;
+    private VaadinService service;
     private DownloadEvent downloadEvent;
     private OutputStream outputStream;
     private Element owner;
@@ -55,6 +57,7 @@ public class FileDownloadHandlerTest {
         request = Mockito.mock(VaadinRequest.class);
         response = Mockito.mock(VaadinResponse.class);
         session = Mockito.mock(VaadinSession.class);
+        service = Mockito.mock(VaadinService.class);
 
         UI ui = Mockito.mock(UI.class);
         // run the command immediately
@@ -73,6 +76,9 @@ public class FileDownloadHandlerTest {
         downloadEvent = new DownloadEvent(request, response, session, owner);
         outputStream = new ByteArrayOutputStream();
         Mockito.when(response.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(response.getService()).thenReturn(service);
+        Mockito.when(service.getMimeType(Mockito.anyString()))
+                .thenReturn("application/octet-stream");
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/FileDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/FileDownloadHandlerTest.java
@@ -181,4 +181,53 @@ public class FileDownloadHandlerTest {
         Assert.assertEquals(List.of("onError"), invocations);
         Mockito.verify(response).setStatus(500);
     }
+
+    @Test
+    public void inline_setFileNameInvokedByDefault()
+            throws IOException, URISyntaxException {
+        URL resource = getClass().getClassLoader().getResource(PATH_TO_FILE);
+        DownloadHandler handler = DownloadHandler
+                .forFile(new File(resource.toURI()), "my-download.bin");
+
+        DownloadEvent event = Mockito.mock(DownloadEvent.class);
+        Mockito.when(event.getSession()).thenReturn(session);
+        Mockito.when(event.getResponse()).thenReturn(response);
+        Mockito.when(event.getOwningElement()).thenReturn(owner);
+        Mockito.when(event.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(response.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(response.getService()).thenReturn(service);
+        Mockito.when(service.getMimeType(Mockito.anyString()))
+                .thenReturn("application/octet-stream");
+
+        handler.handleDownloadRequest(event);
+
+        Mockito.verify(event).setFileName("my-download.bin");
+        Mockito.verify(event).setContentType("application/octet-stream");
+        Mockito.verify(event).setContentLength(165000);
+    }
+
+    @Test
+    public void attachment_doesNotSetFileNameWhenInlined()
+            throws IOException, URISyntaxException {
+        URL resource = getClass().getClassLoader().getResource(PATH_TO_FILE);
+        DownloadHandler handler = DownloadHandler
+                .forFile(new File(resource.toURI()), "my-download.bin")
+                .inline();
+
+        DownloadEvent event = Mockito.mock(DownloadEvent.class);
+        Mockito.when(event.getSession()).thenReturn(session);
+        Mockito.when(event.getResponse()).thenReturn(response);
+        Mockito.when(event.getOwningElement()).thenReturn(owner);
+        Mockito.when(event.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(response.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(response.getService()).thenReturn(service);
+        Mockito.when(service.getMimeType(Mockito.anyString()))
+                .thenReturn("application/octet-stream");
+
+        handler.handleDownloadRequest(event);
+
+        Mockito.verify(event, Mockito.times(0)).setFileName("my-download.bin");
+        Mockito.verify(event).setContentType("application/octet-stream");
+        Mockito.verify(event).setContentLength(165000);
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/FileDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/FileDownloadHandlerTest.java
@@ -70,8 +70,7 @@ public class FileDownloadHandlerTest {
                 .thenReturn(Optional.of(componentOwner));
         Mockito.when(componentOwner.getUI()).thenReturn(Optional.of(ui));
 
-        downloadEvent = new DownloadEvent(request, response, session,
-                "download", "application/octet-stream", owner);
+        downloadEvent = new DownloadEvent(request, response, session, owner);
         outputStream = new ByteArrayOutputStream();
         Mockito.when(response.getOutputStream()).thenReturn(outputStream);
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/InputStreamDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/InputStreamDownloadHandlerTest.java
@@ -36,12 +36,14 @@ import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.server.Command;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
+import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
 
 public class InputStreamDownloadHandlerTest {
     private VaadinRequest request;
     private VaadinResponse response;
     private VaadinSession session;
+    private VaadinService service;
     private DownloadEvent downloadEvent;
     private OutputStream outputStream;
     private Element owner;
@@ -51,6 +53,7 @@ public class InputStreamDownloadHandlerTest {
         request = Mockito.mock(VaadinRequest.class);
         response = Mockito.mock(VaadinResponse.class);
         session = Mockito.mock(VaadinSession.class);
+        service = Mockito.mock(VaadinService.class);
 
         UI ui = Mockito.mock(UI.class);
         // run the command immediately
@@ -69,6 +72,9 @@ public class InputStreamDownloadHandlerTest {
         downloadEvent = new DownloadEvent(request, response, session, owner);
         outputStream = new ByteArrayOutputStream();
         Mockito.when(response.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(response.getService()).thenReturn(service);
+        Mockito.when(service.getMimeType(Mockito.anyString()))
+                .thenReturn("application/octet-stream");
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/InputStreamDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/InputStreamDownloadHandlerTest.java
@@ -66,8 +66,7 @@ public class InputStreamDownloadHandlerTest {
                 .thenReturn(Optional.of(componentOwner));
         Mockito.when(componentOwner.getUI()).thenReturn(Optional.of(ui));
 
-        downloadEvent = new DownloadEvent(request, response, session,
-                "download", "application/octet-stream", owner);
+        downloadEvent = new DownloadEvent(request, response, session, owner);
         outputStream = new ByteArrayOutputStream();
         Mockito.when(response.getOutputStream()).thenReturn(outputStream);
     }
@@ -132,7 +131,7 @@ public class InputStreamDownloadHandlerTest {
         DownloadEvent event = Mockito.mock(DownloadEvent.class);
         Mockito.when(event.getSession()).thenReturn(session);
         Mockito.when(event.getResponse()).thenReturn(response);
-        Mockito.when(event.owningElement()).thenReturn(owner);
+        Mockito.when(event.getOwningElement()).thenReturn(owner);
         OutputStream outputStreamMock = Mockito.mock(OutputStream.class);
         Mockito.doThrow(new IOException("I/O exception")).when(outputStreamMock)
                 .write(Mockito.any(byte[].class), Mockito.anyInt(),

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/InputStreamDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/InputStreamDownloadHandlerTest.java
@@ -24,6 +24,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -185,14 +186,18 @@ public class InputStreamDownloadHandlerTest {
 
     @Test
     public void inline_setFileNameInvokedByDefault() throws IOException {
+        DownloadEvent event = Mockito.mock(DownloadEvent.class);
         DownloadHandler handler = DownloadHandler.fromInputStream(request -> {
+            Mockito.verify(event, Mockito.times(0))
+                    .setFileName("my-download.bin");
+            Mockito.verify(event, Mockito.times(0))
+                    .setContentType("application/octet-stream");
             byte[] data = getBytes();
             ByteArrayInputStream inputStream = new ByteArrayInputStream(data);
-            return new DownloadResponse(inputStream, "download",
+            return new DownloadResponse(inputStream, "my-download.bin",
                     "application/octet-stream", data.length);
-        }, "my-download.bin");
+        });
 
-        DownloadEvent event = Mockito.mock(DownloadEvent.class);
         Mockito.when(event.getSession()).thenReturn(session);
         Mockito.when(event.getRequest()).thenReturn(request);
         Mockito.when(event.getResponse()).thenReturn(response);

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/InputStreamDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/InputStreamDownloadHandlerTest.java
@@ -183,6 +183,58 @@ public class InputStreamDownloadHandlerTest {
         Assert.assertEquals(List.of("onStart", "onError"), invocations);
     }
 
+    @Test
+    public void inline_setFileNameInvokedByDefault() throws IOException {
+        DownloadHandler handler = DownloadHandler.fromInputStream(request -> {
+            byte[] data = getBytes();
+            ByteArrayInputStream inputStream = new ByteArrayInputStream(data);
+            return new DownloadResponse(inputStream, "download",
+                    "application/octet-stream", data.length);
+        }, "my-download.bin");
+
+        DownloadEvent event = Mockito.mock(DownloadEvent.class);
+        Mockito.when(event.getSession()).thenReturn(session);
+        Mockito.when(event.getRequest()).thenReturn(request);
+        Mockito.when(event.getResponse()).thenReturn(response);
+        Mockito.when(event.getOwningElement()).thenReturn(owner);
+        Mockito.when(event.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(response.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(response.getService()).thenReturn(service);
+        Mockito.when(service.getMimeType(Mockito.anyString()))
+                .thenReturn("application/octet-stream");
+
+        handler.handleDownloadRequest(event);
+
+        Mockito.verify(event).setFileName("my-download.bin");
+        Mockito.verify(event).setContentType("application/octet-stream");
+    }
+
+    @Test
+    public void attachment_doesNotSetFileNameWhenInlined() throws IOException {
+        DownloadHandler handler = DownloadHandler.fromInputStream(request -> {
+            byte[] data = getBytes();
+            ByteArrayInputStream inputStream = new ByteArrayInputStream(data);
+            return new DownloadResponse(inputStream, "download",
+                    "application/octet-stream", data.length);
+        }, "my-download.bin").inline();
+
+        DownloadEvent event = Mockito.mock(DownloadEvent.class);
+        Mockito.when(event.getSession()).thenReturn(session);
+        Mockito.when(event.getRequest()).thenReturn(request);
+        Mockito.when(event.getResponse()).thenReturn(response);
+        Mockito.when(event.getOwningElement()).thenReturn(owner);
+        Mockito.when(event.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(response.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(response.getService()).thenReturn(service);
+        Mockito.when(service.getMimeType(Mockito.anyString()))
+                .thenReturn("application/octet-stream");
+
+        handler.handleDownloadRequest(event);
+
+        Mockito.verify(event, Mockito.times(0)).setFileName("my-download.bin");
+        Mockito.verify(event).setContentType("application/octet-stream");
+    }
+
     private static byte[] getBytes() {
         // Simulate a download of 165000 bytes
         byte[] data = new byte[165000];

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandlerTest.java
@@ -83,8 +83,7 @@ public class ServletResourceDownloadHandlerTest {
                 .thenReturn(Optional.of(componentOwner));
         Mockito.when(componentOwner.getUI()).thenReturn(Optional.of(ui));
 
-        downloadEvent = new DownloadEvent(request, response, session,
-                "download", "application/octet-stream", owner);
+        downloadEvent = new DownloadEvent(request, response, session, owner);
         outputStream = new ByteArrayOutputStream();
         Mockito.when(response.getOutputStream()).thenReturn(outputStream);
     }
@@ -147,7 +146,7 @@ public class ServletResourceDownloadHandlerTest {
         Mockito.when(downloadEvent.getRequest()).thenReturn(request);
         Mockito.when(downloadEvent.getSession()).thenReturn(session);
         Mockito.when(downloadEvent.getResponse()).thenReturn(response);
-        Mockito.when(downloadEvent.owningElement()).thenReturn(owner);
+        Mockito.when(downloadEvent.getOwningElement()).thenReturn(owner);
         OutputStream outputStreamMock = Mockito.mock(OutputStream.class);
         Mockito.doThrow(new IOException("I/O exception")).when(outputStreamMock)
                 .write(Mockito.any(byte[].class), Mockito.anyInt(),

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandlerTest.java
@@ -37,6 +37,7 @@ import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.server.Command;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
+import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServlet;
 import com.vaadin.flow.server.VaadinServletService;
 import com.vaadin.flow.server.VaadinSession;
@@ -47,6 +48,7 @@ public class ServletResourceDownloadHandlerTest {
     private VaadinRequest request;
     private VaadinResponse response;
     private VaadinSession session;
+    private VaadinService service;
     private DownloadEvent downloadEvent;
     private OutputStream outputStream;
     private Element owner;
@@ -56,6 +58,7 @@ public class ServletResourceDownloadHandlerTest {
         request = Mockito.mock(VaadinRequest.class);
         response = Mockito.mock(VaadinResponse.class);
         session = Mockito.mock(VaadinSession.class);
+        service = Mockito.mock(VaadinService.class);
         ServletContext servletContext = Mockito.mock(ServletContext.class);
         VaadinServlet vaadinServlet = Mockito.mock(VaadinServlet.class);
         VaadinServletService vaadinService = Mockito
@@ -86,6 +89,9 @@ public class ServletResourceDownloadHandlerTest {
         downloadEvent = new DownloadEvent(request, response, session, owner);
         outputStream = new ByteArrayOutputStream();
         Mockito.when(response.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(response.getService()).thenReturn(service);
+        Mockito.when(service.getMimeType(Mockito.anyString()))
+                .thenReturn("application/octet-stream");
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandlerTest.java
@@ -195,4 +195,48 @@ public class ServletResourceDownloadHandlerTest {
         }
         Assert.assertEquals(List.of("onStart", "onError"), invocations);
     }
+
+    @Test
+    public void inline_setFileNameInvokedByDefault() throws IOException {
+        DownloadHandler handler = DownloadHandler
+                .forServletResource(PATH_TO_FILE, "my-download.bin");
+
+        DownloadEvent event = Mockito.mock(DownloadEvent.class);
+        Mockito.when(event.getSession()).thenReturn(session);
+        Mockito.when(event.getRequest()).thenReturn(request);
+        Mockito.when(event.getResponse()).thenReturn(response);
+        Mockito.when(event.getOwningElement()).thenReturn(owner);
+        Mockito.when(event.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(response.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(response.getService()).thenReturn(service);
+        Mockito.when(service.getMimeType(Mockito.anyString()))
+                .thenReturn("application/octet-stream");
+
+        handler.handleDownloadRequest(event);
+
+        Mockito.verify(event).setFileName("my-download.bin");
+        Mockito.verify(event).setContentType("application/octet-stream");
+    }
+
+    @Test
+    public void attachment_doesNotSetFileNameWhenInlined() throws IOException {
+        DownloadHandler handler = DownloadHandler
+                .forServletResource(PATH_TO_FILE, "my-download.bin").inline();
+
+        DownloadEvent event = Mockito.mock(DownloadEvent.class);
+        Mockito.when(event.getSession()).thenReturn(session);
+        Mockito.when(event.getRequest()).thenReturn(request);
+        Mockito.when(event.getResponse()).thenReturn(response);
+        Mockito.when(event.getOwningElement()).thenReturn(owner);
+        Mockito.when(event.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(response.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(response.getService()).thenReturn(service);
+        Mockito.when(service.getMimeType(Mockito.anyString()))
+                .thenReturn("application/octet-stream");
+
+        handler.handleDownloadRequest(event);
+
+        Mockito.verify(event, Mockito.times(0)).setFileName("my-download.bin");
+        Mockito.verify(event).setContentType("application/octet-stream");
+    }
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DownloadHandlerView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DownloadHandlerView.java
@@ -64,7 +64,7 @@ public class DownloadHandlerView extends Div {
         File jsonFile = new File(getClass().getClassLoader()
                 .getResource("download.json").getFile());
         streamRegistration = VaadinSession.getCurrent().getResourceRegistry()
-                .registerResource(DownloadHandler.forFile(jsonFile));
+                .registerResource(DownloadHandler.forFile(jsonFile).inline());
         registrations.add(streamRegistration);
 
         Anchor fileDownload = new Anchor("", "File DownloadHandler shorthand");
@@ -73,7 +73,8 @@ public class DownloadHandlerView extends Div {
 
         streamRegistration = VaadinSession.getCurrent().getResourceRegistry()
                 .registerResource(DownloadHandler
-                        .forClassResource(this.getClass(), "class-file.json"));
+                        .forClassResource(this.getClass(), "class-file.json")
+                        .inline());
         registrations.add(streamRegistration);
 
         Anchor classDownload = new Anchor("",
@@ -83,7 +84,7 @@ public class DownloadHandlerView extends Div {
 
         streamRegistration = VaadinSession.getCurrent().getResourceRegistry()
                 .registerResource(DownloadHandler
-                        .forServletResource("/WEB-INF/servlet.json"));
+                        .forServletResource("/WEB-INF/servlet.json").inline());
         registrations.add(streamRegistration);
 
         Anchor servletDownload = new Anchor("",
@@ -96,7 +97,8 @@ public class DownloadHandlerView extends Div {
                         new ByteArrayInputStream(
                                 "foo".getBytes(StandardCharsets.UTF_8)),
                         "file+.jpg", "text/plain",
-                        "foo".getBytes(StandardCharsets.UTF_8).length));
+                        "foo".getBytes(StandardCharsets.UTF_8).length))
+                .inline();
         streamRegistration = VaadinSession.getCurrent().getResourceRegistry()
                 .registerResource(inputStream);
         registrations.add(streamRegistration);
@@ -109,7 +111,8 @@ public class DownloadHandlerView extends Div {
         streamRegistration = VaadinSession.getCurrent().getResourceRegistry()
                 .registerResource(DownloadHandler
                         .fromInputStream(downloadEvent -> DownloadResponse
-                                .error(HttpStatusCode.INTERNAL_SERVER_ERROR)));
+                                .error(HttpStatusCode.INTERNAL_SERVER_ERROR))
+                        .inline());
         registrations.add(streamRegistration);
 
         Anchor inputStreamErrorDownload = new Anchor("",


### PR DESCRIPTION
Refactors the `DownloadEvent` to be a normal class.
Removed the getters for file name, type and size and add setters instead that are basically helper methods for setting various attributes to a response.
Adds inline method so that you can call `DownloadHandler.forFile(new File("path/to/file")).inline()` and the download will be inlined onto page.