### PR TITLE
refactor: undeprecate refreshItem, improve its JavaDoc

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataProvider.java
@@ -72,29 +72,7 @@ public abstract class AbstractDataProvider<T, F> implements DataProvider<T, F> {
         fireEvent(new DataChangeEvent<>(this));
     }
 
-    /**
-     * @deprecated since 24.9 and will be removed in Vaadin 25. Use
-     *             {@link #refreshAll()} instead after changes that affect the
-     *             hierarchy.
-     *             <p>
-     *             Note that while {@code refreshAll} clears all items from the
-     *             cache, it then aims to only reload those that are in the
-     *             viewport. It does not trigger eager loading of the full
-     *             dataset, which makes it an acceptable replacement in terms of
-     *             performance.
-     *             <p>
-     *             In Vaadin 25, {@code refreshAll} will receive an update that
-     *             prevents unexpected scroll jumps when used with new flat data
-     *             providers, see https://github.com/vaadin/platform/issues/7843
-     *             for more details.
-     *             <p>
-     *             However, a similar effect to
-     *             {@link #refreshItem(Object, boolean)} will still be
-     *             reproducible by collapsing and expanding an item within the
-     *             same round-trip.
-     */
     @Override
-    @Deprecated(since = "24.9", forRemoval = true)
     public void refreshItem(T item, boolean refreshChildren) {
         fireEvent(new DataRefreshEvent<>(this, item, refreshChildren));
     }

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataChangeEvent.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataChangeEvent.java
@@ -71,9 +71,7 @@ public class DataChangeEvent<T> extends EventObject {
          * @param refreshChildren
          *            whether, in hierarchical providers, subelements should be
          *            refreshed as well
-         * @deprecated since 24.9 and will be removed in Vaadin 25.
          */
-        @Deprecated(since = "24.9", forRemoval = true)
         public DataRefreshEvent(DataProvider<T, ?> source, T item,
                 boolean refreshChildren) {
             super(source);

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataProvider.java
@@ -109,39 +109,20 @@ public interface DataProvider<T, F> extends Serializable {
     void refreshItem(T item);
 
     /**
-     * Refreshes the given item and all of the children of the item as well.
-     *
-     * @see #refreshItem(Object)
-     *
-     *      By default it just does a standard refreshItem, in a hierarchical
-     *      DataProvider it is supposed to refresh all of the children as well
-     *      in case 'refreshChildren' is true.
+     * Refreshes the given item and its children if refreshChildren is true and
+     * a hierarchical data provider is used. Otherwise, it behaves like regular
+     * {@link #refreshItem(Object)}.
+     * <p>
+     * It's important to note that this method resets the item's hierarchy which
+     * can cause a content shift if the item contains expanded children: their
+     * descendants aren't guaranteed to be re-fetched eagerly, which may affect
+     * the overall size of the rendered hierarchy, leading to content shifts.
      *
      * @param item
      *            the item to refresh
      * @param refreshChildren
      *            whether or not to refresh child items
-     * @deprecated since 24.9 and will be removed in Vaadin 25. Use
-     *             {@link #refreshAll()} instead after changes that affect the
-     *             hierarchy.
-     *             <p>
-     *             Note that while {@code refreshAll} clears all items from the
-     *             cache, it then aims to only reload those that are in the
-     *             viewport. It does not trigger eager loading of the full
-     *             dataset, which makes it an acceptable replacement in terms of
-     *             performance.
-     *             <p>
-     *             In Vaadin 25, {@code refreshAll} will receive an update that
-     *             prevents unexpected scroll jumps when used with new flat data
-     *             providers, see https://github.com/vaadin/platform/issues/7843
-     *             for more details.
-     *             <p>
-     *             However, a similar effect to
-     *             {@link #refreshItem(Object, boolean)} will still be
-     *             reproducible by collapsing and expanding an item within the
-     *             same round-trip.
      */
-    @Deprecated(since = "24.9", forRemoval = true)
     default void refreshItem(T item, boolean refreshChildren) {
         refreshItem(item);
     }


### PR DESCRIPTION
## Description

It was decided to keep the `refreshItem(T item, boolean refreshChildren)` method available for non-flat data providers in the new version of  `HierarchicalDataCommunicator`. It doesn't fix scroll issues in every case, but it is known to help avoid them in some situations – for example when the refreshed item doesn't contain _expanded_ children. Since moving to flat data providers can be not straightforward, keeping this method around is the safer option, at least until Vaadin 26.

The PR also improves the JavaDoc of this method to warn about possible content shifts when it's called on items with more than one level of nesting.

Part of #21873 

## Type of change

- [x] Refactor
