### PR TITLE
chore: replace hard-coded resources folder

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerManagerImpl.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerManagerImpl.java
@@ -22,11 +22,13 @@ import java.io.File;
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -249,16 +251,15 @@ public class DevModeHandlerManagerImpl implements DevModeHandlerManager {
     // package-private for testing
     void startWatchingPublicResourcesCss(VaadinContext context,
             ApplicationConfiguration config) {
-        final File projectFolder = config.getProjectFolder();
-        List.of("src/main/resources/META-INF/resources",
-                "src/main/resources/resources", "src/main/resources/static",
-                "src/main/resources/public").stream().map(path -> {
-                    File resourcesFolder = new File(projectFolder, path);
+        final File rootResourcesFolder = config.getJavaResourceFolder();
+        Stream.of("META-INF/resources", "resources", "static", "public")
+                .map(path -> {
+                    File resourcesFolder = new File(rootResourcesFolder, path);
                     if (resourcesFolder.exists()) {
                         return resourcesFolder.getAbsolutePath();
                     }
                     return null;
-                }).filter(path -> path != null).forEach(path -> {
+                }).filter(Objects::nonNull).forEach(path -> {
                     try {
                         File resourcesFolder = new File(path);
                         if (!resourcesFolder.isDirectory()) {

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/PublicResourcesCssLiveUpdaterTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/PublicResourcesCssLiveUpdaterTest.java
@@ -150,6 +150,8 @@ public class PublicResourcesCssLiveUpdaterTest {
         ApplicationConfiguration appConfig = mock(
                 ApplicationConfiguration.class);
         when(appConfig.getProjectFolder()).thenReturn(project);
+        when(appConfig.getJavaResourceFolder())
+                .thenReturn(new File(project, "src/main/resources"));
         when(appConfig.isProductionMode()).thenReturn(false);
         context.setAttribute(ApplicationConfiguration.class, appConfig);
 
@@ -220,6 +222,8 @@ public class PublicResourcesCssLiveUpdaterTest {
         ApplicationConfiguration appConfig = mock(
                 ApplicationConfiguration.class);
         when(appConfig.getProjectFolder()).thenReturn(project);
+        when(appConfig.getJavaResourceFolder())
+                .thenReturn(new File(project, "src/main/resources"));
         when(appConfig.isProductionMode()).thenReturn(false);
         context.setAttribute(ApplicationConfiguration.class, appConfig);
 


### PR DESCRIPTION
Replaces hard-code 'src/main/resource' path with value obtained by 'ApplicationConfiguration.getJavaResourceFolder()' to handle also custom project setups.