### PR TITLE
refactor: Replace type info system with universal @v format

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/flow/util/ClientJsonCodec.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/util/ClientJsonCodec.java
@@ -248,8 +248,8 @@ public class ClientJsonCodec {
         function resolveValue(value) {
             if (value && typeof value === 'object') {
                 // Check if it's a Vaadin type reference
-                if (value.__vaadinType !== undefined) {
-                    switch (value.__vaadinType) {
+                if (value['@vaadin'] !== undefined) {
+                    switch (value['@vaadin']) {
                         case 'component':
                             if (value.nodeId === null || value.nodeId === undefined) {
                                 return null;

--- a/flow-client/src/test-gwt/java/com/vaadin/client/GwtExecuteJavaScriptElementUtilsTest.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/GwtExecuteJavaScriptElementUtilsTest.java
@@ -32,6 +32,7 @@ import elemental.client.Browser;
 import elemental.dom.Element;
 import elemental.json.Json;
 import elemental.json.JsonArray;
+import elemental.json.JsonObject;
 
 public class GwtExecuteJavaScriptElementUtilsTest extends ClientEngineTestBase {
 
@@ -302,10 +303,10 @@ public class GwtExecuteJavaScriptElementUtilsTest extends ClientEngineTestBase {
                     }
                 });
 
-        JsonArray serializedChannel = Json.createArray();
-        serializedChannel.set(0, JsonCodec.RETURN_CHANNEL_TYPE);
-        serializedChannel.set(1, expectedNodeId);
-        serializedChannel.set(2, expectedChannelId);
+        JsonObject serializedChannel = Json.createObject();
+        serializedChannel.put("@v", "return");
+        serializedChannel.put("nodeId", expectedNodeId);
+        serializedChannel.put("channelId", expectedChannelId);
 
         JsonArray invocation = Json.createArray();
         // Assign channel as $0

--- a/flow-client/src/test/java/com/vaadin/client/flow/ExecuteJavaScriptProcessorTest.java
+++ b/flow-client/src/test/java/com/vaadin/client/flow/ExecuteJavaScriptProcessorTest.java
@@ -153,8 +153,8 @@ public class ExecuteJavaScriptProcessorTest {
         node.setDomNode(element);
 
         JsonObject json = Json.createObject();
-        json.put("@vaadin", "component");
-        json.put("nodeId", node.getId());
+        json.put("@v", "node");
+        json.put("id", node.getId());
 
         JsonArray invocation = Stream.of(json, Json.create("$0"))
                 .collect(JsonUtils.asArray());
@@ -189,8 +189,8 @@ public class ExecuteJavaScriptProcessorTest {
         registry.getStateTree().registerNode(node);
 
         JsonObject json = Json.createObject();
-        json.put("@vaadin", "component");
-        json.put("nodeId", node.getId());
+        json.put("@v", "node");
+        json.put("id", node.getId());
 
         JsonArray invocation = Stream.of(json, Json.create("$0"))
                 .collect(JsonUtils.asArray());
@@ -230,8 +230,8 @@ public class ExecuteJavaScriptProcessorTest {
         registry.getStateTree().registerNode(node);
 
         JsonObject json = Json.createObject();
-        json.put("@vaadin", "component");
-        json.put("nodeId", node.getId());
+        json.put("@v", "node");
+        json.put("id", node.getId());
 
         JsonArray invocation = Stream.of(json, Json.create("$0"))
                 .collect(JsonUtils.asArray());
@@ -270,8 +270,8 @@ public class ExecuteJavaScriptProcessorTest {
         registry.getStateTree().registerNode(node);
 
         JsonObject json = Json.createObject();
-        json.put("@vaadin", "component");
-        json.put("nodeId", node.getId());
+        json.put("@v", "node");
+        json.put("id", node.getId());
 
         JsonArray invocation = Stream.of(json, Json.create("$0"))
                 .collect(JsonUtils.asArray());

--- a/flow-client/src/test/java/com/vaadin/client/flow/ExecuteJavaScriptProcessorTest.java
+++ b/flow-client/src/test/java/com/vaadin/client/flow/ExecuteJavaScriptProcessorTest.java
@@ -27,7 +27,6 @@ import com.vaadin.client.Registry;
 import com.vaadin.client.flow.collection.JsArray;
 import com.vaadin.client.flow.collection.JsMap;
 import com.vaadin.client.flow.reactive.Reactive;
-import com.vaadin.flow.internal.JsonCodec;
 import com.vaadin.flow.internal.JsonUtils;
 import com.vaadin.flow.internal.nodefeature.NodeFeatures;
 import com.vaadin.flow.internal.nodefeature.NodeProperties;
@@ -153,8 +152,9 @@ public class ExecuteJavaScriptProcessorTest {
         };
         node.setDomNode(element);
 
-        JsonArray json = JsonUtils.createArray(Json.create(JsonCodec.NODE_TYPE),
-                Json.create(node.getId()));
+        JsonObject json = Json.createObject();
+        json.put("@vaadin", "component");
+        json.put("nodeId", node.getId());
 
         JsonArray invocation = Stream.of(json, Json.create("$0"))
                 .collect(JsonUtils.asArray());
@@ -188,8 +188,9 @@ public class ExecuteJavaScriptProcessorTest {
 
         registry.getStateTree().registerNode(node);
 
-        JsonArray json = JsonUtils.createArray(Json.create(JsonCodec.NODE_TYPE),
-                Json.create(node.getId()));
+        JsonObject json = Json.createObject();
+        json.put("@vaadin", "component");
+        json.put("nodeId", node.getId());
 
         JsonArray invocation = Stream.of(json, Json.create("$0"))
                 .collect(JsonUtils.asArray());
@@ -228,8 +229,9 @@ public class ExecuteJavaScriptProcessorTest {
 
         registry.getStateTree().registerNode(node);
 
-        JsonArray json = JsonUtils.createArray(Json.create(JsonCodec.NODE_TYPE),
-                Json.create(node.getId()));
+        JsonObject json = Json.createObject();
+        json.put("@vaadin", "component");
+        json.put("nodeId", node.getId());
 
         JsonArray invocation = Stream.of(json, Json.create("$0"))
                 .collect(JsonUtils.asArray());
@@ -267,8 +269,9 @@ public class ExecuteJavaScriptProcessorTest {
 
         registry.getStateTree().registerNode(node);
 
-        JsonArray json = JsonUtils.createArray(Json.create(JsonCodec.NODE_TYPE),
-                Json.create(node.getId()));
+        JsonObject json = Json.createObject();
+        json.put("@vaadin", "component");
+        json.put("nodeId", node.getId());
 
         JsonArray invocation = Stream.of(json, Json.create("$0"))
                 .collect(JsonUtils.asArray());

--- a/flow-client/src/test/java/com/vaadin/client/flow/util/ClientJsonCodecTest.java
+++ b/flow-client/src/test/java/com/vaadin/client/flow/util/ClientJsonCodecTest.java
@@ -172,7 +172,7 @@ public class ClientJsonCodecTest {
         beanJson.put("value", 42);
 
         elemental.json.JsonObject componentRef = Json.createObject();
-        componentRef.put("__vaadinType", "component");
+        componentRef.put("@vaadin", "component");
         componentRef.put("nodeId", componentNode.getId());
         beanJson.put("button", componentRef);
 
@@ -254,7 +254,7 @@ public class ClientJsonCodecTest {
         innerBean.put("text", "inner");
 
         elemental.json.JsonObject componentRef = Json.createObject();
-        componentRef.put("__vaadinType", "component");
+        componentRef.put("@vaadin", "component");
         componentRef.put("nodeId", componentNode.getId());
         innerBean.put("component", componentRef);
 
@@ -300,7 +300,7 @@ public class ClientJsonCodecTest {
         beanJson.put("name", "TestBean");
 
         elemental.json.JsonObject componentRef = Json.createObject();
-        componentRef.put("__vaadinType", "component");
+        componentRef.put("@vaadin", "component");
         componentRef.put("nodeId", Json.createNull());
         beanJson.put("unattached", componentRef);
 

--- a/flow-server/src/main/java/com/vaadin/flow/internal/JacksonCodec.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JacksonCodec.java
@@ -188,7 +188,7 @@ public class JacksonCodec {
             } else {
                 // Create component reference as JsonNode and write it
                 ObjectNode ref = JacksonUtils.createObjectNode();
-                ref.put("__vaadinType", "component");
+                ref.put("@vaadin", "component");
 
                 StateNode stateNode = component.getElement().getNode();
                 if (stateNode.isAttached()) {

--- a/flow-server/src/main/java/com/vaadin/flow/internal/JacksonCodec.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JacksonCodec.java
@@ -138,8 +138,12 @@ public class JacksonCodec {
     private static JsonNode encodeNode(Node<?> node) {
         StateNode stateNode = node.getNode();
         if (stateNode.isAttached()) {
-            return wrapComplexValue(NODE_TYPE,
-                    JacksonUtils.getMapper().valueToTree(stateNode.getId()));
+            // Use the same format as ComponentSerializer for consistency
+            ObjectNode ref = JacksonUtils.createObjectNode();
+            ref.put("@vaadin", "component");
+            ref.put("nodeId", stateNode.getId());
+            // Wrap as BEAN_TYPE so client knows to decode it specially
+            return wrapComplexValue(BEAN_TYPE, ref);
         } else {
             return JacksonUtils.getMapper().nullNode();
         }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/JacksonCodec.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JacksonCodec.java
@@ -178,8 +178,8 @@ public class JacksonCodec {
     /**
      * Custom Jackson serializer for Component instances.
      */
-    private static class ComponentSerializer
-            extends ValueSerializer<Component> {
+    private static class ComponentSerializer extends ValueSerializer<Component>
+            implements Serializable {
         @Override
         public void serialize(Component component, JsonGenerator gen,
                 SerializationContext ctxt) throws JacksonException {

--- a/flow-server/src/main/java/com/vaadin/flow/internal/JacksonCodec.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JacksonCodec.java
@@ -61,11 +61,6 @@ import com.vaadin.flow.internal.nodefeature.ReturnChannelRegistration;
  */
 public class JacksonCodec {
     /**
-     * Type id for a complex type array containing an {@link Element}.
-     */
-    public static final int NODE_TYPE = 0;
-
-    /**
      * Type id for a complex type array containing a {@link ArrayNode}.
      */
     public static final int ARRAY_TYPE = 1;
@@ -142,8 +137,9 @@ public class JacksonCodec {
             ObjectNode ref = JacksonUtils.createObjectNode();
             ref.put("@vaadin", "component");
             ref.put("nodeId", stateNode.getId());
-            // Wrap as BEAN_TYPE so client knows to decode it specially
-            return wrapComplexValue(BEAN_TYPE, ref);
+            // Return directly without array wrapper - the @vaadin key is
+            // sufficient identification
+            return ref;
         } else {
             return JacksonUtils.getMapper().nullNode();
         }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/JsonCodec.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JsonCodec.java
@@ -52,11 +52,6 @@ import elemental.json.JsonValue;
  */
 public class JsonCodec {
     /**
-     * Type id for a complex type array containing an {@link Element}.
-     */
-    public static final int NODE_TYPE = 0;
-
-    /**
      * Type id for a complex type array containing a {@link JsonArray}.
      */
     public static final int ARRAY_TYPE = 1;
@@ -121,8 +116,9 @@ public class JsonCodec {
             JsonObject ref = Json.createObject();
             ref.put("@vaadin", "component");
             ref.put("nodeId", stateNode.getId());
-            // Wrap as BEAN_TYPE so client knows to decode it specially
-            return wrapComplexValue(BEAN_TYPE, ref);
+            // Return directly without array wrapper - the @vaadin key is
+            // sufficient identification
+            return ref;
         } else {
             return Json.createNull();
         }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/JsonCodec.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JsonCodec.java
@@ -25,6 +25,7 @@ import com.vaadin.flow.internal.nodefeature.ReturnChannelRegistration;
 
 import elemental.json.Json;
 import elemental.json.JsonArray;
+import elemental.json.JsonObject;
 import elemental.json.JsonType;
 import elemental.json.JsonValue;
 
@@ -65,6 +66,11 @@ public class JsonCodec {
      * {@link ReturnChannelRegistration} reference.
      */
     public static final int RETURN_CHANNEL_TYPE = 2;
+
+    /**
+     * Type id for a complex type array containing a bean object.
+     */
+    public static final int BEAN_TYPE = 5;
 
     private JsonCodec() {
         // Don't create instances
@@ -111,7 +117,12 @@ public class JsonCodec {
     private static JsonValue encodeNode(Node<?> node) {
         StateNode stateNode = node.getNode();
         if (stateNode.isAttached()) {
-            return wrapComplexValue(NODE_TYPE, Json.create(stateNode.getId()));
+            // Use the same format as bean serialization for consistency
+            JsonObject ref = Json.createObject();
+            ref.put("@vaadin", "component");
+            ref.put("nodeId", stateNode.getId());
+            // Wrap as BEAN_TYPE so client knows to decode it specially
+            return wrapComplexValue(BEAN_TYPE, ref);
         } else {
             return Json.createNull();
         }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/BeanSerializationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/BeanSerializationTest.java
@@ -43,18 +43,15 @@ public class BeanSerializationTest {
 
         JsonNode encoded = JacksonCodec.encodeWithTypeInfo(record);
 
-        // Should be [5, {clean json with component ref}]
-        Assert.assertTrue(encoded.isArray());
-        Assert.assertEquals(5, encoded.get(0).asInt()); // BEAN_TYPE
+        // Should be clean JSON with @v node references
+        Assert.assertTrue(encoded.isObject());
+        Assert.assertEquals("Test", encoded.get("text").asText());
+        Assert.assertEquals(42, encoded.get("value").asInt());
 
-        JsonNode bean = encoded.get(1);
-        Assert.assertEquals("Test", bean.get("text").asText());
-        Assert.assertEquals(42, bean.get("value").asInt());
-
-        JsonNode buttonRef = bean.get("button");
-        Assert.assertEquals("component", buttonRef.get("@vaadin").asText());
+        JsonNode buttonRef = encoded.get("button");
+        Assert.assertEquals("node", buttonRef.get("@v").asText());
         Assert.assertEquals(button.getElement().getNode().getId(),
-                buttonRef.get("nodeId").asInt());
+                buttonRef.get("id").asInt());
     }
 
     @Test
@@ -70,13 +67,13 @@ public class BeanSerializationTest {
 
         JsonNode encoded = JacksonCodec.encodeWithTypeInfo(new BeanWithArray());
 
-        JsonNode bean = encoded.get(1);
-        JsonNode items = bean.get("items");
+        // Bean is now encoded directly
+        JsonNode items = encoded.get("items");
         Assert.assertTrue(items.isArray());
         Assert.assertEquals(3, items.size());
 
-        Assert.assertEquals("component", items.get(0).get("@vaadin").asText());
-        Assert.assertEquals("component", items.get(1).get("@vaadin").asText());
+        Assert.assertEquals("node", items.get(0).get("@v").asText());
+        Assert.assertEquals("node", items.get(1).get("@v").asText());
         Assert.assertTrue(items.get(2).isNull());
     }
 
@@ -98,13 +95,14 @@ public class BeanSerializationTest {
 
         JsonNode encoded = JacksonCodec.encodeWithTypeInfo(new OuterBean());
 
-        JsonNode bean = encoded.get(1);
+        // Bean is now encoded directly
+        JsonNode bean = encoded;
         Assert.assertEquals("outer", bean.get("id").asText());
 
         JsonNode nested = bean.get("nested");
         Assert.assertEquals("inner", nested.get("text").asText());
-        Assert.assertEquals("component",
-                nested.get("component").get("@vaadin").asText());
+        Assert.assertEquals("node",
+                nested.get("component").get("@v").asText());
     }
 
     @Test
@@ -119,7 +117,8 @@ public class BeanSerializationTest {
         }
 
         JsonNode encoded = JacksonCodec.encodeWithTypeInfo(new PrimitiveBean());
-        JsonNode bean = encoded.get(1);
+        // Bean is now encoded directly
+        JsonNode bean = encoded;
 
         // All primitives should be direct values, not wrapped
         Assert.assertTrue(bean.get("bool").isBoolean());
@@ -139,7 +138,8 @@ public class BeanSerializationTest {
         }
 
         JsonNode encoded = JacksonCodec.encodeWithTypeInfo(new BeanWithNulls());
-        JsonNode bean = encoded.get(1);
+        // Bean is now encoded directly
+        JsonNode bean = encoded;
 
         Assert.assertTrue(bean.get("text").isNull());
         Assert.assertTrue(bean.get("component").isNull());
@@ -163,27 +163,28 @@ public class BeanSerializationTest {
         }
 
         JsonNode encoded = JacksonCodec.encodeWithTypeInfo(new FormBean());
-        JsonNode bean = encoded.get(1);
+        // Bean is now encoded directly
+        JsonNode bean = encoded;
 
         Assert.assertEquals("TestForm", bean.get("formName").asText());
 
         JsonNode header = bean.get("header");
-        Assert.assertEquals("component", header.get("@vaadin").asText());
+        Assert.assertEquals("node", header.get("@v").asText());
         Assert.assertEquals(button1.getElement().getNode().getId(),
-                header.get("nodeId").asInt());
+                header.get("id").asInt());
 
         JsonNode footer = bean.get("footer");
-        Assert.assertEquals("component", footer.get("@vaadin").asText());
+        Assert.assertEquals("node", footer.get("@v").asText());
         Assert.assertEquals(button2.getElement().getNode().getId(),
-                footer.get("nodeId").asInt());
+                footer.get("id").asInt());
 
         JsonNode actions = bean.get("actions");
         Assert.assertTrue(actions.isArray());
         Assert.assertEquals(2, actions.size());
         Assert.assertEquals(button3.getElement().getNode().getId(),
-                actions.get(0).get("nodeId").asInt());
+                actions.get(0).get("id").asInt());
         Assert.assertEquals(button1.getElement().getNode().getId(),
-                actions.get(1).get("nodeId").asInt());
+                actions.get(1).get("id").asInt());
     }
 
     @Test
@@ -196,11 +197,12 @@ public class BeanSerializationTest {
 
         JsonNode encoded = JacksonCodec
                 .encodeWithTypeInfo(new BeanWithUnattached());
-        JsonNode bean = encoded.get(1);
+        // Bean is now encoded directly
+        JsonNode bean = encoded;
 
-        JsonNode componentRef = bean.get("unattached");
-        Assert.assertEquals("component", componentRef.get("@vaadin").asText());
-        Assert.assertTrue(componentRef.get("nodeId").isNull());
+        JsonNode nodeRef = bean.get("unattached");
+        Assert.assertEquals("node", nodeRef.get("@v").asText());
+        Assert.assertTrue(nodeRef.get("id").isNull());
     }
 
     @Test
@@ -229,7 +231,8 @@ public class BeanSerializationTest {
         }
 
         JsonNode encoded = JacksonCodec.encodeWithTypeInfo(new Level1());
-        JsonNode bean = encoded.get(1);
+        // Bean is now encoded directly
+        JsonNode bean = encoded;
 
         Assert.assertEquals("one", bean.get("level").asText());
 
@@ -238,8 +241,8 @@ public class BeanSerializationTest {
 
         JsonNode level3 = level2.get("nested");
         Assert.assertEquals("three", level3.get("level").asText());
-        Assert.assertEquals("component",
-                level3.get("button").get("@vaadin").asText());
+        Assert.assertEquals("node",
+                level3.get("button").get("@v").asText());
     }
 
     private Component getButton() {

--- a/flow-server/src/test/java/com/vaadin/flow/internal/BeanSerializationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/BeanSerializationTest.java
@@ -52,8 +52,7 @@ public class BeanSerializationTest {
         Assert.assertEquals(42, bean.get("value").asInt());
 
         JsonNode buttonRef = bean.get("button");
-        Assert.assertEquals("component",
-                buttonRef.get("@vaadin").asText());
+        Assert.assertEquals("component", buttonRef.get("@vaadin").asText());
         Assert.assertEquals(button.getElement().getNode().getId(),
                 buttonRef.get("nodeId").asInt());
     }
@@ -76,10 +75,8 @@ public class BeanSerializationTest {
         Assert.assertTrue(items.isArray());
         Assert.assertEquals(3, items.size());
 
-        Assert.assertEquals("component",
-                items.get(0).get("@vaadin").asText());
-        Assert.assertEquals("component",
-                items.get(1).get("@vaadin").asText());
+        Assert.assertEquals("component", items.get(0).get("@vaadin").asText());
+        Assert.assertEquals("component", items.get(1).get("@vaadin").asText());
         Assert.assertTrue(items.get(2).isNull());
     }
 
@@ -202,8 +199,7 @@ public class BeanSerializationTest {
         JsonNode bean = encoded.get(1);
 
         JsonNode componentRef = bean.get("unattached");
-        Assert.assertEquals("component",
-                componentRef.get("@vaadin").asText());
+        Assert.assertEquals("component", componentRef.get("@vaadin").asText());
         Assert.assertTrue(componentRef.get("nodeId").isNull());
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/internal/BeanSerializationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/BeanSerializationTest.java
@@ -53,7 +53,7 @@ public class BeanSerializationTest {
 
         JsonNode buttonRef = bean.get("button");
         Assert.assertEquals("component",
-                buttonRef.get("__vaadinType").asText());
+                buttonRef.get("@vaadin").asText());
         Assert.assertEquals(button.getElement().getNode().getId(),
                 buttonRef.get("nodeId").asInt());
     }
@@ -77,9 +77,9 @@ public class BeanSerializationTest {
         Assert.assertEquals(3, items.size());
 
         Assert.assertEquals("component",
-                items.get(0).get("__vaadinType").asText());
+                items.get(0).get("@vaadin").asText());
         Assert.assertEquals("component",
-                items.get(1).get("__vaadinType").asText());
+                items.get(1).get("@vaadin").asText());
         Assert.assertTrue(items.get(2).isNull());
     }
 
@@ -107,7 +107,7 @@ public class BeanSerializationTest {
         JsonNode nested = bean.get("nested");
         Assert.assertEquals("inner", nested.get("text").asText());
         Assert.assertEquals("component",
-                nested.get("component").get("__vaadinType").asText());
+                nested.get("component").get("@vaadin").asText());
     }
 
     @Test
@@ -171,12 +171,12 @@ public class BeanSerializationTest {
         Assert.assertEquals("TestForm", bean.get("formName").asText());
 
         JsonNode header = bean.get("header");
-        Assert.assertEquals("component", header.get("__vaadinType").asText());
+        Assert.assertEquals("component", header.get("@vaadin").asText());
         Assert.assertEquals(button1.getElement().getNode().getId(),
                 header.get("nodeId").asInt());
 
         JsonNode footer = bean.get("footer");
-        Assert.assertEquals("component", footer.get("__vaadinType").asText());
+        Assert.assertEquals("component", footer.get("@vaadin").asText());
         Assert.assertEquals(button2.getElement().getNode().getId(),
                 footer.get("nodeId").asInt());
 
@@ -203,7 +203,7 @@ public class BeanSerializationTest {
 
         JsonNode componentRef = bean.get("unattached");
         Assert.assertEquals("component",
-                componentRef.get("__vaadinType").asText());
+                componentRef.get("@vaadin").asText());
         Assert.assertTrue(componentRef.get("nodeId").isNull());
     }
 
@@ -243,7 +243,7 @@ public class BeanSerializationTest {
         JsonNode level3 = level2.get("nested");
         Assert.assertEquals("three", level3.get("level").asText());
         Assert.assertEquals("component",
-                level3.get("button").get("__vaadinType").asText());
+                level3.get("button").get("@vaadin").asText());
     }
 
     private Component getButton() {

--- a/flow-server/src/test/java/com/vaadin/flow/internal/BeanSerializationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/BeanSerializationTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.internal;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.UI;
+import tools.jackson.databind.JsonNode;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class BeanSerializationTest {
+
+    @Tag("test-button")
+    private static class TestButton extends Component {
+        public TestButton(String text) {
+            getElement().setText(text);
+        }
+    }
+
+    @Test
+    public void testSimpleRecord() {
+        UI ui = new UI();
+        TestButton button = new TestButton("Click");
+        ui.add(button);
+
+        record SimpleRecord(String text, int value, Component button) {
+        }
+        SimpleRecord record = new SimpleRecord("Test", 42, button);
+
+        JsonNode encoded = JacksonCodec.encodeWithTypeInfo(record);
+
+        // Should be [5, {clean json with component ref}]
+        Assert.assertTrue(encoded.isArray());
+        Assert.assertEquals(5, encoded.get(0).asInt()); // BEAN_TYPE
+
+        JsonNode bean = encoded.get(1);
+        Assert.assertEquals("Test", bean.get("text").asText());
+        Assert.assertEquals(42, bean.get("value").asInt());
+
+        JsonNode buttonRef = bean.get("button");
+        Assert.assertEquals("component",
+                buttonRef.get("__vaadinType").asText());
+        Assert.assertEquals(button.getElement().getNode().getId(),
+                buttonRef.get("nodeId").asInt());
+    }
+
+    @Test
+    public void testBeanWithComponentArray() {
+        UI ui = new UI();
+        Component[] components = new Component[] { new TestButton("Button1"),
+                new TestButton("Button2"), null };
+        ui.add(components[0], components[1]);
+
+        class BeanWithArray {
+            Component[] items = components;
+        }
+
+        JsonNode encoded = JacksonCodec.encodeWithTypeInfo(new BeanWithArray());
+
+        JsonNode bean = encoded.get(1);
+        JsonNode items = bean.get("items");
+        Assert.assertTrue(items.isArray());
+        Assert.assertEquals(3, items.size());
+
+        Assert.assertEquals("component",
+                items.get(0).get("__vaadinType").asText());
+        Assert.assertEquals("component",
+                items.get(1).get("__vaadinType").asText());
+        Assert.assertTrue(items.get(2).isNull());
+    }
+
+    @Test
+    public void testNestedBeans() {
+        UI ui = new UI();
+        TestButton button = new TestButton("Nested");
+        ui.add(button);
+
+        class InnerBean {
+            String text = "inner";
+            Component component = button;
+        }
+
+        class OuterBean {
+            String id = "outer";
+            InnerBean nested = new InnerBean();
+        }
+
+        JsonNode encoded = JacksonCodec.encodeWithTypeInfo(new OuterBean());
+
+        JsonNode bean = encoded.get(1);
+        Assert.assertEquals("outer", bean.get("id").asText());
+
+        JsonNode nested = bean.get("nested");
+        Assert.assertEquals("inner", nested.get("text").asText());
+        Assert.assertEquals("component",
+                nested.get("component").get("__vaadinType").asText());
+    }
+
+    @Test
+    public void testPrimitiveTypes() {
+        class PrimitiveBean {
+            boolean bool = true;
+            int integer = 123;
+            long longVal = 456L;
+            double doubleVal = 3.14;
+            float floatVal = 2.5f;
+            String string = "test";
+        }
+
+        JsonNode encoded = JacksonCodec.encodeWithTypeInfo(new PrimitiveBean());
+        JsonNode bean = encoded.get(1);
+
+        // All primitives should be direct values, not wrapped
+        Assert.assertTrue(bean.get("bool").isBoolean());
+        Assert.assertTrue(bean.get("integer").isNumber());
+        Assert.assertTrue(bean.get("longVal").isNumber());
+        Assert.assertTrue(bean.get("doubleVal").isNumber());
+        Assert.assertTrue(bean.get("floatVal").isNumber());
+        Assert.assertTrue(bean.get("string").isTextual());
+    }
+
+    @Test
+    public void testNullHandling() {
+        class BeanWithNulls {
+            String text = null;
+            Component component = null;
+            Component[] array = new Component[] { null, null };
+        }
+
+        JsonNode encoded = JacksonCodec.encodeWithTypeInfo(new BeanWithNulls());
+        JsonNode bean = encoded.get(1);
+
+        Assert.assertTrue(bean.get("text").isNull());
+        Assert.assertTrue(bean.get("component").isNull());
+        Assert.assertTrue(bean.get("array").isArray());
+        Assert.assertTrue(bean.get("array").get(0).isNull());
+    }
+
+    @Test
+    public void testBeanWithMultipleComponentReferences() {
+        UI ui = new UI();
+        TestButton button1 = new TestButton("Button1");
+        TestButton button2 = new TestButton("Button2");
+        TestButton button3 = new TestButton("Button3");
+        ui.add(button1, button2, button3);
+
+        class FormBean {
+            String formName = "TestForm";
+            Component header = button1;
+            Component footer = button2;
+            Component[] actions = new Component[] { button3, button1 };
+        }
+
+        JsonNode encoded = JacksonCodec.encodeWithTypeInfo(new FormBean());
+        JsonNode bean = encoded.get(1);
+
+        Assert.assertEquals("TestForm", bean.get("formName").asText());
+
+        JsonNode header = bean.get("header");
+        Assert.assertEquals("component", header.get("__vaadinType").asText());
+        Assert.assertEquals(button1.getElement().getNode().getId(),
+                header.get("nodeId").asInt());
+
+        JsonNode footer = bean.get("footer");
+        Assert.assertEquals("component", footer.get("__vaadinType").asText());
+        Assert.assertEquals(button2.getElement().getNode().getId(),
+                footer.get("nodeId").asInt());
+
+        JsonNode actions = bean.get("actions");
+        Assert.assertTrue(actions.isArray());
+        Assert.assertEquals(2, actions.size());
+        Assert.assertEquals(button3.getElement().getNode().getId(),
+                actions.get(0).get("nodeId").asInt());
+        Assert.assertEquals(button1.getElement().getNode().getId(),
+                actions.get(1).get("nodeId").asInt());
+    }
+
+    @Test
+    public void testUnattachedComponent() {
+        TestButton button = new TestButton("Unattached");
+
+        class BeanWithUnattached {
+            Component unattached = button;
+        }
+
+        JsonNode encoded = JacksonCodec
+                .encodeWithTypeInfo(new BeanWithUnattached());
+        JsonNode bean = encoded.get(1);
+
+        JsonNode componentRef = bean.get("unattached");
+        Assert.assertEquals("component",
+                componentRef.get("__vaadinType").asText());
+        Assert.assertTrue(componentRef.get("nodeId").isNull());
+    }
+
+    @Test
+    public void testDeeplyNestedBeans() {
+        UI ui = new UI();
+        TestButton button = new TestButton("Deep");
+        ui.add(button);
+
+        class Level3 {
+            String level = "three";
+            Component button = BeanSerializationTest.this.getButton();
+
+            private Component getButton() {
+                return button;
+            }
+        }
+
+        class Level2 {
+            String level = "two";
+            Level3 nested = new Level3();
+        }
+
+        class Level1 {
+            String level = "one";
+            Level2 nested = new Level2();
+        }
+
+        JsonNode encoded = JacksonCodec.encodeWithTypeInfo(new Level1());
+        JsonNode bean = encoded.get(1);
+
+        Assert.assertEquals("one", bean.get("level").asText());
+
+        JsonNode level2 = bean.get("nested");
+        Assert.assertEquals("two", level2.get("level").asText());
+
+        JsonNode level3 = level2.get("nested");
+        Assert.assertEquals("three", level3.get("level").asText());
+        Assert.assertEquals("component",
+                level3.get("button").get("__vaadinType").asText());
+    }
+
+    private Component getButton() {
+        return new TestButton("Helper");
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
@@ -107,13 +107,9 @@ public class JacksonCodecTest {
         assertJsonEquals(objectMapper.createObjectNode(), JacksonCodec
                 .encodeWithTypeInfo(objectMapper.createObjectNode()));
 
-        // Array is escaped
-        assertJsonEquals(
-                JacksonUtils.createArray(
-                        objectMapper.valueToTree(JacksonCodec.ARRAY_TYPE),
-                        objectMapper.createArrayNode()),
-                JacksonCodec
-                        .encodeWithTypeInfo(objectMapper.createArrayNode()));
+        // Arrays are now encoded directly without wrapping
+        assertJsonEquals(objectMapper.createArrayNode(),
+                JacksonCodec.encodeWithTypeInfo(objectMapper.createArrayNode()));
     }
 
     @Test
@@ -129,11 +125,11 @@ public class JacksonCodecTest {
 
         // Should be a direct object without array wrapper
         Assert.assertTrue("Should be an object", json.isObject());
-        Assert.assertEquals("Should have @vaadin=component", "component",
-                json.get("@vaadin").asText());
-        Assert.assertNotNull("Should have nodeId", json.get("nodeId"));
-        Assert.assertEquals("Should have nodeId matching element",
-                element.getNode().getId(), json.get("nodeId").intValue());
+        Assert.assertEquals("Should have @v=node", "node",
+                json.get("@v").asText());
+        Assert.assertNotNull("Should have id", json.get("id"));
+        Assert.assertEquals("Should have id matching element",
+                element.getNode().getId(), json.get("id").intValue());
     }
 
     @Test
@@ -154,18 +150,7 @@ public class JacksonCodecTest {
                 JsonNode result = JacksonCodec.encodeWithTypeInfo(value);
                 Assert.assertNotNull("Should encode " + value.getClass(),
                         result);
-                // Complex objects should be wrapped with BEAN_TYPE
-                if (!(value instanceof String[])
-                        && !(value instanceof ArrayList)
-                        && !(value instanceof HashSet)
-                        && !(value instanceof HashMap)) {
-                    Assert.assertTrue("Should be wrapped as BEAN_TYPE",
-                            result.isArray());
-                    if (result.isArray() && result.size() >= 1) {
-                        Assert.assertEquals("Should have BEAN_TYPE", 5,
-                                result.get(0).asInt());
-                    }
-                }
+                // Objects are now encoded directly using Jackson without wrapping
             } catch (Exception e) {
                 // Some objects might fail due to Java module access
                 // restrictions - this is expected
@@ -287,10 +272,10 @@ public class JacksonCodecTest {
 
         // Should be a direct object without array wrapper
         Assert.assertTrue("Should be an object", encoded.isObject());
-        Assert.assertEquals("Should have @vaadin=component", "component",
-                encoded.get("@vaadin").asText());
-        Assert.assertNotNull("Should have nodeId", encoded.get("nodeId"));
-        Assert.assertEquals("Should have nodeId matching element",
-                element.getNode().getId(), encoded.get("nodeId").intValue());
+        Assert.assertEquals("Should have @v=node", "node",
+                encoded.get("@v").asText());
+        Assert.assertNotNull("Should have id", encoded.get("id"));
+        Assert.assertEquals("Should have id matching element",
+                element.getNode().getId(), encoded.get("id").intValue());
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
@@ -274,4 +274,27 @@ public class JacksonCodecTest {
         Assert.assertNull(JacksonCodec.decodeAs(objectMapper.valueToTree("foo"),
                 float.class));
     }
+
+    @Test
+    public void encodeWithTypeInfo_singleComponent() {
+        UI ui = new UI();
+        Element element = ElementFactory.createDiv();
+        ui.getElement().appendChild(element);
+
+        JsonNode encoded = JacksonCodec.encodeWithTypeInfo(element);
+
+        // Should be wrapped as [BEAN_TYPE, componentRef]
+        Assert.assertTrue("Should be an array", encoded.isArray());
+        Assert.assertEquals("Should have 2 elements", 2, encoded.size());
+        Assert.assertEquals("First element should be BEAN_TYPE",
+                JacksonCodec.BEAN_TYPE, encoded.get(0).intValue());
+
+        // Check the component reference format
+        JsonNode componentRef = encoded.get(1);
+        Assert.assertTrue("Second element should be an object",
+                componentRef.isObject());
+        Assert.assertEquals("Should have @vaadin=component", "component",
+                componentRef.get("@vaadin").asText());
+        Assert.assertNotNull("Should have nodeId", componentRef.get("nodeId"));
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
@@ -127,11 +127,13 @@ public class JacksonCodecTest {
 
         JsonNode json = JacksonCodec.encodeWithTypeInfo(element);
 
-        assertJsonEquals(
-                JacksonUtils.createArray(
-                        objectMapper.valueToTree(JacksonCodec.NODE_TYPE),
-                        objectMapper.valueToTree(element.getNode().getId())),
-                json);
+        // Should be a direct object without array wrapper
+        Assert.assertTrue("Should be an object", json.isObject());
+        Assert.assertEquals("Should have @vaadin=component", "component",
+                json.get("@vaadin").asText());
+        Assert.assertNotNull("Should have nodeId", json.get("nodeId"));
+        Assert.assertEquals("Should have nodeId matching element",
+                element.getNode().getId(), json.get("nodeId").intValue());
     }
 
     @Test
@@ -283,18 +285,12 @@ public class JacksonCodecTest {
 
         JsonNode encoded = JacksonCodec.encodeWithTypeInfo(element);
 
-        // Should be wrapped as [BEAN_TYPE, componentRef]
-        Assert.assertTrue("Should be an array", encoded.isArray());
-        Assert.assertEquals("Should have 2 elements", 2, encoded.size());
-        Assert.assertEquals("First element should be BEAN_TYPE",
-                JacksonCodec.BEAN_TYPE, encoded.get(0).intValue());
-
-        // Check the component reference format
-        JsonNode componentRef = encoded.get(1);
-        Assert.assertTrue("Second element should be an object",
-                componentRef.isObject());
+        // Should be a direct object without array wrapper
+        Assert.assertTrue("Should be an object", encoded.isObject());
         Assert.assertEquals("Should have @vaadin=component", "component",
-                componentRef.get("@vaadin").asText());
-        Assert.assertNotNull("Should have nodeId", componentRef.get("nodeId"));
+                encoded.get("@vaadin").asText());
+        Assert.assertNotNull("Should have nodeId", encoded.get("nodeId"));
+        Assert.assertEquals("Should have nodeId matching element",
+                element.getNode().getId(), encoded.get("nodeId").intValue());
     }
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ExecJavaScriptIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ExecJavaScriptIT.java
@@ -61,6 +61,87 @@ public class ExecJavaScriptIT extends ChromeBrowserTest {
                 result.getText());
     }
 
+    @Test
+    public void testBeanSerializationSimpleTypes() {
+        open();
+
+        // Test simple bean with only primitive types
+        getButton("simpleBeanButton").click();
+
+        // Wait for the result div to appear
+        WebElement result = waitUntil(
+                d -> findElement(By.id("simpleBeanResult")));
+        Assert.assertEquals("name=TestBean, value=42, active=true",
+                result.getText());
+
+        // Verify status message
+        WebElement status = waitUntil(
+                d -> findElement(By.id("simpleBeanStatus")));
+        Assert.assertEquals("Simple bean sent and received", status.getText());
+    }
+
+    @Test
+    public void testBeanSerializationNestedBeans() {
+        open();
+
+        // Test nested beans
+        getButton("nestedBeanButton").click();
+
+        // Wait for the result div to appear
+        WebElement result = waitUntil(
+                d -> findElement(By.id("nestedBeanResult")));
+        Assert.assertEquals("title=Outer, simple.name=Inner, simple.value=100",
+                result.getText());
+
+        // Verify status message
+        WebElement status = waitUntil(
+                d -> findElement(By.id("nestedBeanStatus")));
+        Assert.assertEquals("Nested bean sent and received", status.getText());
+    }
+
+    @Test
+    public void testBeanSerializationWithComponents() {
+        open();
+
+        // Test bean with component references
+        getButton("componentBeanButton").click();
+
+        // Wait for the components to be added
+        waitUntil(d -> findElement(By.id("beanButton")));
+        waitUntil(d -> findElement(By.id("beanDiv")));
+
+        // Wait for the result div to appear
+        WebElement result = waitUntil(
+                d -> findElement(By.id("componentBeanResult")));
+        String text = result.getText();
+
+        // Verify the bean fields were received
+        Assert.assertTrue("Should contain label",
+                text.contains("label=Main bean"));
+
+        // Verify the button component was resolved correctly
+        Assert.assertTrue("Should contain button tag",
+                text.contains("button.tag=button"));
+        Assert.assertTrue("Should contain button text",
+                text.contains("button.text=Bean Button"));
+
+        // Verify the nested bean fields
+        Assert.assertTrue("Should contain nested description",
+                text.contains("nested.desc=Nested with component"));
+
+        // Verify the nested div component was resolved correctly
+        Assert.assertTrue("Should contain div tag",
+                text.contains("nested.div.tag=div"));
+        Assert.assertTrue("Should contain div text",
+                text.contains("nested.div.text=Bean Div"));
+
+        // Verify status message
+        WebElement status = waitUntil(
+                d -> findElement(By.id("componentBeanStatus")));
+        Assert.assertEquals("Component bean sent and received",
+                status.getText());
+    }
+
     private WebElement getButton(String id) {
         return findElement(By.id(id));
     }


### PR DESCRIPTION
Remove the complex array-based type wrapping system (NODE_TYPE, ARRAY_TYPE,
RETURN_CHANNEL_TYPE, BEAN_TYPE) in favor of a universal @v format that can
be used anywhere in the JSON tree.

Key changes:
- Components: {"@v": "node", "id": nodeId} (was [0, nodeId])
- Return channels: {"@v": "return", "nodeId": x, "channelId": y} (was [2, x, y])
- Arrays: Use standard JSON arrays without wrapping
- Beans: Use standard Jackson serialization with custom serializers

Benefits:
- Simplified architecture with single universal system
- Better performance using native JSON.parse with reviver
- More extensible format for future types
- Cleaner serialization logic without recursive type detection
