### PR TITLE
fix: validate all detected commercial components for Hilla apps

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinBuildFrontendTask.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinBuildFrontendTask.kt
@@ -116,7 +116,9 @@ public abstract class VaadinBuildFrontendTask : DefaultTask() {
             }
         }
         LicenseChecker.setStrictOffline(true)
-        val licenseRequired = BuildFrontendUtil.validateLicenses(adapter.get(), frontendDependencies)
+        val onlyValidateJavaImports = !isHillaUsed()
+        logger.info("============================ Only check Java packages? ${onlyValidateJavaImports}")
+        val licenseRequired = BuildFrontendUtil.validateLicenses(adapter.get(), frontendDependencies, onlyValidateJavaImports)
 
         BuildFrontendUtil.updateBuildFile(adapter.get(), licenseRequired)
     }
@@ -135,8 +137,7 @@ public abstract class VaadinBuildFrontendTask : DefaultTask() {
      * @return `true` to remove created files, `false` to keep the files
      */
     protected open fun cleanFrontendFiles(): Boolean {
-        if (FrontendUtils.isHillaUsed(BuildFrontendUtil.getGeneratedFrontendDirectory(adapter.get()),
-                        adapter.get().classFinder)) {
+        if (isHillaUsed()) {
             /*
              * Override this to not clean generated frontend files after the
              * build. For Hilla, the generated files can still be useful for
@@ -147,4 +148,8 @@ public abstract class VaadinBuildFrontendTask : DefaultTask() {
         }
         return adapter.get().config.cleanFrontendFiles.get()
     }
+
+    private fun isHillaUsed() : Boolean = FrontendUtils.isHillaUsed(
+        BuildFrontendUtil.getGeneratedFrontendDirectory(adapter.get()),
+            adapter.get().classFinder)
 }

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -179,8 +179,9 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo
             }
         }
         LicenseChecker.setStrictOffline(true);
+        boolean onlyValidateJavaImports = !isHillaUsed(frontendDirectory());
         boolean licenseRequired = BuildFrontendUtil.validateLicenses(this,
-                frontendDependencies);
+                frontendDependencies, onlyValidateJavaImports);
 
         BuildFrontendUtil.updateBuildFile(this, licenseRequired);
 

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -347,7 +347,10 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
         if (ex instanceof InvocationTargetException) {
             ex = ex.getCause();
         }
-        StringBuilder errorMessage = new StringBuilder(ex.getMessage());
+        StringBuilder errorMessage = new StringBuilder();
+        if (ex.getMessage() != null) {
+            errorMessage.append(ex.getMessage());
+        }
         Throwable cause = ex.getCause();
         while (cause != null) {
             if (cause.getMessage() != null) {


### PR DESCRIPTION
During frontend build only npm packages imported by Java classes are validate by the license checker. However, for apps with Hilla views the check is skipped for packages imported only by frontend views. This change forces validation for all detected commercial components if the application is using Hilla views.
