### PR TITLE
refactor: deprecate setRequestedRange in favor of setViewportRange

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
@@ -187,7 +187,7 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
 
     /**
      * @deprecated since 24.9 and will be removed in Vaadin 25. Instead,
-     *             {@link #setRequestedRange(int, int)} will handle all
+     *             {@link #setViewportRange(int, int)} will handle all
      *             hierarchy levels.
      */
     @Deprecated(since = "24.9", forRemoval = true)

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
@@ -187,8 +187,8 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
 
     /**
      * @deprecated since 24.9 and will be removed in Vaadin 25. Instead,
-     *             {@link #setViewportRange(int, int)} will handle all
-     *             hierarchy levels.
+     *             {@link #setViewportRange(int, int)} will handle all hierarchy
+     *             levels.
      */
     @Deprecated(since = "24.9", forRemoval = true)
     public void setParentRequestedRange(int start, int length, T parentItem) {

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractLazyDataViewTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractLazyDataViewTest.java
@@ -174,7 +174,7 @@ public class AbstractLazyDataViewTest {
         final AtomicInteger itemCount = new AtomicInteger(0);
         dataView.addItemCountChangeListener(
                 event -> itemCount.set(event.getItemCount()));
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
 
         Assert.assertEquals("Invalid item count reported", 0, itemCount.get());
 
@@ -188,7 +188,7 @@ public class AbstractLazyDataViewTest {
         final AtomicInteger itemCount = new AtomicInteger(0);
         dataView.addItemCountChangeListener(
                 event -> itemCount.set(event.getItemCount()));
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         dataView.setItemCountUnknown();
 
         Assert.assertEquals("Invalid item count reported", 0, itemCount.get());
@@ -230,7 +230,7 @@ public class AbstractLazyDataViewTest {
 
     @Test
     public void getItems_withDefinedSize() {
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         dataCommunicator.setDataProvider(DataProvider.fromCallbacks(query -> {
             query.getOffset();
             query.getLimit();
@@ -244,7 +244,7 @@ public class AbstractLazyDataViewTest {
 
     @Test
     public void getItems_withUndefinedSize() {
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         AtomicInteger limit = new AtomicInteger(50);
         dataCommunicator.setDataProvider(DataProvider.fromCallbacks(query -> {
             query.getOffset();
@@ -270,7 +270,7 @@ public class AbstractLazyDataViewTest {
 
     @Test
     public void getItem_correctIndex_itemObtained() {
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         dataCommunicator.setDataProvider(DataProvider.fromCallbacks(query -> {
             query.getOffset();
             query.getLimit();
@@ -287,7 +287,7 @@ public class AbstractLazyDataViewTest {
     public void getItem_negativeIndex_throws() {
         exceptionRule.expect(IndexOutOfBoundsException.class);
         exceptionRule.expectMessage("Index must be non-negative");
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         dataCommunicator.setDataProvider(DataProvider.fromCallbacks(query -> {
             query.getOffset();
             query.getLimit();
@@ -302,7 +302,7 @@ public class AbstractLazyDataViewTest {
     public void getItem_emptyData_throws() {
         exceptionRule.expect(IndexOutOfBoundsException.class);
         exceptionRule.expectMessage("Requested index 0 on empty data.");
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         dataCommunicator.setDataProvider(DataProvider.fromCallbacks(query -> {
             query.getOffset();
             query.getLimit();
@@ -318,7 +318,7 @@ public class AbstractLazyDataViewTest {
         exceptionRule.expect(IndexOutOfBoundsException.class);
         exceptionRule.expectMessage(
                 "Given index 3 is outside of the accepted range '0 - 2'");
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         dataCommunicator.setDataProvider(DataProvider.fromCallbacks(query -> {
             query.getOffset();
             query.getLimit();

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorAsyncTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorAsyncTest.java
@@ -141,7 +141,7 @@ public class DataCommunicatorAsyncTest {
         ui.getPushConfiguration().setPushMode(PushMode.DISABLED);
         dataCommunicator.setDataProvider(createDataProvider(), null);
         dataCommunicator.enablePushUpdates(executor);
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         fakeClientCommunication();
     }
 
@@ -151,7 +151,7 @@ public class DataCommunicatorAsyncTest {
         ui.getPushConfiguration().setPushMode(PushMode.AUTOMATIC);
         dataCommunicator.setDataProvider(createDataProvider(), null);
         dataCommunicator.enablePushUpdates(executor);
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         fakeClientCommunication();
 
         Assert.assertNotEquals("Expected initial reset not yet done.",

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
@@ -170,7 +170,7 @@ public class DataCommunicatorTest {
 
     @Test
     public void communicator_with_0_items_should_not_refresh_all() {
-        dataCommunicator.setRequestedRange(0, 0);
+        dataCommunicator.setViewportRange(0, 0);
         fakeClientCommunication();
 
         Assert.assertEquals(Range.withLength(0, 0), lastSet);
@@ -178,7 +178,7 @@ public class DataCommunicatorTest {
                 "Only requestAll should clear items. This may make us loop.",
                 lastClear);
 
-        dataCommunicator.setRequestedRange(0, 0);
+        dataCommunicator.setViewportRange(0, 0);
         fakeClientCommunication();
 
         Assert.assertEquals(Range.withLength(0, 0), lastSet);
@@ -191,14 +191,14 @@ public class DataCommunicatorTest {
     public void communicator_with_items_should_send_updates_but_not_refresh_all() {
         dataCommunicator.setDataProvider(createDataProvider(), null);
 
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         fakeClientCommunication();
 
         Assert.assertEquals(
                 "Expected request range for 50 items on first request.",
                 Range.withLength(0, 50), lastSet);
 
-        dataCommunicator.setRequestedRange(0, 70);
+        dataCommunicator.setViewportRange(0, 70);
         fakeClientCommunication();
 
         Assert.assertEquals("Expected request range for 20 new items.",
@@ -208,7 +208,7 @@ public class DataCommunicatorTest {
     @Test
     public void reattach_different_roundtrip_refresh_all() {
         dataCommunicator.setDataProvider(createDataProvider(), null);
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         fakeClientCommunication();
 
         Assert.assertEquals("Expected initial full reset.",
@@ -230,7 +230,7 @@ public class DataCommunicatorTest {
     @Test
     public void reattach_same_roundtrip_refresh_nothing() {
         dataCommunicator.setDataProvider(createDataProvider(), null);
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         fakeClientCommunication();
 
         Assert.assertEquals("Expected initial full reset.",
@@ -277,7 +277,7 @@ public class DataCommunicatorTest {
     @Test
     public void setDataProvider_keyMapperIsReset() {
         dataCommunicator.setDataProvider(createDataProvider(), null);
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         fakeClientCommunication();
 
         Assert.assertEquals(0, dataCommunicator.getKeyMapper().get("1").id);
@@ -378,7 +378,7 @@ public class DataCommunicatorTest {
         ListDataProvider<Item> dataProvider = new ListDataProvider<>(items);
         dataCommunicator.setDataProvider(dataProvider, null);
 
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         fakeClientCommunication();
 
         Item originalItem = items.get(0);
@@ -407,7 +407,7 @@ public class DataCommunicatorTest {
         // The first request will return size 50, but the actual fetch will
         // bring only 40 items. A new size query should then be performed, that
         // will return 40 instead
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         fakeClientCommunication();
 
         Assert.assertEquals(40, lastSet.getEnd());
@@ -423,7 +423,7 @@ public class DataCommunicatorTest {
         dataProvider = Mockito.spy(dataProvider);
 
         dataCommunicator.setDataProvider(dataProvider, null);
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         Assert.assertTrue(dataCommunicator.isDefinedSize());
 
         fakeClientCommunication();
@@ -445,7 +445,7 @@ public class DataCommunicatorTest {
         Mockito.verify(dataProvider, Mockito.times(1)).size(Mockito.any());
         Mockito.verify(dataProvider, Mockito.times(1)).fetch(Mockito.any());
 
-        dataCommunicator.setRequestedRange(50, 50);
+        dataCommunicator.setViewportRange(50, 50);
 
         fakeClientCommunication();
 
@@ -474,7 +474,7 @@ public class DataCommunicatorTest {
         final int itemCountEstimateIncrease = 300;
         dataCommunicator
                 .setItemCountEstimateIncrease(itemCountEstimateIncrease);
-        dataCommunicator.setRequestedRange(150, 50);
+        dataCommunicator.setViewportRange(150, 50);
         Assert.assertFalse(dataCommunicator.isDefinedSize());
 
         fakeClientCommunication();
@@ -510,7 +510,7 @@ public class DataCommunicatorTest {
 
         final int initialCountEstimate = 100;
         dataCommunicator.setItemCountEstimate(initialCountEstimate);
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         Assert.assertFalse(dataCommunicator.isDefinedSize());
 
         fakeClientCommunication();
@@ -520,7 +520,7 @@ public class DataCommunicatorTest {
         Mockito.verify(dataProvider, Mockito.times(0)).size(Mockito.any());
         Mockito.verify(dataProvider, Mockito.times(1)).fetch(Mockito.any());
 
-        dataCommunicator.setRequestedRange(50, 50);
+        dataCommunicator.setViewportRange(50, 50);
 
         fakeClientCommunication();
 
@@ -538,14 +538,14 @@ public class DataCommunicatorTest {
 
         dataCommunicator.setDataProvider(dataProvider, null);
         dataCommunicator.setDefinedSize(false);
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         fakeClientCommunication();
 
         final int initialCountEstimate = 111;
         dataCommunicator.setItemCountEstimate(initialCountEstimate);
         Assert.assertFalse(dataCommunicator.isDefinedSize());
 
-        dataCommunicator.setRequestedRange(50, 100);
+        dataCommunicator.setViewportRange(50, 100);
         fakeClientCommunication();
 
         Assert.assertEquals(
@@ -561,7 +561,7 @@ public class DataCommunicatorTest {
         dataProvider = Mockito.spy(dataProvider);
         dataCommunicator.setDataProvider(dataProvider, null);
         int requestedRangeEnd = 50;
-        dataCommunicator.setRequestedRange(0, requestedRangeEnd);
+        dataCommunicator.setViewportRange(0, requestedRangeEnd);
 
         final int initialCountEstimate = 49;
         dataCommunicator.setItemCountEstimate(initialCountEstimate);
@@ -580,7 +580,7 @@ public class DataCommunicatorTest {
         dataProvider = Mockito.spy(dataProvider);
         dataCommunicator.setDataProvider(dataProvider, null);
         int rangeLength = 100;
-        dataCommunicator.setRequestedRange(400, rangeLength);
+        dataCommunicator.setViewportRange(400, rangeLength);
 
         final int initialCountEstimate = 300;
         dataCommunicator.setItemCountEstimate(initialCountEstimate);
@@ -605,7 +605,7 @@ public class DataCommunicatorTest {
         dataCommunicator.setDataProvider(dataProvider, null);
         final int itemCountEstimate = 1000;
         dataCommunicator.setItemCountEstimate(itemCountEstimate);
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         fakeClientCommunication();
 
         Assert.assertEquals(itemCountEstimate, dataCommunicator.getItemCount());
@@ -615,7 +615,7 @@ public class DataCommunicatorTest {
         // roundtrip where the client will request items because it received
         // less
         // items than expected
-        dataCommunicator.setRequestedRange(900, 100);
+        dataCommunicator.setViewportRange(900, 100);
         fakeClientCommunication();
 
         Assert.assertEquals(exactSize, dataCommunicator.getItemCount());
@@ -639,7 +639,7 @@ public class DataCommunicatorTest {
         dataCommunicator.setDataProvider(dataProvider, null);
         final int itemCountEstimate = 1000;
         dataCommunicator.setItemCountEstimate(itemCountEstimate);
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         fakeClientCommunication();
 
         Assert.assertEquals(exactSize, dataCommunicator.getItemCount());
@@ -655,14 +655,14 @@ public class DataCommunicatorTest {
     @Test
     public void getActiveItemOnIndex_activeRangeChanges_itemsReturned() {
         dataCommunicator.setDataProvider(createDataProvider(300), null);
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         fakeClientCommunication();
         Assert.assertEquals("Wrong active item", new Item(0),
                 dataCommunicator.getItem(0));
         Assert.assertEquals("Wrong active item", new Item(49),
                 dataCommunicator.getItem(49));
 
-        dataCommunicator.setRequestedRange(50, 50);
+        dataCommunicator.setViewportRange(50, 50);
         fakeClientCommunication();
 
         Assert.assertEquals("Wrong active item", new Item(50),
@@ -676,7 +676,7 @@ public class DataCommunicatorTest {
     @Test
     public void isItemActive_newItems() {
         dataCommunicator.setDataProvider(createDataProvider(), null);
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
 
         Assert.assertFalse("Item should not be active",
                 dataCommunicator.isItemActive(new Item(0)));
@@ -690,7 +690,7 @@ public class DataCommunicatorTest {
         Assert.assertFalse("Item should not be active",
                 dataCommunicator.isItemActive(new Item(50)));
 
-        dataCommunicator.setRequestedRange(50, 50);
+        dataCommunicator.setViewportRange(50, 50);
         fakeClientCommunication();
 
         Assert.assertTrue("Item should be active",
@@ -703,7 +703,7 @@ public class DataCommunicatorTest {
 
     @Test
     public void getItem_withDefinedSizeAndCorrectIndex() {
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         dataCommunicator.setDataProvider(DataProvider.fromCallbacks(query -> {
             query.getOffset();
             query.getLimit();
@@ -732,7 +732,7 @@ public class DataCommunicatorTest {
     public void getItem_withDefinedSizeAndNegativeIndex() {
         expectedException.expect(IndexOutOfBoundsException.class);
         expectedException.expectMessage("Index must be non-negative");
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         dataCommunicator.setDataProvider(DataProvider.fromCallbacks(query -> {
             query.getOffset();
             query.getLimit();
@@ -747,7 +747,7 @@ public class DataCommunicatorTest {
     public void getItem_withDefinedSizeAndEmptyDataset() {
         expectedException.expect(IndexOutOfBoundsException.class);
         expectedException.expectMessage("Requested index 0 on empty data.");
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         dataCommunicator.setDataProvider(DataProvider.fromCallbacks(query -> {
             query.getOffset();
             query.getLimit();
@@ -763,7 +763,7 @@ public class DataCommunicatorTest {
         expectedException.expect(IndexOutOfBoundsException.class);
         expectedException.expectMessage(
                 "Given index 3 is outside of the accepted range '0 - 2'");
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         dataCommunicator.setDataProvider(DataProvider.fromCallbacks(query -> {
             query.getOffset();
             query.getLimit();
@@ -779,7 +779,7 @@ public class DataCommunicatorTest {
         final Item initialFilter = new Item(1); // filters all except 2nd item
         final Item newFilter = new Item(2); // filters all except 3rd item
 
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         SerializableConsumer<Item> newFilterProvider = dataCommunicator
                 .setDataProvider(DataProvider.fromFilteringCallbacks(query -> {
                     query.getOffset();
@@ -801,7 +801,7 @@ public class DataCommunicatorTest {
 
     @Test
     public void getItem_withDefinedSizeAndSorting() {
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         dataCommunicator.setDataProvider(DataProvider.fromCallbacks(query -> {
             query.getOffset();
             query.getLimit();
@@ -834,7 +834,7 @@ public class DataCommunicatorTest {
 
     @Test
     public void getItem_withUndefinedSizeAndCorrectIndex() {
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         dataCommunicator.setDataProvider(DataProvider.fromCallbacks(
                 query -> IntStream.of(0, 1, 2).mapToObj(Item::new)
                         .skip(query.getOffset()).limit(query.getLimit()),
@@ -849,7 +849,7 @@ public class DataCommunicatorTest {
         Assert.assertEquals("Wrong item on index 1", new Item(1),
                 dataCommunicator.getItem(1));
 
-        dataCommunicator.setRequestedRange(100, 50);
+        dataCommunicator.setViewportRange(100, 50);
         dataCommunicator.setDataProvider(DataProvider.fromCallbacks(
                 query -> IntStream.range(0, 500).mapToObj(Item::new)
                         .skip(query.getOffset()).limit(query.getLimit()),
@@ -873,7 +873,7 @@ public class DataCommunicatorTest {
 
     @Test
     public void getItem_withUndefinedSizeAndEmptyDataset() {
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         dataCommunicator.setDataProvider(DataProvider.fromCallbacks(
                 query -> IntStream.of(0, 1, 2).mapToObj(Item::new)
                         .skip(query.getOffset()).limit(query.getLimit()),
@@ -901,7 +901,7 @@ public class DataCommunicatorTest {
 
     @Test
     public void getItem_withUndefinedSizeAndIndexOutsideOfRange() {
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         dataCommunicator.setDataProvider(DataProvider.fromCallbacks(
                 query -> IntStream.of(0, 1, 2, 3, 4).mapToObj(Item::new)
                         .skip(query.getOffset()).limit(query.getLimit()),
@@ -924,7 +924,7 @@ public class DataCommunicatorTest {
     public void getItem_withUndefinedSizeAndNegativeIndex() {
         expectedException.expect(IndexOutOfBoundsException.class);
         expectedException.expectMessage("Index must be non-negative");
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         dataCommunicator.setDataProvider(DataProvider.fromCallbacks(query -> {
             query.getOffset();
             query.getLimit();
@@ -941,7 +941,7 @@ public class DataCommunicatorTest {
         final Item initialFilter = new Item(1); // filters all except 2nd item
         final Item newFilter = new Item(2); // filters all except 3rd item
 
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         SerializableConsumer<Item> newFilterProvider = dataCommunicator
                 .setDataProvider(DataProvider.fromFilteringCallbacks(query -> {
                     query.getOffset();
@@ -965,7 +965,7 @@ public class DataCommunicatorTest {
 
     @Test
     public void getItem_withUndefinedSizeAndSorting() {
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         dataCommunicator.setDataProvider(DataProvider.fromCallbacks(query -> {
             query.getOffset();
             query.getLimit();
@@ -1052,7 +1052,7 @@ public class DataCommunicatorTest {
                 }));
         int exactCount = 500;
         dataCommunicator.setDataProvider(createDataProvider(exactCount), null);
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         // exact size
         fakeClientCommunication();
 
@@ -1062,7 +1062,7 @@ public class DataCommunicatorTest {
                 event.getItemCount());
         Assert.assertFalse(event.isItemCountEstimated());
         // no new event fired
-        dataCommunicator.setRequestedRange(450, 50);
+        dataCommunicator.setViewportRange(450, 50);
         fakeClientCommunication();
         Assert.assertNull(cachedEvent.get());
 
@@ -1098,7 +1098,7 @@ public class DataCommunicatorTest {
                 }));
         int exactCount = 500;
         dataCommunicator.setDataProvider(createDataProvider(exactCount), null);
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         dataCommunicator.setDefinedSize(false);
         // initial estimate count of 200
         fakeClientCommunication();
@@ -1108,7 +1108,7 @@ public class DataCommunicatorTest {
                 event.getItemCount());
         Assert.assertTrue(event.isItemCountEstimated());
 
-        dataCommunicator.setRequestedRange(150, 50);
+        dataCommunicator.setViewportRange(150, 50);
         fakeClientCommunication();
 
         event = cachedEvent.getAndSet(null);
@@ -1116,7 +1116,7 @@ public class DataCommunicatorTest {
                 event.getItemCount());
         Assert.assertTrue(event.isItemCountEstimated());
 
-        dataCommunicator.setRequestedRange(350, 50);
+        dataCommunicator.setViewportRange(350, 50);
         fakeClientCommunication();
 
         event = cachedEvent.getAndSet(null);
@@ -1124,7 +1124,7 @@ public class DataCommunicatorTest {
                 event.getItemCount());
         Assert.assertTrue(event.isItemCountEstimated());
 
-        dataCommunicator.setRequestedRange(550, 50);
+        dataCommunicator.setViewportRange(550, 50);
         fakeClientCommunication();
 
         // reaching exact size
@@ -1151,7 +1151,7 @@ public class DataCommunicatorTest {
         // Trigger flush() to set the assumedSize
         fakeClientCommunication();
 
-        dataCommunicator.setRequestedRange(0, 100);
+        dataCommunicator.setViewportRange(0, 100);
         // clean flushRequest
         fakeClientCommunication();
 
@@ -1404,7 +1404,7 @@ public class DataCommunicatorTest {
         AtomicBoolean streamIsClosed = new AtomicBoolean();
         dataCommunicator.setDataProvider(createDataProvider(streamIsClosed),
                 null);
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
 
         fakeClientCommunication();
 
@@ -1440,7 +1440,7 @@ public class DataCommunicatorTest {
                 .spy(DataProvider.ofItems(new Item(0)));
 
         dataCommunicator.setDataProvider(dataProvider, null);
-        dataCommunicator.setRequestedRange(0, 0);
+        dataCommunicator.setViewportRange(0, 0);
 
         fakeClientCommunication();
 
@@ -1451,7 +1451,7 @@ public class DataCommunicatorTest {
 
         // Switch back to normal mode
         dataCommunicator.setFetchEnabled(true);
-        dataCommunicator.setRequestedRange(0, 10);
+        dataCommunicator.setViewportRange(0, 10);
 
         fakeClientCommunication();
 
@@ -1476,7 +1476,7 @@ public class DataCommunicatorTest {
         Assert.assertNotNull("Expected initial filter to be set",
                 dataCommunicator.getFilter());
 
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         fakeClientCommunication();
 
         Assert.assertNotNull("Filter should be retained after data request",
@@ -1488,7 +1488,7 @@ public class DataCommunicatorTest {
         // Check that the filter change works properly
         filterConsumer.accept(item -> item.id > 2);
 
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         fakeClientCommunication();
 
         Assert.assertNotNull("Filter should be retained after data request",
@@ -1514,7 +1514,7 @@ public class DataCommunicatorTest {
                 DataProvider.ofItems(new Item(1), new Item(2), new Item(3)),
                 item -> item.id > 1);
 
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         fakeClientCommunication();
 
         Assert.assertTrue("Expected event to be triggered",
@@ -1532,7 +1532,7 @@ public class DataCommunicatorTest {
                 DataProvider.ofItems(new Item(1), new Item(2), new Item(3)),
                 item -> item.id > 1, false);
 
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
         fakeClientCommunication();
     }
 
@@ -1591,10 +1591,10 @@ public class DataCommunicatorTest {
         dataCommunicator.setDefinedSize(false);
 
         // Scroll forward to populate the DC cache (active items)
-        dataCommunicator.setRequestedRange(0, 100);
+        dataCommunicator.setViewportRange(0, 100);
         fakeClientCommunication();
 
-        dataCommunicator.setRequestedRange(100, 150);
+        dataCommunicator.setViewportRange(100, 150);
         fakeClientCommunication();
 
         // Apply the filter and force the requested range to be shifted back
@@ -1627,7 +1627,7 @@ public class DataCommunicatorTest {
                 super.reset();
             }
         };
-        dataCommunicator.setRequestedRange(0, 100);
+        dataCommunicator.setViewportRange(0, 100);
         AbstractDataProvider<Item, Object> dataProvider = createDataProvider();
         dataCommunicator.setDataProvider(dataProvider, null);
         // Add the component to a parent to trigger handle the attach event
@@ -1653,14 +1653,14 @@ public class DataCommunicatorTest {
     }
 
     @Test
-    public void setRequestedRange_defaultPageSize_tooMuchItemsRequested_maxItemsAllowedRequested() {
+    public void setViewportRange_defaultPageSize_tooMuchItemsRequested_maxItemsAllowedRequested() {
         DataProvider<Item, Object> dataProvider = Mockito
                 .spy(createDataProvider(1000));
         dataCommunicator.setDataProvider(dataProvider, null);
         // Paging is disabled for easier check of requested amount of items
         dataCommunicator.setPagingEnabled(false);
         // More than allowed (500) items requested
-        dataCommunicator.setRequestedRange(0, 501);
+        dataCommunicator.setViewportRange(0, 501);
         fakeClientCommunication();
 
         ArgumentCaptor<Query> queryCaptor = ArgumentCaptor
@@ -1680,7 +1680,7 @@ public class DataCommunicatorTest {
                 .spy(createDataProvider(1000));
         dataCommunicator.setDataProvider(dataProvider, null);
         dataCommunicator.setPageSize(2);
-        dataCommunicator.setRequestedRange(0, 1000);
+        dataCommunicator.setViewportRange(0, 1000);
         fakeClientCommunication();
 
         ArgumentCaptor<Query> queryCaptor = ArgumentCaptor
@@ -1691,7 +1691,7 @@ public class DataCommunicatorTest {
     }
 
     @Test
-    public void setRequestedRange_customPageSize_customPageSizeConsidered_itemsRequested() {
+    public void setViewportRange_customPageSize_customPageSizeConsidered_itemsRequested() {
         int newPageSize = 300;
         dataCommunicator.setPageSize(newPageSize);
 
@@ -1700,7 +1700,7 @@ public class DataCommunicatorTest {
         dataCommunicator.setDataProvider(dataProvider, null);
         // Paging is disabled for easier check of requested amount of items
         dataCommunicator.setPagingEnabled(false);
-        dataCommunicator.setRequestedRange(0, newPageSize * 2);
+        dataCommunicator.setViewportRange(0, newPageSize * 2);
         fakeClientCommunication();
 
         ArgumentCaptor<Query> queryCaptor = ArgumentCaptor
@@ -1721,7 +1721,7 @@ public class DataCommunicatorTest {
     @Test
     public void reattach_differentUI_requestFlushExecuted() {
         dataCommunicator.setDataProvider(createDataProvider(), null);
-        dataCommunicator.setRequestedRange(0, 50);
+        dataCommunicator.setViewportRange(0, 50);
 
         MockUI newUI = new MockUI();
         // simulates preserve on refresh

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicatorDataTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicatorDataTest.java
@@ -290,13 +290,13 @@ public class HierarchicalCommunicatorDataTest {
         dataProvider = new TreeDataProvider<>(treeData);
         communicator.setDataProvider(dataProvider, null);
 
-        communicator.setRequestedRange(0, requestedRangeLength);
+        communicator.setViewportRange(0, requestedRangeLength);
         fakeClientCommunication();
         Assert.assertTrue(communicator.getKeyMapper().has(itemToTest));
         String initialKey = communicator.getKeyMapper().key(itemToTest);
 
         communicator.expand(itemToTest);
-        communicator.setRequestedRange(requestedRangeLength * 2,
+        communicator.setViewportRange(requestedRangeLength * 2,
                 requestedRangeLength);
         fakeClientCommunication();
         assertKeyItemPairIsPresentInKeyMapper(initialKey, itemToTest);

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicatorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicatorTest.java
@@ -231,7 +231,7 @@ public class HierarchicalCommunicatorTest {
         final String secondRoot = "SECONDROOT";
 
         treeData.addItem(null, secondRoot);
-        communicator.setRequestedRange(0, 2);
+        communicator.setViewportRange(0, 2);
 
         invokeFlush();
 


### PR DESCRIPTION
## Description

The PR deprecates `setRequestedRange` and `computeRequestedRange` in favor of `setViewportRange` and `computeViewportRange`. The deprecated methods will be removed in Vaadin 26.

Fixes https://github.com/vaadin/flow/issues/21875

## Type of change

- [x] Refactor
