### PR TITLE
fix: Use handlers registered using ResourceHandlerRegistry

### DIFF
--- a/flow-tests/vaadin-spring-tests/test-spring-boot-contextpath/src/main/resources/application.properties
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-contextpath/src/main/resources/application.properties
@@ -1,4 +1,3 @@
 server.port=8888
 server.servlet.contextPath=/context
-vaadin.exclude-urls=/swagger-ui/**
 

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-jar/src/main/resources/application.properties
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-jar/src/main/resources/application.properties
@@ -1,4 +1,2 @@
 server.port=8888
-vaadin.exclude-urls=/swagger-ui/**
-
 spring.mvc.static-path-pattern=/static/**

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-only-prepare/src/main/resources/application.properties
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-only-prepare/src/main/resources/application.properties
@@ -1,3 +1,2 @@
 server.port=8888
 vaadin.blocked-packages=vaadin-spring/target/test-classes
-vaadin.excludeUrls=/swagger-ui/**

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-reverseproxy/src/main/resources/application.properties
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-reverseproxy/src/main/resources/application.properties
@@ -1,5 +1,4 @@
 server.port=8888
 proxy.port=9999
 proxy.path=/public/path
-vaadin.excludeUrls=/swagger-ui/**
 springdoc.swagger-ui.configUrl=/public/path/v3/api-docs/swagger-config

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-scan/src/main/resources/application.properties
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-scan/src/main/resources/application.properties
@@ -1,2 +1,1 @@
 server.port=8888
-vaadin.exclude-urls=/swagger-ui/**

--- a/flow-tests/vaadin-spring-tests/test-spring-boot/src/main/resources/application.properties
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot/src/main/resources/application.properties
@@ -1,2 +1,1 @@
 server.port=8888
-vaadin.exclude-urls=/swagger-ui/**

--- a/flow-tests/vaadin-spring-tests/test-spring-war/src/main/resources/application.properties
+++ b/flow-tests/vaadin-spring-tests/test-spring-war/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-vaadin.exclude-urls=/swagger-ui/**

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletConfiguration.java
@@ -25,6 +25,8 @@ import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -36,6 +38,7 @@ import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.context.support.ServletContextResource;
 import org.springframework.web.servlet.DispatcherServlet;
 import org.springframework.web.servlet.HandlerExecutionChain;
+import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.handler.SimpleUrlHandlerMapping;
 import org.springframework.web.servlet.mvc.Controller;
 import org.springframework.web.servlet.mvc.ServletForwardingController;
@@ -101,11 +104,11 @@ public class VaadinServletConfiguration {
         private List<String> excludeUrls;
         private AntPathMatcher matcher;
         private UrlPathHelper urlPathHelper = new UrlPathHelper();
-        private SimpleUrlHandlerMapping resourceHandlerMapping;
+        private HandlerMapping resourceHandlerMapping;
 
         public RootExcludeHandler(List<String> excludeUrls,
                 Controller vaadinForwardingController,
-                SimpleUrlHandlerMapping resourceHandlerMapping) {
+                HandlerMapping resourceHandlerMapping) {
             this.excludeUrls = excludeUrls;
             this.resourceHandlerMapping = resourceHandlerMapping;
             matcher = new AntPathMatcher();
@@ -176,23 +179,10 @@ public class VaadinServletConfiguration {
      */
     @Bean
     public RootExcludeHandler vaadinRootMapping(Environment environment,
-            WebApplicationContext webApplicationContext) {
-        SimpleUrlHandlerMapping resourceHandlerMapping = null;
-        try {
-            resourceHandlerMapping = webApplicationContext.getBean(
-                    "resourceHandlerMapping", SimpleUrlHandlerMapping.class);
-        } catch (Exception e) {
-            getLogger().debug(
-                    "Unable to find resourceHandlerMapping bean, "
-                            + "will not handle all static resources correctly",
-                    e);
-        }
+            WebApplicationContext webApplicationContext,
+            @Autowired(required = false) @Qualifier("resourceHandlerMapping") HandlerMapping resourceHandlerMapping) {
         return new RootExcludeHandler(getExcludedUrls(environment),
-                vaadinForwardingController(), resourceHandlerMapping);
-    }
-
-    private Logger getLogger() {
-        return LoggerFactory.getLogger(getClass());
+                vaadinForwardingController(), null);
     }
 
     /**

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletConfiguration.java
@@ -141,14 +141,16 @@ public class VaadinServletConfiguration {
                 // Check if the request is for a static resource
                 HandlerExecutionChain handler = resourceHandlerMapping
                         .getHandler(request);
-                Object innerHandler = handler.getHandler();
-                if (innerHandler instanceof ResourceHttpRequestHandler resourceHttpRequestHandler) {
-                    if (!mapsToRoot(resourceHttpRequestHandler)) {
-                        // We cannot use the context resource mapped to / as
-                        // it would overwrite all
-                        // routes. Anything mapped to only a certain part of
-                        // the app is okay to use.
-                        return handler;
+                if (handler != null) {
+                    Object innerHandler = handler.getHandler();
+                    if (innerHandler instanceof ResourceHttpRequestHandler resourceHttpRequestHandler) {
+                        if (!mapsToRoot(resourceHttpRequestHandler)) {
+                            // We cannot use the context resource mapped to / as
+                            // it would overwrite all
+                            // routes. Anything mapped to only a certain part of
+                            // the app is okay to use.
+                            return handler;
+                        }
                     }
                 }
             }

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletConfiguration.java
@@ -136,17 +136,16 @@ public class VaadinServletConfiguration {
             }
             if (resourceHandlerMapping != null) {
                 // Check if the request is for a static resource
-                Object handler = resourceHandlerMapping.getHandler(request);
-                if (handler instanceof HandlerExecutionChain chain) {
-                    Object innerHandler = chain.getHandler();
-                    if (innerHandler instanceof ResourceHttpRequestHandler resourceHttpRequestHandler) {
-                        if (!mapsToRoot(resourceHttpRequestHandler)) {
-                            // We cannot use the context resource mapped to / as
-                            // it would overwrite all
-                            // routes. Anything mapped to only a certain part of
-                            // the app is okay to use.
-                            return handler;
-                        }
+                HandlerExecutionChain handler = resourceHandlerMapping
+                        .getHandler(request);
+                Object innerHandler = handler.getHandler();
+                if (innerHandler instanceof ResourceHttpRequestHandler resourceHttpRequestHandler) {
+                    if (!mapsToRoot(resourceHttpRequestHandler)) {
+                        // We cannot use the context resource mapped to / as
+                        // it would overwrite all
+                        // routes. Anything mapped to only a certain part of
+                        // the app is okay to use.
+                        return handler;
                     }
                 }
             }

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletConfiguration.java
@@ -184,7 +184,7 @@ public class VaadinServletConfiguration {
             WebApplicationContext webApplicationContext,
             @Autowired(required = false) @Qualifier("resourceHandlerMapping") HandlerMapping resourceHandlerMapping) {
         return new RootExcludeHandler(getExcludedUrls(environment),
-                vaadinForwardingController(), null);
+                vaadinForwardingController(), resourceHandlerMapping);
     }
 
     /**


### PR DESCRIPTION
For instance Swagger uses ResourceHandlerRegistry to register a handler for /swagger-ui/index.html and this is now called without excluding any url from Vaadin
