### PR TITLE
fix: instead of throwing, warn if legace frontend folder is used

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -85,7 +85,7 @@ public class FrontendUtils {
     /**
      * Default folder for the node related content. It's the base directory for
      * {@link Constants#PACKAGE_JSON} and {@link FrontendUtils#NODE_MODULES}.
-     *
+     * <p>
      * By default it's the project root folder.
      */
     public static final String DEFAULT_NODE_DIR = "./";
@@ -111,7 +111,7 @@ public class FrontendUtils {
     /**
      * Path of the folder containing application frontend source files, it needs
      * to be relative to the {@link FrontendUtils#DEFAULT_NODE_DIR}
-     *
+     * <p>
      * By default it is <code>/src/main/frontend</code> in the project folder.
      */
     public static final String DEFAULT_FRONTEND_DIR = DEFAULT_NODE_DIR
@@ -120,7 +120,7 @@ public class FrontendUtils {
     /**
      * Path of the old folder containing application frontend source files, it
      * needs to be relative to the {@link FrontendUtils#DEFAULT_NODE_DIR}
-     *
+     * <p>
      * By default the old folder is <code>/frontend</code> in the project
      * folder.
      */
@@ -260,7 +260,7 @@ public class FrontendUtils {
     /**
      * A parameter for overriding the {@link FrontendUtils#DEFAULT_FRONTEND_DIR}
      * folder.
-     *
+     * <p>
      * NOTE: For internal use only.
      */
     public static final String PARAM_FRONTEND_DIR = "vaadin.frontend.folder";
@@ -484,7 +484,6 @@ public class FrontendUtils {
      *         found.
      * @throws IOException
      *             on error when reading file
-     *
      */
     public static String getIndexHtmlContent(VaadinService service)
             throws IOException {
@@ -507,7 +506,6 @@ public class FrontendUtils {
      *         not found.
      * @throws IOException
      *             on error when reading file
-     *
      */
     public static String getWebComponentHtmlContent(VaadinService service)
             throws IOException {
@@ -644,12 +642,14 @@ public class FrontendUtils {
      */
     public static File getFrontendFolder(File projectRoot, File frontendDir) {
         File legacyDir = new File(projectRoot, LEGACY_FRONTEND_DIR);
+        boolean frontendDirExists = new File(projectRoot, DEFAULT_FRONTEND_DIR)
+                .exists();
 
         if (legacyDir.exists()) {
             boolean configParamPointsToLegacyDir = legacyDir.toPath().toString()
                     .replace("./", "").equals(frontendDir.toPath().toString());
             if (configParamPointsToLegacyDir) {
-                if (new File(projectRoot, DEFAULT_FRONTEND_DIR).exists()) {
+                if (frontendDirExists) {
                     getLogger().warn(
                             "This project has both default ({}) frontend directory"
                                     + " and legacy ({})- frontend directory present, and "
@@ -659,14 +659,13 @@ public class FrontendUtils {
                 }
                 return frontendDir;
             } else {
-                throw new RuntimeException(
-                        "This project has a legacy fronted directory ("
-                                + LEGACY_FRONTEND_DIR
-                                + ") frontend directory present, but no 'frontendDirectory' "
-                                + "configuration parameter set. "
-                                + "Please set the parameter or move the legacy directory contents "
-                                + "to the default frontend folder ("
-                                + DEFAULT_FRONTEND_DIR + ").");
+                getLogger().warn(
+                        "This project has a legacy fronted directory ({}) "
+                                + "present and it will be used as a fallback. "
+                                + "It is recommended to move its contents to "
+                                + "the default frontend directory ({}).",
+                        LEGACY_FRONTEND_DIR, DEFAULT_FRONTEND_DIR);
+                return legacyDir;
             }
         }
 
@@ -754,7 +753,6 @@ public class FrontendUtils {
      *
      * @param configuration
      *            the current deployment configuration
-     *
      * @return {@link #DEFAULT_FRONTEND_DIR} or value of
      *         {@link #PARAM_FRONTEND_DIR} if it is set.
      */
@@ -955,14 +953,14 @@ public class FrontendUtils {
 
     /**
      * Reads input and error stream from the give process asynchronously.
-     *
+     * <p>
      * The method returns a {@link CompletableFuture} that is completed when
      * both the streams are consumed.
-     *
+     * <p>
      * Streams are converted into strings and wrapped into a {@link Pair},
      * mapping input stream into {@link Pair#getFirst()} and error stream into
      * {@link Pair#getSecond()}.
-     *
+     * <p>
      * This method should be mainly used to avoid that {@link Process#waitFor()}
      * hangs indefinitely on some operating systems because process streams are
      * not consumed. See https://github.com/vaadin/flow/issues/15339 for an

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -644,7 +644,7 @@ public class FrontendUtils {
         File legacyDir = new File(projectRoot, LEGACY_FRONTEND_DIR);
 
         if (legacyDir.exists()) {
-            getLogger().warn("This project has a legacy fronted directory ({}) "
+            getLogger().warn("This project has a legacy frontend directory ({}) "
                     + "present and it will be used as a fallback."
                     + "\n\nSupport for the legacy directory will be removed "
                     + "in a future release. Please move its contents to "

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -642,31 +642,17 @@ public class FrontendUtils {
      */
     public static File getFrontendFolder(File projectRoot, File frontendDir) {
         File legacyDir = new File(projectRoot, LEGACY_FRONTEND_DIR);
-        boolean frontendDirExists = new File(projectRoot, DEFAULT_FRONTEND_DIR)
-                .exists();
 
         if (legacyDir.exists()) {
-            boolean configParamPointsToLegacyDir = legacyDir.toPath().toString()
-                    .replace("./", "").equals(frontendDir.toPath().toString());
-            if (configParamPointsToLegacyDir) {
-                if (frontendDirExists) {
-                    getLogger().warn(
-                            "This project has both default ({}) frontend directory"
-                                    + " and legacy ({})- frontend directory present, and "
-                                    + "'frontendDirectory' parameter points to the legacy directory."
-                                    + "\n\nDefault frontend directory will be ignored.",
-                            DEFAULT_FRONTEND_DIR, LEGACY_FRONTEND_DIR);
-                }
-                return frontendDir;
-            } else {
-                getLogger().warn(
-                        "This project has a legacy fronted directory ({}) "
-                                + "present and it will be used as a fallback. "
-                                + "It is recommended to move its contents to "
-                                + "the default frontend directory ({}).",
-                        LEGACY_FRONTEND_DIR, DEFAULT_FRONTEND_DIR);
-                return legacyDir;
-            }
+            getLogger().warn("This project has a legacy fronted directory ({}) "
+                    + "present and it will be used as a fallback."
+                    + "\n\nSupport for the legacy directory will be removed "
+                    + "in a future release. Please move its contents to "
+                    + "the default frontend directory ({}), or delete it "
+                    + "if its contents are not needed in the project. "
+                    + "Also remove 'frontendDirectory' parameter if present.",
+                    LEGACY_FRONTEND_DIR, DEFAULT_FRONTEND_DIR);
+            return legacyDir;
         }
 
         // Legacy dir does not exist. Use default or custom-set dir.

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -644,13 +644,15 @@ public class FrontendUtils {
         File legacyDir = new File(projectRoot, LEGACY_FRONTEND_DIR);
 
         if (legacyDir.exists()) {
-            getLogger().warn("This project has a legacy frontend directory ({}) "
-                    + "present and it will be used as a fallback."
-                    + "\n\nSupport for the legacy directory will be removed "
-                    + "in a future release. Please move its contents to "
-                    + "the default frontend directory ({}), or delete it "
-                    + "if its contents are not needed in the project. "
-                    + "Also remove 'frontendDirectory' parameter if present.",
+            getLogger().warn(
+                    "This project has a legacy frontend directory ({}) "
+                            + "present and it will be used as a fallback."
+                            + "\n\nSupport for the legacy directory will be removed "
+                            + "in a future release. Please move its contents to "
+                            + "the default frontend directory ({}), or delete it "
+                            + "if its contents are not needed in the project. "
+                            + "Also remove 'frontendDirectory' parameter that "
+                            + "points to the legacy directory, if present.",
                     LEGACY_FRONTEND_DIR, DEFAULT_FRONTEND_DIR);
             return legacyDir;
         }

--- a/flow-server/src/test/java/com/vaadin/flow/server/DefaultDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DefaultDeploymentConfigurationTest.java
@@ -296,6 +296,36 @@ public class DefaultDeploymentConfigurationTest {
                 config.isProductionMode());
     }
 
+    @Test
+    public void frontendHotDeploy_hillaInLegacyFrontendFolderExists_usesLegacyAndHotdeploy()
+            throws IOException {
+        File projectRoot = tempFolder.getRoot();
+        File legacyFrontend = tempFolder
+                .newFolder(FrontendUtils.LEGACY_FRONTEND_DIR);
+
+        File legacyFrontendViews = new File(legacyFrontend,
+                FrontendUtils.HILLA_VIEWS_PATH);
+        if (!legacyFrontendViews.mkdir()) {
+            Assert.fail("Failed to generate legacy frontend views folder");
+        }
+
+        File viewFile = new File(legacyFrontendViews, "MyView.tsx");
+        org.apache.commons.io.FileUtils.writeStringToFile(viewFile,
+                "export default function MyView(){}", "UTF-8");
+
+        try (MockedStatic<EndpointRequestUtil> util = Mockito
+                .mockStatic(EndpointRequestUtil.class)) {
+            util.when(EndpointRequestUtil::isHillaAvailable).thenReturn(true);
+            Properties init = new Properties();
+            init.put(FrontendUtils.PROJECT_BASEDIR,
+                    projectRoot.getAbsolutePath());
+            DefaultDeploymentConfiguration config = createDeploymentConfig(
+                    init);
+            Assert.assertEquals("Should use the legacy frontend folder",
+                    Mode.DEVELOPMENT_FRONTEND_LIVERELOAD, config.getMode());
+        }
+    }
+
     private DefaultDeploymentConfiguration createDeploymentConfig(
             Properties initParameters) {
         ApplicationConfiguration appConfig = setupAppConfig();

--- a/flow-server/src/test/java/com/vaadin/flow/server/DefaultDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DefaultDeploymentConfigurationTest.java
@@ -297,7 +297,7 @@ public class DefaultDeploymentConfigurationTest {
     }
 
     @Test
-    public void frontendHotDeploy_hillaInLegacyFrontendFolderExists_usesLegacyAndHotdeploy()
+    public void hillaViewInLegacyFrontendFolderExists_shouldUseLegacyFolderAndHotdeploy()
             throws IOException {
         File projectRoot = tempFolder.getRoot();
         File legacyFrontend = tempFolder


### PR DESCRIPTION
If a legacy frontend folder is found,
log a warning instead of throwing.

Related to https://github.com/vaadin/flow/issues/22126
