### PR TITLE
fix: remove default value for deprecated property

### DIFF
--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -221,8 +221,6 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
      *
      * @deprecated Use {@link #frontendOutputDirectory} instead.
      */
-    @Parameter(defaultValue = "${project.build.outputDirectory}/"
-            + VAADIN_WEBAPP_RESOURCES)
     @Deprecated
     private File webpackOutputDirectory;
 
@@ -641,6 +639,8 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
             if (frontendOutputDirectory == null) {
                 logWarn("'webpackOutputDirectory' property is deprecated and will be removed in future releases. Please use 'frontendOutputDirectory' instead.");
                 frontendOutputDirectory = webpackOutputDirectory;
+                webpackOutputDirectory = null;
+            } else if (webpackOutputDirectory.equals(frontendOutputDirectory)) {
                 webpackOutputDirectory = null;
             } else {
                 logWarn("Both 'frontendOutputDirectory' and 'webpackOutputDirectory' are set. "


### PR DESCRIPTION
Having the default value leads to a wrong warning message "Both 'frontendOutputDirectory' and 'webpackOutputDirectory' are set"