### PR TITLE
Synchronize initial effect invocation

### DIFF
--- a/signals/src/main/java/com/vaadin/signals/impl/Effect.java
+++ b/signals/src/main/java/com/vaadin/signals/impl/Effect.java
@@ -90,7 +90,11 @@ public class Effect {
         assert dispatcher != null;
         this.dispatcher = dispatcher;
 
-        dispatcher.execute(this::revalidate);
+        dispatcher.execute(() -> {
+            synchronized (this) {
+                revalidate();
+            }
+        });
     }
 
     private void revalidate() {


### PR DESCRIPTION
The initial invocation may add listeners to shared signal instances which means that there's a possibility that invalidation is run from a different thread while the initial invocation is still ongoing. This means that the initial effect invocation also needs to be synchronized in the same way as invalidation.