### PR TITLE
chore: migrate from formatter plugin to spotless

### DIFF
--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -42,7 +42,7 @@ jobs:
         id: formatter
         run: |
           echo "Running formatter..."
-          mvn -B -q formatter:format -Dformatter.html.skip=true -P benchmark 2>&1 | grep -v null || true
+          mvn -B -q spotless:apply -P benchmark 2>&1 | grep -v null || true
 
           # Check for modified files
           files=$(git status --porcelain | awk '{print $2}')
@@ -93,11 +93,11 @@ jobs:
 
             - To see a complete report of formatting issues, download the [differences artifact](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
-            - To fix the build, please run `mvn formatter:format` in your branch and commit the changes.
+            - To fix the build, please run `mvn spotless:apply` in your branch and commit the changes.
 
             - Optionally you might add the following line in your `.git/hooks/pre-commit` file:
 
-                  mvn formatter:format
+                  mvn spotless:apply
 
             Here is the list of files with format issues in your PR:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,10 @@ mvn verify -Dit.test=ExecJavaScriptIT
 
 ```bash
 # Format code
-mvn formatter:format
+mvn spotless:apply
+
+# Check code formatting
+mvn spotless:check
 
 # Run checkstyle validation
 mvn checkstyle:check

--- a/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
@@ -211,12 +211,12 @@ public class ApplicationConnection {
             var ur = ap.@ApplicationConnection::registry.@com.vaadin.client.Registry::getURIResolver()();
             return ur.@com.vaadin.client.URIResolver::resolveVaadinUri(Ljava/lang/String;)(uriToResolve);
         });
-
+    
         client.sendEventMessage = $entry(function(nodeId, eventType, eventData) {
             var sc = ap.@ApplicationConnection::registry.@com.vaadin.client.Registry::getServerConnector()();
             sc.@com.vaadin.client.communication.ServerConnector::sendEventMessage(ILjava/lang/String;Lelemental/json/JsonObject;)(nodeId,eventType,eventData);
         });
-
+    
         client.initializing = false;
         client.exportedWebComponents = exportedWebComponents;
         $wnd.Vaadin.Flow.clients[applicationId] = client;
@@ -320,7 +320,7 @@ public class ApplicationConnection {
                 styles: ap.@ApplicationConnection::getElementStyleProperties(*)(nodeId)
             };
         });
-
+    
     }-*/;
 
     /**

--- a/flow-client/src/main/java/com/vaadin/client/PolymerUtils.java
+++ b/flow-client/src/main/java/com/vaadin/client/PolymerUtils.java
@@ -381,7 +381,7 @@ public final class PolymerUtils {
     /*-{
         var isP2Element = (typeof $wnd.Polymer === 'function') && $wnd.Polymer.Element && htmlNode instanceof $wnd.Polymer.Element;
         var isP3Element = htmlNode.constructor.polymerElementVersion !== undefined;
-
+    
         return (isP2Element || isP3Element);
     }-*/;
 

--- a/flow-client/src/main/java/com/vaadin/client/communication/AtmospherePushConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/AtmospherePushConnection.java
@@ -703,7 +703,7 @@ public class AtmospherePushConnection implements PushConnection {
             JavaScriptObject config)
     /*-{
         var self = this;
-
+    
         config.url = uri;
         config.onOpen = $entry(function(response) {
             self.@com.vaadin.client.communication.AtmospherePushConnection::onOpen(*)(response);
@@ -734,7 +734,7 @@ public class AtmospherePushConnection implements PushConnection {
                 return self.@com.vaadin.client.communication.AtmospherePushConnection::getLastSeenServerSyncId(*)();
             }
         };
-
+    
         return $wnd.vaadinPush.atmosphere.subscribe(config);
     }-*/;
 

--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/ServerEventObject.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/ServerEventObject.java
@@ -85,11 +85,11 @@ public final class ServerEventObject extends JavaScriptObject {
         Object.defineProperty(this, name, {
             value: function(promiseId, success, value) {
                 var promise = this[name].promises[promiseId];
-
+    
                 // undefined if client-side node was recreated after execution was scheduled
                 if (promise !== undefined) {
                     delete this[name].promises[promiseId];
-
+    
                     if (success) {
                         // Resolve
                         promise[0](value);
@@ -134,23 +134,23 @@ public final class ServerEventObject extends JavaScriptObject {
             if(args === null) {
                 args = Array.prototype.slice.call(arguments);
             }
-
+    
             var returnValue;
             var promiseId = -1;
-
+    
             if (returnPromise) {
                 var promises = this[@ServerEventObject::PROMISE_CALLBACK_NAME].promises;
-
+    
                 promiseId = promises.length;
-
+    
                 returnValue = new Promise(function(resolve, reject) {
                     // Store each callback for later use
                     promises[promiseId] = [resolve, reject];
                 });
             }
-
+    
             tree.@com.vaadin.client.flow.StateTree::sendTemplateEventToServer(*)(node, methodName, args, promiseId);
-
+    
             return returnValue;
         });
     }-*/;

--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
@@ -315,9 +315,9 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
     private native void hookUpPolymerElement(StateNode node, Element element)
     /*-{
         var self = this;
-
+    
         var originalPropertiesChanged = element._propertiesChanged;
-
+    
         if (originalPropertiesChanged) {
             element._propertiesChanged = function (currentProps, changedProps, oldProps) {
                 $entry(function () {
@@ -326,16 +326,16 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
                 originalPropertiesChanged.apply(this, arguments);
             };
         }
-
-
+    
+    
         var tree = node.@com.vaadin.client.flow.StateNode::getTree()();
-
+    
         var originalReady = element.ready;
-
+    
         element.ready = function (){
             originalReady.apply(this, arguments);
             @com.vaadin.client.PolymerUtils::fireReadyEvent(*)(element);
-
+    
             // The  _propertiesChanged method which is replaced above for the element
             // doesn't do anything for items in dom-repeat.
             // Instead it's called with some meaningful info for the <code>dom-repeat</code> element.
@@ -344,7 +344,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
             // which changes this method for any dom-repeat instance.
             var replaceDomRepeatPropertyChange = function(){
                 var domRepeat = element.root.querySelector('dom-repeat');
-
+    
                 if ( domRepeat ){
                  // If the <code>dom-repeat</code> element is in the DOM then
                  // this method should not be executed anymore. The logic below will replace
@@ -358,12 +358,12 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
                 // if dom-repeat is found => replace _propertiesChanged method in the prototype and mark it as replaced.
                 if ( !domRepeat.constructor.prototype.$propChangedModified){
                     domRepeat.constructor.prototype.$propChangedModified = true;
-
+    
                     var changed = domRepeat.constructor.prototype._propertiesChanged;
-
+    
                     domRepeat.constructor.prototype._propertiesChanged = function(currentProps, changedProps, oldProps){
                         changed.apply(this, arguments);
-
+    
                         var props = Object.getOwnPropertyNames(changedProps);
                         var items = "items.";
                         var i;
@@ -384,7 +384,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
                                     if( currentPropsItem && currentPropsItem.nodeId ){
                                         var nodeId = currentPropsItem.nodeId;
                                         var value = currentPropsItem[propertyName];
-
+    
                                         // this is an attempt to find the template element
                                         // which is not available as a context in the protype method
                                         var host = this.__dataHost;
@@ -395,7 +395,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
                                         while( !host.localName || host.__dataHost ){
                                             host = host.__dataHost;
                                         }
-
+    
                                         $entry(function () {
                                             @SimpleElementBindingStrategy::handleListItemPropertyChange(*)(nodeId, host, propertyName, value, tree);
                                         })();
@@ -406,7 +406,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
                     };
                 }
             };
-
+    
             // dom-repeat doesn't have to be in DOM even if template has it
             //  such situation happens if there is dom-if e.g. which evaluates to <code>false</code> initially.
             // in this case dom-repeat is not yet in the DOM tree until dom-if becomes <code>true</code>
@@ -421,7 +421,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
                 element.addEventListener('dom-change',replaceDomRepeatPropertyChange);
             }
         }
-
+    
     }-*/;
 
     private static void handleListItemPropertyChange(double nodeId,

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ElementPropertyMap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ElementPropertyMap.java
@@ -493,9 +493,9 @@ public class ElementPropertyMap extends AbstractPropertyMap {
      * Here is the logic flow:
      *
      * <pre>
-
-
-
+    
+    
+    
                              +--------------------------------+
                              |                                |
                              | allowUpdateFromClient  is false|

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@
         <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
         <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
         <maven.version>3.9.11</maven.version>
+        <spotless.plugin.version>2.46.1</spotless.plugin.version>
 
         <!-- Frontend -->
         <flow.dev.dependencies.folder>generatedDeps</flow.dev.dependencies.folder>
@@ -330,14 +331,15 @@
 
         <plugins>
             <plugin>
-                <groupId>net.revelc.code.formatter</groupId>
-                <artifactId>formatter-maven-plugin</artifactId>
-                <version>2.29.0</version>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>${spotless.plugin.version}</version>
                 <configuration>
-                    <configFile>${maven.multiModuleProjectDirectory}/eclipse/VaadinJavaConventions.xml</configFile>
-                    <!-- Provide a dummy JS config file to avoid errors -->
-                    <configJsFile>${maven.multiModuleProjectDirectory}/eclipse/VaadinJavaConventions.xml</configJsFile>
-                    <lineEnding>LF</lineEnding>
+                    <java>
+                        <eclipse>
+                            <file>${maven.multiModuleProjectDirectory}/eclipse/VaadinJavaConventions.xml</file>
+                        </eclipse>
+                    </java>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Replace maven formatter plugin with spotless plugin (v2.46.1) for code formatting.

Configuration includes:
- Java formatting using Eclipse formatter (VaadinJavaConventions.xml)

Usage:
- mvn spotless:check - validate formatting
- mvn spotless:apply - apply formatting
