### PR TITLE
test: use npm for pwa tests (2.12)

### DIFF
--- a/flow-tests/test-pwa/pom.xml
+++ b/flow-tests/test-pwa/pom.xml
@@ -35,6 +35,9 @@
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
                 <version>${project.version}</version>
+                <configuration>
+                    <pnpmEnable>false</pnpmEnable>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Fixes Bender jobs failures caused by pnpm 7.33.5 dependencies resolution in `ŧest-pwa` module