### PR TITLE
fix: Component styles feature flag not working in Gradle projects

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateSettingsFile.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateSettingsFile.java
@@ -53,6 +53,7 @@ public class TaskUpdateSettingsFile implements FallibleCommand, Serializable {
     String buildDirectory;
     String themeName;
     PwaConfiguration pwaConfiguration;
+    File javaResourceFolder;
 
     TaskUpdateSettingsFile(Options builder, String themeName,
             PwaConfiguration pwaConfiguration) {
@@ -64,6 +65,7 @@ public class TaskUpdateSettingsFile implements FallibleCommand, Serializable {
         this.buildDirectory = builder.getBuildDirectoryName();
         this.themeName = themeName;
         this.pwaConfiguration = pwaConfiguration;
+        this.javaResourceFolder = builder.getJavaResourceFolder();
     }
 
     @Override
@@ -118,6 +120,9 @@ public class TaskUpdateSettingsFile implements FallibleCommand, Serializable {
         settings.put("i18nOutput", i18nOutputFolderString);
         settings.put("jarResourcesFolder",
                 FrontendUtils.getUnixPath(jarFrontendResourcesFolder.toPath()));
+        
+        settings.put("javaResourceFolder", 
+                javaResourceFolder != null ? FrontendUtils.getUnixPath(javaResourceFolder.toPath()) : "");
 
         settings.put("themeName", themeName);
 

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-handle.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-handle.js
@@ -178,8 +178,15 @@ function handleThemes(themeName, themesFolder, options, logger) {
 
 function getThemeProperties(themeFolder, options) {
   const themePropertyFile = resolve(themeFolder, 'theme.json');
-  let lastIndexOf = options.projectStaticOutput.lastIndexOf("classes");
-  let outputFolder = options.projectStaticOutput.substring(0, lastIndexOf+"classes".length);
+  let outputFolder;
+  if (options.javaResourceFolder) {
+    // Use the explicit javaResourceFolder if provided
+    outputFolder = options.javaResourceFolder;
+  } else {
+    // Fallback to the old logic for backwards compatibility
+    let lastIndexOf = options.projectStaticOutput.lastIndexOf("classes");
+    outputFolder = options.projectStaticOutput.substring(0, lastIndexOf+"classes".length);
+  }
   let featureFlags = resolve(outputFolder, "vaadin-featureflags.properties");
 
   let componentFeature = existsSync(featureFlags) ? /themeComponentStyles(\s+)?=(\s+)?true/.test(readFileSync(featureFlags, { encoding: 'utf8' })) : false;

--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -79,7 +79,8 @@ const themeOptions = {
     ? path.resolve(devBundleFolder, '../assets')
     : path.resolve(__dirname, settings.staticOutput),
   frontendGeneratedFolder: path.resolve(frontendFolder, settings.generatedFolder),
-  projectStaticOutput:  path.resolve(__dirname, settings.staticOutput)
+  projectStaticOutput:  path.resolve(__dirname, settings.staticOutput),
+  javaResourceFolder: settings.javaResourceFolder ? path.resolve(__dirname, settings.javaResourceFolder) : ''
 };
 
 const hasExportedWebComponents = existsSync(path.resolve(frontendFolder, 'web-component.html'));


### PR DESCRIPTION
The theme component styles feature flag (com.vaadin.experimental.themeComponentStyles) was not working in Gradle projects due to the theme plugin incorrectly parsing the path to find the vaadin-featureflags.properties file.

The fix adds an explicit javaResourceFolder path to the theme options, allowing the theme plugin to directly locate the feature flags file instead of trying to parse it from the projectStaticOutput path, which has different structures in Maven and Gradle projects.

Fixes #22073