### PR TITLE
chore: add name tag to flow-plugin-base

### DIFF
--- a/flow-plugins/flow-plugin-base/pom.xml
+++ b/flow-plugins/flow-plugin-base/pom.xml
@@ -6,6 +6,7 @@
         <version>24.8-SNAPSHOT</version>
     </parent>
     <artifactId>flow-plugin-base</artifactId>
+    <name>Flow Plugin Base</name>
 
     <properties>
         <bnd.skip>false</bnd.skip>


### PR DESCRIPTION
missing project name will lead to release failure.