### PR TITLE
fix: do not throw when missing CSS in node_modules

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -500,8 +500,12 @@ abstract class AbstractUpdateImports implements Runnable {
                                 + "then make sure it's correctly configured (e.g. set '%s' property)",
                         FrontendUtils.PARAM_FRONTEND_DIR);
             }
-            throw new IllegalStateException(
-                    notFoundMessage(cssNotFound, prefix, suffix));
+
+            boolean needsNodeModules = options.isFrontendHotdeploy()
+                    || options.isBundleBuild();
+            if (getLogger().isInfoEnabled() && needsNodeModules) {
+                getLogger().info(notFoundMessage(cssNotFound, prefix, suffix));
+            }
         }
         return lines;
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
@@ -393,11 +393,15 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
     }
 
     @Test
-    public void cssFileNotFound_throws() {
+    public void cssFileNotFound_loggerReports() {
         assertTrue(resolveImportFile(frontendDirectory, nodeModulesPath,
                 "@vaadin/vaadin-mixed-component/bar.css").delete());
-        exception.expect(IllegalStateException.class);
         updater.run();
+        String output = logger.getLogs();
+        MatcherAssert.assertThat(output, CoreMatchers.containsString(
+                "Failed to find the following css files in the `node_modules`"));
+        MatcherAssert.assertThat(output, CoreMatchers
+                .containsString("@vaadin/vaadin-mixed-component/bar.css"));
     }
 
     @Test


### PR DESCRIPTION
A missing CSS file in `node_modules` should be reported but not stop the build eagerly, because Vite might be able to resolve that elsewhere (e. g., hoisted setup, plugins, etc).

Fixes #22020
