### PR TITLE
fix: Skip pre-trial validation when clicking on Log in or Sign up

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DebugWindowConnection.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DebugWindowConnection.java
@@ -387,8 +387,7 @@ public class DebugWindowConnection implements BrowserLiveReload {
 
         LicenseChecker.checkLicenseAsync(product.getName(),
                 product.getVersion(), BuildType.DEVELOPMENT,
-                new LicenseDownloadCallback(resource, product),
-                Capabilities.of(Capability.PRE_TRIAL));
+                new LicenseDownloadCallback(resource, product));
         send(resource, "license-download-started", product);
     }
 

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/DebugWindowConnectionLicenseCheckTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/DebugWindowConnectionLicenseCheckTest.java
@@ -228,8 +228,7 @@ public class DebugWindowConnectionLicenseCheckTest {
                         .checkLicenseAsync(eq(TEST_PRODUCT.getName()),
                                 eq(TEST_PRODUCT.getVersion()),
                                 eq(BuildType.DEVELOPMENT),
-                                any(LicenseChecker.Callback.class),
-                                any(Capabilities.class)))
+                                any(LicenseChecker.Callback.class)))
                         .then(i -> {
                             LicenseChecker.Callback callback = i.getArgument(3,
                                     LicenseChecker.Callback.class);


### PR DESCRIPTION
When a Vaadin user wants to Log in or Sing Up in vaadin.com he can click on the corresponding button on the Pre-trial splash screen.

<img width="509" height="311" alt="Screenshot 2025-09-03 at 13 12 02" src="https://github.com/user-attachments/assets/8f83e3fe-6df0-4368-8b05-80aae85d26a2" />

Vaadin then re-validates the Pre-Trial status and sometimes it passes it (trial not started) and sometimes throws (trial expired). 

Vaadin should not re-validate the status once again when Log in is clicked. This just removes the Pre-Trial capability from the  Log in/Sign Up handler.
