### PR TITLE
Disallow update operation in readonly transactions

### DIFF
--- a/signals/src/main/java/com/vaadin/signals/ValueSignal.java
+++ b/signals/src/main/java/com/vaadin/signals/ValueSignal.java
@@ -188,14 +188,13 @@ public class ValueSignal<T> extends Signal<T> {
          * Cannot easily optimize this to directly submit a transaction command
          * since we need the previous value from the set command result
          */
-        SignalOperation<T> setOperation = Transaction.runWithoutTransaction(
-                () -> Transaction.runInTransaction(() -> {
-                    T value = peek();
-                    verifyValue(value);
+        SignalOperation<T> setOperation = Transaction.runInTransaction(() -> {
+            T value = peek();
+            verifyValue(value);
 
-                    T newValue = updater.apply(value);
-                    return value(newValue);
-                }).returnValue());
+            T newValue = updater.apply(value);
+            return value(newValue);
+        }).returnValue();
 
         setOperation.result().whenComplete((result, error) -> {
             if (error != null) {

--- a/signals/src/test/java/com/vaadin/signals/ValueSignalTest.java
+++ b/signals/src/test/java/com/vaadin/signals/ValueSignalTest.java
@@ -637,6 +637,17 @@ public class ValueSignalTest extends SignalTestBase {
     }
 
     @Test
+    void transaction_updateInReadOnlyTransaction_rejected() {
+        ValueSignal<String> signal = new ValueSignal<>("value");
+
+        Transaction.runInTransaction(() -> {
+            assertThrows(IllegalStateException.class, () -> {
+                signal.update(ignore -> "update");
+            });
+        }, Transaction.Type.READ_ONLY);
+    }
+
+    @Test
     void equalsHashCode() {
         ValueSignal<String> signal = new ValueSignal<>(String.class);
         assertEquals(signal, signal);


### PR DESCRIPTION
For some unknown reason, the `update` operation was wrapped in `runWithoutTransaction` which as a side effect meant that updates could be triggered from inside a readonly transaction. I don't see any reason for why `update` would be different from all the other operations, and there's also no previous test that would show why it's necessary.