### PR TITLE
feat: add method for `download`

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
@@ -220,11 +220,40 @@ public class Anchor extends HtmlContainer
         assignHrefAttribute();
         if (downloadHandler instanceof AbstractDownloadHandler<?> abstractDownloadHandler) {
             if (!abstractDownloadHandler.isInline()) {
-                getElement().setAttribute("download", true);
+                setDownload(true);
             } else {
-                getElement().removeAttribute("download");
+                setDownload(false);
             }
         }
+    }
+
+    /**
+     * Set the download state of the anchor.
+     * <p>
+     * {@code true} will add the download attribute making the anchor target to
+     * be downloaded on click.
+     * <p>
+     * {@code false} will remove the download attribute.
+     *
+     * @param download
+     *            {@code true} to add the 'download' attribute and {@code false}
+     *            to remove it
+     */
+    public void setDownload(boolean download) {
+        if (download) {
+            getElement().setAttribute("download", true);
+        } else {
+            getElement().removeAttribute("download");
+        }
+    }
+
+    /**
+     * Check if the anchor target will be downloaded for a click.
+     *
+     * @return {@code true} if download is set for this anchor
+     */
+    public boolean isDownload() {
+        return getElement().hasAttribute("download");
     }
 
     /**

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
@@ -340,7 +340,7 @@ public class AnchorTest extends ComponentTest {
 
         Assert.assertTrue(
                 "Pre-built download handlers should set download attribute",
-                anchor.getElement().hasAttribute("download"));
+                anchor.isDownload());
 
         downloadHandler.inline();
 
@@ -348,7 +348,7 @@ public class AnchorTest extends ComponentTest {
 
         Assert.assertFalse(
                 "Setting inline download handler should clear download attribute",
-                anchor.getElement().hasAttribute("download"));
+                anchor.isDownload());
     }
 
     @Test
@@ -359,13 +359,13 @@ public class AnchorTest extends ComponentTest {
 
         Assert.assertTrue(
                 "Pre-built download handlers should set download attribute",
-                anchor.getElement().hasAttribute("download"));
+                anchor.isDownload());
 
         anchor.setHref(event -> event.getWriter().write("foo"));
 
         Assert.assertTrue(
                 "Setting custom download handler should not clear download attribute",
-                anchor.getElement().hasAttribute("download"));
+                anchor.isDownload());
     }
 
     @Test

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.html;
 
+import java.beans.IntrospectionException;
 import java.util.Optional;
 
 import org.junit.After;
@@ -35,6 +36,13 @@ public class AnchorTest extends ComponentTest {
     public void tearDown() {
         ui = null;
         UI.setCurrent(null);
+    }
+
+    @Override
+    public void setup() throws IntrospectionException, InstantiationException,
+            IllegalAccessException, ClassNotFoundException {
+        whitelistProperty("download");
+        super.setup();
     }
 
     @Test
@@ -320,7 +328,7 @@ public class AnchorTest extends ComponentTest {
 
         Assert.assertTrue(
                 "Pre-built download handlers should set download attribute",
-                anchor.getElement().hasAttribute("download"));
+                anchor.isDownload());
     }
 
     @Test
@@ -369,7 +377,7 @@ public class AnchorTest extends ComponentTest {
 
         Assert.assertFalse(
                 "Inline download handlers should not add download attribute",
-                anchor.getElement().hasAttribute("download"));
+                anchor.isDownload());
     }
 
     private void mockUI() {


### PR DESCRIPTION
Add methods for checking if
anchor is a download and
setting the download status.
