### PR TITLE
chore: use constructor.newinstance

### DIFF
--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/Jsr303Test.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/Jsr303Test.java
@@ -114,13 +114,14 @@ public class Jsr303Test {
     }
 
     @Test
-    public void beanBinderWithoutJsr303() throws ClassNotFoundException,
-            NoSuchMethodException, SecurityException, InstantiationException,
-            IllegalAccessException, IllegalArgumentException,
-            InvocationTargetException, IOException, InterruptedException {
+    public void beanBinderWithoutJsr303()
+            throws ClassNotFoundException, NoSuchMethodException,
+            SecurityException, InstantiationException, IllegalAccessException,
+            IllegalArgumentException, InvocationTargetException, IOException {
         try (URLClassLoader loader = new TestClassLoader()) {
             Class<?> clazz = loader.loadClass(Jsr303UnitTest.class.getName());
-            UnitTest test = (UnitTest) clazz.newInstance();
+            UnitTest test = (UnitTest) clazz.getDeclaredConstructor()
+                    .newInstance();
             test.execute();
         }
     }

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/NotEmptyTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/NotEmptyTest.java
@@ -106,11 +106,11 @@ public class NotEmptyTest {
     public void notEmptyAnnotationIsNotInClasspath()
             throws ClassNotFoundException, NoSuchMethodException,
             SecurityException, InstantiationException, IllegalAccessException,
-            IllegalArgumentException, InvocationTargetException, IOException,
-            InterruptedException {
+            IllegalArgumentException, InvocationTargetException, IOException {
         try (URLClassLoader loader = new TestClassLoader()) {
             Class<?> clazz = loader.loadClass(NotEmptyUnitTest.class.getName());
-            UnitTest test = (UnitTest) clazz.newInstance();
+            UnitTest test = (UnitTest) clazz.getDeclaredConstructor()
+                    .newInstance();
             test.execute();
         }
     }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.html;
 
 import java.beans.IntrospectionException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Optional;
 
 import org.junit.After;
@@ -40,7 +41,8 @@ public class AnchorTest extends ComponentTest {
 
     @Override
     public void setup() throws IntrospectionException, InstantiationException,
-            IllegalAccessException, ClassNotFoundException {
+            IllegalAccessException, ClassNotFoundException,
+            InvocationTargetException, NoSuchMethodException {
         whitelistProperty("download");
         super.setup();
     }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/ComponentTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/ComponentTest.java
@@ -48,7 +48,8 @@ public abstract class ComponentTest {
 
     @Before
     public void setup() throws IntrospectionException, InstantiationException,
-            IllegalAccessException, ClassNotFoundException {
+            IllegalAccessException, ClassNotFoundException,
+            InvocationTargetException, NoSuchMethodException {
         component = createComponent();
         whitelistProperty("visible");
         addProperties();
@@ -122,9 +123,11 @@ public abstract class ComponentTest {
     }
 
     protected Component createComponent() throws InstantiationException,
-            IllegalAccessException, ClassNotFoundException {
+            IllegalAccessException, ClassNotFoundException,
+            NoSuchMethodException, InvocationTargetException {
         String componentClass = getClass().getName().replace("Test", "");
-        return (Component) Class.forName(componentClass).newInstance();
+        return (Component) Class.forName(componentClass)
+                .getDeclaredConstructor().newInstance();
     }
 
     protected Component getComponent() {

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
@@ -138,7 +138,8 @@ public class HtmlComponentSmokeTest {
             // Test that all setters produce a result
             testSetters(instance);
         } catch (InstantiationException | IllegalAccessException
-                | IllegalArgumentException | InvocationTargetException e) {
+                | IllegalArgumentException | InvocationTargetException
+                | NoSuchMethodException e) {
             throw new RuntimeException(e);
         }
     }
@@ -379,12 +380,13 @@ public class HtmlComponentSmokeTest {
 
     private static HtmlComponent createInstance(
             Class<? extends HtmlComponent> clazz)
-            throws InstantiationException, IllegalAccessException {
+            throws InstantiationException, IllegalAccessException,
+            NoSuchMethodException, InvocationTargetException {
         Supplier<HtmlComponent> constructor = customConstructors.get(clazz);
         if (constructor != null) {
             return constructor.get();
         } else {
-            return clazz.newInstance();
+            return clazz.getDeclaredConstructor().newInstance();
         }
     }
 

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/InputTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/InputTest.java
@@ -16,6 +16,8 @@
 package com.vaadin.flow.component.html;
 
 import java.beans.IntrospectionException;
+import java.lang.reflect.InvocationTargetException;
+
 import org.junit.Test;
 
 public class InputTest extends ComponentTest {
@@ -24,7 +26,8 @@ public class InputTest extends ComponentTest {
 
     @Override
     public void setup() throws IntrospectionException, InstantiationException,
-            IllegalAccessException, ClassNotFoundException {
+            IllegalAccessException, ClassNotFoundException,
+            InvocationTargetException, NoSuchMethodException {
         whitelistProperty("valueChangeMode");
         whitelistProperty("valueChangeTimeout");
         super.setup();

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableTest.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.html;
 
 import java.beans.IntrospectionException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
 import org.junit.Test;
@@ -28,7 +29,8 @@ public class NativeTableTest extends ComponentTest {
 
     @Override
     public void setup() throws IntrospectionException, InstantiationException,
-            IllegalAccessException, ClassNotFoundException {
+            IllegalAccessException, ClassNotFoundException,
+            InvocationTargetException, NoSuchMethodException {
         whitelistProperty("captionText");
         super.setup();
     }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/RangeInputTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/RangeInputTest.java
@@ -19,6 +19,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.beans.IntrospectionException;
+import java.lang.reflect.InvocationTargetException;
 
 public class RangeInputTest extends ComponentTest {
 
@@ -26,7 +27,8 @@ public class RangeInputTest extends ComponentTest {
 
     @Override
     public void setup() throws IntrospectionException, InstantiationException,
-            IllegalAccessException, ClassNotFoundException {
+            IllegalAccessException, ClassNotFoundException,
+            InvocationTargetException, NoSuchMethodException {
         whitelistProperty("valueChangeMode");
         whitelistProperty("valueChangeTimeout");
         whitelistProperty("enabled");

--- a/flow-server/src/main/java/com/vaadin/flow/internal/JsonSerializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JsonSerializer.java
@@ -207,7 +207,7 @@ public final class JsonSerializer {
 
         T instance;
         try {
-            instance = type.newInstance();
+            instance = type.getDeclaredConstructor().newInstance();
         } catch (Exception e) {
             throw new IllegalArgumentException(
                     "Could not create an instance of type " + type
@@ -391,7 +391,8 @@ public final class JsonSerializer {
                             + "'. Use Lists, Sets or concrete classes that implement java.util.Collection.");
         }
         try {
-            return (Collection<?>) collectionType.newInstance();
+            return (Collection<?>) collectionType.getDeclaredConstructor()
+                    .newInstance();
         } catch (Exception e) {
             throw new IllegalArgumentException(
                     "Could not create an instance of the collection of type "

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
@@ -203,7 +203,8 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
             }
             throw ex;
         } catch (ClassNotFoundException | InstantiationException
-                | IllegalAccessException | IOException e) {
+                | IllegalAccessException | IOException | NoSuchMethodException
+                | InvocationTargetException e) {
             throw new IllegalStateException(
                     "Unable to compute frontend dependencies", e);
         }
@@ -611,7 +612,8 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
      * if found in the class-path
      */
     private void computeApplicationTheme() throws ClassNotFoundException,
-            InstantiationException, IllegalAccessException, IOException {
+            InstantiationException, IllegalAccessException, IOException,
+            InvocationTargetException, NoSuchMethodException {
 
         // This really should check entry points and not all classes, but the
         // old behavior is retained.. for now..

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScanner.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScanner.java
@@ -386,7 +386,8 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
             themeDefinition = new ThemeDefinition(theme, variant, name);
             try {
                 themeInstance = new ThemeWrapper(theme);
-            } catch (InstantiationException | IllegalAccessException e) {
+            } catch (InstantiationException | IllegalAccessException
+                    | NoSuchMethodException | InvocationTargetException e) {
                 throw new IllegalStateException("Unable to create a new '"
                         + theme.getName() + "' theme instance", e);
             }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/ThemeWrapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/ThemeWrapper.java
@@ -37,8 +37,9 @@ class ThemeWrapper implements AbstractTheme, Serializable {
     private final Serializable instance;
 
     public ThemeWrapper(Class<? extends AbstractTheme> theme)
-            throws InstantiationException, IllegalAccessException {
-        instance = theme.newInstance();
+            throws InstantiationException, IllegalAccessException,
+            NoSuchMethodException, InvocationTargetException {
+        instance = theme.getDeclaredConstructor().newInstance();
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ClassLoaderAwareServletContainerInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ClassLoaderAwareServletContainerInitializer.java
@@ -95,11 +95,12 @@ public interface ClassLoaderAwareServletContainerInitializer
                 Method operation = Stream.of(initializer.getMethods()).filter(
                         method -> method.getName().equals(processMethodName))
                         .findFirst().get();
-                operation.invoke(initializer.newInstance(),
+                operation.invoke(
+                        initializer.getDeclaredConstructor().newInstance(),
                         new Object[] { set, ctx });
             } catch (ClassNotFoundException | IllegalAccessException
                     | IllegalArgumentException | InvocationTargetException
-                    | InstantiationException e) {
+                    | InstantiationException | NoSuchMethodException e) {
                 throw new ServletException(e);
             }
         };

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.server.frontend.scanner;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Optional;
@@ -245,7 +246,7 @@ public class FrontendDependenciesTest {
 
     @Test
     public void defaultThemeIsLoadedForExporters() throws Exception {
-        FakeLumo.class.newInstance();
+        FakeLumo.class.getDeclaredConstructor().newInstance();
         Mockito.when(classFinder.getSubTypesOf(WebComponentExporter.class))
                 .thenReturn(Stream.of(MyExporter.class)
                         .collect(Collectors.toSet()));
@@ -304,9 +305,9 @@ public class FrontendDependenciesTest {
 
     @Test // #9861
     public void visitedExporter_previousEntryPointsNotOverridden()
-            throws InstantiationException, IllegalAccessException {
+            throws Exception {
 
-        FakeLumo.class.newInstance();
+        FakeLumo.class.getDeclaredConstructor().newInstance();
         // Reference found through first entry point
         Mockito.when(classFinder.getAnnotatedClasses(Route.class))
                 .thenReturn(Collections.singleton(ReferenceExporter.class));

--- a/flow-tests/test-frontend/test-bun/src/main/java/com/vaadin/flow/mixedtest/ui/MissingDependenciesView.java
+++ b/flow-tests/test-frontend/test-bun/src/main/java/com/vaadin/flow/mixedtest/ui/MissingDependenciesView.java
@@ -44,7 +44,7 @@ public class MissingDependenciesView extends Div {
         try {
             Component unreferenced = (Component) Class.forName(
                     "com.vaadin.flow.mixedtest.ui.MissingDependenciesView$Unreferenced")
-                    .newInstance();
+                    .getDeclaredConstructor().newInstance();
 
             // Uncomment to test behavior when the component is referenced
             // new Unreferenced();

--- a/flow-tests/test-frontend/test-npm/src/main/java/com/vaadin/flow/mixedtest/ui/MissingDependenciesView.java
+++ b/flow-tests/test-frontend/test-npm/src/main/java/com/vaadin/flow/mixedtest/ui/MissingDependenciesView.java
@@ -44,7 +44,7 @@ public class MissingDependenciesView extends Div {
         try {
             Component unreferenced = (Component) Class.forName(
                     "com.vaadin.flow.mixedtest.ui.MissingDependenciesView$Unreferenced")
-                    .newInstance();
+                    .getDeclaredConstructor().newInstance();
 
             // Uncomment to test behavior when the component is referenced
             // new Unreferenced();

--- a/flow-tests/test-frontend/test-pnpm/src/main/java/com/vaadin/flow/mixedtest/ui/MissingDependenciesView.java
+++ b/flow-tests/test-frontend/test-pnpm/src/main/java/com/vaadin/flow/mixedtest/ui/MissingDependenciesView.java
@@ -44,7 +44,7 @@ public class MissingDependenciesView extends Div {
         try {
             Component unreferenced = (Component) Class.forName(
                     "com.vaadin.flow.mixedtest.ui.MissingDependenciesView$Unreferenced")
-                    .newInstance();
+                    .getDeclaredConstructor().newInstance();
 
             // Uncomment to test behavior when the component is referenced
             // new Unreferenced();

--- a/flow-tests/test-frontend/vite-test-assets/src/main/java/com/vaadin/viteapp/views/template/TemplateView.java
+++ b/flow-tests/test-frontend/vite-test-assets/src/main/java/com/vaadin/viteapp/views/template/TemplateView.java
@@ -38,7 +38,7 @@ public class TemplateView extends Div {
         try {
             Class<?> clazz = Class.forName(
                     "com.vaadin.viteapp.views.template.ReflectivelyReferencedComponent");
-            add((Component) clazz.newInstance());
+            add((Component) clazz.getDeclaredConstructor().newInstance());
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/src/main/java/com/vaadin/flow/testnpmonlyfeatures/bytecodescanning/ByteCodeScanningView.java
+++ b/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/src/main/java/com/vaadin/flow/testnpmonlyfeatures/bytecodescanning/ByteCodeScanningView.java
@@ -27,7 +27,8 @@ public class ByteCodeScanningView extends Div {
     public ByteCodeScanningView() throws Exception {
         Class<?> clazz = Class.forName(
                 "com.vaadin.flow.testnpmonlyfeatures.bytecodescanning.MyButton");
-        Component button = (Component) clazz.newInstance();
+        Component button = (Component) clazz.getDeclaredConstructor()
+                .newInstance();
         button.setId(COMPONENT_ID);
         add(button);
     }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/ui/SerializationTest.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/ui/SerializationTest.java
@@ -40,7 +40,8 @@ public class SerializationTest {
             Collection<Class<? extends Component>> viewClasses = new ViewClassLocator(
                     getClass().getClassLoader()).getAllViewClasses();
             for (Class<? extends Component> viewClass : viewClasses) {
-                Component view = viewClass.newInstance();
+                Component view = viewClass.getDeclaredConstructor()
+                        .newInstance();
                 // view.onLocationChange(new LocationChangeEvent(new Router(),
                 // ui,
                 // NavigationTrigger.PROGRAMMATIC, new Location(""),

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/ui/ToStringTest.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/ui/ToStringTest.java
@@ -29,7 +29,7 @@ public class ToStringTest {
         Collection<Class<? extends Component>> viewClasses = new ViewClassLocator(
                 getClass().getClassLoader()).getAllViewClasses();
         for (Class<? extends Component> viewClass : viewClasses) {
-            Component view = viewClass.newInstance();
+            Component view = viewClass.getDeclaredConstructor().newInstance();
             String string = view.getElement().toString();
             Assert.assertNotNull(string);
             Assert.assertNotEquals("", string);

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/DevModeInitializerClassLoaderTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/DevModeInitializerClassLoaderTest.java
@@ -35,7 +35,7 @@ public class DevModeInitializerClassLoaderTest {
         // Load the base class with the custom loader
         Class<?> clz = customLoader
                 .loadClass(DevModeInitializerTestBase.class.getName());
-        Object initializer = clz.newInstance();
+        Object initializer = clz.getDeclaredConstructor().newInstance();
 
         // Since base class was created using a different classLoader,
         // its methods and fields need to be called using reflection


### PR DESCRIPTION
Use getDeclaredConstructor().newInstance()
instead of using the deprecated
class.newInstance()

Closes #9331