### PR TITLE
chore: ensure consistent order of scanned classes

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/ClassInfo.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/ClassInfo.java
@@ -16,7 +16,7 @@ public class ClassInfo {
     String route = "";
     String layout;
     ThemeData theme = new ThemeData();
-    Set<String> children = new HashSet<>();
+    Set<String> children = new LinkedHashSet<>();
 
     public ClassInfo(String className) {
         this.className = className;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -196,7 +197,7 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
     }
 
     Set<String> collectReachableClasses(EntryPointData entryPointData) {
-        Set<String> classes = new HashSet<>();
+        Set<String> classes = new LinkedHashSet<>();
         collectReachableClasses(entryPointData.getName(), classes);
 
         return classes;

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/UpdateImportsWithByteCodeScannerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/UpdateImportsWithByteCodeScannerTest.java
@@ -67,9 +67,9 @@ public class UpdateImportsWithByteCodeScannerTest
                 "import '@vaadin/vaadin-mixed-component/src/vaadin-something-else';");
         expectedJsModuleImports.add(
                 "import '@vaadin/vaadin-mixed-component/src/vaadin-custom-themed-component.js';");
+        expectedJsModuleImports.add("import 'Frontend/local-p3-template.js';");
         expectedJsModuleImports.add("import 'jsmodule/h.js';");
         expectedJsModuleImports.add("import 'jsmodule/g.js';");
-        expectedJsModuleImports.add("import 'Frontend/local-p3-template.js';");
         expectedJsModuleImports.add("import '" + DepsTests.UI_IMPORT + "';");
         super.assertFullSortOrder(true, expectedJsModuleImports);
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
@@ -240,8 +240,8 @@ public class FrontendDependenciesTest {
         FrontendDependencies dependencies = new FrontendDependencies(
                 classFinder, false, null, true);
 
-        DepsTests.assertImportsExcludingUI(dependencies.getModules(), "foo.js",
-                "baz.js", "bar.js");
+        DepsTests.assertImportsExcludingUI(dependencies.getModules(), "baz.js",
+                "bar.js", "foo.js");
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/ScannerDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/ScannerDependenciesTest.java
@@ -235,7 +235,7 @@ public class ScannerDependenciesTest {
         FrontendDependencies deps = getFrontendDependencies(
                 RouteWithNestedDynamicRouteClass.class);
         DepsTests.assertImportsExcludingUI(deps.getModules(),
-                "dynamic-component.js", "dynamic-route.js",
+                "dynamic-route.js", "dynamic-component.js",
                 "dynamic-layout.js");
     }
 


### PR DESCRIPTION
Maintains a predictable ordering of classes found during class scanning to ensure that iteration over collected elements is consistent with the order of visited classes. This fixes potential test inconsistencies in tests like UpdateImportsWithByteCodeScannerTest where order-dependent assertions rely on stable output.