### PR TITLE
fix: Array type should be serializable

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -1472,8 +1472,8 @@ public class Element extends Node<Element> {
         if (parameters.length == 0) {
             wrappedParameters = new Serializable[] { this };
         } else {
-            wrappedParameters = Arrays.copyOf(parameters,
-                    parameters.length + 1);
+            wrappedParameters = Arrays.copyOf(parameters, parameters.length + 1,
+                    Serializable[].class);
             wrappedParameters[parameters.length] = this;
         }
 

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
@@ -38,6 +38,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Html;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
@@ -2573,6 +2574,27 @@ public class ElementTest extends AbstractNodeTest {
     }
 
     @Test
+    public void givenTypeDefinedArray_ArrayStoreExceptionNotThrown() {
+        Element element = new Element("div") {
+            @Override
+            public PendingJavaScriptResult executeJs(String expression,
+                    Serializable... parameters) {
+                Serializable[] wrappedParameters;
+                if (parameters.length == 0) {
+                    wrappedParameters = new Serializable[] { this };
+                } else {
+                    wrappedParameters = Arrays.copyOf(parameters,
+                            parameters.length + 1, Serializable[].class);
+                    wrappedParameters[parameters.length] = this;
+                }
+                return null;
+            }
+        };
+
+        element.executeJs("foo", new Component[] { new Div() });
+    }
+
+    @Test
     public void callFunction_delegatesToCallJsFunction() {
         AtomicReference<String> invokedFuction = new AtomicReference<>();
         AtomicReference<Serializable[]> invokedParams = new AtomicReference<>();
@@ -2630,6 +2652,10 @@ public class ElementTest extends AbstractNodeTest {
     private static ArrayNode createNumberArray(double... items) {
         return DoubleStream.of(items).mapToObj(JacksonUtils::createNode)
                 .collect(JacksonUtils.asArray());
+    }
+
+    @Tag("div")
+    private static class Div extends Component {
     }
 
 }


### PR DESCRIPTION
Not depending on what type array
is given to Serializable... the
copied array should be of type
Serializable[] to enable
adding Element to it.
