### PR TITLE
test: restore correct behavior for standalone SpringPathAccessChecker tests

### DIFF
--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-standalone-routepathaccesschecker/src/main/java/com/vaadin/flow/spring/flowsecurity/SecurityConfig.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-standalone-routepathaccesschecker/src/main/java/com/vaadin/flow/spring/flowsecurity/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.vaadin.flow.spring.flowsecurity;
 
 import jakarta.servlet.ServletContext;
+
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,10 +16,13 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.DefaultSecurityFilterChain;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.logout.SimpleUrlLogoutSuccessHandler;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.internal.UrlUtil;
+import com.vaadin.flow.server.HandlerHelper;
 import com.vaadin.flow.spring.RootMappedCondition;
 import com.vaadin.flow.spring.VaadinConfigurationProperties;
 import com.vaadin.flow.spring.flowsecurity.data.UserInfo;
@@ -27,10 +31,10 @@ import com.vaadin.flow.spring.flowsecurity.views.LoginView;
 import com.vaadin.flow.spring.security.AuthenticationContext;
 import com.vaadin.flow.spring.security.NavigationAccessControlConfigurer;
 import com.vaadin.flow.spring.security.RequestUtil;
+import com.vaadin.flow.spring.security.UidlRedirectStrategy;
 
 import static com.vaadin.flow.spring.flowsecurity.service.UserInfoService.ROLE_ADMIN;
 import static com.vaadin.flow.spring.security.RequestUtil.antMatchers;
-import static com.vaadin.flow.spring.security.VaadinSecurityConfigurer.vaadin;
 
 @EnableWebSecurity
 @Configuration
@@ -58,7 +62,7 @@ public class SecurityConfig {
     @Bean
     static NavigationAccessControlConfigurer navigationAccessControlConfigurer() {
         return new NavigationAccessControlConfigurer()
-                .withRoutePathAccessChecker();
+                .withLoginView(LoginView.class).withRoutePathAccessChecker();
     }
 
     @Bean
@@ -75,6 +79,16 @@ public class SecurityConfig {
                 // Permit access to static resources
                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations())
                     .permitAll()
+                        // Permit access to vaadin's internal communication
+                        .requestMatchers(request -> HandlerHelper
+                                .isFrameworkInternalRequest("/*", request))
+                        .permitAll()
+                        .requestMatchers(requestUtil::isAnonymousRoute)
+                        .permitAll()
+                        // Permit technical access to vaadin's static files
+                        .requestMatchers("/VAADIN/**").permitAll()
+                        // custom request matchers. using 'routeAwareAntMatcher' to
+                        // allow checking route and alias paths against patterns
                 .requestMatchers(antMatchers("/admin-only/**", "/admin"))
                     .hasAnyRole(ROLE_ADMIN)
                 .requestMatchers(antMatchers("/private"))
@@ -89,23 +103,32 @@ public class SecurityConfig {
                     .hasAnyRole(ROLE_ADMIN)
                 .requestMatchers(antMatchers("/home", "/hey/**"))
                     .permitAll()
-                .requestMatchers(antMatchers("/all-logged-in/**"))
+                .requestMatchers(antMatchers("/all-logged-in/**", "/passthrough/**"))
                     .authenticated()
                 );
         // @formatter:on
-        http.with(vaadin(),
-                cfg -> cfg.loginView(LoginView.class, getLogoutSuccessUrl())
-                        .addLogoutHandler(
-                                (request, response, authentication) -> {
-                                    UI ui = UI.getCurrent();
-                                    ui.accessSynchronously(() -> ui.getPage()
-                                            .setLocation(UrlUtil
-                                                    .getServletPathRelative(
-                                                            getLogoutSuccessUrl(),
-                                                            request)));
-                                }));
+        http.logout(cfg -> {
+            SimpleUrlLogoutSuccessHandler logoutSuccessHandler = new SimpleUrlLogoutSuccessHandler();
+            logoutSuccessHandler.setDefaultTargetUrl(getLogoutSuccessUrl());
+            logoutSuccessHandler
+                    .setRedirectStrategy(new UidlRedirectStrategy());
+            cfg.logoutSuccessHandler(logoutSuccessHandler);
+            cfg.addLogoutHandler((request, response, authentication) -> {
+                UI ui = UI.getCurrent();
+                ui.accessSynchronously(() -> ui.getPage().setLocation(
+                        UrlUtil.getServletPathRelative(getLogoutSuccessUrl(),
+                                request)));
+            });
+        });
+        // Custom login page with form authentication
+        http.formLogin(cfg -> cfg.loginPage("/my/login/page").permitAll());
+        DefaultSecurityFilterChain filterChain = http.build();
+        // Test application uses AuthenticationContext, configure it with
+        // the logout handlers
+        AuthenticationContext.applySecurityConfiguration(http,
+                authenticationContext);
 
-        return http.build();
+        return filterChain;
     }
 
     public String getLogoutSuccessUrl() {


### PR DESCRIPTION
The test module for standalone SpringPathAccessChecker was updated by mistake to use VaadinSecurityConfigurer instead of the manual security configuration. The aim of the test module is to ensure that the path access checker works seamlessly with completely custom Spring Security configuration.

This change restores the original security configuration, with the required adjustments.