### PR TITLE
feat: add Exception to DownloadResponse and TransferContext

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/AbstractDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/AbstractDownloadHandler.java
@@ -39,7 +39,7 @@ public abstract class AbstractDownloadHandler<R extends AbstractDownloadHandler>
         return new TransferContext(transferEvent.getRequest(),
                 transferEvent.getResponse(), transferEvent.getSession(),
                 transferEvent.getFileName(), transferEvent.getOwningElement(),
-                transferEvent.getContentLength());
+                transferEvent.getContentLength(), transferEvent.getException());
     }
 
     protected String getContentType(String fileName, VaadinResponse response) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/ClassDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/ClassDownloadHandler.java
@@ -115,6 +115,7 @@ public class ClassDownloadHandler
             // Set status before output is closed (see #8740)
             downloadEvent.getResponse()
                     .setStatus(HttpStatusCode.INTERNAL_SERVER_ERROR.getCode());
+            downloadEvent.setException(ioe);
             notifyError(downloadEvent, ioe);
             throw ioe;
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadEvent.java
@@ -49,6 +49,7 @@ public class DownloadEvent {
     private String fileName;
     private String contentType;
     private long contentLength = -1;
+    private Exception exception;
 
     public DownloadEvent(VaadinRequest request, VaadinResponse response,
             VaadinSession session, Element owningElement) {
@@ -236,5 +237,13 @@ public class DownloadEvent {
 
     long getContentLength() {
         return contentLength;
+    }
+
+    Exception getException() {
+        return exception;
+    }
+
+    void setException(Exception exception) {
+        this.exception = exception;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadResponse.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadResponse.java
@@ -40,6 +40,7 @@ public class DownloadResponse implements Serializable {
 
     private Integer error;
     private String errorMessage;
+    private Exception exception;
 
     /**
      * Create a download response with content stream and content data.
@@ -122,6 +123,22 @@ public class DownloadResponse implements Serializable {
     }
 
     /**
+     * Generate an error response for download.
+     *
+     * @param statusCode
+     *            error status code
+     * @param exception
+     *            exception that caused the error
+     * @return DownloadResponse for request
+     */
+    public static DownloadResponse error(int statusCode, Exception exception) {
+        DownloadResponse downloadResponse = new DownloadResponse(null, null,
+                null, -1);
+        downloadResponse.setError(statusCode, exception);
+        return downloadResponse;
+    }
+
+    /**
      * Generate an error response for download with message.
      *
      * @param statusCode
@@ -134,6 +151,25 @@ public class DownloadResponse implements Serializable {
         DownloadResponse downloadResponse = new DownloadResponse(null, null,
                 null, -1);
         downloadResponse.setError(statusCode, message);
+        return downloadResponse;
+    }
+
+    /**
+     * Generate an error response for download with message.
+     *
+     * @param statusCode
+     *            error status code
+     * @param message
+     *            error message for details on what went wrong
+     * @param exception
+     *            exception that caused the error
+     * @return DownloadResponse for request
+     */
+    public static DownloadResponse error(int statusCode, String message,
+            Exception exception) {
+        DownloadResponse downloadResponse = new DownloadResponse(null, null,
+                null, -1);
+        downloadResponse.setError(statusCode, message, exception);
         return downloadResponse;
     }
 
@@ -152,6 +188,23 @@ public class DownloadResponse implements Serializable {
     }
 
     /**
+     * Generate an error response for download.
+     *
+     * @param statusCode
+     *            error status code
+     * @param exception
+     *            exception that caused the error
+     * @return DownloadResponse for request
+     */
+    public static DownloadResponse error(HttpStatusCode statusCode,
+            Exception exception) {
+        DownloadResponse downloadResponse = new DownloadResponse(null, null,
+                null, -1);
+        downloadResponse.setError(statusCode, exception);
+        return downloadResponse;
+    }
+
+    /**
      * Generate an error response for download with message.
      *
      * @param statusCode
@@ -165,6 +218,25 @@ public class DownloadResponse implements Serializable {
         DownloadResponse downloadResponse = new DownloadResponse(null, null,
                 null, -1);
         downloadResponse.setError(statusCode, message);
+        return downloadResponse;
+    }
+
+    /**
+     * Generate an error response for download with message.
+     *
+     * @param statusCode
+     *            error status code
+     * @param message
+     *            error message for details on what went wrong
+     * @param exception
+     *            exception that caused the error
+     * @return DownloadResponse for request
+     */
+    public static DownloadResponse error(HttpStatusCode statusCode,
+            String message, Exception exception) {
+        DownloadResponse downloadResponse = new DownloadResponse(null, null,
+                null, -1);
+        downloadResponse.setError(statusCode, message, exception);
         return downloadResponse;
     }
 
@@ -188,6 +260,19 @@ public class DownloadResponse implements Serializable {
     }
 
     /**
+     * Set http error code.
+     *
+     * @param error
+     *            error code
+     * @param exception
+     *            exception that caused the error
+     */
+    public void setError(int error, Exception exception) {
+        this.error = error;
+        this.exception = exception;
+    }
+
+    /**
      * Set http error code and error message.
      *
      * @param error
@@ -201,6 +286,21 @@ public class DownloadResponse implements Serializable {
     }
 
     /**
+     * Set http error code and error message.
+     *
+     * @param error
+     *            error code
+     * @param errorMessage
+     *            error message
+     * @param exception
+     *            exception that caused the error
+     */
+    public void setError(int error, String errorMessage, Exception exception) {
+        setError(error, errorMessage);
+        this.exception = exception;
+    }
+
+    /**
      * Set http error code.
      *
      * @param error
@@ -208,6 +308,19 @@ public class DownloadResponse implements Serializable {
      */
     public void setError(HttpStatusCode error) {
         this.error = error.getCode();
+    }
+
+    /**
+     * Set http error code.
+     *
+     * @param error
+     *            error code
+     * @param exception
+     *            exception that caused the error
+     */
+    public void setError(HttpStatusCode error, Exception exception) {
+        this.error = error.getCode();
+        this.exception = exception;
     }
 
     /**
@@ -221,6 +334,22 @@ public class DownloadResponse implements Serializable {
     public void setError(HttpStatusCode error, String errorMessage) {
         this.error = error.getCode();
         this.errorMessage = errorMessage;
+    }
+
+    /**
+     * Set http error code and error message.
+     *
+     * @param error
+     *            error code
+     * @param errorMessage
+     *            error message
+     * @param exception
+     *            exception that caused the error
+     */
+    public void setError(HttpStatusCode error, String errorMessage,
+            Exception exception) {
+        setError(error, errorMessage);
+        this.exception = exception;
     }
 
     /**
@@ -242,5 +371,15 @@ public class DownloadResponse implements Serializable {
      */
     public String getErrorMessage() {
         return errorMessage;
+    }
+
+    /**
+     * Get the exception that occurred during the download process, if any.
+     *
+     * @return the exception or null if no exception occurred
+     * @see TransferContext#exception()
+     */
+    public Exception getException() {
+        return exception;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/FileDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/FileDownloadHandler.java
@@ -91,6 +91,7 @@ public class FileDownloadHandler
         } catch (IOException ioe) {
             // Set status before output is closed (see #8740)
             response.setStatus(HttpStatusCode.INTERNAL_SERVER_ERROR.getCode());
+            downloadEvent.setException(ioe);
             notifyError(downloadEvent, ioe);
             throw ioe;
         }
@@ -109,6 +110,6 @@ public class FileDownloadHandler
         return new TransferContext(transferEvent.getRequest(),
                 transferEvent.getResponse(), transferEvent.getSession(),
                 getUrlPostfix(), transferEvent.getOwningElement(),
-                file.length());
+                file.length(), transferEvent.getException());
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/InputStreamDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/InputStreamDownloadHandler.java
@@ -63,6 +63,7 @@ public class InputStreamDownloadHandler
             } else {
                 cause = new IOException(e.getMessage(), e);
             }
+            downloadEvent.setException(e);
             notifyError(downloadEvent, cause);
             throw e;
         }
@@ -72,7 +73,13 @@ public class InputStreamDownloadHandler
             if (message == null) {
                 message = "Download failed with code " + download.getError();
             }
-            notifyError(downloadEvent, new IOException(message));
+            IOException ioException = new IOException(message);
+            if (download.getException() != null) {
+                downloadEvent.setException(download.getException());
+            } else {
+                downloadEvent.setException(ioException);
+            }
+            notifyError(downloadEvent, ioException);
             return;
         }
 
@@ -96,6 +103,7 @@ public class InputStreamDownloadHandler
         } catch (IOException ioe) {
             // Set status before output is closed (see #8740)
             response.setStatus(HttpStatusCode.INTERNAL_SERVER_ERROR.getCode());
+            downloadEvent.setException(ioe);
             notifyError(downloadEvent, ioe);
             throw ioe;
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandler.java
@@ -97,6 +97,7 @@ public class ServletResourceDownloadHandler
                 // Set status before output is closed (see #8740)
                 response.setStatus(
                         HttpStatusCode.INTERNAL_SERVER_ERROR.getCode());
+                downloadEvent.setException(ioe);
                 notifyError(downloadEvent, ioe);
                 throw ioe;
             }

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/TransferContext.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/TransferContext.java
@@ -45,10 +45,40 @@ import com.vaadin.flow.server.VaadinSession;
  *            the total number of bytes to be transferred or <code>-1</code> if
  *            total number is unknown in advance, e.g. when reading from an
  *            input stream
+ * @param exception
+ *            An exception that occurred during the transfer, or
+ *            <code>null</code>.
  */
 public record TransferContext(VaadinRequest request, VaadinResponse response,
         VaadinSession session, String fileName, Element owningElement,
-        long contentLength) {
+        long contentLength, Exception exception) {
+
+    /**
+     * Create a transfer context for data transfer progress listeners.
+     *
+     * @param request
+     *            The current Vaadin request instance
+     * @param response
+     *            The current Vaadin response instance
+     * @param session
+     *            The current Vaadin session instance
+     * @param fileName
+     *            The name of the file being transferred. Might be
+     *            <code>null</code> if the file name is not known.
+     * @param owningElement
+     *            The owner element that initiated the transfer. Can be used to
+     *            get element's attributes or properties.
+     * @param contentLength
+     *            the total number of bytes to be transferred or <code>-1</code>
+     *            if total number is unknown in advance, e.g. when reading from
+     *            an input stream
+     */
+    public TransferContext(VaadinRequest request, VaadinResponse response,
+            VaadinSession session, String fileName, Element owningElement,
+            long contentLength) {
+        this(request, response, session, fileName, owningElement, contentLength,
+                null);
+    }
 
     /**
      * Get owner {@link Component} for this data transfer.

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/AbstractDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/AbstractDownloadHandlerTest.java
@@ -20,6 +20,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
@@ -200,6 +201,7 @@ public class AbstractDownloadHandlerTest {
         Assert.assertTrue(successAtomic.get());
         Assert.assertEquals("Hello",
                 outputStream.toString(StandardCharsets.UTF_8));
+        Assert.assertNull(downloadEvent.getException());
 
         OutputStream outputStreamError = Mockito.mock(OutputStream.class);
         Mockito.doThrow(new IOException("Test error")).when(outputStreamError)
@@ -210,6 +212,7 @@ public class AbstractDownloadHandlerTest {
 
         customHandler.handleDownloadRequest(downloadEvent);
         Assert.assertFalse(successAtomic.get());
+        Assert.assertNull(downloadEvent.getException());
     }
 
     @Test
@@ -253,6 +256,7 @@ public class AbstractDownloadHandlerTest {
         Assert.assertEquals(response, context.response());
         Assert.assertEquals(1024, context.contentLength());
         Assert.assertEquals("test.txt", context.fileName());
+        Assert.assertNull(event.getException());
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/ClassDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/ClassDownloadHandlerTest.java
@@ -17,6 +17,7 @@
 package com.vaadin.flow.server.streams;
 
 import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URISyntaxException;
@@ -128,6 +129,7 @@ public class ClassDownloadHandlerTest {
                 transferredBytesRecords.stream().mapToLong(Long::longValue)
                         .toArray());
         Mockito.verify(response).setContentType("application/octet-stream");
+        Assert.assertNull(downloadEvent.getException());
     }
 
     @Test
@@ -178,6 +180,7 @@ public class ClassDownloadHandlerTest {
         } catch (Exception e) {
         }
         Assert.assertEquals(List.of("onStart", "onError"), invocations);
+        Mockito.verify(event).setException(Mockito.any(IOException.class));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/FileDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/FileDownloadHandlerTest.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.server.streams;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URISyntaxException;
@@ -134,6 +135,7 @@ public class FileDownloadHandlerTest {
                         .toArray());
         Mockito.verify(response).setContentType("application/octet-stream");
         Mockito.verify(response).setContentLengthLong(165000);
+        Assert.assertNull(downloadEvent.getException());
     }
 
     @Test
@@ -170,6 +172,9 @@ public class FileDownloadHandlerTest {
                         }
                         Assert.assertEquals(expectedMessage,
                                 reason.getMessage());
+                        Assert.assertNotNull(context.exception());
+                        Assert.assertEquals(FileNotFoundException.class,
+                                context.exception().getClass());
                     }
                 });
 
@@ -179,6 +184,9 @@ public class FileDownloadHandlerTest {
         } catch (Exception e) {
         }
         Assert.assertEquals(List.of("onError"), invocations);
+        Assert.assertNotNull(downloadEvent.getException());
+        Assert.assertEquals(FileNotFoundException.class,
+                downloadEvent.getException().getClass());
         Mockito.verify(response).setStatus(500);
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandlerTest.java
@@ -143,6 +143,7 @@ public class ServletResourceDownloadHandlerTest {
                 transferredBytesRecords.stream().mapToLong(Long::longValue)
                         .toArray());
         Mockito.verify(response).setContentType("application/octet-stream");
+        Assert.assertNull(downloadEvent.getException());
     }
 
     @Test
@@ -194,6 +195,8 @@ public class ServletResourceDownloadHandlerTest {
         } catch (Exception e) {
         }
         Assert.assertEquals(List.of("onStart", "onError"), invocations);
+        Mockito.verify(downloadEvent)
+                .setException(Mockito.any(IOException.class));
     }
 
     @Test

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DownloadHandlerView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DownloadHandlerView.java
@@ -92,6 +92,22 @@ public class DownloadHandlerView extends Div {
                         .inline());
         inputStreamErrorDownload.setId("download-handler-input-stream-error");
 
+        RuntimeException runtimeException = new RuntimeException(
+                "Callback exception");
+        Anchor inputStreamExceptionDownload = new Anchor("",
+                "InputStream DownloadHandler shorthand (EXCEPTION)");
+        inputStreamExceptionDownload.setHref(DownloadHandler
+                .fromInputStream(downloadEvent -> DownloadResponse.error(
+                        HttpStatusCode.INTERNAL_SERVER_ERROR, runtimeException))
+                .inline().whenComplete((e, t) -> {
+                    if (e.exception() == runtimeException) {
+                        e.response()
+                                .setStatus(HttpStatusCode.FORBIDDEN.getCode());
+                    }
+                }));
+        inputStreamExceptionDownload
+                .setId("download-handler-input-stream-exception");
+
         Anchor inputStreamCallbackError = new Anchor("",
                 "InputStream DownloadHandler callback shorthand (CALLBACK EXCEPTION)");
         inputStreamCallbackError
@@ -103,7 +119,7 @@ public class DownloadHandlerView extends Div {
 
         add(handlerDownload, fileDownload, classDownload, servletDownload,
                 inputStreamDownload, inputStreamErrorDownload,
-                inputStreamCallbackError);
+                inputStreamExceptionDownload, inputStreamCallbackError);
 
         NativeButton reattach = new NativeButton("Remove and add back",
                 event -> {

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DownloadHandlerIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DownloadHandlerIT.java
@@ -137,6 +137,20 @@ public class DownloadHandlerIT extends AbstractStreamResourceIT {
     }
 
     @Test
+    public void getDynamicDownloadHandlerFailingInputStream_exceptionIsReceived() {
+        open();
+
+        WebElement link = findElement(
+                By.id("download-handler-input-stream-exception"));
+        link.click();
+
+        getDriver().manage().timeouts().scriptTimeout(Duration.of(15, SECONDS));
+        // download handler completion should set status to 403
+        Assert.assertEquals("HTTP ERROR 403",
+                findElement(By.className("error-code")).getText());
+    }
+
+    @Test
     public void getDynamicDownloadHandlerFailingInputStreamCallback_errorIsReceived() {
         open();
 


### PR DESCRIPTION
Adds `DownloadResponse#exception` and `TransferContext#exception` of type `java.lang.Exception`. Updates DownloadHandlers to fill exception automatically in case of `IOException` (or `RuntimeException`, or error in `DownloadResponse` for `InputStreamDownloadHandler`).

Fixes: #21930
