### PR TITLE
fix: Fix faulty javadoc for acceptNullValues

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/AbstractSinglePropertyField.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/AbstractSinglePropertyField.java
@@ -154,10 +154,10 @@ public abstract class AbstractSinglePropertyField<C extends AbstractField<C, T>,
      * @param defaultValue
      *            the default value to use if the property isn't defined
      * @param acceptNullValues
-     *            if <code>true</code>, an exception will be thrown if the model
-     *            value is set to <code>null</code>; if <code>false</code> the
-     *            property will be removed when the model value is set to
-     *            <code>null</code>
+     *            if <code>true</code>, the property will be removed when the
+     *            model value is set to <code>null</code> ; if
+     *            <code>false</code> an exception will be thrown if the model
+     *            value is set to <code>null</code>
      */
     @SuppressWarnings("unchecked")
     public AbstractSinglePropertyField(String propertyName, T defaultValue,


### PR DESCRIPTION
Fix the javadoc for
acceptNullValues that
mistakenly says that
true throws an exception.

Fixes #22186
