### PR TITLE
fix: call successhandler from access block

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/AbstractFileUploadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/AbstractFileUploadHandler.java
@@ -69,8 +69,11 @@ public abstract class AbstractFileUploadHandler<R extends AbstractFileUploadHand
             notifyError(event, e);
             throw new UncheckedIOException(e);
         }
-        successHandler.accept(new UploadMetadata(event.getFileName(),
-                event.getContentType(), event.getFileSize()), file);
+        event.getUI()
+                .access(() -> successHandler.accept(
+                        new UploadMetadata(event.getFileName(),
+                                event.getContentType(), event.getFileSize()),
+                        file));
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/InMemoryUploadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/InMemoryUploadHandler.java
@@ -53,8 +53,11 @@ public class InMemoryUploadHandler
             notifyError(event, e);
             throw new UncheckedIOException(e);
         }
-        successHandler.accept(new UploadMetadata(event.getFileName(),
-                event.getContentType(), event.getFileSize()), data);
+        event.getUI()
+                .access(() -> successHandler.accept(
+                        new UploadMetadata(event.getFileName(),
+                                event.getContentType(), event.getFileSize()),
+                        data));
     }
 
     @Override

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/UploadTransferProgressTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/UploadTransferProgressTest.java
@@ -127,6 +127,7 @@ public class UploadTransferProgressTest {
             command.execute();
             return null;
         }).when(ui).access(Mockito.any(Command.class));
+        Mockito.when(uploadEvent.getUI()).thenReturn(ui);
 
         Mockito.when(componentOwner.getUI()).thenReturn(Optional.of(ui));
         Mockito.when(uploadEvent.getOwningComponent())


### PR DESCRIPTION
Running successhandler callback from
access so that UI can be updated
directly based on the received data.
