### PR TITLE
fix: Try activate or download a license when 7-day trial expires

### DIFF
--- a/vaadin-dev-server/src/main/frontend/pre-trial-splash-screen.ts
+++ b/vaadin-dev-server/src/main/frontend/pre-trial-splash-screen.ts
@@ -518,16 +518,9 @@ class PreTrial extends HTMLElement {
 // Register the custom element
 customElements.define('vaadin-pretrial', PreTrial);
 
-function openNewWindow(url: string): void {
-  const newWindow = window.open(url, '_blank');
-  if (newWindow) {
-    newWindow.opener = null;
-  }
-}
-
 function primaryButtonClickListener(event: CustomEvent) {
   if (event.detail.expired) {
-    openNewWindow('https://vaadin.com/pricing');
+    tryAcquireLicense();
   } else {
     startPreTrial();
   }


### PR DESCRIPTION
Currently Flow redirects to /pricing which doesn't lead to proKey download even if a user signs in and starts the commercial trial. 

Flow should instead try to download a license with the license checker's `vaadinComIntegration.openBrowserAndWaitForKey` method.

Basically same as for the first splash screen.