### PR TITLE
refactor!: Expand ancestors when resolving hierarchical path

### DIFF
--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorFlatHierarchyTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorFlatHierarchyTest.java
@@ -167,37 +167,9 @@ public class HierarchicalDataCommunicatorFlatHierarchyTest
                 4, "Item 4"));
     }
 
-    @Test
-    public void resolveIndexPath_correctIndexReturned() {
-        dataCommunicator.expand(
-                Arrays.asList(new Item("Item 0"), new Item("Item 0-0")));
-
-        Assert.assertEquals(0, dataCommunicator.resolveIndexPath(0));
-        Assert.assertEquals(104, dataCommunicator.rootCache.getFlatSize());
-
-        Assert.assertEquals(50, dataCommunicator.resolveIndexPath(50));
-        Assert.assertEquals(104, dataCommunicator.rootCache.getFlatSize());
-
-        Assert.assertEquals(54, dataCommunicator.resolveIndexPath(-50));
-        Assert.assertEquals(104, dataCommunicator.rootCache.getFlatSize());
-
-        Assert.assertEquals(0, dataCommunicator.resolveIndexPath(-104));
-        Assert.assertEquals(104, dataCommunicator.rootCache.getFlatSize());
-    }
-
-    @Test
-    public void invalidIndexPath_resolveIndexPath_correctIndexReturned() {
-        dataCommunicator.expand(
-                Arrays.asList(new Item("Item 0"), new Item("Item 0-0")));
-
-        Assert.assertEquals(2, dataCommunicator.resolveIndexPath(2, 2, 2));
-        Assert.assertEquals(104, dataCommunicator.rootCache.getFlatSize());
-
-        Assert.assertEquals(103, dataCommunicator.resolveIndexPath(1000));
-        Assert.assertEquals(104, dataCommunicator.rootCache.getFlatSize());
-
-        Assert.assertEquals(0, dataCommunicator.resolveIndexPath(-1000));
-        Assert.assertEquals(104, dataCommunicator.rootCache.getFlatSize());
+    @Test(expected = UnsupportedOperationException.class)
+    public void resolveIndexPath_throws() {
+        dataCommunicator.resolveIndexPath(2, 2, 2);
     }
 
     @Test

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorIndexPathResolutionTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorIndexPathResolutionTest.java
@@ -32,97 +32,95 @@ public class HierarchicalDataCommunicatorIndexPathResolutionTest
     }
 
     @Test
-    public void positiveIndexes_resolveIndexPath_correctFlatIndexReturned() {
-        dataCommunicator.expand(Arrays.asList(new Item("Item 0"),
-                new Item("Item 1"), new Item("Item 1-1")));
-
+    public void positiveIndexes_resolveIndexPath_ancestorsExpandedAndCorrectFlatIndexReturned() {
         Assert.assertEquals(0, dataCommunicator.resolveIndexPath(0));
         Assert.assertEquals(3, dataCommunicator.rootCache.getFlatSize());
+        Assert.assertFalse(dataCommunicator.isExpanded(new Item("Item 0")));
 
         Assert.assertEquals(1, dataCommunicator.resolveIndexPath(0, 0));
         Assert.assertEquals(5, dataCommunicator.rootCache.getFlatSize());
+        Assert.assertTrue(dataCommunicator.isExpanded(new Item("Item 0")));
 
         Assert.assertEquals(3, dataCommunicator.resolveIndexPath(1));
         Assert.assertEquals(5, dataCommunicator.rootCache.getFlatSize());
+        Assert.assertFalse(dataCommunicator.isExpanded(new Item("Item 1")));
 
         Assert.assertEquals(4, dataCommunicator.resolveIndexPath(1, 0));
         Assert.assertEquals(7, dataCommunicator.rootCache.getFlatSize());
+        Assert.assertTrue(dataCommunicator.isExpanded(new Item("Item 1")));
 
         Assert.assertEquals(5, dataCommunicator.resolveIndexPath(1, 1));
         Assert.assertEquals(7, dataCommunicator.rootCache.getFlatSize());
+        Assert.assertFalse(dataCommunicator.isExpanded(new Item("Item 1-1")));
 
         Assert.assertEquals(6, dataCommunicator.resolveIndexPath(1, 1, 0));
         Assert.assertEquals(8, dataCommunicator.rootCache.getFlatSize());
+        Assert.assertTrue(dataCommunicator.isExpanded(new Item("Item 1-1")));
 
         Assert.assertEquals(7, dataCommunicator.resolveIndexPath(2));
         Assert.assertEquals(8, dataCommunicator.rootCache.getFlatSize());
     }
 
     @Test
-    public void negativeIndexes_resolveIndexPath_correctFlatIndexReturned() {
-        dataCommunicator.expand(Arrays.asList(new Item("Item 0"),
-                new Item("Item 1"), new Item("Item 1-1")));
-
+    public void negativeIndexes_resolveIndexPath_ancestorsExpandedAndCorrectFlatIndexReturned() {
         Assert.assertEquals(0, dataCommunicator.resolveIndexPath(-3));
         Assert.assertEquals(3, dataCommunicator.rootCache.getFlatSize());
+        Assert.assertFalse(dataCommunicator.isExpanded(new Item("Item 0")));
 
         Assert.assertEquals(1, dataCommunicator.resolveIndexPath(-3, -2));
         Assert.assertEquals(5, dataCommunicator.rootCache.getFlatSize());
+        Assert.assertTrue(dataCommunicator.isExpanded(new Item("Item 0")));
 
         Assert.assertEquals(3, dataCommunicator.resolveIndexPath(-2));
         Assert.assertEquals(5, dataCommunicator.rootCache.getFlatSize());
+        Assert.assertFalse(dataCommunicator.isExpanded(new Item("Item 1")));
 
         Assert.assertEquals(4, dataCommunicator.resolveIndexPath(-2, -2));
         Assert.assertEquals(7, dataCommunicator.rootCache.getFlatSize());
+        Assert.assertTrue(dataCommunicator.isExpanded(new Item("Item 1")));
 
         Assert.assertEquals(5, dataCommunicator.resolveIndexPath(-2, -1));
         Assert.assertEquals(7, dataCommunicator.rootCache.getFlatSize());
+        Assert.assertFalse(dataCommunicator.isExpanded(new Item("Item 1-1")));
 
         Assert.assertEquals(6, dataCommunicator.resolveIndexPath(-2, -1, -1));
         Assert.assertEquals(8, dataCommunicator.rootCache.getFlatSize());
+        Assert.assertTrue(dataCommunicator.isExpanded(new Item("Item 1-1")));
 
         Assert.assertEquals(7, dataCommunicator.resolveIndexPath(-1));
         Assert.assertEquals(8, dataCommunicator.rootCache.getFlatSize());
     }
 
     @Test
-    public void exceedingPositiveIndexes_resolveIndexPath_indexesClamped() {
-        dataCommunicator.expand(
-                Arrays.asList(new Item("Item 2"), new Item("Item 2-1")));
-
-        Assert.assertEquals(2, dataCommunicator.resolveIndexPath(100));
-        Assert.assertEquals(3, dataCommunicator.rootCache.getFlatSize());
-
-        Assert.assertEquals(4, dataCommunicator.resolveIndexPath(100, 100));
-        Assert.assertEquals(5, dataCommunicator.rootCache.getFlatSize());
-
-        Assert.assertEquals(5,
-                dataCommunicator.resolveIndexPath(100, 100, 100));
-        Assert.assertEquals(6, dataCommunicator.rootCache.getFlatSize());
-
-        Assert.assertEquals(5,
-                dataCommunicator.resolveIndexPath(100, 100, 100, 100));
-        Assert.assertEquals(6, dataCommunicator.rootCache.getFlatSize());
+    public void resolveIndexPath_ancestorWithoutChildren_throws() {
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> dataCommunicator.resolveIndexPath(0, 0, 0, 0));
     }
 
     @Test
-    public void exceedingNegativeIndexes_resolveIndexPath_indexesClamped() {
+    public void exceedingPositiveIndexes_resolveIndexPath_throws() {
+        dataCommunicator.expand(
+                Arrays.asList(new Item("Item 2"), new Item("Item 2-1")));
+
+        Assert.assertThrows(IndexOutOfBoundsException.class,
+                () -> dataCommunicator.resolveIndexPath(100));
+        Assert.assertThrows(IndexOutOfBoundsException.class,
+                () -> dataCommunicator.resolveIndexPath(100, 100));
+        Assert.assertThrows(IndexOutOfBoundsException.class,
+                () -> dataCommunicator.resolveIndexPath(100, 100, 100));
+    }
+
+    @Test
+    public void exceedingNegativeIndexes_resolveIndexPath_throws() {
         dataCommunicator.expand(
                 Arrays.asList(new Item("Item 0"), new Item("Item 0-0")));
 
-        Assert.assertEquals(0, dataCommunicator.resolveIndexPath(-100));
-        Assert.assertEquals(3, dataCommunicator.rootCache.getFlatSize());
-
-        Assert.assertEquals(1, dataCommunicator.resolveIndexPath(-100, -100));
-        Assert.assertEquals(5, dataCommunicator.rootCache.getFlatSize());
-
-        Assert.assertEquals(2,
-                dataCommunicator.resolveIndexPath(-100, -100, -100));
-        Assert.assertEquals(6, dataCommunicator.rootCache.getFlatSize());
-
-        Assert.assertEquals(2,
-                dataCommunicator.resolveIndexPath(-100, -100, -100, -100));
-        Assert.assertEquals(6, dataCommunicator.rootCache.getFlatSize());
+        Assert.assertThrows(IndexOutOfBoundsException.class,
+                () -> dataCommunicator.resolveIndexPath(-100));
+        Assert.assertThrows(IndexOutOfBoundsException.class,
+                () -> dataCommunicator.resolveIndexPath(-100, -100));
+        Assert.assertThrows(IndexOutOfBoundsException.class,
+                () -> dataCommunicator.resolveIndexPath(-100, -100, -100));
     }
 
     @Test


### PR DESCRIPTION
## Description

This PR refactors `HierarchicalDataCommunicator#resolveIndexPath` to automatically expand all ancestors when resolving a hierarchical path, as this is the desired behavior for `scrollToIndex` and `scrollToItem`. The method now also throws if the hierarchical path contains a non-expandable or out-of-bounds index. Throwing seems safer than silently clamping which can ultimately lead to being scrolled to an unexpected item.

Part of https://github.com/vaadin/flow-components/issues/8076

## Type of change

- [x] Refactor
