### PR TITLE
refactor: deprecate setFilter, improve deprecation texts

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
@@ -186,9 +186,12 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
     }
 
     /**
-     * @deprecated since 24.9 and will be removed in Vaadin 25. Instead,
-     *             {@link #setViewportRange(int, int)} will handle all hierarchy
-     *             levels.
+     * @deprecated since 24.9 and will be removed in Vaadin 25 where
+     *             HierarchicalDataCommunicator will be <a href=
+     *             "https://github.com/vaadin/platform/issues/7843">refactored</a>
+     *             to handle hierarchy management entirely on the server side
+     *             and {@link #setViewportRange(int, int)} will be the method
+     *             responsible for managing the entire viewport range.
      */
     @Deprecated(since = "24.9", forRemoval = true)
     public void setParentRequestedRange(int start, int length, T parentItem) {
@@ -257,7 +260,11 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
      * @param <F>
      *            Query type
      * @return new {@link HierarchyMapper}
-     * @deprecated since 24.9 and will be removed in Vaadin 25.
+     * @deprecated since 24.9 and will be removed in Vaadin 25 where
+     *             HierarchicalDataCommunicator will be <a href=
+     *             "https://github.com/vaadin/platform/issues/7843">refactored</a>
+     *             to handle hierarchy management entirely on the server side,
+     *             requiring data to be stored in a different cache structure.
      */
     @Deprecated(since = "24.9", forRemoval = true)
     protected <F> HierarchyMapper<T, F> createHierarchyMapper(
@@ -294,7 +301,12 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
     }
 
     /**
-     * @deprecated since 24.9 and will be removed in Vaadin 25.
+     * @deprecated since 24.9 and will be removed in Vaadin 25 where
+     *             HierarchicalDataCommunicator will be <a href=
+     *             "https://github.com/vaadin/platform/issues/7843">refactored</a>
+     *             to handle hierarchy management entirely on the server side
+     *             and {@link #confirmUpdate(int)} will be the only method
+     *             called for confirming updates.
      */
     @Deprecated(since = "24.9", forRemoval = true)
     public void confirmUpdate(int id, String parentKey) {
@@ -540,6 +552,13 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
         super.setInMemorySorting(comparator);
     }
 
+    /**
+     * @deprecated since 24.9 and will be removed in Vaadin 25. To control the
+     *             filter from {@link HierarchicalDataCommunicator}, override
+     *             {@link #setDataProvider(HierarchicalDataProvider, Object)}
+     *             and store the returned filter consumer.
+     */
+    @Deprecated(since = "24.9", forRemoval = true)
     protected <F> void setFilter(F filter) {
         if (mapper != null) {
             mapper.setFilter(filter);
@@ -559,7 +578,11 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
      * Returns the {@code HierarchyMapper} used by this data communicator.
      *
      * @return the hierarchy mapper used by this data communicator
-     * @deprecated since 24.9 and will be removed in Vaadin 25.
+     * @deprecated since 24.9 and will be removed in Vaadin 25 where
+     *             HierarchicalDataCommunicator will be <a href=
+     *             "https://github.com/vaadin/platform/issues/7843">refactored</a>
+     *             to handle hierarchy management entirely on the server side,
+     *             requiring data to be stored in a different cache structure.
      */
     @Deprecated(since = "24.9", forRemoval = true)
     protected HierarchyMapper<T, ?> getHierarchyMapper() {
@@ -573,7 +596,10 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
     }
 
     /**
-     * @deprecated since 24.9 and will no longer be called in Vaadin 25.
+     * @deprecated since 24.9 and will no longer be called in Vaadin 25 where
+     *             HierarchicalDataCommunicator will be <a href=
+     *             "https://github.com/vaadin/platform/issues/7843">refactored</a>
+     *             to handle hierarchy management entirely on the server side.
      */
     @Override
     @Deprecated(since = "24.9", forRemoval = true)
@@ -598,7 +624,10 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
     }
 
     /**
-     * @deprecated since 24.9 and will no longer be called in Vaadin 25.
+     * @deprecated since 24.9 and will no longer be called in Vaadin 25 where
+     *             HierarchicalDataCommunicator will be <a href=
+     *             "https://github.com/vaadin/platform/issues/7843">refactored</a>
+     *             to handle hierarchy management entirely on the server side.
      */
     @Override
     @Deprecated(since = "24.9", forRemoval = true)

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchyMapper.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchyMapper.java
@@ -51,7 +51,11 @@ import com.vaadin.flow.internal.Range;
  * @param <F>
  *            the filter type
  * @since 1.2
- * @deprecated since 24.9 and will be removed in Vaadin 25.
+ * @deprecated since 24.9 and will be removed in Vaadin 25 where
+ *             HierarchicalDataCommunicator will be <a href=
+ *             "https://github.com/vaadin/platform/issues/7843">refactored</a>
+ *             to handle hierarchy management entirely on the server side,
+ *             requiring data to be stored in a different cache structure.
  */
 @Deprecated(since = "24.9", forRemoval = true)
 public class HierarchyMapper<T, F> implements Serializable {


### PR DESCRIPTION
## Description

The PR deprecates the protected `setFilter` method in `HierarchicalDataCommunicator` and also improves deprecation texts for other deprecated methods.

Part of #21873 

## Type of change

- [x] Refactor
