### PR TITLE
fix: ensure to add feature-flags import at the start of bundle

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrap.java
@@ -74,7 +74,6 @@ public class TaskGenerateBootstrap extends AbstractTaskClientGenerator {
     @Override
     protected String getFileContent() {
         List<String> lines = new ArrayList<>();
-        lines.add(String.format("import './%s';%n", FEATURE_FLAGS_FILE_NAME));
         lines.add(String.format("import '%s';%n", getIndexTsEntryPath()));
         if (options.isReactEnabled()) {
             lines.add("import './vaadin-react.js';");
@@ -87,6 +86,8 @@ public class TaskGenerateBootstrap extends AbstractTaskClientGenerator {
         for (TypeScriptBootstrapModifier modifier : modifiers) {
             modifier.modify(lines, options, frontDeps);
         }
+        lines.add(0,
+                String.format("import './%s';%n", FEATURE_FLAGS_FILE_NAME));
         return String.join(System.lineSeparator(), lines);
     }
 


### PR DESCRIPTION
## Description

The feature flags import in dev mode with the hot reload disabled ends up after the custom elements definition. This is problematic for cases, like the `layoutComponentsImprovements`, where the feature flag value is checked at the definition time to decide whether some CSS styles should be added or not.

This change moves the appending of the feature flags import to the end of the method, and adds it at the start of the file.

Fixes vaadin/web-components#9571

## Type of change

- Bugfix
