### PR TITLE
fix: Distinguish between missing node and node with null value

### DIFF
--- a/signals/src/main/java/com/vaadin/signals/Signal.java
+++ b/signals/src/main/java/com/vaadin/signals/Signal.java
@@ -1,7 +1,6 @@
 package com.vaadin.signals;
 
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -220,10 +219,6 @@ public abstract class Signal<T> {
      */
     protected abstract Object usageChangeValue(Data data);
 
-    private Optional<Object> usageChangeValue(Transaction transaction) {
-        return transaction.read(tree).data(id).map(this::usageChangeValue);
-    }
-
     boolean isValid(SignalCommand command) {
         if (command instanceof SignalCommand.ConditionCommand) {
             return true;
@@ -389,22 +384,22 @@ public abstract class Signal<T> {
      * @return a usage instance, not <code>null</code>
      */
     protected Usage createUsage(Transaction transaction) {
-        Optional<Object> usageChangeValue = usageChangeValue(transaction);
-        if (usageChangeValue.isEmpty()) {
+        Data data = data(transaction);
+        if (data == null) {
             // Node is removed so no usage to track
             return UsageTracker.NO_USAGE;
         }
 
         // Capture so that we can use it later
-        Object originalValue = usageChangeValue.get();
+        Object originalValue = usageChangeValue(data);
 
         return new Usage() {
             @Override
             public boolean hasChanges() {
-                return usageChangeValue(Transaction.getCurrent())
-                        .map(changeValue -> !Objects.equals(originalValue,
-                                changeValue))
-                        .orElse(Boolean.FALSE);
+                Data currentData = data(Transaction.getCurrent());
+
+                return currentData != null && !Objects.equals(originalValue,
+                        usageChangeValue(currentData));
             }
 
             @Override

--- a/signals/src/test/java/com/vaadin/signals/impl/EffectTest.java
+++ b/signals/src/test/java/com/vaadin/signals/impl/EffectTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -286,6 +287,21 @@ public class EffectTest extends SignalTestBase {
         signal.insertLast("Two");
         assertEquals(List.of(List.of(), List.of("One"), List.of("One", "Two")),
                 invocations);
+    }
+
+    @Test
+    void changeTracking_changeValueToNull_effectTriggered() {
+        ValueSignal<String> signal = new ValueSignal<>("initial");
+        ArrayList<String> invocations = new ArrayList<>();
+
+        Signal.effect(() -> {
+            invocations.add(signal.value());
+        });
+
+        assertEquals(Arrays.asList("initial"), invocations);
+
+        signal.value(null);
+        assertEquals(Arrays.asList("initial", null), invocations);
     }
 
     @Test


### PR DESCRIPTION
A null value in the node caused the usage change value to be an empty optional which was interpreted as a removed node and thus no changes rather than comparing with the original value.

Fixes #21778