### PR TITLE
feat!: Deny access for parent layout with no annotation

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/auth/AccessControlTestClasses.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/auth/AccessControlTestClasses.java
@@ -454,4 +454,13 @@ public class AccessControlTestClasses {
             implements RouterLayout {
     }
 
+    @Tag(Tag.DIV)
+    public static class NoPermitParent extends Component
+            implements RouterLayout {
+    }
+
+    @PermitAll
+    @Route(value = "permitall", layout = NoPermitParent.class)
+    public static class PermitAllWithEmptyParentView extends Component {
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/auth/AnnotatedViewAccessCheckerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/auth/AnnotatedViewAccessCheckerTest.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.server.auth;
 
 import java.security.Principal;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -25,6 +26,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.internal.CurrentInstance;
 import com.vaadin.flow.router.BeforeEnterEvent;
@@ -33,8 +35,11 @@ import com.vaadin.flow.router.Location;
 import com.vaadin.flow.router.NavigationEvent;
 import com.vaadin.flow.router.NavigationTrigger;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouteAliasData;
+import com.vaadin.flow.router.RouteData;
 import com.vaadin.flow.router.RouteNotFoundError;
 import com.vaadin.flow.router.Router;
+import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.router.internal.RouteUtil;
 import com.vaadin.flow.server.MockVaadinContext;
 import com.vaadin.flow.server.RouteRegistry;
@@ -119,6 +124,27 @@ public class AnnotatedViewAccessCheckerTest {
         AccessCheckResult result = checkAccess(PermitAllView.class,
                 User.USER_NO_ROLES);
         Assert.assertEquals(AccessCheckResult.allow(), result);
+    }
+
+    @Test
+    public void loggedInNoRolesAccessToPermitAllViewWithNonAnnotatedParentDenied() {
+        NavigationContext context = setupNavigationContext(
+                AccessControlTestClasses.PermitAllWithEmptyParentView.class,
+                User.USER_NO_ROLES);
+
+        RouteData data = new RouteData(
+                Collections.singletonList(
+                        AccessControlTestClasses.NoPermitParent.class),
+                "permitall", Collections.emptyMap(),
+                AccessControlTestClasses.PermitAllWithEmptyParentView.class,
+                Collections.emptyList());
+        Router router = context.getRouter();
+        RouteRegistry registry = router.getRegistry();
+        Mockito.when(registry.getRegisteredRoutes())
+                .thenReturn(Collections.singletonList(data));
+
+        AccessCheckResult result = this.viewAccessChecker.check(context);
+        Assert.assertEquals(AccessCheckDecision.DENY, result.decision());
     }
 
     @Test


### PR DESCRIPTION
For a parent layout class with
no access control annotation,
the access to routes within this
layout are denied.

Fixes #21832
