### PR TITLE
fix: sw load should not be system dependent

### DIFF
--- a/flow-server/src/main/resources/plugins/vite-plugin-service-worker/index.ts
+++ b/flow-server/src/main/resources/plugins/vite-plugin-service-worker/index.ts
@@ -1,5 +1,5 @@
 /// <reference types="node" />
-import { resolve } from 'node:path';
+import { resolve, relative } from 'node:path';
 import type { RollupOutput } from 'rollup';
 import { build, InlineConfig, Plugin } from 'vite';
 import { getManifest, ManifestTransform } from 'workbox-build';
@@ -97,7 +97,7 @@ export default function serviceWorkerPlugin({ srcPath }: { srcPath: string }): P
       return;
     },
     async load(id) {
-      if (id === swSourcePath) {
+      if (relative(id, swSourcePath).length === 0) {
         return buildOutput.output[0].code;
       }
 


### PR DESCRIPTION
Check the load request as
relative instead of ===
to not have a problem between
systems that use \ instead of /

Fixes #21743
