### PR TITLE
fix: remove name/fileName from inputStreamDownload

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadHandler.java
@@ -242,25 +242,6 @@ public interface DownloadHandler extends ElementRequestHandler {
 
     /**
      * Generate a function for downloading from a generated InputStream with the
-     * given download name.
-     * <p>
-     * <code>DownloadResponse</code> instances can be created using various
-     * factory methods or with new operator.
-     *
-     * @param handler
-     *            handler function that will be called on download
-     * @param name
-     *            resource name
-     * @return DownloadHandler implementation for download from an input stream
-     */
-    static InputStreamDownloadHandler fromInputStream(
-            SerializableFunction<DownloadEvent, DownloadResponse> handler,
-            String name) {
-        return new InputStreamDownloadHandler(handler, name);
-    }
-
-    /**
-     * Generate a function for downloading from a generated InputStream with the
      * given download name and progress listener.
      * <p>
      * <code>DownloadResponse</code> instances can be created using various
@@ -268,17 +249,15 @@ public interface DownloadHandler extends ElementRequestHandler {
      *
      * @param handler
      *            handler function that will be called on download
-     * @param name
-     *            resource name
      * @param listener
      *            listener for transfer progress events
      * @return DownloadHandler implementation for download from an input stream
      */
     static InputStreamDownloadHandler fromInputStream(
             SerializableFunction<DownloadEvent, DownloadResponse> handler,
-            String name, TransferProgressListener listener) {
+            TransferProgressListener listener) {
         InputStreamDownloadHandler downloadHandler = new InputStreamDownloadHandler(
-                handler, name);
+                handler);
         downloadHandler.addTransferProgressListener(listener);
         return downloadHandler;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/InputStreamDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/InputStreamDownloadHandler.java
@@ -19,7 +19,6 @@ package com.vaadin.flow.server.streams;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.UncheckedIOException;
 
 import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.server.HttpStatusCode;
@@ -34,10 +33,9 @@ public class InputStreamDownloadHandler
         extends AbstractDownloadHandler<InputStreamDownloadHandler> {
 
     private final SerializableFunction<DownloadEvent, DownloadResponse> handler;
-    private final String name;
 
     /**
-     * Create a input stream download handler for given event -> response
+     * Create an input stream download handler for given event -> response
      * function.
      *
      * @param handler
@@ -45,27 +43,7 @@ public class InputStreamDownloadHandler
      */
     public InputStreamDownloadHandler(
             SerializableFunction<DownloadEvent, DownloadResponse> handler) {
-        this(handler, null);
-    }
-
-    /**
-     * Create an input stream download handler for given event -> response
-     * function.
-     * <p>
-     * The downloaded file name and download URL postfix will be set to
-     * <code>name</code>.
-     *
-     * @param handler
-     *            serializable function for handling download
-     * @param name
-     *            name to use as the url postfix as download response is not
-     *            generated before postfix
-     */
-    public InputStreamDownloadHandler(
-            SerializableFunction<DownloadEvent, DownloadResponse> handler,
-            String name) {
         this.handler = handler;
-        this.name = name;
     }
 
     @Override
@@ -94,10 +72,5 @@ public class InputStreamDownloadHandler
             notifyError(downloadEvent, ioe);
             throw ioe;
         }
-    }
-
-    @Override
-    public String getUrlPostfix() {
-        return name;
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/InputStreamDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/InputStreamDownloadHandlerTest.java
@@ -88,7 +88,7 @@ public class InputStreamDownloadHandlerTest {
             ByteArrayInputStream inputStream = new ByteArrayInputStream(data);
             return new DownloadResponse(inputStream, "download",
                     "application/octet-stream", data.length);
-        }, "download", new TransferProgressListener() {
+        }, new TransferProgressListener() {
             @Override
             public void onStart(TransferContext context) {
                 Assert.assertEquals(-1, context.contentLength());
@@ -151,7 +151,7 @@ public class InputStreamDownloadHandlerTest {
             ByteArrayInputStream inputStream = new ByteArrayInputStream(data);
             return new DownloadResponse(inputStream, "download",
                     "application/octet-stream", data.length);
-        }, "download", new TransferProgressListener() {
+        }, new TransferProgressListener() {
             @Override
             public void onStart(TransferContext context) {
                 invocations.add("onStart");
@@ -221,7 +221,7 @@ public class InputStreamDownloadHandlerTest {
             ByteArrayInputStream inputStream = new ByteArrayInputStream(data);
             return new DownloadResponse(inputStream, "download",
                     "application/octet-stream", data.length);
-        }, "my-download.bin").inline();
+        }).inline();
 
         DownloadEvent event = Mockito.mock(DownloadEvent.class);
         Mockito.when(event.getSession()).thenReturn(session);


### PR DESCRIPTION
Remove the possibility to give
fileName/name to inputStreamDownloadHandler
as the atual downloaded name is
decided on transfer and will in many cases
not match or be confusing to match in 2 places.
