### PR TITLE
refactor: deprecate refreshItem(item, refreshChildren)

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataProvider.java
@@ -72,6 +72,10 @@ public abstract class AbstractDataProvider<T, F> implements DataProvider<T, F> {
         fireEvent(new DataChangeEvent<>(this));
     }
 
+    /**
+     * @deprecated since 24.9 and will be removed in Vaadin 25. Use
+     *             {@link #refreshAll()} instead.
+     */
     @Override
     public void refreshItem(T item, boolean refreshChildren) {
         fireEvent(new DataRefreshEvent<>(this, item, refreshChildren));

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataProvider.java
@@ -74,12 +74,19 @@ public abstract class AbstractDataProvider<T, F> implements DataProvider<T, F> {
 
     /**
      * @deprecated since 24.9 and will be removed in Vaadin 25. Use
-     *             {@link #refreshAll()} instead. Note that while
-     *             {@link #refreshAll()} clears all cached items, it then only
-     *             reloads items that are currently visible in the viewport. It
-     *             does not trigger eager loading of the entire dataset, making
-     *             it a practical replacement without sacrificing performance
-     *             when working with large datasets.
+     *             {@link #refreshAll()} instead after changes that affect the
+     *             hierarchy.
+     *             <p>
+     *             Note that while {@code refreshAll} clears all items from the
+     *             cache, it then aims to only reload those that are in the
+     *             viewport. It does not trigger eager loading of the full
+     *             dataset, which makes it an acceptable replacement in terms of
+     *             performance.
+     *             <p>
+     *             In Vaadin 25, {@code refreshAll} will receive an update that
+     *             prevents unexpected scroll jumps when using this method with
+     *             new flat data providers. Follow
+     *             https://github.com/vaadin/platform/issues/7843 for updates.
      */
     @Override
     @Deprecated(since = "24.9", forRemoval = true)

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataProvider.java
@@ -77,6 +77,7 @@ public abstract class AbstractDataProvider<T, F> implements DataProvider<T, F> {
      *             {@link #refreshAll()} instead.
      */
     @Override
+    @Deprecated(since = "24.9", forRemoval = true)
     public void refreshItem(T item, boolean refreshChildren) {
         fireEvent(new DataRefreshEvent<>(this, item, refreshChildren));
     }

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataProvider.java
@@ -74,7 +74,12 @@ public abstract class AbstractDataProvider<T, F> implements DataProvider<T, F> {
 
     /**
      * @deprecated since 24.9 and will be removed in Vaadin 25. Use
-     *             {@link #refreshAll()} instead.
+     *             {@link #refreshAll()} instead. Note that while
+     *             {@link #refreshAll()} clears all cached items, it then only
+     *             reloads items that are currently visible in the viewport. It
+     *             does not trigger eager loading of the entire dataset, making
+     *             it a practical replacement without sacrificing performance
+     *             when working with large datasets.
      */
     @Override
     @Deprecated(since = "24.9", forRemoval = true)

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataProvider.java
@@ -88,9 +88,10 @@ public abstract class AbstractDataProvider<T, F> implements DataProvider<T, F> {
      *             providers, see https://github.com/vaadin/platform/issues/7843
      *             for more details.
      *             <p>
-     *             However, a similar effect to {@link #refreshItem(Object)}
-     *             will still be reproducible by collapsing and expanding an
-     *             item within the same round-trip.
+     *             However, a similar effect to
+     *             {@link #refreshItem(Object, boolean)} will still be
+     *             reproducible by collapsing and expanding an item within the
+     *             same round-trip.
      */
     @Override
     @Deprecated(since = "24.9", forRemoval = true)

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataProvider.java
@@ -88,9 +88,9 @@ public abstract class AbstractDataProvider<T, F> implements DataProvider<T, F> {
      *             providers, see https://github.com/vaadin/platform/issues/7843
      *             for more details.
      *             <p>
-     *             However, the current behavior of this method will still be
-     *             reproducible by collapsing and expanding an item within the
-     *             same round-trip.
+     *             However, a similar effect to {@link #refreshItem(Object)}
+     *             will still be reproducible by collapsing and expanding an
+     *             item within the same round-trip.
      */
     @Override
     @Deprecated(since = "24.9", forRemoval = true)

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataProvider.java
@@ -84,9 +84,13 @@ public abstract class AbstractDataProvider<T, F> implements DataProvider<T, F> {
      *             performance.
      *             <p>
      *             In Vaadin 25, {@code refreshAll} will receive an update that
-     *             prevents unexpected scroll jumps when using this method with
-     *             new flat data providers. Follow
-     *             https://github.com/vaadin/platform/issues/7843 for updates.
+     *             prevents unexpected scroll jumps when used with new flat data
+     *             providers, see https://github.com/vaadin/platform/issues/7843
+     *             for more details.
+     *             <p>
+     *             However, the current behavior of this method will still be
+     *             reproducible by collapsing and expanding an item within the
+     *             same round-trip.
      */
     @Override
     @Deprecated(since = "24.9", forRemoval = true)

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataChangeEvent.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataChangeEvent.java
@@ -73,6 +73,7 @@ public class DataChangeEvent<T> extends EventObject {
          *            refreshed as well
          * @deprecated since 24.9 and will be removed in Vaadin 25.
          */
+        @Deprecated(since = "24.9", forRemoval = true)
         public DataRefreshEvent(DataProvider<T, ?> source, T item,
                 boolean refreshChildren) {
             super(source);
@@ -98,6 +99,7 @@ public class DataChangeEvent<T> extends EventObject {
          *         refreshed as well
          * @deprecated since 24.9 and will be removed in Vaadin 25.
          */
+        @Deprecated(since = "24.9", forRemoval = true)
         public boolean isRefreshChildren() {
             return refreshChildren;
         }

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataChangeEvent.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataChangeEvent.java
@@ -71,6 +71,7 @@ public class DataChangeEvent<T> extends EventObject {
          * @param refreshChildren
          *            whether, in hierarchical providers, subelements should be
          *            refreshed as well
+         * @deprecated since 24.9 and will be removed in Vaadin 25.
          */
         public DataRefreshEvent(DataProvider<T, ?> source, T item,
                 boolean refreshChildren) {
@@ -95,6 +96,7 @@ public class DataChangeEvent<T> extends EventObject {
          *
          * @return whether, in hierarchical providers, subelements should be
          *         refreshed as well
+         * @deprecated since 24.9 and will be removed in Vaadin 25.
          */
         public boolean isRefreshChildren() {
             return refreshChildren;

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataProvider.java
@@ -122,7 +122,12 @@ public interface DataProvider<T, F> extends Serializable {
      * @param refreshChildren
      *            whether or not to refresh child items
      * @deprecated since 24.9 and will be removed in Vaadin 25. Use
-     *             {@link #refreshAll()} instead.
+     *             {@link #refreshAll()} instead. Note that while
+     *             {@link #refreshAll()} clears all cached items, it then only
+     *             reloads items that are currently visible in the viewport. It
+     *             does not trigger eager loading of the entire dataset, making
+     *             it a practical replacement without sacrificing performance
+     *             when working with large datasets.
      */
     @Deprecated(since = "24.9", forRemoval = true)
     default void refreshItem(T item, boolean refreshChildren) {

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataProvider.java
@@ -136,9 +136,10 @@ public interface DataProvider<T, F> extends Serializable {
      *             providers, see https://github.com/vaadin/platform/issues/7843
      *             for more details.
      *             <p>
-     *             However, a similar effect to {@link #refreshItem(Object)}
-     *             will still be reproducible by collapsing and expanding an
-     *             item within the same round-trip.
+     *             However, a similar effect to
+     *             {@link #refreshItem(Object, boolean)} will still be
+     *             reproducible by collapsing and expanding an item within the
+     *             same round-trip.
      */
     @Deprecated(since = "24.9", forRemoval = true)
     default void refreshItem(T item, boolean refreshChildren) {

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataProvider.java
@@ -132,9 +132,13 @@ public interface DataProvider<T, F> extends Serializable {
      *             performance.
      *             <p>
      *             In Vaadin 25, {@code refreshAll} will receive an update that
-     *             prevents unexpected scroll jumps when using this method with
-     *             new flat data providers. Follow
-     *             https://github.com/vaadin/platform/issues/7843 for updates.
+     *             prevents unexpected scroll jumps when used with new flat data
+     *             providers, see https://github.com/vaadin/platform/issues/7843
+     *             for more details.
+     *             <p>
+     *             However, the current behavior of this method will still be
+     *             reproducible by collapsing and expanding an item within the
+     *             same round-trip.
      */
     @Deprecated(since = "24.9", forRemoval = true)
     default void refreshItem(T item, boolean refreshChildren) {

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataProvider.java
@@ -121,6 +121,8 @@ public interface DataProvider<T, F> extends Serializable {
      *            the item to refresh
      * @param refreshChildren
      *            whether or not to refresh child items
+     * @deprecated since 24.9 and will be removed in Vaadin 25. Use
+     *             {@link #refreshAll()} instead.
      */
     default void refreshItem(T item, boolean refreshChildren) {
         refreshItem(item);

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataProvider.java
@@ -136,9 +136,9 @@ public interface DataProvider<T, F> extends Serializable {
      *             providers, see https://github.com/vaadin/platform/issues/7843
      *             for more details.
      *             <p>
-     *             However, the current behavior of this method will still be
-     *             reproducible by collapsing and expanding an item within the
-     *             same round-trip.
+     *             However, a similar effect to {@link #refreshItem(Object)}
+     *             will still be reproducible by collapsing and expanding an
+     *             item within the same round-trip.
      */
     @Deprecated(since = "24.9", forRemoval = true)
     default void refreshItem(T item, boolean refreshChildren) {

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataProvider.java
@@ -122,12 +122,19 @@ public interface DataProvider<T, F> extends Serializable {
      * @param refreshChildren
      *            whether or not to refresh child items
      * @deprecated since 24.9 and will be removed in Vaadin 25. Use
-     *             {@link #refreshAll()} instead. Note that while
-     *             {@link #refreshAll()} clears all cached items, it then only
-     *             reloads items that are currently visible in the viewport. It
-     *             does not trigger eager loading of the entire dataset, making
-     *             it a practical replacement without sacrificing performance
-     *             when working with large datasets.
+     *             {@link #refreshAll()} instead after changes that affect the
+     *             hierarchy.
+     *             <p>
+     *             Note that while {@code refreshAll} clears all items from the
+     *             cache, it then aims to only reload those that are in the
+     *             viewport. It does not trigger eager loading of the full
+     *             dataset, which makes it an acceptable replacement in terms of
+     *             performance.
+     *             <p>
+     *             In Vaadin 25, {@code refreshAll} will receive an update that
+     *             prevents unexpected scroll jumps when using this method with
+     *             new flat data providers. Follow
+     *             https://github.com/vaadin/platform/issues/7843 for updates.
      */
     @Deprecated(since = "24.9", forRemoval = true)
     default void refreshItem(T item, boolean refreshChildren) {

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataProvider.java
@@ -124,6 +124,7 @@ public interface DataProvider<T, F> extends Serializable {
      * @deprecated since 24.9 and will be removed in Vaadin 25. Use
      *             {@link #refreshAll()} instead.
      */
+    @Deprecated(since = "24.9", forRemoval = true)
     default void refreshItem(T item, boolean refreshChildren) {
         refreshItem(item);
     }


### PR DESCRIPTION
## Description

Deprecates `refreshItem(T item, boolean refreshChildren)` in favor of `refreshAll`. It cannot be implemented for flat data providers and is already working inconsistently for current data providers. The method will be removed in Vaadin 25. 

Part of https://github.com/vaadin/flow/issues/21873

## Type of change

- [x] Refactor
