### PR TITLE
chore: update ASM to 9.9 to work with Java 26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm</artifactId>
-                <version>9.8</version>
+                <version>9.9</version>
             </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>


### PR DESCRIPTION
fixes #22426 