### PR TITLE
fix(flow-server): declare i18n Vite plugin dependencies

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
@@ -19,6 +19,7 @@
     "rollup-plugin-brotli": "3.1.0",
     "vite-plugin-checker": "0.9.3",
     "workbox-build": "7.3.0",
-    "transform-ast": "2.4.4"
+    "transform-ast": "2.4.4",
+    "magic-string": "0.30.17"
   }
 }

--- a/flow-server/src/main/resources/plugins/rollup-plugin-vaadin-i18n/package.json
+++ b/flow-server/src/main/resources/plugins/rollup-plugin-vaadin-i18n/package.json
@@ -14,5 +14,10 @@
   },
   "files": [
     "rollup-plugin-vaadin-i18n.js"
-  ]
+  ],
+  "dependencies": {
+    "@rollup/pluginutils": "5.1.4",
+    "transform-ast": "2.4.4",
+    "magic-string": "0.30.17"
+  }
 }


### PR DESCRIPTION
Although they are normally installed as Vite transitive dependencies anyway, this makes
'@rollup/pluginutils', 'transform-ast', and 'magic-string' npm packages explicit
 dependencies in projects using dev server or bundle build.
