### PR TITLE
Revert "fix: fix AuthenticationContext bean duplicated definition (#21845) (#21846) (#21847)" (24.8)

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringSecurityAutoConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringSecurityAutoConfiguration.java
@@ -198,7 +198,7 @@ public class SpringSecurityAutoConfiguration {
                 .map(GrantedAuthorityDefaults::getRolePrefix).orElse(null));
     }
 
-    @Bean(name = "VaadinAuthenticationContext")
+    @Bean
     @ConditionalOnMissingBean
     AuthenticationContext authenticationContext() {
         return new AuthenticationContext();

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.spring.security;
 
 import javax.crypto.SecretKey;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -124,10 +123,6 @@ public abstract class VaadinWebSecurity {
     @Autowired
     private ObjectProvider<NavigationAccessControl> accessControlProvider;
 
-    // initialized only for tests, it gets overridden by the injected instance
-    @Autowired
-    private AuthenticationContext authenticationContext = new AuthenticationContext();
-
     private NavigationAccessControl accessControl;
 
     @PostConstruct
@@ -135,6 +130,8 @@ public abstract class VaadinWebSecurity {
         accessControl = accessControlProvider.getIfAvailable();
         authenticationContext.setRolePrefixHolder(vaadinRolePrefixHolder);
     }
+
+    private final AuthenticationContext authenticationContext = new AuthenticationContext();
 
     /**
      * Registers default {@link SecurityFilterChain} bean.
@@ -168,6 +165,7 @@ public abstract class VaadinWebSecurity {
      *
      * @return the authentication-context bean
      */
+    @Bean(name = "VaadinAuthenticationContext")
     public AuthenticationContext getAuthenticationContext() {
         return authenticationContext;
     }


### PR DESCRIPTION
This reverts commit f771039b8eda03a929ff97b99606fd82e7eca212.
