### PR TITLE
feat: Add bean deserialization support for executeJs return values

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -269,6 +269,10 @@ public class Page implements Serializable {
      * it becomes available. If no return value handler is registered, the
      * return value will be ignored.
      * <p>
+     * Return values from JavaScript can be automatically deserialized into Java
+     * objects. All types supported by Jackson for JSON deserialization are
+     * supported as return values, including custom bean classes.
+     * <p>
      * The given parameters will be available to the expression as variables
      * named <code>$0</code>, <code>$1</code>, and so on. All types supported by
      * Jackson for JSON serialization are supported as parameters. Special

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/PendingJavaScriptResult.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/PendingJavaScriptResult.java
@@ -86,6 +86,10 @@ public interface PendingJavaScriptResult extends Serializable {
      * be invoked asynchronously when the result of the execution is sent back
      * to the server.
      * <p>
+     * The JavaScript return value will be automatically converted to the
+     * specified target type. All types supported by Jackson for JSON
+     * deserialization are supported, including custom bean classes.
+     * <p>
      * Handlers can only be added before the execution has been sent to the
      * browser.
      *
@@ -120,6 +124,10 @@ public interface PendingJavaScriptResult extends Serializable {
      * handler will be invoked asynchronously if the execution was successful.
      * In case of a failure, no handler will be run.
      * <p>
+     * The JavaScript return value will be automatically converted to the
+     * specified target type. All types supported by Jackson for JSON
+     * deserialization are supported, including custom bean classes.
+     * <p>
      * A handler can only be added before the execution has been sent to the
      * browser.
      *
@@ -142,6 +150,10 @@ public interface PendingJavaScriptResult extends Serializable {
      * synchronously wait for the result of the execution while holding the
      * session lock since the request handling thread that makes the result
      * available will also need to lock the session.
+     * <p>
+     * The JavaScript return value will be automatically converted to the
+     * specified target type. All types supported by Jackson for JSON
+     * deserialization are supported, including custom bean classes.
      * <p>
      * A completable future can only be created before the execution has been
      * sent to the browser.

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -1453,6 +1453,10 @@ public class Element extends Node<Element> {
      * value once it becomes available. If no return value handler is
      * registered, the return value will be ignored.
      * <p>
+     * Return values from JavaScript can be automatically deserialized into Java
+     * objects. All types supported by Jackson for JSON deserialization are
+     * supported as return values, including custom bean classes.
+     * <p>
      * This element will be available to the expression as <code>this</code>.
      * The given parameters will be available as variables named
      * <code>$0</code>, <code>$1</code>, and so on. All types supported by

--- a/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
@@ -243,7 +243,6 @@ public class JacksonCodecTest {
 
     @Test
     public void testSimpleBeanSerialization() {
-        // Test simple bean serialization without any Components
         SimpleBean bean = new SimpleBean("Test", 42);
 
         JsonNode encoded = JacksonCodec.encodeWithTypeInfo(bean);
@@ -256,7 +255,6 @@ public class JacksonCodecTest {
 
     @Test
     public void testNestedBeanSerialization() {
-        // Test nested beans
         NestedBean nested = new NestedBean("inner", 123);
         OuterBean outer = new OuterBean("outer", nested);
 
@@ -371,6 +369,9 @@ public class JacksonCodecTest {
         public String text;
         public int value;
 
+        public SimpleBean() {
+        }
+
         public SimpleBean(String text, int value) {
             this.text = text;
             this.value = value;
@@ -380,6 +381,9 @@ public class JacksonCodecTest {
     private static class NestedBean {
         public String text;
         public int number;
+
+        public NestedBean() {
+        }
 
         public NestedBean(String text, int number) {
             this.text = text;
@@ -391,10 +395,74 @@ public class JacksonCodecTest {
         public String name;
         public NestedBean nested;
 
+        public OuterBean() {
+        }
+
         public OuterBean(String name, NestedBean nested) {
             this.name = name;
             this.nested = nested;
         }
     }
 
+    @Test
+    public void testDecodeAsSimpleBean() {
+        ObjectNode json = objectMapper.createObjectNode();
+        json.put("text", "TestBean");
+        json.put("value", 42);
+
+        SimpleBean decoded = JacksonCodec.decodeAs(json, SimpleBean.class);
+
+        Assert.assertEquals("TestBean", decoded.text);
+        Assert.assertEquals(42, decoded.value);
+    }
+
+    @Test
+    public void testDecodeAsNestedBean() {
+        ObjectNode nestedJson = objectMapper.createObjectNode();
+        nestedJson.put("text", "NestedTest");
+        nestedJson.put("number", 456);
+
+        ObjectNode outerJson = objectMapper.createObjectNode();
+        outerJson.put("name", "OuterTest");
+        outerJson.set("nested", nestedJson);
+
+        OuterBean decoded = JacksonCodec.decodeAs(outerJson, OuterBean.class);
+
+        Assert.assertEquals("OuterTest", decoded.name);
+        Assert.assertEquals("NestedTest", decoded.nested.text);
+        Assert.assertEquals(456, decoded.nested.number);
+    }
+
+    @Test
+    public void testDecodeAsNullValue() {
+        JsonNode nullNode = objectMapper.nullNode();
+
+        SimpleBean decoded = JacksonCodec.decodeAs(nullNode, SimpleBean.class);
+        Assert.assertNull(decoded);
+    }
+
+    @Test
+    public void testDecodeAsInvalidJson() {
+        JsonNode invalidJson = objectMapper.valueToTree("not an object");
+
+        try {
+            JacksonCodec.decodeAs(invalidJson, SimpleBean.class);
+            Assert.fail("Should have thrown IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            Assert.assertTrue(
+                    e.getMessage().contains("Cannot deserialize JSON to type"));
+        }
+    }
+
+    @Test
+    public void testDecodeAsPreservesExistingBehavior() {
+        Assert.assertEquals("test", JacksonCodec
+                .decodeAs(objectMapper.valueToTree("test"), String.class));
+        Assert.assertEquals(Integer.valueOf(42), JacksonCodec
+                .decodeAs(objectMapper.valueToTree(42), Integer.class));
+        Assert.assertEquals(Boolean.TRUE, JacksonCodec
+                .decodeAs(objectMapper.valueToTree(true), Boolean.class));
+        Assert.assertEquals(Double.valueOf(3.14), JacksonCodec
+                .decodeAs(objectMapper.valueToTree(3.14), Double.class));
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
@@ -455,7 +455,7 @@ public class JacksonCodecTest {
     }
 
     @Test
-    public void testDecodeAsPreservesExistingBehavior() {
+    public void testDecodeAsForPrimitiveTypes() {
         Assert.assertEquals("test", JacksonCodec
                 .decodeAs(objectMapper.valueToTree("test"), String.class));
         Assert.assertEquals(Integer.valueOf(42), JacksonCodec

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ExecJavaScriptView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ExecJavaScriptView.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.uitest.ui;
 import java.io.Serializable;
 
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Input;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Span;
@@ -92,16 +93,36 @@ public class ExecJavaScriptView extends AbstractDivView {
                     add(input);
                 });
 
-        // Bean serialization test
         NativeButton beanButton = createButton("Bean Serialization",
                 "beanButton", e -> testBeanSerialization());
 
+        NativeButton returnBeanButton = createButton("Return Bean",
+                "returnBeanButton", e -> {
+                    UI.getCurrent().getPage().executeJs(
+                            "return {title: 'ReturnedNested', simple: {name: 'InnerReturned', value: 777, active: true}}")
+                            .then(NestedBean.class, bean -> {
+                                Div result = new Div();
+                                result.setId("returnBeanResult");
+                                result.setText("Returned: title=" + bean.title
+                                        + ", simple.name=" + bean.simple.name
+                                        + ", simple.value=" + bean.simple.value
+                                        + ", simple.active="
+                                        + bean.simple.active);
+                                add(result);
+
+                                Div status = new Div();
+                                status.setId("returnBeanStatus");
+                                status.setText("Bean returned");
+                                add(status);
+                            });
+                });
+
         add(alertButton, focusButton, swapText, logButton, createElementButton,
-                elementAwaitButton, pageAwaitButton, beanButton);
+                elementAwaitButton, pageAwaitButton, beanButton,
+                returnBeanButton);
     }
 
     private void testBeanSerialization() {
-        // Test both simple and nested beans in one test
         SimpleBean simple = new SimpleBean("TestBean", 42, true);
         SimpleBean inner = new SimpleBean("Inner", 100, false);
         NestedBean nested = new NestedBean("Outer", inner);
@@ -121,7 +142,7 @@ public class ExecJavaScriptView extends AbstractDivView {
 
                         const statusDiv = document.createElement('div');
                         statusDiv.id = 'beanStatus';
-                        statusDiv.textContent = 'Bean serialization test completed';
+                        statusDiv.textContent = 'Bean serialization completed';
                         document.body.appendChild(statusDiv);
                         """,
                 simple, nested);
@@ -131,6 +152,9 @@ public class ExecJavaScriptView extends AbstractDivView {
         public String name;
         public int value;
         public boolean active;
+
+        public SimpleBean() {
+        }
 
         public SimpleBean(String name, int value, boolean active) {
             this.name = name;
@@ -142,6 +166,9 @@ public class ExecJavaScriptView extends AbstractDivView {
     public static class NestedBean {
         public String title;
         public SimpleBean simple;
+
+        public NestedBean() {
+        }
 
         public NestedBean(String title, SimpleBean simple) {
             this.title = title;

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ExecJavaScriptIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ExecJavaScriptIT.java
@@ -65,19 +65,32 @@ public class ExecJavaScriptIT extends ChromeBrowserTest {
     public void testBeanSerialization() {
         open();
 
-        // Test both simple and nested beans in one consolidated test
         getButton("beanButton").click();
 
-        // Wait for the result div to appear
         WebElement result = waitUntil(d -> findElement(By.id("beanResult")));
         Assert.assertEquals(
                 "simple: name=TestBean, value=42, active=true | nested: title=Outer, inner.name=Inner, inner.value=100",
                 result.getText());
 
-        // Verify status message
         WebElement status = waitUntil(d -> findElement(By.id("beanStatus")));
-        Assert.assertEquals("Bean serialization test completed",
-                status.getText());
+        Assert.assertEquals("Bean serialization completed", status.getText());
+    }
+
+    @Test
+    public void testBeanReturnValue() {
+        open();
+
+        getButton("returnBeanButton").click();
+
+        WebElement result = waitUntil(
+                d -> findElement(By.id("returnBeanResult")));
+        Assert.assertEquals(
+                "Returned: title=ReturnedNested, simple.name=InnerReturned, simple.value=777, simple.active=true",
+                result.getText());
+
+        WebElement status = waitUntil(
+                d -> findElement(By.id("returnBeanStatus")));
+        Assert.assertEquals("Bean returned", status.getText());
     }
 
     private WebElement getButton(String id) {


### PR DESCRIPTION
- Extend JacksonCodec.decodeAs() to deserialize JSON objects into Java beans using Jackson
- Extend JsonCodec.decodeAs() with similar bean deserialization support for consistency
- Add comprehensive unit tests for simple beans, nested beans, null handling, and error cases
- Add default constructors to test bean classes for Jackson compatibility
- Add integration tests with new buttons for testing bean return values from client
- Add ExecJavaScriptIT tests to verify complete client-to-server bean deserialization flow
- Maintain full backward compatibility for existing primitive type decoding
- Support both simple and complex nested bean structures returned from JavaScript

This enables JavaScript code to return complex objects that are automatically
deserialized into typed Java beans on the server side.
