### PR TITLE
fix: notify listeners when InputStream download handler callback fails

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/InputStreamDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/InputStreamDownloadHandlerTest.java
@@ -25,7 +25,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -135,7 +135,7 @@ public class InputStreamDownloadHandlerTest {
 
     @Test
     public void transferProgressListener_addListener_errorOccured_errorlistenerInvoked()
-            throws URISyntaxException, IOException {
+            throws IOException {
         DownloadEvent event = Mockito.mock(DownloadEvent.class);
         Mockito.when(event.getSession()).thenReturn(session);
         Mockito.when(event.getResponse()).thenReturn(response);
@@ -145,36 +145,16 @@ public class InputStreamDownloadHandlerTest {
                 .write(Mockito.any(byte[].class), Mockito.anyInt(),
                         Mockito.anyInt());
         Mockito.when(event.getOutputStream()).thenReturn(outputStreamMock);
-        List<String> invocations = new ArrayList<>();
+        AtomicReference<Boolean> whenCompleteResult = new AtomicReference<>();
+        InvocationTrackingTransferProgressListener transferListener = new InvocationTrackingTransferProgressListener();
         DownloadHandler handler = DownloadHandler.fromInputStream(req -> {
             // Simulate a download of 165000 bytes
             byte[] data = getBytes();
             ByteArrayInputStream inputStream = new ByteArrayInputStream(data);
             return new DownloadResponse(inputStream, "download",
                     "application/octet-stream", data.length);
-        }, new TransferProgressListener() {
-            @Override
-            public void onStart(TransferContext context) {
-                invocations.add("onStart");
-            }
-
-            @Override
-            public void onProgress(TransferContext context,
-                    long transferredBytes, long totalBytes) {
-                invocations.add("onProgress");
-            }
-
-            @Override
-            public void onComplete(TransferContext context,
-                    long transferredBytes) {
-                invocations.add("onComplete");
-            }
-
-            @Override
-            public void onError(TransferContext context, IOException reason) {
-                invocations.add("onError");
-                Assert.assertEquals("I/O exception", reason.getMessage());
-            }
+        }, transferListener).whenComplete((context, success) -> {
+            whenCompleteResult.set(success);
         });
 
         try {
@@ -182,7 +162,45 @@ public class InputStreamDownloadHandlerTest {
             Assert.fail("Expected an IOException to be thrown");
         } catch (Exception e) {
         }
-        Assert.assertEquals(List.of("onStart", "onError"), invocations);
+        Assert.assertEquals(List.of("onStart", "onError"),
+                transferListener.invocations);
+        Assert.assertNotNull("Expected whenComplete to be invoked, but was not",
+                whenCompleteResult.get());
+        Assert.assertFalse(
+                "Expected whenComplete to be invoked with false result, but got true",
+                whenCompleteResult.get());
+
+    }
+
+    @Test
+    public void transferProgressListener_addListener_callbackErrorOccured_errorlistenerInvoked() {
+        DownloadEvent event = Mockito.mock(DownloadEvent.class);
+        Mockito.when(event.getSession()).thenReturn(session);
+        Mockito.when(event.getResponse()).thenReturn(response);
+        Mockito.when(event.getOwningElement()).thenReturn(owner);
+        OutputStream outputStreamMock = Mockito.mock(OutputStream.class);
+        Mockito.when(event.getOutputStream()).thenReturn(outputStreamMock);
+
+        AtomicReference<Boolean> whenCompleteResult = new AtomicReference<>();
+
+        InvocationTrackingTransferProgressListener transferListener = new InvocationTrackingTransferProgressListener();
+        DownloadHandler handler = DownloadHandler.fromInputStream(req -> {
+            throw new IOException("I/O exception");
+        }, transferListener).whenComplete((context, success) -> {
+            whenCompleteResult.set(success);
+        });
+
+        try {
+            handler.handleDownloadRequest(event);
+            Assert.fail("Expected an IOException to be thrown");
+        } catch (Exception e) {
+        }
+        Assert.assertEquals(List.of("onError"), transferListener.invocations);
+        Assert.assertNotNull("Expected whenComplete to be invoked, but was not",
+                whenCompleteResult.get());
+        Assert.assertFalse(
+                "Expected whenComplete to be invoked with false result, but got true",
+                whenCompleteResult.get());
     }
 
     @Test
@@ -327,4 +345,32 @@ public class InputStreamDownloadHandlerTest {
         }
         return data;
     }
+
+    private static class InvocationTrackingTransferProgressListener
+            implements TransferProgressListener {
+        private final List<String> invocations = new ArrayList<>();
+
+        @Override
+        public void onStart(TransferContext context) {
+            invocations.add("onStart");
+        }
+
+        @Override
+        public void onProgress(TransferContext context, long transferredBytes,
+                long totalBytes) {
+            invocations.add("onProgress");
+        }
+
+        @Override
+        public void onComplete(TransferContext context, long transferredBytes) {
+            invocations.add("onComplete");
+        }
+
+        @Override
+        public void onError(TransferContext context, IOException reason) {
+            invocations.add("onError");
+            Assert.assertEquals("I/O exception", reason.getMessage());
+        }
+    }
+
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DownloadHandlerView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DownloadHandlerView.java
@@ -17,20 +17,16 @@ package com.vaadin.flow.uitest.ui;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
 
-import com.vaadin.flow.component.DetachEvent;
 import com.vaadin.flow.component.html.Anchor;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.HttpStatusCode;
 import com.vaadin.flow.server.streams.DownloadEvent;
 import com.vaadin.flow.server.streams.DownloadHandler;
-import com.vaadin.flow.server.HttpStatusCode;
-import com.vaadin.flow.server.StreamRegistration;
-import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.streams.DownloadResponse;
 import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 
@@ -88,7 +84,7 @@ public class DownloadHandlerView extends Div {
         inputStreamDownload.setId("download-handler-input-stream");
 
         Anchor inputStreamErrorDownload = new Anchor("",
-                "InputStream DownloadHandler shorthand");
+                "InputStream DownloadHandler shorthand (ERROR)");
         inputStreamErrorDownload
                 .setHref(DownloadHandler
                         .fromInputStream(downloadEvent -> DownloadResponse
@@ -96,8 +92,18 @@ public class DownloadHandlerView extends Div {
                         .inline());
         inputStreamErrorDownload.setId("download-handler-input-stream-error");
 
+        Anchor inputStreamCallbackError = new Anchor("",
+                "InputStream DownloadHandler callback shorthand (CALLBACK EXCEPTION)");
+        inputStreamCallbackError
+                .setHref(DownloadHandler.fromInputStream(downloadEvent -> {
+                    throw new IOException("Callback exception");
+                }).inline());
+        inputStreamCallbackError
+                .setId("download-handler-input-stream-callback-error");
+
         add(handlerDownload, fileDownload, classDownload, servletDownload,
-                inputStreamDownload, inputStreamErrorDownload);
+                inputStreamDownload, inputStreamErrorDownload,
+                inputStreamCallbackError);
 
         NativeButton reattach = new NativeButton("Remove and add back",
                 event -> {

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TransferProgressListenerView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TransferProgressListenerView.java
@@ -33,6 +33,7 @@ public class TransferProgressListenerView extends Div {
     static final String WHEN_START_ID = "for-servlet-resource-when-start";
     static final String ON_PROGRESS_ID = "for-servlet-resource-on-progress";
     static final String ON_ERROR_ID = "for-servlet-resource-on-error";
+    static final String ON_CALLBACK_ERROR_ID = "from-inputstream-on-callback-error";
     static final String ON_COMPLETE_ID = "for-servlet-resource-when-complete";
 
     public TransferProgressListenerView() {
@@ -99,5 +100,24 @@ public class TransferProgressListenerView extends Div {
         add(imageError);
         add(new Div("Error:"));
         add(forServletResourceOnError);
+
+        Div fromInputStreamOnCallbackError = new Div(
+                "File download onError status (callback error)...");
+        fromInputStreamOnCallbackError.setId(ON_CALLBACK_ERROR_ID);
+        errorDownloadHandler = DownloadHandler.fromInputStream(req -> {
+            throw new IOException("Simulated error");
+        }).whenComplete(success -> {
+            if (!success) {
+                fromInputStreamOnCallbackError.setText(
+                        "File download onError status: callback error");
+            }
+        });
+
+        imageError = new Image(errorDownloadHandler, "no-image");
+
+        add(imageError);
+        add(new Div("Error (callback):"));
+        add(fromInputStreamOnCallbackError);
+
     }
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DownloadHandlerIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DownloadHandlerIT.java
@@ -21,7 +21,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
@@ -135,6 +134,21 @@ public class DownloadHandlerIT extends AbstractStreamResourceIT {
 
         Assert.assertEquals("HTTP ERROR 500",
                 findElement(By.className("error-code")).getText());
+    }
+
+    @Test
+    public void getDynamicDownloadHandlerFailingInputStreamCallback_errorIsReceived() {
+        open();
+
+        WebElement link = findElement(
+                By.id("download-handler-input-stream-callback-error"));
+        link.click();
+
+        getDriver().manage().timeouts().scriptTimeout(Duration.of(15, SECONDS));
+
+        // Jetty error page
+        Assert.assertTrue($("h2").withTextContaining("HTTP ERROR 500")
+                .withTextContaining("java.io.IOException: Callback").exists());
     }
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TransferProgressListenerIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TransferProgressListenerIT.java
@@ -46,6 +46,8 @@ public class TransferProgressListenerIT extends AbstractStreamResourceIT {
                 "File download whenComplete status: completed");
         waitForStatus(TransferProgressListenerView.ON_ERROR_ID,
                 "File download onError status: error");
+        waitForStatus(TransferProgressListenerView.ON_CALLBACK_ERROR_ID,
+                "File download onError status: callback error");
     }
 
     private void waitForStatus(String id, String status) {


### PR DESCRIPTION
When a callback provided to DownloadHandler.fromInputStream throws an IOException the transfer progress listeners are not notified about the error. This change caught IOException potentially thrown by the callback and notifies the registered listeners.

Part of #21931