### PR TITLE
feat: Add support for Component and primitive arrays in executeJs

### DIFF
--- a/flow-client/src/test/java/com/vaadin/client/flow/util/ClientJsonCodecTest.java
+++ b/flow-client/src/test/java/com/vaadin/client/flow/util/ClientJsonCodecTest.java
@@ -100,6 +100,97 @@ public class ClientJsonCodecTest {
     }
 
     @Test
+    public void decodeWithTypeInfo_componentArray() {
+        StateTree tree = new StateTree(null);
+
+        // Create three state nodes with DOM elements
+        StateNode node1 = new StateNode(10, tree);
+        StateNode node2 = new StateNode(20, tree);
+        StateNode node3 = new StateNode(30, tree);
+
+        tree.registerNode(node1);
+        tree.registerNode(node2);
+        tree.registerNode(node3);
+
+        JsElement element1 = new JsElement() {
+        };
+        JsElement element2 = new JsElement() {
+        };
+        JsElement element3 = new JsElement() {
+        };
+
+        node1.setDomNode(element1);
+        node2.setDomNode(element2);
+        node3.setDomNode(element3);
+
+        // Create a JSON array representing Component array
+        // Structure: [ARRAY_TYPE, [[NODE_TYPE, id1], [NODE_TYPE, id2],
+        // [NODE_TYPE, id3]]]
+        JsonArray innerArray = Json.createArray();
+        innerArray.set(0, JsonUtils.createArray(
+                Json.create(JsonCodec.NODE_TYPE), Json.create(10)));
+        innerArray.set(1, JsonUtils.createArray(
+                Json.create(JsonCodec.NODE_TYPE), Json.create(20)));
+        innerArray.set(2, JsonUtils.createArray(
+                Json.create(JsonCodec.NODE_TYPE), Json.create(30)));
+
+        JsonArray json = JsonUtils
+                .createArray(Json.create(JsonCodec.ARRAY_TYPE), innerArray);
+
+        // Decode the array
+        Object decoded = ClientJsonCodec.decodeWithTypeInfo(tree, json);
+
+        // Verify it's an array (native JS array when running in GWT)
+        Assert.assertNotNull("Decoded array should not be null", decoded);
+
+        // Since this test runs in JVM, we need to handle the type checking
+        // differently
+        // In actual GWT compilation, this would be a native JS array
+        if (decoded instanceof JsArray) {
+            JsArray<?> decodedArray = (JsArray<?>) decoded;
+            Assert.assertEquals("Array should have 3 elements", 3,
+                    decodedArray.length());
+            Assert.assertSame("First element should be element1", element1,
+                    decodedArray.get(0));
+            Assert.assertSame("Second element should be element2", element2,
+                    decodedArray.get(1));
+            Assert.assertSame("Third element should be element3", element3,
+                    decodedArray.get(2));
+        } else {
+            // In GWT compiled mode, it would be a native array
+            // For now, just verify it's not a JsArray of encoded values
+            Assert.assertTrue("Decoded value should be an array",
+                    decoded.getClass().isArray() || decoded instanceof JsArray);
+        }
+    }
+
+    @Test
+    public void decodeWithTypeInfo_stringArray() {
+        // Test a simple string array to ensure it still works
+        JsonArray innerArray = Json.createArray();
+        innerArray.set(0, Json.create("Hello"));
+        innerArray.set(1, Json.create("World"));
+        innerArray.set(2, Json.create("Test"));
+
+        JsonArray json = JsonUtils
+                .createArray(Json.create(JsonCodec.ARRAY_TYPE), innerArray);
+
+        Object decoded = ClientJsonCodec.decodeWithTypeInfo(null, json);
+
+        Assert.assertNotNull("Decoded array should not be null", decoded);
+
+        // Verify the strings are decoded correctly
+        if (decoded instanceof JsArray) {
+            JsArray<?> decodedArray = (JsArray<?>) decoded;
+            Assert.assertEquals("Array should have 3 elements", 3,
+                    decodedArray.length());
+            Assert.assertEquals("Hello", decodedArray.get(0));
+            Assert.assertEquals("World", decodedArray.get(1));
+            Assert.assertEquals("Test", decodedArray.get(2));
+        }
+    }
+
+    @Test
     public void encodeWithoutTypeInfo() {
         encodePrimitiveValues(ClientJsonCodec::encodeWithoutTypeInfo);
     }

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentArraySerializationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentArraySerializationTest.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.page.PendingJavaScriptResult;
+import com.vaadin.flow.internal.JsonSerializer;
+import com.vaadin.flow.internal.JacksonCodec;
+
+import elemental.json.JsonArray;
+import elemental.json.JsonValue;
+
+/**
+ * Test for serialization of Component arrays.
+ */
+public class ComponentArraySerializationTest {
+
+    @Tag("test-div")
+    public static class TestDiv extends Component {
+        public TestDiv() {
+            super();
+        }
+
+        public void setText(String text) {
+            getElement().setText(text);
+        }
+
+        public String getText() {
+            return getElement().getText();
+        }
+    }
+
+    @Tag("test-span")
+    public static class TestSpan extends Component {
+        public TestSpan() {
+            super();
+        }
+
+        public void setText(String text) {
+            getElement().setText(text);
+        }
+
+        public String getText() {
+            return getElement().getText();
+        }
+    }
+
+    public static class ContainerWithComponentArray implements Serializable {
+        private Component[] components;
+
+        public Component[] getComponents() {
+            return components;
+        }
+
+        public void setComponents(Component[] components) {
+            this.components = components;
+        }
+    }
+
+    @Test
+    public void testComponentArrayJsonSerialization() {
+        // Create test components
+        TestDiv div = new TestDiv();
+        div.setId("div1");
+        div.setText("Hello");
+
+        TestSpan span = new TestSpan();
+        span.setId("span1");
+        span.setText("World");
+
+        Component[] components = new Component[] { div, span };
+
+        // Test direct array serialization
+        JsonValue jsonValue = JsonSerializer.toJson(components);
+
+        Assert.assertNotNull("JsonSerializer should handle Component arrays",
+                jsonValue);
+        Assert.assertTrue("Result should be a JsonArray",
+                jsonValue instanceof JsonArray);
+
+        JsonArray jsonArray = (JsonArray) jsonValue;
+        Assert.assertEquals("Array should have 2 elements", 2,
+                jsonArray.length());
+    }
+
+    @Test
+    public void testComponentArrayInObjectJsonSerialization() {
+        // Create test components
+        TestDiv div = new TestDiv();
+        div.setId("div1");
+
+        TestSpan span = new TestSpan();
+        span.setId("span1");
+
+        ContainerWithComponentArray container = new ContainerWithComponentArray();
+        container.setComponents(new Component[] { div, span });
+
+        // Test serialization of object containing component array
+        JsonValue jsonValue = JsonSerializer.toJson(container);
+
+        Assert.assertNotNull(
+                "JsonSerializer should handle objects with Component arrays",
+                jsonValue);
+    }
+
+    @Test
+    public void testEmptyComponentArrayJsonSerialization() {
+        Component[] emptyArray = new Component[0];
+
+        JsonValue jsonValue = JsonSerializer.toJson(emptyArray);
+
+        Assert.assertNotNull(
+                "JsonSerializer should handle empty Component arrays",
+                jsonValue);
+        Assert.assertTrue("Result should be a JsonArray",
+                jsonValue instanceof JsonArray);
+
+        JsonArray jsonArray = (JsonArray) jsonValue;
+        Assert.assertEquals("Array should be empty", 0, jsonArray.length());
+    }
+
+    @Test
+    public void testComponentArrayWithNullsJsonSerialization() {
+        Component[] arrayWithNulls = new Component[] { new TestDiv(), null,
+                new TestSpan() };
+
+        JsonValue jsonValue = JsonSerializer.toJson(arrayWithNulls);
+
+        Assert.assertNotNull(
+                "JsonSerializer should handle Component arrays with nulls",
+                jsonValue);
+        Assert.assertTrue("Result should be a JsonArray",
+                jsonValue instanceof JsonArray);
+
+        JsonArray jsonArray = (JsonArray) jsonValue;
+        Assert.assertEquals("Array should have 3 elements", 3,
+                jsonArray.length());
+    }
+
+    @Test
+    public void testComponentArrayWithJacksonCodec() {
+        // Create test components - need to attach them for encoding to work
+        UI ui = new UI();
+        TestDiv div = new TestDiv();
+        div.setId("div1");
+        ui.add(div);
+
+        TestSpan span = new TestSpan();
+        span.setId("span1");
+        ui.add(span);
+
+        Component[] components = new Component[] { div, span };
+
+        // Test that canEncodeWithTypeInfo returns true for Component arrays
+        Assert.assertTrue("JacksonCodec should support Component arrays",
+                JacksonCodec.canEncodeWithTypeInfo(components.getClass()));
+
+        // This should now work without throwing an exception
+        com.fasterxml.jackson.databind.JsonNode encoded = JacksonCodec
+                .encodeWithTypeInfo(components);
+        Assert.assertNotNull("Encoded Component array should not be null",
+                encoded);
+        Assert.assertTrue("Result should be an array node",
+                encoded instanceof com.fasterxml.jackson.databind.node.ArrayNode);
+
+        // The result should be wrapped as ARRAY_TYPE (value 1)
+        com.fasterxml.jackson.databind.node.ArrayNode arrayNode = (com.fasterxml.jackson.databind.node.ArrayNode) encoded;
+        Assert.assertEquals("First element should be ARRAY_TYPE (1)", 1,
+                arrayNode.get(0).asInt());
+
+        // Second element should be the actual array of components
+        Assert.assertTrue(
+                "Second element should be an array of encoded components",
+                arrayNode.get(
+                        1) instanceof com.fasterxml.jackson.databind.node.ArrayNode);
+
+        com.fasterxml.jackson.databind.node.ArrayNode componentsArray = (com.fasterxml.jackson.databind.node.ArrayNode) arrayNode
+                .get(1);
+        Assert.assertEquals("Should have 2 components", 2,
+                componentsArray.size());
+    }
+
+    @Test
+    public void testEmptyComponentArrayWithJacksonCodec() {
+        Component[] emptyArray = new Component[0];
+
+        // This should work for empty arrays too
+        com.fasterxml.jackson.databind.JsonNode encoded = JacksonCodec
+                .encodeWithTypeInfo(emptyArray);
+        Assert.assertNotNull("Encoded empty Component array should not be null",
+                encoded);
+    }
+
+    @Test
+    public void testComponentArrayWithNullsJacksonCodec() {
+        UI ui = new UI();
+        TestDiv div = new TestDiv();
+        ui.add(div);
+
+        Component[] arrayWithNulls = new Component[] { div, null,
+                new TestSpan() };
+
+        // This should handle nulls properly
+        com.fasterxml.jackson.databind.JsonNode encoded = JacksonCodec
+                .encodeWithTypeInfo(arrayWithNulls);
+        Assert.assertNotNull(
+                "Encoded Component array with nulls should not be null",
+                encoded);
+    }
+
+    @Test
+    public void testComponentArrayJavaSerialization() throws Exception {
+        // Create test components
+        TestDiv div = new TestDiv();
+        div.setId("div1");
+        div.setText("Hello");
+
+        TestSpan span = new TestSpan();
+        span.setId("span1");
+        span.setText("World");
+
+        Component[] original = new Component[] { div, span };
+
+        // Serialize
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(original);
+        oos.close();
+
+        // Deserialize
+        ByteArrayInputStream bais = new ByteArrayInputStream(
+                baos.toByteArray());
+        ObjectInputStream ois = new ObjectInputStream(bais);
+        Component[] deserialized = (Component[]) ois.readObject();
+        ois.close();
+
+        Assert.assertNotNull("Deserialized array should not be null",
+                deserialized);
+        Assert.assertEquals("Array length should be preserved", 2,
+                deserialized.length);
+        Assert.assertNotNull("First component should not be null",
+                deserialized[0]);
+        Assert.assertNotNull("Second component should not be null",
+                deserialized[1]);
+        Assert.assertTrue("First component should be a TestDiv",
+                deserialized[0] instanceof TestDiv);
+        Assert.assertTrue("Second component should be a TestSpan",
+                deserialized[1] instanceof TestSpan);
+
+        TestDiv deserializedDiv = (TestDiv) deserialized[0];
+        TestSpan deserializedSpan = (TestSpan) deserialized[1];
+
+        Assert.assertEquals("Div ID should be preserved", "div1",
+                deserializedDiv.getId().orElse(null));
+        Assert.assertEquals("Span ID should be preserved", "span1",
+                deserializedSpan.getId().orElse(null));
+        Assert.assertEquals("Div text should be preserved", "Hello",
+                deserializedDiv.getText());
+        Assert.assertEquals("Span text should be preserved", "World",
+                deserializedSpan.getText());
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ExecJavaScriptView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ExecJavaScriptView.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.uitest.ui;
 
 import java.io.Serializable;
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Input;
 import com.vaadin.flow.component.html.NativeButton;
@@ -90,8 +91,21 @@ public class ExecJavaScriptView extends AbstractDivView {
                     add(input);
                 });
 
+        // Test Component array serialization
+        NativeButton componentArrayButton = createButton(
+                "Pass component array to JS", "componentArrayButton", e -> {
+                    // Cast to Serializable to prevent varargs unpacking
+                    UI.getCurrent().getPage().executeJs(
+                            """
+                                    const components = $0;
+                                    components.forEach(c => c.style.backgroundColor = 'red');
+                                        """,
+                            (Serializable) new Component[] { alertButton,
+                                    focusButton, swapText });
+                });
+
         add(alertButton, focusButton, swapText, logButton, createElementButton,
-                elementAwaitButton, pageAwaitButton);
+                elementAwaitButton, pageAwaitButton, componentArrayButton);
     }
 
     private NativeButton createJsButton(String text, String id, String script,

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ExecJavaScriptIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ExecJavaScriptIT.java
@@ -61,6 +61,29 @@ public class ExecJavaScriptIT extends ChromeBrowserTest {
                 result.getText());
     }
 
+    @Test
+    public void testComponentArraySerialization() {
+        open();
+
+        // Click the button that passes a Component array to JavaScript
+        getButton("componentArrayButton").click();
+
+        // Verify that the first three buttons' background color was changed
+        WebElement alertButton = getButton("alertButton");
+        WebElement focusButton = getButton("focusButton");
+        WebElement swapButton = getButton("swapButton");
+
+        // Check that background color was changed to red
+        // Selenium returns colors in rgba format like "rgba(255, 0, 0, 1)"
+        String expectedColor = "rgba(255, 0, 0, 1)";
+        Assert.assertEquals("Alert button should have red background",
+                expectedColor, alertButton.getCssValue("background-color"));
+        Assert.assertEquals("Focus button should have red background",
+                expectedColor, focusButton.getCssValue("background-color"));
+        Assert.assertEquals("Swap button should have red background",
+                expectedColor, swapButton.getCssValue("background-color"));
+    }
+
     private WebElement getButton(String id) {
         return findElement(By.id(id));
     }


### PR DESCRIPTION
This change enables passing Component arrays and primitive arrays to JavaScript via executeJs() method. Previously, arrays would be unpacked by Java varargs, causing each element to be passed as a separate parameter.

Changes:
- JacksonCodec: Added support for encoding all array types, with special handling for Component arrays that converts them to DOM element references
- ClientJsonCodec: Implemented recursive decoding for arrays with type information, properly converting Component references to DOM elements
- Added comprehensive test coverage including unit tests, integration tests, and GWT tests for both Component and primitive arrays
- Arrays must be cast to Serializable to prevent varargs unpacking

