### PR TITLE
fix: improve TaskExecutor selection strategy in Spring VaadinService

### DIFF
--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/service/SpringVaadinServiceExecutorTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/service/SpringVaadinServiceExecutorTest.java
@@ -23,12 +23,16 @@ import java.util.concurrent.Executor;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration;
+import org.springframework.boot.autoconfigure.task.TaskSchedulingAutoConfiguration;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler;
 
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServiceInitListener;
@@ -48,6 +52,7 @@ public class SpringVaadinServiceExecutorTest {
     static final String CUSTOM_EXECUTOR_VIA_INIT_LISTENER = "CUSTOM_EXECUTOR_VIA_INIT_LISTENER";
     static final String CUSTOM_NAMED_EXECUTOR = "CUSTOM_NAMED_EXECUTOR";
     static final String CUSTOM_EXECUTOR = "CUSTOM_EXECUTOR";
+    static final String CUSTOM_SCHEDULER = "CUSTOM_SCHEDULER";
 
     private final WebApplicationContextRunner contextRunner = new WebApplicationContextRunner()
             .withConfiguration(
@@ -96,10 +101,40 @@ public class SpringVaadinServiceExecutorTest {
 
     @TestConfiguration
     @EnableAsync
+    @EnableScheduling
+    @Import({ TaskExecutionAutoConfiguration.class,
+            TaskSchedulingAutoConfiguration.class })
+    static class AsyncAndSchedulingConfig {
+    }
+
+    @TestConfiguration
+    @EnableAsync
+    @Import({ TaskExecutionAutoConfiguration.class })
+    static class AsyncConfigWithCustomExecutorConfig {
+
+        @Bean
+        TaskExecutor myTaskExecutor() {
+            return new TestTaskExecutor(CUSTOM_EXECUTOR);
+        }
+    }
+
+    @TestConfiguration
+    @EnableAsync
+    @Import({ TaskExecutionAutoConfiguration.class })
     static class AsyncConfigWithNamedExecutorConfig {
         @Bean("VaadinTaskExecutor")
         TaskExecutor taskExecutor() {
             return new TestTaskExecutor(CUSTOM_NAMED_EXECUTOR);
+        }
+    }
+
+    @TestConfiguration
+    @EnableAsync
+    @Import({ TaskExecutionAutoConfiguration.class })
+    static class AsyncConfigWithAnnotatedExecutorConfig {
+        @Bean("VaadinTaskExecutor")
+        TaskExecutor taskExecutor() {
+            return new TestTaskExecutor(CUSTOM_EXECUTOR);
         }
     }
 
@@ -113,6 +148,27 @@ public class SpringVaadinServiceExecutorTest {
         @Bean
         TaskExecutor anotherCustomTaskExecutor() {
             return new TestTaskExecutor(CUSTOM_EXECUTOR);
+        }
+    }
+
+    @TestConfiguration
+    static class CustomExecutorAndSchedulerConfig {
+        @Bean
+        TaskExecutor myCustomTaskExecutor() {
+            return new TestTaskExecutor(CUSTOM_EXECUTOR);
+        }
+
+        @Bean
+        TaskScheduler myCustomTaskScheduler() {
+            return new TestTaskScheduler(CUSTOM_SCHEDULER);
+        }
+    }
+
+    @TestConfiguration
+    static class CustomSchedulerConfig {
+        @Bean
+        TaskScheduler myCustomTaskScheduler() {
+            return new TestTaskScheduler(CUSTOM_SCHEDULER);
         }
     }
 
@@ -178,8 +234,92 @@ public class SpringVaadinServiceExecutorTest {
     }
 
     @Test
+    public void getExecutor_multipleSpringExecutors_returnsSpringDefaultApplicationTaskExecutor() {
+        contextRunner.withUserConfiguration(AsyncAndSchedulingConfig.class)
+                .run(context -> {
+                    VaadinService service = SpringInstantiatorTest
+                            .getService(context, new Properties());
+                    assertInstanceOf(TaskExecutor.class, service.getExecutor(),
+                            "Expected a Spring TaskExecutor");
+                    assertFalse(service.getExecutor() instanceof TaskScheduler,
+                            "Expected a Spring TaskExecutor, but got a TaskScheduler");
+                });
+    }
+
+    @Test
+    public void getExecutor_springDefaultAndCustomNamedExecutorBean_returnsCustomTaskExecutor() {
+        contextRunner
+                .withUserConfiguration(AsyncConfigWithNamedExecutorConfig.class)
+                .run(context -> {
+                    VaadinService service = SpringInstantiatorTest
+                            .getService(context, new Properties());
+                    TestTaskExecutor executor = assertInstanceOf(
+                            TestTaskExecutor.class, service.getExecutor(),
+                            "Expected VaadinService.getExecutor() to return an instance of custom TaskExecutor");
+                    assertEquals(CUSTOM_NAMED_EXECUTOR, executor.name);
+                });
+    }
+
+    @Test
+    public void getExecutor_springDefaultAndCustomAnnotatedExecutorBean_returnsCustomTaskExecutor() {
+        contextRunner
+                .withUserConfiguration(
+                        AsyncConfigWithAnnotatedExecutorConfig.class)
+                .run(context -> {
+                    VaadinService service = SpringInstantiatorTest
+                            .getService(context, new Properties());
+                    TestTaskExecutor executor = assertInstanceOf(
+                            TestTaskExecutor.class, service.getExecutor(),
+                            "Expected VaadinService.getExecutor() to return an instance of custom TaskExecutor");
+                    assertEquals(CUSTOM_EXECUTOR, executor.name);
+                });
+    }
+
+    @Test
+    public void getExecutor_springDefaultAndCustomExecutorBean_returnsCustomTaskExecutor() {
+        contextRunner
+                .withUserConfiguration(
+                        AsyncConfigWithCustomExecutorConfig.class)
+                .run(context -> {
+                    VaadinService service = SpringInstantiatorTest
+                            .getService(context, new Properties());
+                    TestTaskExecutor executor = assertInstanceOf(
+                            TestTaskExecutor.class, service.getExecutor(),
+                            "Expected VaadinService.getExecutor() to return an instance of custom TaskExecutor");
+                    assertEquals(CUSTOM_EXECUTOR, executor.name);
+                });
+    }
+
+    @Test
     public void getExecutor_customExecutorBean_returnsCustomTaskExecutor() {
         contextRunner.withUserConfiguration(CustomExecutorBeanConfig.class)
+                .run(context -> {
+                    VaadinService service = SpringInstantiatorTest
+                            .getService(context, new Properties());
+                    TestTaskExecutor executor = assertInstanceOf(
+                            TestTaskExecutor.class, service.getExecutor(),
+                            "Expected VaadinService.getExecutor() to return an instance of custom TaskExecutor");
+                    assertEquals(CUSTOM_EXECUTOR, executor.name);
+                });
+    }
+
+    @Test
+    public void getExecutor_customSchedulerBean_returnsCustomTaskScheduler() {
+        contextRunner.withUserConfiguration(CustomSchedulerConfig.class)
+                .run(context -> {
+                    VaadinService service = SpringInstantiatorTest
+                            .getService(context, new Properties());
+                    TestTaskScheduler executor = assertInstanceOf(
+                            TestTaskScheduler.class, service.getExecutor(),
+                            "Expected VaadinService.getExecutor() to return an instance of custom TaskExecutor");
+                    assertEquals(CUSTOM_SCHEDULER, executor.name);
+                });
+    }
+
+    @Test
+    public void getExecutor_customExecutorAndSchedulerBeans_returnsCustomTaskExecutor() {
+        contextRunner
+                .withUserConfiguration(CustomExecutorAndSchedulerConfig.class)
                 .run(context -> {
                     VaadinService service = SpringInstantiatorTest
                             .getService(context, new Properties());
@@ -312,5 +452,18 @@ public class SpringVaadinServiceExecutorTest {
         public void execute(Runnable task) {
             task.run();
         }
+    }
+
+    /**
+     * Simple TaskScheduler implementation for testing.
+     */
+    static class TestTaskScheduler extends SimpleAsyncTaskScheduler {
+
+        final String name;
+
+        public TestTaskScheduler(String name) {
+            this.name = name;
+        }
+
     }
 }


### PR DESCRIPTION
When multiple TaskExecutor beans are available at application startup, Vaadin prevents the application startup by throwing an exception. This change applies a smarter selection strategy instead of immediately failing with, by prioritizing regular TaskExecutor beans over TaskScheduler beans when both are present (fixes issues when `@EnableScheduling` is used) and application-defined executors over Spring defaults.

Fixes #21535