### PR TITLE
fix(vaadin-spring): enable client-side redirects for TypeScript login (#21980) (CP: 24.9)

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinSecurityConfigurer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinSecurityConfigurer.java
@@ -698,6 +698,15 @@ public final class VaadinSecurityConfigurer
         getSharedObject(RequestCache.class)
                 .filter(cache -> !(cache instanceof VaadinDefaultRequestCache))
                 .ifPresent(vaadinDefaultRequestCache::setDelegateRequestCache);
+        // VaadinSavedRequestAwareAuthenticationSuccessHandler
+        // uses RequestCache for client-side redirects after TypeScript login
+        getSharedObject(
+                VaadinSavedRequestAwareAuthenticationSuccessHandler.class)
+                .ifPresent(
+                        vaadinSavedRequestAwareAuthenticationSuccessHandler -> {
+                            vaadinSavedRequestAwareAuthenticationSuccessHandler
+                                    .setRequestCache(vaadinDefaultRequestCache);
+                        });
         configurer.requestCache(vaadinDefaultRequestCache);
     }
 

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/stateless/VaadinStatelessSecurityConfigurer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/stateless/VaadinStatelessSecurityConfigurer.java
@@ -52,7 +52,6 @@ import org.springframework.security.web.header.HeaderWriterFilter;
 import org.springframework.security.web.savedrequest.CookieRequestCache;
 import org.springframework.security.web.savedrequest.RequestCache;
 import org.springframework.security.web.util.OnCommittedResponseWrapper;
-import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.vaadin.flow.spring.security.VaadinDefaultRequestCache;

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/VaadinSecurityConfigurerTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/VaadinSecurityConfigurerTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
@@ -58,6 +59,7 @@ import com.vaadin.flow.spring.SpringSecurityAutoConfiguration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @WebAppConfiguration
@@ -247,6 +249,25 @@ class VaadinSecurityConfigurerTest {
         requestCache.saveRequest(request, response);
         assertNull(requestCache.getRequest(request, response),
                 "Request should not have been saved");
+    }
+
+    @Test
+    void loginView_requestCacheApplied() throws Exception {
+        VaadinDefaultRequestCache requestCache = applicationContext
+                .getBean(VaadinDefaultRequestCache.class);
+
+        var mockSuccessHandler = Mockito.mock(
+                VaadinSavedRequestAwareAuthenticationSuccessHandler.class);
+        http.setSharedObject(
+                VaadinSavedRequestAwareAuthenticationSuccessHandler.class,
+                mockSuccessHandler);
+
+        http.with(configurer, c -> {
+            c.loginView("/login");
+        }).build();
+
+        Mockito.verify(mockSuccessHandler, times(1))
+                .setRequestCache(Mockito.eq(requestCache));
     }
 
     @Route


### PR DESCRIPTION
See https://github.com/vaadin/hilla/pull/3807, where the issue currently manifests.

VaadinSavedRequestAwareAuthenticationSuccessHandler isn't actually saved request aware unless RequestCache is correctly shared with it in the configuration, which VaadinSecurityConfigurer was failing to do due to order of events: authentication is configured before customizing request cache. This change makes sure that VaadinDefaultRequestCache instance is set for VaadinSavedRequestAwareAuthenticationSuccessHandler during configuration.
