### PR TITLE
fix: remove pinned async dev dependency from default package.json

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/default/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/default/package.json
@@ -8,7 +8,6 @@
     "lit": "3.3.1"
   },
   "devDependencies": {
-    "async": "3.2.6",
     "glob": "11.0.3",
     "typescript": "5.9.2",
     "workbox-core": "7.3.0",

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -179,7 +179,6 @@ public class NodeUpdaterTest {
         expectedDependencies.add("workbox-core");
         expectedDependencies.add("workbox-precaching");
         expectedDependencies.add("glob");
-        expectedDependencies.add("async");
         return expectedDependencies;
     }
 


### PR DESCRIPTION
The async dependency was originally added in PR #13547 to fix a Prototype Pollution security vulnerability. This is no longer needed as the vulnerability has been resolved in newer versions and there are no direct dependencies requiring async.

- Removed async@3.2.6 from default/package.json devDependencies
- Updated test to reflect the removal

Fixes #21507
