### PR TITLE
feat: add pre-trial splash screen

### DIFF
--- a/vaadin-dev-server/patch-application.js
+++ b/vaadin-dev-server/patch-application.js
@@ -12,7 +12,10 @@ if (!appPath) {
   );
 }
 
-const vaadinFilePath = path.join(appPath, 'frontend', 'generated', 'vaadin.ts');
+let vaadinFilePath = path.join(appPath, 'src', 'main', 'frontend', 'generated', 'vaadin.ts');
+if (!fs.existsSync(vaadinFilePath)) {
+  vaadinFilePath = path.join(appPath, 'frontend', 'generated', 'vaadin.ts');
+}
 if (!fs.existsSync(vaadinFilePath)) {
   throw new Error(
     `Application path does not contain a ./src/main/frontend/generated directory: ${vaadinFilePath}. Make sure to start the app first.`

--- a/vaadin-dev-server/src/main/frontend/pre-trial-splash-screen.ts
+++ b/vaadin-dev-server/src/main/frontend/pre-trial-splash-screen.ts
@@ -1,0 +1,327 @@
+import { ProductAndMessage } from './License';
+
+class PreTrial extends HTMLElement {
+  #parentObserver: MutationObserver | null;
+  #shadowRoot: ShadowRoot;
+  #trialExpired: boolean;
+  #startFailed: boolean | null;
+  private remove: Function;
+
+  constructor() {
+    super();
+
+    this.#parentObserver = null;
+    this.#trialExpired = false;
+    this.#startFailed = null;
+
+    // Create a shadow DOM for encapsulation
+    this.#shadowRoot = this.attachShadow({ mode: 'closed' });
+
+    // Initialize the component
+    this.render();
+    this.setupProtection();
+  }
+
+  // Define the observed attributes for the web component
+  static get observedAttributes(): string[] {
+    return ['expired', 'start-failure'];
+  }
+
+  private render(): void {
+    // Use template string for HTML structure
+    const commonStyles = `
+      <style>
+        :host {
+          position: fixed;
+          bottom: 0;
+          left: 0;
+          right: 0;
+          z-index: 9999;
+          min-height: 100% !important;
+          min-width: 100% !important;
+          display: flex !important;
+          visibility: visible !important;
+          opacity: 1 !important;
+          clip-path: none !important;
+          text-indent: 0 !important;          
+          background-color: rgba(0, 0, 0, 0.5);          
+        }
+        
+        .container {
+          margin: auto;
+          padding: 20px;
+          max-width: 600px;
+          border: 1px solid #ccc;
+          border-radius: 8px;
+          background-color: white;
+          opacity: 1 !important;
+        }
+        
+        h3 {
+          margin: 0 0 10px 0;
+          font-weight: bold;
+          color: black;
+        }
+        
+        p {
+          margin: 0 0 10px 0;
+        }
+        
+        a {
+          color: #007bff;
+          text-decoration: none;
+        }
+        
+        .button-container {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+        }
+        
+        button {                    
+          padding: 8px 16px;
+          border-radius: 4px;
+          cursor: pointer;
+          font-family: inherit;
+          font-size-adjust: none;
+          border: none;
+        }
+        
+        .action-button {
+          background-color: #007bff;
+          color: white;
+        }
+        
+        .login-button {
+          background-color: #ededed;
+        }
+        
+        svg {
+          height: 1em; /* Match the current font size */
+          width: auto; /* Maintain aspect ratio */
+          vertical-align: text-top;
+        }
+        .arrow-icon {
+          margin-left: 5px;
+          font-size: 16px;
+        }
+        
+        strong {
+          font-weight: bold;
+        }
+
+        div.error {
+          color: #9f3a38;
+          background-color: #fff6f6;
+          box-shadow: 0 0 0 1px #e0b4b4 inset, 0 0 0 0 transparent;
+          padding: 1em 1.5em;
+          border-radius: .3rem;
+          margin: 0 0 10px 0;
+        }
+        div.error h4 { margin: 0}
+      </style>
+     `;
+
+    const vaadinLogo = `<svg class='vaadin-logo' width='24' height='24' viewBox='0 0 77.27 73.82' xmlns='http://www.w3.org/2000/svg'>
+        <title>vaadin-logo</title>
+        <path d='M38.65 73.82a4.55 4.55 0 0 0 4.14-2.67l.11-.19 15.88-29.39a5.09 5.09 0 0 0-4.42-7.63c-2.26 0-3.79 1.11-4.83 3.48l-10.89 20.3-10.88-20.27c-1-2.4-2.58-3.5-4.84-3.5a5.09 5.09 0 0 0-4.42 7.62L34.4 71l.07.13a4.55 4.55 0 0 0 4.18 2.73m.01-43.69a4.06 4.06 0 0 0 4.06-4.06v-1a3.86 3.86 0 0 1 3.86-3.84h20.8a9.88 9.88 0 0 0 9.89-9.88V3.78a3.8 3.8 0 0 0-7.1-1.86 3.78 3.78 0 0 0-.48 1.85v2.41a3.86 3.86 0 0 1-3.9 3.82H47a8.13 8.13 0 0 0-8 6.91 12 12 0 0 0-.2 2h-.17a12 12 0 0 0-.2-2 8.13 8.13 0 0 0-8-6.9H11.47A3.86 3.86 0 0 1 7.61 6.2V3.81A3.78 3.78 0 0 0 7.12 2 3.8 3.8 0 0 0 0 3.82v7.61a9.88 9.88 0 0 0 9.89 9.87h20.8a3.86 3.86 0 0 1 3.86 3.84v1a4.06 4.06 0 0 0 4.06 4.06h.05z' data-name='Layer 1' fill='#000000'/>
+     </svg>`;
+
+    this.#shadowRoot.innerHTML = `
+    ${commonStyles}
+    <div class='container'>
+      <h3>${vaadinLogo} ${this.#trialExpired ? 'Trial expired' : 'Start a Trial or Log in'}</h3>
+      <p>
+        To use features such as Vaadin Copilot and other commercial components, you need an active <strong>subscription</strong> or <strong>trial</strong>.
+      </p>
+      <p>
+         <slot name='products'></slot>
+      </p>
+      ${this.#startFailed ? `
+        <div class='error'>
+          <h4>Trial cannot be started</h4>
+            ${this.#trialExpired ?
+        'The trial period has expired. You can get an extended 30-day trial by logging in.'
+        : 'The attempt to start the Trial failed. Please try again later or contact support.'}
+        </div>`
+      : ''
+    }
+      ${!this.#startFailed && this.#trialExpired ? '<p>You can get an extended 30-day trial by logging in.</p>' : ''}
+      <p>
+        By activating the trial, you agree to the <a href='https://vaadin.com/commercial-license-and-service-terms'
+          class='terms-link' target='_blank'>terms and conditions</a>.
+      </p>
+      <p>
+        This trial includes all commercial tools and components. Production builds during the trial will be watermarked.
+      </p>
+      <div class='button-container'>
+        <button class='action-button'>${this.#trialExpired ? 'Extend trial 30 days' : 'Try for 7 days'}</button>
+        <button class='login-button'>
+          Log in / Sign up
+          <svg xmlns='http://www.w3.org/2000/svg'  width='16' height='16' viewBox='0 0 16 16'>
+            <path fill='#444' d='M14 16v-11l-1 1v9h-12v-12h9l1-1h-11v14z'></path>
+            <path fill='#444' d='M16 0h-5l1.8 1.8-6.8 6.8 1.4 1.4 6.8-6.8 1.8 1.8z'></path>
+          </svg>                  
+        </button>          
+      </div>
+    </div>
+      `;
+
+    const actionButton = this.#shadowRoot.querySelector('button.action-button')!;
+    actionButton.addEventListener('click', () => {
+      if (this.#trialExpired) {
+        this.openNewWindow('https://vaadin.com/pricing');
+      } else {
+        (window as any).Vaadin.devTools.startPreTrial();
+      }
+    });
+    const loginButton = this.#shadowRoot.querySelector('button.login-button')!;
+    loginButton.addEventListener('click', () => {
+      this.openNewWindow('https://vaadin.com/my/account');
+    });
+  }
+
+  private openNewWindow(url: string): void {
+    const newWindow = window.open(url, '_blank');
+    if (newWindow) {
+      newWindow.opener = null;
+    }
+  }
+
+  connectedCallback(): void {
+    this.setupParentRemovalProtection();
+  }
+
+  disconnectedCallback(): void {
+    this.cleanup();
+  }
+
+  attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null): void {
+    if (name === 'expired') {
+      this.handleExpiredChange(newValue !== null && newValue !== 'false');
+    } else if (name === 'start-failure') {
+      this.handleStartFailed(newValue === 'expired');
+    }
+  }
+
+  private handleExpiredChange(value: boolean) {
+    if (this.#trialExpired !== value) {
+      this.#trialExpired = value;
+      this.render();
+    }
+  }
+
+  private handleStartFailed(expired: boolean) {
+    if (this.#startFailed !== expired || this.#trialExpired !== expired) {
+      this.#trialExpired = expired;
+      this.#startFailed = true;
+      this.render();
+    }
+  }
+
+  private setupProtection(): void {
+    const originalRemove = Element.prototype.remove;
+    this.remove = function(this: PreTrial): void {
+      console.debug('Attempt to remove vaadin-pretrial detected - restoring');
+      const currentParent = this.parentNode;
+      // Let the removal happen
+      originalRemove.apply(this, arguments);
+      // Re-add the component
+      this.restoreSplashScreen(currentParent as Node);
+    };
+
+    // Protect against style changes
+    this.protectStyles();
+  }
+
+  private setupParentRemovalProtection(): void {
+    // Protect against removal from parent
+    if (!this.#parentObserver && this.parentNode) {
+      this.#parentObserver = new MutationObserver((mutations: MutationRecord[]) => {
+        mutations.forEach((mutation: MutationRecord) => {
+          if (mutation.type === 'childList') {
+            mutation.removedNodes.forEach((node: Node) => {
+              if (node === this) {
+                console.debug('vaadin-pretrial removal detected - restoring');
+                this.restoreSplashScreen(mutation.target);
+              }
+            });
+          }
+        });
+      });
+
+      this.#parentObserver.observe(this.parentNode, {
+        childList: true, subtree: true
+      });
+    }
+  }
+
+  private protectStyles(): void {
+    // Override style setters
+    Object.defineProperty(this, 'style', {
+      get(): object {
+        // return an empty object to prevent programmatic changes
+        return {};
+      },
+      set(_value: CSSStyleDeclaration): void {
+        // prevent setting regular style object
+      }
+    });
+  }
+
+  private cleanup(): void {
+    if (this.#parentObserver) {
+      this.#parentObserver.disconnect();
+    }
+  }
+
+  private restoreSplashScreen(maybeParentNode: Node | null): void {
+    // Re-add the component if it's removed
+    if (!maybeParentNode) {
+      // Splash screen component not yet attached
+      return;
+    }
+    setTimeout(() => {
+      console.debug('Re-adding vaadin-pretrial component');
+      const products = this.querySelector('[slot="products"]');
+      if ((maybeParentNode as ParentNode).contains(this)) {
+        (maybeParentNode as Node).removeChild(this);
+      }
+      const splashScreen = document.createElement('vaadin-pretrial');
+      if (this.#trialExpired) {
+        splashScreen.setAttribute('expired', 'true');
+      }
+      if (this.#startFailed) {
+        splashScreen.setAttribute('start-failure', this.#trialExpired ? 'expired' : '');
+      }
+      if (products) {
+        splashScreen.appendChild(products.cloneNode(true));
+      }
+      (maybeParentNode as Element).appendChild(splashScreen);
+    }, 0);
+  }
+}
+
+// Register the custom element
+customElements.define('vaadin-pretrial', PreTrial);
+
+export const showPreTrialSplashScreen = (shadowRoot: ShadowRoot | null, message: ProductAndMessage) => {
+  if (shadowRoot && !shadowRoot.innerHTML.includes('vaadin-pretrial')) {
+    const expiredPreTrial = message.preTrial?.trialState === 'EXPIRED';
+    shadowRoot.innerHTML = `<slot></slot><vaadin-pretrial ${expiredPreTrial ? 'expired' : ''}>
+      This application is using:
+      <div slot='products'>
+        This application is using:
+        <ul>
+          <li>${message.product.name}</li>
+        </ul>
+      </div>
+    </vaadin-pretrial>`;
+  }
+};
+export const preTrialStartFailed = (expired: boolean, shadowRoot: ShadowRoot | null) => {
+  if (shadowRoot) {
+    const element = shadowRoot.querySelector('vaadin-pretrial');
+    element?.setAttribute('start-failure', expired ? 'expired' : '');
+  }
+};

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/ProductAndMessage.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/ProductAndMessage.java
@@ -17,14 +17,24 @@ package com.vaadin.base.devserver;
 
 import java.io.Serializable;
 
+import com.vaadin.pro.licensechecker.PreTrial;
 import com.vaadin.pro.licensechecker.Product;
 
 class ProductAndMessage implements Serializable {
-    private Product product;
-    private String message;
+    private final Product product;
+    private final String message;
+    private final PreTrial preTrial;
 
     public ProductAndMessage(Product product, String message) {
         this.product = product;
+        this.message = message;
+        this.preTrial = null;
+    }
+
+    public ProductAndMessage(Product product, PreTrial preTrial,
+            String message) {
+        this.product = product;
+        this.preTrial = preTrial;
         this.message = message;
     }
 
@@ -34,5 +44,9 @@ class ProductAndMessage implements Serializable {
 
     public Product getProduct() {
         return product;
+    }
+
+    public PreTrial getPreTrial() {
+        return preTrial;
     }
 }

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/DebugWindowConnectionLicenseCheckTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/DebugWindowConnectionLicenseCheckTest.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.base.devserver;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.atmosphere.cpr.AtmosphereResource;
+import org.atmosphere.cpr.Broadcaster;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Answers;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.server.VaadinContext;
+import com.vaadin.flow.server.startup.ApplicationConfiguration;
+import com.vaadin.pro.licensechecker.BuildType;
+import com.vaadin.pro.licensechecker.LicenseChecker;
+import com.vaadin.pro.licensechecker.LicenseException;
+import com.vaadin.pro.licensechecker.PreTrial;
+import com.vaadin.pro.licensechecker.PreTrialCreationException;
+import com.vaadin.pro.licensechecker.PreTrialLicenseValidationException;
+import com.vaadin.pro.licensechecker.Product;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.same;
+
+public class DebugWindowConnectionLicenseCheckTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final Product TEST_PRODUCT = new Product(
+            "commercial-component", "1.0.0");
+    public static final String INVALID_LICENSE_ERROR = "Invalid license";
+    public static final String MISSING_KEY_ERROR = "Pre trial not started yet.";
+    public static final PreTrial TEST_PRE_TRIAL = new PreTrial("Test trial",
+            PreTrial.PreTrialState.START_ALLOWED, 5, 22);
+
+    private final DebugWindowConnection reload = new DebugWindowConnection(
+            getMockContext());
+    private final ClientMessageReceiver receiver = new ClientMessageReceiver();
+
+    @Test
+    public void checkLicense_validLicense_sendLicenseOk() {
+        DebugWindowMessage message = doLicenseCheck(LicenseCheckResult.VALID);
+        Assert.assertEquals("license-check-ok", message.getCommand());
+        Assert.assertTrue("Expected a Product object in response message",
+                message.getData() instanceof Product);
+        Assert.assertEquals(TEST_PRODUCT.toString(),
+                message.getData().toString());
+    }
+
+    @Test
+    public void checkLicense_invalidLicense_sendLicenseCheckFailed() {
+        DebugWindowMessage message = doLicenseCheck(LicenseCheckResult.INVALID);
+        Assert.assertEquals("license-check-failed", message.getCommand());
+        Assert.assertTrue(
+                "Expected a ProductAndMessage object in response message",
+                message.getData() instanceof ProductAndMessage);
+        ProductAndMessage productAndMessage = (ProductAndMessage) message
+                .getData();
+        Assert.assertEquals(INVALID_LICENSE_ERROR,
+                productAndMessage.getMessage());
+        Assert.assertEquals(TEST_PRODUCT.toString(),
+                productAndMessage.getProduct().toString());
+        Assert.assertNull("Expected pre-trial info to be absent",
+                productAndMessage.getPreTrial());
+    }
+
+    @Test
+    public void checkLicense_noLicenseKeys_sendLicenseCheckFailed() {
+        DebugWindowMessage message = doLicenseCheck(
+                LicenseCheckResult.MISSING_KEYS);
+
+        Assert.assertEquals("license-check-nokey", message.getCommand());
+        Assert.assertTrue(
+                "Expected a ProductAndMessage object in response message",
+                message.getData() instanceof ProductAndMessage);
+        ProductAndMessage productAndMessage = (ProductAndMessage) message
+                .getData();
+        Assert.assertTrue(
+                productAndMessage.getMessage().contains(MISSING_KEY_ERROR));
+        Assert.assertEquals(TEST_PRODUCT.toString(),
+                productAndMessage.getProduct().toString());
+        Assert.assertEquals(TEST_PRODUCT.toString(),
+                productAndMessage.getProduct().toString());
+        Assert.assertNotNull("Expected pre-trial info to be present",
+                productAndMessage.getPreTrial());
+        Assert.assertEquals(TEST_PRE_TRIAL.toString(),
+                productAndMessage.getPreTrial().toString());
+    }
+
+    @Test
+    public void startPreTrial_preTrialAllowed_sendPreTrialInfo() {
+        DebugWindowMessage message = doStartPreTrial(
+                PreTrial.PreTrialState.START_ALLOWED);
+        Assert.assertEquals("license-pretrial-started", message.getCommand());
+        Assert.assertTrue("Expected a PreTrial object in response message",
+                message.getData() instanceof PreTrial);
+        PreTrial preTrial = (PreTrial) message.getData();
+        Assert.assertEquals(TEST_PRE_TRIAL.toString(), preTrial.toString());
+    }
+
+    @Test
+    public void startPreTrial_preTrialRunning_sendPreTrialInfo() {
+        DebugWindowMessage message = doStartPreTrial(
+                PreTrial.PreTrialState.RUNNING);
+        Assert.assertEquals("license-pretrial-started", message.getCommand());
+        Assert.assertTrue("Expected a PreTrial object in response message",
+                message.getData() instanceof PreTrial);
+        PreTrial preTrial = (PreTrial) message.getData();
+        Assert.assertEquals(TEST_PRE_TRIAL.toString(), preTrial.toString());
+    }
+
+    @Test
+    public void startPreTrial_preTrialExpired_sendPreTrialExpiredFailure() {
+        DebugWindowMessage message = doStartPreTrial(
+                PreTrial.PreTrialState.EXPIRED);
+        Assert.assertEquals("license-pretrial-expired", message.getCommand());
+    }
+
+    @Test
+    public void startPreTrial_preTrialNotAllowed_sendPreTrialNotAllowedFailure() {
+        DebugWindowMessage message = doStartPreTrial(null);
+        Assert.assertEquals("license-pretrial-failed", message.getCommand());
+    }
+
+    @Test
+    public void startPreTrial_genericError_sendPreTrialNotAllowedFailure() {
+        DebugWindowMessage message = doStartPreTrial(
+                PreTrial.PreTrialState.ACCESS_DENIED);
+        Assert.assertEquals("license-pretrial-failed", message.getCommand());
+    }
+
+    private enum LicenseCheckResult {
+        VALID, INVALID, MISSING_KEYS
+    }
+
+    private DebugWindowMessage doLicenseCheck(
+            LicenseCheckResult licenseCheckResult) {
+        ObjectNode command = OBJECT_MAPPER.createObjectNode();
+        command.put("command", "checkLicense");
+        command.putPOJO("data", TEST_PRODUCT);
+        return sendAndReceive(command, mockCheckLicense(licenseCheckResult));
+    }
+
+    private DebugWindowMessage doStartPreTrial(
+            PreTrial.PreTrialState preTrialState) {
+        ObjectNode command = OBJECT_MAPPER.createObjectNode();
+        command.put("command", "startPreTrialLicense");
+        return sendAndReceive(command, licenseChecker -> licenseChecker
+                .when(LicenseChecker::startPreTrial).then(i -> {
+                    if (preTrialState == null) {
+                        throw new PreTrialCreationException("BOOM!!!!");
+                    }
+                    return switch (preTrialState) {
+                    case START_ALLOWED -> TEST_PRE_TRIAL;
+                    case RUNNING -> TEST_PRE_TRIAL;
+                    case EXPIRED -> throw new PreTrialCreationException.Expired(
+                            "Trial expired");
+                    case ACCESS_DENIED -> throw new PreTrialCreationException(
+                            "Pre trial not allowed");
+                    };
+                }));
+    }
+
+    private DebugWindowMessage sendAndReceive(ObjectNode command,
+            Consumer<MockedStatic<LicenseChecker>> instrumenter) {
+        receiver.messages.clear();
+        withMockedLicenseChecker(instrumenter,
+                () -> reload.onMessage(receiver.resource, command.toString()));
+        int responses = receiver.messages.size();
+        Assert.assertEquals("Expected messages", 1, responses);
+        DebugWindowMessage message = receiver.messages.get(0);
+        receiver.messages.clear();
+        return message;
+    }
+
+    private void withMockedLicenseChecker(
+            Consumer<MockedStatic<LicenseChecker>> instrumenter,
+            Runnable test) {
+        try (MockedStatic<LicenseChecker> licenseChecker = Mockito
+                .mockStatic(LicenseChecker.class, Answers.RETURNS_MOCKS)) {
+            instrumenter.accept(licenseChecker);
+            test.run();
+        }
+    }
+
+    private Consumer<MockedStatic<LicenseChecker>> mockCheckLicense(
+            LicenseCheckResult licenseCheckResult) {
+        return licenseChecker -> {
+            licenseChecker.when(
+                    () -> LicenseChecker.checkLicense(anyString(), anyString(),
+                            Mockito.any(BuildType.class), Mockito.isNull()))
+                    .then(i -> {
+                        switch (licenseCheckResult) {
+                        case INVALID ->
+                            throw new LicenseException(INVALID_LICENSE_ERROR);
+                        case MISSING_KEYS -> {
+                            throw new PreTrialLicenseValidationException(
+                                    TEST_PRE_TRIAL);
+                        }
+                        default -> {
+                        }
+                        }
+                        return null;
+                    });
+        };
+    }
+
+    private VaadinContext getMockContext() {
+        VaadinContext context = new MockVaadinContext();
+        ApplicationConfiguration appConfig = Mockito
+                .mock(ApplicationConfiguration.class);
+        Mockito.when(appConfig.isProductionMode()).thenReturn(false);
+        context.setAttribute(ApplicationConfiguration.class, appConfig);
+        context.setAttribute(Lookup.class,
+                Lookup.of(appConfig, ApplicationConfiguration.class));
+        return context;
+    }
+
+    private static class ClientMessageReceiver {
+        private final List<DebugWindowMessage> messages = new ArrayList<>();
+        private final AtmosphereResource resource;
+
+        private ClientMessageReceiver() {
+            this.resource = Mockito.mock(AtmosphereResource.class);
+            Broadcaster broadcaster = Mockito.mock(Broadcaster.class);
+            Mockito.when(resource.getBroadcaster()).thenReturn(broadcaster);
+            Mockito.when(broadcaster.broadcast(anyString(), same(resource)))
+                    .then(i -> {
+                        messages.add(deserializeMessage(
+                                i.getArgument(0, String.class)));
+                        return null;
+                    });
+        }
+
+        private DebugWindowMessage deserializeMessage(String message)
+                throws JsonProcessingException {
+            JsonNode json = OBJECT_MAPPER.readTree(message);
+            String command = json.get("command").textValue();
+            JsonNode data = json.get("data");
+            if (command.startsWith("license-check-")) {
+                if (data.has("message") && data.has("product")) {
+                    PreTrial preTrial = null;
+                    if (data.hasNonNull("preTrial")) {
+                        preTrial = deserializePreTrial(data.get("preTrial"));
+                    }
+                    return new DebugWindowMessage(command,
+                            new ProductAndMessage(new Product(
+                                    data.get("product").get("name").textValue(),
+                                    data.get("product").get("version")
+                                            .textValue()),
+                                    preTrial, data.get("message").textValue()));
+                } else if (data.has("name") && data.has("version")) {
+                    return new DebugWindowMessage(command,
+                            new Product(data.get("name").textValue(),
+                                    data.get("version").textValue()));
+                }
+            } else if (command.startsWith("license-pretrial-")) {
+                PreTrial preTrial = deserializePreTrial(data);
+                return new DebugWindowMessage(command, preTrial);
+            }
+            throw new UnsupportedOperationException(
+                    "Unknown message: " + message);
+        }
+
+        private static PreTrial deserializePreTrial(JsonNode data) {
+            if (data.has("trialName")) {
+                return new PreTrial(data.get("trialName").textValue(),
+                        PreTrial.PreTrialState
+                                .valueOf(data.get("trialState").textValue()),
+                        data.get("daysRemaining").intValue(),
+                        data.get("daysRemainingUntilRenewal").intValue());
+            }
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
Shows a splash screen when a commercial component is detected at runtime in development mode but there are no license keys available. The splash screen prevents the user from interacting with the application and allows to either start a pre-trial or to log in to the vaadin.com account and download a license key.
After starting a pre-trial, the page is reloaded to make the application usable.
If the per-trial period has expired, the splash screen presents a button that forwards to the vaadin.com website to extend the trial.
