### PR TITLE
Use UI::access only for ComponentEffect

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -416,11 +416,6 @@ public abstract class VaadinService implements Serializable {
 
             @Override
             public Executor getEffectDispatcher() {
-                return createCurrentUiDispatcher();
-            }
-
-            @Override
-            public Executor getFallbackEffectDispatcher() {
                 return getExecutor();
             }
         }
@@ -1001,8 +996,8 @@ public abstract class VaadinService implements Serializable {
         }
         Object currentSessionLock = wrappedSession
                 .getAttribute(getLockAttributeName());
-        assert (currentSessionLock == null || currentSessionLock == lock)
-                : "Changing the lock for a session is not allowed";
+        assert (currentSessionLock == null
+                || currentSessionLock == lock) : "Changing the lock for a session is not allowed";
 
         wrappedSession.setAttribute(getLockAttributeName(), lock);
     }
@@ -1114,8 +1109,8 @@ public abstract class VaadinService implements Serializable {
      *            Lock instance to unlock
      */
     protected void unlockSession(WrappedSession wrappedSession, Lock lock) {
-        assert ((ReentrantLock) lock).isHeldByCurrentThread()
-                : "Trying to unlock the session but it has not been locked by this thread";
+        assert ((ReentrantLock) lock)
+                .isHeldByCurrentThread() : "Trying to unlock the session but it has not been locked by this thread";
         lock.unlock();
     }
 
@@ -1155,8 +1150,7 @@ public abstract class VaadinService implements Serializable {
     private VaadinSession doFindOrCreateVaadinSession(VaadinRequest request,
             boolean requestCanCreateSession) throws SessionExpiredException {
         assert ((ReentrantLock) getSessionLock(request.getWrappedSession()))
-                .isHeldByCurrentThread()
-                : "Session has not been locked by this thread";
+                .isHeldByCurrentThread() : "Session has not been locked by this thread";
 
         /* Find an existing session for this request. */
         VaadinSession session = getExistingSession(request,
@@ -1217,8 +1211,7 @@ public abstract class VaadinService implements Serializable {
      */
     private VaadinSession createAndRegisterSession(VaadinRequest request) {
         assert ((ReentrantLock) getSessionLock(request.getWrappedSession()))
-                .isHeldByCurrentThread()
-                : "Session has not been locked by this thread";
+                .isHeldByCurrentThread() : "Session has not been locked by this thread";
 
         VaadinSession session = createVaadinSession(request);
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentEffectTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentEffectTest.java
@@ -16,26 +16,185 @@
 package com.vaadin.flow.component;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.Locale;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.CurrentInstance;
+import com.vaadin.flow.server.ErrorEvent;
+import com.vaadin.flow.server.MockVaadinServletService;
+import com.vaadin.flow.server.MockVaadinSession;
 import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.signals.NumberSignal;
 import com.vaadin.signals.ValueSignal;
 import com.vaadin.tests.util.MockUI;
 
 public class ComponentEffectTest {
+    @Test
+    public void effect_triggeredWithOwnerUILocked_effectRunSynchronously() {
+        runWithFeatureFlagEnabled(() -> {
+            MockUI ui = new MockUI();
+
+            AtomicReference<Thread> currentThread = new AtomicReference<>();
+            AtomicReference<UI> currentUI = new AtomicReference<>();
+
+            ComponentEffect.effect(ui, () -> {
+                currentThread.set(Thread.currentThread());
+                currentUI.set(UI.getCurrent());
+            });
+
+            assertSame(Thread.currentThread(), currentThread.get());
+            assertSame(ui, currentUI.get());
+        });
+    }
+
+    @Test
+    public void effect_triggeredWithNoUILocked_effectRunAsynchronously() {
+        runWithFeatureFlagEnabled(() -> {
+            var service = new MockVaadinServletService();
+            VaadinService.setCurrent(service);
+
+            var session = new MockVaadinSession(service);
+            session.lock();
+            var ui = new MockUI(session);
+            session.unlock();
+
+            UI.setCurrent(null);
+
+            AtomicReference<Thread> currentThread = new AtomicReference<>();
+            AtomicReference<UI> currentUI = new AtomicReference<>();
+            CountDownLatch latch = new CountDownLatch(1);
+
+            ComponentEffect.effect(ui, () -> {
+                currentThread.set(Thread.currentThread());
+                currentUI.set(UI.getCurrent());
+                latch.countDown();
+            });
+
+            if (!latch.await(500, TimeUnit.MILLISECONDS)) {
+                fail("Expected signal effect to be computed asynchronously");
+            }
+
+            Assert.assertTrue(
+                    "Expected effect to be executed in Vaadin Executor thread",
+                    currentThread.get().getName()
+                            .startsWith("VaadinTaskExecutor-thread-"));
+            assertSame(ui, currentUI.get());
+        });
+    }
+
+    @Test
+    public void effect_triggeredWithOtherUILocked_effectRunAsynchronously() {
+        runWithFeatureFlagEnabled(() -> {
+            var service = new MockVaadinServletService();
+            VaadinService.setCurrent(service);
+
+            var session = new MockVaadinSession(service);
+            session.lock();
+            var ui = new MockUI(session);
+            session.unlock();
+
+            VaadinSession.setCurrent(null);
+            UI.setCurrent(null);
+
+            MockUI otherUi = new MockUI();
+            UI.setCurrent(otherUi);
+
+            AtomicReference<Thread> currentThread = new AtomicReference<>();
+            AtomicReference<UI> currentUI = new AtomicReference<>();
+            CountDownLatch latch = new CountDownLatch(1);
+
+            ComponentEffect.effect(ui, () -> {
+                currentThread.set(Thread.currentThread());
+                currentUI.set(UI.getCurrent());
+                latch.countDown();
+            });
+
+            if (!latch.await(500, TimeUnit.MILLISECONDS)) {
+                fail("Expected signal effect to be computed asynchronously");
+            }
+
+            Assert.assertTrue(
+                    "Expected effect to be executed in Vaadin Executor thread",
+                    currentThread.get().getName()
+                            .startsWith("VaadinTaskExecutor-thread-"));
+            assertSame(ui, currentUI.get());
+        });
+    }
+
+    @Test
+    public void effect_throwExceptionWhenRunningDirectly_delegatedToErrorHandler() {
+        runWithFeatureFlagEnabled(() -> {
+            var service = new MockVaadinServletService();
+            VaadinService.setCurrent(service);
+
+            var session = new MockVaadinSession(service);
+            session.lock();
+            var ui = new MockUI(session);
+
+            var events = new ArrayList<ErrorEvent>();
+            session.setErrorHandler(events::add);
+
+            ComponentEffect.effect(ui, () -> {
+                throw new RuntimeException("Expected exception");
+            });
+
+            assertEquals(1, events.size());
+            assertEquals(RuntimeException.class,
+                    events.get(0).getThrowable().getClass());
+        });
+    }
+
+    @Test
+    public void effect_throwExceptionWhenRunningAsynchronously_delegatedToErrorHandler() {
+        runWithFeatureFlagEnabled(() -> {
+            var service = new MockVaadinServletService();
+            VaadinService.setCurrent(service);
+
+            var session = new MockVaadinSession(service);
+            session.lock();
+            var ui = new MockUI(session);
+
+            var events = new LinkedBlockingQueue<ErrorEvent>();
+            session.setErrorHandler(events::add);
+
+            UI.setCurrent(null);
+            session.unlock();
+
+            ComponentEffect.effect(ui, () -> {
+                throw new RuntimeException("Expected exception");
+            });
+
+            ErrorEvent event = events.poll(500, TimeUnit.MILLISECONDS);
+            assertNotNull(event);
+
+            Throwable throwable = event.getThrowable();
+            assertEquals(ExecutionException.class, throwable.getClass());
+            assertEquals(RuntimeException.class,
+                    throwable.getCause().getClass());
+        });
+    }
+
     @Test
     public void effect_componentAttachedAndDetached_effectEnabledAndDisabled() {
         runWithFeatureFlagEnabled(() -> {
@@ -182,7 +341,12 @@ public class ComponentEffectTest {
         });
     }
 
-    private static void runWithFeatureFlagEnabled(Runnable test) {
+    @FunctionalInterface
+    private interface InterruptableRunnable {
+        void run() throws InterruptedException;
+    }
+
+    private static void runWithFeatureFlagEnabled(InterruptableRunnable test) {
         try (var featureFlagStaticMock = mockStatic(FeatureFlags.class)) {
             FeatureFlags flags = mock(FeatureFlags.class);
             when(flags.isEnabled(FeatureFlags.FLOW_FULLSTACK_SIGNALS.getId()))
@@ -190,6 +354,8 @@ public class ComponentEffectTest {
             featureFlagStaticMock.when(() -> FeatureFlags.get(any()))
                     .thenReturn(flags);
             test.run();
+        } catch (InterruptedException e) {
+            throw new AssertionError(e);
         } finally {
             VaadinService.getCurrent().destroy();
             CurrentInstance.clearAll();

--- a/signals/src/test/java/com/vaadin/signals/SignalEnvironmentTest.java
+++ b/signals/src/test/java/com/vaadin/signals/SignalEnvironmentTest.java
@@ -42,11 +42,6 @@ public class SignalEnvironmentTest extends SignalTestBase {
             }
 
             @Override
-            public Executor getFallbackEffectDispatcher() {
-                return null;
-            }
-
-            @Override
             public Executor getEffectDispatcher() {
                 return null;
             }
@@ -81,11 +76,6 @@ public class SignalEnvironmentTest extends SignalTestBase {
             @Override
             public Executor getResultNotifier() {
                 count.incrementAndGet();
-                return null;
-            }
-
-            @Override
-            public Executor getFallbackEffectDispatcher() {
                 return null;
             }
 
@@ -136,46 +126,23 @@ public class SignalEnvironmentTest extends SignalTestBase {
     void effectDispatcher_noDispathcer_runsImmediately() {
         AtomicInteger count = new AtomicInteger();
 
-        SignalEnvironment.getCurrentEffectDispatcher()
+        SignalEnvironment.getDefaultEffectDispatcher()
                 .execute(() -> count.incrementAndGet());
 
         assertEquals(1, count.get());
     }
 
     @Test
-    void effectDispatcher_setWhenAccessed_usedAfterCleared() {
+    void effectDispatcher_setWhenDispatching_runThroughDispatcher() {
         AtomicInteger count = new AtomicInteger();
 
-        TestExecutor effectDispatcher = useTestEffectDispatcher();
-        TestExecutor fallbackEffectDispatcher = useTestFallbackEffectDispatcher();
+        TestExecutor testDispatcher = useTestEffectDispatcher();
 
-        Executor dispatcher = SignalEnvironment.getCurrentEffectDispatcher();
-        clearTestEffectDispatcher();
-
-        dispatcher.execute(() -> count.incrementAndGet());
+        SignalEnvironment.getDefaultEffectDispatcher()
+                .execute(() -> count.incrementAndGet());
         assertEquals(0, count.get());
 
-        effectDispatcher.runPendingTasks();
+        testDispatcher.runPendingTasks();
         assertEquals(1, count.get());
-
-        assertEquals(0, fallbackEffectDispatcher.countPendingTasks());
-    }
-
-    @Test
-    void fallbackEffectDispatcher_setWhenDispatching_runThroughDispatcher() {
-        AtomicInteger count = new AtomicInteger();
-
-        Executor dispatcher = SignalEnvironment.getCurrentEffectDispatcher();
-
-        TestExecutor effectDispatcher = useTestEffectDispatcher();
-        TestExecutor fallbackEffectDispatcher = useTestFallbackEffectDispatcher();
-
-        dispatcher.execute(() -> count.incrementAndGet());
-        assertEquals(0, count.get());
-
-        fallbackEffectDispatcher.runPendingTasks();
-        assertEquals(1, count.get());
-
-        assertEquals(0, effectDispatcher.countPendingTasks());
     }
 }

--- a/signals/src/test/java/com/vaadin/signals/SignalTestBase.java
+++ b/signals/src/test/java/com/vaadin/signals/SignalTestBase.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.BeforeAll;
 public class SignalTestBase {
     private static final ThreadLocal<Executor> currentResultNotifier = new ThreadLocal<Executor>();
     private static final ThreadLocal<Executor> currentEffectDispatcher = new ThreadLocal<Executor>();
-    private static final ThreadLocal<Executor> currentFallbackEffectDispatcher = new ThreadLocal<Executor>();
 
     protected class TestExecutor implements Executor {
         private final ArrayList<Runnable> tasks = new ArrayList<>();
@@ -73,11 +72,6 @@ public class SignalTestBase {
                     public Executor getEffectDispatcher() {
                         return currentEffectDispatcher.get();
                     }
-
-                    @Override
-                    public Executor getFallbackEffectDispatcher() {
-                        return currentFallbackEffectDispatcher.get();
-                    }
                 });
     }
 
@@ -102,23 +96,10 @@ public class SignalTestBase {
         return dispatcher;
     }
 
-    protected void clearTestEffectDispatcher() {
-        currentEffectDispatcher.remove();
-    }
-
-    protected TestExecutor useTestFallbackEffectDispatcher() {
-        TestExecutor dispatcher = new TestExecutor();
-
-        currentFallbackEffectDispatcher.set(dispatcher);
-
-        return dispatcher;
-    }
-
     @AfterEach
     void clear() {
         currentResultNotifier.remove();
         currentEffectDispatcher.remove();
-        currentFallbackEffectDispatcher.remove();
         SignalFactory.IN_MEMORY_SHARED.clear();
     }
 }

--- a/signals/src/test/java/com/vaadin/signals/impl/EffectTest.java
+++ b/signals/src/test/java/com/vaadin/signals/impl/EffectTest.java
@@ -340,6 +340,7 @@ public class EffectTest extends SignalTestBase {
         Signal.effect(() -> {
             invocations.add(signal.value());
         });
+        dispatcher.runPendingTasks();
         assertEquals(List.of("initial"), invocations);
 
         signal.value("update1");
@@ -360,6 +361,7 @@ public class EffectTest extends SignalTestBase {
         Runnable closer = Signal.effect(() -> {
             invocations.add(signal.value());
         });
+        dispatcher.runPendingTasks();
         assertEquals(List.of("initial"), invocations);
 
         signal.value("update");


### PR DESCRIPTION
Remove the distinction between effect dispatchers and fallback effect dispatchers since only the "fallback" variant is relevant now.

The initial effect invocation now goes through the dispatcher so that `UI.getCurrent()` is never defined when using `Signal.effect`.

Fixes #22153
Fixes #22157