### PR TITLE
fix!: Give more data to FileFactory

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/AbstractFileUploadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/AbstractFileUploadHandler.java
@@ -53,9 +53,11 @@ public abstract class AbstractFileUploadHandler<R extends AbstractFileUploadHand
 
     @Override
     public void handleUploadRequest(UploadEvent event) throws IOException {
+        UploadMetadata metadata = new UploadMetadata(event.getFileName(),
+                event.getContentType(), event.getFileSize());
         File file;
         try {
-            file = fileFactory.createFile(event.getFileName());
+            file = fileFactory.createFile(metadata);
             try (InputStream inputStream = event.getInputStream();
                     FileOutputStream outputStream = new FileOutputStream(
                             file)) {
@@ -68,10 +70,7 @@ public abstract class AbstractFileUploadHandler<R extends AbstractFileUploadHand
         }
         event.getUI().access(() -> {
             try {
-                successCallback.complete(
-                        new UploadMetadata(event.getFileName(),
-                                event.getContentType(), event.getFileSize()),
-                        file);
+                successCallback.complete(metadata, file);
             } catch (IOException e) {
                 throw new UncheckedIOException("Error in file upload callback",
                         e);

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/FileFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/FileFactory.java
@@ -31,9 +31,9 @@ public interface FileFactory extends Serializable {
     /**
      * Create a new file for given file name.
      *
-     * @param fileName
-     *            file name to create file for
+     * @param uploadMetadata
+     *            metadata for upload that should get a file created
      * @return {@link File} that should be used
      */
-    File createFile(String fileName) throws IOException;
+    File createFile(UploadMetadata uploadMetadata) throws IOException;
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/TemporaryFileFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/TemporaryFileFactory.java
@@ -32,7 +32,7 @@ public class TemporaryFileFactory implements FileFactory {
      * Create a new temporary file for filename. Adds the suffix {@code .tmp}
      */
     @Override
-    public File createFile(String fileName) throws IOException {
+    public File createFile(UploadMetadata uploadMetadata) throws IOException {
 
         Path tempDirPath;
         try {
@@ -41,6 +41,8 @@ public class TemporaryFileFactory implements FileFactory {
             throw new IOException("Failed to create temp directory", e);
         }
 
-        return Files.createTempFile(tempDirPath, fileName, ".tmp").toFile();
+        return Files
+                .createTempFile(tempDirPath, uploadMetadata.fileName(), ".tmp")
+                .toFile();
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/UploadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/UploadHandlerTest.java
@@ -280,8 +280,9 @@ public class UploadHandlerTest {
 
         FileUploadHandler uploadHandler = UploadHandler.toFile(
                 (uploadMetadata, file) -> outputFiles.add(file),
-                (fileName) -> new File(System.getProperty("java.io.tmpdir"),
-                        fileName));
+                (uploadMetadata) -> new File(
+                        System.getProperty("java.io.tmpdir"),
+                        uploadMetadata.fileName()));
 
         StreamRegistration streamRegistration = streamResourceRegistry
                 .registerResource(uploadHandler);
@@ -658,7 +659,7 @@ public class UploadHandlerTest {
     public void fileUploadCallback_doesNotRequireCatch() {
         new FileUploadHandler((meta, file) -> {
             new FileInputStream(file);
-        }, fileName -> new File("foo"));
+        }, uploadMetadata -> new File("foo"));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/UploadTransferProgressTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/UploadTransferProgressTest.java
@@ -141,8 +141,8 @@ public class UploadTransferProgressTest {
         AtomicReference<File> expectedFile = new AtomicReference<>();
         List<String> invocations = new ArrayList<>();
         List<Long> transferredBytesRecords = new ArrayList<>();
-        UploadHandler handler = UploadHandler
-                .toFile((meta, file) -> actualFile.set(file), (fileName) -> {
+        UploadHandler handler = UploadHandler.toFile(
+                (meta, file) -> actualFile.set(file), (uploadMetadata) -> {
                     try {
                         File file = temporaryFolder.newFile(DUMMY_FILE_NAME);
                         expectedFile.set(file);
@@ -166,7 +166,7 @@ public class UploadTransferProgressTest {
             throws URISyntaxException {
         List<String> invocations = new ArrayList<>();
         UploadHandler handler = UploadHandler.toFile((meta, file) -> {
-        }, (fileName) -> {
+        }, (uploadMetadata) -> {
             throw new IOException("Test exception");
         }, createErrorTransferProgressListener(invocations));
 


### PR DESCRIPTION
Have FileFactory get more
information on upload by
giving it UploadMetadata
instead of only filename.
