### PR TITLE
refactor: deprecate HierarchyMapper

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchyMapper.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchyMapper.java
@@ -53,6 +53,7 @@ import com.vaadin.flow.internal.Range;
  * @since 1.2
  * @deprecated since 24.9 and will be removed in Vaadin 25.
  */
+@Deprecated(since = "24.9", forRemoval = true)
 public class HierarchyMapper<T, F> implements Serializable {
 
     // childMap is only used for finding parents of items and clean up on

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchyMapper.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchyMapper.java
@@ -51,6 +51,7 @@ import com.vaadin.flow.internal.Range;
  * @param <F>
  *            the filter type
  * @since 1.2
+ * @deprecated since 24.9 and will be removed in Vaadin 25.
  */
 public class HierarchyMapper<T, F> implements Serializable {
 


### PR DESCRIPTION
## Description

Deprecates `HierarchyMapper` with plans to remove it in Vaadin 25.

Part of #21873 
