### PR TITLE
test: fix node and npm supported version tests

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -68,7 +68,7 @@ public class FrontendTools {
     /**
      * This is the version shipped with the default Node version.
      */
-    public static final String DEFAULT_NPM_VERSION = "11.5.1";
+    public static final String DEFAULT_NPM_VERSION = "11.6.0";
 
     public static final String DEFAULT_PNPM_VERSION = "8.6.11";
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -66,7 +66,7 @@ import static org.junit.Assert.assertEquals;
 @Category(SlowTests.class)
 public class FrontendToolsTest {
 
-    private static final String SUPPORTED_NODE_BUT_OLDER_THAN_AUTOINSTALLED = "20.0.0";
+    private static final String SUPPORTED_NODE_BUT_OLDER_THAN_AUTOINSTALLED = "24.0.0";
 
     public static final String DEFAULT_NODE = FrontendUtils.isWindows()
             ? "node\\node.exe"


### PR DESCRIPTION
Also bumps DEFAULT_NPM_VERSION to 11.6.0, as it is the default for Node 24.9.0