### PR TITLE
Add clarifying comments to async signal confirmation

### DIFF
--- a/signals/src/main/java/com/vaadin/signals/impl/AsynchronousSignalTree.java
+++ b/signals/src/main/java/com/vaadin/signals/impl/AsynchronousSignalTree.java
@@ -57,6 +57,7 @@ public abstract class AsynchronousSignalTree extends SignalTree {
 
             confirmed = new Snapshot(builder);
 
+            // Remove any pending commands that are now confirmed from the queue
             unconfirmedCommands.removeHandledCommands(results.keySet());
 
             Snapshot oldSubmitted = submitted;
@@ -67,6 +68,7 @@ public abstract class AsynchronousSignalTree extends SignalTree {
              * in that case
              */
             if (!unconfirmedCommands.isEmpty()) {
+                // Re-apply pending commands that remain in the queue
                 builder.apply(unconfirmedCommands.getCommands());
 
                 submitted = new Snapshot(builder);


### PR DESCRIPTION
The need was discovered when explaining the algorithm to others