### PR TITLE
refactor: make requestFlush method protected

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -1120,11 +1120,11 @@ public class DataCommunicator<T> implements Serializable {
         }
     }
 
-    private void requestFlush() {
+    protected void requestFlush() {
         requestFlush(false);
     }
 
-    private void requestFlush(boolean forced) {
+    protected void requestFlush(boolean forced) {
         if (!shouldRequestFlush(forced)) {
             return;
         }


### PR DESCRIPTION
## Description

The PR changes the visibility of `DataCommunicator#requestFlush` to protected to allow access and overriding in HierarchicalDataCommunicator.

Fixes https://github.com/vaadin/flow/issues/21890

## Type of change

- [x] Refactor
