### PR TITLE
fix: Add IOException to handlers signature

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/AbstractFileUploadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/AbstractFileUploadHandler.java
@@ -55,7 +55,7 @@ public abstract class AbstractFileUploadHandler<R extends AbstractFileUploadHand
     }
 
     @Override
-    public void handleUploadRequest(UploadEvent event) {
+    public void handleUploadRequest(UploadEvent event) throws IOException {
         File file;
         try {
             file = fileFactory.createFile(event.getFileName());
@@ -67,7 +67,7 @@ public abstract class AbstractFileUploadHandler<R extends AbstractFileUploadHand
             }
         } catch (IOException e) {
             notifyError(event, e);
-            throw new UncheckedIOException(e);
+            throw e;
         }
         successHandler.accept(new UploadMetadata(event.getFileName(),
                 event.getContentType(), event.getFileSize()), file);

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/ClassDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/ClassDownloadHandler.java
@@ -79,7 +79,8 @@ public class ClassDownloadHandler
     }
 
     @Override
-    public void handleDownloadRequest(DownloadEvent downloadEvent) {
+    public void handleDownloadRequest(DownloadEvent downloadEvent)
+            throws IOException {
         if (clazz.getResource(resourceName) == null) {
             LoggerFactory.getLogger(ClassDownloadHandler.class)
                     .warn("No resource found for '{}'", resourceName);
@@ -97,7 +98,7 @@ public class ClassDownloadHandler
             downloadEvent.getResponse()
                     .setStatus(HttpStatusCode.INTERNAL_SERVER_ERROR.getCode());
             notifyError(downloadEvent, ioe);
-            throw new UncheckedIOException(ioe);
+            throw ioe;
         }
 
         downloadEvent.getResponse()

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadHandler.java
@@ -17,6 +17,7 @@
 package com.vaadin.flow.server.streams;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Optional;
 
 import com.vaadin.flow.dom.Element;
@@ -40,11 +41,13 @@ public interface DownloadHandler extends ElementRequestHandler {
      * @param event
      *            download event containing the necessary data for writing the
      *            response
+     * @throws IOException
+     *             if an IO error occurred during download
      */
-    void handleDownloadRequest(DownloadEvent event);
+    void handleDownloadRequest(DownloadEvent event) throws IOException;
 
     default void handleRequest(VaadinRequest request, VaadinResponse response,
-            VaadinSession session, Element owner) {
+            VaadinSession session, Element owner) throws IOException {
         String fileName = getUrlPostfix() == null ? "" : getUrlPostfix();
 
         DownloadEvent downloadEvent = new DownloadEvent(request, response,

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/ElementRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/ElementRequestHandler.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.server.streams;
 
+import java.io.IOException;
 import java.io.Serializable;
 
 import com.vaadin.flow.dom.DisabledUpdateMode;
@@ -47,9 +48,11 @@ public interface ElementRequestHandler extends Serializable {
      *            VaadinSession current VaadinSession
      * @param owner
      *            Element owner element
+     * @throws IOException
+     *             if an IO error occurred during data transfer
      */
     void handleRequest(VaadinRequest request, VaadinResponse response,
-            VaadinSession session, Element owner);
+            VaadinSession session, Element owner) throws IOException;
 
     /**
      * Optional URL postfix allows appending an application-controlled string,

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/FileDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/FileDownloadHandler.java
@@ -62,7 +62,8 @@ public class FileDownloadHandler
     }
 
     @Override
-    public void handleDownloadRequest(DownloadEvent downloadEvent) {
+    public void handleDownloadRequest(DownloadEvent downloadEvent)
+            throws IOException {
         VaadinResponse response = downloadEvent.getResponse();
         try (OutputStream outputStream = downloadEvent.getOutputStream();
                 FileInputStream inputStream = new FileInputStream(file)) {
@@ -72,7 +73,7 @@ public class FileDownloadHandler
             // Set status before output is closed (see #8740)
             response.setStatus(HttpStatusCode.INTERNAL_SERVER_ERROR.getCode());
             notifyError(downloadEvent, ioe);
-            throw new UncheckedIOException(ioe);
+            throw ioe;
         }
         response.setContentType(downloadEvent.getContentType());
         response.setContentLength(Math.toIntExact(file.length()));

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/InMemoryUploadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/InMemoryUploadHandler.java
@@ -40,7 +40,7 @@ public class InMemoryUploadHandler
     }
 
     @Override
-    public void handleUploadRequest(UploadEvent event) {
+    public void handleUploadRequest(UploadEvent event) throws IOException {
         byte[] data;
         try {
             try (InputStream inputStream = event.getInputStream();
@@ -51,7 +51,7 @@ public class InMemoryUploadHandler
             }
         } catch (IOException e) {
             notifyError(event, e);
-            throw new UncheckedIOException(e);
+            throw e;
         }
         successHandler.accept(new UploadMetadata(event.getFileName(),
                 event.getContentType(), event.getFileSize()), data);

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/InputStreamDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/InputStreamDownloadHandler.java
@@ -66,7 +66,8 @@ public class InputStreamDownloadHandler
     }
 
     @Override
-    public void handleDownloadRequest(DownloadEvent downloadEvent) {
+    public void handleDownloadRequest(DownloadEvent downloadEvent)
+            throws IOException {
         DownloadResponse download = handler.apply(downloadEvent);
         VaadinResponse response = downloadEvent.getResponse();
         if (download.hasError()) {
@@ -82,7 +83,7 @@ public class InputStreamDownloadHandler
             // Set status before output is closed (see #8740)
             response.setStatus(HttpStatusCode.INTERNAL_SERVER_ERROR.getCode());
             notifyError(downloadEvent, ioe);
-            throw new UncheckedIOException(ioe);
+            throw ioe;
         }
 
         response.setContentType(download.getContentType());

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandler.java
@@ -64,7 +64,8 @@ public class ServletResourceDownloadHandler
     }
 
     @Override
-    public void handleDownloadRequest(DownloadEvent downloadEvent) {
+    public void handleDownloadRequest(DownloadEvent downloadEvent)
+            throws IOException {
         VaadinService service = downloadEvent.getRequest().getService();
         if (service instanceof VaadinServletService servletService) {
             try (OutputStream outputStream = downloadEvent.getOutputStream();
@@ -77,7 +78,7 @@ public class ServletResourceDownloadHandler
                 downloadEvent.getResponse().setStatus(
                         HttpStatusCode.INTERNAL_SERVER_ERROR.getCode());
                 notifyError(downloadEvent, ioe);
-                throw new UncheckedIOException(ioe);
+                throw ioe;
             }
 
             downloadEvent.getResponse()

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/UploadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/UploadHandler.java
@@ -67,8 +67,10 @@ public interface UploadHandler extends ElementRequestHandler {
      * @param event
      *            upload event containing the necessary data for getting the
      *            request
+     * @throws IOException
+     *             if an error occurs during upload
      */
-    void handleUploadRequest(UploadEvent event);
+    void handleUploadRequest(UploadEvent event) throws IOException;
 
     /**
      * Method called by framework when

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/UploadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/UploadHandler.java
@@ -97,7 +97,7 @@ public interface UploadHandler extends ElementRequestHandler {
     }
 
     default void handleRequest(VaadinRequest request, VaadinResponse response,
-            VaadinSession session, Element owner) {
+            VaadinSession session, Element owner) throws IOException {
         boolean isMultipartUpload = request instanceof HttpServletRequest
                 && JakartaServletFileUpload
                         .isMultipartContent((HttpServletRequest) request);

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/UploadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/UploadHandlerTest.java
@@ -114,7 +114,7 @@ public class UploadHandlerTest {
     }
 
     @Test
-    public void doUploadHandleXhrFilePost_happyPath_setContentTypeAndResponseHandled() {
+    public void doUploadHandleXhrFilePost_happyPath_setContentTypeAndResponseHandled() throws IOException {
         UploadHandler handler = (event) -> {
             event.getResponse().setContentType("text/html; charset=utf-8");
         };
@@ -127,7 +127,7 @@ public class UploadHandlerTest {
     }
 
     @Test
-    public void doUploadHandleXhrFilePost_unhappyPath_responseHandled() {
+    public void doUploadHandleXhrFilePost_unhappyPath_responseHandled() throws IOException {
         UploadHandler handler = (event) -> {
             throw new RuntimeException("Exception in xrh upload");
         };

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/UploadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/UploadHandlerTest.java
@@ -1,6 +1,5 @@
 package com.vaadin.flow.server.communication;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -42,7 +41,6 @@ import com.vaadin.flow.server.StreamResourceRegistry;
 import com.vaadin.flow.server.VaadinResponse;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServletRequest;
-import com.vaadin.flow.server.streams.DownloadHandler;
 import com.vaadin.flow.server.streams.FileUploadHandler;
 import com.vaadin.flow.server.streams.InMemoryUploadHandler;
 import com.vaadin.flow.server.streams.TemporaryFileUploadHandler;

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/UploadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/UploadHandlerTest.java
@@ -1,6 +1,8 @@
 package com.vaadin.flow.server.communication;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
@@ -40,6 +42,7 @@ import com.vaadin.flow.server.StreamResourceRegistry;
 import com.vaadin.flow.server.VaadinResponse;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServletRequest;
+import com.vaadin.flow.server.streams.DownloadHandler;
 import com.vaadin.flow.server.streams.FileUploadHandler;
 import com.vaadin.flow.server.streams.InMemoryUploadHandler;
 import com.vaadin.flow.server.streams.TemporaryFileUploadHandler;
@@ -512,6 +515,13 @@ public class UploadHandlerTest {
         handler.handleRequest(session, request, response);
 
         Assert.assertTrue("Handled was not called at the end", handled.get());
+    }
+
+    @Test
+    public void doesNotRequireToCatchIOException() {
+        UploadHandler handler = event -> {
+            new FileInputStream(new File("foo"));
+        };
     }
 
     private Part createPart(InputStream inputStream, String contentType,

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/UploadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/UploadHandlerTest.java
@@ -114,7 +114,8 @@ public class UploadHandlerTest {
     }
 
     @Test
-    public void doUploadHandleXhrFilePost_happyPath_setContentTypeAndResponseHandled() throws IOException {
+    public void doUploadHandleXhrFilePost_happyPath_setContentTypeAndResponseHandled()
+            throws IOException {
         UploadHandler handler = (event) -> {
             event.getResponse().setContentType("text/html; charset=utf-8");
         };
@@ -127,7 +128,8 @@ public class UploadHandlerTest {
     }
 
     @Test
-    public void doUploadHandleXhrFilePost_unhappyPath_responseHandled() throws IOException {
+    public void doUploadHandleXhrFilePost_unhappyPath_responseHandled()
+            throws IOException {
         UploadHandler handler = (event) -> {
             throw new RuntimeException("Exception in xrh upload");
         };

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/AbstractDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/AbstractDownloadHandlerTest.java
@@ -18,6 +18,8 @@ package com.vaadin.flow.server.streams;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
@@ -193,5 +195,12 @@ public class AbstractDownloadHandlerTest {
 
         customHandler.handleDownloadRequest(downloadEvent);
         Assert.assertFalse(successAtomic.get());
+    }
+
+    @Test
+    public void doesNotRequireToCatchIOException() {
+        DownloadHandler handler = event -> {
+            new FileInputStream(new File("foo"));
+        };
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/ClassDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/ClassDownloadHandlerTest.java
@@ -75,7 +75,7 @@ public class ClassDownloadHandlerTest {
 
     @Test
     public void transferProgressListener_addListener_listenersInvoked()
-            throws URISyntaxException {
+            throws URISyntaxException, IOException {
         List<String> invocations = new ArrayList<>();
         List<Long> transferredBytesRecords = new ArrayList<>();
         DownloadHandler handler = DownloadHandler.forClassResource(

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/FileDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/FileDownloadHandlerTest.java
@@ -78,7 +78,7 @@ public class FileDownloadHandlerTest {
 
     @Test
     public void transferProgressListener_addListener_listenersInvoked()
-            throws URISyntaxException {
+            throws URISyntaxException, IOException {
         List<String> invocations = new ArrayList<>();
         List<Long> transferredBytesRecords = new ArrayList<>();
         URL resource = getClass().getClassLoader().getResource(PATH_TO_FILE);

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/InputStreamDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/InputStreamDownloadHandlerTest.java
@@ -74,7 +74,7 @@ public class InputStreamDownloadHandlerTest {
 
     @Test
     public void transferProgressListener_addListener_listenersInvoked()
-            throws URISyntaxException {
+            throws URISyntaxException, IOException {
         List<String> invocations = new ArrayList<>();
         List<Long> transferredBytesRecords = new ArrayList<>();
         DownloadHandler handler = DownloadHandler.fromInputStream(request -> {

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandlerTest.java
@@ -91,7 +91,7 @@ public class ServletResourceDownloadHandlerTest {
 
     @Test
     public void transferProgressListener_addListener_listenersInvoked()
-            throws URISyntaxException {
+            throws URISyntaxException, IOException {
         List<String> invocations = new ArrayList<>();
         List<Long> transferredBytesRecords = new ArrayList<>();
         DownloadHandler handler = DownloadHandler.forServletResource(


### PR DESCRIPTION
This adds the IOException to Download/Upload handlers signature to not require catching the exception in lambda.