### PR TITLE
fix: make sure request principal is available (#22368) (CP: 24.8)

### DIFF
--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/pom.xml
@@ -182,6 +182,9 @@
 				<groupId>com.vaadin</groupId>
 				<artifactId>flow-maven-plugin</artifactId>
 				<version>${project.version}</version>
+				<configuration>
+					<frontendHotdeploy>false</frontendHotdeploy>
+				</configuration>
 				<executions>
 					<execution>
 						<goals>

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/main/java/com/vaadin/flow/spring/flowsecurity/SecurityConfig.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/main/java/com/vaadin/flow/spring/flowsecurity/SecurityConfig.java
@@ -1,12 +1,21 @@
 package com.vaadin.flow.spring.flowsecurity;
 
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.internal.UrlUtil;
+import com.vaadin.flow.internal.hilla.FileRouterRequestUtil;
+import com.vaadin.flow.spring.RootMappedCondition;
+import com.vaadin.flow.spring.VaadinConfigurationProperties;
+import com.vaadin.flow.spring.flowsecurity.data.UserInfo;
+import com.vaadin.flow.spring.flowsecurity.service.UserInfoService;
+import com.vaadin.flow.spring.flowsecurity.views.LoginView;
+import com.vaadin.flow.spring.security.NavigationAccessControlConfigurer;
+import com.vaadin.flow.spring.security.VaadinAwareSecurityContextHolderStrategyConfiguration;
+import com.vaadin.flow.spring.security.VaadinSecurityConfigurer;
 import jakarta.servlet.ServletContext;
-
-import java.util.stream.Collectors;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -14,22 +23,17 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
 
-import com.vaadin.flow.component.UI;
-import com.vaadin.flow.internal.UrlUtil;
-import com.vaadin.flow.spring.RootMappedCondition;
-import com.vaadin.flow.spring.VaadinConfigurationProperties;
-import com.vaadin.flow.spring.flowsecurity.data.UserInfo;
-import com.vaadin.flow.spring.flowsecurity.service.UserInfoService;
-import com.vaadin.flow.spring.flowsecurity.views.LoginView;
-import com.vaadin.flow.spring.security.NavigationAccessControlConfigurer;
-import com.vaadin.flow.spring.security.VaadinWebSecurity;
+import java.util.stream.Collectors;
 
 import static com.vaadin.flow.spring.flowsecurity.service.UserInfoService.ROLE_ADMIN;
+import static com.vaadin.flow.spring.security.RequestUtil.antMatchers;
 
 @EnableWebSecurity
 @Configuration
-public class SecurityConfig extends VaadinWebSecurity {
+@Import(VaadinAwareSecurityContextHolderStrategyConfiguration.class)
+public class SecurityConfig {
 
     @Autowired
     private UserInfoService userInfoService;
@@ -44,6 +48,21 @@ public class SecurityConfig extends VaadinWebSecurity {
     static NavigationAccessControlConfigurer navigationAccessControlConfigurer() {
         return new NavigationAccessControlConfigurer()
                 .withRoutePathAccessChecker();
+    }
+
+    /*
+     * Simulates Hilla implementation that accesses request principal.
+     */
+    @Bean
+    FileRouterRequestUtil sutbFileRouterRequestUtil() {
+        return request -> {
+            var principal = request.getUserPrincipal();
+            if (principal != null) {
+                // do nothing, just prevent IDE from complaining about unused
+                // variable
+            }
+            return false;
+        };
     }
 
     public String getLogoutSuccessUrl() {
@@ -61,40 +80,38 @@ public class SecurityConfig extends VaadinWebSecurity {
         return logoutSuccessUrl;
     }
 
-    @Override
-    public void configure(HttpSecurity http) throws Exception {
-        // @formatter:off
+    @Bean
+    SecurityFilterChain vaadinSecurityFilterChain(HttpSecurity http)
+            throws Exception {
         http.authorizeHttpRequests(cfg -> cfg
                 .requestMatchers(antMatchers("/admin-only/**", "/admin"))
-                    .hasAnyRole(ROLE_ADMIN)
-                .requestMatchers(antMatchers("/private"))
-                    .authenticated()
-                .requestMatchers(antMatchers("/", "/public/**", "/another", "/menu-list"))
-                    .permitAll()
-                .requestMatchers(antMatchers("/error"))
-                    .permitAll()
+                .hasAnyRole(ROLE_ADMIN).requestMatchers(antMatchers("/private"))
+                .authenticated()
+                .requestMatchers(antMatchers("/", "/public/**", "/another",
+                        "/menu-list"))
+                .permitAll().requestMatchers(antMatchers("/error")).permitAll()
                 // routes aliases
                 .requestMatchers(antMatchers("/alias-for-admin"))
-                    .hasAnyRole(ROLE_ADMIN)
-                .requestMatchers(antMatchers("/home", "/hey/**"))
-                    .permitAll()
-        );
+                .hasAnyRole(ROLE_ADMIN)
+                .requestMatchers(antMatchers("/home", "/hey/**")).permitAll()
+                .requestMatchers(antMatchers("/all-logged-in/**"))
+                .authenticated());
         // @formatter:on
-
-        super.configure(http);
-        if (getLogoutSuccessUrl().equals("/")) {
-            // Test the default url with empty context path
-            setLoginView(http, LoginView.class);
-        } else {
-            setLoginView(http, LoginView.class, getLogoutSuccessUrl());
-        }
-        http.logout(cfg -> cfg
-                .addLogoutHandler((request, response, authentication) -> {
-                    UI ui = UI.getCurrent();
-                    ui.accessSynchronously(() -> ui.getPage()
-                            .setLocation(UrlUtil.getServletPathRelative(
-                                    getLogoutSuccessUrl(), request)));
-                }));
+        http.with(VaadinSecurityConfigurer.vaadin(), vaadin -> {
+            if (getLogoutSuccessUrl().equals("/")) {
+                // Test the default url with empty context path
+                vaadin.loginView(LoginView.class);
+            } else {
+                vaadin.loginView(LoginView.class, getLogoutSuccessUrl());
+            }
+            vaadin.addLogoutHandler((request, response, authentication) -> {
+                UI ui = UI.getCurrent();
+                ui.accessSynchronously(() -> ui.getPage().setLocation(
+                        UrlUtil.getServletPathRelative(getLogoutSuccessUrl(),
+                                request)));
+            });
+        });
+        return http.build();
     }
 
     @Bean

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/main/java/com/vaadin/hilla/EndpointController.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/main/java/com/vaadin/hilla/EndpointController.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package com.vaadin.hilla;
+
+// Stub class to simulate the presence of Hilla
+class EndpointController {
+}

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/RequestUtil.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/RequestUtil.java
@@ -1,20 +1,5 @@
 package com.vaadin.flow.spring.security;
 
-import java.util.Optional;
-import java.util.stream.Stream;
-
-import jakarta.servlet.http.HttpServletRequest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.web.servlet.ServletRegistrationBean;
-import org.springframework.http.HttpMethod;
-import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
-import org.springframework.security.web.util.matcher.RequestMatcher;
-import org.springframework.stereotype.Component;
-
 import com.vaadin.flow.internal.hilla.EndpointRequestUtil;
 import com.vaadin.flow.internal.hilla.FileRouterRequestUtil;
 import com.vaadin.flow.router.Location;
@@ -31,8 +16,25 @@ import com.vaadin.flow.server.auth.AccessCheckResult;
 import com.vaadin.flow.server.auth.AnonymousAllowed;
 import com.vaadin.flow.server.auth.NavigationAccessControl;
 import com.vaadin.flow.server.auth.NavigationContext;
+import com.vaadin.flow.spring.AuthenticationUtil;
 import com.vaadin.flow.spring.SpringServlet;
 import com.vaadin.flow.spring.VaadinConfigurationProperties;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.servlet.ServletRegistrationBean;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.stereotype.Component;
+
+import java.security.Principal;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
  * Contains utility methods related to request handling.
@@ -138,7 +140,8 @@ public class RequestUtil {
         if (ROUTE_PATH_MATCHER_RUNNING.get() == null) {
             ROUTE_PATH_MATCHER_RUNNING.set(Boolean.TRUE);
             try {
-                return isAnonymousRouteInternal(request);
+                return isAnonymousRouteInternal(
+                        PrincipalAwareRequestWrapper.wrap(request));
             } finally {
                 ROUTE_PATH_MATCHER_RUNNING.remove();
             }
@@ -230,6 +233,23 @@ public class RequestUtil {
         return Stream.of(patterns)
                 .map(p -> AntPathRequestMatcher.antMatcher(HttpMethod.GET, p))
                 .toArray(RequestMatcher[]::new);
+    }
+
+    /**
+     * Wraps a given {@link RequestMatcher} to ensure requests are processed
+     * with the principal awareness provided by
+     * {@link RequestUtil.PrincipalAwareRequestWrapper}.
+     *
+     * @param matcher
+     *            the {@link RequestMatcher} to be wrapped
+     * @return a {@link RequestMatcher} that processes requests using a
+     *         {@link RequestUtil.PrincipalAwareRequestWrapper} for principal
+     *         awareness
+     */
+    public static RequestMatcher principalAwareRequestMatcher(
+            RequestMatcher matcher) {
+        return request -> matcher.matches(
+                RequestUtil.PrincipalAwareRequestWrapper.wrap(request));
     }
 
     private boolean isAnonymousRouteInternal(HttpServletRequest request) {
@@ -346,6 +366,47 @@ public class RequestUtil {
             path = path.substring(1);
         }
         return urlMapping + "/" + path;
+    }
+
+    /**
+     * A wrapper for {@link HttpServletRequest} that provides additional
+     * functionality to handle the user principal retrieval in a safer manner.
+     * <p>
+     * This class extends {@link HttpServletRequestWrapper} and overrides its
+     * {@code getUserPrincipal()} method to handle cases where the operation
+     * might not be supported by the underlying {@link HttpServletRequest}, for
+     * example when called by a Spring request matcher in the context of
+     * {@code WebInvocationPrivilegeEvaluator} permissions evaluation.
+     */
+    static class PrincipalAwareRequestWrapper
+            extends HttpServletRequestWrapper {
+
+        private PrincipalAwareRequestWrapper(HttpServletRequest request) {
+            super(request);
+        }
+
+        @Override
+        public Principal getUserPrincipal() {
+            try {
+                return super.getUserPrincipal();
+            } catch (UnsupportedOperationException e) {
+                return AuthenticationUtil.getSecurityHolderAuthentication();
+            }
+        }
+
+        static HttpServletRequest wrap(HttpServletRequest request) {
+            if (request instanceof PrincipalAwareRequestWrapper) {
+                return request;
+            }
+            HttpServletRequest maybeWrapper = request;
+            while (maybeWrapper instanceof HttpServletRequestWrapper wrapper) {
+                if (wrapper instanceof PrincipalAwareRequestWrapper) {
+                    return request;
+                }
+                maybeWrapper = (HttpServletRequest) wrapper.getRequest();
+            }
+            return new PrincipalAwareRequestWrapper(request);
+        }
     }
 
     private Logger getLogger() {

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/SpringAccessPathChecker.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/SpringAccessPathChecker.java
@@ -16,13 +16,15 @@
 
 package com.vaadin.flow.spring.security;
 
+import com.vaadin.flow.server.auth.AccessPathChecker;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.access.AuthorizationManagerWebInvocationPrivilegeEvaluator.HttpServletRequestTransformer;
+import org.springframework.security.web.access.WebInvocationPrivilegeEvaluator;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
 import java.security.Principal;
 import java.util.function.Predicate;
-
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.access.WebInvocationPrivilegeEvaluator;
-
-import com.vaadin.flow.server.auth.AccessPathChecker;
 
 /**
  * A Spring specific route path access checker that delegates the check to
@@ -47,6 +49,51 @@ import com.vaadin.flow.server.auth.AccessPathChecker;
  * NavigationAccessControlConfigurer navigationAccessControlConfigurer() {
  *     return new NavigationAccessControlConfigurer()
  *             .withRoutePathAccessChecker().withLoginView(LoginView.class);
+ * }
+ * }
+ * </pre>
+ *
+ * <h2>Custom Request Transformer</h2>
+ * <p>
+ * When using {@link SpringAccessPathChecker} with Spring Security request
+ * matchers that need to access
+ * {@link jakarta.servlet.http.HttpServletRequest#getUserPrincipal()}, you may
+ * need to create a custom
+ * {@link org.springframework.security.web.access.AuthorizationManagerWebInvocationPrivilegeEvaluator.HttpServletRequestTransformer}
+ * bean using
+ * {@link #principalAwareRequestTransformer(org.springframework.security.web.access.AuthorizationManagerWebInvocationPrivilegeEvaluator.HttpServletRequestTransformer)}.
+ * This prevents {@link UnsupportedOperationException}s that can occur when
+ * Spring Security request matchers attempt to access user principal
+ * information.
+ *
+ * <pre>
+ * {@code
+ * &#64;Bean
+ * &#64;Primary
+ * HttpServletRequestTransformer customRequestTransformer() {
+ *     return SpringAccessPathChecker.principalAwareRequestTransformer(
+ *             new PathPatternRequestTransformer());
+ * }
+ * }
+ * </pre>
+ *
+ * An alternative is to use wrap the single request matchers using
+ * {@link RequestUtil#principalAwareRequestMatcher(RequestMatcher)}.
+ *
+ * <pre>
+ * {@code
+ * &#64;Bean
+ * public SecurityFilterChain webFilterChain(HttpSecurity http) {
+ *     http.authorizeRequests(cfg -> cfg.requestMatchers(RequestUtil.principalAwareRequestMatcher(
+ *          request -> {
+ *              ...
+ *              if (request.getUserPrincipal() == null) {
+ *                  ....;
+ *              }
+ *              ...
+ *              return true;
+ *          }
+ *     ));
  * }
  * }
  * </pre>
@@ -92,4 +139,27 @@ public class SpringAccessPathChecker implements AccessPathChecker {
         return evaluator.isAllowed(path,
                 SecurityContextHolder.getContext().getAuthentication());
     }
+
+    /**
+     * Provides a security-aware HTTP request transformer that applies
+     * additional processing to the transformed request using
+     * {@link RequestUtil.PrincipalAwareRequestWrapper}.
+     * <p>
+     * A custom {@link HttpServletRequestTransformer} bean handling
+     * {@link HttpServletRequest#getUserPrincipal()} method should be exposed by
+     * the application when {@link SpringAccessPathChecker} is used in
+     * conjunction with Spring Security request matchers that requires to access
+     * that information to prevent {@link UnsupportedOperationException}s.
+     *
+     * @param transformer
+     *            the original HTTP request transformer to be wrapped
+     * @return a new HTTP request transformer that wraps the transformed request
+     *         with enhanced security awareness
+     */
+    public static HttpServletRequestTransformer principalAwareRequestTransformer(
+            HttpServletRequestTransformer transformer) {
+        return request -> RequestUtil.PrincipalAwareRequestWrapper
+                .wrap(transformer.transform(request));
+    }
+
 }

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinSecurityConfigurer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinSecurityConfigurer.java
@@ -15,12 +15,14 @@
  */
 package com.vaadin.flow.spring.security;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Optional;
-import java.util.function.Consumer;
-
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.internal.AnnotationReader;
+import com.vaadin.flow.internal.hilla.EndpointRequestUtil;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.internal.RouteUtil;
+import com.vaadin.flow.server.VaadinServletContext;
+import com.vaadin.flow.server.auth.NavigationAccessControl;
+import com.vaadin.flow.server.auth.RoutePathAccessChecker;
 import jakarta.servlet.ServletContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,13 +61,11 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatchers;
 import org.springframework.web.context.WebApplicationContext;
 
-import com.vaadin.flow.component.Component;
-import com.vaadin.flow.internal.AnnotationReader;
-import com.vaadin.flow.internal.hilla.EndpointRequestUtil;
-import com.vaadin.flow.router.Route;
-import com.vaadin.flow.router.internal.RouteUtil;
-import com.vaadin.flow.server.VaadinServletContext;
-import com.vaadin.flow.server.auth.NavigationAccessControl;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
 
 import static com.vaadin.flow.spring.security.VaadinWebSecurity.getDefaultHttpSecurityPermitMatcher;
 import static com.vaadin.flow.spring.security.VaadinWebSecurity.getDefaultWebSecurityIgnoreMatcher;
@@ -482,13 +482,23 @@ public final class VaadinSecurityConfigurer
                 getDefaultHttpSecurityPermitMatcher(urlMapping),
                 getDefaultWebSecurityIgnoreMatcher(urlMapping));
         if (EndpointRequestUtil.isHillaAvailable()) {
-            return RequestMatchers.anyOf(baseMatcher,
-                    // Matchers for known Hilla views
-                    getRequestUtil()::isAllowedHillaView,
-                    // Matcher for public Hilla endpoints
-                    getRequestUtil()::isAnonymousEndpoint);
+            return toRequestPrincipalAwareMatcher(
+                    RequestMatchers.anyOf(baseMatcher,
+                            // Matchers for known Hilla views
+                            getRequestUtil()::isAllowedHillaView,
+                            // Matcher for public Hilla endpoints
+                            getRequestUtil()::isAnonymousEndpoint));
         }
-        return baseMatcher;
+        return toRequestPrincipalAwareMatcher(baseMatcher);
+    }
+
+    private RequestMatcher toRequestPrincipalAwareMatcher(
+            RequestMatcher matcher) {
+        if (enableNavigationAccessControl && getNavigationAccessControl()
+                .hasAccessChecker(RoutePathAccessChecker.class)) {
+            return RequestUtil.principalAwareRequestMatcher(matcher);
+        }
+        return matcher;
     }
 
     @Override
@@ -519,11 +529,13 @@ public final class VaadinSecurityConfigurer
         if (enableAuthorizedRequestsConfiguration && !alreadyInitializedOnce) {
             http.authorizeHttpRequests(this::customizeAuthorizeHttpRequests);
         }
+
         // The init method might be called multiple times if the configurer is
         // added during initialization of another configurer. This flag allows
         // tracking whether initialization has already happened once to avoid
         // redundant configuration (e.g., adding request matchers twice).
         alreadyInitializedOnce = true;
+
     }
 
     @Override

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -15,16 +15,17 @@
  */
 package com.vaadin.flow.spring.security;
 
-import javax.crypto.SecretKey;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.function.Consumer;
-import java.util.stream.Stream;
-
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.internal.AnnotationReader;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.internal.RouteUtil;
+import com.vaadin.flow.server.HandlerHelper;
+import com.vaadin.flow.server.VaadinServletContext;
+import com.vaadin.flow.server.auth.NavigationAccessControl;
+import com.vaadin.flow.server.auth.RoutePathAccessChecker;
+import com.vaadin.flow.server.auth.ViewAccessChecker;
+import com.vaadin.flow.spring.security.stateless.VaadinStatelessSecurityConfigurer;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -64,16 +65,15 @@ import org.springframework.security.web.util.matcher.OrRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.web.context.WebApplicationContext;
 
-import com.vaadin.flow.component.Component;
-import com.vaadin.flow.internal.AnnotationReader;
-import com.vaadin.flow.router.BeforeEnterEvent;
-import com.vaadin.flow.router.Route;
-import com.vaadin.flow.router.internal.RouteUtil;
-import com.vaadin.flow.server.HandlerHelper;
-import com.vaadin.flow.server.VaadinServletContext;
-import com.vaadin.flow.server.auth.NavigationAccessControl;
-import com.vaadin.flow.server.auth.ViewAccessChecker;
-import com.vaadin.flow.spring.security.stateless.VaadinStatelessSecurityConfigurer;
+import javax.crypto.SecretKey;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 /**
  * Provides basic Vaadin component-based security configuration for the project.
@@ -206,22 +206,28 @@ public abstract class VaadinWebSecurity {
         http.authorizeHttpRequests(urlRegistry -> {
             // Vaadin internal requests must always be allowed to allow public
             // Flow pages and/or login page implemented using Flow.
-            urlRegistry.requestMatchers(requestUtil::isFrameworkInternalRequest)
+            urlRegistry
+                    .requestMatchers(toRequestPrincipalAwareMatcher(
+                            requestUtil::isFrameworkInternalRequest))
                     .permitAll();
             // Public endpoints are OK to access
-            urlRegistry.requestMatchers(requestUtil::isAnonymousEndpoint)
-                    .permitAll();
+            urlRegistry.requestMatchers(toRequestPrincipalAwareMatcher(
+                    requestUtil::isAnonymousEndpoint)).permitAll();
             // Checks for known Hilla views
-            urlRegistry.requestMatchers(requestUtil::isAllowedHillaView)
-                    .permitAll();
+            urlRegistry.requestMatchers(toRequestPrincipalAwareMatcher(
+                    requestUtil::isAllowedHillaView)).permitAll();
             // Public routes are OK to access
-            urlRegistry.requestMatchers(requestUtil::isAnonymousRoute)
+            urlRegistry.requestMatchers(toRequestPrincipalAwareMatcher(
+                    requestUtil::isAnonymousRoute)).permitAll();
+            urlRegistry.requestMatchers(toRequestPrincipalAwareMatcher(
+                    getDefaultHttpSecurityPermitMatcher(
+                            requestUtil.getUrlMapping())))
                     .permitAll();
-            urlRegistry.requestMatchers(getDefaultHttpSecurityPermitMatcher(
-                    requestUtil.getUrlMapping())).permitAll();
             // matcher for Vaadin static (public) resources
-            urlRegistry.requestMatchers(getDefaultWebSecurityIgnoreMatcher(
-                    requestUtil.getUrlMapping())).permitAll();
+            urlRegistry.requestMatchers(toRequestPrincipalAwareMatcher(
+                    getDefaultWebSecurityIgnoreMatcher(
+                            requestUtil.getUrlMapping())))
+                    .permitAll();
             // matcher for custom PWA icons and favicon
             urlRegistry.requestMatchers(requestUtil::isCustomWebIcon)
                     .permitAll();
@@ -852,6 +858,15 @@ public abstract class VaadinWebSecurity {
         public void beforeEnter(BeforeEnterEvent beforeEnterEvent) {
             accessControl.beforeEnter(beforeEnterEvent);
         }
+    }
+
+    private RequestMatcher toRequestPrincipalAwareMatcher(
+            RequestMatcher matcher) {
+        if (enableNavigationAccessControl() && getNavigationAccessControl()
+                .hasAccessChecker(RoutePathAccessChecker.class)) {
+            return RequestUtil.principalAwareRequestMatcher(matcher);
+        }
+        return matcher;
     }
 
 }

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/UserPrincipalRequestMatcherSpringAccessPathCheckerTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/UserPrincipalRequestMatcherSpringAccessPathCheckerTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.spring.security;
+
+import com.vaadin.flow.spring.AuthenticationUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AuthorizationManagerWebInvocationPrivilegeEvaluator.HttpServletRequestTransformer;
+import org.springframework.security.web.access.PathPatternRequestTransformer;
+import org.springframework.security.web.access.WebInvocationPrivilegeEvaluator;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
+
+import java.security.Principal;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringJUnitWebConfig
+@ContextConfiguration(classes = UserPrincipalRequestMatcherSpringAccessPathCheckerTest.TestConfig.class)
+class UserPrincipalRequestMatcherSpringAccessPathCheckerTest {
+
+    @Autowired
+    private SpringAccessPathChecker accessPathChecker;
+
+    @Test
+    @WithMockUser(roles = "GUEST")
+    void checkAccess_user_requestMatchersCanAccessUserPrincipal() {
+        assertTrue(checkAccess("path"),
+                "Access allowed to authenticated users");
+    }
+
+    @Test
+    @WithAnonymousUser
+    void checkAccess_anonymous_requestMatchersCanAccessUserPrincipal() {
+        assertFalse(checkAccess("path"), "Access denied to anonymous users");
+    }
+
+    private boolean checkAccess(String path) {
+        Principal principal = SecurityContextHolder.getContext()
+                .getAuthentication();
+        Function<String, Boolean> roleChecker = AuthenticationUtil
+                .getSecurityHolderRoleChecker();
+        return accessPathChecker.hasAccess(path, principal, roleChecker::apply);
+    }
+
+    @Configuration
+    @EnableWebSecurity
+    public static class TestConfig {
+
+        @Bean
+        SpringAccessPathChecker urlMappingPathAccessChecker(
+                WebInvocationPrivilegeEvaluator evaluator) {
+            return new SpringAccessPathChecker(evaluator);
+        }
+
+        /**
+         * Provides a custom {@link HttpServletRequestTransformer} to be used by
+         * {@link SpringAccessPathChecker}.
+         * <p>
+         * The aim is to test integration of the transformer security-aware
+         * request transformer provided by {@link RequestUtil} with Spring
+         * Security defaults.
+         *
+         * @return a configured {@link HttpServletRequestTransformer} instance
+         */
+        @Bean
+        HttpServletRequestTransformer httpServletRequestTransformer() {
+            HttpServletRequestTransformer transformer = new PathPatternRequestTransformer();
+            transformer = SpringAccessPathChecker
+                    .principalAwareRequestTransformer(transformer);
+            return transformer;
+        }
+
+        @Bean
+        SecurityFilterChain testingFilterChain(HttpSecurity http)
+                throws Exception {
+            http.authorizeHttpRequests(cfg -> cfg
+                    .requestMatchers(new UserPrincipalRequestMatcher())
+                    .authenticated());
+            return http.build();
+        }
+    }
+
+    static class UserPrincipalRequestMatcher implements RequestMatcher {
+
+        private boolean enabled;
+
+        @Override
+        public boolean matches(HttpServletRequest request) {
+            // Throws unsupported operation exception if a request transformer
+            // is not set
+            Principal userPrincipal = request.getUserPrincipal();
+            return userPrincipal != null && userPrincipal.getName() != null;
+        }
+    }
+
+}


### PR DESCRIPTION
When Spring Security request matchers are executed within SpringPathAccessChecker the request object is a stub instance that throw UnsupportedOperationException for many methods. This can cause failure when the path access checker is used in combination with request matchers that, for example, try to access the request user principal. An example is the pre-configured 'isAllowedHillaView' matcher.
This change wraps the request matchers configured by Vaadin so that the request principal is taken from the Spring Security context, if not available on the request.

In addition provides documentation and helper to set a global HttpServletRequestTransformer to augment all requests handled by WebInvocationPrivilegeEvaluator with the proper getUserPrincipal method override.

Fixes #22284