### PR TITLE
fix: Avoid NPE when tracking usage for removed nodes

### DIFF
--- a/signals/src/main/java/com/vaadin/signals/impl/UsageTracker.java
+++ b/signals/src/main/java/com/vaadin/signals/impl/UsageTracker.java
@@ -116,7 +116,10 @@ public class UsageTracker {
         Runnable onNextChange(TransientListener listener);
     }
 
-    private static final Usage NO_USAGE = new Usage() {
+    /**
+     * A usage that doesn't have any changes and never fires any events.
+     */
+    public static final Usage NO_USAGE = new Usage() {
         @Override
         public boolean hasChanges() {
             return false;

--- a/signals/src/test/java/com/vaadin/signals/ValueSignalTest.java
+++ b/signals/src/test/java/com/vaadin/signals/ValueSignalTest.java
@@ -454,6 +454,34 @@ public class ValueSignalTest extends SignalTestBase {
     }
 
     @Test
+    void usageTracking_removeSignalAfterTracking_hasNoChanges() {
+        ListSignal<String> list = new ListSignal<>(String.class);
+        ValueSignal<String> signal = list.insertLast("value").signal();
+
+        Usage usage = UsageTracker.track(() -> {
+            signal.value();
+        });
+
+        list.remove(signal);
+
+        assertFalse(usage.hasChanges());
+    }
+
+    @Test
+    void usageTracking_removeSignalBeforeTracking_hasNoChanges() {
+        ListSignal<String> list = new ListSignal<>(String.class);
+        ValueSignal<String> signal = list.insertLast("value").signal();
+
+        list.remove(signal);
+
+        Usage usage = UsageTracker.track(() -> {
+            signal.value();
+        });
+
+        assertFalse(usage.hasChanges());
+    }
+
+    @Test
     void result_successfulOperation_resolvedThroughOverrideDispatcher() {
         TestExecutor dispatcher = useTestOverrideDispatcher();
 


### PR DESCRIPTION
The change value cannot be extracted if there's no data node in the tree. Check for this both when creating the usage instance and when later evaluating whether it has changes.

Note that removing a node is not seen as changing the node itself but only as a change to the node's parent.