### PR TITLE
chore: downgrade byte-buddy to 1.12.23 (2.12)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
             <dependency>
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy</artifactId>
-                <version>1.17.5</version>
+                <version>1.12.23</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Downgrade the byte-buddy version to prevent class scanning issues caused by Java 24 classes present in the latest multi version artifact.