### PR TITLE
chore: upgrade commons dependencies to resolve vulnerability (23.6)

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.5</version>
+            <version>1.6</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.6</version>
+            <version>1.6.0</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <!-- Frontend -->
         <flow.dev.dependencies.folder>generatedDeps</flow.dev.dependencies.folder>
         <flow.dev.dependencies.file>devDependencies.json</flow.dev.dependencies.file>
-
+c
         <!-- Used in OSGi manifests -->
         <jsoup.version>1.15.3</jsoup.version>
         <!-- Note that this should be kept in sync with the class Constants -->
@@ -212,7 +212,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.12.0</version>
+                <version>3.18.0</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <!-- Frontend -->
         <flow.dev.dependencies.folder>generatedDeps</flow.dev.dependencies.folder>
         <flow.dev.dependencies.file>devDependencies.json</flow.dev.dependencies.file>
-c
+
         <!-- Used in OSGi manifests -->
         <jsoup.version>1.15.3</jsoup.version>
         <!-- Note that this should be kept in sync with the class Constants -->


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2025-48976
https://nvd.nist.gov/vuln/detail/CVE-2025-48924