### PR TITLE
test: Add comprehensive Map serialization tests for executeJs

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
@@ -21,6 +21,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import tools.jackson.databind.JsonNode;
@@ -548,6 +549,87 @@ public class JacksonCodecTest {
         Assert.assertEquals(1, encoded.get(0).asInt());
         Assert.assertEquals(2, encoded.get(1).asInt());
         Assert.assertEquals(3, encoded.get(2).asInt());
+    }
+
+    @Test
+    public void testMapOfBeansSerialization() {
+        Map<String, SimpleBean> beanMap = new HashMap<>();
+        beanMap.put("first", new SimpleBean("FirstBean", 100));
+        beanMap.put("second", new SimpleBean("SecondBean", 200));
+        beanMap.put("third", new SimpleBean("ThirdBean", 300));
+
+        JsonNode encoded = JacksonCodec.encodeWithTypeInfo(beanMap);
+
+        // Should be JSON object
+        Assert.assertTrue("Should be object", encoded.isObject());
+        Assert.assertEquals("Should have 3 entries", 3, encoded.size());
+
+        Assert.assertEquals("FirstBean",
+                encoded.get("first").get("text").asText());
+        Assert.assertEquals(100, encoded.get("first").get("value").asInt());
+        Assert.assertEquals("SecondBean",
+                encoded.get("second").get("text").asText());
+        Assert.assertEquals(200, encoded.get("second").get("value").asInt());
+        Assert.assertEquals("ThirdBean",
+                encoded.get("third").get("text").asText());
+        Assert.assertEquals(300, encoded.get("third").get("value").asInt());
+    }
+
+    @Test
+    public void testMapOfBeansDeserialization() {
+        // Create JSON object manually
+        ObjectNode bean1 = objectMapper.createObjectNode();
+        bean1.put("text", "Alpha");
+        bean1.put("value", 111);
+
+        ObjectNode bean2 = objectMapper.createObjectNode();
+        bean2.put("text", "Beta");
+        bean2.put("value", 222);
+
+        ObjectNode mapJson = objectMapper.createObjectNode();
+        mapJson.set("keyA", bean1);
+        mapJson.set("keyB", bean2);
+
+        // Test that Jackson can handle Map<String, SimpleBean> deserialization
+        Map<String, SimpleBean> decoded = JacksonUtils.getMapper().convertValue(
+                mapJson,
+                JacksonUtils.getMapper().getTypeFactory().constructMapType(
+                        Map.class, String.class, SimpleBean.class));
+
+        Assert.assertEquals("Should have 2 entries", 2, decoded.size());
+        Assert.assertNotNull("Should have keyA", decoded.get("keyA"));
+        Assert.assertEquals("Alpha", decoded.get("keyA").text);
+        Assert.assertEquals(111, decoded.get("keyA").value);
+        Assert.assertNotNull("Should have keyB", decoded.get("keyB"));
+        Assert.assertEquals("Beta", decoded.get("keyB").text);
+        Assert.assertEquals(222, decoded.get("keyB").value);
+    }
+
+    @Test
+    public void testNestedMapSerialization() {
+        Map<String, Object> nestedMap = new HashMap<>();
+        nestedMap.put("bean", new SimpleBean("NestedBean", 999));
+        nestedMap.put("number", 42);
+        nestedMap.put("text", "Hello");
+
+        Map<String, Object> outerMap = new HashMap<>();
+        outerMap.put("nested", nestedMap);
+        outerMap.put("simple", "value");
+
+        JsonNode encoded = JacksonCodec.encodeWithTypeInfo(outerMap);
+
+        // Should be JSON object
+        Assert.assertTrue("Should be object", encoded.isObject());
+        Assert.assertEquals("Should have 2 entries", 2, encoded.size());
+        Assert.assertEquals("value", encoded.get("simple").asText());
+
+        JsonNode nestedJson = encoded.get("nested");
+        Assert.assertTrue("Nested should be object", nestedJson.isObject());
+        Assert.assertEquals(42, nestedJson.get("number").asInt());
+        Assert.assertEquals("Hello", nestedJson.get("text").asText());
+        Assert.assertEquals("NestedBean",
+                nestedJson.get("bean").get("text").asText());
+        Assert.assertEquals(999, nestedJson.get("bean").get("value").asInt());
     }
 
     @Test

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ExecJavaScriptView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ExecJavaScriptView.java
@@ -17,7 +17,9 @@ package com.vaadin.flow.uitest.ui;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.UI;
@@ -141,6 +143,27 @@ public class ExecJavaScriptView extends AbstractDivView {
                             });
                 });
 
+        NativeButton mapButton = createButton("Map Serialization", "mapButton",
+                e -> testMapSerialization());
+
+        NativeButton returnMapButton = createButton("Return Map",
+                "returnMapButton", e -> {
+                    UI.getCurrent().getPage().executeJs(
+                            "return {alpha: {name: 'AlphaBean', value: 111, active: true}, beta: {name: 'BetaBean', value: 222, active: false}}")
+                            .then(Map.class, map -> {
+                                Div result = new Div();
+                                result.setId("returnMapResult");
+                                result.setText("Returned map with " + map.size()
+                                        + " entries");
+                                add(result);
+
+                                Div status = new Div();
+                                status.setId("returnMapStatus");
+                                status.setText("Map returned");
+                                add(status);
+                            });
+                });
+
         NativeButton componentArrayButton = createButton("Component Array",
                 "componentArrayButton", e -> testComponentArraySerialization());
 
@@ -182,8 +205,8 @@ public class ExecJavaScriptView extends AbstractDivView {
 
         add(alertButton, focusButton, swapText, logButton, createElementButton,
                 elementAwaitButton, pageAwaitButton, beanButton,
-                returnBeanButton, listButton, returnListButton,
-                componentArrayButton, beanWithComponentButton,
+                returnBeanButton, listButton, returnListButton, mapButton,
+                returnMapButton, componentArrayButton, beanWithComponentButton,
                 clientCallableBeanButton, clientCallableListButton,
                 clientCallableNestedButton);
     }
@@ -241,6 +264,37 @@ public class ExecJavaScriptView extends AbstractDivView {
                         document.body.appendChild(statusDiv);
                         """,
                 beanList);
+    }
+
+    private void testMapSerialization() {
+        Map<String, SimpleBean> beanMap = new HashMap<>();
+        beanMap.put("first", new SimpleBean("FirstKey", 100, true));
+        beanMap.put("second", new SimpleBean("SecondKey", 200, false));
+        beanMap.put("third", new SimpleBean("ThirdKey", 300, true));
+
+        UI.getCurrent().getPage().executeJs(
+                """
+                        const beanMap = $0;
+                        let result = 'Map: ';
+                        const keys = Object.keys(beanMap);
+                        for (let i = 0; i < keys.length; i++) {
+                            const key = keys[i];
+                            const bean = beanMap[key];
+                            result += `${key}: name=${bean.name}, value=${bean.value}, active=${bean.active}`;
+                            if (i < keys.length - 1) result += ' | ';
+                        }
+
+                        const resultDiv = document.createElement('div');
+                        resultDiv.id = 'mapResult';
+                        resultDiv.textContent = result;
+                        document.body.appendChild(resultDiv);
+
+                        const statusDiv = document.createElement('div');
+                        statusDiv.id = 'mapStatus';
+                        statusDiv.textContent = 'Map serialization completed';
+                        document.body.appendChild(statusDiv);
+                        """,
+                beanMap);
     }
 
     private void testComponentArraySerialization() {

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ExecJavaScriptIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ExecJavaScriptIT.java
@@ -124,6 +124,44 @@ public class ExecJavaScriptIT extends ChromeBrowserTest {
     }
 
     @Test
+    public void testMapSerialization() {
+        open();
+
+        getButton("mapButton").click();
+
+        WebElement result = waitUntil(d -> findElement(By.id("mapResult")));
+        String resultText = result.getText();
+
+        // Verify Map prefix and all entries are present
+        Assert.assertTrue("Should start with 'Map: '",
+                resultText.startsWith("Map: "));
+        Assert.assertTrue("Should contain 'first' key", resultText
+                .contains("first: name=FirstKey, value=100, active=true"));
+        Assert.assertTrue("Should contain 'second' key", resultText
+                .contains("second: name=SecondKey, value=200, active=false"));
+        Assert.assertTrue("Should contain 'third' key", resultText
+                .contains("third: name=ThirdKey, value=300, active=true"));
+
+        WebElement status = waitUntil(d -> findElement(By.id("mapStatus")));
+        Assert.assertEquals("Map serialization completed", status.getText());
+    }
+
+    @Test
+    public void testMapReturnValue() {
+        open();
+
+        getButton("returnMapButton").click();
+
+        WebElement result = waitUntil(
+                d -> findElement(By.id("returnMapResult")));
+        Assert.assertEquals("Returned map with 2 entries", result.getText());
+
+        WebElement status = waitUntil(
+                d -> findElement(By.id("returnMapStatus")));
+        Assert.assertEquals("Map returned", status.getText());
+    }
+
+    @Test
     public void testComponentArraySerialization() {
         open();
 


### PR DESCRIPTION
Add unit and integration tests for Map<String, Bean> support in executeJs:
- JacksonCodecTest: serialization, deserialization, and nested maps
- ExecJavaScriptView: map parameter and return value UI tests
- ExecJavaScriptIT: browser integration tests for map handling
