### PR TITLE
chore: mark vaadin-dev-server as development-tool

### DIFF
--- a/vaadin-dev-server/pom.xml
+++ b/vaadin-dev-server/pom.xml
@@ -127,6 +127,7 @@
           <archive>
             <manifestEntries>
               <Dependencies>jdk.unsupported</Dependencies>
+              <Spring-Boot-Jar-Type>development-tool</Spring-Boot-Jar-Type>
             </manifestEntries>
           </archive>
         </configuration>


### PR DESCRIPTION
Add Spring-Boot-Jar-Type: development-tool to vaadin-dev-server manifest to exclude it from Spring Boot uber-jar package automatically.

RelatesTo: vaadin/flow#17737

WIP: `development-tool` type is new feature available in Spring Boot 4 RC. In current state Spring boot removes dependency always in runtime. Need to have it to be excluded only from the uber-jar package build for production, before this can be merged.