### PR TITLE
fix: fix AuthenticationContext bean duplicated definition (#21845)

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringSecurityAutoConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringSecurityAutoConfiguration.java
@@ -198,7 +198,7 @@ public class SpringSecurityAutoConfiguration {
                 .map(GrantedAuthorityDefaults::getRolePrefix).orElse(null));
     }
 
-    @Bean
+    @Bean(name = "VaadinAuthenticationContext")
     @ConditionalOnMissingBean
     AuthenticationContext authenticationContext() {
         return new AuthenticationContext();

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.spring.security;
 
 import javax.crypto.SecretKey;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -123,6 +124,10 @@ public abstract class VaadinWebSecurity {
     @Autowired
     private ObjectProvider<NavigationAccessControl> accessControlProvider;
 
+    // initialized only for tests, it gets overridden by the injected instance
+    @Autowired
+    private AuthenticationContext authenticationContext = new AuthenticationContext();
+
     private NavigationAccessControl accessControl;
 
     @PostConstruct
@@ -130,8 +135,6 @@ public abstract class VaadinWebSecurity {
         accessControl = accessControlProvider.getIfAvailable();
         authenticationContext.setRolePrefixHolder(vaadinRolePrefixHolder);
     }
-
-    private final AuthenticationContext authenticationContext = new AuthenticationContext();
 
     /**
      * Registers default {@link SecurityFilterChain} bean.
@@ -165,7 +168,6 @@ public abstract class VaadinWebSecurity {
      *
      * @return the authentication-context bean
      */
-    @Bean(name = "VaadinAuthenticationContext")
     public AuthenticationContext getAuthenticationContext() {
         return authenticationContext;
     }


### PR DESCRIPTION
Removes the AuthenticationContext bean definition from VaadinWebSecurity so there's a single overridable bean in SpringSecurityAutoConfiguration.

Fixes #21835
