### PR TITLE
fix: Improve javadoc and handle unknown content length as -1

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/AbstractDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/AbstractDownloadHandler.java
@@ -39,7 +39,7 @@ public abstract class AbstractDownloadHandler<R extends AbstractDownloadHandler>
         return new TransferContext(transferEvent.getRequest(),
                 transferEvent.getResponse(), transferEvent.getSession(),
                 transferEvent.getFileName(), transferEvent.getOwningElement(),
-                -1);
+                transferEvent.getContentLength());
     }
 
     protected String getContentType(String fileName, VaadinResponse response) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadEvent.java
@@ -48,7 +48,7 @@ public class DownloadEvent {
     private Element owningElement;
     private String fileName;
     private String contentType;
-    private long contentLength;
+    private long contentLength = -1;
 
     public DownloadEvent(VaadinRequest request, VaadinResponse response,
             VaadinSession session, Element owningElement) {
@@ -165,9 +165,9 @@ public class DownloadEvent {
     }
 
     /**
-     * Sets the length of the content body in the response. This method utilizes
-     * the HTTP Content-Length header to specify the length of the content being
-     * sent to the client.
+     * Sets the length of the content body in the response if the length is not
+     * <code>-1</code>. This method utilizes the HTTP Content-Length header to
+     * specify the length of the content being sent to the client.
      * <p>
      * To be called before the response is committed.
      *
@@ -175,12 +175,18 @@ public class DownloadEvent {
      *            the length of the response content in bytes
      */
     public void setContentLength(long contentLength) {
-        response.setContentLengthLong(contentLength);
+        if (contentLength != -1) {
+            response.setContentLengthLong(contentLength);
+        }
         this.contentLength = contentLength;
     }
 
     /**
      * Get owner {@link Component} for this event.
+     * <p>
+     * The download handler may change the component's state during donwload,
+     * e.g. disable or hide it during download or get the component's own data
+     * like id.
      *
      * @return owning component or null in none defined
      */
@@ -190,6 +196,11 @@ public class DownloadEvent {
 
     /**
      * Get the owning element for the download related to this event.
+     * <p>
+     * The download handler may use element's attributes or properties to define
+     * what to download or change the element, e.g. element's id or data id to
+     * fetch a row from a database or disable element once the download is
+     * started.
      *
      * @return owning element
      */

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadHandler.java
@@ -226,7 +226,10 @@ public interface DownloadHandler extends ElementRequestHandler {
     }
 
     /**
-     * Generate a function for downloading from a generated inputStream.
+     * Generate a function for downloading from a generated InputStream.
+     * <p>
+     * <code>DownloadResponse</code> instances can be created using various
+     * factory methods or with new operator.
      *
      * @param handler
      *            handler function that will be called on download
@@ -238,8 +241,11 @@ public interface DownloadHandler extends ElementRequestHandler {
     }
 
     /**
-     * Generate a function for downloading from a generated inputStream with the
+     * Generate a function for downloading from a generated InputStream with the
      * given download name.
+     * <p>
+     * <code>DownloadResponse</code> instances can be created using various
+     * factory methods or with new operator.
      *
      * @param handler
      *            handler function that will be called on download
@@ -254,8 +260,11 @@ public interface DownloadHandler extends ElementRequestHandler {
     }
 
     /**
-     * Generate a function for downloading from a generated inputStream with the
+     * Generate a function for downloading from a generated InputStream with the
      * given download name and progress listener.
+     * <p>
+     * <code>DownloadResponse</code> instances can be created using various
+     * factory methods or with new operator.
      *
      * @param handler
      *            handler function that will be called on download

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadResponse.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadResponse.java
@@ -52,7 +52,7 @@ public class DownloadResponse implements Serializable {
      * @param contentType
      *            content type
      * @param size
-     *            byte size of stream
+     *            byte size of a stream or <code>-1</code> if unknown
      */
     public DownloadResponse(InputStream inputStream, String fileName,
             String contentType, int size) {
@@ -92,7 +92,7 @@ public class DownloadResponse implements Serializable {
     }
 
     /**
-     * Get the defined size for the content
+     * Get the defined size for the content or <code>-1</code> if unknown.
      *
      * @return content size
      */

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/TransferContext.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/TransferContext.java
@@ -30,15 +30,17 @@ import com.vaadin.flow.server.VaadinSession;
  * data transfer progress or a notification.
  *
  * @param request
- *            current Vaadin request instance
+ *            The current Vaadin request instance
  * @param response
- *            current Vaadin response instance
+ *            The current Vaadin response instance
  * @param session
- *            current Vaadin session instance
+ *            The current Vaadin session instance
  * @param fileName
- *            name of the file being transferred
+ *            The name of the file being transferred. Might be <code>null</code>
+ *            if the file name is not known.
  * @param owningElement
- *            the element that initiated the transfer
+ *            The owner element that initiated the transfer. Can be used to get
+ *            element's attributes or properties.
  * @param contentLength
  *            the total number of bytes to be transferred or <code>-1</code> if
  *            total number is unknown in advance, e.g. when reading from an
@@ -49,18 +51,24 @@ public record TransferContext(VaadinRequest request, VaadinResponse response,
         long contentLength) {
 
     /**
-     * Get owner {@link Component} for this event.
+     * Get owner {@link Component} for this data transfer.
+     * <p>
+     * The progress listener may change the component's state during donwload,
+     * e.g. disable or hide it during transfer or get the component's own data
+     * like id.
      *
-     * @return owning component or null in none defined
+     * @return owning component or null if none is defined
      */
     public Component getOwningComponent() {
         return owningElement.getComponent().orElse(null);
     }
 
     /**
-     * Get the UI instance for this request.
+     * Get the current UI instance for this data transfer that can be used to
+     * make asynchronnous UI updates with
+     * {@link UI#access(com.vaadin.flow.server.Command)}.
      *
-     * @return Current UI
+     * @return Current UI instance
      */
     public UI getUI() {
         Optional<Component> component = owningElement.getComponent();

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/TransferProgressAwareHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/TransferProgressAwareHandler.java
@@ -90,10 +90,8 @@ public abstract class TransferProgressAwareHandler<T, R extends TransferProgress
      * <p>
      * The call of the given callback is wrapped by the
      * {@link com.vaadin.flow.component.UI#access(Command)} to send UI changes
-     * defined here when the download or upload request is being handled. Thus,
-     * no need to call {@link com.vaadin.flow.component.UI#access(Command)} in
-     * the implementation of the given handler. This needs
-     * {@link com.vaadin.flow.component.page.Push} to be enabled in the
+     * defined here when the download or upload request is being handled. This
+     * needs {@link com.vaadin.flow.component.page.Push} to be enabled in the
      * application to properly send the UI changes to client.
      *
      * @param startHandler
@@ -118,10 +116,8 @@ public abstract class TransferProgressAwareHandler<T, R extends TransferProgress
      * <p>
      * The call of the given callback is wrapped by the
      * {@link com.vaadin.flow.component.UI#access(Command)} to send UI changes
-     * defined here when the download or upload request is being handled. Thus,
-     * no need to call {@link com.vaadin.flow.component.UI#access(Command)} in
-     * the implementation of the given handler. This needs
-     * {@link com.vaadin.flow.component.page.Push} to be enabled in the
+     * defined here when the download or upload request is being handled. This
+     * needs {@link com.vaadin.flow.component.page.Push} to be enabled in the
      * application to properly send the UI changes to client.
      *
      * @param progressHandler
@@ -160,11 +156,12 @@ public abstract class TransferProgressAwareHandler<T, R extends TransferProgress
      * <p>
      * The call of the given callback is wrapped by the
      * {@link com.vaadin.flow.component.UI#access(Command)} to send UI changes
-     * defined here when the download or upload request is being handled. Thus,
-     * no need to call {@link com.vaadin.flow.component.UI#access(Command)} in
-     * the implementation of the given handler. This needs
-     * {@link com.vaadin.flow.component.page.Push} to be enabled in the
+     * defined here when the download or upload request is being handled. This
+     * needs {@link com.vaadin.flow.component.page.Push} to be enabled in the
      * application to properly send the UI changes to client.
+     * <p>
+     * The default progress report internal is <code>65536</code> bytes. To
+     * change it, use {@link #onProgress(SerializableBiConsumer, long)}.
      *
      * @param progressHandler
      *            the handler to be called with the current and total bytes
@@ -182,10 +179,8 @@ public abstract class TransferProgressAwareHandler<T, R extends TransferProgress
      * <p>
      * The call of the given callback is wrapped by the
      * {@link com.vaadin.flow.component.UI#access(Command)} to send UI changes
-     * defined here when the download or upload request is being handled. Thus,
-     * no need to call {@link com.vaadin.flow.component.UI#access(Command)} in
-     * the implementation of the given handler. This needs
-     * {@link com.vaadin.flow.component.page.Push} to be enabled in the
+     * defined here when the download or upload request is being handled. This
+     * needs {@link com.vaadin.flow.component.page.Push} to be enabled in the
      * application to properly send the UI changes to client.
      *
      * @param completeOrTerminateHandler

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/TransferProgressListener.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/TransferProgressListener.java
@@ -82,12 +82,13 @@ public interface TransferProgressListener extends Serializable {
      * <p>
      * The call of this method is wrapped by the
      * {@link com.vaadin.flow.component.UI#access(com.vaadin.flow.server.Command)}
-     * to send UI changes defined here when the download or upload request is
-     * being handled. Thus, no need to call
-     * {@link com.vaadin.flow.component.UI#access(com.vaadin.flow.server.Command)}
-     * in the implementation of this method. This needs
+     * to send UI changes defined here asynchronously when the download or
+     * upload request is being handled. This needs
      * {@link com.vaadin.flow.component.page.Push} to be enabled in the
      * application to properly send the UI changes to client.
+     * <p>
+     * The default progress report internal is <code>65536</code> bytes. To
+     * change it, override {@link #progressReportInterval()}.
      *
      * @param context
      *            the context of the transfer
@@ -147,6 +148,8 @@ public interface TransferProgressListener extends Serializable {
      * Returns the interval in bytes for reporting progress.
      * <p>
      * <code>-1</code> to not report progress.
+     * <p>
+     * The default value is <code>65536</code> bytes.
      *
      * @return the interval in bytes
      */

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/AbstractDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/AbstractDownloadHandlerTest.java
@@ -43,6 +43,7 @@ import com.vaadin.flow.function.SerializableRunnable;
 import com.vaadin.flow.server.Command;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
+import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.shared.Registration;
 
@@ -228,5 +229,30 @@ public class AbstractDownloadHandlerTest {
     public void inline_inlinedWhenExplicitlyCalled() {
         handler.inline();
         Assert.assertTrue(handler.isInline());
+    }
+
+    @Test
+    public void getTransferContext_returnsExpectedContextFromEvent() {
+        VaadinRequest request = Mockito.mock(VaadinRequest.class);
+        VaadinResponse response = Mockito.mock(VaadinResponse.class);
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        Element owner = Mockito.mock(Element.class);
+        DownloadEvent event = new DownloadEvent(request, response, session,
+                owner);
+        event.setContentLength(1024);
+        event.setFileName("test.txt");
+        AbstractDownloadHandler<AbstractDownloadHandler> handler = new AbstractDownloadHandler<>() {
+            @Override
+            public void handleDownloadRequest(DownloadEvent event)
+                    throws IOException {
+            }
+        };
+        TransferContext context = handler.getTransferContext(event);
+        Assert.assertEquals(owner, context.owningElement());
+        Assert.assertEquals(session, context.session());
+        Assert.assertEquals(request, context.request());
+        Assert.assertEquals(response, context.response());
+        Assert.assertEquals(1024, context.contentLength());
+        Assert.assertEquals("test.txt", context.fileName());
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/DownloadEventTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/DownloadEventTest.java
@@ -71,4 +71,14 @@ public class DownloadEventTest {
         downloadEvent.setContentLength(contentLength);
         Mockito.verify(response).setContentLengthLong(contentLength);
     }
+
+    @Test
+    public void setContentLenght_unknownLength_doesNotSetContentLengthToResponse() {
+        DownloadEvent downloadEvent = new DownloadEvent(request, response,
+                session, null);
+        int contentLength = -1;
+        downloadEvent.setContentLength(contentLength);
+        Mockito.verify(response, Mockito.times(0))
+                .setContentLengthLong(contentLength);
+    }
 }


### PR DESCRIPTION
Better explains the methods in `DownloadEvent`, `TransferContext`, `fromInputStream` factory methods in download handler as well as explains -1 for unknown length and handles it accordingly.