### PR TITLE
Don't let signals fail service init

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -323,7 +323,19 @@ public abstract class VaadinService implements Serializable {
                             + " providing a custom Executor instance.");
         }
 
-        initSignalsEnvironment();
+        try {
+            initSignalsEnvironment();
+        } catch (Exception e) {
+            if (FeatureFlags.get(getContext())
+                    .isEnabled(FeatureFlags.FLOW_FULLSTACK_SIGNALS.getId())) {
+                throw e;
+            } else {
+                getLogger().info(
+                        "Error initializing signals. This is non-fatal since signals are "
+                                + "a preview feature and the feature flag is not enabled.",
+                        e);
+            }
+        }
 
         DeploymentConfiguration configuration = getDeploymentConfiguration();
         if (!configuration.isProductionMode()) {


### PR DESCRIPTION
While we allow ourselves to be less careful with changes related to signals while the feature is behind a feature flag, we want to prevent mistakes or e.g. version mismatches from causing problems. We cannot do the whole initialization only when the flag is enabled since that removes our possibility of providing useful message if trying to use the feature without the flag enabled.