### PR TITLE
chore: remove empty @since javadoc tags

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/BinderValidationErrorHandler.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/BinderValidationErrorHandler.java
@@ -30,7 +30,6 @@ import com.vaadin.flow.component.HasValue;
  * @see DefaultBinderValidationErrorHandler
  * @see Binder#setValidationErrorHandler(BinderValidationErrorHandler)
  * @author Vaadin Ltd
- * @since
  *
  */
 public interface BinderValidationErrorHandler extends Serializable {

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/BindingException.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/BindingException.java
@@ -24,7 +24,6 @@ import com.vaadin.flow.data.binder.Binder.Binding;
  * validator, converter, etc. behavior.
  *
  * @author Vaadin Ltd
- * @since
  *
  * @see BindingExceptionHandler
  */

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/BindingExceptionHandler.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/BindingExceptionHandler.java
@@ -28,7 +28,6 @@ import com.vaadin.flow.data.binder.Binder.Binding;
  * {@link HasValue} object is the source of the exception).
  *
  * @author Vaadin Ltd
- * @since
  *
  * @see BindingException
  */

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/DefaultBinderValidationErrorHandler.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/DefaultBinderValidationErrorHandler.java
@@ -40,7 +40,6 @@ import com.vaadin.flow.dom.ThemeList;
  *
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 public class DefaultBinderValidationErrorHandler

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/DefaultBindingExceptionHandler.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/DefaultBindingExceptionHandler.java
@@ -34,7 +34,6 @@ import com.vaadin.flow.server.startup.ApplicationConfiguration;
  * exception is not produced if the element has no any attribute or property.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 public class DefaultBindingExceptionHandler implements BindingExceptionHandler {

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/HasItemComponents.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/HasItemComponents.java
@@ -31,7 +31,6 @@ import com.vaadin.flow.component.HasElement;
  * {@link #prependComponents(Object, Component...)}.
  *
  * @author Vaadin Ltd
- * @since
  *
  * @param <T>
  *            the type of the displayed items

--- a/flow-data/src/main/java/com/vaadin/flow/data/converter/ConverterFactory.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/converter/ConverterFactory.java
@@ -23,7 +23,6 @@ import java.util.Optional;
  * model and a presentation type.
  *
  * @author Vaadin Ltd
- * @since
  */
 public interface ConverterFactory extends Serializable {
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/converter/DefaultConverterFactory.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/converter/DefaultConverterFactory.java
@@ -34,7 +34,6 @@ import com.vaadin.flow.internal.ReflectTools;
  * converters defined in {@code com.vaadin.flow.data.converters} package.
  *
  * @author Vaadin Ltd
- * @since
  */
 public enum DefaultConverterFactory implements ConverterFactory {
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataView.java
@@ -28,7 +28,6 @@ import com.vaadin.flow.shared.Registration;
  *
  * @param <T>
  *            data type
- * @since
  */
 public interface DataView<T> extends Serializable {
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataViewUtils.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataViewUtils.java
@@ -27,7 +27,6 @@ import com.vaadin.flow.function.SerializablePredicate;
  * simplify the filtering and sorting handling, but not limited to it.
  *
  * @author Vaadin Ltd
- * @since
  */
 public final class DataViewUtils {
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/HasDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/HasDataView.java
@@ -29,7 +29,6 @@ import java.io.Serializable;
  *            filter type
  * @param <V>
  *            DataView type
- * @since
  */
 public interface HasDataView<T, F, V extends DataView<T>> extends Serializable {
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/HasLazyDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/HasLazyDataView.java
@@ -28,7 +28,6 @@ import java.util.Collection;
  *            filter type
  * @param <V>
  *            DataView type
- * @since
  */
 public interface HasLazyDataView<T, F, V extends LazyDataView<T>>
         extends Serializable {

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/HasListDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/HasListDataView.java
@@ -27,7 +27,6 @@ import java.util.Collection;
  *            item type
  * @param <V>
  *            DataView type
- * @since
  */
 public interface HasListDataView<T, V extends ListDataView<T, ?>>
         extends Serializable {

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/IdentifierProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/IdentifierProvider.java
@@ -22,7 +22,6 @@ import com.vaadin.flow.function.ValueProvider;
  *
  * @param <T>
  *            the type of the item
- * @since
  */
 @FunctionalInterface
 public interface IdentifierProvider<T> extends ValueProvider<T, Object> {

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/ItemCountChangeEvent.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/ItemCountChangeEvent.java
@@ -35,7 +35,6 @@ import com.vaadin.flow.component.ComponentEvent;
  *
  * @param <T>
  *            the event source type
- * @since
  */
 public class ItemCountChangeEvent<T extends Component>
         extends ComponentEvent<T> {

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/ItemCountChangeListener.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/ItemCountChangeListener.java
@@ -37,7 +37,6 @@ import java.io.Serializable;
  * }
  * </pre>
  *
- * @since
  */
 @FunctionalInterface
 public interface ItemCountChangeListener extends Serializable {

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/LazyDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/LazyDataView.java
@@ -20,7 +20,6 @@ package com.vaadin.flow.data.provider;
  *
  * @param <T>
  *            data type
- * @since
  */
 public interface LazyDataView<T> extends DataView<T> {
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/ListDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/ListDataView.java
@@ -33,7 +33,6 @@ import com.vaadin.flow.function.ValueProvider;
  *            data type
  * @param <V>
  *            ListDataView type
- * @since
  */
 public interface ListDataView<T, V extends ListDataView<T, ?>>
         extends DataView<T> {

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/NativeDetailsElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/NativeDetailsElement.java
@@ -23,7 +23,6 @@ import com.vaadin.testbench.elementsbase.Element;
 /**
  * A TestBench element representing a <code>&lt;details&gt;</code> element.
  *
- * @since
  */
 @Element("details")
 public class NativeDetailsElement extends TestBenchElement {

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/AnchorTarget.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/AnchorTarget.java
@@ -20,7 +20,6 @@ package com.vaadin.flow.component.html;
  * <code>&lt;a&gt;</code> element.
  *
  * @author Vaadin Ltd
- * @since
  */
 public enum AnchorTarget implements AnchorTargetValue {
     /**

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/AnchorTargetValue.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/AnchorTargetValue.java
@@ -25,7 +25,6 @@ import java.util.stream.Stream;
  * element.
  *
  * @author Vaadin Ltd
- * @since
  *
  * @see AnchorTarget
  *

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/HtmlObject.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/HtmlObject.java
@@ -34,7 +34,6 @@ import com.vaadin.flow.server.streams.DownloadHandler;
  * Component representing a <code>&lt;object&gt;</code> element.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 @Tag(Tag.OBJECT)

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeDetails.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeDetails.java
@@ -34,7 +34,6 @@ import com.vaadin.flow.shared.Registration;
  * Component representing a <code>&lt;details&gt;</code> element.
  *
  * @author Vaadin Ltd
- * @since
  */
 @Tag(Tag.DETAILS)
 public class NativeDetails extends HtmlComponent

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Param.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Param.java
@@ -29,7 +29,6 @@ import com.vaadin.flow.component.Tag;
  * @see HtmlObject
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 @Tag(Tag.PARAM)

--- a/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/BundleLitParser.java
+++ b/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/BundleLitParser.java
@@ -32,7 +32,6 @@ import com.vaadin.flow.internal.StringUtil;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
  *
  * @see LitTemplateParser
  */

--- a/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/IllegalAttributeException.java
+++ b/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/IllegalAttributeException.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.component.littemplate;
 /**
  * Thrown to indicate that an element had an illegal or inappropriate attribute.
  *
- * @since
  */
 public class IllegalAttributeException extends RuntimeException {
 

--- a/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/InjectableLitElementInitializer.java
+++ b/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/InjectableLitElementInitializer.java
@@ -30,7 +30,6 @@ import com.vaadin.flow.dom.Element;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 public class InjectableLitElementInitializer

--- a/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/LitTemplate.java
+++ b/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/LitTemplate.java
@@ -54,7 +54,6 @@ import com.vaadin.flow.server.VaadinService;
  * @see Id
  *
  * @author Vaadin Ltd
- * @since
  */
 public abstract class LitTemplate extends Component
         implements HasStyle, Template {

--- a/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/LitTemplateDataAnalyzer.java
+++ b/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/LitTemplateDataAnalyzer.java
@@ -37,7 +37,6 @@ import com.vaadin.flow.server.VaadinService;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 class LitTemplateDataAnalyzer implements Serializable {

--- a/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/LitTemplateInitializer.java
+++ b/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/LitTemplateInitializer.java
@@ -30,7 +30,6 @@ import com.vaadin.flow.server.VaadinService;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 public class LitTemplateInitializer {

--- a/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/LitTemplateParser.java
+++ b/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/LitTemplateParser.java
@@ -32,7 +32,6 @@ import com.vaadin.flow.server.VaadinService;
  * @see LitTemplateParserImpl
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 @FunctionalInterface
@@ -55,7 +54,6 @@ public interface LitTemplateParser {
      *
      * @author Vaadin Ltd
      * @see LitTemplateParser
-     * @since
      *
      */
     class LitTemplateParserFactory {
@@ -77,7 +75,6 @@ public interface LitTemplateParser {
      * as an {@link Element} instance.
      *
      * @author Vaadin Ltd
-     * @since
      *
      */
     class TemplateData {

--- a/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/internal/LitTemplateParserImpl.java
+++ b/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/internal/LitTemplateParserImpl.java
@@ -61,7 +61,6 @@ import com.vaadin.flow.shared.ui.LoadMode;
  *
  *
  * @author Vaadin Ltd
- * @since
  *
  * @see BundleLitParser
  */

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FrontendDanceMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FrontendDanceMojo.java
@@ -21,7 +21,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 /**
  * This is the hidden `vaadin:dance` to clean up the frontend files.
  *
- * @since
  */
 @Mojo(name = "dance", defaultPhase = LifecyclePhase.PRE_CLEAN)
 public class FrontendDanceMojo extends CleanFrontendMojo {

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/utils/ResourceProviderImpl.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/utils/ResourceProviderImpl.java
@@ -28,7 +28,6 @@ import com.vaadin.flow.server.frontend.scanner.ClassFinder;
  * {@link ResourceProvider} for use with plugin execution.
  *
  * @author Vaadin Ltd
- * @since
  */
 class ResourceProviderImpl implements ResourceProvider {
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/InjectablePolymerElementInitializer.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/InjectablePolymerElementInitializer.java
@@ -21,7 +21,6 @@ import com.vaadin.flow.dom.Element;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
  * @deprecated {@code InjectableLitElementInitializer} should be used for Lit
  *             templates since polymer support is deprecated, we recommend you
  *             to use {@code LitTemplate} instead. Read more details from

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/TemplateParser.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/TemplateParser.java
@@ -91,7 +91,6 @@ public interface TemplateParser {
      * <p>
      *
      * @author Vaadin Ltd
-     * @since
      *
      */
     class TemplateParserFactory {

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/rpc/PolymerPublishedEventRpcHandler.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/rpc/PolymerPublishedEventRpcHandler.java
@@ -30,7 +30,6 @@ import com.vaadin.flow.templatemodel.ModelType;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
  */
 // This is OSGi specific annotation for the class which may be used without
 // OSGi. But RetentionPolicy.CLASS used for the annotation makes it safe to use

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasAriaLabel.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasAriaLabel.java
@@ -50,7 +50,6 @@ import com.vaadin.flow.dom.ElementConstants;
  * details.
  *
  * @author Vaadin Ltd
- * @since
  */
 public interface HasAriaLabel extends HasElement {
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasLabel.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasLabel.java
@@ -37,7 +37,6 @@ import com.vaadin.flow.dom.ElementConstants;
  * }</pre>
  *
  * @author Vaadin Ltd
- * @since
  */
 public interface HasLabel extends HasElement {
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasText.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasText.java
@@ -43,7 +43,6 @@ public interface HasText extends HasElement {
      * Represents <code>"white-space"</code> style values.
      *
      * @author Vaadin Ltd
-     * @since
      *
      */
     enum WhiteSpace {

--- a/flow-server/src/main/java/com/vaadin/flow/component/Shortcuts.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Shortcuts.java
@@ -157,7 +157,6 @@ public final class Shortcuts {
      * @return a registration for removing the locator, does not affect active
      *         shortcuts or if the locator has changed from what was set for
      *         this registration
-     * @since
      */
     public static Registration setShortcutListenOnElement(
             String elementLocatorJs, Component listenOnComponent) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/template/Id.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/template/Id.java
@@ -113,7 +113,6 @@ import com.vaadin.flow.dom.Element;
  *
  *
  * @author Vaadin Ltd
- * @since
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)

--- a/flow-server/src/main/java/com/vaadin/flow/component/template/internal/AbstractInjectableElementInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/template/internal/AbstractInjectableElementInitializer.java
@@ -30,7 +30,6 @@ import com.vaadin.flow.dom.Element;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 public abstract class AbstractInjectableElementInitializer

--- a/flow-server/src/main/java/com/vaadin/flow/component/template/internal/AttributeInitializationStrategy.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/template/internal/AttributeInitializationStrategy.java
@@ -23,7 +23,6 @@ import com.vaadin.flow.dom.Element;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 class AttributeInitializationStrategy implements ElementInitializationStrategy {

--- a/flow-server/src/main/java/com/vaadin/flow/component/template/internal/DeprecatedPolymerPublishedEventHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/template/internal/DeprecatedPolymerPublishedEventHandler.java
@@ -28,7 +28,6 @@ import com.vaadin.flow.component.Component;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
  *
  * @deprecated Polymer template support is deprecated - we recommend you to use
  *             {@code LitTemplate} instead. Read more details from <a href=

--- a/flow-server/src/main/java/com/vaadin/flow/component/template/internal/DeprecatedPolymerTemplate.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/template/internal/DeprecatedPolymerTemplate.java
@@ -23,7 +23,6 @@ import java.io.Serializable;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
  *
  * @deprecated Polymer template support is deprecated - we recommend you to use
  *             {@code LitTemplate} instead. Read more details from <a href=

--- a/flow-server/src/main/java/com/vaadin/flow/component/template/internal/ElementInitializationStrategy.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/template/internal/ElementInitializationStrategy.java
@@ -24,7 +24,6 @@ import com.vaadin.flow.dom.Element;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 @FunctionalInterface

--- a/flow-server/src/main/java/com/vaadin/flow/component/template/internal/IdCollector.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/template/internal/IdCollector.java
@@ -38,7 +38,6 @@ import com.vaadin.flow.internal.ReflectTools;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
  */
 public class IdCollector {
     private static final String DEPRECATED_ID = "com.vaadin.flow.component.polymertemplate.Id";

--- a/flow-server/src/main/java/com/vaadin/flow/component/template/internal/IdMapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/template/internal/IdMapper.java
@@ -35,7 +35,6 @@ import com.vaadin.flow.internal.nodefeature.VirtualChildrenList;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
  */
 public class IdMapper implements Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/template/internal/InjectableFieldConsumer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/template/internal/InjectableFieldConsumer.java
@@ -23,7 +23,6 @@ import java.lang.reflect.Field;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 @FunctionalInterface

--- a/flow-server/src/main/java/com/vaadin/flow/component/template/internal/ParserData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/template/internal/ParserData.java
@@ -26,7 +26,6 @@ import java.util.Map;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 public class ParserData {

--- a/flow-server/src/main/java/com/vaadin/flow/component/template/internal/PropertyInitializationStrategy.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/template/internal/PropertyInitializationStrategy.java
@@ -23,7 +23,6 @@ import com.vaadin.flow.dom.Element;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 class PropertyInitializationStrategy implements ElementInitializationStrategy {

--- a/flow-server/src/main/java/com/vaadin/flow/di/AbstractLookupInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/di/AbstractLookupInitializer.java
@@ -63,7 +63,6 @@ import com.vaadin.flow.server.startup.LookupServletContainerInitializer;
  * </ul>
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 public interface AbstractLookupInitializer {

--- a/flow-server/src/main/java/com/vaadin/flow/di/InstantiatorFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/di/InstantiatorFactory.java
@@ -21,7 +21,6 @@ import com.vaadin.flow.server.VaadinService;
  * A factory for an {@link Instantiator}.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 public interface InstantiatorFactory {

--- a/flow-server/src/main/java/com/vaadin/flow/di/Lookup.java
+++ b/flow-server/src/main/java/com/vaadin/flow/di/Lookup.java
@@ -67,7 +67,6 @@ import com.vaadin.flow.server.VaadinServlet;
  *
  * @see Instantiator
  * @author Vaadin Ltd
- * @since
  */
 public interface Lookup {
 

--- a/flow-server/src/main/java/com/vaadin/flow/di/LookupInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/di/LookupInitializer.java
@@ -56,7 +56,6 @@ import com.vaadin.flow.server.startup.DefaultApplicationConfigurationFactory;
  * Default implementation of {@link AbstractLookupInitializer}.
  *
  * @author Vaadin Ltd
- * @since
  *
  * @see AbstractLookupInitializer
  */
@@ -73,7 +72,6 @@ public class LookupInitializer implements AbstractLookupInitializer {
      * Default implementation of {@link Lookup}.
      *
      * @author Vaadin Ltd
-     * @since
      *
      */
     protected static class LookupImpl implements Lookup {
@@ -155,7 +153,6 @@ public class LookupInitializer implements AbstractLookupInitializer {
      * Default implementation of {@link ResourceProvider}.
      *
      * @author Vaadin Ltd
-     * @since
      *
      */
     protected static class ResourceProviderImpl implements ResourceProvider {
@@ -235,7 +232,6 @@ public class LookupInitializer implements AbstractLookupInitializer {
      * Default implementation of {@link AppShellPredicate}.
      *
      * @author Vaadin Ltd
-     * @since
      *
      */
     protected static class AppShellPredicateImpl implements AppShellPredicate {

--- a/flow-server/src/main/java/com/vaadin/flow/di/OneTimeInitializerPredicate.java
+++ b/flow-server/src/main/java/com/vaadin/flow/di/OneTimeInitializerPredicate.java
@@ -34,7 +34,6 @@ package com.vaadin.flow.di;
  * is executed only once.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 @FunctionalInterface

--- a/flow-server/src/main/java/com/vaadin/flow/di/ResourceProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/di/ResourceProvider.java
@@ -28,7 +28,6 @@ import java.util.List;
  * identified by the provided context.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 public interface ResourceProvider {

--- a/flow-server/src/main/java/com/vaadin/flow/function/VaadinApplicationInitializationBootstrap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/VaadinApplicationInitializationBootstrap.java
@@ -33,7 +33,6 @@ import com.vaadin.flow.server.VaadinContext;
  * depends on {@link Lookup} presence.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 @FunctionalInterface

--- a/flow-server/src/main/java/com/vaadin/flow/internal/ApplicationClassLoaderAccess.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/ApplicationClassLoaderAccess.java
@@ -28,7 +28,6 @@ import com.vaadin.flow.server.VaadinContext;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 @FunctionalInterface

--- a/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReloadAccessor.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReloadAccessor.java
@@ -29,7 +29,6 @@ import com.vaadin.flow.server.startup.ApplicationConfiguration;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 public interface BrowserLiveReloadAccessor {

--- a/flow-server/src/main/java/com/vaadin/flow/internal/DevModeHandlerManager.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/DevModeHandlerManager.java
@@ -31,7 +31,6 @@ import com.vaadin.flow.server.startup.VaadinInitializerException;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 public interface DevModeHandlerManager {

--- a/flow-server/src/main/java/com/vaadin/flow/internal/VaadinContextInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/VaadinContextInitializer.java
@@ -32,7 +32,6 @@ import com.vaadin.flow.server.VaadinServlet;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 @FunctionalInterface

--- a/flow-server/src/main/java/com/vaadin/flow/router/DefaultRoutePathProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/DefaultRoutePathProvider.java
@@ -22,7 +22,6 @@ import org.osgi.service.component.annotations.Component;
  * Default implementation for {@link RoutePathProvider}.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 @Component(service = RoutePathProvider.class, property = Constants.SERVICE_RANKING

--- a/flow-server/src/main/java/com/vaadin/flow/router/InvalidLocationException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/InvalidLocationException.java
@@ -19,7 +19,6 @@ package com.vaadin.flow.router;
  * Thrown to indicate that a {@link Location} instance is invalid.
  *
  * @author Vaadin Ltd
- * @since
  *
  * @see Location
  */

--- a/flow-server/src/main/java/com/vaadin/flow/router/RoutePathProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RoutePathProvider.java
@@ -20,7 +20,6 @@ package com.vaadin.flow.router;
  * components annotated with {@code @Route(Route.NAMING_CONVENTION)}.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 @FunctionalInterface

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/DefaultErrorHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/DefaultErrorHandler.java
@@ -25,7 +25,6 @@ import java.lang.annotation.Target;
  * Marks an HasErrorParameter view as Framework default handler so it can be
  * disregarded if there is a custom view for the same Exception.
  *
- * @since
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/flow-server/src/main/java/com/vaadin/flow/server/AbstractConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AbstractConfiguration.java
@@ -31,7 +31,6 @@ import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DISABLE_XS
  * servlet level,...).
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 public interface AbstractConfiguration extends Serializable {

--- a/flow-server/src/main/java/com/vaadin/flow/server/AbstractPropertyConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AbstractPropertyConfiguration.java
@@ -26,7 +26,6 @@ import static com.vaadin.flow.server.Constants.VAADIN_PREFIX;
  * Provides a configuration based on string properties.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 public abstract class AbstractPropertyConfiguration

--- a/flow-server/src/main/java/com/vaadin/flow/server/ErrorRouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/ErrorRouteRegistry.java
@@ -24,7 +24,6 @@ import com.vaadin.flow.router.internal.ErrorTargetEntry;
  * Interface class for RouteRegistries that can be used to request for error
  * navigation views for Exceptions.
  *
- * @since
  */
 public interface ErrorRouteRegistry extends Serializable {
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -28,7 +28,6 @@ import com.vaadin.flow.component.UI;
  * parameters here.
  *
  * @author Vaadin Ltd
- * @since
  */
 public class InitParameters implements Serializable {
 
@@ -128,7 +127,6 @@ public class InitParameters implements Serializable {
     /*
      * Configuration parameter name for enabling usage statistics.
      *
-     * @since
      */
     public static final String SERVLET_PARAMETER_DEVMODE_STATISTICS = "devmode.usageStatistics.enabled";
 
@@ -145,7 +143,6 @@ public class InitParameters implements Serializable {
      * ({@link #SERVLET_PARAMETER_DEVMODE_ENABLE_DEV_TOOLS} is set to {@code
      * false}), the live reload will be disabled as well.
      *
-     * @since
      */
     public static final String SERVLET_PARAMETER_DEVMODE_ENABLE_LIVE_RELOAD = "devmode.liveReload.enabled";
 
@@ -162,7 +159,6 @@ public class InitParameters implements Serializable {
      * {@link com.vaadin.flow.component.UI} instances will be serialized.
      * Otherwise, it won't be serialized.
      *
-     * @since
      */
     public static final String APPLICATION_PARAMETER_DEVMODE_ENABLE_SERIALIZE_SESSION = "devmode.sessionSerialization.enabled";
 
@@ -170,7 +166,6 @@ public class InitParameters implements Serializable {
      * Configuration parameter name for enabling component tracking in
      * development mode. If not set, tracking is enabled by default.
      *
-     * @since
      */
     public static final String APPLICATION_PARAMETER_DEVMODE_ENABLE_COMPONENT_TRACKER = "devmode.componentTracker.enabled";
 
@@ -200,7 +195,6 @@ public class InitParameters implements Serializable {
      * Configuration parameter name for requiring node executable installed in
      * home directory.
      *
-     * @since
      */
     public static final String REQUIRE_HOME_NODE_EXECUTABLE = "require.home.node";
 
@@ -208,7 +202,6 @@ public class InitParameters implements Serializable {
      * Configuration parameter name for requiring node executable installed in
      * home directory.
      *
-     * @since
      */
     public static final String NODE_AUTO_UPDATE = "node.auto.update";
 
@@ -225,7 +218,6 @@ public class InitParameters implements Serializable {
     /**
      * Configuration name for the build folder.
      *
-     * @since
      */
     public static final String BUILD_FOLDER = "build.folder";
 
@@ -233,7 +225,6 @@ public class InitParameters implements Serializable {
      * Packages, in addition to the internally used ones, to run postinstall
      * scripts for.
      *
-     * @since
      */
     public static final String ADDITIONAL_POSTINSTALL_PACKAGES = "npm.postinstallPackages";
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/StaticFileHandlerFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StaticFileHandlerFactory.java
@@ -19,7 +19,6 @@ package com.vaadin.flow.server;
  * A factory to create a {@link StaticFileHandler}.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 public interface StaticFileHandlerFactory {

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinConfig.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinConfig.java
@@ -23,7 +23,6 @@ import java.util.Enumeration;
  * for Config objects for instance <code>ServletConfig</code> and
  * <code>PortletConfig</code>.
  *
- * @since
  */
 public interface VaadinConfig extends Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinContext.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinContext.java
@@ -69,7 +69,6 @@ public interface VaadinContext extends Serializable {
      * @param value
      *            the attribute value to set, or <code>null</code> to remove the
      *            current value
-     * @since
      */
     <T> void setAttribute(Class<T> clazz, T value);
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletConfig.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletConfig.java
@@ -23,7 +23,6 @@ import java.util.Objects;
 /**
  * {@link VaadinConfig} implementation for Servlets.
  *
- * @since
  */
 public class VaadinServletConfig implements VaadinConfig {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FallibleCommand.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FallibleCommand.java
@@ -26,7 +26,6 @@ import com.vaadin.flow.server.ExecutionFailedException;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
  */
 public interface FallibleCommand {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendVersion.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendVersion.java
@@ -25,7 +25,6 @@ import java.util.regex.Pattern;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
  */
 public class FrontendVersion
         implements Serializable, Comparable<FrontendVersion> {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateViteDevMode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateViteDevMode.java
@@ -29,7 +29,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
  */
 public class TaskGenerateViteDevMode extends AbstractTaskClientGenerator {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskInstallFrontendBuildPlugins.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskInstallFrontendBuildPlugins.java
@@ -40,7 +40,6 @@ import static com.vaadin.flow.server.frontend.FrontendPluginsUtil.PLUGIN_TARGET;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
  */
 public class TaskInstallFrontendBuildPlugins implements FallibleCommand {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateThemeImport.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateThemeImport.java
@@ -43,7 +43,6 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.THEME_IMPORTS_NAME;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
  */
 public class TaskUpdateThemeImport
         extends AbstractFileGeneratorFallibleCommand {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/ArchiveExtractionException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/ArchiveExtractionException.java
@@ -22,7 +22,6 @@ package com.vaadin.flow.server.frontend.installer;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
  */
 public class ArchiveExtractionException extends Exception {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/ArchiveExtractor.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/ArchiveExtractor.java
@@ -24,7 +24,6 @@ import java.io.File;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
  */
 interface ArchiveExtractor {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/DefaultArchiveExtractor.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/DefaultArchiveExtractor.java
@@ -38,7 +38,6 @@ import org.apache.commons.io.IOUtils;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
  */
 public final class DefaultArchiveExtractor implements ArchiveExtractor {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/DefaultFileDownloader.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/DefaultFileDownloader.java
@@ -45,7 +45,6 @@ import org.slf4j.LoggerFactory;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
  */
 public final class DefaultFileDownloader implements FileDownloader {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/DownloadException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/DownloadException.java
@@ -22,7 +22,6 @@ package com.vaadin.flow.server.frontend.installer;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
  */
 public final class DownloadException extends Exception {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/FileDownloader.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/FileDownloader.java
@@ -25,7 +25,6 @@ import java.net.URI;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
  */
 public interface FileDownloader {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/InstallationException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/InstallationException.java
@@ -22,7 +22,6 @@ package com.vaadin.flow.server.frontend.installer;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
  */
 public class InstallationException extends Exception {
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
@@ -46,7 +46,6 @@ import com.vaadin.flow.server.frontend.FrontendVersion;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
  */
 public class NodeInstaller {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/Platform.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/Platform.java
@@ -31,7 +31,6 @@ import static com.vaadin.flow.server.frontend.installer.NodeInstaller.UNOFFICIAL
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
  */
 public class Platform {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/ProxyConfig.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/ProxyConfig.java
@@ -33,7 +33,6 @@ import org.slf4j.LoggerFactory;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
  */
 public class ProxyConfig {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/VerificationException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/VerificationException.java
@@ -20,7 +20,6 @@ package com.vaadin.flow.server.frontend.installer;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
  */
 public final class VerificationException extends Exception {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/AbstractDependenciesScanner.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/AbstractDependenciesScanner.java
@@ -30,7 +30,6 @@ import com.vaadin.flow.theme.AbstractTheme;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
  */
 abstract class AbstractDependenciesScanner
         implements FrontendDependenciesScanner {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesScanner.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesScanner.java
@@ -31,7 +31,6 @@ import com.vaadin.flow.theme.ThemeDefinition;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
  */
 public interface FrontendDependenciesScanner extends Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScanner.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScanner.java
@@ -55,7 +55,6 @@ import static com.vaadin.flow.server.frontend.scanner.FrontendClassVisitor.DEV;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
  */
 class FullDependenciesScanner extends AbstractDependenciesScanner {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/ThemeWrapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/ThemeWrapper.java
@@ -31,7 +31,6 @@ import com.vaadin.flow.theme.AbstractTheme;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
- * @since
  */
 class ThemeWrapper implements AbstractTheme, Serializable {
     private final Serializable instance;

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractConfigurationFactory.java
@@ -63,7 +63,6 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.PROJECT_BASEDIR;
  * A configuration factory base logic which reads the token file.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 public class AbstractConfigurationFactory implements Serializable {

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/AppShellPredicate.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/AppShellPredicate.java
@@ -22,7 +22,6 @@ import com.vaadin.flow.component.page.AppShellConfigurator;
  * for the web application.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 @FunctionalInterface

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ApplicationConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ApplicationConfiguration.java
@@ -31,7 +31,6 @@ import com.vaadin.flow.server.VaadinContext;
  * container level configuration (e.g. Servlet).
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 public interface ApplicationConfiguration extends AbstractConfiguration {

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ApplicationConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ApplicationConfigurationFactory.java
@@ -21,7 +21,6 @@ import com.vaadin.flow.server.VaadinContext;
  * A factory for {@link ApplicationConfiguration}.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 public interface ApplicationConfigurationFactory {

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DefaultApplicationConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DefaultApplicationConfigurationFactory.java
@@ -47,7 +47,6 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.TOKEN_FILE;
  * Default implementation of {@link ApplicationConfigurationFactory}.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 @Component(service = ApplicationConfigurationFactory.class, property = Constants.SERVICE_RANKING

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DeferredServletContextInitializers.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DeferredServletContextInitializers.java
@@ -34,7 +34,6 @@ import com.vaadin.flow.server.VaadinContext;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 class DeferredServletContextInitializers {
@@ -45,7 +44,6 @@ class DeferredServletContextInitializers {
      * is initialized with {@link Lookup}.
      *
      * @author Vaadin Ltd
-     * @since
      *
      */
     interface Initializer {

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/LookupServletContainerInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/LookupServletContainerInitializer.java
@@ -50,7 +50,6 @@ import com.vaadin.flow.server.frontend.EndpointGeneratorTaskFactory;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 @HandlesTypes({ ResourceProvider.class, InstantiatorFactory.class,

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinContextStartupInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinContextStartupInitializer.java
@@ -31,7 +31,6 @@ import com.vaadin.flow.server.VaadinContext;
  * {@link ClassLoaderAwareServletContainerInitializer#onStartup(Set, ServletContext)})</li>
  * </ul>
  *
- * @since
  *
  * @see ClassLoaderAwareServletContainerInitializer
  * @see VaadinServletContextStartupInitializer

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinInitializerException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinInitializerException.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.server.startup;
 /**
  * Indicates an issue during Vaadin initialization.
  *
- * @since
  */
 public class VaadinInitializerException extends Exception {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinServletContextStartupInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinServletContextStartupInitializer.java
@@ -32,7 +32,6 @@ import com.vaadin.flow.server.VaadinServletContext;
  * and perform any required programmatic registration of servlets, filters, and
  * listeners in response to it.
  *
- * @since
  *
  * @see ClassLoaderAwareServletContainerInitializer
  */

--- a/flow-server/src/main/java/com/vaadin/flow/shared/GwtIncompatible.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/GwtIncompatible.java
@@ -26,7 +26,6 @@ import java.lang.annotation.Target;
  * <code>gwt-shared</code>. See the documentation for
  * <code>com.google.gwt.core.shared.GwtIncompatible</code> for more information.
  *
- * @since
  */
 @Retention(RetentionPolicy.SOURCE)
 @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR,

--- a/flow-server/src/main/java/com/vaadin/flow/shared/Registration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/Registration.java
@@ -50,7 +50,6 @@ public interface Registration extends Serializable {
      *            not <code>null</code>
      * @return a registration that will invoke the command once, not
      *         <code>null</code>
-     * @since
      */
     @GwtIncompatible("Command is not in a package available to GWT")
     static Registration once(Command command) {
@@ -75,7 +74,6 @@ public interface Registration extends Serializable {
      *            the registrations to remove, not <code>null</code>
      * @return a registration that removes all provided registrations, not
      *         <code>null</code>
-     * @since
      */
     static Registration combine(Registration... registrations) {
         Objects.requireNonNull(registrations);
@@ -99,7 +97,6 @@ public interface Registration extends Serializable {
      *            the item to add and remove
      * @return a registration that will remove the item from the collection, not
      *         <code>null</code>
-     * @since
      */
     static <T> Registration addAndRemove(Collection<T> collection, T item) {
         collection.add(item);

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerManagerImpl.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerManagerImpl.java
@@ -51,7 +51,6 @@ import com.vaadin.flow.server.startup.VaadinInitializerException;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
  */
 public class DevModeHandlerManagerImpl implements DevModeHandlerManager {
 

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/stats/DevModeUsageStatistics.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/stats/DevModeUsageStatistics.java
@@ -34,7 +34,6 @@ import com.vaadin.pro.licensechecker.MachineId;
  * For internal use only. May be renamed or removed in a future release.
  *
  * @author Vaadin Ltd
- * @since
  */
 public class DevModeUsageStatistics {
 

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringApplicationConfigurationFactory.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringApplicationConfigurationFactory.java
@@ -27,7 +27,6 @@ import com.vaadin.flow.server.startup.DefaultApplicationConfigurationFactory;
  * Passes Spring application properties to the Vaadin application configuration.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 public class SpringApplicationConfigurationFactory

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringLookupInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringLookupInitializer.java
@@ -42,7 +42,6 @@ import com.vaadin.flow.server.VaadinServletContext;
  * Spring aware {@link LookupInitializer} implementation.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 public class SpringLookupInitializer extends LookupInitializer {

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinApplicationConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinApplicationConfiguration.java
@@ -40,7 +40,6 @@ import com.vaadin.flow.spring.security.SpringMenuAccessControl;
  * application if there is no developer provided factory available.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 @Configuration

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/annotation/RouteScope.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/annotation/RouteScope.java
@@ -48,7 +48,6 @@ import com.vaadin.flow.spring.scopes.VaadinRouteScope;
  * (but the "initial" calculated owner is still in the navigation chain).
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 @Scope(VaadinRouteScope.VAADIN_ROUTE_SCOPE_NAME)

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/annotation/RouteScopeOwner.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/annotation/RouteScopeOwner.java
@@ -34,7 +34,6 @@ import com.vaadin.flow.router.RouterLayout;
  * {@link RouterLayout}, or a {@link HasErrorParameter}.
  *
  * @author Vaadin Ltd
- * @since
  *
  */
 @Qualifier

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/scopes/VaadinRouteScope.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/scopes/VaadinRouteScope.java
@@ -54,7 +54,6 @@ import com.vaadin.flow.spring.annotation.RouteScopeOwner;
  *
  * @see com.vaadin.flow.spring.annotation.VaadinSessionScope
  * @author Vaadin Ltd
- * @since
  *
  */
 public class VaadinRouteScope extends AbstractScope {


### PR DESCRIPTION
Remove all empty `@since` tags that had no version information across the entire Flow project. These empty tags were causing javadoc warnings and provided no useful documentation.
