### PR TITLE
chore: replace empty <p></p> javadoc tags with <p>

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/AttachmentType.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/AttachmentType.java
@@ -18,7 +18,7 @@ package com.vaadin.flow.component.html;
 /**
  * Mode settings for anchor.
  * <p>
- * </p>
+ *
  * {@link #DOWNLOAD} will set the download attribute to Anchor, where as
  * {@link #INLINE} will remove it.
  */

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/RangeInput.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/RangeInput.java
@@ -32,7 +32,7 @@ import com.vaadin.flow.data.value.ValueChangeMode;
 /**
  * Creates a new input element with type "range".
  * <p>
- * </p>
+ *
  * Note: Slider doesn't support the read-only mode and will disable itself
  * instead.
  */
@@ -169,12 +169,12 @@ public class RangeInput extends AbstractSinglePropertyField<RangeInput, Double>
      * The step attribute is a number that specifies the granularity that the
      * value must adhere to.
      * <p>
-     * </p>
+     *
      * The step attribute can also be set to null. This step value means that no
      * stepping interval is implied and any value is allowed in the specified
      * range
      * <p>
-     * </p>
+     *
      * The default stepping value for range inputs is 1, allowing only integers
      * to be entered, unless the stepping base is not an integer; for example,
      * if you set min to -10 and value to 1.5, then a step of 1 will allow only
@@ -192,12 +192,12 @@ public class RangeInput extends AbstractSinglePropertyField<RangeInput, Double>
      * The step attribute is a number that specifies the granularity that the
      * value must adhere to.
      * <p>
-     * </p>
+     *
      * The step attribute can also be set to null. This step value means that no
      * stepping interval is implied and any value is allowed in the specified
      * range
      * <p>
-     * </p>
+     *
      * The default stepping value for range inputs is 1, allowing only integers
      * to be entered, unless the stepping base is not an integer; for example,
      * if you set min to -10 and value to 1.5, then a step of 1 will allow only
@@ -214,7 +214,7 @@ public class RangeInput extends AbstractSinglePropertyField<RangeInput, Double>
     /**
      * Sets the orientation of the range slider.
      * <p>
-     * </p>
+     *
      * <a href=
      * "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range#non-standard_attributes">Non-standard
      * Attribute</a>. Since the vertical orientation is not standardized yet,
@@ -222,7 +222,7 @@ public class RangeInput extends AbstractSinglePropertyField<RangeInput, Double>
      * feature to work on Firefox 120+, Chromium 119+, Edge 119+ and Safari
      * 17.1+.
      * <p>
-     * </p>
+     *
      * The orient attribute defines the orientation of the range slider. Values
      * include horizontal, meaning the range is rendered horizontally, and
      * vertical, where the range is rendered vertically.
@@ -256,12 +256,12 @@ public class RangeInput extends AbstractSinglePropertyField<RangeInput, Double>
     /**
      * Gets the orientation of the range slider.
      * <p>
-     * </p>
+     *
      * <a href=
      * "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range#non-standard_attributes">Non-standard
      * Attribute</a>.
      * <p>
-     * </p>
+     *
      * The orient attribute defines the orientation of the range slider. Values
      * include horizontal, meaning the range is rendered horizontally, and
      * vertical, where the range is rendered vertically.

--- a/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/BundleLitParser.java
+++ b/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/BundleLitParser.java
@@ -78,7 +78,7 @@ public final class BundleLitParser {
      * <p>
      * <code>return[\s]*html[\s]*(\`)</code> finds the return statement
      * <p>
-     * </p>
+     *
      * <code>([\s\S]*?)</code> captures all text until we encounter the end
      * character with <code>\1;}</code> e.g. <code>';}</code>
      */

--- a/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
+++ b/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
@@ -120,7 +120,7 @@ public class BuildDevBundleMojo extends AbstractMojo
      * mirror. Defaults to null which will cause the downloader to use
      * {@link NodeInstaller#DEFAULT_NODEJS_DOWNLOAD_ROOT}.
      * <p>
-     * </p>
+     *
      * Example: <code>"https://nodejs.org/dist/"</code>.
      */
     @Parameter(property = InitParameters.NODE_DOWNLOAD_ROOT)

--- a/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/Reflector.java
+++ b/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/Reflector.java
@@ -85,7 +85,7 @@ public final class Reflector {
     /**
      * Gets a {@link Reflector} instance usable with the caller class loader.
      * <p>
-     * </p>
+     *
      * Reflector instances are cached in Maven plugin context, but instances
      * might be associated to the plugin class loader, thus not working with
      * classes loaded by the isolated class loader. This method returns the
@@ -171,7 +171,7 @@ public final class Reflector {
      * Creates a copy of the given Flow mojo, loading classes the isolated
      * classloader.
      * <p>
-     * </p>
+     *
      * Loads the given mojo class from the isolated class loader and then
      * creates a new instance for it and fills all field copying values from the
      * original mojo. The input mojo must have a public no-args constructor.
@@ -200,7 +200,7 @@ public final class Reflector {
     /**
      * Gets a new {@link Reflector} instance for the current Mojo execution.
      * <p>
-     * </p>
+     *
      * An isolated class loader is created based on project and plugin
      * dependencies, with the first ones having precedence over the seconds. The
      * maven.api class realm is used as parent classloader, allowing usage of

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -119,7 +119,7 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
      * mirror. Defaults to null which will cause the downloader to use
      * {@link NodeInstaller#DEFAULT_NODEJS_DOWNLOAD_ROOT}.
      * <p>
-     * </p>
+     *
      * Example: <code>"https://nodejs.org/dist/"</code>.
      */
     @Parameter(property = InitParameters.NODE_DOWNLOAD_ROOT)

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FrontendScannerConfig.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FrontendScannerConfig.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  * plugin. This class allows enabling or disabling the scanner and defining
  * inclusion and exclusion rules.
  * <p>
- * </p>
+ *
  * Exclusions have higher priority and are checked first. If an artifact matches
  * an exclusion rule, it is not scanned. If no exclusion rule applies, inclusion
  * rules are evaluated. If the artifact doesn't even match the inclusion rule,
@@ -89,7 +89,7 @@ public class FrontendScannerConfig {
     /**
      * Sets if the output directory should be included in the scan.
      * <p>
-     * </p>
+     *
      * Can be turned on to make scanning faster if the maven module itself does
      * not have classes referencing frontend resources or Vaadin components or
      * add-ons.
@@ -159,7 +159,7 @@ public class FrontendScannerConfig {
      * Determines whether the given artifact should be analyzed by the frontend
      * scanner.
      * <p>
-     * </p>
+     *
      * Exclusions have higher priority and are checked first. If an artifact
      * matches an exclusion rule, it is not scanned. If no exclusion rule
      * applies, inclusion rules are evaluated.
@@ -225,7 +225,7 @@ public class FrontendScannerConfig {
     /**
      * Represents a pattern-based matcher for Maven artifacts.
      * <p>
-     * </p>
+     *
      * Patterns can use the wildcard {@code *}, but only at the beginning or end
      * of the rule. Examples of valid patterns:
      * <ul>
@@ -277,7 +277,7 @@ public class FrontendScannerConfig {
         /**
          * Sets the pattern for matching the artifact's group ID.
          * <p>
-         * </p>
+         *
          * The argument must be a valid pattern as describe in the class
          * Javadoc. {@literal null} is and allowed and value, and it acts like
          * setting {@code *}, meaning every group ID is allowed.
@@ -304,7 +304,7 @@ public class FrontendScannerConfig {
         /**
          * Sets the pattern for matching the artifact's artifact ID.
          * <p>
-         * </p>
+         *
          * The argument must be a valid pattern as describe in the class
          * Javadoc. {@literal null} is and allowed and value, and it acts like
          * setting {@code *}, meaning every artifact ID is allowed.

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/Reflector.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/Reflector.java
@@ -99,7 +99,7 @@ public final class Reflector {
     /**
      * Gets a {@link Reflector} instance usable with the caller class loader.
      * <p>
-     * </p>
+     *
      * Reflector instances are cached in Maven plugin context, but instances
      * might be associated to the plugin class loader, thus not working with
      * classes loaded by the isolated class loader. This method returns the
@@ -213,7 +213,7 @@ public final class Reflector {
     /**
      * Gets a new {@link Reflector} instance for the current Mojo execution.
      * <p>
-     * </p>
+     *
      * An isolated class loader is created based on project and plugin
      * dependencies, with the first ones having precedence over the seconds. The
      * maven.api class realm is used as parent classloader, allowing usage of
@@ -426,7 +426,7 @@ public final class Reflector {
      * A URL class loader implementation with delegation to a provided class
      * loader and Platform class loader.
      * <p>
-     * </p>
+     *
      * If the class or resource cannot be resolved against the given URLs, it
      * tries to load them from a provided class loader and lastly fallbacks to
      * Platform class loader in case of failure.
@@ -632,7 +632,7 @@ public final class Reflector {
     /**
      * Marks a type as cloneable by Reflector into a different classloader.
      * <p>
-     * </p>
+     *
      * Annotated class must be serializable and deserializable into JSON.
      */
     @Retention(RetentionPolicy.RUNTIME)

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/ArtifactMatcherTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/ArtifactMatcherTest.java
@@ -279,7 +279,7 @@ public class ArtifactMatcherTest {
     /**
      * Creates an Artifact instance based on the give coordinates.
      * <p>
-     * </p>
+     *
      *
      * Allowed syntaxes:
      *

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/it/IntegrationTestHelper.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/it/IntegrationTestHelper.java
@@ -35,7 +35,7 @@ public class IntegrationTestHelper {
      * Checks that javascript modules has been found during production build and
      * correctly imported into the generated bundle.
      * <p>
-     * </p>
+     *
      * Helper for {@literal src/it/frontend-scanner-tuning-project} test. It
      * expects that the test projects copies frontend generated import file and
      * chunks into {@code importsDir} folder, and checks if the import statement
@@ -67,7 +67,7 @@ public class IntegrationTestHelper {
      *         └── generated-flow-imports.js
      * </pre>
      * <p>
-     * </p>
+     *
      *
      * Example invocation:
      *

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBuild.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBuild.java
@@ -99,7 +99,7 @@ public interface PluginAdapterBuild extends PluginAdapterBase {
      * Checks if the artifact defined by given coordinates is a dependency of
      * the project, present at runtime.
      * <p>
-     * </p>
+     *
      * If the dependency is missing or in invalid scope, the method produces a
      * message containing the necessary instructions to fix the project and
      * notifies the caller by invoking the provided message consumer, if

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/BundleParser.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/BundleParser.java
@@ -64,7 +64,7 @@ public final class BundleParser {
      * <code>[\s]*return[\s]*html([\`|\'|\"])</code> finds the return statement
      * and captures the used string character
      * <p>
-     * </p>
+     *
      * <code>([\s\S]*)\1;[\s]*\}</code> captures all text until we encounter the
      * end character with <code>;}</code> e.g. <code>';}</code>
      */

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -1180,7 +1180,7 @@ public class UIInternals implements Serializable {
      * Re-navigates to the current route. Also re-instantiates the route target
      * component, and optionally all layouts in the route chain.
      * <p>
-     * </p>
+     *
      * If modal components are currently defined for the UI, the whole route
      * chain will be refreshed regardless the {@code refreshRouteChain}
      * parameter, because otherwise it would not be possible to preserve the

--- a/flow-server/src/main/java/com/vaadin/flow/hotswap/Hotswapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/hotswap/Hotswapper.java
@@ -126,7 +126,7 @@ public class Hotswapper implements ServiceDestroyListener, SessionInitListener,
      * Called by hotswap tools when one or more application classes have been
      * updated.
      * <p>
-     * </p>
+     *
      * This method delegates update operations to registered
      * {@link VaadinHotswapper} implementors. invoking first
      * {@link VaadinHotswapper#onClassLoadEvent(VaadinService, Set, boolean)}
@@ -168,7 +168,7 @@ public class Hotswapper implements ServiceDestroyListener, SessionInitListener,
      * Called by hotswap tools when one or more application resources have been
      * changed.
      * <p>
-     * </p>
+     *
      *
      * @param createdResources
      *            the list of potentially newly created resources. Never
@@ -553,7 +553,7 @@ public class Hotswapper implements ServiceDestroyListener, SessionInitListener,
     /**
      * Register the hotwsapper entry point for the given {@link VaadinService}.
      * <p>
-     * </p>
+     *
      * The hotswapper is registered only in development mode.
      *
      * @param vaadinService

--- a/flow-server/src/main/java/com/vaadin/flow/hotswap/VaadinHotswapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/hotswap/VaadinHotswapper.java
@@ -47,7 +47,7 @@ public interface VaadinHotswapper {
      * Called by Vaadin hotswap entry point when one or more application classes
      * have been updated.
      * <p>
-     * </p>
+     *
      * This method is meant to perform application-wide updates. Operation
      * targeting Vaadin session should be implemented in
      * {@link #onClassLoadEvent(VaadinSession, Set, boolean)} method.
@@ -74,7 +74,7 @@ public interface VaadinHotswapper {
      * Called by Vaadin hotswap entry point when one or more application classes
      * have been updated.
      * <p>
-     * </p>
+     *
      * This method is meant to perform updates at {@link VaadinSession} level.
      * Operation targeting the entire application should be implemented in
      * {@link #onClassLoadEvent(VaadinService, Set, boolean)} method.

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/RouteRegistryHotswapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/RouteRegistryHotswapper.java
@@ -49,7 +49,7 @@ public class RouteRegistryHotswapper implements VaadinHotswapper {
     /**
      * Updates both application registry, to reflect provided class changes.
      * <p>
-     * </p>
+     *
      * For modified route classes, the following changes are taken into account:
      * <ul>
      * <li>{@link Route} annotation removed: the previous route is removed from

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/RouteUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/RouteUtil.java
@@ -374,7 +374,7 @@ public class RouteUtil {
      * Updates route registry as necessary when classes have been added /
      * modified / deleted.
      * <p>
-     * </p>
+     *
      * Registry Update rules:
      * <ul>
      * <li>a route is preserved if the class does not have a {@link Route}

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -1590,7 +1590,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
      * (typically styles.css or document.css), which are served in express build
      * mode by static file server directly from frontend/themes folder.
      * <p>
-     * </p>
+     *
      * This method does not verify that the style sheet exists, so it may end up
      * at runtime with broken links. Use
      * {@link #getStylesheetLinks(VaadinContext, String, File)} if you want only
@@ -1612,7 +1612,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
      * (typically styles.css or document.css), which are served in express build
      * mode by static file server directly from frontend/themes folder.
      * <p>
-     * </p>
+     *
      * This method return links only for existing style sheet files.
      *
      * @param context

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/AccessCheckDecisionResolver.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/AccessCheckDecisionResolver.java
@@ -34,16 +34,16 @@ public interface AccessCheckDecisionResolver extends Serializable {
      * Determines if access is granted for a specific navigation context, based
      * on the decisions provided by {@link NavigationAccessChecker}s.
      * <p>
-     * </p>
+     *
      * The decision resolver should grant access or deny it by returning an
      * appropriate {@link AccessCheckResult} object.
      * <p>
-     * </p>
+     *
      * The expected result of the method should be
      * {@link AccessCheckDecision#ALLOW} or {@link AccessCheckDecision#DENY}, or
      * {@link AccessCheckDecision#REJECT}.
      * <p>
-     * </p>
+     *
      * A {@link AccessCheckDecision#NEUTRAL} result does not make because it
      * does not provide meaningful information to
      * {@link NavigationAccessControl} to complete the access check process. For

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/AccessCheckResult.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/AccessCheckResult.java
@@ -108,7 +108,7 @@ public class AccessCheckResult implements Serializable {
     /**
      * Create a result instance for the provided decision and reason.
      * <p>
-     * </p>
+     *
      * The {@code reason} cannot be {@literal null} for
      * {@link AccessCheckDecision#DENY} and {@link AccessCheckDecision#REJECT}.
      * For {@link AccessCheckDecision#ALLOW} the reason is ignored.

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/MenuAccessControl.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/MenuAccessControl.java
@@ -73,7 +73,7 @@ public interface MenuAccessControl extends Serializable {
     /**
      * Determines if current user has permissions to access the given view.
      * <p>
-     * </p>
+     *
      * It checks view against authentication state: - If view does not require
      * login -> allow - If not authenticated and login required -> deny. - If
      * user doesn't have correct roles -> deny.

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/NavigationAccessChecker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/NavigationAccessChecker.java
@@ -102,14 +102,14 @@ public interface NavigationAccessChecker extends Serializable {
      * {@link NavigationContext#neutral()}.
      *
      * <p>
-     * </p>
+     *
      * The check is performed for both regular navigation and during error
      * handling rerouting. The current phase can be checked with the
      * {@link NavigationContext#isErrorHandling()} flag. The checker
      * implementation can decide to ignore the error handling phase, by
      * returning a {@link NavigationContext#neutral()} result.
      * <p>
-     * </p>
+     *
      * Method implementation is not supposed to throw any kind of exception.
      *
      * @param context

--- a/flow-server/src/main/java/com/vaadin/flow/server/dau/DAUCustomizer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/dau/DAUCustomizer.java
@@ -50,7 +50,7 @@ public interface DAUCustomizer extends Serializable {
      * {@link UI#getCurrent()} can also be used to find more information to help
      * the decision.
      * <p>
-     * </p>
+     *
      * The default implementation returns
      * {@link EnforcementNotificationMessages#DEFAULT}.
      *
@@ -67,7 +67,7 @@ public interface DAUCustomizer extends Serializable {
      * Gets the function to be used to determine the user identity for the
      * current request.
      * <p>
-     * </p>
+     *
      * By default, returns {@literal null}, meaning that user identity is not
      * computed.
      *

--- a/flow-server/src/main/java/com/vaadin/flow/server/dau/DAUUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/dau/DAUUtils.java
@@ -113,7 +113,7 @@ public final class DAUUtils {
     /**
      * Parses DAU cookie value to extract tracking information.
      * <p>
-     * </p>
+     *
      * Cookie value is expected to be in format
      * {@literal trackingHash$creationTime}, with {@literal creationTime}
      * expressed as the number of milliseconds from the epoch of
@@ -175,7 +175,7 @@ public final class DAUUtils {
     /**
      * Gets the enforcement messages for the given request.
      * <p>
-     * </p>
+     *
      * Enforcement messages are get from the registered {@link DAUCustomizer},
      * if available. Otherwise, the default messages are returned.
      *
@@ -249,7 +249,7 @@ public final class DAUUtils {
     /**
      * Gets if a request should be considered for DAU tracking or not.
      * <p>
-     * </p>
+     *
      * Request that should be taken into account for DAU tracking are:
      *
      * <ul>
@@ -354,7 +354,7 @@ public final class DAUUtils {
      * Track DAU and check if enforcement should apply to the given request. If
      * enforcement is needed, the enforcement messages are returned.
      * <p>
-     * </p>
+     *
      * Method checks if the current request should be considered for DAU
      * tracking by using {@link #isDauEnabled(VaadinService)}.
      *

--- a/flow-server/src/main/java/com/vaadin/flow/server/dau/FlowDauIntegration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/dau/FlowDauIntegration.java
@@ -48,7 +48,7 @@ public final class FlowDauIntegration {
      * Generates a new cookie for counting daily active users within 24 hour
      * time interval.
      * <p>
-     * </p>
+     *
      * Cookie value is formatted as {@code  trackingHash$creationTime}, with
      * {@code creationTime} expressed as number of milliseconds from the epoch
      * of 1970-01-01T00:00:00Z. The cookie creation time is required on
@@ -73,12 +73,12 @@ public final class FlowDauIntegration {
     /**
      * Tracks the current user with the given optional identity.
      * <p>
-     * </p>
+     *
      * Tracking the user may raise an enforcement exception, that is stored and
      * applied later by calling
      * {@link #applyEnforcement(VaadinRequest, Predicate)} method.
      * <p>
-     * </p>
+     *
      * Tracking for UIDL requests is postponed until the message is parsed, to
      * prevent UI poll events to be considered as user interaction.
      *
@@ -125,7 +125,7 @@ public final class FlowDauIntegration {
      * Potentially applies enforcement to the current request if DAU limit is
      * exceeded.
      * <p>
-     * </p>
+     *
      * If enforcement has to be applied an {@link EnforcementException} is
      * thrown.
      *

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/CssBundler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/CssBundler.java
@@ -83,12 +83,12 @@ public class CssBundler {
     /**
      * Recurse over CSS import and inlines all ot them into a single CSS block.
      * <p>
-     * </p>
+     *
      * Unresolvable imports are put on the top of the resulting code, because
      * {@code @import} statements must come before any other CSS instruction,
      * otherwise the import is ignored by the browser.
      * <p>
-     * </p>
+     *
      * Along with import resolution and code inline, URLs
      * ({@code url('image.png')} referencing theme resources or assets are
      * rewritten to be correctly served by Vaadin at runtime.

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/Options.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/Options.java
@@ -947,7 +947,7 @@ public class Options implements Serializable {
      * Sets whether generated files from a previous execution that are no more
      * created should be removed.
      * <p>
-     * </p>
+     *
      * By default, the odl generated files are preserved.
      *
      * @param clean

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateReactFiles.java
@@ -216,7 +216,7 @@ public class TaskGenerateReactFiles
     /**
      * Writes the `layout.json` file in the frontend generated folder.
      * <p>
-     * </p>
+     *
      *
      * @param options
      *            the task options

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/ClassFinder.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/ClassFinder.java
@@ -259,7 +259,7 @@ public interface ClassFinder extends Serializable {
      * Determines whether the specified class should be inspected for
      * Vaadin-related resources.
      * <p>
-     * </p>
+     *
      * The default implementation always returns {@code true}, meaning all
      * classes are considered inspectable. Implementations may override this
      * method to provide custom filtering logic.

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevBundleBuildingHandler.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevBundleBuildingHandler.java
@@ -34,11 +34,11 @@ import com.vaadin.flow.server.VaadinSession;
  * progress" HTML page to the user, during the creation of the development
  * bundle.
  * <p>
- * </p>
+ *
  * The {@link #getPort()} method returns a fixed value of {@literal -1}, meaning
  * that this handler will not start a server listening for incoming requests.
  * <p>
- * </p>
+ *
  * Most of the other methods should not be invoked, and they may throw an
  * exception if called.
  */

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/NamedDaemonThreadFactory.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/NamedDaemonThreadFactory.java
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * A factory for creating daemon threads with custom naming conventions, used to
  * generate threads with a predefined naming pattern.
  * <p>
- * </p>
+ *
  * This class implements the {@link ThreadFactory} interface to provide a
  * mechanism for instantiating threads that are configured with specific
  * attributes such as name prefix, thread priority, and daemon status.

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/AuthenticationContext.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/AuthenticationContext.java
@@ -224,7 +224,7 @@ public class AuthenticationContext {
     /**
      * Checks whether the current authenticated user has the given role.
      * <p>
-     * </p>
+     *
      * The role must be provided without the role prefix, for example
      * {@code hasRole("USER")} instead of {@code hasRole("ROLE_USER")}.
      *
@@ -240,7 +240,7 @@ public class AuthenticationContext {
     /**
      * Checks whether the current authenticated user has any of the given roles.
      * <p>
-     * </p>
+     *
      * Roles must be provided without the role prefix, for example
      * {@code hasAnyRole(Set.of("USER", "ADMIN"))} instead of
      * {@code hasAnyRole(Set.of("ROLE_USER", "ROLE_ADMIN"))}.
@@ -264,7 +264,7 @@ public class AuthenticationContext {
     /**
      * Checks whether the current authenticated user has any of the given roles.
      * <p>
-     * </p>
+     *
      * Roles must be provided without the role prefix, for example
      * {@code hasAnyRole("USER", "ADMIN")} instead of
      * {@code hasAnyRole("ROLE_USER", "ROLE_ADMIN")}.
@@ -284,7 +284,7 @@ public class AuthenticationContext {
     /**
      * Checks whether the current authenticated user has all the given roles.
      * <p>
-     * </p>
+     *
      * Roles must be provided without the role prefix, for example
      * {@code hasAllRoles(Set.of("USER", "ADMIN"))} instead of
      * {@code hasAllRoles(Set.of("ROLE_USER", "ROLE_ADMIN"))}.
@@ -309,7 +309,7 @@ public class AuthenticationContext {
     /**
      * Checks whether the current authenticated user has all the given roles.
      * <p>
-     * </p>
+     *
      * Roles must be provided without the role prefix, for example
      * {@code hasAllRoles("USER", "ADMIN")} instead of
      * {@code hasAllRoles("ROLE_USER", "ROLE_ADMIN")}.

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/NavigationAccessControlConfigurer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/NavigationAccessControlConfigurer.java
@@ -37,18 +37,18 @@ import com.vaadin.flow.server.auth.RoutePathAccessChecker;
  * To configure Flow navigation access control, a Spring bean on type
  * {@link NavigationAccessControlConfigurer} should be defined.
  * <p>
- * </p>
+ *
  * In Spring Boot applications, a default
  * {@link NavigationAccessControlConfigurer} bean is provided. It activates
  * {@link AnnotatedViewAccessChecker}, but it disables the
  * {@link NavigationAccessControl}, for backward compatibility.
  * <p>
- * </p>
+ *
  * However, if Spring Security is configured extending
  * {@link VaadinWebSecurity}, the {@link NavigationAccessControl} is enabled
  * automatically.
  * <p>
- * </p>
+ *
  *
  * Default settings can be overridden by defining a custom
  * {@link NavigationAccessControlConfigurer} bean.
@@ -64,7 +64,7 @@ import com.vaadin.flow.server.auth.RoutePathAccessChecker;
  * </pre>
  *
  * <p>
- * </p>
+ *
  * NOTE: if the bean in exposed in a configuration class that extends
  * {@link VaadinWebSecurity}, the method must be defined {@code static} to
  * prevent cyclic dependencies errors.
@@ -82,7 +82,7 @@ import com.vaadin.flow.server.auth.RoutePathAccessChecker;
  * </pre>
  *
  * <p>
- * </p>
+ *
  * {@link NavigationAccessControl} bean can be configured by:
  *
  * <ul>
@@ -92,7 +92,7 @@ import com.vaadin.flow.server.auth.RoutePathAccessChecker;
  * <li>completely disable access control</li>
  * </ul>
  * <p>
- * </p>
+ *
  * The {@link NavigationAccessControl} will automatically be disabled if no
  * navigation access checkers are provided.
  *

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/SpringAccessPathChecker.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/SpringAccessPathChecker.java
@@ -31,14 +31,14 @@ import com.vaadin.flow.server.auth.AccessPathChecker;
  * A Spring specific route path access checker that delegates the check to
  * Spring Security.
  * <p>
- * </p>
+ *
  * It is used in combination with
  * {@link com.vaadin.flow.server.auth.RoutePathAccessChecker} to provide
  * path-based security to Flow
  * {@link com.vaadin.flow.server.auth.NavigationAccessControl}.
  *
  * <p>
- * </p>
+ *
  * To enable it, define a {@link NavigationAccessControlConfigurer} bean,
  * configured using
  * {@link NavigationAccessControlConfigurer#withRoutePathAccessChecker()}

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/SpringMenuAccessControl.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/SpringMenuAccessControl.java
@@ -24,7 +24,7 @@ import com.vaadin.flow.server.menu.AvailableViewInfo;
  * A Spring specific menu access control that falls back to Spring mechanisms
  * for view access checking, when the generic mechanisms do not work.
  * <p>
- * </p>
+ *
  * In Spring Boot application, a {@link SpringMenuAccessControl} is provided by
  * default, if Spring Security is available.
  */

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/SpringNavigationAccessControl.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/SpringNavigationAccessControl.java
@@ -31,7 +31,7 @@ import com.vaadin.flow.server.auth.NavigationAccessControl;
  * mechanisms for user retrieval and role checking, when the generic mechanisms
  * do not work.
  * <p>
- * </p>
+ *
  * In Spring Boot application, a {@link SpringNavigationAccessControl} is
  * provided by default, but its behavior can be configured by defining a
  * {@link NavigationAccessControlConfigurer} bean.

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -600,7 +600,7 @@ public abstract class VaadinWebSecurity {
      * Sets up the login page URI of the OAuth2 provider on the specified
      * HttpSecurity instance.
      * <p>
-     * </p>
+     *
      * This method also configures a logout success handler that redirects to
      * the application base URL after logout.
      *
@@ -622,12 +622,12 @@ public abstract class VaadinWebSecurity {
      * Sets up the login page URI of the OAuth2 provider and the post logout URI
      * on the specified HttpSecurity instance.
      * <p>
-     * </p>
+     *
      * The post logout redirect uri can be relative or absolute URI or a
      * template. The supported uri template variables are: {baseScheme},
      * {baseHost}, {basePort} and {basePath}.
      * <p>
-     * </p>
+     *
      * NOTE: "{baseUrl}" is also supported, which is the same as
      * "{baseScheme}://{baseHost}{basePort}{basePath}" handler.
      * setPostLogoutRedirectUri("{baseUrl}");
@@ -666,7 +666,7 @@ public abstract class VaadinWebSecurity {
      * Gets a {@code OidcClientInitiatedLogoutSuccessHandler} instance that
      * redirects to the given URL after logout.
      * <p>
-     * </p>
+     *
      * If a {@code ClientRegistrationRepository} bean is not registered in the
      * application context, the method returns {@literal null}.
      *

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/stateless/VaadinStatelessSecurityConfigurer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/stateless/VaadinStatelessSecurityConfigurer.java
@@ -100,7 +100,7 @@ public final class VaadinStatelessSecurityConfigurer<H extends HttpSecurityBuild
      * Applies configuration required to enable stateless security for a Vaadin
      * application.
      * <p>
-     * </p>
+     *
      * Use {@code customizer} to tune {@link VaadinStatelessSecurityConfigurer},
      * or {@link Customizer#withDefaults()} to accept the default values.
      *


### PR DESCRIPTION
Replace all instances of empty paragraph tags (`<p></p>`) with just
the opening `<p>` tag in javadoc comments. Empty closing `</p>` tags
were causing javadoc warnings and provided no semantic value.
