### PR TITLE
chore: bump vite to 6.3.6

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
@@ -9,7 +9,7 @@
   "license": "Apache-2.0",
   "dependencies": {},
   "devDependencies": {
-    "vite": "6.3.5",
+    "vite": "6.3.6",
     "@vitejs/plugin-react": "4.5.0",
     "@preact/signals-react-transform": "0.5.1",
     "@rollup/plugin-replace": "6.0.2",


### PR DESCRIPTION
two vulnerabilities have been reported regarding vite 6.3.5/6.3.4.

https://nvd.nist.gov/vuln/detail/CVE-2025-58751
https://nvd.nist.gov/vuln/detail/CVE-2025-58752