### PR TITLE
fix: read PageTitle annotation from application-defined class

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -1097,9 +1097,11 @@ public abstract class AbstractNavigationStateRenderer
 
     private static void updatePageTitle(NavigationEvent navigationEvent,
             Component routeTarget, String route) {
-
+        Instantiator instantiator = navigationEvent.getUI().getSession()
+                .getService().getInstantiator();
         Supplier<String> lookForTitleInTarget = () -> lookForTitleInTarget(
-                routeTarget).map(PageTitle::value).orElse("");
+                instantiator.getApplicationClass(routeTarget))
+                .map(PageTitle::value).orElse("");
 
         // check for HasDynamicTitle in current router targets chain
         String title = RouteUtil.getDynamicTitle(navigationEvent.getUI())
@@ -1113,9 +1115,8 @@ public abstract class AbstractNavigationStateRenderer
     }
 
     private static Optional<PageTitle> lookForTitleInTarget(
-            Component routeTarget) {
-        return Optional.ofNullable(
-                routeTarget.getClass().getAnnotation(PageTitle.class));
+            Class<?> routeTarget) {
+        return Optional.ofNullable(routeTarget.getAnnotation(PageTitle.class));
     }
 
     private static boolean isPreserveOnRefreshTarget(


### PR DESCRIPTION
If a route component instance is proxied by a DI framework the PageTitle annotation from the concrete class might not be accessible because it is not inheritable. This change tries to read the annotation from the application-defined class instead of using the route instance class directly.

Fixes vaadin/quarkus#67
