### PR TITLE
fix: always wait for navigated event for title

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/Flow.tsx
@@ -455,7 +455,7 @@ function Flow() {
         [navigate]
     );
 
-  useEffect(() => {
+    useEffect(() => {
         // @ts-ignore
         window.addEventListener('vaadin-router-go', vaadinRouterGoEventHandler);
         // @ts-ignore


### PR DESCRIPTION
When running with react-router
always wait for vaadin-navigated
event before updating the title.

In these cases the title update is
always from the server.

Fixes #21171
