### PR TITLE
refactor: Reduce HierarchicalDataCommunicator's network usage

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
@@ -675,28 +675,15 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
         if (end < flatSize) {
             update.clear(end, flatSize - end);
         }
-
-        List<JsonValue> jsonItems = new ArrayList<>();
         for (int i = 0; i < items.size(); i++) {
             var item = items.get(i);
-            var itemIndex = start + i;
+            var index = start + i;
 
             if (flushRequest.isViewportInvalidated()
                     || flushRequest.isItemInvalidated(item)
-                    || flushRequest.isIndexInvalidated(itemIndex)) {
-                jsonItems.add(generateItemJson(item));
-
-                if (i < items.size() - 1) {
-                    continue;
-                }
+                    || flushRequest.isIndexInvalidated(index)) {
+                update.set(index, List.of(generateItemJson(item)));
             }
-
-            if (jsonItems.isEmpty()) {
-                continue;
-            }
-
-            update.set(itemIndex - jsonItems.size() + 1, jsonItems);
-            jsonItems.clear();
         }
         update.commit(nextUpdateId++);
     }

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.data.provider.hierarchy;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -656,7 +655,7 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
 
         ensureRootCache();
 
-        if (viewportRange.getStart() >= rootCache.getSize()) {
+        if (viewportRange.getStart() >= rootCache.getFlatSize()) {
             setViewportRange(0, viewportRange.length());
         }
 
@@ -664,7 +663,7 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
         var start = viewportRange.getStart();
         var end = viewportRange.getEnd();
 
-        var items = preloadFlatRangeForward(start, length);
+        var result = preloadFlatRangeForward(start, length);
 
         var flatSize = rootCache.getFlatSize();
 
@@ -675,8 +674,8 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
         if (end < flatSize) {
             update.clear(end, flatSize - end);
         }
-        for (int i = 0; i < items.size(); i++) {
-            var item = items.get(i);
+        for (int i = 0; i < result.size(); i++) {
+            var item = result.get(i);
             var index = start + i;
 
             if (flushRequest.isViewportInvalidated()
@@ -734,6 +733,7 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
                 @Override
                 void removeItemContext(T item) {
                     super.removeItemContext(item);
+
                     getKeyMapper().remove(item);
                     dataGenerator.destroyData(item);
                 }

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.data.provider.hierarchy;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -742,7 +743,7 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
         return rootCache;
     }
 
-    private static class FlushRequest<T> {
+    private static class FlushRequest<T> implements Serializable {
         private boolean viewportInvalidated = false;
         private Set<T> invalidatedItems = new HashSet<>();
         private Set<Range> invalidatedRanges = new HashSet<>();

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
@@ -675,20 +675,29 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
         if (end < flatSize) {
             update.clear(end, flatSize - end);
         }
+
         List<JsonValue> jsonItems = new ArrayList<>();
         for (int i = 0; i < items.size(); i++) {
             var item = items.get(i);
-            var index = start + i;
+            var itemIndex = start + i;
 
             if (flushRequest.isViewportInvalidated()
                     || flushRequest.isItemInvalidated(item)
-                    || flushRequest.isIndexInvalidated(index)) {
+                    || flushRequest.isIndexInvalidated(itemIndex)) {
                 jsonItems.add(generateItemJson(item));
-            } else {
-                jsonItems.add(Json.createNull());
+
+                if (i < items.size() - 1) {
+                    continue;
+                }
             }
+
+            if (jsonItems.isEmpty()) {
+                continue;
+            }
+
+            update.set(itemIndex - jsonItems.size() + 1, jsonItems);
+            jsonItems.clear();
         }
-        update.set(start, jsonItems);
         update.commit(nextUpdateId++);
     }
 

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/AbstractHierarchicalDataCommunicatorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/AbstractHierarchicalDataCommunicatorTest.java
@@ -40,6 +40,10 @@ abstract public class AbstractHierarchicalDataCommunicatorTest {
             return state;
         }
 
+        public void setState(String state) {
+            this.state = state;
+        }
+
         public String getName() {
             return name;
         }
@@ -99,11 +103,8 @@ abstract public class AbstractHierarchicalDataCommunicatorTest {
                 end < size ? Mockito.times(1) : Mockito.never())
                 .clear(end, size - end);
         Mockito.verify(arrayUpdate, Mockito.atMost(length)).set(
-                Mockito.intThat(index -> index >= start && index < end),
+                Mockito.intThat(index -> start <= index && index < end),
                 Mockito.anyList());
-
-        var items = captureArrayUpdateItems();
-        Assert.assertTrue(items.size() <= Math.min(size, length));
     }
 
     protected void assertArrayUpdateSize(int size) {
@@ -115,7 +116,7 @@ abstract public class AbstractHierarchicalDataCommunicatorTest {
         ArgumentCaptor<List<JsonValue>> argumentCaptor = ArgumentCaptor
                 .forClass(List.class);
 
-        Mockito.verify(arrayUpdate, Mockito.atLeastOnce()).set(Mockito.anyInt(),
+        Mockito.verify(arrayUpdate, Mockito.atLeast(0)).set(Mockito.anyInt(),
                 argumentCaptor.capture());
         return argumentCaptor.getAllValues().stream().flatMap(List::stream)
                 .toList();

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorDataRefreshTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorDataRefreshTest.java
@@ -122,10 +122,8 @@ public class HierarchicalDataCommunicatorDataRefreshTest
         dataCommunicator.refresh(item0_0_0);
 
         fakeClientCommunication();
-        assertArrayUpdateItems("name", "Item 0", "Item 0-0", "Item 0-0-0",
-                "Item 1");
-        assertArrayUpdateItems("state", "initial", "refreshed", "refreshed",
-                "initial");
+        assertArrayUpdateItems("name", "Item 0-0", "Item 0-0-0");
+        assertArrayUpdateItems("state", "refreshed", "refreshed");
     }
 
     @Test

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorDataRefreshTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorDataRefreshTest.java
@@ -1,6 +1,7 @@
 package com.vaadin.flow.data.provider.hierarchy;
 
 import java.util.Arrays;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -83,9 +84,16 @@ public class HierarchicalDataCommunicatorDataRefreshTest
         dataCommunicator.expand(treeData.getRootItems());
         dataCommunicator.setViewportRange(0, 4);
         fakeClientCommunication();
-        assertArrayUpdateItems("name", "Item 0", "Item 1", "Item 2", "Item 3");
-        assertArrayUpdateItems("state", "initial", "initial", "initial",
-                "initial");
+        assertArrayUpdateItems("name", Map.of( //
+                0, "Item 0", //
+                1, "Item 1", //
+                2, "Item 2", //
+                3, "Item 3"));
+        assertArrayUpdateItems("state", Map.of( //
+                0, "initial", //
+                1, "initial", //
+                2, "initial", //
+                3, "initial"));
 
         Mockito.clearInvocations(arrayUpdater, arrayUpdate);
 
@@ -96,8 +104,13 @@ public class HierarchicalDataCommunicatorDataRefreshTest
         dataCommunicator.refresh(item2);
 
         fakeClientCommunication();
-        assertArrayUpdateItems("name", "Item 0", "Item 2");
-        assertArrayUpdateItems("state", "refreshed", "refreshed");
+        assertArrayUpdateItems("name", Map.of( //
+                0, "Item 0", //
+                2, "Item 2" //
+        ));
+        assertArrayUpdateItems("state", Map.of( //
+                0, "refreshed", //
+                2, "refreshed"));
     }
 
     @Test
@@ -107,10 +120,16 @@ public class HierarchicalDataCommunicatorDataRefreshTest
                 Arrays.asList(new Item("Item 0"), new Item("Item 0-0")));
         dataCommunicator.setViewportRange(0, 4);
         fakeClientCommunication();
-        assertArrayUpdateItems("name", "Item 0", "Item 0-0", "Item 0-0-0",
-                "Item 1");
-        assertArrayUpdateItems("state", "initial", "initial", "initial",
-                "initial");
+        assertArrayUpdateItems("name", Map.of( //
+                0, "Item 0", //
+                1, "Item 0-0", //
+                2, "Item 0-0-0", //
+                3, "Item 1"));
+        assertArrayUpdateItems("state", Map.of( //
+                0, "initial", //
+                1, "initial", //
+                2, "initial", //
+                3, "initial"));
 
         Mockito.clearInvocations(arrayUpdater, arrayUpdate);
 
@@ -121,8 +140,12 @@ public class HierarchicalDataCommunicatorDataRefreshTest
         dataCommunicator.refresh(item0_0_0);
 
         fakeClientCommunication();
-        assertArrayUpdateItems("name", "Item 0-0", "Item 0-0-0");
-        assertArrayUpdateItems("state", "refreshed", "refreshed");
+        assertArrayUpdateItems("name", Map.of( //
+                1, "Item 0-0", //
+                2, "Item 0-0-0"));
+        assertArrayUpdateItems("state", Map.of( //
+                1, "refreshed", //
+                2, "refreshed"));
     }
 
     @Test
@@ -142,8 +165,14 @@ public class HierarchicalDataCommunicatorDataRefreshTest
 
         dataCommunicator.setViewportRange(48, 3);
         fakeClientCommunication();
-        assertArrayUpdateItems("name", "Item 48", "Item 49", "Item 49-0");
-        assertArrayUpdateItems("state", "initial", "refreshed", "initial");
+        assertArrayUpdateItems("name", Map.of( //
+                48, "Item 48", //
+                49, "Item 49", //
+                50, "Item 49-0"));
+        assertArrayUpdateItems("state", Map.of( //
+                48, "initial", //
+                49, "refreshed", //
+                50, "initial"));
     }
 
     @Test
@@ -171,8 +200,8 @@ public class HierarchicalDataCommunicatorDataRefreshTest
         dataCommunicator.setViewportRange(0, 4);
         fakeClientCommunication();
 
-        var keys = captureArrayUpdateItems().stream()
-                .map((item) -> ((JsonObject) item).getString("key")).toList();
+        var keys = captureArrayUpdateItems().values().stream()
+                .map((item) -> item.getString("key")).toList();
         Assert.assertEquals("initial", keyMapper.get(keys.get(0)).getState());
         Assert.assertEquals("initial", keyMapper.get(keys.get(1)).getState());
         Assert.assertEquals("initial", keyMapper.get(keys.get(2)).getState());
@@ -198,8 +227,13 @@ public class HierarchicalDataCommunicatorDataRefreshTest
                         new Item("Item 1"), new Item("Item 1-0")));
         dataCommunicator.setViewportRange(0, 6);
         fakeClientCommunication();
-        assertArrayUpdateItems("name", "Item 0", "Item 0-0", "Item 0-0-0",
-                "Item 1", "Item 1-0", "Item 1-0-0");
+        assertArrayUpdateItems("name", Map.of( //
+                0, "Item 0", //
+                1, "Item 0-0", //
+                2, "Item 0-0-0", //
+                3, "Item 1", //
+                4, "Item 1-0", //
+                5, "Item 1-0-0"));
 
         Mockito.clearInvocations(arrayUpdater, arrayUpdate);
 
@@ -208,8 +242,13 @@ public class HierarchicalDataCommunicatorDataRefreshTest
         dataCommunicator.refresh(new Item("Item 1"), true);
 
         fakeClientCommunication();
-        assertArrayUpdateItems("name", "Item 0", "Item 1", "Item 1-0",
-                "Item 1-0-0", "Item 0-0", "Item 0-0-0");
+        assertArrayUpdateItems("name", Map.of( //
+                0, "Item 0", //
+                1, "Item 1", //
+                2, "Item 1-0", //
+                3, "Item 1-0-0", //
+                4, "Item 0-0", //
+                5, "Item 0-0-0"));
     }
 
     @Test
@@ -258,8 +297,13 @@ public class HierarchicalDataCommunicatorDataRefreshTest
                 Arrays.asList(new Item("Item 1"), new Item("Item 1-0")));
         dataCommunicator.setViewportRange(0, 6);
         fakeClientCommunication();
-        assertArrayUpdateItems("name", "Item 0", "Item 1", "Item 1-0",
-                "Item 1-0-0", "Item 2", "Item 3");
+        assertArrayUpdateItems("name", Map.of( //
+                0, "Item 0", //
+                1, "Item 1", //
+                2, "Item 1-0", //
+                3, "Item 1-0-0", //
+                4, "Item 2", //
+                5, "Item 3"));
 
         Mockito.clearInvocations(arrayUpdater, arrayUpdate);
 
@@ -267,8 +311,12 @@ public class HierarchicalDataCommunicatorDataRefreshTest
         treeData.removeItem(new Item("Item 1-0"));
         dataCommunicator.reset();
         fakeClientCommunication();
-        assertArrayUpdateItems("name", "Item 1", "Item 2", "Item 3", "Item 4",
-                "Item 5");
+        assertArrayUpdateItems("name", Map.of( //
+                0, "Item 1", //
+                1, "Item 2", //
+                2, "Item 3", //
+                3, "Item 4", //
+                4, "Item 5"));
     }
 
     @Test

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorDataRefreshTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorDataRefreshTest.java
@@ -126,6 +126,27 @@ public class HierarchicalDataCommunicatorDataRefreshTest
     }
 
     @Test
+    public void refreshItemsOutOfViewport_updateRangeSentOnlyAfterItemEntersViewport() {
+        populateTreeData(treeData, 50, 1);
+        dataCommunicator.expand(new Item("Item 49"));
+        dataCommunicator.setViewportRange(0, 3);
+        fakeClientCommunication();
+        Mockito.clearInvocations(arrayUpdater, arrayUpdate);
+
+        var item = treeData.getRootItems().get(49);
+        item.setState("refreshed");
+        dataCommunicator.refresh(item);
+
+        fakeClientCommunication();
+        Mockito.verifyNoInteractions(arrayUpdater, arrayUpdate);
+
+        dataCommunicator.setViewportRange(48, 3);
+        fakeClientCommunication();
+        assertArrayUpdateItems("name", "Item 48", "Item 49", "Item 49-0");
+        assertArrayUpdateItems("state", "initial", "refreshed", "initial");
+    }
+
+    @Test
     public void refreshItems_dataGeneratorRefreshItemCalled() {
         populateTreeData(treeData, 2, 1, 1);
 

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorDataRefreshTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorDataRefreshTest.java
@@ -126,7 +126,7 @@ public class HierarchicalDataCommunicatorDataRefreshTest
     }
 
     @Test
-    public void refreshItemsOutOfViewport_updateRangeSentOnlyAfterItemEntersViewport() {
+    public void refreshItemsOutOfViewport_updatedRangeSentOnlyAfterItemEntersViewport() {
         populateTreeData(treeData, 50, 1);
         dataCommunicator.expand(new Item("Item 49"));
         dataCommunicator.setViewportRange(0, 3);

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorDataRefreshTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorDataRefreshTest.java
@@ -96,9 +96,8 @@ public class HierarchicalDataCommunicatorDataRefreshTest
         dataCommunicator.refresh(item2);
 
         fakeClientCommunication();
-        assertArrayUpdateItems("name", "Item 0", "Item 1", "Item 2", "Item 3");
-        assertArrayUpdateItems("state", "refreshed", "initial", "refreshed",
-                "initial");
+        assertArrayUpdateItems("name", "Item 0", "Item 2");
+        assertArrayUpdateItems("state", "refreshed", "refreshed");
     }
 
     @Test

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorFlatHierarchyTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorFlatHierarchyTest.java
@@ -1,6 +1,7 @@
 package com.vaadin.flow.data.provider.hierarchy;
 
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -98,8 +99,13 @@ public class HierarchicalDataCommunicatorFlatHierarchyTest
 
         assertArrayUpdateSize(106);
         assertArrayUpdateRange(0, 6);
-        assertArrayUpdateItems("name", "Item 0", "Item 0-0", "Item 0-0-0",
-                "Item 0-0-1", "Item 0-1", "Item 1");
+        assertArrayUpdateItems("name", Map.of( //
+                0, "Item 0", //
+                1, "Item 0-0", //
+                2, "Item 0-0-0", //
+                3, "Item 0-0-1", //
+                4, "Item 0-1", //
+                5, "Item 1"));
 
         Mockito.clearInvocations(arrayUpdater, arrayUpdate);
 
@@ -108,8 +114,13 @@ public class HierarchicalDataCommunicatorFlatHierarchyTest
 
         assertArrayUpdateSize(106);
         assertArrayUpdateRange(100, 6);
-        assertArrayUpdateItems("name", "Item 96", "Item 97", "Item 98",
-                "Item 99", "Item 99-0", "Item 99-1");
+        assertArrayUpdateItems("name", Map.of( //
+                100, "Item 96", //
+                101, "Item 97", //
+                102, "Item 98", //
+                103, "Item 99", //
+                104, "Item 99-0", //
+                105, "Item 99-1"));
     }
 
     @Test
@@ -119,8 +130,11 @@ public class HierarchicalDataCommunicatorFlatHierarchyTest
 
         assertArrayUpdateSize(100);
         assertArrayUpdateRange(10, 4);
-        assertArrayUpdateItems("name", "Item 10", "Item 11", "Item 12",
-                "Item 13");
+        assertArrayUpdateItems("name", Map.of( //
+                10, "Item 10", //
+                11, "Item 11", //
+                12, "Item 12", //
+                13, "Item 13"));
 
         Mockito.clearInvocations(arrayUpdater, arrayUpdate);
 
@@ -129,8 +143,11 @@ public class HierarchicalDataCommunicatorFlatHierarchyTest
 
         assertArrayUpdateSize(102);
         assertArrayUpdateRange(10, 4);
-        assertArrayUpdateItems("name", "Item 10", "Item 10-0", "Item 10-1",
-                "Item 11");
+        assertArrayUpdateItems("name", Map.of(//
+                10, "Item 10", //
+                11, "Item 10-0", //
+                12, "Item 10-1", //
+                13, "Item 11"));
 
         Mockito.clearInvocations(arrayUpdater, arrayUpdate);
 
@@ -139,22 +156,28 @@ public class HierarchicalDataCommunicatorFlatHierarchyTest
 
         assertArrayUpdateSize(100);
         assertArrayUpdateRange(10, 4);
-        assertArrayUpdateItems("name", "Item 10", "Item 11", "Item 12",
-                "Item 13");
+        assertArrayUpdateItems("name", Map.of( //
+                10, "Item 10", //
+                11, "Item 11", //
+                12, "Item 12", //
+                13, "Item 13"));
     }
 
     @Test
     public void refreshItem_updatedRangeSent() {
         dataCommunicator.setViewportRange(0, 4);
         fakeClientCommunication();
-        assertArrayUpdateItems("state", "initial", "initial", "initial",
-                "initial");
+        assertArrayUpdateItems("state", Map.of( //
+                0, "initial", //
+                1, "initial", //
+                2, "initial", //
+                3, "initial"));
 
         Mockito.clearInvocations(arrayUpdater, arrayUpdate);
 
         dataCommunicator.refresh(new Item("Item 0", "refreshed"));
         fakeClientCommunication();
-        assertArrayUpdateItems("state", "refreshed");
+        assertArrayUpdateItems("state", Map.of(0, "refreshed"));
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -168,8 +191,12 @@ public class HierarchicalDataCommunicatorFlatHierarchyTest
                 Arrays.asList(new Item("Item 1"), new Item("Item 1-0")));
         dataCommunicator.setViewportRange(0, 5);
         fakeClientCommunication();
-        assertArrayUpdateItems("name", "Item 0", "Item 1", "Item 1-0",
-                "Item 1-0-0", "Item 1-0-1");
+        assertArrayUpdateItems("name", Map.of( //
+                0, "Item 0", //
+                1, "Item 1", //
+                2, "Item 1-0", //
+                3, "Item 1-0-0", //
+                4, "Item 1-0-1"));
 
         Mockito.clearInvocations(arrayUpdater, arrayUpdate);
 
@@ -177,8 +204,12 @@ public class HierarchicalDataCommunicatorFlatHierarchyTest
         treeData.removeItem(new Item("Item 1-0"));
         dataCommunicator.reset();
         fakeClientCommunication();
-        assertArrayUpdateItems("name", "Item 1", "Item 1-1", "Item 2", "Item 3",
-                "Item 4");
+        assertArrayUpdateItems("name", Map.of( //
+                0, "Item 1", //
+                1, "Item 1-1", //
+                2, "Item 2", //
+                3, "Item 3", //
+                4, "Item 4"));
     }
 
     @Test

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorFlatHierarchyTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorFlatHierarchyTest.java
@@ -154,8 +154,7 @@ public class HierarchicalDataCommunicatorFlatHierarchyTest
 
         dataCommunicator.refresh(new Item("Item 0", "refreshed"));
         fakeClientCommunication();
-        assertArrayUpdateItems("state", "refreshed", "initial", "initial",
-                "initial");
+        assertArrayUpdateItems("state", "refreshed");
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorIndexPathResolutionTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorIndexPathResolutionTest.java
@@ -1,6 +1,7 @@
 package com.vaadin.flow.data.provider.hierarchy;
 
 import java.util.Arrays;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -131,7 +132,7 @@ public class HierarchicalDataCommunicatorIndexPathResolutionTest
         fakeClientCommunication();
         assertArrayUpdateSize(3);
         assertArrayUpdateRange(2, 1);
-        assertArrayUpdateItems("name", "Item 2");
+        assertArrayUpdateItems("name", Map.of(2, "Item 2"));
 
         Mockito.clearInvocations(arrayUpdater, arrayUpdate);
 
@@ -143,6 +144,6 @@ public class HierarchicalDataCommunicatorIndexPathResolutionTest
         fakeClientCommunication();
         assertArrayUpdateSize(5);
         assertArrayUpdateRange(2, 1);
-        assertArrayUpdateItems("name", "Item 0-1");
+        assertArrayUpdateItems("name", Map.of(2, "Item 0-1"));
     }
 }

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorIndexPathResolutionTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorIndexPathResolutionTest.java
@@ -21,11 +21,11 @@ public class HierarchicalDataCommunicatorIndexPathResolutionTest
         populateTreeData(treeData, 3, 2, 1);
 
         var dataGenerator = new CompositeDataGenerator<Item>();
-        dataGenerator.addDataGenerator((item, json) -> json.put("name", item.getName()));
+        dataGenerator.addDataGenerator(
+                (item, json) -> json.put("name", item.getName()));
 
-        dataCommunicator = new HierarchicalDataCommunicator<>(
-                dataGenerator, arrayUpdater,
-                ui.getElement().getNode(), () -> null);
+        dataCommunicator = new HierarchicalDataCommunicator<>(dataGenerator,
+                arrayUpdater, ui.getElement().getNode(), () -> null);
         dataCommunicator.setDataProvider(new TreeDataProvider<>(treeData),
                 null);
     }

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorIndexPathResolutionTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorIndexPathResolutionTest.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import com.vaadin.flow.data.provider.CompositeDataGenerator;
 
@@ -19,8 +20,11 @@ public class HierarchicalDataCommunicatorIndexPathResolutionTest
         var treeData = new TreeData<Item>();
         populateTreeData(treeData, 3, 2, 1);
 
+        var dataGenerator = new CompositeDataGenerator<Item>();
+        dataGenerator.addDataGenerator((item, json) -> json.put("name", item.getName()));
+
         dataCommunicator = new HierarchicalDataCommunicator<>(
-                new CompositeDataGenerator<Item>(), arrayUpdater,
+                dataGenerator, arrayUpdater,
                 ui.getElement().getNode(), () -> null);
         dataCommunicator.setDataProvider(new TreeDataProvider<>(treeData),
                 null);
@@ -118,5 +122,27 @@ public class HierarchicalDataCommunicatorIndexPathResolutionTest
         Assert.assertEquals(2,
                 dataCommunicator.resolveIndexPath(-100, -100, -100, -100));
         Assert.assertEquals(6, dataCommunicator.rootCache.getFlatSize());
+    }
+
+    @Test
+    public void setViewportRange_resolveIndexPage_entireRangeSentWhenSizeChanged() {
+        dataCommunicator.expand(new Item("Item 0"));
+        dataCommunicator.setViewportRange(2, 1);
+        fakeClientCommunication();
+        assertArrayUpdateSize(3);
+        assertArrayUpdateRange(2, 1);
+        assertArrayUpdateItems("name", "Item 2");
+
+        Mockito.clearInvocations(arrayUpdater, arrayUpdate);
+
+        dataCommunicator.resolveIndexPath(0);
+        fakeClientCommunication();
+        Mockito.verifyNoInteractions(arrayUpdater, arrayUpdate);
+
+        dataCommunicator.resolveIndexPath(0, 0);
+        fakeClientCommunication();
+        assertArrayUpdateSize(5);
+        assertArrayUpdateRange(2, 1);
+        assertArrayUpdateItems("name", "Item 0-1");
     }
 }

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorViewportTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorViewportTest.java
@@ -56,6 +56,45 @@ public class HierarchicalDataCommunicatorViewportTest
     }
 
     @Test
+    public void setViewportRange_flush_setOverlappingRange_partialRangeSent() {
+        populateTreeData(treeData, 100, 2, 2);
+        dataCommunicator.setViewportRange(0, 5);
+        fakeClientCommunication();
+
+        Mockito.clearInvocations(arrayUpdater, arrayUpdate);
+
+        dataCommunicator.setViewportRange(3, 5);
+        fakeClientCommunication();
+
+        assertArrayUpdateSize(100);
+        assertArrayUpdateRange(3, 5);
+        assertArrayUpdateItems("name", "Item 5", "Item 6", "Item 7");
+
+        Mockito.clearInvocations(arrayUpdater, arrayUpdate);
+
+        dataCommunicator.setViewportRange(0, 10);
+        fakeClientCommunication();
+
+        assertArrayUpdateSize(100);
+        assertArrayUpdateRange(0, 10);
+        assertArrayUpdateItems("name", "Item 0", "Item 1", "Item 2", "Item 8", "Item 9");
+
+        Mockito.clearInvocations(arrayUpdater, arrayUpdate);
+
+        dataCommunicator.setViewportRange(3, 5);
+        fakeClientCommunication();
+
+        Mockito.verifyNoInteractions(arrayUpdater, arrayUpdate);
+
+        dataCommunicator.setViewportRange(0, 5);
+        fakeClientCommunication();
+
+        assertArrayUpdateSize(100);
+        assertArrayUpdateRange(0, 5);
+        assertArrayUpdateItems("name", "Item 0", "Item 1", "Item 2");
+    }
+
+    @Test
     public void setViewportRangeMultipleTimes_flush_onlyLastRangeSent() {
         populateTreeData(treeData, 100, 2, 2);
         dataCommunicator.setViewportRange(0, 10);

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorViewportTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorViewportTest.java
@@ -1,5 +1,7 @@
 package com.vaadin.flow.data.provider.hierarchy;
 
+import java.util.Map;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -36,13 +38,16 @@ public class HierarchicalDataCommunicatorViewportTest
     public void setViewportRange_flush_requestedRangeSent() {
         populateTreeData(treeData, 100, 2, 2);
         dataCommunicator.setViewportRange(0, 5);
-
         fakeClientCommunication();
 
         assertArrayUpdateSize(100);
         assertArrayUpdateRange(0, 5);
-        assertArrayUpdateItems("name", "Item 0", "Item 1", "Item 2", "Item 3",
-                "Item 4");
+        assertArrayUpdateItems("name", Map.of( //
+                0, "Item 0", //
+                1, "Item 1", //
+                2, "Item 2", //
+                3, "Item 3", //
+                4, "Item 4"));
 
         Mockito.clearInvocations(arrayUpdater, arrayUpdate);
 
@@ -51,8 +56,12 @@ public class HierarchicalDataCommunicatorViewportTest
 
         assertArrayUpdateSize(100);
         assertArrayUpdateRange(95, 5);
-        assertArrayUpdateItems("name", "Item 95", "Item 96", "Item 97",
-                "Item 98", "Item 99");
+        assertArrayUpdateItems("name", Map.of( //
+                95, "Item 95", //
+                96, "Item 96", //
+                97, "Item 97", //
+                98, "Item 98", //
+                99, "Item 99"));
     }
 
     @Test
@@ -68,7 +77,10 @@ public class HierarchicalDataCommunicatorViewportTest
 
         assertArrayUpdateSize(100);
         assertArrayUpdateRange(3, 5);
-        assertArrayUpdateItems("name", "Item 5", "Item 6", "Item 7");
+        assertArrayUpdateItems("name", Map.of( //
+                5, "Item 5", //
+                6, "Item 6", //
+                7, "Item 7"));
 
         Mockito.clearInvocations(arrayUpdater, arrayUpdate);
 
@@ -77,8 +89,12 @@ public class HierarchicalDataCommunicatorViewportTest
 
         assertArrayUpdateSize(100);
         assertArrayUpdateRange(0, 10);
-        assertArrayUpdateItems("name", "Item 0", "Item 1", "Item 2", "Item 8",
-                "Item 9");
+        assertArrayUpdateItems("name", Map.of( //
+                0, "Item 0", //
+                1, "Item 1", //
+                2, "Item 2", //
+                8, "Item 8", //
+                9, "Item 9"));
 
         Mockito.clearInvocations(arrayUpdater, arrayUpdate);
 
@@ -92,7 +108,10 @@ public class HierarchicalDataCommunicatorViewportTest
 
         assertArrayUpdateSize(100);
         assertArrayUpdateRange(0, 5);
-        assertArrayUpdateItems("name", "Item 0", "Item 1", "Item 2");
+        assertArrayUpdateItems("name", Map.of( //
+                0, "Item 0", //
+                1, "Item 1", //
+                2, "Item 2"));
     }
 
     @Test
@@ -104,7 +123,9 @@ public class HierarchicalDataCommunicatorViewportTest
 
         assertArrayUpdateSize(100);
         assertArrayUpdateRange(50, 2);
-        assertArrayUpdateItems("name", "Item 50", "Item 51");
+        assertArrayUpdateItems("name", Map.of( //
+                50, "Item 50", //
+                51, "Item 51"));
     }
 
     @Test
@@ -117,8 +138,13 @@ public class HierarchicalDataCommunicatorViewportTest
 
         assertArrayUpdateSize(102);
         assertArrayUpdateRange(0, 6);
-        assertArrayUpdateItems("name", "Item 0", "Item 0-0", "Item 0-1",
-                "Item 1", "Item 2", "Item 3");
+        assertArrayUpdateItems("name", Map.of( //
+                0, "Item 0", //
+                1, "Item 0-0", //
+                2, "Item 0-1", //
+                3, "Item 1", //
+                4, "Item 2", //
+                5, "Item 3"));
 
         Mockito.clearInvocations(arrayUpdater, arrayUpdate);
 
@@ -127,8 +153,13 @@ public class HierarchicalDataCommunicatorViewportTest
 
         assertArrayUpdateSize(104);
         assertArrayUpdateRange(0, 6);
-        assertArrayUpdateItems("name", "Item 0", "Item 0-0", "Item 0-0-0",
-                "Item 0-0-1", "Item 0-1", "Item 1");
+        assertArrayUpdateItems("name", Map.of( //
+                0, "Item 0", //
+                1, "Item 0-0", //
+                2, "Item 0-0-0", //
+                3, "Item 0-0-1", //
+                4, "Item 0-1", //
+                5, "Item 1"));
 
         Mockito.clearInvocations(arrayUpdater, arrayUpdate);
 
@@ -137,8 +168,13 @@ public class HierarchicalDataCommunicatorViewportTest
 
         assertArrayUpdateSize(102);
         assertArrayUpdateRange(0, 6);
-        assertArrayUpdateItems("name", "Item 0", "Item 0-0", "Item 0-1",
-                "Item 1", "Item 2", "Item 3");
+        assertArrayUpdateItems("name", Map.of( //
+                0, "Item 0", //
+                1, "Item 0-0", //
+                2, "Item 0-1", //
+                3, "Item 1", //
+                4, "Item 2", //
+                5, "Item 3"));
 
         Mockito.clearInvocations(arrayUpdater, arrayUpdate);
 
@@ -147,8 +183,13 @@ public class HierarchicalDataCommunicatorViewportTest
 
         assertArrayUpdateSize(100);
         assertArrayUpdateRange(0, 6);
-        assertArrayUpdateItems("name", "Item 0", "Item 1", "Item 2", "Item 3",
-                "Item 4", "Item 5");
+        assertArrayUpdateItems("name", Map.of( //
+                0, "Item 0", //
+                1, "Item 1", //
+                2, "Item 2", //
+                3, "Item 3", //
+                4, "Item 4", //
+                5, "Item 5"));
     }
 
     @Test
@@ -160,8 +201,13 @@ public class HierarchicalDataCommunicatorViewportTest
 
         assertArrayUpdateSize(100);
         assertArrayUpdateRange(0, 6);
-        assertArrayUpdateItems("name", "Item 0", "Item 1", "Item 2", "Item 3",
-                "Item 4", "Item 5");
+        assertArrayUpdateItems("name", Map.of( //
+                0, "Item 0", //
+                1, "Item 1", //
+                2, "Item 2", //
+                3, "Item 3", //
+                4, "Item 4", //
+                5, "Item 5"));
 
         Mockito.clearInvocations(arrayUpdater, arrayUpdate);
 
@@ -170,8 +216,13 @@ public class HierarchicalDataCommunicatorViewportTest
 
         assertArrayUpdateSize(104);
         assertArrayUpdateRange(0, 6);
-        assertArrayUpdateItems("name", "Item 0", "Item 0-0", "Item 0-0-0",
-                "Item 0-0-1", "Item 0-1", "Item 1");
+        assertArrayUpdateItems("name", Map.of( //
+                0, "Item 0", //
+                1, "Item 0-0", //
+                2, "Item 0-0-0", //
+                3, "Item 0-0-1", //
+                4, "Item 0-1", //
+                5, "Item 1"));
 
         Mockito.clearInvocations(arrayUpdater, arrayUpdate);
 
@@ -180,8 +231,13 @@ public class HierarchicalDataCommunicatorViewportTest
 
         assertArrayUpdateSize(100);
         assertArrayUpdateRange(0, 6);
-        assertArrayUpdateItems("name", "Item 0", "Item 1", "Item 2", "Item 3",
-                "Item 4", "Item 5");
+        assertArrayUpdateItems("name", Map.of( //
+                0, "Item 0", //
+                1, "Item 1", //
+                2, "Item 2", //
+                3, "Item 3", //
+                4, "Item 4", //
+                5, "Item 5"));
     }
 
     @Test

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorViewportTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorViewportTest.java
@@ -77,7 +77,8 @@ public class HierarchicalDataCommunicatorViewportTest
 
         assertArrayUpdateSize(100);
         assertArrayUpdateRange(0, 10);
-        assertArrayUpdateItems("name", "Item 0", "Item 1", "Item 2", "Item 8", "Item 9");
+        assertArrayUpdateItems("name", "Item 0", "Item 1", "Item 2", "Item 8",
+                "Item 9");
 
         Mockito.clearInvocations(arrayUpdater, arrayUpdate);
 

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorViewportTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorViewportTest.java
@@ -36,6 +36,7 @@ public class HierarchicalDataCommunicatorViewportTest
     public void setViewportRange_flush_requestedRangeSent() {
         populateTreeData(treeData, 100, 2, 2);
         dataCommunicator.setViewportRange(0, 5);
+
         fakeClientCommunication();
 
         assertArrayUpdateSize(100);


### PR DESCRIPTION
## Description

The PR reduces HierarchicalDataCommunicator's network usage. Instead of sending the entire viewport on every flush, it now sends `$connector.set` calls with just the new / changed items when possible. A full viewport is still sent when an action changes the flat size.

Depends on 
- https://github.com/vaadin/flow-components/pull/7905

Part of #21989 

## Type of change

- [x] Refactor
