### PR TITLE
fix: handle ArrayNode in MapPutChange to fix ReactAdapterComponent.setState() (#22251)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/change/MapPutChange.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/change/MapPutChange.java
@@ -17,6 +17,7 @@
 package com.vaadin.flow.internal.change;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.NumericNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -32,6 +33,7 @@ import com.vaadin.flow.shared.JsonConstants;
 
 import elemental.json.Json;
 import elemental.json.JsonObject;
+import elemental.json.JsonValue;
 
 /**
  * Change describing a changed value in a map feature.
@@ -109,6 +111,13 @@ public class MapPutChange extends NodeFeatureChange {
         } else if (value instanceof TextNode node) {
             json.put(JsonConstants.CHANGE_PUT_VALUE, Json.create(JacksonCodec
                     .encodeWithConstantPool(node, constantPool).textValue()));
+        } else if (value instanceof ArrayNode node) {
+            // Convert ArrayNode to Elemental JSON array
+            json.put(JsonConstants.CHANGE_PUT_VALUE,
+                    (JsonValue) Json.instance()
+                            .parse(JacksonCodec
+                                    .encodeWithConstantPool(node, constantPool)
+                                    .toString()));
         } else if (value instanceof ValueNode node) {
             json.put(JsonConstants.CHANGE_PUT_VALUE, Json.create(JacksonCodec
                     .encodeWithConstantPool(node, constantPool).toString()));

--- a/flow-server/src/main/java/com/vaadin/flow/internal/change/MapPutChange.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/change/MapPutChange.java
@@ -114,10 +114,8 @@ public class MapPutChange extends NodeFeatureChange {
         } else if (value instanceof ArrayNode node) {
             // Convert ArrayNode to Elemental JSON array
             json.put(JsonConstants.CHANGE_PUT_VALUE,
-                    (JsonValue) Json.instance()
-                            .parse(JacksonCodec
-                                    .encodeWithConstantPool(node, constantPool)
-                                    .toString()));
+                    JacksonUtils.createElementalArray((ArrayNode) JacksonCodec
+                            .encodeWithConstantPool(node, constantPool)));
         } else if (value instanceof ValueNode node) {
             json.put(JsonConstants.CHANGE_PUT_VALUE, Json.create(JacksonCodec
                     .encodeWithConstantPool(node, constantPool).toString()));

--- a/flow-server/src/main/java/com/vaadin/flow/internal/change/MapPutChange.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/change/MapPutChange.java
@@ -16,7 +16,6 @@
 
 package com.vaadin.flow.internal.change;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.NumericNode;
@@ -26,6 +25,7 @@ import com.fasterxml.jackson.databind.node.ValueNode;
 
 import com.vaadin.flow.internal.ConstantPool;
 import com.vaadin.flow.internal.JacksonCodec;
+import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.internal.JsonCodec;
 import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.internal.nodefeature.NodeFeature;
@@ -33,7 +33,6 @@ import com.vaadin.flow.shared.JsonConstants;
 
 import elemental.json.Json;
 import elemental.json.JsonObject;
-import elemental.json.JsonValue;
 
 /**
  * Change describing a changed value in a map feature.

--- a/flow-server/src/test/java/com/vaadin/flow/internal/change/MapPutChangeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/change/MapPutChangeTest.java
@@ -17,6 +17,7 @@
 package com.vaadin.flow.internal.change;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Assert;
@@ -85,6 +86,26 @@ public class MapPutChangeTest {
         JsonNode nodeValue = json.get(JsonConstants.CHANGE_PUT_NODE_VALUE);
         Assert.assertSame(JsonNodeType.NUMBER, nodeValue.getNodeType());
         Assert.assertEquals(value.getId(), nodeValue.intValue());
+    }
+
+    @Test
+    public void testArrayNodeValue() {
+        // Test for issue #22251 - ArrayNode should be handled properly
+        ArrayNode arrayNode = JacksonUtils.createArrayNode();
+        arrayNode.add("USA");
+        arrayNode.add("Canada");
+        arrayNode.add("Mexico");
+
+        MapPutChange change = new MapPutChange(feature, "countries", arrayNode);
+        ObjectNode json = change.toJson(null);
+
+        JsonNode arrayValue = json.get(JsonConstants.CHANGE_PUT_VALUE);
+        Assert.assertNotNull("ArrayNode should be encoded", arrayValue);
+        Assert.assertSame(JsonNodeType.ARRAY, arrayValue.getNodeType());
+        Assert.assertEquals(3, arrayValue.size());
+        Assert.assertEquals("USA", arrayValue.get(0).textValue());
+        Assert.assertEquals("Canada", arrayValue.get(1).textValue());
+        Assert.assertEquals("Mexico", arrayValue.get(2).textValue());
     }
 
     private JsonNode getValue(Object input) {


### PR DESCRIPTION
When setState() is called with a String array in ReactAdapterComponent, the array gets converted to Jackson's ArrayNode. MapPutChange.populateJson() did not handle ArrayNode, causing it to fall through to the else clause which uses the old Elemental JsonCodec that doesn't recognize Jackson types.

This resulted in: IllegalArgumentException: Can't encode class com.fasterxml.jackson.databind.node.ArrayNode to json

The fix adds a specific case to handle ArrayNode values by converting them to Elemental JSON using Json.instance().parse().

Fixes #22251

🤖 Generated with [Claude Code](https://claude.ai/code)
