### PR TITLE
fix: when using pnpm write overrides under pnpm

### DIFF
--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/CleanFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/CleanFrontendUtil.java
@@ -38,6 +38,7 @@ public class CleanFrontendUtil {
     public static final String DEPENDENCIES = "dependencies";
     public static final String DEV_DEPENDENCIES = "devDependencies";
     public static final String OVERRIDES = "overrides";
+    public static final String PNPM = "pnpm";
 
     /**
      * Exception thrown when cleaning the frontend fails.
@@ -207,6 +208,9 @@ public class CleanFrontendUtil {
         ObjectNode devDependencies = (ObjectNode) packageJson
                 .get(DEV_DEPENDENCIES);
         ObjectNode overridesSection = (ObjectNode) packageJson.get(OVERRIDES);
+        ObjectNode pnpmOverridesSection = packageJson.has(PNPM)
+                ? (ObjectNode) packageJson.get(PNPM).get(OVERRIDES)
+                : null;
 
         if (packageJson.has(VAADIN)) {
             ObjectNode vaadin = (ObjectNode) packageJson.get(VAADIN);
@@ -219,6 +223,7 @@ public class CleanFrontendUtil {
             cleanObject(dependencies, vaadinDependencies);
             cleanObject(devDependencies, vaadinDevDependencies);
             cleanObject(overridesSection, vaadinDependencies, false);
+            cleanObject(pnpmOverridesSection, vaadinDependencies, false);
 
             packageJson.remove(VAADIN);
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -76,6 +76,7 @@ public abstract class NodeUpdater implements FallibleCommand {
     static final String HASH_KEY = "hash";
     static final String DEV_DEPENDENCIES = "devDependencies";
     static final String OVERRIDES = "overrides";
+    static final String PNPM = "pnpm";
 
     private static final String DEP_LICENSE_KEY = "license";
     private static final String DEP_LICENSE_DEFAULT = "UNLICENSED";


### PR DESCRIPTION
For pnpm usage write the overrides
section under the pnpm object
instead of the root of the package.json

Fixes #21724
Fixes #21682

