### PR TITLE
feat: Add bean serialization support

### DIFF
--- a/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/PolymerTemplateTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/PolymerTemplateTest.java
@@ -69,7 +69,7 @@ public class PolymerTemplateTest extends HasCurrentService {
     private DeploymentConfiguration configuration;
 
     private List<Object> executionOrder = new ArrayList<>();
-    private List<Serializable[]> executionParams = new ArrayList<>();
+    private List<Object[]> executionParams = new ArrayList<>();
 
     // Field to prevent current instance from being garbage collected
     private UI ui;
@@ -477,7 +477,7 @@ public class PolymerTemplateTest extends HasCurrentService {
 
                 @Override
                 public PendingJavaScriptResult executeJs(String expression,
-                        Serializable... parameters) {
+                        Object... parameters) {
                     executionOrder.add(expression);
                     executionParams.add(parameters);
                     return null;
@@ -963,7 +963,7 @@ public class PolymerTemplateTest extends HasCurrentService {
         Assert.assertEquals("this.populateModelProperties($0, $1)",
                 executionOrder.get(1));
 
-        Serializable[] params = executionParams.get(1);
+        Object[] params = executionParams.get(1);
         ArrayNode properties = (ArrayNode) params[1];
         Assert.assertEquals(1, properties.size());
         Assert.assertEquals("title", properties.get(0).asText());
@@ -982,7 +982,7 @@ public class PolymerTemplateTest extends HasCurrentService {
         Assert.assertEquals("this.registerUpdatableModelProperties($0, $1)",
                 executionOrder.get(0));
 
-        Serializable[] params = executionParams.get(0);
+        Object[] params = executionParams.get(0);
         ArrayNode properties = (ArrayNode) params[1];
         Assert.assertEquals(2, properties.size());
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -109,8 +109,8 @@ public class UIInternals implements Serializable {
     private static Set<String> bundledImports = BundleUtils.loadBundleImports();
 
     /**
-     * A {@link Page#executeJs(String, Object...)} invocation that has not
-     * yet been sent to the client.
+     * A {@link Page#executeJs(String, Object...)} invocation that has not yet
+     * been sent to the client.
      */
     public static class JavaScriptInvocation implements Serializable {
         private final String expression;
@@ -124,8 +124,7 @@ public class UIInternals implements Serializable {
          * @param parameters
          *            a list of parameters to use when invoking the script
          */
-        public JavaScriptInvocation(String expression,
-                Object... parameters) {
+        public JavaScriptInvocation(String expression, Object... parameters) {
             /*
              * To ensure attached elements are actually attached, the parameters
              * won't be serialized until the phase the UIDL message is created.

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -109,12 +109,12 @@ public class UIInternals implements Serializable {
     private static Set<String> bundledImports = BundleUtils.loadBundleImports();
 
     /**
-     * A {@link Page#executeJs(String, Serializable...)} invocation that has not
+     * A {@link Page#executeJs(String, Object...)} invocation that has not
      * yet been sent to the client.
      */
     public static class JavaScriptInvocation implements Serializable {
         private final String expression;
-        private final List<Serializable> parameters = new ArrayList<>();
+        private final List<Object> parameters = new ArrayList<>();
 
         /**
          * Creates a new invocation.
@@ -125,7 +125,7 @@ public class UIInternals implements Serializable {
          *            a list of parameters to use when invoking the script
          */
         public JavaScriptInvocation(String expression,
-                Serializable... parameters) {
+                Object... parameters) {
             /*
              * To ensure attached elements are actually attached, the parameters
              * won't be serialized until the phase the UIDL message is created.

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
@@ -27,7 +27,7 @@ import com.vaadin.flow.server.VaadinSession;
  * <p>
  * Please note that all information is fetched only once, and <em>not updated
  * automatically</em>. To retrieve updated values, you can execute JS with
- * {@link Page#executeJs(String, Serializable...)} and get the current value
+ * {@link Page#executeJs(String, Object...)} and get the current value
  * back.
  *
  * @author Vaadin Ltd

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
@@ -27,8 +27,7 @@ import com.vaadin.flow.server.VaadinSession;
  * <p>
  * Please note that all information is fetched only once, and <em>not updated
  * automatically</em>. To retrieve updated values, you can execute JS with
- * {@link Page#executeJs(String, Object...)} and get the current value
- * back.
+ * {@link Page#executeJs(String, Object...)} and get the current value back.
  *
  * @author Vaadin Ltd
  * @since 2.0

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -274,11 +274,12 @@ public class Page implements Serializable {
      * Jackson for JSON serialization are supported as parameters. Special
      * cases:
      * <ul>
-     * <li>{@link Element} - will be sent as <code>null</code> if the
-     * server-side element instance is not attached when the invocation is sent
-     * to the client
-     * <li>{@link tools.jackson.databind.node.BaseJsonNode} - sent as-is without
-     * additional wrapping
+     * <li>{@link Element} (will be sent as a DOM element reference to the
+     * browser if the server-side element instance is attached when the
+     * invocation is sent to the client, or as <code>null</code> if not
+     * attached)
+     * <li>{@link tools.jackson.databind.node.BaseJsonNode} (sent as-is without
+     * additional wrapping)
      * </ul>
      * Note that the parameter variables can only be used in contexts where a
      * JavaScript variable can be used. You should for instance do

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -281,6 +281,7 @@ public class Page implements Serializable {
      * <li>{@link Element} (will be sent as <code>null</code> if the server-side
      * element instance is not attached when the invocation is sent to the
      * client)
+     * <li>Any bean object (serialized using Jackson and available as a standard JavaScript object)
      * </ul>
      * Note that the parameter variables can only be used in contexts where a
      * JavaScript variable can be used. You should for instance do
@@ -296,7 +297,7 @@ public class Page implements Serializable {
      *         the expression
      */
     public PendingJavaScriptResult executeJs(String expression,
-            Serializable... parameters) {
+            Object... parameters) {
         JavaScriptInvocation invocation = new JavaScriptInvocation(expression,
                 parameters);
 
@@ -545,7 +546,7 @@ public class Page implements Serializable {
      * proxy between the client and the server.
      * <p>
      * In case you need more control over the execution you can use
-     * {@link #executeJs(String, Serializable...)} by passing
+     * {@link #executeJs(String, Object...)} by passing
      * {@code return window.location.href}.
      * <p>
      * <em>NOTE: </em> the URL is not escaped, use {@link URL#toURI()} to escape
@@ -578,7 +579,7 @@ public class Page implements Serializable {
      * request and passed to the callback.
      * <p>
      * In case you need more control over the execution you can use
-     * {@link #executeJs(String, Serializable...)} by passing
+     * {@link #executeJs(String, Object...)} by passing
      * {@code return document.dir}.
      *
      * @param callback

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -270,18 +270,13 @@ public class Page implements Serializable {
      * return value will be ignored.
      * <p>
      * The given parameters will be available to the expression as variables
-     * named <code>$0</code>, <code>$1</code>, and so on. Supported parameter
-     * types are:
+     * named <code>$0</code>, <code>$1</code>, and so on. All types supported
+     * by Jackson for JSON serialization are supported as parameters. Special
+     * cases:
      * <ul>
-     * <li>{@link String}
-     * <li>{@link Integer}
-     * <li>{@link Double}
-     * <li>{@link Boolean}
-     * <li>{@link tools.jackson.databind.node.BaseJsonNode}
-     * <li>{@link Element} (will be sent as <code>null</code> if the server-side
-     * element instance is not attached when the invocation is sent to the
-     * client)
-     * <li>Any bean object (serialized using Jackson and available as a standard JavaScript object)
+     * <li>{@link Element} - will be sent as <code>null</code> if the server-side
+     * element instance is not attached when the invocation is sent to the client
+     * <li>{@link tools.jackson.databind.node.BaseJsonNode} - sent as-is without additional wrapping
      * </ul>
      * Note that the parameter variables can only be used in contexts where a
      * JavaScript variable can be used. You should for instance do

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -310,6 +310,24 @@ public class Page implements Serializable {
     }
 
     /**
+     * Executes the given JavaScript expression in the browser.
+     *
+     * @deprecated Use {@link #executeJs(String, Object...)} instead. This method
+     *             exists only for binary compatibility.
+     * @param expression
+     *            the JavaScript expression to execute
+     * @param parameters
+     *            parameters to pass to the expression
+     * @return a pending result that can be used to get a value returned from
+     *         the expression
+     */
+    @Deprecated
+    public PendingJavaScriptResult executeJs(String expression,
+            Serializable[] parameters) {
+        return executeJs(expression, (Object[]) parameters);
+    }
+
+    /**
      * Gets a representation of <code>window.history</code> for this page.
      *
      * @return the history representation

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -270,13 +270,15 @@ public class Page implements Serializable {
      * return value will be ignored.
      * <p>
      * The given parameters will be available to the expression as variables
-     * named <code>$0</code>, <code>$1</code>, and so on. All types supported
-     * by Jackson for JSON serialization are supported as parameters. Special
+     * named <code>$0</code>, <code>$1</code>, and so on. All types supported by
+     * Jackson for JSON serialization are supported as parameters. Special
      * cases:
      * <ul>
-     * <li>{@link Element} - will be sent as <code>null</code> if the server-side
-     * element instance is not attached when the invocation is sent to the client
-     * <li>{@link tools.jackson.databind.node.BaseJsonNode} - sent as-is without additional wrapping
+     * <li>{@link Element} - will be sent as <code>null</code> if the
+     * server-side element instance is not attached when the invocation is sent
+     * to the client
+     * <li>{@link tools.jackson.databind.node.BaseJsonNode} - sent as-is without
+     * additional wrapping
      * </ul>
      * Note that the parameter variables can only be used in contexts where a
      * JavaScript variable can be used. You should for instance do
@@ -307,8 +309,8 @@ public class Page implements Serializable {
     /**
      * Executes the given JavaScript expression in the browser.
      *
-     * @deprecated Use {@link #executeJs(String, Object...)} instead. This method
-     *             exists only for binary compatibility.
+     * @deprecated Use {@link #executeJs(String, Object...)} instead. This
+     *             method exists only for binary compatibility.
      * @param expression
      *            the JavaScript expression to execute
      * @param parameters

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -1380,8 +1380,8 @@ public class Element extends Node<Element> {
      * registered, the return value will be ignored.
      * <p>
      * The function will be called after all pending DOM updates have completed,
-     * at the same time that {@link Page#executeJs(String, Object...)}
-     * calls are invoked.
+     * at the same time that {@link Page#executeJs(String, Object...)} calls are
+     * invoked.
      * <p>
      * If the element is not attached or not visible, the function call will be
      * deferred until the element is attached and visible.
@@ -1390,10 +1390,10 @@ public class Element extends Node<Element> {
      *            the name of the function to call, may contain dots to indicate
      *            a function on a property.
      * @param arguments
-     *            the arguments to pass to the function. All types supported
-     *            by Jackson for JSON serialization are supported. Special
-     *            cases: {@link Element} instances will be sent as
-     *            <code>null</code> if not attached when invoked.
+     *            the arguments to pass to the function. All types supported by
+     *            Jackson for JSON serialization are supported. Special cases:
+     *            {@link Element} instances will be sent as <code>null</code> if
+     *            not attached when invoked.
      * @return a pending result that can be used to get a return value from the
      *         execution
      */
@@ -1424,8 +1424,8 @@ public class Element extends Node<Element> {
      * Calls the given JavaScript function with this element as
      * <code>this</code> and the given arguments.
      *
-     * @deprecated Use {@link #callJsFunction(String, Object...)} instead. This method
-     *             exists only for binary compatibility.
+     * @deprecated Use {@link #callJsFunction(String, Object...)} instead. This
+     *             method exists only for binary compatibility.
      * @param functionName
      *            the name of the function to call
      * @param arguments
@@ -1454,12 +1454,13 @@ public class Element extends Node<Element> {
      * <p>
      * This element will be available to the expression as <code>this</code>.
      * The given parameters will be available as variables named
-     * <code>$0</code>, <code>$1</code>, and so on. All types supported
-     * by Jackson for JSON serialization are supported as parameters. Special
+     * <code>$0</code>, <code>$1</code>, and so on. All types supported by
+     * Jackson for JSON serialization are supported as parameters. Special
      * cases:
      * <ul>
-     * <li>{@link Element} - will be sent as <code>null</code> if the server-side
-     * element instance is not attached when the invocation is sent to the client
+     * <li>{@link Element} - will be sent as <code>null</code> if the
+     * server-side element instance is not attached when the invocation is sent
+     * to the client
      * <li>{@link BaseJsonNode} - sent as-is without additional wrapping
      * </ul>
      * Note that the parameter variables can only be used in contexts where a
@@ -1486,7 +1487,8 @@ public class Element extends Node<Element> {
         if (parameters.length == 0) {
             wrappedParameters = new Object[] { this };
         } else {
-            wrappedParameters = Arrays.copyOf(parameters, parameters.length + 1);
+            wrappedParameters = Arrays.copyOf(parameters,
+                    parameters.length + 1);
             wrappedParameters[parameters.length] = this;
         }
 
@@ -1502,8 +1504,8 @@ public class Element extends Node<Element> {
      * Asynchronously runs the given JavaScript expression in the browser in the
      * context of this element.
      *
-     * @deprecated Use {@link #executeJs(String, Object...)} instead. This method
-     *             exists only for binary compatibility.
+     * @deprecated Use {@link #executeJs(String, Object...)} instead. This
+     *             method exists only for binary compatibility.
      * @param expression
      *            the JavaScript expression to invoke
      * @param parameters

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -1392,8 +1392,9 @@ public class Element extends Node<Element> {
      * @param arguments
      *            the arguments to pass to the function. All types supported by
      *            Jackson for JSON serialization are supported. Special cases:
-     *            {@link Element} instances will be sent as <code>null</code> if
-     *            not attached when invoked.
+     *            {@link Element} instances (will be sent as DOM element
+     *            references to the browser if attached when invoked, or as
+     *            <code>null</code> if not attached).
      * @return a pending result that can be used to get a return value from the
      *         execution
      */
@@ -1458,10 +1459,11 @@ public class Element extends Node<Element> {
      * Jackson for JSON serialization are supported as parameters. Special
      * cases:
      * <ul>
-     * <li>{@link Element} - will be sent as <code>null</code> if the
-     * server-side element instance is not attached when the invocation is sent
-     * to the client
-     * <li>{@link BaseJsonNode} - sent as-is without additional wrapping
+     * <li>{@link Element} (will be sent as a DOM element reference to the
+     * browser if the server-side element instance is attached when the
+     * invocation is sent to the client, or as <code>null</code> if not
+     * attached)
+     * <li>{@link BaseJsonNode} (sent as-is without additional wrapping)
      * </ul>
      * Note that the parameter variables can only be used in contexts where a
      * JavaScript variable can be used. You should for instance do

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -1421,6 +1421,25 @@ public class Element extends Node<Element> {
                 + paramPlaceholderString + ")", jsParameters);
     }
 
+    /**
+     * Calls the given JavaScript function with this element as
+     * <code>this</code> and the given arguments.
+     *
+     * @deprecated Use {@link #callJsFunction(String, Object...)} instead. This method
+     *             exists only for binary compatibility.
+     * @param functionName
+     *            the name of the function to call
+     * @param arguments
+     *            the arguments to pass to the function
+     * @return a pending result that can be used to get a return value from the
+     *         execution
+     */
+    @Deprecated
+    public PendingJavaScriptResult callJsFunction(String functionName,
+            Serializable[] arguments) {
+        return callJsFunction(functionName, (Object[]) arguments);
+    }
+
     // When updating JavaDocs here, keep in sync with Page.executeJavaScript
     /**
      * Asynchronously runs the given JavaScript expression in the browser in the
@@ -1483,6 +1502,25 @@ public class Element extends Node<Element> {
 
         return scheduleJavaScriptInvocation(wrappedExpression,
                 wrappedParameters);
+    }
+
+    /**
+     * Asynchronously runs the given JavaScript expression in the browser in the
+     * context of this element.
+     *
+     * @deprecated Use {@link #executeJs(String, Object...)} instead. This method
+     *             exists only for binary compatibility.
+     * @param expression
+     *            the JavaScript expression to invoke
+     * @param parameters
+     *            parameters to pass to the expression
+     * @return a pending result that can be used to get a value returned from
+     *         the expression
+     */
+    @Deprecated
+    public PendingJavaScriptResult executeJs(String expression,
+            Serializable[] parameters) {
+        return executeJs(expression, (Object[]) parameters);
     }
 
     private PendingJavaScriptResult scheduleJavaScriptInvocation(

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -1380,7 +1380,7 @@ public class Element extends Node<Element> {
      * registered, the return value will be ignored.
      * <p>
      * The function will be called after all pending DOM updates have completed,
-     * at the same time that {@link Page#executeJs(String, Serializable...)}
+     * at the same time that {@link Page#executeJs(String, Object...)}
      * calls are invoked.
      * <p>
      * If the element is not attached or not visible, the function call will be
@@ -1399,7 +1399,7 @@ public class Element extends Node<Element> {
      *         execution
      */
     public PendingJavaScriptResult callJsFunction(String functionName,
-            Serializable... arguments) {
+            Object... arguments) {
         assert functionName != null;
         assert !functionName.startsWith(".")
                 : "Function name should not start with a dot";
@@ -1447,6 +1447,7 @@ public class Element extends Node<Element> {
      * <li>{@link Element} (will be sent as <code>null</code> if the server-side
      * element instance is not attached when the invocation is sent to the
      * client)
+     * <li>Any bean object (serialized using Jackson and available as a standard JavaScript object)
      * </ul>
      * Note that the parameter variables can only be used in contexts where a
      * JavaScript variable can be used. You should for instance do
@@ -1465,15 +1466,14 @@ public class Element extends Node<Element> {
      *         the expression
      */
     public PendingJavaScriptResult executeJs(String expression,
-            Serializable... parameters) {
+            Object... parameters) {
 
         // Add "this" as the last parameter
-        Serializable[] wrappedParameters;
+        Object[] wrappedParameters;
         if (parameters.length == 0) {
-            wrappedParameters = new Serializable[] { this };
+            wrappedParameters = new Object[] { this };
         } else {
-            wrappedParameters = Arrays.copyOf(parameters, parameters.length + 1,
-                    Serializable[].class);
+            wrappedParameters = Arrays.copyOf(parameters, parameters.length + 1);
             wrappedParameters[parameters.length] = this;
         }
 
@@ -1486,7 +1486,7 @@ public class Element extends Node<Element> {
     }
 
     private PendingJavaScriptResult scheduleJavaScriptInvocation(
-            String expression, Serializable[] parameters) {
+            String expression, Object[] parameters) {
         StateNode node = getNode();
 
         JavaScriptInvocation invocation = new JavaScriptInvocation(expression,

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -1386,15 +1386,14 @@ public class Element extends Node<Element> {
      * If the element is not attached or not visible, the function call will be
      * deferred until the element is attached and visible.
      *
-     * @see JsonCodec JsonCodec for supported argument types
-     *
      * @param functionName
      *            the name of the function to call, may contain dots to indicate
      *            a function on a property.
      * @param arguments
-     *            the arguments to pass to the function. Must be of a type
-     *            supported by the communication mechanism, as defined by
-     *            {@link JsonCodec}
+     *            the arguments to pass to the function. All types supported
+     *            by Jackson for JSON serialization are supported. Special
+     *            cases: {@link Element} instances will be sent as
+     *            <code>null</code> if not attached when invoked.
      * @return a pending result that can be used to get a return value from the
      *         execution
      */
@@ -1455,18 +1454,13 @@ public class Element extends Node<Element> {
      * <p>
      * This element will be available to the expression as <code>this</code>.
      * The given parameters will be available as variables named
-     * <code>$0</code>, <code>$1</code>, and so on. Supported parameter types
-     * are:
+     * <code>$0</code>, <code>$1</code>, and so on. All types supported
+     * by Jackson for JSON serialization are supported as parameters. Special
+     * cases:
      * <ul>
-     * <li>{@link String}
-     * <li>{@link Integer}
-     * <li>{@link Double}
-     * <li>{@link Boolean}
-     * <li>{@link BaseJsonNode}
-     * <li>{@link Element} (will be sent as <code>null</code> if the server-side
-     * element instance is not attached when the invocation is sent to the
-     * client)
-     * <li>Any bean object (serialized using Jackson and available as a standard JavaScript object)
+     * <li>{@link Element} - will be sent as <code>null</code> if the server-side
+     * element instance is not attached when the invocation is sent to the client
+     * <li>{@link BaseJsonNode} - sent as-is without additional wrapping
      * </ul>
      * Note that the parameter variables can only be used in contexts where a
      * JavaScript variable can be used. You should for instance do

--- a/flow-server/src/main/java/com/vaadin/flow/internal/JacksonCodec.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JacksonCodec.java
@@ -90,7 +90,9 @@ public class JacksonCodec {
     public static JsonNode encodeWithTypeInfo(Object value) {
         assert value == null || canEncodeWithTypeInfo(value.getClass());
 
-        if (value instanceof Component) {
+        if (value == null) {
+            return encodeWithoutTypeInfo(value);
+        } else if (value instanceof Component) {
             return encodeNode(((Component) value).getElement());
         } else if (value instanceof Node<?>) {
             return encodeNode((Node<?>) value);
@@ -154,19 +156,17 @@ public class JacksonCodec {
     /**
      * Helper for checking whether the type is supported by
      * {@link #encodeWithTypeInfo(Object)}. Supported values types are
-     * {@link Node}, {@link Component}, {@link ReturnChannelRegistration} and
-     * anything accepted by {@link #canEncodeWithoutTypeInfo(Class)}.
+     * {@link Node}, {@link Component}, {@link ReturnChannelRegistration},
+     * anything accepted by {@link #canEncodeWithoutTypeInfo(Class)},
+     * and any bean object.
      *
      * @param type
      *            the type to check
      * @return whether the type can be encoded
      */
     public static boolean canEncodeWithTypeInfo(Class<?> type) {
-        return canEncodeWithoutTypeInfo(type)
-                || Node.class.isAssignableFrom(type)
-                || Component.class.isAssignableFrom(type)
-                || ReturnChannelRegistration.class.isAssignableFrom(type)
-                || Serializable.class.isAssignableFrom(type);
+        // All types can be encoded - either as primitives, special types, or beans
+        return true;
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/internal/JacksonCodec.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JacksonCodec.java
@@ -66,10 +66,6 @@ public class JacksonCodec {
      */
     public static final int RETURN_CHANNEL_TYPE = 2;
 
-    /**
-     * Type id for a complex type array containing a bean object.
-     */
-    public static final int BEAN_TYPE = 5;
 
     private JacksonCodec() {
         // Don't create instances
@@ -106,9 +102,8 @@ public class JacksonCodec {
             }
             return encoded;
         } else {
-            // Encode as bean using Jackson serialization
-            JsonNode beanJson = JacksonUtils.getMapper().valueToTree(value);
-            return wrapComplexValue(BEAN_TYPE, beanJson);
+            // Encode as bean using Jackson serialization - send directly as JSON
+            return JacksonUtils.getMapper().valueToTree(value);
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/internal/JacksonCodec.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JacksonCodec.java
@@ -84,7 +84,6 @@ public class JacksonCodec {
      * @return the value encoded as JSON
      */
     public static JsonNode encodeWithTypeInfo(Object value) {
-        assert value == null || canEncodeWithTypeInfo(value.getClass());
 
         if (value == null) {
             return encodeWithoutTypeInfo(value);
@@ -148,21 +147,6 @@ public class JacksonCodec {
                 || JsonNode.class.isAssignableFrom(type);
     }
 
-    /**
-     * Helper for checking whether the type is supported by
-     * {@link #encodeWithTypeInfo(Object)}. Supported values types are
-     * {@link Node}, {@link Component}, {@link ReturnChannelRegistration},
-     * anything accepted by {@link #canEncodeWithoutTypeInfo(Class)},
-     * and any bean object.
-     *
-     * @param type
-     *            the type to check
-     * @return whether the type can be encoded
-     */
-    public static boolean canEncodeWithTypeInfo(Class<?> type) {
-        // All types can be encoded - either as primitives, special types, or beans
-        return true;
-    }
 
     /**
      * Encodes a "primitive" value or a constant pool reference to JSON. This
@@ -218,7 +202,6 @@ public class JacksonCodec {
         } else if (JsonNode.class.isAssignableFrom(type)) {
             return (JsonNode) value;
         }
-        assert !canEncodeWithoutTypeInfo(type);
         throw new IllegalArgumentException(
                 "Can't encode " + value.getClass() + " to json");
     }
@@ -284,7 +267,6 @@ public class JacksonCodec {
         } else if (JsonNode.class.isAssignableFrom(type)) {
             return type.cast(json);
         } else {
-            assert !canEncodeWithoutTypeInfo(type);
             throw new IllegalArgumentException(
                     "Unknown type " + type.getName());
         }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/JacksonCodec.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JacksonCodec.java
@@ -66,7 +66,6 @@ public class JacksonCodec {
      */
     public static final int RETURN_CHANNEL_TYPE = 2;
 
-
     private JacksonCodec() {
         // Don't create instances
     }
@@ -101,7 +100,8 @@ public class JacksonCodec {
             }
             return encoded;
         } else {
-            // Encode as bean using Jackson serialization - send directly as JSON
+            // Encode as bean using Jackson serialization - send directly as
+            // JSON
             return JacksonUtils.getMapper().valueToTree(value);
         }
     }
@@ -146,7 +146,6 @@ public class JacksonCodec {
                 || Double.class.equals(type) || Boolean.class.equals(type)
                 || JsonNode.class.isAssignableFrom(type);
     }
-
 
     /**
      * Encodes a "primitive" value or a constant pool reference to JSON. This

--- a/flow-server/src/main/java/com/vaadin/flow/internal/JsonCodec.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JsonCodec.java
@@ -90,7 +90,9 @@ public class JsonCodec {
     public static JsonValue encodeWithTypeInfo(Object value) {
         assert value == null || canEncodeWithTypeInfo(value.getClass());
 
-        if (value instanceof Component) {
+        if (value == null) {
+            return encodeWithoutTypeInfo(value);
+        } else if (value instanceof Component) {
             return encodeNode(((Component) value).getElement());
         } else if (value instanceof Node<?>) {
             return encodeNode((Node<?>) value);
@@ -151,19 +153,17 @@ public class JsonCodec {
     /**
      * Helper for checking whether the type is supported by
      * {@link #encodeWithTypeInfo(Object)}. Supported values types are
-     * {@link Node}, {@link Component}, {@link ReturnChannelRegistration} and
-     * anything accepted by {@link #canEncodeWithoutTypeInfo(Class)}.
+     * {@link Node}, {@link Component}, {@link ReturnChannelRegistration},
+     * anything accepted by {@link #canEncodeWithoutTypeInfo(Class)},
+     * and any bean object.
      *
      * @param type
      *            the type to check
      * @return whether the type can be encoded
      */
     public static boolean canEncodeWithTypeInfo(Class<?> type) {
-        return canEncodeWithoutTypeInfo(type)
-                || Node.class.isAssignableFrom(type)
-                || Component.class.isAssignableFrom(type)
-                || ReturnChannelRegistration.class.isAssignableFrom(type)
-                || Serializable.class.isAssignableFrom(type);
+        // All types can be encoded - either as primitives, special types, or beans
+        return true;
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/internal/JsonCodec.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JsonCodec.java
@@ -66,6 +66,11 @@ public class JsonCodec {
      */
     public static final int RETURN_CHANNEL_TYPE = 2;
 
+    /**
+     * Type id for a complex type array containing a bean object.
+     */
+    public static final int BEAN_TYPE = 5;
+
     private JsonCodec() {
         // Don't create instances
     }
@@ -91,13 +96,17 @@ public class JsonCodec {
             return encodeNode((Node<?>) value);
         } else if (value instanceof ReturnChannelRegistration) {
             return encodeReturnChannel((ReturnChannelRegistration) value);
-        } else {
+        } else if (canEncodeWithoutTypeInfo(value.getClass())) {
             JsonValue encoded = encodeWithoutTypeInfo(value);
             if (encoded.getType() == JsonType.ARRAY) {
                 // Must "escape" arrays
                 encoded = wrapComplexValue(ARRAY_TYPE, encoded);
             }
             return encoded;
+        } else {
+            // Encode as bean using Jackson via JsonValue conversion
+            JsonValue beanJson = JsonUtils.writeValue(value);
+            return wrapComplexValue(BEAN_TYPE, beanJson);
         }
     }
 
@@ -153,7 +162,8 @@ public class JsonCodec {
         return canEncodeWithoutTypeInfo(type)
                 || Node.class.isAssignableFrom(type)
                 || Component.class.isAssignableFrom(type)
-                || ReturnChannelRegistration.class.isAssignableFrom(type);
+                || ReturnChannelRegistration.class.isAssignableFrom(type)
+                || Serializable.class.isAssignableFrom(type);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/internal/JsonCodec.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JsonCodec.java
@@ -66,7 +66,6 @@ public class JsonCodec {
      */
     public static final int RETURN_CHANNEL_TYPE = 2;
 
-
     private JsonCodec() {
         // Don't create instances
     }
@@ -101,7 +100,8 @@ public class JsonCodec {
             }
             return encoded;
         } else {
-            // Encode as bean using Jackson via JsonValue conversion - send directly as JSON
+            // Encode as bean using Jackson via JsonValue conversion - send
+            // directly as JSON
             return JsonUtils.writeValue(value);
         }
     }
@@ -143,7 +143,6 @@ public class JsonCodec {
                 || Double.class.equals(type) || Boolean.class.equals(type)
                 || JsonValue.class.isAssignableFrom(type);
     }
-
 
     /**
      * Encodes a "primitive" value or a constant pool reference to JSON. This

--- a/flow-server/src/main/java/com/vaadin/flow/internal/JsonCodec.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JsonCodec.java
@@ -66,10 +66,6 @@ public class JsonCodec {
      */
     public static final int RETURN_CHANNEL_TYPE = 2;
 
-    /**
-     * Type id for a complex type array containing a bean object.
-     */
-    public static final int BEAN_TYPE = 5;
 
     private JsonCodec() {
         // Don't create instances
@@ -106,9 +102,8 @@ public class JsonCodec {
             }
             return encoded;
         } else {
-            // Encode as bean using Jackson via JsonValue conversion
-            JsonValue beanJson = JsonUtils.writeValue(value);
-            return wrapComplexValue(BEAN_TYPE, beanJson);
+            // Encode as bean using Jackson via JsonValue conversion - send directly as JSON
+            return JsonUtils.writeValue(value);
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/internal/JsonCodec.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JsonCodec.java
@@ -84,7 +84,6 @@ public class JsonCodec {
      * @return the value encoded as JSON
      */
     public static JsonValue encodeWithTypeInfo(Object value) {
-        assert value == null || canEncodeWithTypeInfo(value.getClass());
 
         if (value == null) {
             return encodeWithoutTypeInfo(value);
@@ -145,21 +144,6 @@ public class JsonCodec {
                 || JsonValue.class.isAssignableFrom(type);
     }
 
-    /**
-     * Helper for checking whether the type is supported by
-     * {@link #encodeWithTypeInfo(Object)}. Supported values types are
-     * {@link Node}, {@link Component}, {@link ReturnChannelRegistration},
-     * anything accepted by {@link #canEncodeWithoutTypeInfo(Class)},
-     * and any bean object.
-     *
-     * @param type
-     *            the type to check
-     * @return whether the type can be encoded
-     */
-    public static boolean canEncodeWithTypeInfo(Class<?> type) {
-        // All types can be encoded - either as primitives, special types, or beans
-        return true;
-    }
 
     /**
      * Encodes a "primitive" value or a constant pool reference to JSON. This
@@ -208,7 +192,6 @@ public class JsonCodec {
         } else if (JsonValue.class.isAssignableFrom(type)) {
             return (JsonValue) value;
         }
-        assert !canEncodeWithoutTypeInfo(type);
         throw new IllegalArgumentException(
                 "Can't encode " + value.getClass() + " to json");
     }
@@ -273,7 +256,6 @@ public class JsonCodec {
         } else if (JsonValue.class.isAssignableFrom(type)) {
             return type.cast(json);
         } else {
-            assert !canEncodeWithoutTypeInfo(type);
             throw new IllegalArgumentException(
                     "Unknown type " + type.getName());
         }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/AbstractServerHandlers.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/AbstractServerHandlers.java
@@ -204,15 +204,7 @@ public abstract class AbstractServerHandlers<T>
      *            method to check return type for
      */
     protected void ensureSupportedReturnType(Method method) {
-        if (!void.class.equals(method.getReturnType())) {
-            String msg = String.format(Locale.ENGLISH,
-                    "Only void handler methods are supported. "
-                            + "Component '%s' has method '%s' annotated with '%s' whose return type is not void but \"%s\"",
-                    method.getDeclaringClass().getName(), method.getName(),
-                    getHandlerAnnotationFqn(),
-                    method.getReturnType().getSimpleName());
-            throw new IllegalStateException(msg);
-        }
+        // Default implementation allows all return types
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ClientCallableHandlers.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ClientCallableHandlers.java
@@ -54,13 +54,12 @@ public class ClientCallableHandlers extends AbstractServerHandlers<Component> {
 
     @Override
     protected void ensureSupportedParameterTypes(Method method) {
-        // decoder may be able to convert any value to any type so no need to
-        // limit supported types
+        // All parameter types are supported through JSON deserialization
     }
 
     @Override
     protected void ensureSupportedReturnType(Method method) {
-        // All types are now supported since we can encode any object as a bean
+        // All return types are supported through JSON serialization
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ClientCallableHandlers.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ClientCallableHandlers.java
@@ -57,7 +57,6 @@ public class ClientCallableHandlers extends AbstractServerHandlers<Component> {
         // All parameter types are supported through JSON deserialization
     }
 
-
     @Override
     protected DisabledUpdateMode getUpdateMode(Method method) {
         return method.getAnnotation(ClientCallable.class).value();

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ClientCallableHandlers.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ClientCallableHandlers.java
@@ -57,10 +57,6 @@ public class ClientCallableHandlers extends AbstractServerHandlers<Component> {
         // All parameter types are supported through JSON deserialization
     }
 
-    @Override
-    protected void ensureSupportedReturnType(Method method) {
-        // All return types are supported through JSON serialization
-    }
 
     @Override
     protected DisabledUpdateMode getUpdateMode(Method method) {

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ClientCallableHandlers.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ClientCallableHandlers.java
@@ -60,21 +60,7 @@ public class ClientCallableHandlers extends AbstractServerHandlers<Component> {
 
     @Override
     protected void ensureSupportedReturnType(Method method) {
-        Class<?> returnType = method.getReturnType();
-        if (returnType.isPrimitive()) {
-            returnType = ReflectTools.convertPrimitiveType(returnType);
-        }
-
-        if (!void.class.equals(returnType)
-                && !JsonCodec.canEncodeWithTypeInfo(returnType)) {
-            String msg = String.format(Locale.ENGLISH,
-                    "Only return types that can be used as Element.executeJs parameters are supported. "
-                            + "Component '%s' has method '%s' annotated with '%s' whose return type is \"%s\"",
-                    method.getDeclaringClass().getName(), method.getName(),
-                    getHandlerAnnotationFqn(),
-                    method.getReturnType().getSimpleName());
-            throw new IllegalStateException(msg);
-        }
+        // All types are now supported since we can encode any object as a bean
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/PolymerServerEventHandlers.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/PolymerServerEventHandlers.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Parameter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -81,6 +82,19 @@ public class PolymerServerEventHandlers
     @Override
     protected String getHandlerAnnotationFqn() {
         return "com.vaadin.flow.component.polymertemplate.EventHandler";
+    }
+
+    @Override
+    protected void ensureSupportedReturnType(Method method) {
+        if (!void.class.equals(method.getReturnType())) {
+            String msg = String.format(Locale.ENGLISH,
+                    "Only void handler methods are supported. "
+                            + "Component '%s' has method '%s' annotated with '%s' whose return type is not void but \"%s\"",
+                    method.getDeclaringClass().getName(), method.getName(),
+                    getHandlerAnnotationFqn(),
+                    method.getReturnType().getSimpleName());
+            throw new IllegalStateException(msg);
+        }
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/shared/JsonConstants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/JsonConstants.java
@@ -161,7 +161,7 @@ public class JsonConstants implements Serializable {
 
     /**
      * Key used for data related to
-     * {@link Page#executeJs(String, Serializable...)} in UIDL messages.
+     * {@link Page#executeJs(String, Object...)} in UIDL messages.
      */
     public static final String UIDL_KEY_EXECUTE = "execute";
 

--- a/flow-server/src/main/java/com/vaadin/flow/shared/JsonConstants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/JsonConstants.java
@@ -160,8 +160,8 @@ public class JsonConstants implements Serializable {
     public static final String RPC_EVENT_DATA = "data";
 
     /**
-     * Key used for data related to
-     * {@link Page#executeJs(String, Object...)} in UIDL messages.
+     * Key used for data related to {@link Page#executeJs(String, Object...)} in
+     * UIDL messages.
      */
     public static final String UIDL_KEY_EXECUTE = "execute";
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
@@ -450,8 +450,8 @@ public class JavaScriptBootstrapUITest {
         Mockito.when(stateTree.getRootNode()).thenReturn(stateNode);
 
         ArgumentCaptor<String> execJs = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<Serializable[]> execArg = ArgumentCaptor
-                .forClass(Serializable[].class);
+        ArgumentCaptor<Object[]> execArg = ArgumentCaptor
+                .forClass(Object[].class);
 
         try (MockedStatic<MenuRegistry> menuRegistry = Mockito
                 .mockStatic(MenuRegistry.class)) {
@@ -466,7 +466,7 @@ public class JavaScriptBootstrapUITest {
             boolean reactEnabled = ui.getSession().getConfiguration()
                     .isReactEnabled();
 
-            final Serializable[] execValues = execArg.getValue();
+            final Object[] execValues = execArg.getValue();
             if (reactEnabled) {
                 assertEquals(REACT_PUSHSTATE_TO, execJs.getValue());
                 assertEquals(1, execValues.length);
@@ -509,8 +509,8 @@ public class JavaScriptBootstrapUITest {
         Page page = mockPage();
 
         ArgumentCaptor<String> execJs = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<Serializable[]> execArg = ArgumentCaptor
-                .forClass(Serializable[].class);
+        ArgumentCaptor<Object[]> execArg = ArgumentCaptor
+                .forClass(Object[].class);
 
         // Dirty view is allowed after clean view
         ui.navigate("dirty");
@@ -521,7 +521,7 @@ public class JavaScriptBootstrapUITest {
         boolean reactEnabled = ui.getSession().getConfiguration()
                 .isReactEnabled();
 
-        final Serializable[] execValues = execArg.getValue();
+        final Object[] execValues = execArg.getValue();
         if (reactEnabled) {
             assertEquals(REACT_PUSHSTATE_TO, execJs.getValue());
         } else {

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/HistoryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/HistoryTest.java
@@ -48,7 +48,7 @@ public class HistoryTest {
 
         private String expression;
 
-        private Serializable[] parameters;
+        private Object[] parameters;
 
         public TestPage(UI ui) {
             super(ui);
@@ -56,7 +56,7 @@ public class HistoryTest {
 
         @Override
         public PendingJavaScriptResult executeJs(String expression,
-                Serializable... parameters) {
+                Object... parameters) {
             this.expression = expression;
             this.parameters = parameters;
             return null;

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
@@ -55,7 +55,7 @@ public class PageTest {
 
         private String expression;
 
-        private Serializable firstParam;
+        private Object firstParam;
 
         public TestPage(UI ui) {
             super(ui);
@@ -63,7 +63,7 @@ public class PageTest {
 
         @Override
         public PendingJavaScriptResult executeJs(String expression,
-                Serializable... parameters) {
+                Object... parameters) {
             this.expression = expression;
             firstParam = parameters[0];
             count++;
@@ -92,7 +92,7 @@ public class PageTest {
         final Page page = new Page(mockUI) {
             @Override
             public PendingJavaScriptResult executeJs(String expression,
-                    Serializable... params) {
+                    Object... params) {
                 super.executeJs(expression, params);
 
                 return new PendingJavaScriptResult() {
@@ -158,7 +158,7 @@ public class PageTest {
         final Page page = new Page(mockUI) {
             @Override
             public PendingJavaScriptResult executeJs(String expression,
-                    Serializable... params) {
+                    Object... params) {
                 super.executeJs(expression, params);
 
                 return new PendingJavaScriptResult() {
@@ -217,7 +217,7 @@ public class PageTest {
         final Page page = new Page(mockUI) {
             @Override
             public PendingJavaScriptResult executeJs(String expression,
-                    Serializable... params) {
+                    Object... params) {
                 super.executeJs(expression, params);
                 Assert.assertEquals(
                         "Expected javascript for fetching location is wrong.",
@@ -318,17 +318,17 @@ public class PageTest {
     @Test
     public void executeJavaScript_delegatesToExecJs() {
         AtomicReference<String> invokedExpression = new AtomicReference<>();
-        AtomicReference<Serializable[]> invokedParams = new AtomicReference<>();
+        AtomicReference<Object[]> invokedParams = new AtomicReference<>();
 
         Page page = new Page(new MockUI()) {
             @Override
             public PendingJavaScriptResult executeJs(String expression,
-                    Serializable... parameters) {
+                    Object... parameters) {
                 String oldExpression = invokedExpression.getAndSet(expression);
                 Assert.assertNull("There should be no old expression",
                         oldExpression);
 
-                Serializable[] oldParams = invokedParams.getAndSet(parameters);
+                Object[] oldParams = invokedParams.getAndSet(parameters);
                 Assert.assertNull("There should be no old params", oldParams);
 
                 return null;
@@ -348,11 +348,11 @@ public class PageTest {
     @Test
     public void open_openInSameWindow_closeTheClientApplication() {
         AtomicReference<String> capture = new AtomicReference<>();
-        List<Serializable> params = new ArrayList<>();
+        List<Object> params = new ArrayList<>();
         Page page = new Page(new MockUI()) {
             @Override
             public PendingJavaScriptResult executeJs(String expression,
-                    Serializable[] parameters) {
+                    Object... parameters) {
                 capture.set(expression);
                 params.addAll(Arrays.asList(parameters));
                 return Mockito.mock(PendingJavaScriptResult.class);

--- a/flow-server/src/test/java/com/vaadin/flow/component/webcomponent/WebComponentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/webcomponent/WebComponentTest.java
@@ -169,6 +169,6 @@ public class WebComponentTest {
                 (ValueNode) JacksonUtils.createNode(true));
         verify(element, Mockito.times(5)).executeJs(
                 ArgumentMatchers.anyString(),
-                ArgumentMatchers.any(Serializable[].class));
+                ArgumentMatchers.any(Object[].class));
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementJacksonTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementJacksonTest.java
@@ -2585,17 +2585,17 @@ public class ElementJacksonTest extends AbstractNodeTest {
     @Test
     public void executeJavaScript_delegatesToExecJs() {
         AtomicReference<String> invokedExpression = new AtomicReference<>();
-        AtomicReference<Serializable[]> invokedParams = new AtomicReference<>();
+        AtomicReference<Object[]> invokedParams = new AtomicReference<>();
 
         Element element = new Element("div") {
             @Override
             public PendingJavaScriptResult executeJs(String expression,
-                    Serializable... parameters) {
+                    Object... parameters) {
                 String oldExpression = invokedExpression.getAndSet(expression);
                 Assert.assertNull("There should be no old expression",
                         oldExpression);
 
-                Serializable[] oldParams = invokedParams.getAndSet(parameters);
+                Object[] oldParams = invokedParams.getAndSet(parameters);
                 Assert.assertNull("There should be no old params", oldParams);
 
                 return null;
@@ -2612,17 +2612,17 @@ public class ElementJacksonTest extends AbstractNodeTest {
     @Test
     public void callFunction_delegatesToCallJsFunction() {
         AtomicReference<String> invokedFuction = new AtomicReference<>();
-        AtomicReference<Serializable[]> invokedParams = new AtomicReference<>();
+        AtomicReference<Object[]> invokedParams = new AtomicReference<>();
 
         Element element = new Element("div") {
             @Override
             public PendingJavaScriptResult callJsFunction(String functionName,
-                    Serializable... arguments) {
+                    Object... arguments) {
                 String oldExpression = invokedFuction.getAndSet(functionName);
                 Assert.assertNull("There should be no old function name",
                         oldExpression);
 
-                Serializable[] oldParams = invokedParams.getAndSet(arguments);
+                Object[] oldParams = invokedParams.getAndSet(arguments);
                 Assert.assertNull("There should be no old params", oldParams);
 
                 return null;
@@ -2647,7 +2647,7 @@ public class ElementJacksonTest extends AbstractNodeTest {
         Assert.assertEquals(child, parent.getChild(index));
     }
 
-    private void assertPendingJs(UI ui, String js, Serializable... arguments) {
+    private void assertPendingJs(UI ui, String js, Object... arguments) {
         List<PendingJavaScriptInvocation> pendingJs = ui.getInternals()
                 .dumpPendingJavaScriptInvocations();
         JavaScriptInvocation expected = new JavaScriptInvocation(js, arguments);

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
@@ -2558,17 +2558,17 @@ public class ElementTest extends AbstractNodeTest {
     @Test
     public void executeJavaScript_delegatesToExecJs() {
         AtomicReference<String> invokedExpression = new AtomicReference<>();
-        AtomicReference<Serializable[]> invokedParams = new AtomicReference<>();
+        AtomicReference<Object[]> invokedParams = new AtomicReference<>();
 
         Element element = new Element("div") {
             @Override
             public PendingJavaScriptResult executeJs(String expression,
-                    Serializable... parameters) {
+                    Object... parameters) {
                 String oldExpression = invokedExpression.getAndSet(expression);
                 Assert.assertNull("There should be no old expression",
                         oldExpression);
 
-                Serializable[] oldParams = invokedParams.getAndSet(parameters);
+                Object[] oldParams = invokedParams.getAndSet(parameters);
                 Assert.assertNull("There should be no old params", oldParams);
 
                 return null;
@@ -2587,7 +2587,7 @@ public class ElementTest extends AbstractNodeTest {
         Element element = new Element("div") {
             @Override
             public PendingJavaScriptResult executeJs(String expression,
-                    Serializable... parameters) {
+                    Object... parameters) {
                 Serializable[] wrappedParameters;
                 if (parameters.length == 0) {
                     wrappedParameters = new Serializable[] { this };
@@ -2606,17 +2606,17 @@ public class ElementTest extends AbstractNodeTest {
     @Test
     public void callFunction_delegatesToCallJsFunction() {
         AtomicReference<String> invokedFuction = new AtomicReference<>();
-        AtomicReference<Serializable[]> invokedParams = new AtomicReference<>();
+        AtomicReference<Object[]> invokedParams = new AtomicReference<>();
 
         Element element = new Element("div") {
             @Override
             public PendingJavaScriptResult callJsFunction(String functionName,
-                    Serializable... arguments) {
+                    Object... arguments) {
                 String oldExpression = invokedFuction.getAndSet(functionName);
                 Assert.assertNull("There should be no old function name",
                         oldExpression);
 
-                Serializable[] oldParams = invokedParams.getAndSet(arguments);
+                Object[] oldParams = invokedParams.getAndSet(arguments);
                 Assert.assertNull("There should be no old params", oldParams);
 
                 return null;
@@ -2641,7 +2641,7 @@ public class ElementTest extends AbstractNodeTest {
         Assert.assertEquals(child, parent.getChild(index));
     }
 
-    private void assertPendingJs(UI ui, String js, Serializable... arguments) {
+    private void assertPendingJs(UI ui, String js, Object... arguments) {
         List<PendingJavaScriptInvocation> pendingJs = ui.getInternals()
                 .dumpPendingJavaScriptInvocations();
         JavaScriptInvocation expected = new JavaScriptInvocation(js, arguments);

--- a/flow-server/src/test/java/com/vaadin/flow/hotswap/HotswapperTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/hotswap/HotswapperTest.java
@@ -1333,7 +1333,7 @@ public class HotswapperTest {
                 }
                 return null;
             }).when(pageSpy).executeJs(Mockito.anyString(),
-                    Mockito.any(Serializable[].class));
+                    Mockito.any(Object[].class));
         }
 
         @Override

--- a/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
@@ -68,7 +68,8 @@ public class JacksonCodecTest {
         assertJsonEquals(objectMapper.createArrayNode(),
                 objectMapper.createArrayNode());
 
-        // Test specific complex types - these are now handled via Jackson serialization
+        // Test specific complex types - these are now handled via Jackson
+        // serialization
         testComplexTypeSerialization();
     }
 
@@ -275,57 +276,74 @@ public class JacksonCodecTest {
         // Test Object - should serialize as empty object
         Object obj = new Object();
         JsonNode objEncoded = JacksonCodec.encodeWithTypeInfo(obj);
-        Assert.assertTrue("Object should serialize as JSON object", objEncoded.isObject());
-        Assert.assertEquals("Object should serialize as empty object", 0, objEncoded.size());
+        Assert.assertTrue("Object should serialize as JSON object",
+                objEncoded.isObject());
+        Assert.assertEquals("Object should serialize as empty object", 0,
+                objEncoded.size());
 
         // Test StateNode - should serialize as object with state properties
         StateNode stateNode = new StateNode();
         JsonNode stateNodeEncoded = JacksonCodec.encodeWithTypeInfo(stateNode);
-        Assert.assertTrue("StateNode should serialize as JSON object", stateNodeEncoded.isObject());
+        Assert.assertTrue("StateNode should serialize as JSON object",
+                stateNodeEncoded.isObject());
         // StateNode should have some internal structure
-        Assert.assertTrue("StateNode should have properties", stateNodeEncoded.size() > 0);
+        Assert.assertTrue("StateNode should have properties",
+                stateNodeEncoded.size() > 0);
 
         // Test Date - should serialize as timestamp number or ISO string
-        Date date = new Date(1234567890000L); // Fixed timestamp for consistent testing
+        Date date = new Date(1234567890000L); // Fixed timestamp for consistent
+                                              // testing
         JsonNode dateEncoded = JacksonCodec.encodeWithTypeInfo(date);
-        Assert.assertTrue("Date should serialize as number or string", 
+        Assert.assertTrue("Date should serialize as number or string",
                 dateEncoded.isNumber() || dateEncoded.isTextual());
         if (dateEncoded.isNumber()) {
-            Assert.assertEquals("Date should serialize to correct timestamp", 
+            Assert.assertEquals("Date should serialize to correct timestamp",
                     1234567890000L, dateEncoded.asLong());
         }
 
         // Test String array - should serialize as JSON array
-        String[] stringArray = new String[]{"hello", "world"};
+        String[] stringArray = new String[] { "hello", "world" };
         JsonNode arrayEncoded = JacksonCodec.encodeWithTypeInfo(stringArray);
-        Assert.assertTrue("String array should serialize as JSON array", arrayEncoded.isArray());
-        Assert.assertEquals("Array should have correct length", 2, arrayEncoded.size());
-        Assert.assertEquals("First element should be correct", "hello", arrayEncoded.get(0).asText());
-        Assert.assertEquals("Second element should be correct", "world", arrayEncoded.get(1).asText());
+        Assert.assertTrue("String array should serialize as JSON array",
+                arrayEncoded.isArray());
+        Assert.assertEquals("Array should have correct length", 2,
+                arrayEncoded.size());
+        Assert.assertEquals("First element should be correct", "hello",
+                arrayEncoded.get(0).asText());
+        Assert.assertEquals("Second element should be correct", "world",
+                arrayEncoded.get(1).asText());
 
         // Test ArrayList - should serialize as JSON array
         ArrayList<String> arrayList = new ArrayList<>();
         arrayList.add("item1");
         arrayList.add("item2");
         JsonNode listEncoded = JacksonCodec.encodeWithTypeInfo(arrayList);
-        Assert.assertTrue("ArrayList should serialize as JSON array", listEncoded.isArray());
-        Assert.assertEquals("List should have correct size", 2, listEncoded.size());
-        Assert.assertEquals("First list item should be correct", "item1", listEncoded.get(0).asText());
-        Assert.assertEquals("Second list item should be correct", "item2", listEncoded.get(1).asText());
+        Assert.assertTrue("ArrayList should serialize as JSON array",
+                listEncoded.isArray());
+        Assert.assertEquals("List should have correct size", 2,
+                listEncoded.size());
+        Assert.assertEquals("First list item should be correct", "item1",
+                listEncoded.get(0).asText());
+        Assert.assertEquals("Second list item should be correct", "item2",
+                listEncoded.get(1).asText());
 
         // Test HashSet - should serialize as JSON array (order may vary)
         HashSet<String> hashSet = new HashSet<>();
         hashSet.add("value1");
         hashSet.add("value2");
         JsonNode setEncoded = JacksonCodec.encodeWithTypeInfo(hashSet);
-        Assert.assertTrue("HashSet should serialize as JSON array", setEncoded.isArray());
-        Assert.assertEquals("Set should have correct size", 2, setEncoded.size());
+        Assert.assertTrue("HashSet should serialize as JSON array",
+                setEncoded.isArray());
+        Assert.assertEquals("Set should have correct size", 2,
+                setEncoded.size());
         // Verify both values are present (order not guaranteed with HashSet)
         boolean hasValue1 = false, hasValue2 = false;
         for (JsonNode node : setEncoded) {
             String value = node.asText();
-            if ("value1".equals(value)) hasValue1 = true;
-            if ("value2".equals(value)) hasValue2 = true;
+            if ("value1".equals(value))
+                hasValue1 = true;
+            if ("value2".equals(value))
+                hasValue2 = true;
         }
         Assert.assertTrue("Set should contain value1", hasValue1);
         Assert.assertTrue("Set should contain value2", hasValue2);
@@ -336,11 +354,16 @@ public class JacksonCodecTest {
         hashMap.put("key2", 42);
         hashMap.put("key3", true);
         JsonNode mapEncoded = JacksonCodec.encodeWithTypeInfo(hashMap);
-        Assert.assertTrue("HashMap should serialize as JSON object", mapEncoded.isObject());
-        Assert.assertEquals("Map should have correct size", 3, mapEncoded.size());
-        Assert.assertEquals("String value should be correct", "stringValue", mapEncoded.get("key1").asText());
-        Assert.assertEquals("Integer value should be correct", 42, mapEncoded.get("key2").asInt());
-        Assert.assertEquals("Boolean value should be correct", true, mapEncoded.get("key3").asBoolean());
+        Assert.assertTrue("HashMap should serialize as JSON object",
+                mapEncoded.isObject());
+        Assert.assertEquals("Map should have correct size", 3,
+                mapEncoded.size());
+        Assert.assertEquals("String value should be correct", "stringValue",
+                mapEncoded.get("key1").asText());
+        Assert.assertEquals("Integer value should be correct", 42,
+                mapEncoded.get("key2").asInt());
+        Assert.assertEquals("Boolean value should be correct", true,
+                mapEncoded.get("key3").asBoolean());
     }
 
     // Test classes

--- a/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
@@ -146,14 +146,11 @@ public class JacksonCodecTest {
         for (Object value : withTypeInfoUnsupportedValues) {
             JsonNode encoded = JacksonCodec.encodeWithTypeInfo(value);
             
-            // Should be [5, {json object}] - encoded as beans
-            Assert.assertTrue("Should be array for " + value.getClass(), encoded.isArray());
-            Assert.assertEquals("Should be wrapped with BEAN_TYPE for " + value.getClass(),
-                    JacksonCodec.BEAN_TYPE, encoded.get(0).asInt());
-            
-            // The second element should be the Jackson-serialized object
-            JsonNode beanJson = encoded.get(1);
-            Assert.assertNotNull("Bean JSON should not be null for " + value.getClass(), beanJson);
+            // Should be directly encoded as JSON objects (no type wrapper needed)
+            Assert.assertNotNull("Bean JSON should not be null for " + value.getClass(), encoded);
+            // For objects, should be object node; for collections, array node, etc.
+            Assert.assertTrue("Should be valid JSON for " + value.getClass(), 
+                    encoded.isObject() || encoded.isArray() || encoded.isValueNode());
         }
     }
 
@@ -263,14 +260,10 @@ public class JacksonCodecTest {
 
         JsonNode encoded = JacksonCodec.encodeWithTypeInfo(bean);
 
-        // Should be [5, {json object}]
-        Assert.assertTrue("Should be array", encoded.isArray());
-        Assert.assertEquals("Should be wrapped with BEAN_TYPE",
-                JacksonCodec.BEAN_TYPE, encoded.get(0).asInt());
-
-        JsonNode beanJson = encoded.get(1);
-        Assert.assertEquals("Test", beanJson.get("text").asText());
-        Assert.assertEquals(42, beanJson.get("value").asInt());
+        // Should be directly encoded as JSON object
+        Assert.assertTrue("Should be object", encoded.isObject());
+        Assert.assertEquals("Test", encoded.get("text").asText());
+        Assert.assertEquals(42, encoded.get("value").asInt());
     }
 
     @Test
@@ -281,15 +274,11 @@ public class JacksonCodecTest {
 
         JsonNode encoded = JacksonCodec.encodeWithTypeInfo(outer);
 
-        // Should be [5, {json object}]
-        Assert.assertTrue("Should be array", encoded.isArray());
-        Assert.assertEquals("Should be wrapped with BEAN_TYPE",
-                JacksonCodec.BEAN_TYPE, encoded.get(0).asInt());
+        // Should be directly encoded as JSON object
+        Assert.assertTrue("Should be object", encoded.isObject());
+        Assert.assertEquals("outer", encoded.get("name").asText());
 
-        JsonNode beanJson = encoded.get(1);
-        Assert.assertEquals("outer", beanJson.get("name").asText());
-
-        JsonNode nestedJson = beanJson.get("nested");
+        JsonNode nestedJson = encoded.get("nested");
         Assert.assertEquals("inner", nestedJson.get("text").asText());
         Assert.assertEquals(123, nestedJson.get("number").asInt());
     }
@@ -332,14 +321,10 @@ public class JacksonCodecTest {
         
         JsonNode encoded = JacksonCodec.encodeWithTypeInfo(bean);
         
-        // Should be [5, {json object}]
-        Assert.assertTrue("Should be array", encoded.isArray());
-        Assert.assertEquals("Should be wrapped with BEAN_TYPE",
-                JacksonCodec.BEAN_TYPE, encoded.get(0).asInt());
-        
-        JsonNode beanJson = encoded.get(1);
-        Assert.assertEquals("TestBean", beanJson.get("text").asText());
-        Assert.assertEquals(42, beanJson.get("value").asInt());
+        // Should be directly encoded as JSON object
+        Assert.assertTrue("Should be object", encoded.isObject());
+        Assert.assertEquals("TestBean", encoded.get("text").asText());
+        Assert.assertEquals(42, encoded.get("value").asInt());
     }
 
     private static class NonSerializableBean {

--- a/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
@@ -68,16 +68,8 @@ public class JacksonCodecTest {
         assertJsonEquals(objectMapper.createArrayNode(),
                 objectMapper.createArrayNode());
 
-        // Test that complex types work with type info
-        for (Object value : complexTypeValues) {
-            JsonNode encoded = JacksonCodec.encodeWithTypeInfo(value);
-            Assert.assertNotNull(
-                    "Bean JSON should not be null for " + value.getClass(),
-                    encoded);
-            Assert.assertTrue("Should be valid JSON for " + value.getClass(),
-                    encoded.isObject() || encoded.isArray()
-                            || encoded.isValueNode());
-        }
+        // Test specific complex types - these are now handled via Jackson serialization
+        testComplexTypeSerialization();
     }
 
     @Test
@@ -276,6 +268,79 @@ public class JacksonCodecTest {
         JsonNode nestedJson = encoded.get("nested");
         Assert.assertEquals("inner", nestedJson.get("text").asText());
         Assert.assertEquals(123, nestedJson.get("number").asInt());
+    }
+
+    @Test
+    public void testComplexTypeSerialization() {
+        // Test Object - should serialize as empty object
+        Object obj = new Object();
+        JsonNode objEncoded = JacksonCodec.encodeWithTypeInfo(obj);
+        Assert.assertTrue("Object should serialize as JSON object", objEncoded.isObject());
+        Assert.assertEquals("Object should serialize as empty object", 0, objEncoded.size());
+
+        // Test StateNode - should serialize as object with state properties
+        StateNode stateNode = new StateNode();
+        JsonNode stateNodeEncoded = JacksonCodec.encodeWithTypeInfo(stateNode);
+        Assert.assertTrue("StateNode should serialize as JSON object", stateNodeEncoded.isObject());
+        // StateNode should have some internal structure
+        Assert.assertTrue("StateNode should have properties", stateNodeEncoded.size() > 0);
+
+        // Test Date - should serialize as timestamp number or ISO string
+        Date date = new Date(1234567890000L); // Fixed timestamp for consistent testing
+        JsonNode dateEncoded = JacksonCodec.encodeWithTypeInfo(date);
+        Assert.assertTrue("Date should serialize as number or string", 
+                dateEncoded.isNumber() || dateEncoded.isTextual());
+        if (dateEncoded.isNumber()) {
+            Assert.assertEquals("Date should serialize to correct timestamp", 
+                    1234567890000L, dateEncoded.asLong());
+        }
+
+        // Test String array - should serialize as JSON array
+        String[] stringArray = new String[]{"hello", "world"};
+        JsonNode arrayEncoded = JacksonCodec.encodeWithTypeInfo(stringArray);
+        Assert.assertTrue("String array should serialize as JSON array", arrayEncoded.isArray());
+        Assert.assertEquals("Array should have correct length", 2, arrayEncoded.size());
+        Assert.assertEquals("First element should be correct", "hello", arrayEncoded.get(0).asText());
+        Assert.assertEquals("Second element should be correct", "world", arrayEncoded.get(1).asText());
+
+        // Test ArrayList - should serialize as JSON array
+        ArrayList<String> arrayList = new ArrayList<>();
+        arrayList.add("item1");
+        arrayList.add("item2");
+        JsonNode listEncoded = JacksonCodec.encodeWithTypeInfo(arrayList);
+        Assert.assertTrue("ArrayList should serialize as JSON array", listEncoded.isArray());
+        Assert.assertEquals("List should have correct size", 2, listEncoded.size());
+        Assert.assertEquals("First list item should be correct", "item1", listEncoded.get(0).asText());
+        Assert.assertEquals("Second list item should be correct", "item2", listEncoded.get(1).asText());
+
+        // Test HashSet - should serialize as JSON array (order may vary)
+        HashSet<String> hashSet = new HashSet<>();
+        hashSet.add("value1");
+        hashSet.add("value2");
+        JsonNode setEncoded = JacksonCodec.encodeWithTypeInfo(hashSet);
+        Assert.assertTrue("HashSet should serialize as JSON array", setEncoded.isArray());
+        Assert.assertEquals("Set should have correct size", 2, setEncoded.size());
+        // Verify both values are present (order not guaranteed with HashSet)
+        boolean hasValue1 = false, hasValue2 = false;
+        for (JsonNode node : setEncoded) {
+            String value = node.asText();
+            if ("value1".equals(value)) hasValue1 = true;
+            if ("value2".equals(value)) hasValue2 = true;
+        }
+        Assert.assertTrue("Set should contain value1", hasValue1);
+        Assert.assertTrue("Set should contain value2", hasValue2);
+
+        // Test HashMap - should serialize as JSON object
+        HashMap<String, Object> hashMap = new HashMap<>();
+        hashMap.put("key1", "stringValue");
+        hashMap.put("key2", 42);
+        hashMap.put("key3", true);
+        JsonNode mapEncoded = JacksonCodec.encodeWithTypeInfo(hashMap);
+        Assert.assertTrue("HashMap should serialize as JSON object", mapEncoded.isObject());
+        Assert.assertEquals("Map should have correct size", 3, mapEncoded.size());
+        Assert.assertEquals("String value should be correct", "stringValue", mapEncoded.get("key1").asText());
+        Assert.assertEquals("Integer value should be correct", 42, mapEncoded.get("key2").asInt());
+        Assert.assertEquals("Boolean value should be correct", true, mapEncoded.get("key3").asBoolean());
     }
 
     // Test classes

--- a/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
@@ -35,9 +35,9 @@ import com.vaadin.flow.dom.ElementFactory;
 import com.vaadin.flow.internal.nodefeature.ElementChildrenList;
 
 public class JacksonCodecTest {
-    private static final List<Object> complexTypeValues = Arrays
-            .asList(new Object(), new StateNode(), new Date(), new String[0],
-                    new ArrayList<>(), new HashSet<>(), new HashMap<>());
+    private static final List<Object> complexTypeValues = Arrays.asList(
+            new Object(), new StateNode(), new Date(), new String[0],
+            new ArrayList<>(), new HashSet<>(), new HashMap<>());
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -71,16 +71,18 @@ public class JacksonCodecTest {
         // Test that complex types work with type info
         for (Object value : complexTypeValues) {
             JsonNode encoded = JacksonCodec.encodeWithTypeInfo(value);
-            Assert.assertNotNull("Bean JSON should not be null for " + value.getClass(), encoded);
-            Assert.assertTrue("Should be valid JSON for " + value.getClass(), 
-                    encoded.isObject() || encoded.isArray() || encoded.isValueNode());
+            Assert.assertNotNull(
+                    "Bean JSON should not be null for " + value.getClass(),
+                    encoded);
+            Assert.assertTrue("Should be valid JSON for " + value.getClass(),
+                    encoded.isObject() || encoded.isArray()
+                            || encoded.isValueNode());
         }
     }
 
     @Test
     public void encodeWithoutTypeInfo_unsupportedTypes() {
-        List<Object> unsupported = new ArrayList<>(
-                complexTypeValues);
+        List<Object> unsupported = new ArrayList<>(complexTypeValues);
         unsupported.add(ElementFactory.createDiv());
 
         for (Object value : unsupported) {
@@ -146,7 +148,6 @@ public class JacksonCodecTest {
 
         assertJsonEquals(objectMapper.nullNode(), json);
     }
-
 
     private static void assertJsonEquals(JsonNode expected, JsonNode actual) {
         Assert.assertTrue(

--- a/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
@@ -36,7 +36,7 @@ import com.vaadin.flow.dom.ElementFactory;
 import com.vaadin.flow.internal.nodefeature.ElementChildrenList;
 
 public class JacksonCodecTest {
-    private static final List<Object> withTypeInfoUnsupportedValues = Arrays
+    private static final List<Object> complexTypeValues = Arrays
             .asList(new Object(), new StateNode(), new Date(), new String[0],
                     new ArrayList<>(), new HashSet<>(), new HashMap<>());
 
@@ -73,7 +73,7 @@ public class JacksonCodecTest {
     @Test
     public void encodeWithoutTypeInfo_unsupportedTypes() {
         List<Object> unsupported = new ArrayList<>(
-                withTypeInfoUnsupportedValues);
+                complexTypeValues);
         unsupported.add(ElementFactory.createDiv());
 
         for (Object value : unsupported) {
@@ -141,9 +141,8 @@ public class JacksonCodecTest {
     }
 
     @Test
-    public void encodeWithTypeInfo_formerlyUnsupportedTypesNowEncodedAsBeans() {
-        // These types were previously unsupported but now should be encoded as beans
-        for (Object value : withTypeInfoUnsupportedValues) {
+    public void encodeWithTypeInfo_complexTypesEncodedAsBeans() {
+        for (Object value : complexTypeValues) {
             JsonNode encoded = JacksonCodec.encodeWithTypeInfo(value);
             
             // Should be directly encoded as JSON objects (no type wrapper needed)

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
@@ -364,7 +364,7 @@ public class NavigationStateRendererTest {
             final Page page = new Page(this) {
                 @Override
                 public PendingJavaScriptResult executeJs(String expression,
-                        Serializable... params) {
+                        Object... params) {
                     jsInvoked.set(true);
                     return super.executeJs(expression, params);
                 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ExecJavaScriptView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ExecJavaScriptView.java
@@ -93,59 +93,64 @@ public class ExecJavaScriptView extends AbstractDivView {
                 });
 
         // Bean serialization tests
-        NativeButton simpleBeanButton = createButton("Simple Bean", "simpleBeanButton", 
-                e -> testSimpleBean());
-        NativeButton nestedBeanButton = createButton("Nested Bean", "nestedBeanButton", 
-                e -> testNestedBean());
+        NativeButton simpleBeanButton = createButton("Simple Bean",
+                "simpleBeanButton", e -> testSimpleBean());
+        NativeButton nestedBeanButton = createButton("Nested Bean",
+                "nestedBeanButton", e -> testNestedBean());
 
         add(alertButton, focusButton, swapText, logButton, createElementButton,
-                elementAwaitButton, pageAwaitButton, simpleBeanButton, nestedBeanButton);
+                elementAwaitButton, pageAwaitButton, simpleBeanButton,
+                nestedBeanButton);
     }
 
     private void testSimpleBean() {
         SimpleBean bean = new SimpleBean("TestBean", 42, true);
-        
-        UI.getCurrent().getPage().executeJs("""
-            const bean = $0;
-            const result = `name=${bean.name}, value=${bean.value}, active=${bean.active}`;
-            
-            const resultDiv = document.createElement('div');
-            resultDiv.id = 'simpleBeanResult';
-            resultDiv.textContent = result;
-            document.body.appendChild(resultDiv);
-            
-            const statusDiv = document.createElement('div');
-            statusDiv.id = 'simpleBeanStatus';
-            statusDiv.textContent = 'Simple bean sent and received';
-            document.body.appendChild(statusDiv);
-            """, bean);
+
+        UI.getCurrent().getPage().executeJs(
+                """
+                        const bean = $0;
+                        const result = `name=${bean.name}, value=${bean.value}, active=${bean.active}`;
+
+                        const resultDiv = document.createElement('div');
+                        resultDiv.id = 'simpleBeanResult';
+                        resultDiv.textContent = result;
+                        document.body.appendChild(resultDiv);
+
+                        const statusDiv = document.createElement('div');
+                        statusDiv.id = 'simpleBeanStatus';
+                        statusDiv.textContent = 'Simple bean sent and received';
+                        document.body.appendChild(statusDiv);
+                        """,
+                bean);
     }
 
     private void testNestedBean() {
         SimpleBean inner = new SimpleBean("Inner", 100, false);
         NestedBean outer = new NestedBean("Outer", inner);
-        
-        UI.getCurrent().getPage().executeJs("""
-            const bean = $0;
-            const result = `title=${bean.title}, simple.name=${bean.simple.name}, simple.value=${bean.simple.value}`;
-            
-            const resultDiv = document.createElement('div');
-            resultDiv.id = 'nestedBeanResult';
-            resultDiv.textContent = result;
-            document.body.appendChild(resultDiv);
-            
-            const statusDiv = document.createElement('div');
-            statusDiv.id = 'nestedBeanStatus';
-            statusDiv.textContent = 'Nested bean sent and received';
-            document.body.appendChild(statusDiv);
-            """, outer);
+
+        UI.getCurrent().getPage().executeJs(
+                """
+                        const bean = $0;
+                        const result = `title=${bean.title}, simple.name=${bean.simple.name}, simple.value=${bean.simple.value}`;
+
+                        const resultDiv = document.createElement('div');
+                        resultDiv.id = 'nestedBeanResult';
+                        resultDiv.textContent = result;
+                        document.body.appendChild(resultDiv);
+
+                        const statusDiv = document.createElement('div');
+                        statusDiv.id = 'nestedBeanStatus';
+                        statusDiv.textContent = 'Nested bean sent and received';
+                        document.body.appendChild(statusDiv);
+                        """,
+                outer);
     }
 
-    public static class SimpleBean implements Serializable {
+    public static class SimpleBean {
         public String name;
         public int value;
         public boolean active;
-        
+
         public SimpleBean(String name, int value, boolean active) {
             this.name = name;
             this.value = value;
@@ -153,10 +158,10 @@ public class ExecJavaScriptView extends AbstractDivView {
         }
     }
 
-    public static class NestedBean implements Serializable {
+    public static class NestedBean {
         public String title;
         public SimpleBean simple;
-        
+
         public NestedBean(String title, SimpleBean simple) {
             this.title = title;
             this.simple = simple;

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ExecJavaScriptView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ExecJavaScriptView.java
@@ -92,8 +92,75 @@ public class ExecJavaScriptView extends AbstractDivView {
                     add(input);
                 });
 
+        // Bean serialization tests
+        NativeButton simpleBeanButton = createButton("Simple Bean", "simpleBeanButton", 
+                e -> testSimpleBean());
+        NativeButton nestedBeanButton = createButton("Nested Bean", "nestedBeanButton", 
+                e -> testNestedBean());
+
         add(alertButton, focusButton, swapText, logButton, createElementButton,
-                elementAwaitButton, pageAwaitButton);
+                elementAwaitButton, pageAwaitButton, simpleBeanButton, nestedBeanButton);
+    }
+
+    private void testSimpleBean() {
+        SimpleBean bean = new SimpleBean("TestBean", 42, true);
+        
+        UI.getCurrent().getPage().executeJs("""
+            const bean = $0;
+            const result = `name=${bean.name}, value=${bean.value}, active=${bean.active}`;
+            
+            const resultDiv = document.createElement('div');
+            resultDiv.id = 'simpleBeanResult';
+            resultDiv.textContent = result;
+            document.body.appendChild(resultDiv);
+            
+            const statusDiv = document.createElement('div');
+            statusDiv.id = 'simpleBeanStatus';
+            statusDiv.textContent = 'Simple bean sent and received';
+            document.body.appendChild(statusDiv);
+            """, bean);
+    }
+
+    private void testNestedBean() {
+        SimpleBean inner = new SimpleBean("Inner", 100, false);
+        NestedBean outer = new NestedBean("Outer", inner);
+        
+        UI.getCurrent().getPage().executeJs("""
+            const bean = $0;
+            const result = `title=${bean.title}, simple.name=${bean.simple.name}, simple.value=${bean.simple.value}`;
+            
+            const resultDiv = document.createElement('div');
+            resultDiv.id = 'nestedBeanResult';
+            resultDiv.textContent = result;
+            document.body.appendChild(resultDiv);
+            
+            const statusDiv = document.createElement('div');
+            statusDiv.id = 'nestedBeanStatus';
+            statusDiv.textContent = 'Nested bean sent and received';
+            document.body.appendChild(statusDiv);
+            """, outer);
+    }
+
+    public static class SimpleBean implements Serializable {
+        public String name;
+        public int value;
+        public boolean active;
+        
+        public SimpleBean(String name, int value, boolean active) {
+            this.name = name;
+            this.value = value;
+            this.active = active;
+        }
+    }
+
+    public static class NestedBean implements Serializable {
+        public String title;
+        public SimpleBean simple;
+        
+        public NestedBean(String title, SimpleBean simple) {
+            this.title = title;
+            this.simple = simple;
+        }
     }
 
     private NativeButton createJsButton(String text, String id, String script,

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ExecJavaScriptView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ExecJavaScriptView.java
@@ -92,58 +92,39 @@ public class ExecJavaScriptView extends AbstractDivView {
                     add(input);
                 });
 
-        // Bean serialization tests
-        NativeButton simpleBeanButton = createButton("Simple Bean",
-                "simpleBeanButton", e -> testSimpleBean());
-        NativeButton nestedBeanButton = createButton("Nested Bean",
-                "nestedBeanButton", e -> testNestedBean());
+        // Bean serialization test
+        NativeButton beanButton = createButton("Bean Serialization",
+                "beanButton", e -> testBeanSerialization());
 
         add(alertButton, focusButton, swapText, logButton, createElementButton,
-                elementAwaitButton, pageAwaitButton, simpleBeanButton,
-                nestedBeanButton);
+                elementAwaitButton, pageAwaitButton, beanButton);
     }
 
-    private void testSimpleBean() {
-        SimpleBean bean = new SimpleBean("TestBean", 42, true);
-
-        UI.getCurrent().getPage().executeJs(
-                """
-                        const bean = $0;
-                        const result = `name=${bean.name}, value=${bean.value}, active=${bean.active}`;
-
-                        const resultDiv = document.createElement('div');
-                        resultDiv.id = 'simpleBeanResult';
-                        resultDiv.textContent = result;
-                        document.body.appendChild(resultDiv);
-
-                        const statusDiv = document.createElement('div');
-                        statusDiv.id = 'simpleBeanStatus';
-                        statusDiv.textContent = 'Simple bean sent and received';
-                        document.body.appendChild(statusDiv);
-                        """,
-                bean);
-    }
-
-    private void testNestedBean() {
+    private void testBeanSerialization() {
+        // Test both simple and nested beans in one test
+        SimpleBean simple = new SimpleBean("TestBean", 42, true);
         SimpleBean inner = new SimpleBean("Inner", 100, false);
-        NestedBean outer = new NestedBean("Outer", inner);
+        NestedBean nested = new NestedBean("Outer", inner);
 
         UI.getCurrent().getPage().executeJs(
                 """
-                        const bean = $0;
-                        const result = `title=${bean.title}, simple.name=${bean.simple.name}, simple.value=${bean.simple.value}`;
-
+                        const simpleBean = $0;
+                        const nestedBean = $1;
+                        
+                        const simpleResult = `simple: name=${simpleBean.name}, value=${simpleBean.value}, active=${simpleBean.active}`;
+                        const nestedResult = `nested: title=${nestedBean.title}, inner.name=${nestedBean.simple.name}, inner.value=${nestedBean.simple.value}`;
+                        
                         const resultDiv = document.createElement('div');
-                        resultDiv.id = 'nestedBeanResult';
-                        resultDiv.textContent = result;
+                        resultDiv.id = 'beanResult';
+                        resultDiv.textContent = simpleResult + ' | ' + nestedResult;
                         document.body.appendChild(resultDiv);
-
+                        
                         const statusDiv = document.createElement('div');
-                        statusDiv.id = 'nestedBeanStatus';
-                        statusDiv.textContent = 'Nested bean sent and received';
+                        statusDiv.id = 'beanStatus';
+                        statusDiv.textContent = 'Bean serialization test completed';
                         document.body.appendChild(statusDiv);
                         """,
-                outer);
+                simple, nested);
     }
 
     public static class SimpleBean {

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ExecJavaScriptView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ExecJavaScriptView.java
@@ -110,15 +110,15 @@ public class ExecJavaScriptView extends AbstractDivView {
                 """
                         const simpleBean = $0;
                         const nestedBean = $1;
-                        
+
                         const simpleResult = `simple: name=${simpleBean.name}, value=${simpleBean.value}, active=${simpleBean.active}`;
                         const nestedResult = `nested: title=${nestedBean.title}, inner.name=${nestedBean.simple.name}, inner.value=${nestedBean.simple.value}`;
-                        
+
                         const resultDiv = document.createElement('div');
                         resultDiv.id = 'beanResult';
                         resultDiv.textContent = simpleResult + ' | ' + nestedResult;
                         document.body.appendChild(resultDiv);
-                        
+
                         const statusDiv = document.createElement('div');
                         statusDiv.id = 'beanStatus';
                         statusDiv.textContent = 'Bean serialization test completed';

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ExecJavaScriptIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ExecJavaScriptIT.java
@@ -61,6 +61,44 @@ public class ExecJavaScriptIT extends ChromeBrowserTest {
                 result.getText());
     }
 
+    @Test
+    public void testBeanSerializationSimpleTypes() {
+        open();
+
+        // Test simple bean with only primitive types
+        getButton("simpleBeanButton").click();
+
+        // Wait for the result div to appear
+        WebElement result = waitUntil(
+                d -> findElement(By.id("simpleBeanResult")));
+        Assert.assertEquals("name=TestBean, value=42, active=true",
+                result.getText());
+
+        // Verify status message
+        WebElement status = waitUntil(
+                d -> findElement(By.id("simpleBeanStatus")));
+        Assert.assertEquals("Simple bean sent and received", status.getText());
+    }
+
+    @Test
+    public void testBeanSerializationNestedBeans() {
+        open();
+
+        // Test nested beans
+        getButton("nestedBeanButton").click();
+
+        // Wait for the result div to appear
+        WebElement result = waitUntil(
+                d -> findElement(By.id("nestedBeanResult")));
+        Assert.assertEquals("title=Outer, simple.name=Inner, simple.value=100",
+                result.getText());
+
+        // Verify status message
+        WebElement status = waitUntil(
+                d -> findElement(By.id("nestedBeanStatus")));
+        Assert.assertEquals("Nested bean sent and received", status.getText());
+    }
+
     private WebElement getButton(String id) {
         return findElement(By.id(id));
     }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ExecJavaScriptIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ExecJavaScriptIT.java
@@ -62,41 +62,22 @@ public class ExecJavaScriptIT extends ChromeBrowserTest {
     }
 
     @Test
-    public void testBeanSerializationSimpleTypes() {
+    public void testBeanSerialization() {
         open();
 
-        // Test simple bean with only primitive types
-        getButton("simpleBeanButton").click();
+        // Test both simple and nested beans in one consolidated test
+        getButton("beanButton").click();
 
         // Wait for the result div to appear
         WebElement result = waitUntil(
-                d -> findElement(By.id("simpleBeanResult")));
-        Assert.assertEquals("name=TestBean, value=42, active=true",
+                d -> findElement(By.id("beanResult")));
+        Assert.assertEquals("simple: name=TestBean, value=42, active=true | nested: title=Outer, inner.name=Inner, inner.value=100",
                 result.getText());
 
         // Verify status message
         WebElement status = waitUntil(
-                d -> findElement(By.id("simpleBeanStatus")));
-        Assert.assertEquals("Simple bean sent and received", status.getText());
-    }
-
-    @Test
-    public void testBeanSerializationNestedBeans() {
-        open();
-
-        // Test nested beans
-        getButton("nestedBeanButton").click();
-
-        // Wait for the result div to appear
-        WebElement result = waitUntil(
-                d -> findElement(By.id("nestedBeanResult")));
-        Assert.assertEquals("title=Outer, simple.name=Inner, simple.value=100",
-                result.getText());
-
-        // Verify status message
-        WebElement status = waitUntil(
-                d -> findElement(By.id("nestedBeanStatus")));
-        Assert.assertEquals("Nested bean sent and received", status.getText());
+                d -> findElement(By.id("beanStatus")));
+        Assert.assertEquals("Bean serialization test completed", status.getText());
     }
 
     private WebElement getButton(String id) {

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ExecJavaScriptIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ExecJavaScriptIT.java
@@ -69,15 +69,15 @@ public class ExecJavaScriptIT extends ChromeBrowserTest {
         getButton("beanButton").click();
 
         // Wait for the result div to appear
-        WebElement result = waitUntil(
-                d -> findElement(By.id("beanResult")));
-        Assert.assertEquals("simple: name=TestBean, value=42, active=true | nested: title=Outer, inner.name=Inner, inner.value=100",
+        WebElement result = waitUntil(d -> findElement(By.id("beanResult")));
+        Assert.assertEquals(
+                "simple: name=TestBean, value=42, active=true | nested: title=Outer, inner.name=Inner, inner.value=100",
                 result.getText());
 
         // Verify status message
-        WebElement status = waitUntil(
-                d -> findElement(By.id("beanStatus")));
-        Assert.assertEquals("Bean serialization test completed", status.getText());
+        WebElement status = waitUntil(d -> findElement(By.id("beanStatus")));
+        Assert.assertEquals("Bean serialization test completed",
+                status.getText());
     }
 
     private WebElement getButton(String id) {


### PR DESCRIPTION
Implements bean-only serialization using Jackson.
Beans are serialized on server and handled as standard JS objects on client.
