### PR TITLE
refactor: undeprecate isRefreshChildren method

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataChangeEvent.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataChangeEvent.java
@@ -95,9 +95,7 @@ public class DataChangeEvent<T> extends EventObject {
          *
          * @return whether, in hierarchical providers, subelements should be
          *         refreshed as well
-         * @deprecated since 24.9 and will be removed in Vaadin 25.
          */
-        @Deprecated(since = "24.9", forRemoval = true)
         public boolean isRefreshChildren() {
             return refreshChildren;
         }


### PR DESCRIPTION
## Description

The `isRefreshChildren` method was forgotten to be undeprecated.

Follow-up to #21953 

## Type of change

- [x] Refactor
