### PR TITLE
fix: when using pnpm write overrides under pnpm (CP: 24.7)

### DIFF
--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/CleanFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/CleanFrontendUtil.java
@@ -39,6 +39,7 @@ public class CleanFrontendUtil {
     public static final String DEPENDENCIES = "dependencies";
     public static final String DEV_DEPENDENCIES = "devDependencies";
     public static final String OVERRIDES = "overrides";
+    public static final String PNPM = "pnpm";
 
     /**
      * Exception thrown when cleaning the frontend fails.
@@ -206,6 +207,9 @@ public class CleanFrontendUtil {
         JsonObject dependencies = packageJson.getObject(DEPENDENCIES);
         JsonObject devDependencies = packageJson.getObject(DEV_DEPENDENCIES);
         JsonObject overridesSection = packageJson.getObject(OVERRIDES);
+        JsonObject pnpmOverridesSection = packageJson.hasKey(PNPM)
+                ? packageJson.getObject(PNPM).getObject(OVERRIDES)
+                : null;
 
         if (packageJson.hasKey(VAADIN)) {
             JsonObject vaadin = packageJson.getObject(VAADIN);
@@ -217,6 +221,7 @@ public class CleanFrontendUtil {
             cleanObject(dependencies, vaadinDependencies);
             cleanObject(devDependencies, vaadinDevDependencies);
             cleanObject(overridesSection, vaadinDependencies, false);
+            cleanObject(pnpmOverridesSection, vaadinDependencies, false);
 
             packageJson.remove(VAADIN);
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -77,6 +77,7 @@ public abstract class NodeUpdater implements FallibleCommand {
     static final String HASH_KEY = "hash";
     static final String DEV_DEPENDENCIES = "devDependencies";
     static final String OVERRIDES = "overrides";
+    static final String PNPM = "pnpm";
 
     private static final String DEP_LICENSE_KEY = "license";
     private static final String DEP_LICENSE_DEFAULT = "UNLICENSED";

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -45,6 +45,11 @@ import com.vaadin.flow.server.Platform;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 
+import static com.vaadin.flow.server.frontend.VersionsJsonConverter.JS_VERSION;
+import static com.vaadin.flow.server.frontend.VersionsJsonConverter.NPM_NAME;
+import static com.vaadin.flow.server.frontend.VersionsJsonConverter.NPM_VERSION;
+import static com.vaadin.flow.server.frontend.VersionsJsonConverter.VAADIN_CORE_NPM_PACKAGE;
+
 /**
  * Updates <code>package.json</code> by visiting {@link NpmPackage} annotations
  * found in the classpath. It also visits classes annotated with
@@ -114,6 +119,7 @@ public class TaskUpdatePackages extends NodeUpdater {
 
         ObjectNode overridesSection = getOverridesSection(packageJson);
         final JsonNode dependencies = packageJson.get(DEPENDENCIES);
+        ObjectNode fullPlatformDependencies = getFullPlatformDependencies();
         for (String dependency : JacksonUtils.getKeys(versionsJson)) {
             if (!overridesSection.has(dependency)
                     && shouldLockDependencyVersion(dependency, dependencies,
@@ -133,7 +139,106 @@ public class TaskUpdatePackages extends NodeUpdater {
             }
         }
 
+        /*
+         * Remove platform dependencies for all existing dependencies and
+         * devDependencies
+         */
+        for (String dependency : JacksonUtils.getKeys(dependencies)) {
+            fullPlatformDependencies.remove(dependency);
+        }
+        for (String dependency : JacksonUtils.getKeys(devDependencies)) {
+            fullPlatformDependencies.remove(dependency);
+        }
+
+        // After removing any existing dependencies and devDependencies add all
+        // platform versions to overrides block
+        for (String dependency : JacksonUtils
+                .getKeys(fullPlatformDependencies)) {
+            try {
+                FrontendVersion frontendVersion = new FrontendVersion(
+                        fullPlatformDependencies.get(dependency).textValue());
+                if ("SNAPSHOT".equals(frontendVersion.getBuildIdentifier())) {
+                    continue;
+                }
+                overridesSection.set(dependency, JacksonUtils
+                        .createNode(frontendVersion.getFullVersion()));
+                versionLockingUpdated = true;
+            } catch (NumberFormatException nfe) {
+                continue;
+            }
+        }
+
         return versionLockingUpdated;
+    }
+
+    /**
+     * Collect all platform npm dependencies from vaadin-core-versions.json and
+     * vaadin-versions.json to use in overrides so that any component versions
+     * get locked even when they are transitive.
+     *
+     * @return json containing all npm keys and versions
+     * @throws IOException
+     *             thrown for exception reading stream
+     */
+    private ObjectNode getFullPlatformDependencies() throws IOException {
+        ObjectNode platformDependencies = JacksonUtils.createObjectNode();
+        URL coreVersionsResource = finder
+                .getResource(Constants.VAADIN_CORE_VERSIONS_JSON);
+        if (coreVersionsResource == null) {
+            return platformDependencies;
+        }
+
+        try (InputStream content = coreVersionsResource.openStream()) {
+            collectDependencies(
+                    JacksonUtils.readTree(
+                            IOUtils.toString(content, StandardCharsets.UTF_8)),
+                    platformDependencies);
+        }
+
+        URL vaadinVersionsResource = finder
+                .getResource(Constants.VAADIN_VERSIONS_JSON);
+        if (vaadinVersionsResource == null) {
+            // vaadin is not on the classpath, only vaadin-core is present.
+            return platformDependencies;
+        }
+
+        try (InputStream content = vaadinVersionsResource.openStream()) {
+            collectDependencies(
+                    JacksonUtils.readTree(
+                            IOUtils.toString(content, StandardCharsets.UTF_8)),
+                    platformDependencies);
+        }
+
+        return platformDependencies;
+    }
+
+    private void collectDependencies(JsonNode obj, ObjectNode collection) {
+        for (String key : JacksonUtils.getKeys(obj)) {
+            JsonNode value = obj.get(key);
+            if (!(value instanceof ObjectNode)) {
+                continue;
+            }
+            if (value.has(NPM_NAME)) {
+                String npmName = value.get(NPM_NAME).textValue();
+                if (Objects.equals(npmName, VAADIN_CORE_NPM_PACKAGE)) {
+                    return;
+                }
+                String version;
+                if (value.has(NPM_VERSION)) {
+                    version = value.get(NPM_VERSION).textValue();
+                } else if (value.has(JS_VERSION)) {
+                    version = value.get(JS_VERSION).textValue();
+                } else {
+                    log().debug(
+                            "dependency '{}' has no 'npmVersion'/'jsVersion'.",
+                            npmName);
+                    continue;
+                }
+                collection.put(npmName, version);
+            } else {
+                collectDependencies(value, collection);
+            }
+        }
     }
 
     private boolean shouldLockDependencyVersion(String dependency,
@@ -166,9 +271,37 @@ public class TaskUpdatePackages extends NodeUpdater {
 
     private ObjectNode getOverridesSection(ObjectNode packageJson) {
         ObjectNode overridesSection = (ObjectNode) packageJson.get(OVERRIDES);
+        ObjectNode oldOverrides = null;
+        if (options.isEnablePnpm()) {
+            if (overridesSection != null) {
+                oldOverrides = overridesSection;
+                // remove npm overrides when moving to pnpm
+                packageJson.remove(OVERRIDES);
+            }
+            JsonNode pnpm = packageJson.get(PNPM);
+            if (pnpm == null) {
+                overridesSection = null;
+            } else {
+                overridesSection = (ObjectNode) pnpm.get(OVERRIDES);
+            }
+        } else if (packageJson.has(PNPM)) {
+            oldOverrides = overridesSection;
+            // remove pnpm overrides for npm
+            ((ObjectNode) packageJson.get(PNPM)).remove(OVERRIDES);
+        }
         if (overridesSection == null) {
-            overridesSection = JacksonUtils.createObjectNode();
-            packageJson.set(OVERRIDES, overridesSection);
+            overridesSection = oldOverrides == null
+                    ? JacksonUtils.createObjectNode()
+                    : oldOverrides;
+            if (options.isEnablePnpm()) {
+                ObjectNode pnpmNode = packageJson.has(PNPM)
+                        ? (ObjectNode) packageJson.get(PNPM)
+                        : JacksonUtils.createObjectNode();
+                packageJson.set(PNPM, pnpmNode);
+                pnpmNode.set(OVERRIDES, overridesSection);
+            } else {
+                packageJson.set(OVERRIDES, overridesSection);
+            }
         }
         return overridesSection;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonConverter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonConverter.java
@@ -43,9 +43,9 @@ class VersionsJsonConverter {
 
     static final String VAADIN_CORE_NPM_PACKAGE = "@vaadin/vaadin-core";
     static final String VAADIN_BUNDLES = "@vaadin/bundles";
-    private static final String JS_VERSION = "jsVersion";
-    private static final String NPM_NAME = "npmName";
-    private static final String NPM_VERSION = "npmVersion";
+    static final String JS_VERSION = "jsVersion";
+    static final String NPM_NAME = "npmName";
+    static final String NPM_VERSION = "npmVersion";
 
     /**
      * Key for exclusions array.

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
@@ -21,6 +21,7 @@ import static com.vaadin.flow.server.Constants.TARGET;
 import static com.vaadin.flow.server.frontend.NodeUpdater.DEPENDENCIES;
 import static com.vaadin.flow.server.frontend.NodeUpdater.DEV_DEPENDENCIES;
 import static com.vaadin.flow.server.frontend.NodeUpdater.OVERRIDES;
+import static com.vaadin.flow.server.frontend.NodeUpdater.PNPM;
 import static com.vaadin.flow.server.frontend.NodeUpdater.VAADIN_DEP_KEY;
 import static com.vaadin.flow.server.frontend.VersionsJsonConverter.VAADIN_CORE_NPM_PACKAGE;
 import static org.junit.Assert.assertTrue;
@@ -41,6 +42,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.BaseJsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Before;
@@ -52,6 +56,7 @@ import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
@@ -131,11 +136,12 @@ public class TaskUpdatePackagesNpmTest {
         runTestWithoutPreexistingPackageJson();
 
         // user pins a transitive dependency in package.json
-        final JsonObject packageJsonJson = getOrCreatePackageJson();
-        JsonObject dependencies = packageJsonJson.getObject(DEPENDENCIES);
+        final ObjectNode packageJsonJson = getOrCreatePackageJson();
+        ObjectNode dependencies = (ObjectNode) packageJsonJson
+                .get(DEPENDENCIES);
         dependencies.put(VAADIN_ELEMENT_MIXIN, USER_SPECIFIED_MIXIN_VERSION);
         FileUtils.writeStringToFile(new File(npmFolder, PACKAGE_JSON),
-                packageJsonJson.toJson(), StandardCharsets.UTF_8);
+                packageJsonJson.toPrettyString(), StandardCharsets.UTF_8);
 
         final TaskUpdatePackages task = createTask(
                 createApplicationDependencies());
@@ -202,10 +208,9 @@ public class TaskUpdatePackagesNpmTest {
 
         Mockito.when(finder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(versionJsonFile.toURI().toURL());
-        JsonObject dependencies = getOrCreatePackageJson()
-                .getObject(DEPENDENCIES);
+        JsonNode dependencies = getOrCreatePackageJson().get(DEPENDENCIES);
         Assert.assertEquals(PLATFORM_DIALOG_VERSION,
-                dependencies.get(VAADIN_DIALOG).asString());
+                dependencies.get(VAADIN_DIALOG).textValue());
     }
 
     @Test
@@ -316,11 +321,11 @@ public class TaskUpdatePackagesNpmTest {
                 StandardCharsets.UTF_8);
 
         // Move element-mixin to devDependencies
-        JsonObject packageJson = getOrCreatePackageJson();
-        packageJson.getObject(DEV_DEPENDENCIES).put(VAADIN_ELEMENT_MIXIN,
-                PLATFORM_ELEMENT_MIXIN_VERSION);
-        FileUtils.writeStringToFile(this.packageJson, packageJson.toJson(),
-                StandardCharsets.UTF_8);
+        ObjectNode packageJson = getOrCreatePackageJson();
+        ((ObjectNode) packageJson.get(DEV_DEPENDENCIES))
+                .put(VAADIN_ELEMENT_MIXIN, PLATFORM_ELEMENT_MIXIN_VERSION);
+        FileUtils.writeStringToFile(this.packageJson,
+                packageJson.toPrettyString(), StandardCharsets.UTF_8);
 
         // Remove VAADIN_ELEMENT_MIXIN from the application dependencies
         applicationDependencies.remove(VAADIN_ELEMENT_MIXIN);
@@ -352,11 +357,11 @@ public class TaskUpdatePackagesNpmTest {
     @Test
     public void npmIsInUse_packageJsonHasNonNumericVersion_versionNotOverridden()
             throws IOException {
-        final JsonObject packageJson = getOrCreatePackageJson();
-        JsonObject dependencies = packageJson.getObject(DEPENDENCIES);
+        final ObjectNode packageJson = getOrCreatePackageJson();
+        ObjectNode dependencies = (ObjectNode) packageJson.get(DEPENDENCIES);
         dependencies.put(VAADIN_ELEMENT_MIXIN, "file:../foobar");
         FileUtils.writeStringToFile(new File(npmFolder, PACKAGE_JSON),
-                packageJson.toJson(), StandardCharsets.UTF_8);
+                packageJson.toPrettyString(), StandardCharsets.UTF_8);
 
         createBasicVaadinVersionsJson();
 
@@ -374,9 +379,9 @@ public class TaskUpdatePackagesNpmTest {
     @Test
     public void missingTypeInPackageJson_typeModuleIsAdded()
             throws IOException {
-        JsonObject packageJson = getOrCreatePackageJson();
+        ObjectNode packageJson = getOrCreatePackageJson();
         Assert.assertFalse("No type should be available",
-                packageJson.hasKey("type"));
+                packageJson.has("type"));
 
         createBasicVaadinVersionsJson();
 
@@ -388,18 +393,18 @@ public class TaskUpdatePackagesNpmTest {
         packageJson = getOrCreatePackageJson();
 
         Assert.assertTrue("Type should have been addded.",
-                packageJson.hasKey("type"));
+                packageJson.has("type"));
         Assert.assertEquals("Type should be module", "module",
-                packageJson.getString("type"));
+                packageJson.get("type").textValue());
     }
 
     @Test
     public void faultyTypeInPackageJson_typeModuleIsAdded() throws IOException {
-        JsonObject packageJson = getOrCreatePackageJson();
+        ObjectNode packageJson = getOrCreatePackageJson();
         packageJson.put("type", "commonjs");
 
         FileUtils.writeStringToFile(new File(npmFolder, PACKAGE_JSON),
-                packageJson.toJson(), StandardCharsets.UTF_8);
+                packageJson.toPrettyString(), StandardCharsets.UTF_8);
 
         createBasicVaadinVersionsJson();
 
@@ -411,25 +416,25 @@ public class TaskUpdatePackagesNpmTest {
         packageJson = getOrCreatePackageJson();
 
         Assert.assertTrue("Type should not have been removed",
-                packageJson.hasKey("type"));
+                packageJson.has("type"));
         Assert.assertEquals("Type should have been updated to 'module'",
-                "module", packageJson.getString("type"));
+                "module", packageJson.get("type").textValue());
     }
 
     @Test
     public void npmIsInUse_packageJsonVersionIsUpdated_vaadinSectionIsNotChanged()
             throws IOException {
-        final JsonObject packageJson = getOrCreatePackageJson();
-        JsonObject dependencies = packageJson.getObject(DEPENDENCIES);
+        final ObjectNode packageJson = (ObjectNode) getOrCreatePackageJson();
+        ObjectNode dependencies = (ObjectNode) packageJson.get(DEPENDENCIES);
         dependencies.put(VAADIN_ELEMENT_MIXIN, "1.2.3");
-        JsonObject vaadinSection = Json.createObject();
-        JsonObject vaadinDependencies = Json.createObject();
-        packageJson.put(VAADIN_DEP_KEY, vaadinSection);
-        vaadinSection.put(DEPENDENCIES, vaadinDependencies);
+        ObjectNode vaadinSection = JacksonUtils.createObjectNode();
+        ObjectNode vaadinDependencies = JacksonUtils.createObjectNode();
+        packageJson.set(VAADIN_DEP_KEY, vaadinSection);
+        vaadinSection.set(DEPENDENCIES, vaadinDependencies);
         vaadinDependencies.put(VAADIN_ELEMENT_MIXIN,
                 PLATFORM_ELEMENT_MIXIN_VERSION);
         FileUtils.writeStringToFile(new File(npmFolder, PACKAGE_JSON),
-                packageJson.toJson(), StandardCharsets.UTF_8);
+                packageJson.toPrettyString(), StandardCharsets.UTF_8);
 
         createBasicVaadinVersionsJson();
 
@@ -437,11 +442,11 @@ public class TaskUpdatePackagesNpmTest {
                 createApplicationDependencies());
         task.execute();
 
-        JsonObject newVaadinDeps = getOrCreatePackageJson()
-                .getObject(VAADIN_DEP_KEY).getObject(DEPENDENCIES);
+        JsonNode newVaadinDeps = getOrCreatePackageJson().get(VAADIN_DEP_KEY)
+                .get(DEPENDENCIES);
 
         Assert.assertEquals(PLATFORM_ELEMENT_MIXIN_VERSION,
-                newVaadinDeps.getString(VAADIN_ELEMENT_MIXIN));
+                newVaadinDeps.get(VAADIN_ELEMENT_MIXIN).textValue());
     }
 
     // #11025
@@ -473,18 +478,18 @@ public class TaskUpdatePackagesNpmTest {
         verifyVersions(PLATFORM_DIALOG_VERSION, expectedElementMixinVersion,
                 null);
         verifyVersionLockingWithNpmOverrides(true, true, false);
-        final JsonObject packageJson = getOrCreatePackageJson();
-        JsonObject dependencies = packageJson.getObject(DEPENDENCIES);
+        final ObjectNode packageJson = getOrCreatePackageJson();
+        JsonNode dependencies = packageJson.get(DEPENDENCIES);
 
         Assert.assertFalse(
                 VAADIN_CORE_NPM_PACKAGE
                         + " version should not be written to package.json",
-                dependencies.hasKey(VAADIN_CORE_NPM_PACKAGE));
-        final JsonObject vaadinDependencies = packageJson
-                .getObject(VAADIN_DEP_KEY).getObject(DEPENDENCIES);
+                dependencies.has(VAADIN_CORE_NPM_PACKAGE));
+        final JsonNode vaadinDependencies = packageJson.get(VAADIN_DEP_KEY)
+                .get(DEPENDENCIES);
         Assert.assertFalse(VAADIN_CORE_NPM_PACKAGE
                 + " version should not be written to vaadin dependencies in package.json",
-                vaadinDependencies.hasKey(VAADIN_CORE_NPM_PACKAGE));
+                vaadinDependencies.has(VAADIN_CORE_NPM_PACKAGE));
     }
 
     @Test
@@ -498,8 +503,8 @@ public class TaskUpdatePackagesNpmTest {
         // map it's set after
         map.put("baz", "foobar");
 
-        JsonObject packageJson = getOrCreatePackageJson();
-        JsonObject dependencies = packageJson.getObject(DEPENDENCIES);
+        ObjectNode packageJson = getOrCreatePackageJson();
+        ObjectNode dependencies = (ObjectNode) packageJson.get(DEPENDENCIES);
 
         packageJson.remove(DEPENDENCIES);
 
@@ -509,15 +514,15 @@ public class TaskUpdatePackagesNpmTest {
         packageJson.put("type", "module");
 
         LinkedHashSet<String> mainKeys = new LinkedHashSet<>(
-                Arrays.asList(packageJson.keys()));
+                JacksonUtils.getKeys(packageJson));
 
-        packageJson.put(DEPENDENCIES, dependencies);
+        packageJson.set(DEPENDENCIES, dependencies);
 
         // Json object preserve the order of keys
         dependencies.put("foo-pack", "bar");
         dependencies.put("baz-pack", "foobar");
         FileUtils.writeStringToFile(new File(npmFolder, PACKAGE_JSON),
-                packageJson.toJson(), StandardCharsets.UTF_8);
+                packageJson.toPrettyString(), StandardCharsets.UTF_8);
 
         TaskUpdatePackages task = createTask(map);
 
@@ -526,7 +531,7 @@ public class TaskUpdatePackagesNpmTest {
         // now read the package json file
         packageJson = getOrCreatePackageJson();
 
-        List<String> list = Arrays.asList(packageJson.keys());
+        List<String> list = JacksonUtils.getKeys(packageJson);
         int indexOfOverrides = list.indexOf(OVERRIDES);
         if (indexOfOverrides == -1) {
             // the "vaadin" key is the last one if no overrides
@@ -538,7 +543,7 @@ public class TaskUpdatePackagesNpmTest {
 
         List<String> keysBeforeDeps = new ArrayList<>();
 
-        for (String key : packageJson.keys()) {
+        for (String key : JacksonUtils.getKeys(packageJson)) {
             if (key.equals(DEV_DEPENDENCIES) || key.equals(DEPENDENCIES)) {
                 break;
             }
@@ -550,13 +555,13 @@ public class TaskUpdatePackagesNpmTest {
         // the order of the main keys is the same
         Assert.assertArrayEquals(mainKeys.toArray(), keysBeforeDeps.toArray());
 
-        checkOrder(DEPENDENCIES, packageJson.getObject(DEPENDENCIES));
-        checkOrder(DEV_DEPENDENCIES, packageJson.getObject(DEV_DEPENDENCIES));
-        checkOrder(VAADIN_DEP_KEY, packageJson.getObject(VAADIN_DEP_KEY));
+        checkOrder(DEPENDENCIES, packageJson.get(DEPENDENCIES));
+        checkOrder(DEV_DEPENDENCIES, packageJson.get(DEV_DEPENDENCIES));
+        checkOrder(VAADIN_DEP_KEY, packageJson.get(VAADIN_DEP_KEY));
     }
 
-    private void checkOrder(String path, JsonObject object) {
-        String[] keys = object.keys();
+    private void checkOrder(String path, JsonNode object) {
+        List<String> keys = JacksonUtils.getKeys(object);
         if (path.isEmpty()) {
             Assert.assertTrue("Keys in the package Json are not sorted",
                     isSorted(keys));
@@ -567,19 +572,19 @@ public class TaskUpdatePackagesNpmTest {
                     isSorted(keys));
         }
         for (String key : keys) {
-            JsonValue value = object.get(key);
-            if (value instanceof JsonObject) {
-                checkOrder(path + "/" + key, (JsonObject) value);
+            JsonNode value = object.get(key);
+            if (value instanceof ObjectNode) {
+                checkOrder(path + "/" + key, value);
             }
         }
     }
 
-    private boolean isSorted(String[] array) {
-        if (array.length < 2) {
+    private boolean isSorted(List<String> array) {
+        if (array.size() < 2) {
             return true;
         }
-        for (int i = 0; i < array.length - 1; i++) {
-            if (array[i].compareTo(array[i + 1]) > 0) {
+        for (int i = 0; i < array.size() - 1; i++) {
+            if (array.get(i).compareTo(array.get(i + 1)) > 0) {
                 return false;
             }
         }
@@ -617,25 +622,25 @@ public class TaskUpdatePackagesNpmTest {
 
     @Test
     public void nonNumericVersionsNotPinned() throws IOException {
-        final JsonObject packageJson = getOrCreatePackageJson();
+        final JsonNode packageJson = getOrCreatePackageJson();
         createBasicVaadinVersionsJson();
-        JsonObject dependencies = packageJson.getObject(DEPENDENCIES);
+        ObjectNode dependencies = (ObjectNode) packageJson.get(DEPENDENCIES);
         dependencies.put("localdep", "./localdeps/localdep");
         File file = new File(npmFolder, PACKAGE_JSON);
-        FileUtils.writeStringToFile(file, packageJson.toJson(),
+        FileUtils.writeStringToFile(file, packageJson.toPrettyString(),
                 StandardCharsets.UTF_8);
 
-        Assert.assertFalse(packageJson.hasKey("overrides")
-                && packageJson.getObject("overrides").hasKey("localdep"));
+        Assert.assertFalse(packageJson.has("overrides")
+                && packageJson.get("overrides").has("localdep"));
 
         final TaskUpdatePackages task = createTask(
                 createApplicationDependencies());
         task.execute();
 
-        final JsonObject newPackageJson = getOrCreatePackageJson();
+        final JsonNode newPackageJson = getOrCreatePackageJson();
 
-        Assert.assertFalse(newPackageJson.hasKey("overrides")
-                && newPackageJson.getObject("overrides").hasKey("localdep"));
+        Assert.assertFalse(newPackageJson.has("overrides")
+                && newPackageJson.get("overrides").has("localdep"));
     }
 
     @Test
@@ -705,6 +710,81 @@ public class TaskUpdatePackagesNpmTest {
     }
 
     @Test
+    public void oldVersionsJson_shouldDowngrade_verifyPnpmOverrides()
+            throws IOException {
+        // run the basic test to produce an existing package.json
+        runTestWithoutPreexistingPackageJson();
+        // write new versions json and scanned deps
+        final String oldPlatformVersion = "1.0.0";
+        createVaadinVersionsJson(oldPlatformVersion, oldPlatformVersion,
+                oldPlatformVersion);
+
+        final Map<String, String> applicationDependencies = createApplicationDependencies();
+        final String appDependencyVersion = "1.5.0";
+        applicationDependencies.put(VAADIN_DIALOG, appDependencyVersion);
+        final TaskUpdatePackages task = createTask(applicationDependencies,
+                true);
+        task.execute();
+        Assert.assertTrue("Updates not picked", task.modified);
+
+        verifyVersions(appDependencyVersion, oldPlatformVersion,
+                oldPlatformVersion);
+        verifyVersionLockingWithPnpmOverrides(true, true, true);
+    }
+
+    @Test
+    public void npmOverridesExist_customOverridesCopiedOver_verifyPnpmOverrides()
+            throws IOException {
+        // run the basic test to produce an existing package.json
+        runTestWithoutPreexistingPackageJson();
+        // write new versions json and scanned deps
+        final String oldPlatformVersion = "1.0.0";
+        createVaadinVersionsJson(oldPlatformVersion, oldPlatformVersion,
+                oldPlatformVersion);
+
+        String CUSTOM_COMPONENT = "@custom/component";
+
+        try {
+            ObjectNode versionJson = getOrCreatePackageJson();
+            if (versionJson.has(OVERRIDES)) {
+                ((ObjectNode) versionJson.get(OVERRIDES)).set(CUSTOM_COMPONENT,
+                        JacksonUtils.createNode("1.2.1"));
+            } else {
+                ObjectNode npmOverrides = JacksonUtils.createObjectNode();
+                npmOverrides.set(CUSTOM_COMPONENT,
+                        JacksonUtils.createNode("1.2.1"));
+                versionJson.set(OVERRIDES, npmOverrides);
+            }
+            FileUtils.write(packageJson, versionJson.toPrettyString(),
+                    StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        final Map<String, String> applicationDependencies = createApplicationDependencies();
+        final String appDependencyVersion = "1.5.0";
+        applicationDependencies.put(VAADIN_DIALOG, appDependencyVersion);
+        final TaskUpdatePackages task = createTask(applicationDependencies,
+                true);
+        task.execute();
+        Assert.assertTrue("Updates not picked", task.modified);
+
+        verifyVersions(appDependencyVersion, oldPlatformVersion,
+                oldPlatformVersion);
+        verifyVersionLockingWithPnpmOverrides(true, true, true);
+
+        JsonNode pnpm = getOrCreatePackageJson().get(PNPM);
+        Assert.assertNotNull("Object for 'pnpm' should exist", pnpm);
+        JsonNode overrides = pnpm.get(OVERRIDES);
+        Assert.assertNotNull("Object for 'overrides' should exist", overrides);
+
+        Assert.assertTrue("Custom component override was not present",
+                overrides.has(CUSTOM_COMPONENT));
+        Assert.assertEquals("1.2.1",
+                overrides.get(CUSTOM_COMPONENT).textValue());
+    }
+
+    @Test
     public void reactEnabled_scannerDependencies_coreDependenciesNotAdded()
             throws IOException {
         createVaadinVersionsJson(PLATFORM_DIALOG_VERSION,
@@ -720,26 +800,20 @@ public class TaskUpdatePackagesNpmTest {
                 frontendDependenciesScanner, options) {
         };
         task.execute();
-        final JsonObject newPackageJson = getOrCreatePackageJson();
+        final ObjectNode newPackageJson = getOrCreatePackageJson();
 
-        Assert.assertTrue(
-                newPackageJson.hasKey("dependencies") && newPackageJson
-                        .getObject("dependencies").hasKey(VAADIN_DIALOG));
-        Assert.assertTrue(newPackageJson.hasKey("vaadin")
-                && newPackageJson.getObject("vaadin").getObject("dependencies")
-                        .hasKey(VAADIN_DIALOG));
-        Assert.assertTrue(
-                newPackageJson.hasKey("dependencies") && newPackageJson
-                        .getObject("dependencies").hasKey(VAADIN_OVERLAY));
-        Assert.assertTrue(newPackageJson.hasKey("vaadin")
-                && newPackageJson.getObject("vaadin").getObject("dependencies")
-                        .hasKey(VAADIN_OVERLAY));
-        Assert.assertTrue(
-                newPackageJson.hasKey("dependencies") && newPackageJson
-                        .getObject("dependencies").hasKey(REACT_COMPONENTS));
-        Assert.assertTrue(newPackageJson.hasKey("vaadin")
-                && newPackageJson.getObject("vaadin").getObject("dependencies")
-                        .hasKey(REACT_COMPONENTS));
+        Assert.assertTrue(newPackageJson.has("dependencies")
+                && newPackageJson.get("dependencies").has(VAADIN_DIALOG));
+        Assert.assertTrue(newPackageJson.has("vaadin") && newPackageJson
+                .get("vaadin").get("dependencies").has(VAADIN_DIALOG));
+        Assert.assertTrue(newPackageJson.has("dependencies")
+                && newPackageJson.get("dependencies").has(VAADIN_OVERLAY));
+        Assert.assertTrue(newPackageJson.has("vaadin") && newPackageJson
+                .get("vaadin").get("dependencies").has(VAADIN_OVERLAY));
+        Assert.assertTrue(newPackageJson.has("dependencies")
+                && newPackageJson.get("dependencies").has(REACT_COMPONENTS));
+        Assert.assertTrue(newPackageJson.has("vaadin") && newPackageJson
+                .get("vaadin").get("dependencies").has(REACT_COMPONENTS));
     }
 
     @Test
@@ -759,26 +833,20 @@ public class TaskUpdatePackagesNpmTest {
                 frontendDependenciesScanner, options) {
         };
         task.execute();
-        final JsonObject newPackageJson = getOrCreatePackageJson();
+        final JsonNode newPackageJson = getOrCreatePackageJson();
 
-        Assert.assertFalse(
-                newPackageJson.hasKey("dependencies") && newPackageJson
-                        .getObject("dependencies").hasKey(VAADIN_DIALOG));
-        Assert.assertFalse(newPackageJson.hasKey("vaadin")
-                && newPackageJson.getObject("vaadin").getObject("dependencies")
-                        .hasKey(VAADIN_DIALOG));
-        Assert.assertFalse(
-                newPackageJson.hasKey("dependencies") && newPackageJson
-                        .getObject("dependencies").hasKey(VAADIN_OVERLAY));
-        Assert.assertFalse(newPackageJson.hasKey("vaadin")
-                && newPackageJson.getObject("vaadin").getObject("dependencies")
-                        .hasKey(VAADIN_OVERLAY));
-        Assert.assertTrue(
-                newPackageJson.hasKey("dependencies") && newPackageJson
-                        .getObject("dependencies").hasKey(REACT_COMPONENTS));
-        Assert.assertTrue(newPackageJson.hasKey("vaadin")
-                && newPackageJson.getObject("vaadin").getObject("dependencies")
-                        .hasKey(REACT_COMPONENTS));
+        Assert.assertFalse(newPackageJson.has("dependencies")
+                && newPackageJson.get("dependencies").has(VAADIN_DIALOG));
+        Assert.assertFalse(newPackageJson.has("vaadin") && newPackageJson
+                .get("vaadin").get("dependencies").has(VAADIN_DIALOG));
+        Assert.assertFalse(newPackageJson.has("dependencies")
+                && newPackageJson.get("dependencies").has(VAADIN_OVERLAY));
+        Assert.assertFalse(newPackageJson.has("vaadin") && newPackageJson
+                .get("vaadin").get("dependencies").has(VAADIN_OVERLAY));
+        Assert.assertTrue(newPackageJson.has("dependencies")
+                && newPackageJson.get("dependencies").has(REACT_COMPONENTS));
+        Assert.assertTrue(newPackageJson.has("vaadin") && newPackageJson
+                .get("vaadin").get("dependencies").has(REACT_COMPONENTS));
     }
 
     @Test
@@ -797,26 +865,20 @@ public class TaskUpdatePackagesNpmTest {
                 frontendDependenciesScanner, options) {
         };
         task.execute();
-        final JsonObject newPackageJson = getOrCreatePackageJson();
+        final JsonNode newPackageJson = getOrCreatePackageJson();
 
-        Assert.assertFalse(
-                newPackageJson.hasKey("dependencies") && newPackageJson
-                        .getObject("dependencies").hasKey(VAADIN_DIALOG));
-        Assert.assertFalse(newPackageJson.hasKey("vaadin")
-                && newPackageJson.getObject("vaadin").getObject("dependencies")
-                        .hasKey(VAADIN_DIALOG));
-        Assert.assertTrue(
-                newPackageJson.hasKey("dependencies") && newPackageJson
-                        .getObject("dependencies").hasKey(VAADIN_OVERLAY));
-        Assert.assertTrue(newPackageJson.hasKey("vaadin")
-                && newPackageJson.getObject("vaadin").getObject("dependencies")
-                        .hasKey(VAADIN_OVERLAY));
-        Assert.assertTrue(
-                newPackageJson.hasKey("dependencies") && newPackageJson
-                        .getObject("dependencies").hasKey(REACT_COMPONENTS));
-        Assert.assertTrue(newPackageJson.hasKey("vaadin")
-                && newPackageJson.getObject("vaadin").getObject("dependencies")
-                        .hasKey(REACT_COMPONENTS));
+        Assert.assertFalse(newPackageJson.has("dependencies")
+                && newPackageJson.get("dependencies").has(VAADIN_DIALOG));
+        Assert.assertFalse(newPackageJson.has("vaadin") && newPackageJson
+                .get("vaadin").get("dependencies").has(VAADIN_DIALOG));
+        Assert.assertTrue(newPackageJson.has("dependencies")
+                && newPackageJson.get("dependencies").has(VAADIN_OVERLAY));
+        Assert.assertTrue(newPackageJson.has("vaadin") && newPackageJson
+                .get("vaadin").get("dependencies").has(VAADIN_OVERLAY));
+        Assert.assertTrue(newPackageJson.has("dependencies")
+                && newPackageJson.get("dependencies").has(REACT_COMPONENTS));
+        Assert.assertTrue(newPackageJson.has("vaadin") && newPackageJson
+                .get("vaadin").get("dependencies").has(REACT_COMPONENTS));
     }
 
     @Test
@@ -834,26 +896,20 @@ public class TaskUpdatePackagesNpmTest {
                 frontendDependenciesScanner, options) {
         };
         task.execute();
-        final JsonObject newPackageJson = getOrCreatePackageJson();
+        final JsonNode newPackageJson = getOrCreatePackageJson();
 
-        Assert.assertTrue(
-                newPackageJson.hasKey("dependencies") && newPackageJson
-                        .getObject("dependencies").hasKey(VAADIN_DIALOG));
-        Assert.assertTrue(newPackageJson.hasKey("vaadin")
-                && newPackageJson.getObject("vaadin").getObject("dependencies")
-                        .hasKey(VAADIN_DIALOG));
-        Assert.assertTrue(
-                newPackageJson.hasKey("dependencies") && newPackageJson
-                        .getObject("dependencies").hasKey(VAADIN_OVERLAY));
-        Assert.assertTrue(newPackageJson.hasKey("vaadin")
-                && newPackageJson.getObject("vaadin").getObject("dependencies")
-                        .hasKey(VAADIN_OVERLAY));
-        Assert.assertFalse(
-                newPackageJson.hasKey("dependencies") && newPackageJson
-                        .getObject("dependencies").hasKey(REACT_COMPONENTS));
-        Assert.assertFalse(newPackageJson.hasKey("vaadin")
-                && newPackageJson.getObject("vaadin").getObject("dependencies")
-                        .hasKey(REACT_COMPONENTS));
+        Assert.assertTrue(newPackageJson.has("dependencies")
+                && newPackageJson.get("dependencies").has(VAADIN_DIALOG));
+        Assert.assertTrue(newPackageJson.has("vaadin") && newPackageJson
+                .get("vaadin").get("dependencies").has(VAADIN_DIALOG));
+        Assert.assertTrue(newPackageJson.has("dependencies")
+                && newPackageJson.get("dependencies").has(VAADIN_OVERLAY));
+        Assert.assertTrue(newPackageJson.has("vaadin") && newPackageJson
+                .get("vaadin").get("dependencies").has(VAADIN_OVERLAY));
+        Assert.assertFalse(newPackageJson.has("dependencies")
+                && newPackageJson.get("dependencies").has(REACT_COMPONENTS));
+        Assert.assertFalse(newPackageJson.has("vaadin") && newPackageJson
+                .get("vaadin").get("dependencies").has(REACT_COMPONENTS));
 
     }
 
@@ -868,7 +924,7 @@ public class TaskUpdatePackagesNpmTest {
                 .withNpmExcludeWebComponents(true);
         // with scanned application dependencies
         execTaskUpdatePackages(createApplicationDependencies(), options);
-        JsonObject pkgJson = getOrCreatePackageJson();
+        JsonNode pkgJson = getOrCreatePackageJson();
 
         assertTrue(hasInDependencies(pkgJson, VAADIN_DIALOG));
         assertTrue(hasInVaadinDependencies(pkgJson, VAADIN_DIALOG));
@@ -902,7 +958,7 @@ public class TaskUpdatePackagesNpmTest {
 
         // with scanned application dependencies
         execTaskUpdatePackages(createApplicationDependencies(), options);
-        JsonObject pkgJson = getOrCreatePackageJson();
+        JsonNode pkgJson = getOrCreatePackageJson();
 
         assertFalse(hasInDependencies(pkgJson, VAADIN_DIALOG));
         assertFalse(hasInVaadinDependencies(pkgJson, VAADIN_DIALOG));
@@ -935,7 +991,7 @@ public class TaskUpdatePackagesNpmTest {
 
         // with scanned application dependencies
         execTaskUpdatePackages(createApplicationDependencies(), options);
-        JsonObject pkgJson = getOrCreatePackageJson();
+        JsonNode pkgJson = getOrCreatePackageJson();
 
         assertTrue(hasInDependencies(pkgJson, VAADIN_DIALOG));
         assertTrue(hasInVaadinDependencies(pkgJson, VAADIN_DIALOG));
@@ -969,7 +1025,7 @@ public class TaskUpdatePackagesNpmTest {
 
         // with scanned application dependencies
         execTaskUpdatePackages(createApplicationDependencies(), options);
-        JsonObject pkgJson = getOrCreatePackageJson();
+        JsonNode pkgJson = getOrCreatePackageJson();
 
         assertFalse(hasInDependencies(pkgJson, VAADIN_DIALOG));
         assertFalse(hasInVaadinDependencies(pkgJson, VAADIN_DIALOG));
@@ -1003,15 +1059,15 @@ public class TaskUpdatePackagesNpmTest {
         task.execute();
     }
 
-    private boolean hasInDependencies(JsonObject newPackageJson, String key) {
-        return newPackageJson.hasKey("dependencies")
-                && newPackageJson.getObject("dependencies").hasKey(key);
+    private boolean hasInDependencies(JsonNode newPackageJson, String key) {
+        return newPackageJson.has("dependencies")
+                && newPackageJson.get("dependencies").has(key);
     }
 
-    private boolean hasInVaadinDependencies(JsonObject newPackageJson,
+    private boolean hasInVaadinDependencies(JsonNode newPackageJson,
             String key) {
-        return newPackageJson.hasKey("vaadin") && newPackageJson
-                .getObject("vaadin").getObject("dependencies").hasKey(key);
+        return newPackageJson.has("vaadin")
+                && newPackageJson.get("vaadin").get("dependencies").has(key);
     }
 
     private void createBasicVaadinVersionsJson() {
@@ -1094,15 +1150,15 @@ public class TaskUpdatePackagesNpmTest {
         };
     }
 
-    private JsonObject getOrCreatePackageJson() throws IOException {
+    private ObjectNode getOrCreatePackageJson() throws IOException {
         if (packageJson.exists()) {
-            return Json.parse(FileUtils.readFileToString(packageJson,
+            return JacksonUtils.readTree(FileUtils.readFileToString(packageJson,
                     StandardCharsets.UTF_8));
         } else {
-            final JsonObject packageJsonJson = Json.createObject();
-            packageJsonJson.put(DEPENDENCIES, Json.createObject());
+            final ObjectNode packageJsonJson = JacksonUtils.createObjectNode();
+            packageJsonJson.set(DEPENDENCIES, JacksonUtils.createObjectNode());
             FileUtils.writeStringToFile(new File(npmFolder, PACKAGE_JSON),
-                    packageJsonJson.toJson(), StandardCharsets.UTF_8);
+                    packageJsonJson.toPrettyString(), StandardCharsets.UTF_8);
             return packageJsonJson;
         }
     }
@@ -1110,50 +1166,50 @@ public class TaskUpdatePackagesNpmTest {
     private void verifyVersions(String expectedDialogVersion,
             String expectedElementMixinVersion, String expectedOverlayVersion)
             throws IOException {
-        JsonObject dependencies = getOrCreatePackageJson()
-                .getObject(DEPENDENCIES);
+        JsonNode dependencies = getOrCreatePackageJson().get(DEPENDENCIES);
         if (expectedDialogVersion == null) {
             Assert.assertNull("Dependency added when it should not have been",
                     dependencies.get(VAADIN_DIALOG));
         } else {
             Assert.assertEquals(expectedDialogVersion,
-                    dependencies.getString(VAADIN_DIALOG));
+                    dependencies.get(VAADIN_DIALOG).textValue());
         }
         if (expectedElementMixinVersion == null) {
             Assert.assertNull("Dependency added when it should not have been",
                     dependencies.get(VAADIN_ELEMENT_MIXIN));
         } else {
             Assert.assertEquals(expectedElementMixinVersion,
-                    dependencies.getString(VAADIN_ELEMENT_MIXIN));
+                    dependencies.get(VAADIN_ELEMENT_MIXIN).textValue());
         }
         if (expectedOverlayVersion == null) {
             Assert.assertNull("Dependency added when it should not have been",
                     dependencies.get(VAADIN_OVERLAY));
         } else {
             Assert.assertEquals(expectedOverlayVersion,
-                    dependencies.getString(VAADIN_OVERLAY));
+                    dependencies.get(VAADIN_OVERLAY).textValue());
         }
     }
 
     private void verifyVersionLockingWithNpmOverrides(boolean hasDialogLocking,
             boolean hasElementMixinLocking, boolean hasOverlayLocking)
             throws IOException {
-        JsonObject overrides = getOrCreatePackageJson().getObject(OVERRIDES);
+        JsonNode overrides = getOrCreatePackageJson().get(OVERRIDES);
+        Assert.assertNotNull("Object for 'overrides' should exist", overrides);
 
         if (hasDialogLocking) {
             Assert.assertTrue("Dialog override was not present",
-                    overrides.hasKey(VAADIN_DIALOG));
+                    overrides.has(VAADIN_DIALOG));
             Assert.assertEquals("$" + VAADIN_DIALOG,
-                    overrides.getString(VAADIN_DIALOG));
+                    overrides.get(VAADIN_DIALOG).textValue());
         } else {
             Assert.assertNull("vaadin-dialog dependency should not be present",
                     overrides.get(VAADIN_DIALOG));
         }
         if (hasElementMixinLocking) {
             Assert.assertTrue("Element-Mixin override was not present",
-                    overrides.hasKey(VAADIN_ELEMENT_MIXIN));
+                    overrides.has(VAADIN_ELEMENT_MIXIN));
             Assert.assertEquals("$" + VAADIN_ELEMENT_MIXIN,
-                    overrides.getString(VAADIN_ELEMENT_MIXIN));
+                    overrides.get(VAADIN_ELEMENT_MIXIN).textValue());
         } else {
             Assert.assertNull(
                     "vaadin-element-mixin dependency should not be present",
@@ -1161,9 +1217,47 @@ public class TaskUpdatePackagesNpmTest {
         }
         if (hasOverlayLocking) {
             Assert.assertTrue("Overlay override was not present",
-                    overrides.hasKey(VAADIN_OVERLAY));
+                    overrides.has(VAADIN_OVERLAY));
             Assert.assertEquals("$" + VAADIN_OVERLAY,
-                    overrides.getString(VAADIN_OVERLAY));
+                    overrides.get(VAADIN_OVERLAY).textValue());
+        } else {
+            Assert.assertNull("vaadin-overlay dependency should not be present",
+                    overrides.get(VAADIN_OVERLAY));
+        }
+    }
+
+    private void verifyVersionLockingWithPnpmOverrides(boolean hasDialogLocking,
+            boolean hasElementMixinLocking, boolean hasOverlayLocking)
+            throws IOException {
+        JsonNode pnpm = getOrCreatePackageJson().get(PNPM);
+        Assert.assertNotNull("Object for 'pnpm' should exist", pnpm);
+        JsonNode overrides = pnpm.get(OVERRIDES);
+        Assert.assertNotNull("Object for 'overrides' should exist", overrides);
+
+        if (hasDialogLocking) {
+            Assert.assertTrue("Dialog override was not present",
+                    overrides.has(VAADIN_DIALOG));
+            Assert.assertEquals("$" + VAADIN_DIALOG,
+                    overrides.get(VAADIN_DIALOG).textValue());
+        } else {
+            Assert.assertNull("vaadin-dialog dependency should not be present",
+                    overrides.get(VAADIN_DIALOG));
+        }
+        if (hasElementMixinLocking) {
+            Assert.assertTrue("Element-Mixin override was not present",
+                    overrides.has(VAADIN_ELEMENT_MIXIN));
+            Assert.assertEquals("$" + VAADIN_ELEMENT_MIXIN,
+                    overrides.get(VAADIN_ELEMENT_MIXIN).textValue());
+        } else {
+            Assert.assertNull(
+                    "vaadin-element-mixin dependency should not be present",
+                    overrides.get(VAADIN_ELEMENT_MIXIN));
+        }
+        if (hasOverlayLocking) {
+            Assert.assertTrue("Overlay override was not present",
+                    overrides.has(VAADIN_OVERLAY));
+            Assert.assertEquals("$" + VAADIN_OVERLAY,
+                    overrides.get(VAADIN_OVERLAY).textValue());
         } else {
             Assert.assertNull("vaadin-overlay dependency should not be present",
                     overrides.get(VAADIN_OVERLAY));


### PR DESCRIPTION
For pnpm usage write the overrides
section under the pnpm object
instead of the root of the package.json

Fixes #21724
Fixes #21682

add all component versions to overrides.

Will use $NAME for existing dependencies
and devDpendencies.
For other components in vaadin-versions
and vaadin-core-versions version value
will be added to overrides.

Keep existing overrides content from othe system if any

Keep the existing overrides when
moving from npm to pnpm and vice versa

Refactor test to use Jackson
