### PR TITLE
refactor: replace and deprecate webpackOutputDirectory method

### DIFF
--- a/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
+++ b/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
@@ -495,6 +495,11 @@ public class BuildDevBundleMojo extends AbstractMojo
 
     @Override
     public File webpackOutputDirectory() {
+        return frontendOutputDirectory();
+    }
+
+    @Override
+    public File frontendOutputDirectory() {
         return new File(project.getBuild().getOutputDirectory(),
                 VAADIN_WEBAPP_RESOURCES);
     }

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
@@ -233,8 +233,10 @@ internal class GradlePluginAdapter private constructor(
         return File(buildResourcesDir, Constants.VAADIN_SERVLET_RESOURCES)
     }
 
-    override fun webpackOutputDirectory(): File =
-        config.webpackOutputDirectory.get()
+    override fun webpackOutputDirectory(): File = frontendOutputDirectory()
+
+    override fun frontendOutputDirectory(): File =
+        config.frontendOutputDirectory.get()
 
     override fun frontendResourcesDirectory(): File =
         config.frontendResourcesDirectory.get()

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/PrepareFrontendInputProperties.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/PrepareFrontendInputProperties.kt
@@ -44,8 +44,8 @@ internal class PrepareFrontendInputProperties(
 
     @Input
     @Optional
-    fun getWebpackOutputDirectory(): Provider<String> =
-        config.webpackOutputDirectory
+    fun getFrontendOutputDirectory(): Provider<String> =
+        config.frontendOutputDirectory
             .filterExists()
             .absolutePath
 
@@ -53,7 +53,8 @@ internal class PrepareFrontendInputProperties(
     fun getNpmFolder(): Provider<String> = config.npmFolder.absolutePath
 
     @Input
-    fun getFrontendDirectory(): Provider<String> = config.frontendDirectory.absolutePath
+    fun getFrontendDirectory(): Provider<String> =
+        config.frontendDirectory.absolutePath
 
     @Input
     fun getGenerateBundle(): Provider<Boolean> = config.generateBundle

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
@@ -44,11 +44,22 @@ public abstract class VaadinFlowPluginExtension @Inject constructor(private val 
     public abstract val productionMode: Property<Boolean>
 
     /**
-     * The folder where webpack should output index.js and other generated
+     * The folder where the frontend build tool should output index.js and other generated
      * files. Defaults to `null` which will use the auto-detected value of
      * resoucesDir of the main SourceSet, usually `build/resources/main/META-INF/VAADIN/webapp/`.
      */
+    @Deprecated(
+        "use frontendOutputDirectory instead",
+        replaceWith = ReplaceWith("frontendOutputDirectory")
+    )
     public abstract val webpackOutputDirectory: Property<File>
+
+    /**
+     * The folder where the frontend build tool should output index.js and other generated
+     * files. Defaults to `null` which will use the auto-detected value of
+     * resoucesDir of the main SourceSet, usually `build/resources/main/META-INF/VAADIN/webapp/`.
+     */
+    public abstract val frontendOutputDirectory: Property<File>
 
     /**
      * The folder where `package.json` file is located. Default is project root
@@ -365,14 +376,18 @@ public class PluginEffectiveConfiguration(
             }
 
 
-    public val webpackOutputDirectory: Provider<File> =
-        extension.webpackOutputDirectory
-            .convention(sourceSetName.map {
-                File(
-                    project.getBuildResourcesDir(it),
-                    Constants.VAADIN_WEBAPP_RESOURCES
+    public val frontendOutputDirectory: Provider<File> =
+        extension.frontendOutputDirectory.convention(
+            extension.webpackOutputDirectory
+                .convention(
+                    sourceSetName.map {
+                        File(
+                            project.getBuildResourcesDir(it),
+                            Constants.VAADIN_WEBAPP_RESOURCES
+                        )
+                    }
                 )
-            })
+        )
 
     public val npmFolder: Provider<File> = extension.npmFolder
         .convention(project.projectDir)
@@ -617,7 +632,7 @@ public class PluginEffectiveConfiguration(
     override fun toString(): String = "PluginEffectiveConfiguration(" +
             "productionMode=${productionMode.get()}, " +
             "applicationIdentifier=${applicationIdentifier.get()}, " +
-            "webpackOutputDirectory=${webpackOutputDirectory.get()}, " +
+            "frontendOutputDirectory=${frontendOutputDirectory.get()}, " +
             "npmFolder=${npmFolder.get()}, " +
             "frontendDirectory=${frontendDirectory.get()}, " +
             "generateBundle=${generateBundle.get()}, " +
@@ -661,16 +676,6 @@ public class PluginEffectiveConfiguration(
                 project,
                 VaadinFlowPluginExtension.get(project)
             )
-
-        /*
-        public fun toolsSettings(extension: VaadinFlowPluginExtension): Provider<FrontendToolsSettings> =
-            extension.npmFolder.map {
-                FrontendToolsSettings(it.absolutePath) {
-                    FrontendUtils.getVaadinHomeDirectory()
-                        .absolutePath
-                }
-            }
-         */
 
     }
 }

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.plugin.maven;
 
 import javax.inject.Inject;
-
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -219,10 +218,21 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
     /**
      * The folder where the frontend build tool should output index.js and other
      * generated files.
+     *
+     * @deprecated Use {@link #frontendOutputDirectory} instead.
      */
     @Parameter(defaultValue = "${project.build.outputDirectory}/"
             + VAADIN_WEBAPP_RESOURCES)
+    @Deprecated
     private File webpackOutputDirectory;
+
+    /**
+     * The folder where the frontend build tool should output index.js and other
+     * generated files.
+     */
+    @Parameter(defaultValue = "${project.build.outputDirectory}/"
+            + VAADIN_WEBAPP_RESOURCES)
+    private File frontendOutputDirectory;
 
     /**
      * Build directory for the project.
@@ -650,8 +660,24 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
 
     @Override
     public File webpackOutputDirectory() {
+        return frontendOutputDirectory();
+    }
 
-        return webpackOutputDirectory;
+    @Override
+    public File frontendOutputDirectory() {
+        if (webpackOutputDirectory != null) {
+            if (frontendOutputDirectory == null) {
+                logWarn("'webpackOutputDirectory' property is deprecated and will be removed in future releases. Please use 'frontendOutputDirectory' instead.");
+                frontendOutputDirectory = webpackOutputDirectory;
+                webpackOutputDirectory = null;
+            } else {
+                logWarn("Both 'frontendOutputDirectory' and 'webpackOutputDirectory' are set. "
+                        + "'webpackOutputDirectory' property will be removed in future releases and will be ignored. "
+                        + "Please use only 'frontendOutputDirectory'.");
+                webpackOutputDirectory = null;
+            }
+        }
+        return frontendOutputDirectory;
     }
 
     @Override

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -153,7 +153,7 @@ public class BuildFrontendUtil {
                 .withFrontendHotdeploy(adapter.isFrontendHotdeploy())
                 .withFrontendDirectory(getFrontendDirectory(adapter))
                 .withBuildDirectory(adapter.buildFolder())
-                .withBuildResultFolders(adapter.webpackOutputDirectory(),
+                .withBuildResultFolders(adapter.frontendOutputDirectory(),
                         adapter.servletResourceOutputDirectory())
                 .withJarFrontendResourcesFolder(
                         getJarFrontendResourcesFolder(adapter))
@@ -337,7 +337,7 @@ public class BuildFrontendUtil {
                     .withFrontendDirectory(getFrontendDirectory(adapter))
                     .withBuildDirectory(adapter.buildFolder())
                     .withRunNpmInstall(adapter.runNpmInstall())
-                    .withBuildResultFolders(adapter.webpackOutputDirectory(),
+                    .withBuildResultFolders(adapter.frontendOutputDirectory(),
                             adapter.servletResourceOutputDirectory())
                     .enablePackagesUpdate(true)
                     .useByteCodeScanner(adapter.optimizeBundle())
@@ -410,7 +410,7 @@ public class BuildFrontendUtil {
                     .withFrontendDirectory(getFrontendDirectory(adapter))
                     .withBuildDirectory(adapter.buildFolder())
                     .withRunNpmInstall(adapter.runNpmInstall())
-                    .withBuildResultFolders(adapter.webpackOutputDirectory(),
+                    .withBuildResultFolders(adapter.frontendOutputDirectory(),
                             adapter.servletResourceOutputDirectory())
                     .enablePackagesUpdate(true).useByteCodeScanner(false)
                     .withJarFrontendResourcesFolder(
@@ -596,7 +596,7 @@ public class BuildFrontendUtil {
      */
     public static boolean validateLicenses(PluginAdapterBase adapter,
             FrontendDependenciesScanner frontendDependencies) {
-        File outputFolder = adapter.webpackOutputDirectory();
+        File outputFolder = adapter.frontendOutputDirectory();
 
         String statsJsonContent = null;
         try {

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBase.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBase.java
@@ -278,8 +278,20 @@ public interface PluginAdapterBase {
      * files.
      *
      * @return {@link File}
+     * @deprecated since 24.8, use {@link #frontendOutputDirectory()} instead.
      */
+    @Deprecated(since = "24.8", forRemoval = true)
     File webpackOutputDirectory();
+
+    /**
+     * The folder where the frontend build tool should output index.js and other
+     * generated files.
+     *
+     * @return {@link File}
+     */
+    default File frontendOutputDirectory() {
+        return webpackOutputDirectory();
+    }
 
     /**
      * The folder where everything is built into.


### PR DESCRIPTION
This change deprecates `webpackOutputDirectory` method and replaces it with a newly introduced `frontendOutputDirectory` method.

Fixes #21635
