### PR TITLE
test: disable backgrounding occluded windows in headless chrome

### DIFF
--- a/flow-test-util/src/main/java/com/vaadin/flow/testutil/ChromeBrowserTest.java
+++ b/flow-test-util/src/main/java/com/vaadin/flow/testutil/ChromeBrowserTest.java
@@ -173,6 +173,14 @@ public class ChromeBrowserTest extends ViewOrUITest {
     static ChromeOptions createHeadlessChromeOptions() {
         final ChromeOptions options = new ChromeOptions();
         options.addArguments("--headless=new", "--disable-gpu");
+
+        // When running tests in parallel, a tab may be treated as backgrounded
+        // if its window is occluded (aka obscured) by another. This can prevent
+        // requestAnimationFrame callbacks and other timing-sensitive events
+        // from running, which may cause tests to fail. This flag disables that
+        // behavior.
+        options.addArguments("--disable-backgrounding-occluded-windows");
+
         return options;
     }
 }


### PR DESCRIPTION
## Description

The PR adds `--disable-backgrounding-occluded-windows` to Headless Chrome options to ensure `requestAnimationFrame` callbacks aren't skipped when running integration tests locally on macOS.

Although https://github.com/teamcapybara/capybara/issues/2796#issuecomment-2678172710 suggests that the issue only occurs when running tests in parallel, I'm actually facing it when running a single test using `-Dfailsafe.forkCount=1` on my local machine in https://github.com/vaadin/flow-components/pull/7681:

```
mvn verify -f vaadin-grid-flow-parent/vaadin-grid-flow-integration-tests -Dit.test=TreeGridMultiSelectionIT -Dfailsafe.forkCount=1
```

Adding the mentioned flag makes this test – and many others like ItemCountCallbackComboBoxIT, MenuBarPageIT – pass.

## Type of change

- [x] Internal
