### PR TITLE
fix: Null for primitive should not fail decode

### DIFF
--- a/flow-polymer-template/src/test/java/com/vaadin/flow/server/communication/rpc/PolymerPublishedServerEventHandlerRpcHandlerTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/server/communication/rpc/PolymerPublishedServerEventHandlerRpcHandlerTest.java
@@ -452,7 +452,7 @@ public class PolymerPublishedServerEventHandlerRpcHandlerTest {
     }
 
     @Test
-    public void nullValueShouldFailForPrimitive() {
+    public void nullValueShouldNotFailForPrimitive() {
         ArrayNode array = JacksonUtils.createArrayNode();
         array.add(JacksonUtils.nullNode());
         MethodWithParameters component = new MethodWithParameters();
@@ -460,13 +460,11 @@ public class PolymerPublishedServerEventHandlerRpcHandlerTest {
         component.booleanArg = true;
 
         // Passing null to a primitive parameter should throw an exception
-        Assert.assertThrows(IllegalArgumentException.class, () -> {
-            PublishedServerEventHandlerRpcHandler.invokeMethod(component,
-                    component.getClass(), "intMethod", array, -1);
-        });
+        PublishedServerEventHandlerRpcHandler.invokeMethod(component,
+                component.getClass(), "intMethod", array, -1);
 
         // Verify the field was not modified
-        Assert.assertEquals(-1, component.intArg);
+        Assert.assertEquals(0, component.intArg);
     }
 
     @Test(expected = IllegalStateException.class)

--- a/flow-server/src/main/java/com/vaadin/flow/internal/JacksonUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JacksonUtils.java
@@ -38,6 +38,7 @@ import tools.jackson.core.type.TypeReference;
 import tools.jackson.core.util.DefaultPrettyPrinter;
 import tools.jackson.core.util.Separators;
 import tools.jackson.core.util.Separators.Spacing;
+import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
@@ -71,7 +72,9 @@ public final class JacksonUtils {
     private static final String CANNOT_CONVERT_NULL_TO_OBJECT = "Cannot convert null to Java object";
 
     private static final ObjectMapper objectMapper = JsonMapper.builder()
-            .enable(JsonReadFeature.ALLOW_SINGLE_QUOTES).build();
+            .enable(JsonReadFeature.ALLOW_SINGLE_QUOTES)
+            .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+            .build();
 
     public static ObjectMapper getMapper() {
         return objectMapper;

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentEventBusTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentEventBusTest.java
@@ -177,18 +177,18 @@ public class ComponentEventBusTest {
     }
 
     @Test
-    public void mappedDomEvent_fire_missingData_shouldFail() {
+    public void mappedDomEvent_fire_missingData() {
         TestComponent c = new TestComponent();
         EventTracker<MappedToDomEvent> eventListener = new EventTracker<>();
         c.addListener(MappedToDomEvent.class, eventListener);
 
-        // Missing primitive boolean data should cause event creation to fail
-        Assert.assertThrows(IllegalArgumentException.class, () -> {
-            fireDomEvent(c, "dom-event", createData("event.someData", 2));
-        });
+        fireDomEvent(c, "dom-event", createData("event.someData", 2));
 
-        // Event should not have been called due to the failure
-        eventListener.assertEventNotCalled();
+        eventListener.assertEventCalled(c, true);
+        Assert.assertEquals(2, eventListener.getEvent().getSomeData());
+        Assert.assertNull(eventListener.getEvent().getMoreData());
+        Assert.assertFalse(eventListener.getEvent().getPrimitiveBoolean());
+        Assert.assertNull(eventListener.getEvent().getObjectBoolean());
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
@@ -434,10 +434,5 @@ public class JacksonCodecTest {
         Assert.assertEquals(Double.valueOf(3.14), JacksonCodec
                 .decodeAs(objectMapper.valueToTree(3.14), Double.class));
     }
-
-    @Test
-    public void decodeNullToPrimitive_returnsNullAndDoesNotThrow() {
-        Assert.assertNull(
-                JacksonCodec.decodeAs(JacksonUtils.nullNode(), int.class));
-    }
+    
 }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
@@ -434,4 +434,10 @@ public class JacksonCodecTest {
         Assert.assertEquals(Double.valueOf(3.14), JacksonCodec
                 .decodeAs(objectMapper.valueToTree(3.14), Double.class));
     }
+
+    @Test
+    public void decodeNullToPrimitive_returnsNullAndDoesNotThrow() {
+        Assert.assertNull(
+                JacksonCodec.decodeAs(JacksonUtils.nullNode(), int.class));
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
@@ -434,5 +434,5 @@ public class JacksonCodecTest {
         Assert.assertEquals(Double.valueOf(3.14), JacksonCodec
                 .decodeAs(objectMapper.valueToTree(3.14), Double.class));
     }
-    
+
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/PublishedServerEventHandlerRpcHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/PublishedServerEventHandlerRpcHandlerTest.java
@@ -495,7 +495,7 @@ public class PublishedServerEventHandlerRpcHandlerTest {
     }
 
     @Test
-    public void nullValueShouldFailForPrimitive() {
+    public void nullValueShouldReturnZeroForPrimitive() {
         ArrayNode array = JacksonUtils.createArrayNode();
         array.add(JacksonUtils.nullNode());
         MethodWithParameters component = new MethodWithParameters();
@@ -503,13 +503,11 @@ public class PublishedServerEventHandlerRpcHandlerTest {
         component.booleanArg = true;
 
         // Passing null to a primitive parameter should throw an exception
-        Assert.assertThrows(IllegalArgumentException.class, () -> {
-            PublishedServerEventHandlerRpcHandler.invokeMethod(component,
-                    component.getClass(), "intMethod", array, -1);
-        });
+        PublishedServerEventHandlerRpcHandler.invokeMethod(component,
+                component.getClass(), "intMethod", array, -1);
 
         // Verify the field was not modified
-        Assert.assertEquals(-1, component.intArg);
+        Assert.assertEquals(0, component.intArg);
     }
 
     @Test(expected = IllegalStateException.class)


### PR DESCRIPTION
Decoding null to primitive should
not fail as dom event data
may be missing parts sent from the client.