### PR TITLE
fix: Add attribute always when file name is set

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
@@ -119,9 +119,6 @@ public class Anchor extends HtmlContainer
      * Creates an anchor component with the given text content and a callback
      * that handles data download from the server to the client when clicking an
      * anchor.
-     * <p>
-     * Sets the 'download' attribute for link when given a non-inline handler
-     * implementing AbstractDownloadHandler.
      *
      * @see #setHref(DownloadHandler)
      * @see #setText(String)
@@ -206,9 +203,6 @@ public class Anchor extends HtmlContainer
      * Sets the URL that this anchor links to and that is bound to a given
      * {@link DownloadHandler} callback on the server for handling data download
      * from the server to the client when clicking an anchor.
-     * <p>
-     * Sets the 'download' attribute for link when given a non-inline handler
-     * implementing AbstractDownloadHandler.
      *
      * @param downloadHandler
      *            the callback that handles data download, not null
@@ -218,10 +212,6 @@ public class Anchor extends HtmlContainer
                 downloadHandler, this.getElement());
         setRouterIgnore(true);
         assignHrefAttribute();
-        if (downloadHandler instanceof AbstractDownloadHandler<?> abstractDownloadHandler
-                && !abstractDownloadHandler.isInline()) {
-            getElement().setAttribute("download", true);
-        }
     }
 
     /**

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
@@ -310,30 +310,6 @@ public class AnchorTest extends ComponentTest {
         Assert.assertNotEquals(href, anchor.getHref());
     }
 
-    @Test
-    public void anchorWithDownloadHandler_downloadAttributeIsSet() {
-        mockUI();
-        DownloadHandler downloadHandler = DownloadHandler
-                .forServletResource("null/path");
-        Anchor anchor = new Anchor(downloadHandler, "bar");
-
-        Assert.assertTrue(
-                "Pre-built download handlers should set download attribute",
-                anchor.getElement().hasAttribute("download"));
-    }
-
-    @Test
-    public void anchorWithDownloadHandler_inlineSet_downloadAttributeIsNotSet() {
-        mockUI();
-        DownloadHandler downloadHandler = DownloadHandler
-                .forServletResource("null/path").inline();
-        Anchor anchor = new Anchor(downloadHandler, "bar");
-
-        Assert.assertFalse(
-                "Inline download handlers should not add download attribute",
-                anchor.getElement().hasAttribute("download"));
-    }
-
     private void mockUI() {
         ui = new UI();
         UI.setCurrent(ui);

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadEvent.java
@@ -132,8 +132,8 @@ public class DownloadEvent {
     /**
      * Sets the name of the file to be downloaded. This method utilizes the HTTP
      * Content-Disposition header to specify the name of the file to be
-     * downloaded and additionally sets the "download" attribute to the owner
-     * element.
+     * downloaded and additionally sets the "download" attribute to the
+     * &lt;a&gt; element.
      * <p>
      * To be called before the response is committed.
      * <p>

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadEvent.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.server.VaadinRequest;
@@ -131,12 +132,13 @@ public class DownloadEvent {
     /**
      * Sets the name of the file to be downloaded. This method utilizes the HTTP
      * Content-Disposition header to specify the name of the file to be
-     * downloaded.
+     * downloaded and additionally sets the "download" attribute to the owner
+     * element.
      * <p>
      * To be called before the response is committed.
      * <p>
-     * If the <code>fileName</code> is <code>null</code>, the
-     * Content-Disposition header won't be set.
+     * If the <code>fileName</code> is <code>null</code>, neither the
+     * Content-Disposition header, nor the attribute are set.
      *
      * @param fileName
      *            the name to be assigned to the file
@@ -151,6 +153,10 @@ public class DownloadEvent {
             response.setHeader("Content-Disposition",
                     "attachment; filename=\"" + fileName + "\"");
         }
+        if (Tag.A.equals(getOwningElement().getTag())) {
+            getOwningElement().setAttribute("download", true);
+        }
+
         this.fileName = fileName;
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/DownloadEventTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/DownloadEventTest.java
@@ -2,10 +2,12 @@ package com.vaadin.flow.server.streams;
 
 import java.io.IOException;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
 import com.vaadin.flow.server.VaadinService;
@@ -29,21 +31,25 @@ public class DownloadEventTest {
 
     @Test
     public void setFileName_nonEmptyFileName_setsContentDispositionFilenameQuotedToResponse() {
+        Element element = new Element("a");
         DownloadEvent downloadEvent = new DownloadEvent(request, response,
-                session, null);
+                session, element);
         String fileName = "test.txt";
         downloadEvent.setFileName(fileName);
         Mockito.verify(response).setHeader("Content-Disposition",
                 "attachment; filename=\"" + fileName + "\"");
+        Assert.assertTrue(element.hasAttribute("download"));
     }
 
     @Test
     public void setFileName_emptyFileName_setsContentDispositionToResponse() {
+        Element element = new Element("a");
         DownloadEvent downloadEvent = new DownloadEvent(request, response,
-                session, null);
+                session, element);
         String fileName = "";
         downloadEvent.setFileName(fileName);
         Mockito.verify(response).setHeader("Content-Disposition", "attachment");
+        Assert.assertTrue(element.hasAttribute("download"));
     }
 
     @Test


### PR DESCRIPTION
Related-to https://github.com/vaadin/flow/issues/21587

Always adds the attribute to &lt;a&gt; when `event.setFileName()` is called.