### PR TITLE
feat: add ElementRequestHandler to Element

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/HtmlObject.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/HtmlObject.java
@@ -328,9 +328,7 @@ public class HtmlObject extends HtmlContainer implements
             // where it is 'attachment' by default
             handler.inline();
         }
-        getElement().setAttribute("data",
-                new StreamResourceRegistry.ElementStreamResource(data,
-                        this.getElement()));
+        getElement().setAttribute("data", data);
     }
 
     /**

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
@@ -201,9 +201,7 @@ public class IFrame extends HtmlComponent implements HasAriaLabel {
             // where it is 'attachment' by default
             handler.inline();
         }
-        getElement().setAttribute("src",
-                new StreamResourceRegistry.ElementStreamResource(
-                        downloadHandler, this.getElement()));
+        getElement().setAttribute("src", downloadHandler);
     }
 
     /**

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
@@ -165,9 +165,7 @@ public class Image extends HtmlContainer
             // where it is 'attachment' by default
             handler.inline();
         }
-        getElement().setAttribute("src",
-                new StreamResourceRegistry.ElementStreamResource(
-                        downloadHandler, this.getElement()));
+        getElement().setAttribute("src", downloadHandler);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -55,6 +55,9 @@ import com.vaadin.flow.internal.nodefeature.VirtualChildrenList;
 import com.vaadin.flow.server.AbstractStreamResource;
 import com.vaadin.flow.server.Command;
 import com.vaadin.flow.server.StreamResource;
+import com.vaadin.flow.server.StreamResourceRegistry;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.server.streams.ElementRequestHandler;
 import com.vaadin.flow.shared.Registration;
 
 import elemental.json.Json;
@@ -347,6 +350,33 @@ public class Element extends Node<Element> {
         }
 
         return this;
+    }
+
+
+    /**
+     * Sets the given attribute to the given {@link ElementRequestHandler} value.
+     * <p>
+     * Attribute names are considered case insensitive and all names will be
+     * converted to lower case automatically.
+     * <p>
+     * This is a convenience method to register a {@link ElementRequestHandler}
+     * instance into the session and use the registered resource URI as an
+     * element attribute.
+     * <p>
+     *
+     * @see #setAttribute(String, String)
+     *
+     * @param attribute
+     *            the name of the attribute
+     * @param requestHandler
+     *            the resource value, not null
+     * @return this element
+     */
+    public Element setAttribute(String attribute, ElementRequestHandler requestHandler) {
+        AbstractStreamResource resource = new StreamResourceRegistry.ElementStreamResource(
+                    requestHandler, this);
+
+       return setAttribute(attribute, resource);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/StreamResourceRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StreamResourceRegistry.java
@@ -149,12 +149,7 @@ public class StreamResourceRegistry implements Serializable {
             ElementRequestHandler elementRequestHandler, Element owner) {
         AbstractStreamResource wrappedResource = new ElementStreamResource(
                 elementRequestHandler, owner);
-        session.checkHasLock(
-                "Session needs to be locked when registering stream resources.");
-        StreamRegistration registration = new Registration(this,
-                wrappedResource.getId(), wrappedResource.getName());
-        res.put(registration.getResourceUri(), wrappedResource);
-        return registration;
+        return registerResource(wrappedResource);
     }
 
     /**

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DownloadHandlerView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DownloadHandlerView.java
@@ -37,8 +37,6 @@ import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 @Route(value = "com.vaadin.flow.uitest.ui.DownloadHandlerView", layout = ViewTestLayout.class)
 public class DownloadHandlerView extends Div {
 
-    List<StreamRegistration> registrations = new ArrayList<>();
-
     public DownloadHandlerView() {
 
         DownloadHandler downloadHandler = new DownloadHandler() {
@@ -53,43 +51,29 @@ public class DownloadHandlerView extends Div {
             }
         };
 
-        StreamRegistration streamRegistration = VaadinSession.getCurrent()
-                .getResourceRegistry().registerResource(downloadHandler);
-        registrations.add(streamRegistration);
 
         Anchor handlerDownload = new Anchor("", "Textual DownloadHandler");
-        handlerDownload.setHref(streamRegistration.getResource());
+        handlerDownload.setHref(downloadHandler);
         handlerDownload.setId("download-handler-text");
 
         File jsonFile = new File(getClass().getClassLoader()
                 .getResource("download.json").getFile());
-        streamRegistration = VaadinSession.getCurrent().getResourceRegistry()
-                .registerResource(DownloadHandler.forFile(jsonFile).inline());
-        registrations.add(streamRegistration);
 
         Anchor fileDownload = new Anchor("", "File DownloadHandler shorthand");
-        fileDownload.setHref(streamRegistration.getResource());
+        fileDownload.setHref(DownloadHandler.forFile(jsonFile).inline());
         fileDownload.setId("download-handler-file");
-
-        streamRegistration = VaadinSession.getCurrent().getResourceRegistry()
-                .registerResource(DownloadHandler
-                        .forClassResource(this.getClass(), "class-file.json")
-                        .inline());
-        registrations.add(streamRegistration);
 
         Anchor classDownload = new Anchor("",
                 "Class resource DownloadHandler shorthand");
-        classDownload.setHref(streamRegistration.getResource());
+        classDownload.setHref(DownloadHandler
+                .forClassResource(this.getClass(), "class-file.json")
+                .inline());
         classDownload.setId("download-handler-class");
-
-        streamRegistration = VaadinSession.getCurrent().getResourceRegistry()
-                .registerResource(DownloadHandler
-                        .forServletResource("/WEB-INF/servlet.json").inline());
-        registrations.add(streamRegistration);
 
         Anchor servletDownload = new Anchor("",
                 "Servlet resource DownloadHandler shorthand");
-        servletDownload.setHref(streamRegistration.getResource());
+        servletDownload.setHref(DownloadHandler
+                .forServletResource("/WEB-INF/servlet.json").inline());
         servletDownload.setId("download-handler-servlet");
 
         DownloadHandler inputStream = DownloadHandler
@@ -99,25 +83,18 @@ public class DownloadHandlerView extends Div {
                         "file+.jpg", "text/plain",
                         "foo".getBytes(StandardCharsets.UTF_8).length))
                 .inline();
-        streamRegistration = VaadinSession.getCurrent().getResourceRegistry()
-                .registerResource(inputStream);
-        registrations.add(streamRegistration);
 
         Anchor inputStreamDownload = new Anchor("",
                 "InputStream DownloadHandler shorthand");
-        inputStreamDownload.setHref(streamRegistration.getResource());
+        inputStreamDownload.setHref(inputStream);
         inputStreamDownload.setId("download-handler-input-stream");
-
-        streamRegistration = VaadinSession.getCurrent().getResourceRegistry()
-                .registerResource(DownloadHandler
-                        .fromInputStream(downloadEvent -> DownloadResponse
-                                .error(HttpStatusCode.INTERNAL_SERVER_ERROR))
-                        .inline());
-        registrations.add(streamRegistration);
 
         Anchor inputStreamErrorDownload = new Anchor("",
                 "InputStream DownloadHandler shorthand");
-        inputStreamErrorDownload.setHref(streamRegistration.getResource());
+        inputStreamErrorDownload.setHref(DownloadHandler
+                .fromInputStream(downloadEvent -> DownloadResponse
+                        .error(HttpStatusCode.INTERNAL_SERVER_ERROR))
+                .inline());
         inputStreamErrorDownload.setId("download-handler-input-stream-error");
 
         add(handlerDownload, fileDownload, classDownload, servletDownload,
@@ -131,10 +108,5 @@ public class DownloadHandlerView extends Div {
         reattach.setId("detach-attach");
 
         add(reattach);
-    }
-
-    @Override
-    protected void onDetach(DetachEvent detachEvent) {
-        registrations.forEach(StreamRegistration::unregister);
     }
 }


### PR DESCRIPTION
Add possibility to give a
ElementRequestHandler as attribute
to Element so you can directly
use .setAttribute("xyz", downloadHandler)
and  .setAttribute("xyz", uploadHandler)

