### PR TITLE
chore: Deprecate Theme annotation and CssImport parameters

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/dependency/CssImport.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/dependency/CssImport.java
@@ -123,6 +123,7 @@ public @interface CssImport {
      *
      * @return the include value.
      */
+    @Deprecated(since = "25.0")
     String include() default "";
 
     /**
@@ -130,6 +131,7 @@ public @interface CssImport {
      *
      * @return the id.
      */
+    @Deprecated(since = "25.0")
     String id() default "";
 
     /**
@@ -137,7 +139,11 @@ public @interface CssImport {
      * target.
      *
      * @return the themable element.
+     *
+     * @deprecated Component styling can be done entirely with normal "light
+     *             DOM" CSS.
      */
+    @Deprecated(since = "25.0")
     String themeFor() default "";
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/theme/Theme.java
+++ b/flow-server/src/main/java/com/vaadin/flow/theme/Theme.java
@@ -75,11 +75,17 @@ import java.lang.annotation.Target;
  * @see AbstractTheme
  * @see NoTheme
  * @since 1.0
+ * @deprecated As of Vaadin 25, this annotation is deprecated. The theming
+ *             system has been reworked to use
+ *             {@link com.vaadin.flow.component.dependency.CssImport} to load
+ *             one or more stylesheets and use mechanisms native to HTML, CSS
+ *             and React (e.g. {@code @import url("morestyles.css")} in CSS).
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 @Documented
+@Deprecated(since = "25.0")
 public @interface Theme {
 
     /**


### PR DESCRIPTION
Related-to https://github.com/vaadin/platform/issues/7453