### PR TITLE
fix: do not generate list for empty string

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
@@ -370,12 +370,12 @@ public class DevModeInitializer implements Serializable {
         }
     }
 
-    private static List<String> getFrontendExtraFileExtensions(
+    static List<String> getFrontendExtraFileExtensions(
             ApplicationConfiguration config) {
-        List<String> stringProperty = Arrays.asList(config
+        List<String> stringProperty = Arrays.stream(config
                 .getStringProperty(InitParameters.FRONTEND_EXTRA_EXTENSIONS, "")
-                .split(","));
-        return stringProperty;
+                .split(",")).filter(input -> !input.isEmpty()).toList();
+        return stringProperty.isEmpty() ? null : stringProperty;
     }
 
     private static Logger log() {

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
@@ -374,7 +374,7 @@ public class DevModeInitializer implements Serializable {
             ApplicationConfiguration config) {
         List<String> stringProperty = Arrays.stream(config
                 .getStringProperty(InitParameters.FRONTEND_EXTRA_EXTENSIONS, "")
-                .split(",")).filter(input -> !input.isEmpty()).toList();
+                .split(",")).filter(input -> !input.isBlank()).toList();
         return stringProperty.isEmpty() ? null : stringProperty;
     }
 

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/DevModeInitializerTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/DevModeInitializerTest.java
@@ -539,6 +539,27 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
         }
     }
 
+    @Test
+    public void getFrontendExtraExtensions_noExtensionsSet_returnsNull() {
+        Mockito.when(appConfig.getStringProperty(
+                InitParameters.FRONTEND_EXTRA_EXTENSIONS, "")).thenReturn("");
+
+        List<String> frontendExtraFileExtensions = DevModeInitializer
+                .getFrontendExtraFileExtensions(appConfig);
+        Assert.assertNull(frontendExtraFileExtensions);
+    }
+
+    @Test
+    public void getFrontendExtraExtensions_extensionsSet_returnsExtensionsList() {
+        Mockito.when(appConfig.getStringProperty(
+                InitParameters.FRONTEND_EXTRA_EXTENSIONS, ""))
+                .thenReturn(".svg,.ico,png");
+
+        List<String> frontendExtraFileExtensions = DevModeInitializer
+                .getFrontendExtraFileExtensions(appConfig);
+        Assert.assertEquals(3, frontendExtraFileExtensions.size());
+    }
+
     private void loadingJars_allFilesExist(String resourcesFolder)
             throws IOException, VaadinInitializerException {
         loadingJarsWithProtocol_allFilesExist(resourcesFolder,


### PR DESCRIPTION
Do not generate a 1 item
list for the default empty
string in dev mode init
for file extensions.

Fixes #21509
