### PR TITLE
fix: log "Connection remotely closed" IOException at debug level

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PushAtmosphereHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PushAtmosphereHandler.java
@@ -115,8 +115,14 @@ public class PushAtmosphereHandler extends AbstractReflectorAtmosphereHandler
 
         @Override
         public void onThrowable(AtmosphereResourceEvent event) {
-            getLogger().error("Exception in push connection",
-                    event.throwable());
+            Throwable throwable = event.throwable();
+            if (throwable instanceof IOException
+                    && throwable.getMessage() != null && throwable.getMessage()
+                            .contains("Connection remotely closed")) {
+                getLogger().debug("Push connection remotely closed", throwable);
+            } else {
+                getLogger().error("Exception in push connection", throwable);
+            }
             pushHandler.connectionLost(event);
         }
     }


### PR DESCRIPTION
Fixes #21782

Changes the log level from ERROR to DEBUG for the specific IOException that occurs when a client connection dies during push communication. This reduces noise in logs, especially during integration tests.

This is similar to https://github.com/vaadin/flow/blob/c80f04ca11951e72672840c4c90123e5d4adbe04/flow-server/src/main/java/com/vaadin/flow/server/StreamResource.java#L90