### PR TITLE
fix: Inline download in data html elements

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/HtmlObject.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/HtmlObject.java
@@ -26,6 +26,7 @@ import com.vaadin.flow.component.PropertyDescriptor;
 import com.vaadin.flow.component.PropertyDescriptors;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.server.AbstractStreamResource;
+import com.vaadin.flow.server.streams.AbstractDownloadHandler;
 import com.vaadin.flow.server.streams.DownloadHandler;
 import com.vaadin.flow.server.StreamResource;
 import com.vaadin.flow.server.StreamResourceRegistry;
@@ -294,12 +295,17 @@ public class HtmlObject extends HtmlContainer implements
 
     /**
      * Sets the URL for {@link DownloadHandler} callback as "data" attribute
-     * value .
+     * value.
      *
      * @param data
-     *            a "data" attribute value,, not {@code null}
+     *            a "data" attribute value, not {@code null}
      */
     public void setData(DownloadHandler data) {
+        if (data instanceof AbstractDownloadHandler<?> handler) {
+            // change disposition to inline in pre-defined handlers,
+            // where it is 'attachment' by default
+            handler.inline();
+        }
         getElement().setAttribute("data",
                 new StreamResourceRegistry.ElementStreamResource(data,
                         this.getElement()));

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/HtmlObject.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/HtmlObject.java
@@ -143,6 +143,9 @@ public class HtmlObject extends HtmlContainer implements
      * Creates a new <code>&lt;object&gt;</code> component with given
      * {@link DownloadHandler} callback for providing an object data and type
      * value.
+     * <p>
+     * Sets the <code>Content-Disposition</code> header to <code>inline</code>
+     * for pre-defined download handlers, created by factory methods.
      *
      * @see #setData(DownloadHandler)
      * @see #setType(String)
@@ -160,6 +163,9 @@ public class HtmlObject extends HtmlContainer implements
     /**
      * Creates a new <code>&lt;object&gt;</code> component with given data
      * resource, type value and "param" components.
+     * <p>
+     * Sets the <code>Content-Disposition</code> header to <code>inline</code>
+     * for pre-defined download handlers, created by factory methods.
      *
      * @see #setData(String)
      * @see #setType(String)
@@ -182,6 +188,9 @@ public class HtmlObject extends HtmlContainer implements
     /**
      * Creates a new <code>&lt;object&gt;</code> component with given data
      * resource, type value and "param" components.
+     * <p>
+     * Sets the <code>Content-Disposition</code> header to <code>inline</code>
+     * for pre-defined download handlers, created by factory methods.
      *
      * @see #setData(String)
      * @see #setType(String)
@@ -202,6 +211,9 @@ public class HtmlObject extends HtmlContainer implements
     /**
      * Creates a new <code>&lt;object&gt;</code> component with given data
      * resource, type value and "param" components.
+     * <p>
+     * Sets the <code>Content-Disposition</code> header to <code>inline</code>
+     * for pre-defined download handlers, created by factory methods.
      *
      * @see #setData(String)
      * @see #setType(String)
@@ -293,6 +305,9 @@ public class HtmlObject extends HtmlContainer implements
     /**
      * Sets the URL for {@link DownloadHandler} callback as "data" attribute
      * value.
+     * <p>
+     * Sets the <code>Content-Disposition</code> header to <code>inline</code>
+     * for pre-defined download handlers, created by factory methods.
      *
      * @param data
      *            a "data" attribute value, not {@code null}

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/HtmlObject.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/HtmlObject.java
@@ -145,7 +145,9 @@ public class HtmlObject extends HtmlContainer implements
      * value.
      * <p>
      * Sets the <code>Content-Disposition</code> header to <code>inline</code>
-     * for pre-defined download handlers, created by factory methods.
+     * for pre-defined download handlers, created by factory methods in
+     * {@link DownloadHandler}, as well as for other
+     * {@link AbstractDownloadHandler} implementations.
      *
      * @see #setData(DownloadHandler)
      * @see #setType(String)
@@ -165,7 +167,9 @@ public class HtmlObject extends HtmlContainer implements
      * resource, type value and "param" components.
      * <p>
      * Sets the <code>Content-Disposition</code> header to <code>inline</code>
-     * for pre-defined download handlers, created by factory methods.
+     * for pre-defined download handlers, created by factory methods in
+     * {@link DownloadHandler}, as well as for other
+     * {@link AbstractDownloadHandler} implementations.
      *
      * @see #setData(String)
      * @see #setType(String)
@@ -190,7 +194,9 @@ public class HtmlObject extends HtmlContainer implements
      * resource, type value and "param" components.
      * <p>
      * Sets the <code>Content-Disposition</code> header to <code>inline</code>
-     * for pre-defined download handlers, created by factory methods.
+     * for pre-defined download handlers, created by factory methods in
+     * {@link DownloadHandler}, as well as for other
+     * {@link AbstractDownloadHandler} implementations.
      *
      * @see #setData(String)
      * @see #setType(String)
@@ -213,7 +219,9 @@ public class HtmlObject extends HtmlContainer implements
      * resource, type value and "param" components.
      * <p>
      * Sets the <code>Content-Disposition</code> header to <code>inline</code>
-     * for pre-defined download handlers, created by factory methods.
+     * for pre-defined download handlers, created by factory methods in
+     * {@link DownloadHandler}, as well as for other
+     * {@link AbstractDownloadHandler} implementations.
      *
      * @see #setData(String)
      * @see #setType(String)
@@ -307,7 +315,9 @@ public class HtmlObject extends HtmlContainer implements
      * value.
      * <p>
      * Sets the <code>Content-Disposition</code> header to <code>inline</code>
-     * for pre-defined download handlers, created by factory methods.
+     * for pre-defined download handlers, created by factory methods in
+     * {@link DownloadHandler}, as well as for other
+     * {@link AbstractDownloadHandler} implementations.
      *
      * @param data
      *            a "data" attribute value, not {@code null}

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/HtmlObject.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/HtmlObject.java
@@ -174,8 +174,7 @@ public class HtmlObject extends HtmlContainer implements
      *            parameter components
      */
     public HtmlObject(DownloadHandler data, String type, Param... params) {
-        setData(new StreamResourceRegistry.ElementStreamResource(data,
-                this.getElement()));
+        setData(data);
         setType(type);
         add(params);
     }
@@ -196,8 +195,7 @@ public class HtmlObject extends HtmlContainer implements
      *            parameter components
      */
     public HtmlObject(DownloadHandler data, Param... params) {
-        setData(new StreamResourceRegistry.ElementStreamResource(data,
-                this.getElement()));
+        setData(data);
         add(params);
     }
 
@@ -215,8 +213,7 @@ public class HtmlObject extends HtmlContainer implements
      *            component
      */
     public HtmlObject(DownloadHandler data) {
-        setData(new StreamResourceRegistry.ElementStreamResource(data,
-                this.getElement()));
+        setData(data);
     }
 
     /**

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
@@ -142,7 +142,9 @@ public class IFrame extends HtmlComponent implements HasAriaLabel {
      * resource from server.
      * <p>
      * Sets the <code>Content-Disposition</code> header to <code>inline</code>
-     * for pre-defined download handlers, created by factory methods.
+     * for pre-defined download handlers, created by factory methods in
+     * {@link DownloadHandler}, as well as for other
+     * {@link AbstractDownloadHandler} implementations.
      *
      * @param downloadHandler
      *            the download handler callback that provides a resource from
@@ -184,7 +186,9 @@ public class IFrame extends HtmlComponent implements HasAriaLabel {
      * {@link DownloadHandler} callback.
      * <p>
      * Sets the <code>Content-Disposition</code> header to <code>inline</code>
-     * for pre-defined download handlers, created by factory methods.
+     * for pre-defined download handlers, created by factory methods in
+     * {@link DownloadHandler}, as well as for other
+     * {@link AbstractDownloadHandler} implementations.
      *
      * @see #setSrc(String)
      *

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
@@ -140,6 +140,9 @@ public class IFrame extends HtmlComponent implements HasAriaLabel {
     /**
      * Creates a new iframe with download handler callback that provides a
      * resource from server.
+     * <p>
+     * Sets the <code>Content-Disposition</code> header to <code>inline</code>
+     * for pre-defined download handlers, created by factory methods.
      *
      * @param downloadHandler
      *            the download handler callback that provides a resource from
@@ -179,6 +182,9 @@ public class IFrame extends HtmlComponent implements HasAriaLabel {
     /**
      * Sets the source of the iframe with a source URL with the URL of the given
      * {@link DownloadHandler} callback.
+     * <p>
+     * Sets the <code>Content-Disposition</code> header to <code>inline</code>
+     * for pre-defined download handlers, created by factory methods.
      *
      * @see #setSrc(String)
      *

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
@@ -21,6 +21,7 @@ import com.vaadin.flow.component.PropertyDescriptor;
 import com.vaadin.flow.component.PropertyDescriptors;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.server.AbstractStreamResource;
+import com.vaadin.flow.server.streams.AbstractDownloadHandler;
 import com.vaadin.flow.server.streams.DownloadHandler;
 import com.vaadin.flow.server.StreamResource;
 import com.vaadin.flow.server.StreamResourceRegistry;
@@ -185,6 +186,11 @@ public class IFrame extends HtmlComponent implements HasAriaLabel {
      *            the download handler resource, not null
      */
     public void setSrc(DownloadHandler downloadHandler) {
+        if (downloadHandler instanceof AbstractDownloadHandler<?> handler) {
+            // change disposition to inline in pre-defined handlers,
+            // where it is 'attachment' by default
+            handler.inline();
+        }
         getElement().setAttribute("src",
                 new StreamResourceRegistry.ElementStreamResource(
                         downloadHandler, this.getElement()));

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
@@ -24,6 +24,7 @@ import com.vaadin.flow.component.PropertyDescriptor;
 import com.vaadin.flow.component.PropertyDescriptors;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.server.AbstractStreamResource;
+import com.vaadin.flow.server.streams.AbstractDownloadHandler;
 import com.vaadin.flow.server.streams.DownloadHandler;
 import com.vaadin.flow.server.StreamResource;
 import com.vaadin.flow.server.StreamResourceRegistry;
@@ -149,6 +150,11 @@ public class Image extends HtmlContainer
      *            the download handler resource, not null
      */
     public void setSrc(DownloadHandler downloadHandler) {
+        if (downloadHandler instanceof AbstractDownloadHandler<?> handler) {
+            // change disposition to inline in pre-defined handlers,
+            // where it is 'attachment' by default
+            handler.inline();
+        }
         getElement().setAttribute("src",
                 new StreamResourceRegistry.ElementStreamResource(
                         downloadHandler, this.getElement()));

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
@@ -98,7 +98,9 @@ public class Image extends HtmlContainer
      * default empty string which is not retained with {@link #setAlt(String)}.
      * <p>
      * Sets the <code>Content-Disposition</code> header to <code>inline</code>
-     * for pre-defined download handlers, created by factory methods.
+     * for pre-defined download handlers, created by factory methods in
+     * {@link DownloadHandler}, as well as for other
+     * {@link AbstractDownloadHandler} implementations.
      *
      * @param downloadHandler
      *            the download handler callback that provides an image data, not
@@ -150,7 +152,9 @@ public class Image extends HtmlContainer
      * callback.
      * <p>
      * Sets the <code>Content-Disposition</code> header to <code>inline</code>
-     * for pre-defined download handlers, created by factory methods.
+     * for pre-defined download handlers, created by factory methods in
+     * {@link DownloadHandler}, as well as for other
+     * {@link AbstractDownloadHandler} implementations.
      *
      * @param downloadHandler
      *            the download handler resource, not null

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
@@ -96,6 +96,9 @@ public class Image extends HtmlContainer
      * <p>
      * The alternative text given to constructor is always set even if it is the
      * default empty string which is not retained with {@link #setAlt(String)}.
+     * <p>
+     * Sets the <code>Content-Disposition</code> header to <code>inline</code>
+     * for pre-defined download handlers, created by factory methods.
      *
      * @param downloadHandler
      *            the download handler callback that provides an image data, not
@@ -145,6 +148,9 @@ public class Image extends HtmlContainer
     /**
      * Sets the image URL with the URL of the given {@link DownloadHandler}
      * callback.
+     * <p>
+     * Sets the <code>Content-Disposition</code> header to <code>inline</code>
+     * for pre-defined download handlers, created by factory methods.
      *
      * @param downloadHandler
      *            the download handler resource, not null

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlObjectTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlObjectTest.java
@@ -24,10 +24,14 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.CurrentInstance;
 import com.vaadin.flow.server.StreamResource;
 import com.vaadin.flow.server.StreamResourceRegistry;
 import com.vaadin.flow.server.StreamResourceWriter;
+import com.vaadin.flow.server.streams.DownloadHandler;
+import com.vaadin.flow.server.streams.DownloadResponse;
+import com.vaadin.flow.server.streams.InputStreamDownloadHandler;
 
 public class HtmlObjectTest extends ComponentTest {
 
@@ -101,5 +105,55 @@ public class HtmlObjectTest extends ComponentTest {
         Assert.assertTrue("Data should be set as dynamic resource.",
                 object.getElement().getAttribute("data")
                         .startsWith("VAADIN/dynamic/resource/-1/"));
+    }
+
+    @Test
+    public void downloadHandler_isSetToInline() {
+        Element element = Mockito.mock(Element.class);
+        class TestHtmlObject extends HtmlObject {
+            public TestHtmlObject(DownloadHandler downloadHandler) {
+                super(downloadHandler);
+            }
+
+            public TestHtmlObject(DownloadHandler downloadHandler,
+                    Param... params) {
+                super(downloadHandler, params);
+            }
+
+            public TestHtmlObject(DownloadHandler data, String type) {
+                super(data, type);
+            }
+
+            public TestHtmlObject(DownloadHandler data, String type,
+                    Param... params) {
+                super(data, type, params);
+            }
+
+            @Override
+            public Element getElement() {
+                return element;
+            }
+        }
+        InputStreamDownloadHandler handler = createDummyDownloadHandler();
+        Assert.assertFalse(handler.isInline());
+        new TestHtmlObject(handler);
+        Assert.assertTrue(handler.isInline());
+
+        handler = createDummyDownloadHandler();
+        new TestHtmlObject(handler, "type");
+        Assert.assertTrue(handler.isInline());
+
+        handler = createDummyDownloadHandler();
+        new TestHtmlObject(handler, "type", new Param("param", "paramValue"));
+        Assert.assertTrue(handler.isInline());
+
+        handler = createDummyDownloadHandler();
+        new TestHtmlObject(handler, new Param("param", "paramValue"));
+        Assert.assertTrue(handler.isInline());
+    }
+
+    private InputStreamDownloadHandler createDummyDownloadHandler() {
+        return DownloadHandler
+                .fromInputStream(event -> DownloadResponse.error(500));
     }
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/IFrameTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/IFrameTest.java
@@ -17,6 +17,11 @@ package com.vaadin.flow.component.html;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.server.streams.DownloadHandler;
+import com.vaadin.flow.server.streams.DownloadResponse;
+import com.vaadin.flow.server.streams.InputStreamDownloadHandler;
+
+import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -61,5 +66,26 @@ public class IFrameTest extends ComponentTest {
     @Override
     public void testHasAriaLabelIsImplemented() {
         super.testHasAriaLabelIsImplemented();
+    }
+
+    @Test
+    public void downloadHandler_isSetToInline() {
+        Element element = Mockito.mock(Element.class);
+        class TestIFrame extends IFrame {
+            public TestIFrame(DownloadHandler downloadHandler) {
+                super(downloadHandler);
+            }
+
+            @Override
+            public Element getElement() {
+                return element;
+            }
+        }
+        // dummy handler
+        InputStreamDownloadHandler handler = DownloadHandler
+                .fromInputStream(event -> DownloadResponse.error(500));
+        Assert.assertFalse(handler.isInline());
+        new TestIFrame(handler);
+        Assert.assertTrue(handler.isInline());
     }
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/ImageTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/ImageTest.java
@@ -15,10 +15,17 @@
  */
 package com.vaadin.flow.component.html;
 
+import java.io.ByteArrayInputStream;
 import java.util.Optional;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.server.streams.DownloadHandler;
+import com.vaadin.flow.server.streams.DownloadResponse;
+import com.vaadin.flow.server.streams.InputStreamDownloadHandler;
 
 public class ImageTest extends ComponentTest {
 
@@ -43,5 +50,26 @@ public class ImageTest extends ComponentTest {
         img.setAlt(null);
         Assert.assertEquals(Optional.empty(), img.getAlt());
         Assert.assertFalse(img.getElement().hasAttribute("alt"));
+    }
+
+    @Test
+    public void downloadHandler_isSetToInline() {
+        Element element = Mockito.mock(Element.class);
+        class TestImage extends Image {
+            public TestImage(DownloadHandler downloadHandler, String alt) {
+                super(downloadHandler, alt);
+            }
+
+            @Override
+            public Element getElement() {
+                return element;
+            }
+        }
+        // dummy handler
+        InputStreamDownloadHandler handler = DownloadHandler
+                .fromInputStream(event -> DownloadResponse.error(500));
+        Assert.assertFalse(handler.isInline());
+        new TestImage(handler, "test.png");
+        Assert.assertTrue(handler.isInline());
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/AbstractDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/AbstractDownloadHandler.java
@@ -51,7 +51,8 @@ public abstract class AbstractDownloadHandler<R extends AbstractDownloadHandler>
      * Sets this download content to be displayed inside the Web page, or as the
      * Web page, e.g. as an image or inside an iframe.
      * <p>
-     * Sets the 'Content-Disposition' attribute to 'inline'.
+     * Implementations of this class should ensure that the
+     * 'Content-Disposition' attribute is 'inline', if this method is called.
      *
      * @return this instance for method chaining
      */


### PR DESCRIPTION
Automatically sets pre-defined download handlers to inline in data html components.