### PR TITLE
feat: Make current user available without an AuthenticationContext instance

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/AuthenticationContext.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/AuthenticationContext.java
@@ -111,7 +111,8 @@ public class AuthenticationContext {
      *             if the current user instance does not match the given
      *             {@code userType}.
      */
-    public static <U> Optional<U> getCurrentAuthenticatedUser(Class<U> userType) {
+    public static <U> Optional<U> getCurrentAuthenticatedUser(
+            Class<U> userType) {
         return getAuthentication().map(Authentication::getPrincipal)
                 .map(userType::cast);
     }

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/AuthenticationContext.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/AuthenticationContext.java
@@ -91,7 +91,7 @@ public class AuthenticationContext {
      *             if the current user instance does not match the given
      *             {@code userType}.
      */
-    public <U> Optional<U> getAuthenticatedUser(Class<U> userType) {
+    public static <U> Optional<U> getAuthenticatedUser(Class<U> userType) {
         return getAuthentication().map(Authentication::getPrincipal)
                 .map(userType::cast);
     }

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/AuthenticationContext.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/AuthenticationContext.java
@@ -91,7 +91,27 @@ public class AuthenticationContext {
      *             if the current user instance does not match the given
      *             {@code userType}.
      */
-    public static <U> Optional<U> getAuthenticatedUser(Class<U> userType) {
+    public <U> Optional<U> getAuthenticatedUser(Class<U> userType) {
+        return getCurrentAuthenticatedUser(userType);
+    }
+
+    /**
+     * Gets an {@link Optional} with an instance of the current user if it has
+     * been authenticated, or empty if the user is not authenticated.
+     *
+     * Anonymous users are considered not authenticated.
+     *
+     * @param <U>
+     *            the type parameter of the expected user instance
+     * @param userType
+     *            the type of the expected user instance
+     * @return an {@link Optional} with the current authenticated user, or empty
+     *         if none available
+     * @throws ClassCastException
+     *             if the current user instance does not match the given
+     *             {@code userType}.
+     */
+    public static <U> Optional<U> getCurrentAuthenticatedUser(Class<U> userType) {
         return getAuthentication().map(Authentication::getPrincipal)
                 .map(userType::cast);
     }


### PR DESCRIPTION
Makes it possible to write an application method like

```
public static Optional<User> getCurrentUser() {
    return AuthenticationContext.getAuthenticatedUser(AppUserInfo.class).map(AppUserInfo::user);
}
```

instead of re-implementing everything from AuthenticationContext
