### PR TITLE
chore: Do not use deprecated asText and textValue

### DIFF
--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/testcomponents/TestSelectComponent.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/testcomponents/TestSelectComponent.java
@@ -95,7 +95,7 @@ public class TestSelectComponent<T>
             ArrayNode presentation) {
         Set<T> set = new HashSet<>();
         for (int i = 0; i < presentation.size(); i++) {
-            set.add(group.keyMapper.get(presentation.get(i).asText()));
+            set.add(group.keyMapper.get(presentation.get(i).asString()));
         }
         return set;
     }

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/CompositeDataGeneratorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/CompositeDataGeneratorTest.java
@@ -96,9 +96,9 @@ public class CompositeDataGeneratorTest {
         ObjectNode json = JacksonUtils.createObjectNode();
         composite.generateData("item1", json);
 
-        Assert.assertEquals("value1", json.get("mock1").asText());
-        Assert.assertEquals("value2", json.get("mock2").asText());
-        Assert.assertEquals("value3", json.get("mock3").asText());
+        Assert.assertEquals("value1", json.get("mock1").asString());
+        Assert.assertEquals("value2", json.get("mock2").asString());
+        Assert.assertEquals("value3", json.get("mock3").asString());
         Assert.assertThat(mock1.getProcessed(), CoreMatchers.hasItem("item1"));
         Assert.assertThat(mock2.getProcessed(), CoreMatchers.hasItem("item1"));
         Assert.assertThat(mock3.getProcessed(), CoreMatchers.hasItem("item1"));

--- a/flow-html-components-testbench/src/test/java/com/vaadin/flow/component/html/testbench/SelectView.java
+++ b/flow-html-components-testbench/src/test/java/com/vaadin/flow/component/html/testbench/SelectView.java
@@ -36,7 +36,7 @@ public class SelectView extends Div {
         select.setAttribute("id", "input");
         select.addEventListener("change", e -> {
             log.setText("Value is '"
-                    + e.getEventData().get("element.value").asText() + "'");
+                    + e.getEventData().get("element.value").asString() + "'");
         }).synchronizeProperty("element.value");
         add(log);
         getElement().appendChild(select);

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -734,8 +734,8 @@ public class BuildFrontendUtil {
                     continue;
                 }
                 final JsonNode cvdlModule = cvdlModules.get(key);
-                components.add(new Product(cvdlModule.get("name").textValue(),
-                        cvdlModule.get("version").textValue()));
+                components.add(new Product(cvdlModule.get("name").asString(),
+                        cvdlModule.get("version").asString()));
             }
         }
         return components;

--- a/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
+++ b/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
@@ -340,9 +340,8 @@ public class BuildFrontendUtilTest {
         JsonNode buildInfoJsonProd = JacksonUtils
                 .readTree(Files.readString(tokenFile.toPath()));
         Assert.assertEquals("Wrong application identifier in token file",
-                "TEST_APP_ID",
-                buildInfoJsonProd.get(InitParameters.APPLICATION_IDENTIFIER)
-                        .asString());
+                "TEST_APP_ID", buildInfoJsonProd
+                        .get(InitParameters.APPLICATION_IDENTIFIER).asString());
     }
 
     @Test

--- a/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
+++ b/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
@@ -342,7 +342,7 @@ public class BuildFrontendUtilTest {
         Assert.assertEquals("Wrong application identifier in token file",
                 "TEST_APP_ID",
                 buildInfoJsonProd.get(InitParameters.APPLICATION_IDENTIFIER)
-                        .textValue());
+                        .asString());
     }
 
     @Test

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/PolymerTemplateTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/PolymerTemplateTest.java
@@ -965,7 +965,7 @@ public class PolymerTemplateTest extends HasCurrentService {
         Object[] params = executionParams.get(1);
         ArrayNode properties = (ArrayNode) params[1];
         Assert.assertEquals(1, properties.size());
-        Assert.assertEquals("title", properties.get(0).asText());
+        Assert.assertEquals("title", properties.get(0).asString());
     }
 
     @Test
@@ -986,8 +986,8 @@ public class PolymerTemplateTest extends HasCurrentService {
         Assert.assertEquals(2, properties.size());
 
         Set<String> props = new HashSet<>();
-        props.add(properties.get(0).asText());
-        props.add(properties.get(1).asText());
+        props.add(properties.get(0).asString());
+        props.add(properties.get(1).asString());
         // all model properties except 'list' which has no getter
         Assert.assertTrue(props.contains("message"));
         Assert.assertTrue(props.contains("title"));
@@ -1110,16 +1110,16 @@ public class PolymerTemplateTest extends HasCurrentService {
             String payload) {
         JsonNode object = (JsonNode) node.getFeature(ElementData.class)
                 .getPayload();
-        Assert.assertEquals(type, object.get(NodeProperties.TYPE).asText());
+        Assert.assertEquals(type, object.get(NodeProperties.TYPE).asString());
         Assert.assertEquals(payload,
-                object.get(NodeProperties.PAYLOAD).asText());
+                object.get(NodeProperties.PAYLOAD).asString());
     }
 
     private void assertTemplateInTempalte(StateNode node) {
         JsonNode object = (JsonNode) node.getFeature(ElementData.class)
                 .getPayload();
         Assert.assertEquals(NodeProperties.TEMPLATE_IN_TEMPLATE,
-                object.get(NodeProperties.TYPE).asText());
+                object.get(NodeProperties.TYPE).asString());
 
         Assert.assertTrue(
                 object.get(NodeProperties.PAYLOAD) instanceof ArrayNode);

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/server/communication/rpc/PolymerPublishedServerEventHandlerRpcHandlerTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/server/communication/rpc/PolymerPublishedServerEventHandlerRpcHandlerTest.java
@@ -447,7 +447,7 @@ public class PolymerPublishedServerEventHandlerRpcHandlerTest {
         PublishedServerEventHandlerRpcHandler.invokeMethod(component,
                 component.getClass(), "varArgMethod", array, -1);
 
-        Assert.assertArrayEquals(new String[] { value.get(0).asText() },
+        Assert.assertArrayEquals(new String[] { value.get(0).asString() },
                 component.varArg);
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentEffect.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentEffect.java
@@ -177,7 +177,7 @@ public final class ComponentEffect {
      *
      * ComponentEffect.bindChildren(component, taskList, taskValueSignal -> {
      *     var listItem = new ListItem();
-     *     ComponentEffect.bind(listItem, taskValueSignal, HasText::setText);
+     *     ComponentEffect.bind(listItem, taskValueSignal, HasString::setText);
      *     return listItem;
      * });
      * </pre>

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/PendingJavaScriptInvocation.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/PendingJavaScriptInvocation.java
@@ -105,7 +105,7 @@ public class PendingJavaScriptInvocation implements PendingJavaScriptResult {
     public void completeExceptionally(JsonNode value) {
         assert isSubscribed();
 
-        String message = value.asText();
+        String message = value.asString();
 
         if (errorHandler != null) {
             errorHandler.accept(message);

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -533,7 +533,7 @@ public class Page implements Serializable {
             final JsonNode jsValue = jsonObj.get(key);
             if (jsValue != null
                     && JsonNodeType.STRING.equals(jsValue.getNodeType())) {
-                return jsValue.asText();
+                return jsValue.asString();
             } else {
                 return null;
             }

--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponent.java
@@ -232,7 +232,7 @@ public final class WebComponent<C extends Component> implements Serializable {
                     ((ValueNode) value).doubleValue());
         } else if (value instanceof ValueNode) {
             componentHost.executeJs(UPDATE_PROPERTY, propertyName,
-                    ((ValueNode) value).asText());
+                    ((ValueNode) value).asString());
         } else if (value instanceof BaseJsonNode) {
             // this gets around executeJavaScript limitation.
             // Since properties can take JSON values, this was needed to allow

--- a/flow-server/src/main/java/com/vaadin/flow/dom/DomEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/DomEvent.java
@@ -78,7 +78,7 @@ public class DomEvent extends EventObject {
         if (jsonValue == null) {
             return DebouncePhase.LEADING;
         } else {
-            return DebouncePhase.forIdentifier(jsonValue.asText());
+            return DebouncePhase.forIdentifier(jsonValue.asString());
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/BasicElementStateProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/BasicElementStateProvider.java
@@ -367,7 +367,7 @@ public class BasicElementStateProvider extends AbstractNodeStateProvider {
         boolean visitDescendants;
         if (payload instanceof JsonNode) {
             JsonNode object = (JsonNode) payload;
-            String type = object.get(NodeProperties.TYPE).asText();
+            String type = object.get(NodeProperties.TYPE).asString();
             if (NodeProperties.IN_MEMORY_CHILD.equals(type)) {
                 visitDescendants = visitor
                         .visit(NodeVisitor.ElementType.VIRTUAL, element);

--- a/flow-server/src/main/java/com/vaadin/flow/i18n/TranslationFileRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/i18n/TranslationFileRequestHandler.java
@@ -205,7 +205,7 @@ public class TranslationFileRequestHandler extends SynchronizedRequestHandler {
                                 String[] keys = new String[keysNode.size()];
 
                                 for (int i = 0; i < keysNode.size(); i++) {
-                                    keys[i] = keysNode.get(i).asText();
+                                    keys[i] = keysNode.get(i).asString();
                                 }
 
                                 chunkData.put(chunkName, keys);

--- a/flow-server/src/main/java/com/vaadin/flow/internal/JacksonSerializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JacksonSerializer.java
@@ -338,7 +338,7 @@ public final class JacksonSerializer {
     private static Optional<?> tryToConvertFromSimpleType(Class<?> type,
             JsonNode json) {
         if (type.isAssignableFrom(String.class)) {
-            return Optional.of(json.asText());
+            return Optional.of(json.asString());
         }
         if (type.isAssignableFrom(int.class)
                 || type.isAssignableFrom(Integer.class)) {
@@ -362,15 +362,15 @@ public final class JacksonSerializer {
         }
         if (type.isAssignableFrom(char.class)
                 || type.isAssignableFrom(Character.class)) {
-            return Optional.of(json.asText().charAt(0));
+            return Optional.of(json.asString().charAt(0));
         }
         if (type.isAssignableFrom(Boolean.class)
                 || type.isAssignableFrom(boolean.class)) {
             return Optional.of(json.asBoolean());
         }
         if (type.isEnum()) {
-            return Optional.of(
-                    Enum.valueOf((Class<? extends Enum>) type, json.asText()));
+            return Optional.of(Enum.valueOf((Class<? extends Enum>) type,
+                    json.asString()));
         }
         if (JsonNode.class.isAssignableFrom(type)) {
             return Optional.of(json);

--- a/flow-server/src/main/java/com/vaadin/flow/internal/JacksonUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JacksonUtils.java
@@ -344,7 +344,7 @@ public final class JacksonUtils {
     public static boolean stringEqual(JsonNode a, JsonNode b) {
         assert a.getNodeType() == JsonNodeType.STRING;
         assert b.getNodeType() == JsonNodeType.STRING;
-        return a.asText().equals(b.asText());
+        return a.asString().equals(b.asString());
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ElementAttributeMap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ElementAttributeMap.java
@@ -118,7 +118,7 @@ public class ElementAttributeMap extends NodeMap {
             // The only object which may be set by the current imlp contains
             // "uri" attribute, only this situation is expected here.
             assert node.has(NodeProperties.URI_ATTRIBUTE);
-            return node.get(NodeProperties.URI_ATTRIBUTE).textValue();
+            return node.get(NodeProperties.URI_ATTRIBUTE).asString();
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/internal/springcsrf/SpringCsrfTokenUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/springcsrf/SpringCsrfTokenUtil.java
@@ -69,11 +69,11 @@ public class SpringCsrfTokenUtil {
                     && springCsrfTokenJson.has(SPRING_CSRF_TOKEN_PROPERTY)
                     && springCsrfTokenJson.has(SPRING_CSRF_HEADER_PROPERTY)) {
                 String token = springCsrfTokenJson
-                        .get(SPRING_CSRF_TOKEN_PROPERTY).textValue();
+                        .get(SPRING_CSRF_TOKEN_PROPERTY).asString();
                 String headerName = springCsrfTokenJson
-                        .get(SPRING_CSRF_HEADER_PROPERTY).textValue();
+                        .get(SPRING_CSRF_HEADER_PROPERTY).asString();
                 String parameterName = springCsrfTokenJson
-                        .get(SPRING_CSRF_PARAMETER_PROPERTY).textValue();
+                        .get(SPRING_CSRF_PARAMETER_PROPERTY).asString();
 
                 return Optional.of(
                         new SpringCsrfToken(headerName, parameterName, token));

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -719,14 +719,14 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
 
         private Element createDependencyElement(BootstrapContext context,
                 ObjectNode dependencyJson) {
-            String type = dependencyJson.get(Dependency.KEY_TYPE).textValue();
+            String type = dependencyJson.get(Dependency.KEY_TYPE).asString();
             if (Dependency.Type.contains(type)) {
                 Dependency.Type dependencyType = Dependency.Type.valueOf(type);
                 return createDependencyElement(context.getUriResolver(),
                         LoadMode.INLINE, dependencyJson, dependencyType);
             }
             return Jsoup.parse(
-                    dependencyJson.get(Dependency.KEY_CONTENTS).textValue(), "",
+                    dependencyJson.get(Dependency.KEY_CONTENTS).asString(), "",
                     Parser.xmlParser());
         }
 
@@ -847,7 +847,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             for (int i = 0; i < dependencies.size(); i++) {
                 ObjectNode dependencyJson = (ObjectNode) dependencies.get(i);
                 Dependency.Type dependencyType = Dependency.Type.valueOf(
-                        dependencyJson.get(Dependency.KEY_TYPE).textValue());
+                        dependencyJson.get(Dependency.KEY_TYPE).asString());
                 Element dependencyElement = createDependencyElement(uriResolver,
                         loadMode, dependencyJson, dependencyType);
 
@@ -1093,7 +1093,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             boolean inlineElement = loadMode == LoadMode.INLINE;
             String url = dependency.has(Dependency.KEY_URL)
                     ? resolver.resolveVaadinUri(
-                            dependency.get(Dependency.KEY_URL).textValue())
+                            dependency.get(Dependency.KEY_URL).asString())
                     : null;
 
             final Element dependencyElement;
@@ -1115,7 +1115,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
 
             if (inlineElement) {
                 dependencyElement.appendChild(new DataNode(
-                        dependency.get(Dependency.KEY_CONTENTS).textValue()));
+                        dependency.get(Dependency.KEY_CONTENTS).asString()));
             }
 
             return dependencyElement;

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
@@ -104,7 +104,7 @@ public class ServerRpcHandler implements Serializable {
             if (token == null) {
                 csrfToken = ApplicationConstants.CSRF_TOKEN_DEFAULT_VALUE;
             } else {
-                String csrfToken = token.asText();
+                String csrfToken = token.asString();
                 if (csrfToken.isEmpty()) {
                     csrfToken = ApplicationConstants.CSRF_TOKEN_DEFAULT_VALUE;
                 }
@@ -445,8 +445,9 @@ public class ServerRpcHandler implements Serializable {
             // channel events
             for (int i = 0; i < invocations.size(); i++) {
                 JsonNode json = invocations.get(i);
-                String type = json.has("type") ? json.get("type").asText() : "";
-                String event = json.has("event") ? json.get("event").asText()
+                String type = json.has("type") ? json.get("type").asString()
+                        : "";
+                String event = json.has("event") ? json.get("event").asString()
                         : "";
                 if (!JsonConstants.RPC_TYPE_CHANNEL.equals(type)
                         && (!JsonConstants.RPC_TYPE_EVENT.equals(type)
@@ -475,7 +476,7 @@ public class ServerRpcHandler implements Serializable {
 
         for (int i = 0; i < rpcArray.size(); i++) {
             JsonNode json = rpcArray.get(i);
-            String type = json.has("type") ? json.get("type").asText() : "";
+            String type = json.has("type") ? json.get("type").asString() : "";
             Double node = json.has("node") ? json.get("node").doubleValue()
                     : null;
             Double feature = json.has("feature")
@@ -530,7 +531,7 @@ public class ServerRpcHandler implements Serializable {
 
         for (int i = 0; i < invocationsData.size(); i++) {
             JsonNode invocationJson = invocationsData.get(i);
-            String type = invocationJson.get(JsonConstants.RPC_TYPE).asText();
+            String type = invocationJson.get(JsonConstants.RPC_TYPE).asString();
             assert type != null;
             if (JsonConstants.RPC_TYPE_MAP_SYNC.equals(type)) {
                 // Handle these before any RPC invocations.
@@ -560,7 +561,7 @@ public class ServerRpcHandler implements Serializable {
     }
 
     private void handleInvocationData(UI ui, JsonNode invocationJson) {
-        String type = invocationJson.get(JsonConstants.RPC_TYPE).asText();
+        String type = invocationJson.get(JsonConstants.RPC_TYPE).asString();
         RpcInvocationHandler handler = getInvocationHandlers().get(type);
         if (handler == null) {
             throw new IllegalArgumentException(

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlRequestHandler.java
@@ -261,7 +261,7 @@ public class UidlRequestHandler extends SynchronizedRequestHandler
                 if (!arr.get(j).getNodeType().equals(JsonNodeType.STRING)) {
                     continue;
                 }
-                String script = arr.get(j).textValue();
+                String script = arr.get(j).asString();
                 if (script.contains("history.pushState")) {
                     idx = i;
                     continue;
@@ -329,7 +329,7 @@ public class UidlRequestHandler extends SynchronizedRequestHandler
         if (!location.has(LOCATION)) {
             return null;
         }
-        String url = location.get(LOCATION).textValue();
+        String url = location.get(LOCATION).asString();
         Matcher match = URL_PATTERN.matcher(url);
         if (match.find()) {
             location.put(LOCATION, match.group(1));
@@ -344,13 +344,13 @@ public class UidlRequestHandler extends SynchronizedRequestHandler
                 || !rpc.get(2).getNodeType().equals(JsonNodeType.STRING)
                 || !rpc.get(3).getNodeType().equals(JsonNodeType.ARRAY)
                 || !"com.vaadin.shared.extension.javascriptmanager.ExecuteJavaScriptRpc"
-                        .equals(rpc.get(1).textValue())
-                || !"executeJavaScript".equals(rpc.get(2).textValue())) {
+                        .equals(rpc.get(1).asString())
+                || !"executeJavaScript".equals(rpc.get(2).asString())) {
             return null;
         }
         ArrayNode scripts = (ArrayNode) rpc.get(3);
         for (int j = 0; j < scripts.size(); j++) {
-            String exec = scripts.get(j).textValue();
+            String exec = scripts.get(j).asString();
             Matcher match = HASH_PATTERN.matcher(exec);
             if (match.find()) {
                 // replace JS with a noop

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/AbstractRpcInvocationHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/AbstractRpcInvocationHandler.java
@@ -144,7 +144,7 @@ public abstract class AbstractRpcInvocationHandler
     private boolean isPollEventInvocation(JsonNode invocationJson) {
         return invocationJson.has(JsonConstants.RPC_EVENT_TYPE)
                 && PollEvent.DOM_EVENT_NAME.equalsIgnoreCase(invocationJson
-                        .get(JsonConstants.RPC_EVENT_TYPE).asText());
+                        .get(JsonConstants.RPC_EVENT_TYPE).asString());
     }
 
     private boolean isPollingEnabledForUI(UI ui) {
@@ -192,8 +192,8 @@ public abstract class AbstractRpcInvocationHandler
         if (!invocationJson.has(JsonConstants.RPC_TYPE)) {
             return false;
         }
-        if (!JsonConstants.RPC_TYPE_EVENT
-                .equals(invocationJson.get(JsonConstants.RPC_TYPE).asText())) {
+        if (!JsonConstants.RPC_TYPE_EVENT.equals(
+                invocationJson.get(JsonConstants.RPC_TYPE).asString())) {
             return false;
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/AttachExistingElementRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/AttachExistingElementRpcHandler.java
@@ -63,7 +63,7 @@ public class AttachExistingElementRpcHandler
         int assignedId = invocationJson
                 .get(JsonConstants.RPC_ATTACH_ASSIGNED_ID).intValue();
         String tag = invocationJson.get(JsonConstants.RPC_ATTACH_TAG_NAME)
-                .asText();
+                .asString();
         int index = invocationJson.get(JsonConstants.RPC_ATTACH_INDEX)
                 .intValue();
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/EventRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/EventRpcHandler.java
@@ -50,7 +50,7 @@ public class EventRpcHandler extends AbstractRpcInvocationHandler {
         assert invocationJson.has(JsonConstants.RPC_EVENT_TYPE);
 
         String eventType = invocationJson.get(JsonConstants.RPC_EVENT_TYPE)
-                .asText();
+                .asString();
 
         JsonNode eventData = invocationJson.get(JsonConstants.RPC_EVENT_DATA);
         if (eventData == null) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/MapSyncRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/MapSyncRpcHandler.java
@@ -80,7 +80,7 @@ public class MapSyncRpcHandler extends AbstractRpcInvocationHandler {
         List<DisabledUpdateMode> seenUpdateModes = new ArrayList<>();
 
         String property = invocationJson.get(JsonConstants.RPC_PROPERTY)
-                .asText();
+                .asString();
 
         if (node.hasFeature(ElementListenerMap.class)) {
             DisabledUpdateMode eventMode = node
@@ -133,7 +133,7 @@ public class MapSyncRpcHandler extends AbstractRpcInvocationHandler {
                     .getFeature(ElementListenerMap.class);
             return invocationJson.has(JsonConstants.RPC_PROPERTY)
                     && listenerMap.hasAllowInertForProperty(invocationJson
-                            .get(JsonConstants.RPC_PROPERTY).asText());
+                            .get(JsonConstants.RPC_PROPERTY).asString());
         } else {
             return super.allowInert(ui, invocationJson);
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/NavigationRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/NavigationRpcHandler.java
@@ -55,7 +55,7 @@ public class NavigationRpcHandler implements RpcInvocationHandler {
             BaseJsonNode state = (BaseJsonNode) invocationJson
                     .get(JsonConstants.RPC_NAVIGATION_STATE);
             String location = invocationJson
-                    .get(JsonConstants.RPC_NAVIGATION_LOCATION).asText();
+                    .get(JsonConstants.RPC_NAVIGATION_LOCATION).asString();
             boolean triggeredByLink = invocationJson
                     .has(JsonConstants.RPC_NAVIGATION_ROUTERLINK);
             NavigationTrigger trigger = triggeredByLink

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/PublishedServerEventHandlerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/PublishedServerEventHandlerRpcHandler.java
@@ -80,7 +80,7 @@ public class PublishedServerEventHandlerRpcHandler
             JsonNode invocationJson) {
         assert invocationJson.has(JsonConstants.RPC_TEMPLATE_EVENT_METHOD_NAME);
         String methodName = invocationJson
-                .get(JsonConstants.RPC_TEMPLATE_EVENT_METHOD_NAME).asText();
+                .get(JsonConstants.RPC_TEMPLATE_EVENT_METHOD_NAME).asString();
         if (methodName == null) {
             throw new IllegalArgumentException(
                     "Event handler method name may not be null");

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/StringToEnumDecoder.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/StringToEnumDecoder.java
@@ -42,7 +42,7 @@ public class StringToEnumDecoder implements RpcDecoder {
     @Override
     public <T> T decode(JsonNode value, Class<T> type)
             throws RpcDecodeException {
-        String stringValue = value.asText();
+        String stringValue = value.asString();
         Enum<?> result = Enum.valueOf((Class<? extends Enum>) type,
                 stringValue);
         return type.cast(result);

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/StringToNumberDecoder.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/StringToNumberDecoder.java
@@ -52,7 +52,7 @@ public class StringToNumberDecoder implements RpcDecoder {
     @Override
     public <T> T decode(JsonNode value, Class<T> type)
             throws RpcDecodeException {
-        String stringValue = value.asText();
+        String stringValue = value.asString();
         try {
             Number number = parseNumber(stringValue);
             if (Number.class.equals(type)) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/CvdlProducts.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/CvdlProducts.java
@@ -50,9 +50,8 @@ public class CvdlProducts {
             JsonNode packageJson = JacksonUtils.readTree(FileUtils
                     .readFileToString(packageJsonFile, StandardCharsets.UTF_8));
             if (packageJson.has(CVDL_PACKAGE_KEY)) {
-                return new Product(
-                        packageJson.get(CVDL_PACKAGE_KEY).textValue(),
-                        packageJson.get("version").textValue());
+                return new Product(packageJson.get(CVDL_PACKAGE_KEY).asString(),
+                        packageJson.get("version").asString());
             }
             return null;
         } catch (IOException e) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -1106,7 +1106,7 @@ public class FrontendUtils {
             return null;
         }
         try {
-            final String versionString = sourceJson.get(pkg).textValue();
+            final String versionString = sourceJson.get(pkg).asString();
             return new FrontendVersion(pkg, versionString);
         } catch (ClassCastException classCastException) { // NOSONAR
             LoggerFactory.getLogger(FrontendVersion.class).warn(

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -161,7 +161,7 @@ public abstract class NodeUpdater implements FallibleCommand {
         ObjectNode vaadinVersionsJson = getFilteredVersionsFromResource(
                 vaadinVersionsResource, Constants.VAADIN_VERSIONS_JSON);
         for (String key : JacksonUtils.getKeys(vaadinVersionsJson)) {
-            versionsJson.put(key, vaadinVersionsJson.get(key).textValue());
+            versionsJson.put(key, vaadinVersionsJson.get(key).asString());
         }
 
         return versionsJson;
@@ -246,7 +246,7 @@ public abstract class NodeUpdater implements FallibleCommand {
 
         // Clean previously installed plugins
         for (String depKey : JacksonUtils.getKeys(devDependencies)) {
-            String depVersion = devDependencies.get(depKey).textValue();
+            String depVersion = devDependencies.get(depKey).asString();
             if (depKey.startsWith(atVaadinPrefix)
                     && depVersion.startsWith(pluginTargetPrefix)) {
                 devDependencies.remove(depKey);
@@ -324,7 +324,7 @@ public abstract class NodeUpdater implements FallibleCommand {
                 return new HashMap<>();
             }
             for (String key : JacksonUtils.getKeys(dependencies)) {
-                map.put(key, dependencies.get(key).textValue());
+                map.put(key, dependencies.get(key).asString());
             }
 
             return map;
@@ -427,7 +427,7 @@ public abstract class NodeUpdater implements FallibleCommand {
 
         if (vaadinDeps.has(pkg)) {
             if (version == null) {
-                version = vaadinDeps.get(pkg).textValue();
+                version = vaadinDeps.get(pkg).asString();
             }
             return handleExistingVaadinDep(json, pkg, version, vaadinDeps);
         } else {
@@ -448,7 +448,7 @@ public abstract class NodeUpdater implements FallibleCommand {
             FrontendVersion existingVersion = toVersion(json, pkg);
             return newVersion.isNewerThan(existingVersion);
         } catch (NumberFormatException e) {
-            if (VAADIN_FORM_PKG.equals(pkg) && json.get(pkg).textValue()
+            if (VAADIN_FORM_PKG.equals(pkg) && json.get(pkg).asString()
                     .contains(VAADIN_FORM_PKG_LEGACY_VERSION)) {
                 return true;
             } else {
@@ -496,7 +496,7 @@ public abstract class NodeUpdater implements FallibleCommand {
              */
         }
         // always update vaadin version to the latest set version
-        if (!version.equals(vaadinDeps.get(pkg).textValue())) {
+        if (!version.equals(vaadinDeps.get(pkg).asString())) {
             vaadinDeps.put(pkg, version);
             updatedVaadinVersionSection = true;
         }
@@ -512,7 +512,7 @@ public abstract class NodeUpdater implements FallibleCommand {
     }
 
     private static FrontendVersion toVersion(JsonNode json, String key) {
-        return new FrontendVersion(json.get(key).textValue());
+        return new FrontendVersion(json.get(key).asString());
     }
 
     String writePackageFile(JsonNode packageJson) throws IOException {
@@ -581,7 +581,7 @@ public abstract class NodeUpdater implements FallibleCommand {
             for (String key : JacksonUtils.getKeys(packageJsonVersions)) {
                 if (!versionsJson.has(key)) {
                     versionsJson.put(key,
-                            packageJsonVersions.get(key).textValue());
+                            packageJsonVersions.get(key).asString());
                 }
             }
         }
@@ -600,7 +600,7 @@ public abstract class NodeUpdater implements FallibleCommand {
         final JsonNode dependencies = packageJson.get(DEPENDENCIES);
         if (dependencies != null) {
             for (String key : JacksonUtils.getKeys(dependencies)) {
-                versionsJson.put(key, dependencies.get(key).textValue());
+                versionsJson.put(key, dependencies.get(key).asString());
             }
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGeneratePackageJson.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGeneratePackageJson.java
@@ -47,7 +47,7 @@ public class TaskGeneratePackageJson extends NodeUpdater {
             modified = updateDefaultDependencies(mainContent);
             if (modified) {
                 if (!mainContent.has("type") || !mainContent.get("type")
-                        .textValue().equals("module")) {
+                        .asString().equals("module")) {
                     mainContent.put("type", "module");
                     log().info(
                             """

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsConfig.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsConfig.java
@@ -155,7 +155,7 @@ public class TaskGenerateTsConfig extends AbstractTaskClientGenerator {
 
     private String getEsTargetVersion(String tsConfig) {
         JsonNode parsed = parseTsConfig(tsConfig);
-        return parsed.get(COMPILER_OPTIONS).get(ES_TARGET_VERSION).textValue();
+        return parsed.get(COMPILER_OPTIONS).get(ES_TARGET_VERSION).asString();
     }
 
     private ObjectNode parseTsConfig(String tsConfig) {
@@ -243,10 +243,10 @@ public class TaskGenerateTsConfig extends AbstractTaskClientGenerator {
 
     private String getConfigVersion(JsonNode projectTsConfigContent) {
         if (projectTsConfigContent.has(VERSION)) {
-            return projectTsConfigContent.get(VERSION).textValue();
+            return projectTsConfigContent.get(VERSION).asString();
         }
         if (projectTsConfigContent.has(OLD_VERSION_KEY)) {
-            return projectTsConfigContent.get(OLD_VERSION_KEY).textValue();
+            return projectTsConfigContent.get(OLD_VERSION_KEY).asString();
         }
         return null;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -148,7 +148,7 @@ public class TaskRunNpmInstall implements FallibleCommand {
                 packageUpdater.log().warn("No vaadin object in package.json");
                 return;
             }
-            final String hash = vaadin.get(HASH_KEY).textValue();
+            final String hash = vaadin.get(HASH_KEY).asString();
 
             final Map<String, String> updates = new HashMap<>();
             updates.put(HASH_KEY, hash);
@@ -185,16 +185,16 @@ public class TaskRunNpmInstall implements FallibleCommand {
                     .getVaadinJsonContents();
             if (nodeModulesVaadinJson.has(HASH_KEY)) {
                 final JsonNode packageJson = packageUpdater.getPackageJson();
-                if (!nodeModulesVaadinJson.get(HASH_KEY).textValue()
+                if (!nodeModulesVaadinJson.get(HASH_KEY).asString()
                         .equals(packageJson.get(VAADIN_DEP_KEY).get(HASH_KEY)
-                                .textValue())) {
+                                .asString())) {
                     return true;
                 }
 
                 if (nodeModulesVaadinJson.has(PROJECT_FOLDER)
                         && !options.getNpmFolder().getAbsolutePath()
                                 .equals(nodeModulesVaadinJson
-                                        .get(PROJECT_FOLDER).textValue())) {
+                                        .get(PROJECT_FOLDER).asString())) {
                     return true;
                 }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonConverter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonConverter.java
@@ -150,8 +150,8 @@ class VersionsJsonConverter {
 
     private void addDependency(JsonNode obj) {
         assert obj.has(NPM_NAME);
-        String npmName = obj.get(NPM_NAME).textValue();
-        String mode = obj.has(MODE) ? obj.get(MODE).textValue() : null;
+        String npmName = obj.get(NPM_NAME).asString();
+        String mode = obj.has(MODE) ? obj.get(MODE).asString() : null;
         String version;
         // #11025
         if (Objects.equals(npmName, VAADIN_CORE_NPM_PACKAGE)) {
@@ -177,9 +177,9 @@ class VersionsJsonConverter {
             return;
         }
         if (obj.has(NPM_VERSION)) {
-            version = obj.get(NPM_VERSION).textValue();
+            version = obj.get(NPM_VERSION).asString();
         } else if (obj.has(JS_VERSION)) {
-            version = obj.get(JS_VERSION).textValue();
+            version = obj.get(JS_VERSION).asString();
         } else {
             throw new IllegalStateException("Vaadin code versions file "
                     + "contains unexpected data: dependency '" + npmName
@@ -198,7 +198,7 @@ class VersionsJsonConverter {
             ArrayNode array = (ArrayNode) obj.get(EXCLUSIONS);
             if (array != null) {
                 IntStream.range(0, array.size())
-                        .forEach(i -> exclusions.add(array.get(i).textValue()));
+                        .forEach(i -> exclusions.add(array.get(i).asString()));
             }
         }
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonFilter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonFilter.java
@@ -74,11 +74,11 @@ class VersionsJsonFilter {
                 if (version.isNewerThan(userManagedVersion)) {
                     LoggerFactory.getLogger("Versions").warn(
                             OLDER_VERSION_WARNING,
-                            userManagedDependencies.get(key).textValue(), key,
-                            versions.get(key).textValue());
+                            userManagedDependencies.get(key).asString(), key,
+                            versions.get(key).asString());
                 }
             }
-            json.put(key, versions.get(key).textValue());
+            json.put(key, versions.get(key).asString());
         }
         return json;
     }
@@ -100,7 +100,7 @@ class VersionsJsonFilter {
 
             for (String key : JacksonUtils.getKeys(dependencies)) {
                 if (isUserChanged(key, vaadinDep, dependencies)) {
-                    json.put(key, dependencies.get(key).textValue());
+                    json.put(key, dependencies.get(key).asString());
                 }
             }
         }
@@ -113,17 +113,17 @@ class VersionsJsonFilter {
         if (vaadinDep.has(key)) {
             try {
                 FrontendVersion vaadin = new FrontendVersion(key,
-                        vaadinDep.get(key).textValue());
+                        vaadinDep.get(key).asString());
                 FrontendVersion dep = new FrontendVersion(key,
-                        dependencies.get(key).textValue());
+                        dependencies.get(key).asString());
                 return !vaadin.isEqualTo(dep);
             } catch (NumberFormatException nfe) {
                 LoggerFactory.getLogger("VersionsFilter").debug(
                         "Received version with non numbers {} and {}",
-                        vaadinDep.get(key).textValue(),
-                        dependencies.get(key).textValue());
-                return !vaadinDep.get(key).textValue()
-                        .equals(dependencies.get(key).textValue());
+                        vaadinDep.get(key).asString(),
+                        dependencies.get(key).asString());
+                return !vaadinDep.get(key).asString()
+                        .equals(dependencies.get(key).asString());
             }
         }
         // User changed if not in vaadin dependency

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractConfigurationFactory.java
@@ -92,7 +92,7 @@ public class AbstractConfigurationFactory implements Serializable {
             params.put(EXTERNAL_STATS_FILE, Boolean.toString(true));
             if (buildInfo.has(EXTERNAL_STATS_URL_TOKEN)) {
                 params.put(EXTERNAL_STATS_URL,
-                        buildInfo.get(EXTERNAL_STATS_URL_TOKEN).textValue());
+                        buildInfo.get(EXTERNAL_STATS_URL_TOKEN).asString());
             }
             // NO OTHER CONFIGURATION:
             return params;
@@ -107,28 +107,28 @@ public class AbstractConfigurationFactory implements Serializable {
         }
 
         if (buildInfo.has(NPM_TOKEN)) {
-            params.put(PROJECT_BASEDIR, buildInfo.get(NPM_TOKEN).textValue());
-            verifyFolderExists(params, buildInfo.get(NPM_TOKEN).textValue());
+            params.put(PROJECT_BASEDIR, buildInfo.get(NPM_TOKEN).asString());
+            verifyFolderExists(params, buildInfo.get(NPM_TOKEN).asString());
         }
 
         if (buildInfo.has(NODE_VERSION)) {
-            params.put(NODE_VERSION, buildInfo.get(NODE_VERSION).textValue());
+            params.put(NODE_VERSION, buildInfo.get(NODE_VERSION).asString());
         }
         if (buildInfo.has(NODE_DOWNLOAD_ROOT)) {
             params.put(NODE_DOWNLOAD_ROOT,
-                    buildInfo.get(NODE_DOWNLOAD_ROOT).textValue());
+                    buildInfo.get(NODE_DOWNLOAD_ROOT).asString());
         }
 
         if (buildInfo.has(FRONTEND_TOKEN)) {
             params.put(FrontendUtils.PARAM_FRONTEND_DIR,
-                    buildInfo.get(FRONTEND_TOKEN).textValue());
+                    buildInfo.get(FRONTEND_TOKEN).asString());
             // Only verify frontend folder if it's not a subfolder of the
             // npm folder.
             if (!buildInfo.has(NPM_TOKEN)
-                    || !buildInfo.get(FRONTEND_TOKEN).textValue()
-                            .startsWith(buildInfo.get(NPM_TOKEN).textValue())) {
+                    || !buildInfo.get(FRONTEND_TOKEN).asString()
+                            .startsWith(buildInfo.get(NPM_TOKEN).asString())) {
                 verifyFolderExists(params,
-                        buildInfo.get(FRONTEND_TOKEN).textValue());
+                        buildInfo.get(FRONTEND_TOKEN).asString());
             }
         }
 
@@ -146,27 +146,27 @@ public class AbstractConfigurationFactory implements Serializable {
                                     .booleanValue()));
         }
         if (buildInfo.has(CONNECT_JAVA_SOURCE_FOLDER_TOKEN)) {
-            params.put(CONNECT_JAVA_SOURCE_FOLDER_TOKEN, buildInfo
-                    .get(CONNECT_JAVA_SOURCE_FOLDER_TOKEN).textValue());
+            params.put(CONNECT_JAVA_SOURCE_FOLDER_TOKEN,
+                    buildInfo.get(CONNECT_JAVA_SOURCE_FOLDER_TOKEN).asString());
         }
         if (buildInfo.has(Constants.JAVA_RESOURCE_FOLDER_TOKEN)) {
             params.put(Constants.JAVA_RESOURCE_FOLDER_TOKEN, buildInfo
-                    .get(Constants.JAVA_RESOURCE_FOLDER_TOKEN).textValue());
+                    .get(Constants.JAVA_RESOURCE_FOLDER_TOKEN).asString());
         }
         if (buildInfo.has(CONNECT_OPEN_API_FILE_TOKEN)) {
             params.put(CONNECT_OPEN_API_FILE_TOKEN,
-                    buildInfo.get(CONNECT_OPEN_API_FILE_TOKEN).textValue());
+                    buildInfo.get(CONNECT_OPEN_API_FILE_TOKEN).asString());
         }
         if (buildInfo.has(CONNECT_APPLICATION_PROPERTIES_TOKEN)) {
             params.put(CONNECT_APPLICATION_PROPERTIES_TOKEN, buildInfo
-                    .get(CONNECT_APPLICATION_PROPERTIES_TOKEN).textValue());
+                    .get(CONNECT_APPLICATION_PROPERTIES_TOKEN).asString());
         }
         if (buildInfo.has(PROJECT_FRONTEND_GENERATED_DIR_TOKEN)) {
             params.put(PROJECT_FRONTEND_GENERATED_DIR_TOKEN, buildInfo
-                    .get(PROJECT_FRONTEND_GENERATED_DIR_TOKEN).textValue());
+                    .get(PROJECT_FRONTEND_GENERATED_DIR_TOKEN).asString());
         }
         if (buildInfo.has(BUILD_FOLDER)) {
-            params.put(BUILD_FOLDER, buildInfo.get(BUILD_FOLDER).textValue());
+            params.put(BUILD_FOLDER, buildInfo.get(BUILD_FOLDER).asString());
         }
         if (buildInfo.has(DISABLE_PREPARE_FRONTEND_CACHE)) {
             UsageStatistics.markAsUsed("flow/always-execute-prepare-frontend",
@@ -178,7 +178,7 @@ public class AbstractConfigurationFactory implements Serializable {
         }
         if (buildInfo.has(APPLICATION_IDENTIFIER)) {
             params.put(APPLICATION_IDENTIFIER,
-                    buildInfo.get(APPLICATION_IDENTIFIER).textValue());
+                    buildInfo.get(APPLICATION_IDENTIFIER).asString());
         }
         if (buildInfo.has(DAU_TOKEN)) {
             params.put(DAU_TOKEN,
@@ -191,7 +191,7 @@ public class AbstractConfigurationFactory implements Serializable {
 
         if (buildInfo.has(InitParameters.FRONTEND_EXTRA_EXTENSIONS)) {
             params.put(InitParameters.FRONTEND_EXTRA_EXTENSIONS, buildInfo
-                    .get(InitParameters.FRONTEND_EXTRA_EXTENSIONS).textValue());
+                    .get(InitParameters.FRONTEND_EXTRA_EXTENSIONS).asString());
         }
 
         if (buildInfo.has(NPM_EXCLUDE_WEB_COMPONENTS)) {

--- a/flow-server/src/test/java/com/vaadin/flow/component/JavaScriptInvocationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/JavaScriptInvocationTest.java
@@ -39,6 +39,6 @@ public class JavaScriptInvocationTest {
         Assert.assertEquals(2, deserialized.getParameters().size());
         Assert.assertEquals("string", deserialized.getParameters().get(0));
         Assert.assertEquals("jsonString",
-                ((JsonNode) deserialized.getParameters().get(1)).asText());
+                ((JsonNode) deserialized.getParameters().get(1)).asString());
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/StylesheetRemovalTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/StylesheetRemovalTest.java
@@ -205,7 +205,7 @@ public class StylesheetRemovalTest {
                 .get("stylesheetRemovals");
         Assert.assertEquals("Should have one removal", 1, removalsArray.size());
         Assert.assertEquals("Removal ID should match", depId,
-                removalsArray.get(0).asText());
+                removalsArray.get(0).asString());
 
         // After creating UIDL, removals should be cleared
         Set<String> pendingRemovals = internals.getPendingStyleSheetRemovals();

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
@@ -641,7 +641,7 @@ public class ElementTest extends AbstractNodeTest {
 
         element.setPropertyBean("p", new SimpleBean());
         ObjectNode json = (ObjectNode) element.getPropertyRaw("p");
-        Assert.assertEquals("value", json.get("string").asText());
+        Assert.assertEquals("value", json.get("string").asString());
         Assert.assertEquals(1.0, json.get("number").doubleValue(), 0.0);
         Assert.assertEquals(2.3f, json.get("flt").floatValue(), 0.0);
         Assert.assertEquals(4.56, json.get("dbl").doubleValue(), 0.0);
@@ -655,8 +655,8 @@ public class ElementTest extends AbstractNodeTest {
         list.add(bean2);
         element.setPropertyList("p", list);
         ArrayNode jsonArray = (ArrayNode) element.getPropertyRaw("p");
-        Assert.assertEquals("bean1", jsonArray.get(0).get("string").asText());
-        Assert.assertEquals("bean2", jsonArray.get(1).get("string").asText());
+        Assert.assertEquals("bean1", jsonArray.get(0).get("string").asString());
+        Assert.assertEquals("bean2", jsonArray.get(1).get("string").asString());
 
         Map<String, SimpleBean> map = new HashMap<>();
         map.put("one", bean1);
@@ -664,9 +664,9 @@ public class ElementTest extends AbstractNodeTest {
         element.setPropertyMap("p", map);
         JsonNode jsonObject = (JsonNode) element.getPropertyRaw("p");
         Assert.assertEquals("bean1",
-                jsonObject.get("one").get("string").asText());
+                jsonObject.get("one").get("string").asString());
         Assert.assertEquals("bean2",
-                jsonObject.get("two").get("string").asText());
+                jsonObject.get("two").get("string").asString());
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
@@ -218,7 +218,7 @@ public class JacksonCodecTest {
 
         // Should be directly encoded as JSON object
         Assert.assertTrue("Should be object", encoded.isObject());
-        Assert.assertEquals("Test", encoded.get("text").asText());
+        Assert.assertEquals("Test", encoded.get("text").asString());
         Assert.assertEquals(42, encoded.get("value").asInt());
     }
 
@@ -231,10 +231,10 @@ public class JacksonCodecTest {
 
         // Should be directly encoded as JSON object
         Assert.assertTrue("Should be object", encoded.isObject());
-        Assert.assertEquals("outer", encoded.get("name").asText());
+        Assert.assertEquals("outer", encoded.get("name").asString());
 
         JsonNode nestedJson = encoded.get("nested");
-        Assert.assertEquals("inner", nestedJson.get("text").asText());
+        Assert.assertEquals("inner", nestedJson.get("text").asString());
         Assert.assertEquals(123, nestedJson.get("number").asInt());
     }
 
@@ -276,9 +276,9 @@ public class JacksonCodecTest {
         Assert.assertEquals("Array should have correct length", 2,
                 arrayEncoded.size());
         Assert.assertEquals("First element should be correct", "hello",
-                arrayEncoded.get(0).asText());
+                arrayEncoded.get(0).asString());
         Assert.assertEquals("Second element should be correct", "world",
-                arrayEncoded.get(1).asText());
+                arrayEncoded.get(1).asString());
 
         // Test ArrayList - should serialize as JSON array
         ArrayList<String> arrayList = new ArrayList<>();
@@ -290,9 +290,9 @@ public class JacksonCodecTest {
         Assert.assertEquals("List should have correct size", 2,
                 listEncoded.size());
         Assert.assertEquals("First list item should be correct", "item1",
-                listEncoded.get(0).asText());
+                listEncoded.get(0).asString());
         Assert.assertEquals("Second list item should be correct", "item2",
-                listEncoded.get(1).asText());
+                listEncoded.get(1).asString());
 
         // Test HashSet - should serialize as JSON array (order may vary)
         HashSet<String> hashSet = new HashSet<>();
@@ -306,7 +306,7 @@ public class JacksonCodecTest {
         // Verify both values are present (order not guaranteed with HashSet)
         boolean hasValue1 = false, hasValue2 = false;
         for (JsonNode node : setEncoded) {
-            String value = node.asText();
+            String value = node.asString();
             if ("value1".equals(value))
                 hasValue1 = true;
             if ("value2".equals(value))
@@ -326,7 +326,7 @@ public class JacksonCodecTest {
         Assert.assertEquals("Map should have correct size", 3,
                 mapEncoded.size());
         Assert.assertEquals("String value should be correct", "stringValue",
-                mapEncoded.get("key1").asText());
+                mapEncoded.get("key1").asString());
         Assert.assertEquals("Integer value should be correct", 42,
                 mapEncoded.get("key2").asInt());
         Assert.assertEquals("Boolean value should be correct", true,
@@ -446,11 +446,11 @@ public class JacksonCodecTest {
         Assert.assertTrue("Should be array", encoded.isArray());
         Assert.assertEquals("Should have 3 beans", 3, encoded.size());
 
-        Assert.assertEquals("First", encoded.get(0).get("text").asText());
+        Assert.assertEquals("First", encoded.get(0).get("text").asString());
         Assert.assertEquals(1, encoded.get(0).get("value").asInt());
-        Assert.assertEquals("Second", encoded.get(1).get("text").asText());
+        Assert.assertEquals("Second", encoded.get(1).get("text").asString());
         Assert.assertEquals(2, encoded.get(1).get("value").asInt());
-        Assert.assertEquals("Third", encoded.get(2).get("text").asText());
+        Assert.assertEquals("Third", encoded.get(2).get("text").asString());
         Assert.assertEquals(3, encoded.get(2).get("value").asInt());
     }
 
@@ -495,7 +495,7 @@ public class JacksonCodecTest {
         Set<String> texts = new HashSet<>();
         Set<Integer> values = new HashSet<>();
         for (JsonNode node : encoded) {
-            texts.add(node.get("text").asText());
+            texts.add(node.get("text").asString());
             values.add(node.get("value").asInt());
         }
 
@@ -566,13 +566,13 @@ public class JacksonCodecTest {
         Assert.assertEquals("Should have 3 entries", 3, encoded.size());
 
         Assert.assertEquals("FirstBean",
-                encoded.get("first").get("text").asText());
+                encoded.get("first").get("text").asString());
         Assert.assertEquals(100, encoded.get("first").get("value").asInt());
         Assert.assertEquals("SecondBean",
-                encoded.get("second").get("text").asText());
+                encoded.get("second").get("text").asString());
         Assert.assertEquals(200, encoded.get("second").get("value").asInt());
         Assert.assertEquals("ThirdBean",
-                encoded.get("third").get("text").asText());
+                encoded.get("third").get("text").asString());
         Assert.assertEquals(300, encoded.get("third").get("value").asInt());
     }
 
@@ -622,14 +622,14 @@ public class JacksonCodecTest {
         // Should be JSON object
         Assert.assertTrue("Should be object", encoded.isObject());
         Assert.assertEquals("Should have 2 entries", 2, encoded.size());
-        Assert.assertEquals("value", encoded.get("simple").asText());
+        Assert.assertEquals("value", encoded.get("simple").asString());
 
         JsonNode nestedJson = encoded.get("nested");
         Assert.assertTrue("Nested should be object", nestedJson.isObject());
         Assert.assertEquals(42, nestedJson.get("number").asInt());
-        Assert.assertEquals("Hello", nestedJson.get("text").asText());
+        Assert.assertEquals("Hello", nestedJson.get("text").asString());
         Assert.assertEquals("NestedBean",
-                nestedJson.get("bean").get("text").asText());
+                nestedJson.get("bean").get("text").asString());
         Assert.assertEquals(999, nestedJson.get("bean").get("value").asInt());
     }
 
@@ -686,7 +686,7 @@ public class JacksonCodecTest {
         JsonNode beanJson = listEncoded.get(0);
         Assert.assertTrue("Bean should serialize as object",
                 beanJson.isObject());
-        Assert.assertEquals("TestComponent", beanJson.get("name").asText());
+        Assert.assertEquals("TestComponent", beanJson.get("name").asString());
         Assert.assertEquals(42, beanJson.get("value").asInt());
         Assert.assertTrue("Bean should have component field",
                 beanJson.has("component"));
@@ -735,7 +735,7 @@ public class JacksonCodecTest {
 
         // First bean
         JsonNode firstBean = encoded.get(0);
-        Assert.assertEquals("First", firstBean.get("name").asText());
+        Assert.assertEquals("First", firstBean.get("name").asString());
         Assert.assertEquals(10, firstBean.get("value").asInt());
         Assert.assertTrue("First bean should have component",
                 firstBean.has("component"));
@@ -745,7 +745,7 @@ public class JacksonCodecTest {
 
         // Second bean
         JsonNode secondBean = encoded.get(1);
-        Assert.assertEquals("Second", secondBean.get("name").asText());
+        Assert.assertEquals("Second", secondBean.get("name").asString());
         Assert.assertEquals(20, secondBean.get("value").asInt());
         Assert.assertTrue("Second bean should have component",
                 secondBean.has("component"));

--- a/flow-server/src/test/java/com/vaadin/flow/internal/JacksonSerializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/JacksonSerializerTest.java
@@ -297,7 +297,7 @@ public class JacksonSerializerTest {
         JsonNode json = JacksonSerializer.toJson("someString");
         Assert.assertTrue("The JsonNode should be instanceof JsonString",
                 json instanceof StringNode);
-        Assert.assertEquals("someString", json.asText());
+        Assert.assertEquals("someString", json.asString());
 
         json = JacksonSerializer.toJson(0);
         Assert.assertTrue("The JsonNode should be instanceof JsonNumber",
@@ -337,7 +337,7 @@ public class JacksonSerializerTest {
         json = JacksonSerializer.toJson(SomeEnum.SOME_VALUE_1);
         Assert.assertTrue("The JsonNode should be instanceof JsonString",
                 json instanceof StringNode);
-        Assert.assertEquals(SomeEnum.SOME_VALUE_1.name(), json.asText());
+        Assert.assertEquals(SomeEnum.SOME_VALUE_1.name(), json.asString());
     }
 
     @Test
@@ -374,7 +374,7 @@ public class JacksonSerializerTest {
         // char is a different case, it is a string at the json
         Assert.assertTrue(object.has("charProperty"));
         Assert.assertEquals((char) 0,
-                object.get("charProperty").asText().charAt(0));
+                object.get("charProperty").asString().charAt(0));
 
         bean = JacksonSerializer.toObject(ObjectWithSimpleTypes.class, json);
         Assert.assertNotNull(bean);
@@ -406,7 +406,7 @@ public class JacksonSerializerTest {
 
         JsonNode object = json;
         Assert.assertEquals("someProperty",
-                object.get("stringProperty").asText());
+                object.get("stringProperty").asString());
         Assert.assertEquals(1, object.get("intProperty").intValue(), PRECISION);
         Assert.assertEquals(2, object.get("integerProperty").intValue(),
                 PRECISION);
@@ -431,11 +431,12 @@ public class JacksonSerializerTest {
         Assert.assertEquals(true, object.get("booleanProperty").booleanValue());
         Assert.assertEquals(false,
                 object.get("booleanObjectProperty").booleanValue());
-        Assert.assertEquals('c', object.get("charProperty").asText().charAt(0));
+        Assert.assertEquals('c',
+                object.get("charProperty").asString().charAt(0));
         Assert.assertEquals('C',
-                object.get("characterProperty").asText().charAt(0));
+                object.get("characterProperty").asString().charAt(0));
         Assert.assertEquals(SomeEnum.SOME_VALUE_2.name(),
-                object.get("enumProperty").asText());
+                object.get("enumProperty").asString());
 
         bean = JacksonSerializer.toObject(ObjectWithSimpleTypes.class, json);
         Assert.assertNotNull(bean);
@@ -522,7 +523,7 @@ public class JacksonSerializerTest {
         Assert.assertNotNull("The object1 should be not be null", object);
 
         Assert.assertEquals("someProperty",
-                object.get("stringProperty").asText());
+                object.get("stringProperty").asString());
         Assert.assertEquals(1, object.get("intProperty").intValue(), PRECISION);
         Assert.assertEquals(2, object.get("integerProperty").intValue(),
                 PRECISION);
@@ -547,17 +548,18 @@ public class JacksonSerializerTest {
         Assert.assertEquals(true, object.get("booleanProperty").booleanValue());
         Assert.assertEquals(false,
                 object.get("booleanObjectProperty").booleanValue());
-        Assert.assertEquals('c', object.get("charProperty").asText().charAt(0));
+        Assert.assertEquals('c',
+                object.get("charProperty").asString().charAt(0));
         Assert.assertEquals('C',
-                object.get("characterProperty").asText().charAt(0));
+                object.get("characterProperty").asString().charAt(0));
         Assert.assertEquals(SomeEnum.SOME_VALUE_2.name(),
-                object.get("enumProperty").asText());
+                object.get("enumProperty").asString());
 
         object = json.get("object2");
         Assert.assertNotNull("The object2 should be not be null", object);
 
         Assert.assertEquals("someOtherProperty",
-                object.get("stringProperty").asText());
+                object.get("stringProperty").asString());
         Assert.assertEquals(10, object.get("intProperty").intValue(),
                 PRECISION);
         Assert.assertEquals(20, object.get("integerProperty").intValue(),
@@ -583,15 +585,16 @@ public class JacksonSerializerTest {
         Assert.assertEquals(true, object.get("booleanProperty").booleanValue());
         Assert.assertEquals(false,
                 object.get("booleanObjectProperty").booleanValue());
-        Assert.assertEquals('d', object.get("charProperty").asText().charAt(0));
+        Assert.assertEquals('d',
+                object.get("charProperty").asString().charAt(0));
         Assert.assertEquals('D',
-                object.get("characterProperty").asText().charAt(0));
+                object.get("characterProperty").asString().charAt(0));
         Assert.assertEquals(SomeEnum.SOME_VALUE_1.name(),
-                object.get("enumProperty").asText());
+                object.get("enumProperty").asString());
 
         object = json.get("record");
         Assert.assertNotNull("The record should be not be null", object);
-        Assert.assertEquals("someone", object.get("name").asText());
+        Assert.assertEquals("someone", object.get("name").asString());
         Assert.assertEquals(42, object.get("age").intValue(), PRECISION);
     }
 
@@ -700,8 +703,8 @@ public class JacksonSerializerTest {
 
         JsonNode jsonObject = json;
         ArrayNode array = (ArrayNode) jsonObject.get("listOfStrings");
-        Assert.assertEquals("string1", array.get(0).asText());
-        Assert.assertEquals("string2", array.get(1).asText());
+        Assert.assertEquals("string1", array.get(0).asString());
+        Assert.assertEquals("string2", array.get(1).asString());
 
         array = (ArrayNode) jsonObject.get("setOfIntegers");
         Assert.assertEquals(3, array.get(0).intValue(), PRECISION);
@@ -745,11 +748,11 @@ public class JacksonSerializerTest {
         Assert.assertNotNull(nestedRecord);
         Assert.assertNotNull(nestedObject);
 
-        Assert.assertEquals("someone", nestedRecord.get("name").asText());
+        Assert.assertEquals("someone", nestedRecord.get("name").asString());
         Assert.assertEquals(42, nestedRecord.get("age").intValue(), PRECISION);
 
         Assert.assertEquals("someProperty",
-                nestedObject.get("stringProperty").asText());
+                nestedObject.get("stringProperty").asString());
         Assert.assertEquals(1, nestedObject.get("intProperty").intValue(),
                 PRECISION);
         Assert.assertEquals(2, nestedObject.get("integerProperty").intValue(),
@@ -777,11 +780,11 @@ public class JacksonSerializerTest {
         Assert.assertFalse(
                 nestedObject.get("booleanObjectProperty").asBoolean());
         Assert.assertEquals('c',
-                nestedObject.get("charProperty").asText().charAt(0));
+                nestedObject.get("charProperty").asString().charAt(0));
         Assert.assertEquals('C',
-                nestedObject.get("characterProperty").asText().charAt(0));
+                nestedObject.get("characterProperty").asString().charAt(0));
         Assert.assertEquals(SomeEnum.SOME_VALUE_2.name(),
-                nestedObject.get("enumProperty").asText());
+                nestedObject.get("enumProperty").asString());
 
         mainRecord = JacksonSerializer.toObject(RecordWithRecordAndObject.class,
                 json);

--- a/flow-server/src/test/java/com/vaadin/flow/internal/JacksonUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/JacksonUtilsTest.java
@@ -192,7 +192,7 @@ public class JacksonUtilsTest {
                 mapper.nullNode());
 
         Assert.assertEquals(2, array.size());
-        Assert.assertEquals("string", array.get(0).asText());
+        Assert.assertEquals("string", array.get(0).asString());
         Assert.assertTrue(array.get(1).isNull());
     }
 
@@ -219,7 +219,7 @@ public class JacksonUtilsTest {
 
         Assert.assertEquals(2, JacksonUtils.getKeys(object).size());
         Assert.assertEquals(3, object.get("integer").asInt(), 0);
-        Assert.assertEquals("foo", object.get("string").asText());
+        Assert.assertEquals("foo", object.get("string").asString());
     }
 
     @Test
@@ -341,7 +341,7 @@ public class JacksonUtilsTest {
     @Test
     public void simpleBeanToJson() {
         ObjectNode json = JacksonUtils.beanToJson(new SimpleBean());
-        Assert.assertEquals("value", json.get("string").asText());
+        Assert.assertEquals("value", json.get("string").asString());
         Assert.assertEquals(1.0, json.get("number").asDouble(), 0.0);
         Assert.assertEquals(2.3f, json.get("flt").floatValue(), 0.0);
         Assert.assertEquals(4.56, json.get("dbl").asDouble(), 0.0);
@@ -350,9 +350,9 @@ public class JacksonUtilsTest {
     @Test
     public void nestedBeanToJson() {
         ObjectNode json = JacksonUtils.beanToJson(new ParentBean());
-        Assert.assertEquals("parent", json.get("parentValue").asText());
+        Assert.assertEquals("parent", json.get("parentValue").asString());
         JsonNode child = json.get("child");
-        Assert.assertEquals("child", child.get("childValue").asText());
+        Assert.assertEquals("child", child.get("childValue").asString());
     }
 
     @Test
@@ -411,10 +411,10 @@ public class JacksonUtilsTest {
         JsonNode childBeanMap = json.get("childBeanMap");
         JsonNode firstChild = childBeanMap.get("First");
         Assert.assertEquals("firstChildValue",
-                firstChild.get("childValue").asText());
+                firstChild.get("childValue").asString());
         JsonNode secondChild = childBeanMap.get("Second");
         Assert.assertEquals("secondChildValue",
-                secondChild.get("childValue").asText());
+                secondChild.get("childValue").asString());
 
         JsonNode integerList = json.get("integerList");
         Assert.assertEquals(3, integerList.get(0).asInt(), 0);
@@ -423,9 +423,9 @@ public class JacksonUtilsTest {
 
         JsonNode childBeanList = json.get("childBeanList");
         Assert.assertEquals("firstChildValue",
-                childBeanList.get(0).get("childValue").asText());
+                childBeanList.get(0).get("childValue").asString());
         Assert.assertEquals("secondChildValue",
-                childBeanList.get(1).get("childValue").asText());
+                childBeanList.get(1).get("childValue").asString());
     }
 
     @Test
@@ -439,8 +439,8 @@ public class JacksonUtilsTest {
         list.add(bean2);
         ArrayNode json = JacksonUtils.listToJson(list);
 
-        Assert.assertEquals("bean1", json.get(0).get("string").asText());
-        Assert.assertEquals("bean2", json.get(1).get("string").asText());
+        Assert.assertEquals("bean1", json.get(0).get("string").asString());
+        Assert.assertEquals("bean2", json.get(1).get("string").asString());
     }
 
     @Test
@@ -455,8 +455,8 @@ public class JacksonUtilsTest {
         map.put("two", bean2);
         ObjectNode json = JacksonUtils.mapToJson(map);
 
-        Assert.assertEquals("bean1", json.get("one").get("string").asText());
-        Assert.assertEquals("bean2", json.get("two").get("string").asText());
+        Assert.assertEquals("bean1", json.get("one").get("string").asString());
+        Assert.assertEquals("bean2", json.get("two").get("string").asString());
     }
 
     public record Person(String name, double age, boolean canSwim) {

--- a/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/VirtualChildrenListTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/VirtualChildrenListTest.java
@@ -45,7 +45,7 @@ public class VirtualChildrenListTest {
                 .getPayload();
         Assert.assertNotNull(payload);
 
-        Assert.assertEquals("foo", payload.get(NodeProperties.TYPE).asText());
+        Assert.assertEquals("foo", payload.get(NodeProperties.TYPE).asString());
 
         StateNode anotherChild = new StateNode(ElementData.class);
         list.add(0, anotherChild, "bar", (String) null);
@@ -56,7 +56,7 @@ public class VirtualChildrenListTest {
                 .getPayload();
         Assert.assertNotNull(payload);
 
-        Assert.assertEquals("bar", payload.get(NodeProperties.TYPE).asText());
+        Assert.assertEquals("bar", payload.get(NodeProperties.TYPE).asString());
     }
 
     @Test
@@ -69,9 +69,9 @@ public class VirtualChildrenListTest {
                 .getPayload();
         Assert.assertNotNull(payload);
 
-        Assert.assertEquals("foo", payload.get(NodeProperties.TYPE).asText());
+        Assert.assertEquals("foo", payload.get(NodeProperties.TYPE).asString());
         Assert.assertEquals("bar",
-                payload.get(NodeProperties.PAYLOAD).asText());
+                payload.get(NodeProperties.PAYLOAD).asString());
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandlerTest.java
@@ -110,12 +110,12 @@ public class JavaScriptBootstrapHandlerTest {
         Assert.assertFalse(json.get("appConfig").has("webComponentMode"));
 
         Assert.assertEquals("./",
-                json.get("appConfig").get("contextRootUrl").asText());
+                json.get("appConfig").get("contextRootUrl").asString());
         Assert.assertNull(
                 "ServiceUrl should not be set. It will be computed by flow-client",
                 json.get("appConfig").get("serviceUrl"));
         Assert.assertEquals("http://localhost:8888/",
-                json.get("appConfig").get("requestURL").asText());
+                json.get("appConfig").get("requestURL").asString());
 
         Assert.assertFalse(json.has("pushScript"));
     }
@@ -169,7 +169,7 @@ public class JavaScriptBootstrapHandlerTest {
         JsonNode json = JacksonUtils.readTree(response.getPayload());
 
         // Using regex, because version depends on the build
-        Assert.assertTrue(json.get("pushScript").asText().matches(
+        Assert.assertTrue(json.get("pushScript").asString().matches(
                 "^\\./VAADIN/static/push/vaadinPush\\.js\\?v=[\\w\\.\\-]+$"));
     }
 
@@ -187,7 +187,7 @@ public class JavaScriptBootstrapHandlerTest {
         JsonNode json = JacksonUtils.readTree(response.getPayload());
 
         // Using regex, because version depends on the build
-        Assert.assertTrue(json.get("pushScript").asText().matches(
+        Assert.assertTrue(json.get("pushScript").asString().matches(
                 "^\\./VAADIN/static/push/vaadinPush\\.js\\?v=[\\w\\.\\-]+$"));
     }
 
@@ -222,7 +222,7 @@ public class JavaScriptBootstrapHandlerTest {
         JsonNode json = JacksonUtils.readTree(response.getPayload());
 
         // Using regex, because version depends on the build
-        Assert.assertTrue(json.get("pushScript").asText().matches(
+        Assert.assertTrue(json.get("pushScript").asString().matches(
                 "^\\./VAADIN/static/push/vaadinPush\\.js\\?v=[\\w\\.\\-]+$"));
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/PublishedServerEventHandlerRpcHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/PublishedServerEventHandlerRpcHandlerTest.java
@@ -490,7 +490,7 @@ public class PublishedServerEventHandlerRpcHandlerTest {
         PublishedServerEventHandlerRpcHandler.invokeMethod(component,
                 component.getClass(), "varArgMethod", array, -1);
 
-        Assert.assertArrayEquals(new String[] { value.get(0).asText() },
+        Assert.assertArrayEquals(new String[] { value.get(0).asString() },
                 component.varArg);
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/dau/DAUUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/dau/DAUUtilsTest.java
@@ -256,7 +256,7 @@ public class DAUUtilsTest {
             String expectedValue, JsonNode json) {
         if (expectedValue != null) {
             Assert.assertEquals(expectedKey, expectedValue,
-                    json.get(expectedKey).asText());
+                    json.get(expectedKey).asString());
         } else {
             Assert.assertEquals("expected key " + expectedKey + " to be null",
                     JsonNodeType.NULL, json.get(expectedKey).getNodeType());

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
@@ -308,9 +308,9 @@ public abstract class AbstractNodeUpdatePackagesTest
         Assert.assertEquals(
                 "Vaadin dependency should be updated to latest DevDependency",
                 version, json.get(VAADIN_DEP_KEY).get(DEV_DEPENDENCIES).get(key)
-                        .textValue());
+                        .asString());
         Assert.assertEquals("DevDependency should stay the same as it was",
-                version, json.get(DEV_DEPENDENCIES).get(key).textValue());
+                version, json.get(DEV_DEPENDENCIES).get(key).asString());
     }
 
     @Test
@@ -467,7 +467,7 @@ public abstract class AbstractNodeUpdatePackagesTest
 
         ObjectNode newDependencies = JacksonUtils.createObjectNode();
         dependencyKeys.forEach(key -> newDependencies.put(key,
-                dependencies.get(key).textValue()));
+                dependencies.get(key).asString()));
 
         json.set(DEPENDENCIES, newDependencies);
 
@@ -615,7 +615,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         JsonNode dependencies = getPackageJson(packageJson).get(DEPENDENCIES);
         Assert.assertTrue(dependencies.has("@custom/timer"));
         Assert.assertEquals("3.3.0",
-                dependencies.get("@custom/timer").textValue());
+                dependencies.get("@custom/timer").asString());
     }
 
     @Test
@@ -671,7 +671,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         for (Map.Entry<String, String> entry : packages.entrySet()) {
             Assert.assertTrue(dependencies.has(entry.getKey()));
             Assert.assertEquals(entry.getValue(),
-                    dependencies.get(entry.getKey()).textValue());
+                    dependencies.get(entry.getKey()).asString());
         }
 
         packages.clear();
@@ -687,7 +687,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         for (Map.Entry<String, String> entry : packages.entrySet()) {
             Assert.assertTrue(dependencies.has(entry.getKey()));
             Assert.assertEquals(entry.getValue(),
-                    dependencies.get(entry.getKey()).textValue());
+                    dependencies.get(entry.getKey()).asString());
         }
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -233,7 +233,7 @@ public class NodeUpdaterTest {
         nodeUpdater.updateDefaultDependencies(packageJson);
 
         Assert.assertEquals("11.0.3", packageJson
-                .get(NodeUpdater.DEV_DEPENDENCIES).get("glob").textValue());
+                .get(NodeUpdater.DEV_DEPENDENCIES).get("glob").asString());
     }
 
     @Test // #6907 test when user has set newer versions
@@ -249,7 +249,7 @@ public class NodeUpdaterTest {
         nodeUpdater.updateDefaultDependencies(packageJson);
 
         Assert.assertEquals("78.2.3", packageJson
-                .get(NodeUpdater.DEV_DEPENDENCIES).get("vite").textValue());
+                .get(NodeUpdater.DEV_DEPENDENCIES).get("vite").asString());
     }
 
     @Test
@@ -272,7 +272,7 @@ public class NodeUpdaterTest {
                 formPackage, newVersion);
 
         Assert.assertEquals(newVersion, packageJson
-                .get(NodeUpdater.DEPENDENCIES).get(formPackage).textValue());
+                .get(NodeUpdater.DEPENDENCIES).get(formPackage).asString());
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -331,17 +331,17 @@ public class TaskRunNpmInstallTest {
                 UTF_8.name());
         JsonNode localHash = JacksonUtils.readTree(fileContent);
         Assert.assertNotEquals("We should have a non empty hash key", "",
-                localHash.get(HASH_KEY).textValue());
+                localHash.get(HASH_KEY).asString());
 
         // Update package json and hash as if someone had pushed to code repo.
         packageJson = getNodeUpdater().getPackageJson();
         ((ObjectNode) packageJson.get(VAADIN_DEP_KEY).get(DEPENDENCIES))
                 .put("a-avataaar", "^1.2.5");
-        String hash = packageJson.get(VAADIN_DEP_KEY).get(HASH_KEY).textValue();
+        String hash = packageJson.get(VAADIN_DEP_KEY).get(HASH_KEY).asString();
         updatePackageHash(packageJson);
 
         Assert.assertNotEquals("Hash should have been updated", hash,
-                packageJson.get(VAADIN_DEP_KEY).get(HASH_KEY).textValue());
+                packageJson.get(VAADIN_DEP_KEY).get(HASH_KEY).asString());
 
         getNodeUpdater().writePackageFile(packageJson);
         logger = Mockito.mock(Logger.class);
@@ -478,7 +478,7 @@ public class TaskRunNpmInstallTest {
         setupEsbuildAndFooInstallation();
 
         String packageJsonHash = getNodeUpdater().getPackageJson()
-                .get(VAADIN_DEP_KEY).get(HASH_KEY).textValue();
+                .get(VAADIN_DEP_KEY).get(HASH_KEY).asString();
         ObjectNode vaadinJson = JacksonUtils.createObjectNode();
         vaadinJson.put(HASH_KEY, packageJsonHash);
         vaadinJson.put(PROJECT_FOLDER, npmFolder.getAbsolutePath());
@@ -510,13 +510,13 @@ public class TaskRunNpmInstallTest {
                 .get(VAADIN_DEP_KEY).get(DEPENDENCIES);
         ObjectNode dependencies = JacksonUtils.createObjectNode();
         for (String key : JacksonUtils.getKeys(vaadinDep)) {
-            dependencies.put(key, vaadinDep.get(key).textValue());
+            dependencies.put(key, vaadinDep.get(key).asString());
         }
         ObjectNode vaadinDevDep = (ObjectNode) packageJson.get(VAADIN_DEP_KEY)
                 .get(DEV_DEPENDENCIES);
         ObjectNode devDependencies = JacksonUtils.createObjectNode();
         for (String key : JacksonUtils.getKeys(vaadinDevDep)) {
-            devDependencies.put(key, vaadinDevDep.get(key).textValue());
+            devDependencies.put(key, vaadinDevDep.get(key).asString());
         }
         packageJson.set(DEPENDENCIES, dependencies);
         packageJson.set(DEV_DEPENDENCIES, devDependencies);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -156,7 +156,7 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
 
         // Platform version takes precedence over dev deps
         Assert.assertEquals(PINNED_VERSION,
-                object.get("@vaadin/vaadin-overlay").textValue());
+                object.get("@vaadin/vaadin-overlay").asString());
     }
 
     @Test
@@ -229,10 +229,10 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
 
         Assert.assertEquals("Login version is the same for user and platform.",
                 loginVersion,
-                generatedVersions.get("@vaadin/vaadin-login").textValue());
+                generatedVersions.get("@vaadin/vaadin-login").asString());
         Assert.assertEquals("Notification version should use platform",
                 versionsNotificationVersion, generatedVersions
-                        .get("@vaadin/vaadin-notification").textValue());
+                        .get("@vaadin/vaadin-notification").asString());
     }
 
     @Test
@@ -331,7 +331,7 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         JsonNode overlayPackage = JacksonUtils.readTree(FileUtils
                 .readFileToString(overlayPackageJson, StandardCharsets.UTF_8));
         Assert.assertEquals(customOverlayVersion,
-                overlayPackage.get("version").textValue());
+                overlayPackage.get("version").asString());
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateSettingsFileTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateSettingsFileTest.java
@@ -100,7 +100,7 @@ public class TaskUpdateSettingsFileTest {
 
     private void assertPathsMatchProjectFolder(JsonNode json) {
         ABSOLUTE_PATH_ENTRIES.forEach(key -> {
-            String path = json.get(key).asText();
+            String path = json.get(key).asString();
             Assert.assertTrue(
                     "Expected '" + key + "' to have an absolute path matching "
                             + temporaryFolder.getRoot().getPath() + ", but was "

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/VersionsJsonFilterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/VersionsJsonFilterTest.java
@@ -156,7 +156,7 @@ public class VersionsJsonFilterTest {
         Assert.assertTrue(filteredJson.has("@polymer/iron-list"));
 
         Assert.assertEquals("1.1.2",
-                filteredJson.get("@vaadin/vaadin-progress-bar").textValue());
+                filteredJson.get("@vaadin/vaadin-progress-bar").asString());
     }
 
     private void assertFilterPlatformVersions_multipleUserChanged_correctlyIgnored(
@@ -202,7 +202,7 @@ public class VersionsJsonFilterTest {
             Assert.assertEquals(
                     String.format("Got wrong version for '%s'", entry.getKey()),
                     entry.getValue(),
-                    filteredJson.get(entry.getKey()).textValue());
+                    filteredJson.get(entry.getKey()).asString());
         }
     }
 
@@ -224,15 +224,15 @@ public class VersionsJsonFilterTest {
         Assert.assertEquals(
                 "'progress-bar' should be the same in package and versions",
                 "1.1.2",
-                filteredJson.get("@vaadin/vaadin-progress-bar").textValue());
+                filteredJson.get("@vaadin/vaadin-progress-bar").asString());
         Assert.assertEquals(
                 "'upload' should be the same in package and versions", "4.2.2",
-                filteredJson.get("@vaadin/vaadin-upload").textValue());
+                filteredJson.get("@vaadin/vaadin-upload").asString());
         Assert.assertEquals(
                 "'enforced' version should come from platform (upgrade)",
-                "1.5.0", filteredJson.get("enforced").textValue());
+                "1.5.0", filteredJson.get("enforced").asString());
         Assert.assertEquals(
                 "'iron-list' version should come from platform (downgrade)",
-                "2.0.19", filteredJson.get("@polymer/iron-list").textValue());
+                "2.0.19", filteredJson.get("@polymer/iron-list").asString());
     }
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/BasicElementView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/BasicElementView.java
@@ -45,7 +45,7 @@ public class BasicElementView extends AbstractDivView {
 
         button.addEventListener("click", e -> {
             JsonNode eventData = e.getEventData();
-            String buttonText = eventData.get("element.textContent").asText();
+            String buttonText = eventData.get("element.textContent").asString();
             int clientX = eventData.get("event.clientX").intValue();
             int clientY = eventData.get("event.clientY").intValue();
             Element greeting = ElementFactory.createDiv(

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DomEventFilterView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DomEventFilterView.java
@@ -79,7 +79,7 @@ public class DomEventFilterView extends AbstractDivView {
         debounce.setAttribute("id", "debounce");
         debounce.addEventListener("input", e -> {
             addMessage("input:%s, phase:%s".formatted(
-                    e.getEventData().get("element.value").asText(),
+                    e.getEventData().get("element.value").asString(),
                     e.getPhase()));
         }).addEventData("element.value").debounce(1000);
         debounce.addEventListener("click", e -> {
@@ -90,7 +90,7 @@ public class DomEventFilterView extends AbstractDivView {
         leading.setAttribute("id", "leading");
         leading.addEventListener("input", e -> {
             addMessage("input:%s, phase:%s".formatted(
-                    e.getEventData().get("element.value").asText(),
+                    e.getEventData().get("element.value").asString(),
                     e.getPhase()));
         }).addEventData("element.value").debounce(1000, DebouncePhase.LEADING);
 
@@ -98,7 +98,7 @@ public class DomEventFilterView extends AbstractDivView {
         leadingAndTrailing.setAttribute("id", "leading-trailing");
         leadingAndTrailing.addEventListener("input", e -> {
             addMessage("input:%s, phase:%s".formatted(
-                    e.getEventData().get("element.value").asText(),
+                    e.getEventData().get("element.value").asString(),
                     e.getPhase()));
         }).addEventData("element.value").debounce(1000, DebouncePhase.LEADING,
                 DebouncePhase.TRAILING);
@@ -107,7 +107,7 @@ public class DomEventFilterView extends AbstractDivView {
         throttle.setAttribute("id", "throttle");
         throttle.addEventListener("input", e -> {
             addMessage("input:%s, phase:%s".formatted(
-                    e.getEventData().get("element.value").asText(),
+                    e.getEventData().get("element.value").asString(),
                     e.getPhase()));
         }).addEventData("element.value").throttle(2000); // this is leading +
                                                          // intermediate
@@ -119,7 +119,7 @@ public class DomEventFilterView extends AbstractDivView {
         godMode.setAttribute("id", "godMode");
         godMode.addEventListener("input", e -> {
             addMessage("godmode:%s, phase:%s".formatted(
-                    e.getEventData().get("element.value").asText(),
+                    e.getEventData().get("element.value").asString(),
                     e.getPhase()));
         }).addEventData("element.value").debounce(1000, DebouncePhase.LEADING,
                 DebouncePhase.TRAILING, DebouncePhase.INTERMEDIATE); // this is

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ReturnChannelView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ReturnChannelView.java
@@ -31,7 +31,7 @@ public class ReturnChannelView extends AbstractDivView {
         ReturnChannelRegistration channel = button.getNode()
                 .getFeature(ReturnChannelMap.class)
                 .registerChannel(arguments -> button.setText(
-                        "Click registered: " + arguments.get(0).asText()));
+                        "Click registered: " + arguments.get(0).asString()));
 
         button.executeJs(
                 "this.addEventListener('click', function() { $0('hello') })",

--- a/flow-webpush/src/main/java/com/vaadin/flow/server/webpush/WebPush.java
+++ b/flow-webpush/src/main/java/com/vaadin/flow/server/webpush/WebPush.java
@@ -268,7 +268,7 @@ public class WebPush {
             // It may happen that an error is sent as a plain string
             if (json.getNodeType() == JsonNodeType.STRING) {
                 responseJson = JacksonUtils.createObjectNode();
-                responseJson.put("message", json.asText());
+                responseJson.put("message", json.asString());
             } else {
                 responseJson = JacksonUtils.readTree(json.toString());
             }
@@ -283,10 +283,10 @@ public class WebPush {
     private WebPushSubscription generateSubscription(
             ObjectNode subscriptionJson) {
         WebPushKeys keys = new WebPushKeys(
-                subscriptionJson.get("keys").get("p256dh").asText(),
-                subscriptionJson.get("keys").get("auth").asText());
+                subscriptionJson.get("keys").get("p256dh").asString(),
+                subscriptionJson.get("keys").get("auth").asString());
         return new WebPushSubscription(
-                subscriptionJson.get("endpoint").asText(), keys);
+                subscriptionJson.get("endpoint").asString(), keys);
     }
 
     private Logger getLogger() {

--- a/signals/src/test/java/com/vaadin/signals/impl/StagedTransactionTest.java
+++ b/signals/src/test/java/com/vaadin/signals/impl/StagedTransactionTest.java
@@ -521,7 +521,7 @@ public class StagedTransactionTest {
             Transaction.getCurrent().include(tree,
                     TestUtil.writeRootValueCommand("observer"), null);
 
-            String value = TestUtil.readTransactionRootValue(tree).asText();
+            String value = TestUtil.readTransactionRootValue(tree).asString();
             valueInObserver.set(value);
 
             return false;
@@ -534,7 +534,7 @@ public class StagedTransactionTest {
 
         assertEquals("observer", valueInObserver.get());
         assertEquals("observer",
-                TestUtil.readConfirmedRootValue(tree).asText());
+                TestUtil.readConfirmedRootValue(tree).asString());
     }
 
     @Test

--- a/signals/src/test/java/com/vaadin/signals/impl/TransactionTest.java
+++ b/signals/src/test/java/com/vaadin/signals/impl/TransactionTest.java
@@ -305,7 +305,7 @@ public class TransactionTest {
 
         List<String> invocations = new ArrayList<>();
         tree.observeNextChange(Id.ZERO, immediate -> {
-            invocations.add(TestUtil.readTransactionRootValue(tree).asText());
+            invocations.add(TestUtil.readTransactionRootValue(tree).asString());
             return true;
         });
 

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DebugWindowConnection.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DebugWindowConnection.java
@@ -301,11 +301,11 @@ public class DebugWindowConnection implements BrowserLiveReload {
             return;
         }
         JsonNode json = JacksonUtils.readTree(message);
-        String command = json.get("command").textValue();
+        String command = json.get("command").asString();
         JsonNode data = json.get("data");
         if ("setFeature".equals(command)) {
             FeatureFlags.get(context).setEnabled(
-                    data.get("featureId").textValue(),
+                    data.get("featureId").asString(),
                     data.get("enabled").booleanValue());
         } else if ("reportTelemetry".equals(command)) {
             DevModeUsageStatistics.handleBrowserData(data);
@@ -334,8 +334,8 @@ public class DebugWindowConnection implements BrowserLiveReload {
 
     private void handleLicenseCheck(AtmosphereResource resource,
             JsonNode data) {
-        String name = data.get("name").textValue();
-        String version = data.get("version").textValue();
+        String name = data.get("name").asString();
+        String version = data.get("version").asString();
         Product product = new Product(name, version);
         PreTrial preTrial = null;
         String command = null;
@@ -366,8 +366,8 @@ public class DebugWindowConnection implements BrowserLiveReload {
 
     private void handleLicenseKeyDownload(AtmosphereResource resource,
             JsonNode data) {
-        String name = data.get("name").textValue();
-        String version = data.get("version").textValue();
+        String name = data.get("name").asString();
+        String version = data.get("version").asString();
         Product product = new Product(name, version);
 
         LicenseChecker.checkLicenseAsync(product.getName(),

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/stats/JsonHelpers.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/stats/JsonHelpers.java
@@ -56,7 +56,7 @@ class JsonHelpers {
 
         for (final JsonNode p : arrayNode) {
             if (p != null && p.has(idField)
-                    && id.equals(p.get(idField).asText())) {
+                    && id.equals(p.get(idField).asString())) {
                 return (ObjectNode) p;
             }
         }

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/stats/ProKey.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/stats/ProKey.java
@@ -122,8 +122,8 @@ class ProKey {
         ProKey proKey = new ProKey(null, null);
         try {
             JsonNode json = JsonHelpers.getJsonMapper().readTree(jsonFile);
-            proKey = new ProKey(json.get(FIELD_NAME).asText(),
-                    json.get(FIELD_KEY).asText());
+            proKey = new ProKey(json.get(FIELD_NAME).asString(),
+                    json.get(FIELD_KEY).asString());
             return proKey;
         } catch (JacksonException | NullPointerException e) {
             getLogger().debug("Failed to parse proKey from json file", e);

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/stats/StatisticsContainer.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/stats/StatisticsContainer.java
@@ -134,7 +134,7 @@ public class StatisticsContainer {
      * @return the value of the field as a string
      */
     public String getValue(String name) {
-        return json.get(name).asText();
+        return json.get(name).asString();
     }
 
     /**

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/stats/StatisticsSender.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/stats/StatisticsSender.java
@@ -66,7 +66,7 @@ public class StatisticsSender {
      */
     String getLastServerMessage(ObjectNode json) {
         return json.has(StatisticsConstants.FIELD_SERVER_MESSAGE)
-                ? json.get(StatisticsConstants.FIELD_SERVER_MESSAGE).asText()
+                ? json.get(StatisticsConstants.FIELD_SERVER_MESSAGE).asString()
                 : null;
     }
 
@@ -158,7 +158,7 @@ public class StatisticsSender {
      */
     String getLastSendStatus(ObjectNode json) {
         try {
-            return json.get(StatisticsConstants.FIELD_LAST_STATUS).asText();
+            return json.get(StatisticsConstants.FIELD_LAST_STATUS).asString();
         } catch (Exception e) {
             // Use default value in case of any problems
             getLogger().debug(
@@ -221,7 +221,7 @@ public class StatisticsSender {
                 global.setValue(StatisticsConstants.FIELD_LAST_SENT,
                         System.currentTimeMillis());
                 global.setValue(StatisticsConstants.FIELD_LAST_STATUS, response
-                        .get(StatisticsConstants.FIELD_LAST_STATUS).asText());
+                        .get(StatisticsConstants.FIELD_LAST_STATUS).asString());
 
                 // Use different interval, if requested in response or default
                 // to 24H
@@ -244,7 +244,7 @@ public class StatisticsSender {
                                 .isTextual()) {
                     String msg = response
                             .get(StatisticsConstants.FIELD_SERVER_MESSAGE)
-                            .asText();
+                            .asString();
                     global.setValue(StatisticsConstants.FIELD_SERVER_MESSAGE,
                             msg);
                     message.set(msg);
@@ -253,7 +253,7 @@ public class StatisticsSender {
             });
 
             // If data was sent ok, clear the existing project data
-            if (response.get(StatisticsConstants.FIELD_LAST_STATUS).asText()
+            if (response.get(StatisticsConstants.FIELD_LAST_STATUS).asString()
                     .startsWith("200:")) {
                 storage.clearAllProjectData();
             }

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/stats/UserKey.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/stats/UserKey.java
@@ -40,7 +40,7 @@ class UserKey {
         String keyFromFile = null;
         try {
             JsonNode value = JsonHelpers.getJsonMapper().readTree(keyFile);
-            keyFromFile = value.get(FIELD_KEY).asText();
+            keyFromFile = value.get(FIELD_KEY).asString();
         } catch (Exception e) {
             getLogger().debug("Unable to read UserKey", e);
         }

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/stats/DevModeUsageStatisticsTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/stats/DevModeUsageStatisticsTest.java
@@ -64,7 +64,7 @@ public class DevModeUsageStatisticsTest extends AbstractStatisticsTest {
 
         ObjectNode json = storage.readProject();
         Assert.assertEquals("https://start.vaadin.com/test/1",
-                json.get(StatisticsConstants.FIELD_SOURCE_ID).asText());
+                json.get(StatisticsConstants.FIELD_SOURCE_ID).asString());
     }
 
     @Test
@@ -75,7 +75,7 @@ public class DevModeUsageStatisticsTest extends AbstractStatisticsTest {
 
         ObjectNode json = storage.readProject();
         Assert.assertEquals("https://start.vaadin.com/test/2",
-                json.get(StatisticsConstants.FIELD_SOURCE_ID).asText());
+                json.get(StatisticsConstants.FIELD_SOURCE_ID).asString());
     }
 
     @Test
@@ -86,7 +86,7 @@ public class DevModeUsageStatisticsTest extends AbstractStatisticsTest {
 
         ObjectNode json = storage.readProject();
         Assert.assertEquals("https://start.vaadin.com/test/3",
-                json.get(StatisticsConstants.FIELD_SOURCE_ID).asText());
+                json.get(StatisticsConstants.FIELD_SOURCE_ID).asString());
     }
 
     @Test
@@ -97,7 +97,7 @@ public class DevModeUsageStatisticsTest extends AbstractStatisticsTest {
 
         ObjectNode json = storage.readProject();
         Assert.assertEquals("https://start.vaadin.com/test/4",
-                json.get(StatisticsConstants.FIELD_SOURCE_ID).asText());
+                json.get(StatisticsConstants.FIELD_SOURCE_ID).asString());
     }
 
     @Test
@@ -279,7 +279,7 @@ public class DevModeUsageStatisticsTest extends AbstractStatisticsTest {
 
         final ObjectNode project = storage.read();
         Assert.assertEquals(MachineId.get(),
-                project.get(StatisticsConstants.FIELD_MACHINE_ID).asText());
+                project.get(StatisticsConstants.FIELD_MACHINE_ID).asString());
     }
 
     private static JsonNode wrapStats(String data) {


### PR DESCRIPTION
Change the use of deprecated methods
asText and textValue to asString
