### PR TITLE
fix: prevent deletion of css.generated.js files

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRemoveOldFrontendGeneratedFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRemoveOldFrontendGeneratedFiles.java
@@ -155,6 +155,10 @@ public class TaskRemoveOldFrontendGeneratedFiles implements FallibleCommand {
                 frontendGeneratedFolder.resolve("file-routes.ts")));
         knownFiles.add(normalizePath(
                 frontendGeneratedFolder.resolve("file-routes.json")));
+        knownFiles.add(normalizePath(
+                frontendGeneratedFolder.resolve("css.generated.js")));
+        knownFiles.add(normalizePath(
+                frontendGeneratedFolder.resolve("css.generated.d.ts")));
         knownFiles.addAll(hillaGeneratedFiles());
         return path -> knownFiles.contains(path) || path.getFileName()
                 .toString().matches("theme(\\.(js|d\\.ts)|-.*\\.generated.js)");

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRemoveOldFrontendGeneratedFilesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRemoveOldFrontendGeneratedFilesTest.java
@@ -161,9 +161,12 @@ public class TaskRemoveOldFrontendGeneratedFilesTest {
                                 "generated-flow-webcomponent-imports.js"))
                         .toFile(),
                 new File(generatedFolder, "routes.tsx"),
-                new File(generatedFolder, "routes.ts"), generatedFolder.toPath()
-                        .resolve(Path.of("flow", "Flow.tsx")).toFile(),
-                new File(generatedFolder, "file-routes.ts"));
+                new File(generatedFolder, "routes.ts"),
+                generatedFolder.toPath().resolve(Path.of("flow", "Flow.tsx"))
+                        .toFile(),
+                new File(generatedFolder, "file-routes.ts"),
+                new File(generatedFolder, "css.generated.js"),
+                new File(generatedFolder, "css.generated.d.ts"));
         for (File file : knownFiles) {
             file.getParentFile().mkdirs();
             Files.writeString(file.toPath(), "TEST");


### PR DESCRIPTION
Prevents frontend compilation failures on hot reload caused by the deletion of css.generated.js and css.generated.d.ts generated files when the prepare frontend task is executed.

Fixes #21892
