### PR TITLE
feat: initialize signals environment

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.vaadin</groupId>
@@ -21,7 +22,11 @@
             <artifactId>flow-push</artifactId>
             <version>${project.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>signals</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.vaadin.servletdetector</groupId>
             <artifactId>throw-if-servlet3</artifactId>

--- a/flow-server/src/main/java/com/vaadin/experimental/DisabledFeatureException.java
+++ b/flow-server/src/main/java/com/vaadin/experimental/DisabledFeatureException.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.experimental;
+
+/**
+ * Exception thrown when attempting to use a feature controlled by a feature
+ * flag that is not enabled at runtime.
+ * <p>
+ * This exception is thrown when code attempts to use experimental functionality
+ * that requires an explicit opt-in via the FeatureFlags system. To resolve this
+ * exception, ensure the corresponding feature is enabled before using the
+ * functionality.
+ * <p>
+ * For internal use only. May be renamed or removed in a future release.
+ */
+public class DisabledFeatureException extends RuntimeException {
+
+    /**
+     * Constructs an exception for when an attempt is made to use a feature that
+     * is disabled.
+     *
+     * @param feature
+     *            the disabled feature that was attempted to be used
+     */
+    public DisabledFeatureException(Feature feature) {
+        super("""
+                '%s' is currently an experimental feature and needs to be \
+                explicitly enabled. The feature can be enabled using Copilot, in the \
+                experimental features tab, or by adding a \
+                `src/main/resources/vaadin-featureflags.properties` file with the following content: \
+                `com.vaadin.experimental.%s=true`"""
+                .formatted(feature.getTitle(), feature.getId()));
+
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
+++ b/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
@@ -85,6 +85,10 @@ public class FeatureFlags implements Serializable {
             "Hilla Full-stack Signals", "fullstackSignals",
             "https://github.com/vaadin/hilla/discussions/1902", true, null);
 
+    public static final Feature FLOW_FULLSTACK_SIGNALS = new Feature(
+            "Flow Full-stack Signals", "flowFullstackSignals",
+            "https://github.com/vaadin/platform/issues/7373", true, null);
+
     public static final Feature DASHBOARD_COMPONENT = new Feature(
             "Dashboard component (Pro)", "dashboardComponent",
             "https://github.com/vaadin/platform/issues/6626", true,
@@ -144,6 +148,7 @@ public class FeatureFlags implements Serializable {
         features.add(new Feature(FORM_FILLER_ADDON));
         features.add(new Feature(HILLA_I18N));
         features.add(new Feature(HILLA_FULLSTACK_SIGNALS));
+        features.add(new Feature(FLOW_FULLSTACK_SIGNALS));
         features.add(new Feature(COPILOT_EXPERIMENTAL));
         features.add(new Feature(DASHBOARD_COMPONENT));
         features.add(new Feature(CARD_COMPONENT));

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -391,7 +391,7 @@ public abstract class VaadinService implements Serializable {
         }
         if (!SignalEnvironment.tryInitialize(createDefaultObjectMapper(),
                 signalsExecutor)) {
-            getLogger().warn("Signals environment it is already initialized. "
+            getLogger().warn("Signals environment is already initialized. "
                     + "It is recommended to let Vaadin setup Signals environment to prevent unexpected behavior. "
                     + "Please, avoid calling SignalEnvironment.tryInitialize() in application code.");
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -51,14 +51,19 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.experimental.DisabledFeatureException;
+import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.di.DefaultInstantiator;
 import com.vaadin.flow.di.Instantiator;
@@ -95,6 +100,7 @@ import com.vaadin.flow.shared.ApplicationConstants;
 import com.vaadin.flow.shared.JsonConstants;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.shared.communication.PushMode;
+import com.vaadin.signals.SignalEnvironment;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -318,6 +324,8 @@ public abstract class VaadinService implements Serializable {
                             + " providing a custom Executor instance.");
         }
 
+        initSignalsEnvironment();
+
         DeploymentConfiguration configuration = getDeploymentConfiguration();
         if (!configuration.isProductionMode()) {
             Logger logger = getLogger();
@@ -342,6 +350,54 @@ public abstract class VaadinService implements Serializable {
                 getRouteRegistry().getRegisteredRoutes());
 
         initialized = true;
+    }
+
+    private void initSignalsEnvironment() {
+        Executor signalsExecutor;
+        Supplier<Executor> flowDispatcherOverride;
+        FeatureFlags featureFlags = FeatureFlags.get(getContext());
+        if (featureFlags
+                .isEnabled(FeatureFlags.FLOW_FULLSTACK_SIGNALS.getId())) {
+            signalsExecutor = this.executor;
+            flowDispatcherOverride = () -> {
+                UI owner = UI.getCurrent();
+                if (owner == null) {
+                    return null;
+                }
+
+                return task -> {
+                    if (UI.getCurrent() == owner) {
+                        task.run();
+                    } else {
+                        try {
+                            SignalEnvironment.defaultDispatcher()
+                                    .execute(() -> owner.access(task::run));
+                        } catch (Exception e) {
+                            // a task is submitted when executor is shut down,
+                            // ignore
+                        }
+                    }
+                };
+            };
+        } else {
+            signalsExecutor = task -> {
+                throw new DisabledFeatureException(
+                        FeatureFlags.FLOW_FULLSTACK_SIGNALS);
+            };
+            flowDispatcherOverride = () -> {
+                throw new DisabledFeatureException(
+                        FeatureFlags.FLOW_FULLSTACK_SIGNALS);
+            };
+        }
+        if (!SignalEnvironment.tryInitialize(createDefaultObjectMapper(),
+                signalsExecutor)) {
+            getLogger().warn("Signals environment it is already initialized. "
+                    + "It is recommended to let Vaadin setup Signals environment to prevent unexpected behavior. "
+                    + "Please, avoid calling SignalEnvironment.tryInitialize() in application code.");
+        }
+        Runnable unregister = SignalEnvironment
+                .addDispatcherOverride(flowDispatcherOverride);
+        addServiceDestroyListener(event -> unregister.run());
     }
 
     private void addRouterUsageStatistics() {
@@ -618,6 +674,20 @@ public abstract class VaadinService implements Serializable {
      */
     public Executor getExecutor() {
         return executor;
+    }
+
+    /**
+     * Creates and configures a default instance of {@link ObjectMapper}. The
+     * configured {@link ObjectMapper} includes the registration of the
+     * {@link JavaTimeModule} to handle serialization and deserialization of
+     * Java time API objects.
+     *
+     * @return the configured {@link ObjectMapper} instance
+     */
+    protected ObjectMapper createDefaultObjectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        return objectMapper;
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/server/MockVaadinServletService.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/MockVaadinServletService.java
@@ -15,14 +15,23 @@
  */
 package com.vaadin.flow.server;
 
-import java.util.Collections;
-import java.util.List;
-
 import jakarta.servlet.ServletException;
 
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.mockito.Mockito;
+
 import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.router.DefaultRoutePathProvider;
+import com.vaadin.flow.router.RoutePathProvider;
 import com.vaadin.flow.router.Router;
+import com.vaadin.signals.SignalEnvironment;
 import com.vaadin.tests.util.MockDeploymentConfiguration;
 
 /**
@@ -37,6 +46,8 @@ public class MockVaadinServletService extends VaadinServletService {
     private Router router;
 
     private DeploymentConfiguration configuration;
+
+    private Lookup lookup;
 
     private static class MockVaadinServlet extends VaadinServlet {
 
@@ -117,10 +128,19 @@ public class MockVaadinServletService extends VaadinServletService {
     @Override
     public void init() {
         try {
+            resetSignalEnvironment();
             MockVaadinServlet servlet = (MockVaadinServlet) getServlet();
             servlet.service = this;
             if (getServlet().getServletConfig() == null) {
                 getServlet().init(new MockServletConfig());
+            }
+            if (lookup == null
+                    && getContext().getAttribute(Lookup.class) == null) {
+                lookup = Mockito.mock(Lookup.class);
+                Mockito.when(lookup.lookup(RoutePathProvider.class))
+                        .thenReturn(new DefaultRoutePathProvider());
+                instrumentMockLookup(lookup);
+                getContext().setAttribute(Lookup.class, lookup);
             }
             super.init();
         } catch (ServiceException | ServletException e) {
@@ -128,8 +148,16 @@ public class MockVaadinServletService extends VaadinServletService {
         }
     }
 
+    protected void instrumentMockLookup(Lookup lookup) {
+        // no-op
+    }
+
     public void setConfiguration(DeploymentConfiguration configuration) {
         this.configuration = configuration;
+    }
+
+    public Lookup getLookup() {
+        return lookup;
     }
 
     @Override
@@ -137,4 +165,21 @@ public class MockVaadinServletService extends VaadinServletService {
         return configuration != null ? configuration
                 : super.getDeploymentConfiguration();
     }
+
+    private void resetSignalEnvironment() {
+        try {
+            Field state = SignalEnvironment.class.getDeclaredField("state");
+            state.setAccessible(true);
+            ((AtomicReference<?>) state.get(null)).set(null);
+
+            Field dispatcherOverrides = SignalEnvironment.class
+                    .getDeclaredField("dispatcherOverrides");
+            dispatcherOverrides.setAccessible(true);
+            ((List<?>) dispatcherOverrides.get(null)).clear();
+
+        } catch (Exception e) {
+            throw new AssertionError("Failed to reset Signal environment", e);
+        }
+    }
+
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServiceSignalsInitializationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServiceSignalsInitializationTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.server;
+
+import java.util.ArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import net.jcip.annotations.NotThreadSafe;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.experimental.DisabledFeatureException;
+import com.vaadin.experimental.FeatureFlags;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.internal.CurrentInstance;
+import com.vaadin.signals.ListSignal;
+import com.vaadin.signals.Signal;
+import com.vaadin.tests.util.AlwaysLockedVaadinSession;
+import com.vaadin.tests.util.MockUI;
+
+import static org.junit.Assert.assertThrows;
+
+@NotThreadSafe
+public class VaadinServiceSignalsInitializationTest {
+
+    @Before
+    @After
+    public void clearTestEnvironment() {
+        CurrentInstance.clearAll();
+    }
+
+    @Test
+    public void init_signalsFeatureFlagOff_throwsWhenSignalUsed() {
+        String signalsFeatureFlagKey = FeatureFlags.SYSTEM_PROPERTY_PREFIX_EXPERIMENTAL
+                + FeatureFlags.FLOW_FULLSTACK_SIGNALS.getId();
+        var signalsFlag = System.getProperty(signalsFeatureFlagKey);
+        try {
+            System.setProperty(signalsFeatureFlagKey, "false");
+            // VaadinService makes sure that Signal environment will fail if the
+            // feature flag is not enabled
+            new MockVaadinServletService();
+            var error = assertThrows(DisabledFeatureException.class,
+                    () -> Signal.effect(() -> {
+                    }));
+            Assert.assertTrue(error.getMessage()
+                    .contains(FeatureFlags.FLOW_FULLSTACK_SIGNALS.getId()));
+        } finally {
+            if (signalsFlag != null) {
+                System.setProperty(signalsFeatureFlagKey, signalsFlag);
+            } else {
+                System.clearProperty(signalsFeatureFlagKey);
+            }
+        }
+    }
+
+    @Test
+    public void init_signalsFeatureFlagOn_flowSignalEnvironmentInitialized()
+            throws InterruptedException {
+
+        String signalsFeatureFlagKey = FeatureFlags.SYSTEM_PROPERTY_PREFIX_EXPERIMENTAL
+                + FeatureFlags.FLOW_FULLSTACK_SIGNALS.getId();
+        var signalsFlag = System.getProperty(signalsFeatureFlagKey);
+        try {
+            System.setProperty(signalsFeatureFlagKey, "true");
+            var service = new MockVaadinServletService();
+
+            var latch = new CountDownLatch(2);
+            AlwaysLockedVaadinSession session = new AlwaysLockedVaadinSession(
+                    service);
+            var ui = new MockUI(session);
+            var signal = new ListSignal<>(String.class);
+
+            record EffectExecution(UI ui, String threadName) {
+            }
+            var invocations = new ArrayList<EffectExecution>();
+
+            try {
+                Signal.effect(() -> {
+                    // Should run in Flow defined dispatcher, so UI should be
+                    // available
+                    invocations.add(new EffectExecution(UI.getCurrent(),
+                            Thread.currentThread().getName()));
+                    signal.value();
+                    latch.countDown();
+                });
+                Assert.assertEquals("Expected effect to be executed", 1,
+                        invocations.size());
+                // First execution in main thread
+                var execution = invocations.get(0);
+                Assert.assertEquals(
+                        "Expected UI to be available during sync effect execution",
+                        execution.ui, ui);
+                Assert.assertFalse(
+                        "Expected effect to be executed in main thread",
+                        execution.threadName
+                                .startsWith("VaadinTaskExecutor-thread-"));
+            } finally {
+                UI.setCurrent(null);
+                session.unlock();
+            }
+
+            signal.insertLast("update");
+
+            if (!latch.await(500, TimeUnit.SECONDS)) {
+                Assert.fail(
+                        "Expected signal effect to be computed asynchronously");
+            }
+
+            Assert.assertEquals("Expected effect to be executed twice", 2,
+                    invocations.size());
+            // Second execution in Vaadin executor thread
+            var execution = invocations.get(1);
+            Assert.assertEquals(
+                    "Expected UI to be available during async effect execution",
+                    execution.ui, ui);
+            Assert.assertTrue(
+                    "Expected effect to be executed in Vaadin Executor thread",
+                    execution.threadName
+                            .startsWith("VaadinTaskExecutor-thread-"));
+        } finally {
+            if (signalsFlag != null) {
+                System.setProperty(signalsFeatureFlagKey, signalsFlag);
+            } else {
+                System.clearProperty(signalsFeatureFlagKey);
+            }
+        }
+    }
+
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletServiceTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletServiceTest.java
@@ -1,16 +1,8 @@
 package com.vaadin.flow.server;
 
-import com.vaadin.flow.di.Instantiator;
-import com.vaadin.flow.server.MockServletServiceSessionSetup.TestVaadinServletService;
-import com.vaadin.flow.theme.AbstractTheme;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -20,6 +12,17 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.server.MockServletServiceSessionSetup.TestVaadinServletService;
+import com.vaadin.flow.theme.AbstractTheme;
 
 import static org.mockito.Mockito.when;
 
@@ -127,6 +130,8 @@ public class VaadinServletServiceTest {
         VaadinServlet servlet = Mockito.mock(VaadinServlet.class);
         ServletContext context = Mockito.mock(ServletContext.class);
         when(servlet.getServletContext()).thenReturn(context);
+        when(context.getAttribute(Lookup.class.getName()))
+                .thenReturn(Mockito.mock(Lookup.class));
 
         ClassLoader loader = Mockito.mock(ClassLoader.class);
         when(context.getClassLoader()).thenReturn(loader);

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/PushHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/PushHandlerTest.java
@@ -113,7 +113,8 @@ public class PushHandlerTest {
         context.setAttribute(ApplicationConfiguration.class,
                 applicationConfiguration);
 
-        BrowserLiveReload liveReload = mockBrowserLiveReloadImpl(context);
+        BrowserLiveReload liveReload = mockBrowserLiveReloadImpl(
+                service.getLookup());
 
         AtomicReference<AtmosphereResource> res = new AtomicReference<>();
         runTest(service, (handler, resource) -> {
@@ -142,8 +143,7 @@ public class PushHandlerTest {
         deploymentConfiguration.setDevToolsEnabled(true);
         setProductionMode(service, false);
 
-        VaadinContext context = service.getContext();
-        mockBrowserLiveReloadImpl(context);
+        mockBrowserLiveReloadImpl(service.getLookup());
 
         AtomicReference<AtmosphereResource> res = new AtomicReference<>();
         runTest(service, (handler, resource) -> {
@@ -428,16 +428,10 @@ public class PushHandlerTest {
         }
     }
 
-    public static BrowserLiveReload mockBrowserLiveReloadImpl(
-            VaadinContext context) {
+    public static BrowserLiveReload mockBrowserLiveReloadImpl(Lookup lookup) {
         BrowserLiveReload liveReload = Mockito.mock(BrowserLiveReload.class);
-        Lookup lookup = Lookup.of(new BrowserLiveReloadAccessor() {
-            @Override
-            public BrowserLiveReload getLiveReload(VaadinContext context) {
-                return liveReload;
-            }
-        }, BrowserLiveReloadAccessor.class);
-        context.setAttribute(Lookup.class, lookup);
+        Mockito.when(lookup.lookup(BrowserLiveReloadAccessor.class))
+                .thenReturn(context -> liveReload);
         return liveReload;
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandlerViteTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandlerViteTest.java
@@ -19,6 +19,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 
@@ -195,9 +196,12 @@ public class WebComponentBootstrapHandlerViteTest {
             protected PwaRegistry getPwaRegistry() {
                 return registry;
             };
-        };
 
-        initLookup(service);
+            @Override
+            protected void instrumentMockLookup(Lookup lookup) {
+                initLookup(lookup);
+            }
+        };
 
         VaadinSession session = new MockVaadinSession(service);
         session.lock();
@@ -231,8 +235,12 @@ public class WebComponentBootstrapHandlerViteTest {
     public void writeBootstrapPage_devToolsDisabled()
             throws IOException, ServiceException {
         TestWebComponentBootstrapHandler handler = new TestWebComponentBootstrapHandler();
-        VaadinServletService service = new MockVaadinServletService();
-        initLookup(service);
+        VaadinServletService service = new MockVaadinServletService() {
+            @Override
+            protected void instrumentMockLookup(Lookup lookup) {
+                initLookup(lookup);
+            }
+        };
 
         VaadinSession session = new MockVaadinSession(service);
         session.lock();
@@ -296,9 +304,12 @@ public class WebComponentBootstrapHandlerViteTest {
     public void writeBootstrapPage_withExportChunk()
             throws IOException, ServiceException {
         TestWebComponentBootstrapHandler handler = new TestWebComponentBootstrapHandler();
-        VaadinServletService service = new MockVaadinServletService();
-
-        initLookup(service);
+        VaadinServletService service = new MockVaadinServletService() {
+            @Override
+            protected void instrumentMockLookup(Lookup lookup) {
+                initLookup(lookup);
+            }
+        };
 
         VaadinSession session = new MockVaadinSession(service);
         session.lock();
@@ -330,9 +341,12 @@ public class WebComponentBootstrapHandlerViteTest {
     public void writeBootstrapPage_noExportChunk()
             throws IOException, ServiceException {
         TestWebComponentBootstrapHandler handler = new TestWebComponentBootstrapHandler();
-        VaadinServletService service = new MockVaadinServletService();
-
-        initLookup(service);
+        VaadinServletService service = new MockVaadinServletService() {
+            @Override
+            protected void instrumentMockLookup(Lookup lookup) {
+                initLookup(lookup);
+            }
+        };
 
         VaadinSession session = new MockVaadinSession(service);
         session.lock();
@@ -409,11 +423,8 @@ public class WebComponentBootstrapHandlerViteTest {
         return request;
     }
 
-    private void initLookup(VaadinServletService service) throws IOException {
-        VaadinContext context = service.getContext();
-        Lookup lookup = Mockito.mock(Lookup.class);
-        context.setAttribute(Lookup.class, lookup);
-
+    private void initLookup(Lookup lookup) {
+        Mockito.reset(lookup);
         ResourceProvider provider = Mockito.mock(ResourceProvider.class);
 
         Mockito.when(lookup.lookup(ResourceProvider.class))
@@ -423,11 +434,16 @@ public class WebComponentBootstrapHandlerViteTest {
                 .thenAnswer(answer -> WebComponentBootstrapHandlerViteTest.class
                         .getClassLoader().getResource(answer.getArgument(0)));
 
-        Mockito.when(provider.getClientResourceAsStream(
-                "META-INF/resources/" + ApplicationConstants.CLIENT_ENGINE_PATH
-                        + "/compile.properties"))
-                .thenAnswer(invocation -> new ByteArrayInputStream(
-                        "jsFile=foo".getBytes(StandardCharsets.UTF_8)));
+        try {
+            Mockito.when(
+                    provider.getClientResourceAsStream("META-INF/resources/"
+                            + ApplicationConstants.CLIENT_ENGINE_PATH
+                            + "/compile.properties"))
+                    .thenAnswer(invocation -> new ByteArrayInputStream(
+                            "jsFile=foo".getBytes(StandardCharsets.UTF_8)));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     private VaadinResponse getMockResponse(ByteArrayOutputStream stream)

--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
@@ -69,6 +69,7 @@ public abstract class ClassesSerializableTest extends ClassFinder {
                 ".*\\.demo\\..*", "com\\.vaadin\\..*Util(s)?(\\$\\w+)?$",
                 "com\\.vaadin\\.flow\\.osgi\\.support\\..*",
                 "com\\.vaadin\\.flow\\.server\\.osgi\\..*",
+                "com\\.vaadin\\.signals\\..*",
                 "com\\.vaadin\\.base\\.devserver\\.DevServerOutputTracker.*",
                 "com\\.vaadin\\.base\\.devserver\\.viteproxy\\..*",
                 "com\\.vaadin\\.base\\.devserver\\.stats..*",

--- a/signals/src/main/java/com/vaadin/signals/SignalEnvironment.java
+++ b/signals/src/main/java/com/vaadin/signals/SignalEnvironment.java
@@ -40,7 +40,7 @@ public class SignalEnvironment {
 
     private static final AtomicReference<InitializationState> state = new AtomicReference<>();
 
-    private static final List<Supplier<Executor>> dispacherOverrides = new CopyOnWriteArrayList<>();
+    private static final List<Supplier<Executor>> dispatcherOverrides = new CopyOnWriteArrayList<>();
 
     private SignalEnvironment() {
         // Only static stuff
@@ -99,9 +99,9 @@ public class SignalEnvironment {
      */
     public static Runnable addDispatcherOverride(
             Supplier<Executor> dispatcherOverride) {
-        dispacherOverrides.add(0, Objects.requireNonNull(dispatcherOverride));
+        dispatcherOverrides.add(0, Objects.requireNonNull(dispatcherOverride));
         return () -> {
-            dispacherOverrides.remove(dispatcherOverride);
+            dispatcherOverrides.remove(dispatcherOverride);
         };
     }
 
@@ -171,7 +171,7 @@ public class SignalEnvironment {
     }
 
     private static Executor resolveDispatcher(Executor baseline) {
-        for (Supplier<Executor> supplier : dispacherOverrides) {
+        for (Supplier<Executor> supplier : dispatcherOverrides) {
             Executor override = supplier.get();
             if (override != null) {
                 return override;


### PR DESCRIPTION
Configures Signals environment when VaadinService is initialized, providing Vaadin defaults Executor and ObjectMapper.
Signals functionality is behind a feature flag; if the flag is not set, an exception is thrown at runtime if Signals are used.

Closes #21474
Closes #21475