### PR TITLE
fix: make access denied a warning

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/AnnotatedViewAccessChecker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/AnnotatedViewAccessChecker.java
@@ -107,7 +107,7 @@ public class AnnotatedViewAccessChecker implements NavigationAccessChecker {
                     boolean hasAccess = accessAnnotationChecker.hasAccess(
                             parent, context.getPrincipal(), context::hasRole);
                     if (!hasAccess) {
-                        LOGGER.debug(
+                        LOGGER.warn(
                                 "Denied access to view due to parent layout '{}' access rules",
                                 parent.getSimpleName());
                         return context.deny(


### PR DESCRIPTION
Make the access denied issue
when paren layout access is
denied a warning log instead
of a debug log.
