### PR TITLE
fix: download sets content-disposition

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/ClassDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/ClassDownloadHandler.java
@@ -24,6 +24,7 @@ import java.io.UncheckedIOException;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.server.HttpStatusCode;
+import com.vaadin.flow.server.VaadinResponse;
 
 /**
  * Download handler for serving a class resource.
@@ -104,6 +105,9 @@ public class ClassDownloadHandler
                     getContentType(resourceName, downloadEvent.getResponse()));
             if (!isInline()) {
                 downloadEvent.setFileName(resourceName);
+            } else {
+                downloadEvent.getResponse().setHeader("Content-Disposition",
+                        "inline");
             }
             TransferUtil.transfer(inputStream, outputStream,
                     getTransferContext(downloadEvent), getListeners());

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/FileDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/FileDownloadHandler.java
@@ -79,6 +79,9 @@ public class FileDownloadHandler
             String resourceName = getUrlPostfix();
             if (!isInline()) {
                 downloadEvent.setFileName(resourceName);
+            } else {
+                downloadEvent.getResponse().setHeader("Content-Disposition",
+                        "inline");
             }
             downloadEvent
                     .setContentType(getContentType(resourceName, response));

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/InputStreamDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/InputStreamDownloadHandler.java
@@ -62,6 +62,9 @@ public class InputStreamDownloadHandler
 
         if (!isInline()) {
             downloadEvent.setFileName(downloadName);
+        } else {
+            downloadEvent.getResponse().setHeader("Content-Disposition",
+                    "inline");
         }
 
         try (OutputStream outputStream = downloadEvent.getOutputStream();

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandler.java
@@ -87,6 +87,9 @@ public class ServletResourceDownloadHandler
                         .setContentType(getContentType(resourceName, response));
                 if (!isInline()) {
                     downloadEvent.setFileName(resourceName);
+                } else {
+                    downloadEvent.getResponse().setHeader("Content-Disposition",
+                            "inline");
                 }
                 TransferUtil.transfer(inputStream, outputStream,
                         getTransferContext(downloadEvent), getListeners());

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/ClassDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/ClassDownloadHandlerTest.java
@@ -221,4 +221,21 @@ public class ClassDownloadHandlerTest {
         Mockito.verify(event, Mockito.times(0)).setFileName("my-download.pdf");
         Mockito.verify(event).setContentType("application/pdf");
     }
+
+    @Test
+    public void handleSetToInline_contentTypeIsInline() throws IOException {
+        DownloadHandler handler = DownloadHandler.forClassResource(
+                this.getClass(), PATH_TO_FILE, "my-download.pdf").inline();
+
+        DownloadEvent event = new DownloadEvent(request, response, session,
+                new Element("t"));
+        Mockito.when(response.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(response.getService()).thenReturn(service);
+        Mockito.when(service.getMimeType(Mockito.anyString()))
+                .thenReturn("application/octet-stream");
+
+        handler.handleDownloadRequest(event);
+
+        Mockito.verify(response).setHeader("Content-Disposition", "inline");
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/FileDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/FileDownloadHandlerTest.java
@@ -230,4 +230,24 @@ public class FileDownloadHandlerTest {
         Mockito.verify(event).setContentType("application/octet-stream");
         Mockito.verify(event).setContentLength(165000);
     }
+
+    @Test
+    public void handleSetToInline_contentTypeIsInline()
+            throws IOException, URISyntaxException {
+        URL resource = getClass().getClassLoader().getResource(PATH_TO_FILE);
+        DownloadHandler handler = DownloadHandler
+                .forFile(new File(resource.toURI()), "my-download.bin")
+                .inline();
+
+        DownloadEvent event = new DownloadEvent(request, response, session,
+                new Element("t"));
+        Mockito.when(response.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(response.getService()).thenReturn(service);
+        Mockito.when(service.getMimeType(Mockito.anyString()))
+                .thenReturn("application/octet-stream");
+
+        handler.handleDownloadRequest(event);
+
+        Mockito.verify(response).setHeader("Content-Disposition", "inline");
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/InputStreamDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/InputStreamDownloadHandlerTest.java
@@ -296,6 +296,29 @@ public class InputStreamDownloadHandlerTest {
         Mockito.verify(response).setContentType(contentType);
     }
 
+    @Test
+    public void handleSetToInline_contentTypeIsInline() throws IOException {
+        InputStream stream = Mockito.mock(InputStream.class);
+        Mockito.when(
+                stream.read(Mockito.any(), Mockito.anyInt(), Mockito.anyInt()))
+                .thenReturn(-1);
+        DownloadHandler handler = DownloadHandler
+                .fromInputStream(event -> new DownloadResponse(stream,
+                        "download", "application/octet-stream", 0))
+                .inline();
+
+        DownloadEvent event = new DownloadEvent(request, response, session,
+                new Element("t"));
+        Mockito.when(response.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(response.getService()).thenReturn(service);
+        Mockito.when(service.getMimeType(Mockito.anyString()))
+                .thenReturn("application/octet-stream");
+
+        handler.handleDownloadRequest(event);
+
+        Mockito.verify(response).setHeader("Content-Disposition", "inline");
+    }
+
     private static byte[] getBytes() {
         // Simulate a download of 165000 bytes
         byte[] data = new byte[165000];

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandlerTest.java
@@ -239,4 +239,21 @@ public class ServletResourceDownloadHandlerTest {
         Mockito.verify(event, Mockito.times(0)).setFileName("my-download.bin");
         Mockito.verify(event).setContentType("application/octet-stream");
     }
+
+    @Test
+    public void handleSetToInline_contentTypeIsInline() throws IOException {
+        DownloadHandler handler = DownloadHandler
+                .forServletResource(PATH_TO_FILE, "my-download.bin").inline();
+
+        DownloadEvent event = new DownloadEvent(request, response, session,
+                new Element("t"));
+        Mockito.when(response.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(response.getService()).thenReturn(service);
+        Mockito.when(service.getMimeType(Mockito.anyString()))
+                .thenReturn("application/octet-stream");
+
+        handler.handleDownloadRequest(event);
+
+        Mockito.verify(response).setHeader("Content-Disposition", "inline");
+    }
 }


### PR DESCRIPTION
Download handlers should set
content-disposition: inline
when inline has been invoked.
