### PR TITLE
Remove confusing HTML mentions in Javadocs for PageTitle

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/PageTitle.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/PageTitle.java
@@ -22,7 +22,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Defines the HTML page title for a navigation target.
+ * Defines the page title for a navigation target.
  *
  * @since 1.0
  */
@@ -31,7 +31,7 @@ import java.lang.annotation.Target;
 public @interface PageTitle {
 
     /**
-     * Gets the HTML title that should be used.
+     * Gets the title that should be used.
      * <p>
      * Empty string will clear any previous page title. In that case the browser
      * will decide what to show as the title, most likely the url.


### PR DESCRIPTION
"HTML page title" can give the impression that the string is interpreted as HTML and would thus need to be escaped to avoid XSS. This is not the case – the string is in fact used as plain text.