### PR TITLE
chore: Bump frontend dependencies (24.9)

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/default/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/default/package.json
@@ -5,11 +5,11 @@
     "@polymer/polymer": "3.5.2",
     "@vaadin/common-frontend": "0.0.19",
     "construct-style-sheets-polyfill": "3.1.0",
-    "lit": "3.3.0"
+    "lit": "3.3.1"
   },
   "devDependencies": {
     "async": "3.2.6",
-    "glob": "11.0.2",
+    "glob": "11.0.3",
     "typescript": "5.8.3",
     "workbox-core": "7.3.0",
     "workbox-precaching": "7.3.0",

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/react-router/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/react-router/package.json
@@ -4,10 +4,10 @@
   "dependencies": {
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-router": "7.6.1"
+    "react-router": "7.6.3"
   },
   "devDependencies": {
-    "@types/react": "18.3.23",
+    "@types/react": "18.3.24",
     "@types/react-dom": "18.3.7"
   }
 }

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/react19/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/react19/package.json
@@ -2,11 +2,11 @@
   "private": true,
   "description": "A list of Flow dependencies when using React 19",
   "dependencies": {
-    "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react": "19.1.1",
+    "react-dom": "19.1.1"
   },
   "devDependencies": {
-    "@types/react": "19.1.6",
-    "@types/react-dom": "19.1.5"
+    "@types/react": "19.1.13",
+    "@types/react-dom": "19.1.9"
   }
 }

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
@@ -10,16 +10,16 @@
   "dependencies": {},
   "devDependencies": {
     "vite": "6.3.6",
-    "@vitejs/plugin-react": "4.5.0",
-    "@preact/signals-react-transform": "0.5.1",
+    "@vitejs/plugin-react": "4.7.0",
+    "@preact/signals-react-transform": "0.6.0",
     "@rollup/plugin-replace": "6.0.2",
-    "@rollup/pluginutils": "5.1.4",
+    "@rollup/pluginutils": "5.3.0",
     "@babel/preset-react": "7.27.1",
     "rollup-plugin-visualizer": "5.14.0",
     "rollup-plugin-brotli": "3.1.0",
-    "vite-plugin-checker": "0.9.3",
+    "vite-plugin-checker": "0.10.3",
     "workbox-build": "7.3.0",
     "transform-ast": "2.4.4",
-    "magic-string": "0.30.17"
+    "magic-string": "0.30.19"
   }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -241,7 +241,7 @@ public class NodeUpdaterTest {
                 "7.0.0");
         nodeUpdater.updateDefaultDependencies(packageJson);
 
-        Assert.assertEquals("11.0.2", packageJson
+        Assert.assertEquals("11.0.3", packageJson
                 .get(NodeUpdater.DEV_DEPENDENCIES).get("glob").textValue());
     }
 

--- a/flow-tests/test-themes/pom-devbundle.xml
+++ b/flow-tests/test-themes/pom-devbundle.xml
@@ -46,6 +46,7 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-dev-bundle-plugin</artifactId>
+                <version>${project.version}</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Left out
```
 typescript  5.8.3  →  5.9.2
 react-router  7.6.3  →  7.9.1
```

React router could maybe be included?