### PR TITLE
fix: fix AuthenticationContext bean duplicated definition

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringSecurityAutoConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringSecurityAutoConfiguration.java
@@ -198,7 +198,7 @@ public class SpringSecurityAutoConfiguration {
                 .map(GrantedAuthorityDefaults::getRolePrefix).orElse(null));
     }
 
-    @Bean
+    @Bean(name = "VaadinAuthenticationContext")
     @ConditionalOnMissingBean
     AuthenticationContext authenticationContext() {
         return new AuthenticationContext();

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -19,7 +19,9 @@ import jakarta.annotation.PostConstruct;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
 import javax.crypto.SecretKey;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -121,6 +123,10 @@ public abstract class VaadinWebSecurity {
     @Autowired
     private ObjectProvider<NavigationAccessControl> accessControlProvider;
 
+    // initialized only for tests, it gets overridden by the injected instance
+    @Autowired
+    private AuthenticationContext authenticationContext = new AuthenticationContext();
+
     private NavigationAccessControl accessControl;
 
     @PostConstruct
@@ -128,8 +134,6 @@ public abstract class VaadinWebSecurity {
         accessControl = accessControlProvider.getIfAvailable();
         authenticationContext.setRolePrefixHolder(vaadinRolePrefixHolder);
     }
-
-    private final AuthenticationContext authenticationContext = new AuthenticationContext();
 
     /**
      * Registers default {@link SecurityFilterChain} bean.
@@ -163,7 +167,6 @@ public abstract class VaadinWebSecurity {
      *
      * @return the authentication-context bean
      */
-    @Bean(name = "VaadinAuthenticationContext")
     public AuthenticationContext getAuthenticationContext() {
         return authenticationContext;
     }


### PR DESCRIPTION
Removes the AuthenticationContext bean definition from VaadinWebSecurity so there's a single overridable bean in SpringSecurityAutoConfiguration.

Fixes #21835