### PR TITLE
chore!: Remove isMultipart method

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/UploadEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/UploadEvent.java
@@ -212,13 +212,4 @@ public class UploadEvent {
             session.unlock();
         }
     }
-
-    /**
-     * Check if this file is part of a multipart upload request.
-     *
-     * @return {@code true} if multipart request
-     */
-    public boolean isMultipartRequest() {
-        return part != null || item != null;
-    }
 }


### PR DESCRIPTION
We don't want the multipart way of upload to leak into handlers API.
We may want to remove multipart in the future, so lets not stick with it.