### PR TITLE
fix: check legacy frontend folder from prepare step

### DIFF
--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
@@ -24,6 +24,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import com.vaadin.flow.plugin.base.BuildFrontendUtil;
+import com.vaadin.flow.server.frontend.FrontendUtils;
 
 /**
  * This goal checks that node and npm tools are installed and creates or updates
@@ -51,6 +52,8 @@ public class PrepareFrontendMojo extends FlowModeAbstractMojo {
         // Inform m2eclipse that the directory containing the token file has
         // been updated in order to trigger server re-deployment (#6103)
         triggerRefresh(tokenFile.getParentFile());
+
+        FrontendUtils.checkLegacyFrontendFolder(projectBaseDirectory());
 
         try {
             BuildFrontendUtil.prepareFrontend(this);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -641,24 +641,36 @@ public class FrontendUtils {
      * @return frontend directory to use
      */
     public static File getFrontendFolder(File projectRoot, File frontendDir) {
-        File legacyDir = new File(projectRoot, LEGACY_FRONTEND_DIR);
+        if (!frontendDir.exists() && frontendDir.toPath()
+                .endsWith(DEFAULT_FRONTEND_DIR.substring(2))) {
+            File legacy = new File(projectRoot, LEGACY_FRONTEND_DIR);
+            if (legacy.exists()) {
+                return legacy;
+            }
+        }
+        return frontendDir;
+    }
 
-        if (legacyDir.exists()) {
+    /**
+     * Check for existence of legacy frontend folder and log a warning if it is
+     * present.
+     *
+     * @param projectRoot
+     *            project's root directory
+     */
+    public static void checkLegacyFrontendFolder(Path projectRoot) {
+        if (new File(projectRoot.toString(), LEGACY_FRONTEND_DIR).exists()) {
             getLogger().warn(
                     "This project has a legacy frontend directory ({}) "
-                            + "present and it will be used as a fallback."
-                            + "\n\nSupport for the legacy directory will be removed "
+                            + "present and it will be used as a fallback. "
+                            + "Support for the legacy directory will be removed "
                             + "in a future release. Please move its contents to "
                             + "the default frontend directory ({}), or delete it "
                             + "if its contents are not needed in the project. "
                             + "Also remove 'frontendDirectory' parameter that "
                             + "points to the legacy directory, if present.",
                     LEGACY_FRONTEND_DIR, DEFAULT_FRONTEND_DIR);
-            return legacyDir;
         }
-
-        // Legacy dir does not exist. Use default or custom-set dir.
-        return frontendDir;
     }
 
     /**


### PR DESCRIPTION
avoids flooding log output with warnings