### PR TITLE
chore: Rollback to Spring Boot 3.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <failOnMissingWebXml>false</failOnMissingWebXml>
 
         <!-- Dependencies -->
-        <spring.boot.version>4.0.0-SNAPSHOT</spring.boot.version>
+        <spring.boot.version>3.5.3</spring.boot.version>
         <jakarta.ee.version>11.0.0</jakarta.ee.version>
         <gwt.version>2.9.0</gwt.version>
         <hibernate.validator.version>9.0.1.Final</hibernate.validator.version>


### PR DESCRIPTION
It's too early to upgrade to SB 4.0.0-SNAPSHOT as 4 is under intensive development and may be broken that blocks us.