### PR TITLE
chore: Add automated frontend dependency updates

### DIFF
--- a/.github/workflows/update-frontend-dependencies.yml
+++ b/.github/workflows/update-frontend-dependencies.yml
@@ -1,0 +1,72 @@
+name: Update Frontend Dependencies
+
+on:
+  schedule:
+    # Runs at 04:00 UTC every Monday
+    - cron: '0 4 * * 1'
+  workflow_dispatch:  # Allow manual trigger
+
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: [main, '25.2', '25.1', '25.0', '24.10', '24.9']
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+          # Custom token so the created PR triggers CI and can push to the repo
+          token: ${{ secrets.VAADIN_BOT_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run dependency update script
+        run: |
+          chmod +x scripts/update-frontend-dependencies.sh
+          ./scripts/update-frontend-dependencies.sh
+
+      - name: Determine update strategy description
+        run: |
+          if [ "${{ matrix.branch }}" = "main" ]; then
+            echo "UPDATE_DESC=All new versions (major, minor, patch)" >> $GITHUB_ENV
+          else
+            echo "UPDATE_DESC=Patch releases only" >> $GITHUB_ENV
+          fi
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.VAADIN_BOT_TOKEN }}
+          branch: update-frontend-dependencies-${{ matrix.branch }}
+          base: ${{ matrix.branch }}
+          commit-message: "chore: Update frontend dependencies (${{ matrix.branch }})"
+          title: "chore: Update frontend dependencies (${{ matrix.branch }})"
+          body: |
+            ## Automated Frontend Dependency Updates
+
+            This PR contains automated updates to frontend dependencies.
+
+            ### Update Strategy
+            - Target Branch: ${{ matrix.branch }}
+            - Updates: ${{ env.UPDATE_DESC }}
+
+            ### Changes
+            The dependencies have been updated using `npm-check-updates`.
+
+            ---
+            *This PR was automatically created by the update-frontend-dependencies workflow.*
+          labels: |
+            dependencies
+            automated
+          assignees: |
+            ${{ github.repository_owner }}

--- a/scripts/update-frontend-dependencies.sh
+++ b/scripts/update-frontend-dependencies.sh
@@ -9,10 +9,8 @@ currentBranch=$(git rev-parse --abbrev-ref HEAD)
 # Determine update strategy based on branch
 if [ "$currentBranch" = "main" ]; then
   updateTarget="latest"
-  commitMessage="chore: Bump frontend dependencies to latest versions"
 else
   updateTarget="patch"
-  commitMessage="chore: Bump frontend dependencies (patch releases only)"
 fi
 
 echo "Current branch: $currentBranch"
@@ -57,8 +55,3 @@ if [ "$deprecationFound" = true ]; then
   echo "Please review and update these packages manually."
   exit 1
 fi
-
-git add "$depsFolder"
-git commit -m "$commitMessage"
-
-

--- a/scripts/update-frontend-dependencies.sh
+++ b/scripts/update-frontend-dependencies.sh
@@ -3,6 +3,13 @@
 scriptDir=$(dirname $0)
 depsFolder=$scriptDir/../flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies
 
+ncuVersion=22.2.3
+# Skip versions younger than this. Must be at least the minimum frontend
+# package age that Flow enforces on npm install (Options default: 1 day),
+# or the created PR fails its first build because npm refuses to install
+# the too-new package.
+cooldown=1
+
 # Get current git branch
 currentBranch=$(git rev-parse --abbrev-ref HEAD)
 
@@ -19,7 +26,7 @@ echo "Update strategy: $updateTarget"
 for a in "$depsFolder"/*
 do
   pushd $a
-  npx npm-check-updates@18.1.1 -u -t "$updateTarget"
+  npx npm-check-updates@$ncuVersion -u -t "$updateTarget" --cooldown $cooldown
   popd
 done
 
@@ -34,7 +41,7 @@ do
   folderName=$(basename "$a")
 
   # Run npm-check-updates with --no-deprecated to find deprecated packages
-  deprecatedOutput=$(npx npm-check-updates@18.1.1 --no-deprecated 2>&1)
+  deprecatedOutput=$(npx npm-check-updates@$ncuVersion --no-deprecated --cooldown $cooldown 2>&1)
 
   # Check if there are any deprecated packages (output will contain package names if found)
   if echo "$deprecatedOutput" | grep -q "deprecated"; then


### PR DESCRIPTION
- Add weekly GitHub workflow (Mondays 04:00 UTC) that runs the update script and opens a PR per branch via peter-evans/create-pull-request
- Matrix over main, 25.2, 25.1, 25.0, 24.10 and 24.9
- Use VAADIN_BOT_TOKEN so the created PRs trigger CI
- Update strategy is branch-based: latest versions on main, patch only on maintenance branches
- Let create-pull-request handle the commit/branch/push; drop committing from the update script
