### PR TITLE
fix: Update beanstore ui if changed

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/scopes/VaadinRouteScope.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/scopes/VaadinRouteScope.java
@@ -90,6 +90,11 @@ public class VaadinRouteScope extends AbstractScope {
                                 .remove(getUIStoreKey(uiInstance)));
                 routeStores.put(key, beanStore);
             }
+            if (!ui.equals(beanStore.currentUI)) {
+                // Reloading for new UI on same window name. Update UI for
+                // beanStore.
+                beanStore.currentUI = ui;
+            }
             return beanStore;
         }
 


### PR DESCRIPTION
Update the beanstore currentUI
instance if it is changed due
to a reload or bookmark navigation
where the window name stays the same.

Fixes #21417
