### PR TITLE
chore: downgrade vite-plugin-checker to support node 20 (23.6)

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
@@ -12,7 +12,7 @@
     "vite": "3.2.11",
     "@rollup/plugin-replace": "3.1.0",
     "rollup-plugin-brotli": "3.1.0",
-    "vite-plugin-checker": "0.9.3",
+    "vite-plugin-checker": "0.6.4",
     "mkdirp": "3.0.1",
     "workbox-build": "6.6.1",
     "@rollup/pluginutils": "4.2.1",


### PR DESCRIPTION
Since version 0.7.0, vite-plugin-checker is an ES Module, and its import in vite.generated.ts fails with ERR_REQUIRE_ESM error. This change downgrades the plugin to a version compatible with Node 20/ Vite 3
