### PR TITLE
feat: Add a short method to SortDirection enum

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/SortDirection.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/SortDirection.java
@@ -41,4 +41,16 @@ public enum SortDirection {
     public SortDirection getOpposite() {
         return ASCENDING.equals(this) ? DESCENDING : ASCENDING;
     }
+
+    /**
+     * Get the short name of the sort direction.
+     *
+     * @return The shortened representation of the sort direction, either "asc" or "desc"
+     */
+    public String getShortName() {
+        return switch (this){
+            case ASCENDING -> "asc";
+            case DESCENDING -> "desc";
+        };
+    }
 }

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/SortDirection.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/SortDirection.java
@@ -48,9 +48,6 @@ public enum SortDirection {
      * @return The shortened representation of the sort direction, either "asc" or "desc"
      */
     public String getShortName() {
-        return switch (this){
-            case ASCENDING -> "asc";
-            case DESCENDING -> "desc";
-        };
+        return ASCENDING.equals(this) ? "asc" : "desc";
     }
 }


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description
The `SortDirection` enum only provides `name()`, `getOpposite()` methods. This change introduces a new method called `getShortName()` which returns shortened version of `SortDirection`. This short names can be useful in the SQL queries etc.

Fixes #21693 

## Type of change

- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
