### PR TITLE
fix: Clean up client keys only after viewport update is confirmed

### DIFF
--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/AbstractHierarchicalDataCommunicatorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/AbstractHierarchicalDataCommunicatorTest.java
@@ -152,6 +152,12 @@ abstract public class AbstractHierarchicalDataCommunicatorTest {
         return result;
     }
 
+    protected int captureArrayUpdateId() {
+        var argumentCaptor = ArgumentCaptor.forClass(Integer.class);
+        Mockito.verify(arrayUpdate).commit(argumentCaptor.capture());
+        return argumentCaptor.getValue();
+    }
+
     protected int captureArrayUpdateSize() {
         var argumentCaptor = ArgumentCaptor.forClass(Integer.class);
         Mockito.verify(arrayUpdater).startUpdate(argumentCaptor.capture());

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorBasicTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorBasicTest.java
@@ -188,8 +188,6 @@ public class HierarchicalDataCommunicatorBasicTest
         Assert.assertEquals(-1, dataCommunicator.getDepth(new Item("Item 1")));
 
         fakeClientCommunication();
-
-        // Loaded
         Assert.assertEquals(0, dataCommunicator.getDepth(new Item("Item 0")));
         Assert.assertEquals(1, dataCommunicator.getDepth(new Item("Item 0-0")));
         Assert.assertEquals(2,
@@ -198,12 +196,6 @@ public class HierarchicalDataCommunicatorBasicTest
 
         dataCommunicator.setViewportRange(4, 4);
         fakeClientCommunication();
-
-        // Out of new viewport
-        Assert.assertEquals(-1,
-                dataCommunicator.getDepth(new Item("Item 0-0")));
-
-        // Within new viewport
         Assert.assertEquals(0, dataCommunicator.getDepth(new Item("Item 5")));
     }
 

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorDataGenerationTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorDataGenerationTest.java
@@ -69,19 +69,24 @@ public class HierarchicalDataCommunicatorDataGenerationTest
     }
 
     @Test
-    @SuppressWarnings("unchecked")
-    public void changeViewportRangeBackAndForth_destroyDataCalledForNoLongerVisibleItems() {
+    public void changeViewportRangeBackAndForth_destroyDataCalledForNoLongerVisibleItemsAfterConfirmation() {
         populateTreeData(treeData, 100, 2);
         dataCommunicator.expand(new Item("Item 0"));
+
         dataCommunicator.setViewportRange(0, 4);
         fakeClientCommunication();
-
+        dataCommunicator.confirmUpdate(captureArrayUpdateId());
         Mockito.verify(dataGenerator, Mockito.never())
                 .destroyData(Mockito.any());
 
+        Mockito.clearInvocations(dataGenerator, arrayUpdater, arrayUpdate);
+
         dataCommunicator.setViewportRange(2, 4);
         fakeClientCommunication();
+        Mockito.verify(dataGenerator, Mockito.never())
+                .destroyData(Mockito.any()); // not confirmed yet
 
+        dataCommunicator.confirmUpdate(captureArrayUpdateId());
         Mockito.verify(dataGenerator) //
                 .destroyData(new Item("Item 0"));
         Mockito.verify(dataGenerator) //
@@ -91,11 +96,14 @@ public class HierarchicalDataCommunicatorDataGenerationTest
         Mockito.verify(dataGenerator, Mockito.never())
                 .destroyData(new Item("Item 1"));
 
-        Mockito.clearInvocations(dataGenerator);
+        Mockito.clearInvocations(dataGenerator, arrayUpdater, arrayUpdate);
 
         dataCommunicator.setViewportRange(0, 4);
         fakeClientCommunication();
+        Mockito.verify(dataGenerator, Mockito.never())
+                .destroyData(Mockito.any()); // not confirmed yet
 
+        dataCommunicator.confirmUpdate(captureArrayUpdateId());
         Mockito.verify(dataGenerator, Mockito.never())
                 .destroyData(new Item("Item 0"));
         Mockito.verify(dataGenerator, Mockito.never())

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorKeyGenerationTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorKeyGenerationTest.java
@@ -89,21 +89,27 @@ public class HierarchicalDataCommunicatorKeyGenerationTest
     }
 
     @Test
-    public void changeViewportRangeBackAndForth_noLongerVisibleKeysRemoved() {
+    public void changeViewportRangeBackAndForth_noLongerVisibleKeysRemovedAfterConfirmation() {
         populateTreeData(treeData, 100, 2);
         dataCommunicator.expand(new Item("Item 0"));
+
         dataCommunicator.setViewportRange(0, 4);
         fakeClientCommunication();
-
+        dataCommunicator.confirmUpdate(captureArrayUpdateId());
         Assert.assertTrue(keyMapper.has(new Item("Item 0")));
         Assert.assertTrue(keyMapper.has(new Item("Item 0-0")));
         Assert.assertTrue(keyMapper.has(new Item("Item 0-1")));
         Assert.assertTrue(keyMapper.has(new Item("Item 1")));
         Assert.assertFalse(keyMapper.has(new Item("Item 2")));
 
-        dataCommunicator.setViewportRange(2, 4);
-        fakeClientCommunication();
+        Mockito.clearInvocations(arrayUpdater, arrayUpdate);
 
+        dataCommunicator.setViewportRange(2, 4);
+        fakeClientCommunication(); // not confirmed yet
+        Assert.assertTrue(keyMapper.has(new Item("Item 0")));
+        Assert.assertTrue(keyMapper.has(new Item("Item 0-0")));
+
+        dataCommunicator.confirmUpdate(captureArrayUpdateId()); // confirmed
         Assert.assertFalse(keyMapper.has(new Item("Item 0")));
         Assert.assertFalse(keyMapper.has(new Item("Item 0-0")));
         Assert.assertTrue(keyMapper.has(new Item("Item 0-1")));
@@ -111,9 +117,14 @@ public class HierarchicalDataCommunicatorKeyGenerationTest
         Assert.assertTrue(keyMapper.has(new Item("Item 2")));
         Assert.assertTrue(keyMapper.has(new Item("Item 3")));
 
-        dataCommunicator.setViewportRange(0, 4);
-        fakeClientCommunication();
+        Mockito.clearInvocations(arrayUpdater, arrayUpdate);
 
+        dataCommunicator.setViewportRange(0, 4);
+        fakeClientCommunication(); // not confirmed yet
+        Assert.assertTrue(keyMapper.has(new Item("Item 2")));
+        Assert.assertTrue(keyMapper.has(new Item("Item 3")));
+
+        dataCommunicator.confirmUpdate(captureArrayUpdateId()); // confirmed
         Assert.assertTrue(keyMapper.has(new Item("Item 0")));
         Assert.assertTrue(keyMapper.has(new Item("Item 0-0")));
         Assert.assertTrue(keyMapper.has(new Item("Item 0-1")));


### PR DESCRIPTION
## Description

This PR updates HierarchicalDataCommunicator to clean up no longer visible items, their client keys and generated data in `confirmUpdate` instead of `flush`.  Removing client keys from `keyMapper` in `flush` is too early, since there may be new pending client requests (for example, item selection) that were made while the current request was in progress and they might still rely on those keys.

Fixes https://github.com/vaadin/flow-components/issues/8040

## Type of change

- [x] Bugfix
