### PR TITLE
chore: migrate formatter check to GitHub Actions

### DIFF
--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -1,0 +1,114 @@
+name: Formatter
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Cancel previous runs if a new one is triggered
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  formatter:
+    name: Verify Java code format
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Run formatter
+        id: formatter
+        run: |
+          echo "Running formatter..."
+          mvn -B -q formatter:format -Dformatter.html.skip=true -P benchmark 2>&1 | grep -v null || true
+
+          # Check for modified files
+          files=$(git status --porcelain | awk '{print $2}')
+          modified=$(echo "$files" | wc -w | xargs)
+
+          echo "modified=$modified" >> $GITHUB_OUTPUT
+
+          if [ "$modified" -gt 0 ]; then
+            echo "Modified files:"
+            echo "$files"
+            git diff > formatter-diff.txt
+            echo "files<<EOF" >> $GITHUB_OUTPUT
+            echo "$files" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Upload formatter diff
+        if: steps.formatter.outputs.modified != '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: formatter-diff
+          path: formatter-diff.txt
+          retention-days: 30
+
+      - name: Find existing comment
+        if: steps.formatter.outputs.modified != '0'
+        uses: peter-evans/find-comment@v3
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- tc-formatter -->'
+
+      - name: Create or update comment
+        if: steps.formatter.outputs.modified != '0'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
+          body: |
+            <!-- tc-formatter -->
+            ### Format Checker Report
+
+            ![BLOCKER][BLOCKER] There are **${{ steps.formatter.outputs.modified }} files** with format errors
+
+            [BLOCKER]: https://sonarsource.github.io/sonar-github/severity-blocker.png 'Severity: BLOCKER'
+
+            - To see a complete report of formatting issues, download the [differences artifact](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+            - To fix the build, please run `mvn formatter:format` in your branch and commit the changes.
+
+            - Optionally you might add the following line in your `.git/hooks/pre-commit` file:
+
+                  mvn formatter:format
+
+            Here is the list of files with format issues in your PR:
+
+            ```
+            ${{ steps.formatter.outputs.files }}
+            ```
+
+      - name: Delete comment if formatting is correct
+        if: steps.formatter.outputs.modified == '0' && steps.find-comment.outputs.comment-id != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.deleteComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: ${{ steps.find-comment.outputs.comment-id }}
+            })
+
+      - name: Fail if formatting issues exist
+        if: steps.formatter.outputs.modified != '0'
+        run: |
+          echo "::error::There are ${{ steps.formatter.outputs.modified }} files with format errors"
+          exit 1


### PR DESCRIPTION
Converts the formatter build configuration to a GitHub Actions workflow that runs on pull requests. The workflow verifies Java code formatting using Maven formatter plugin and posts results as PR comments.

Key features:
- Runs formatter:format and checks for formatting issues
- Posts PR comment with list of files needing formatting
- Uploads diff artifact for detailed review
- Auto-deletes comment when formatting is correct
