### PR TITLE
fix: Store UI reference on start (#22532)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/AbstractFileUploadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/AbstractFileUploadHandler.java
@@ -55,6 +55,7 @@ public abstract class AbstractFileUploadHandler<R extends AbstractFileUploadHand
     public void handleUploadRequest(UploadEvent event) throws IOException {
         UploadMetadata metadata = new UploadMetadata(event.getFileName(),
                 event.getContentType(), event.getFileSize());
+        setTransferUI(event.getUI());
         File file;
         try {
             file = fileFactory.createFile(metadata);

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/ClassDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/ClassDownloadHandler.java
@@ -90,6 +90,7 @@ public class ClassDownloadHandler
     @Override
     public void handleDownloadRequest(DownloadEvent downloadEvent)
             throws IOException {
+        setTransferUI(downloadEvent.getUI());
         if (clazz.getResource(resourceName) == null) {
             LoggerFactory.getLogger(ClassDownloadHandler.class)
                     .warn("No resource found for '{}'", resourceName);

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/FileDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/FileDownloadHandler.java
@@ -73,6 +73,7 @@ public class FileDownloadHandler
     @Override
     public void handleDownloadRequest(DownloadEvent downloadEvent)
             throws IOException {
+        setTransferUI(downloadEvent.getUI());
         VaadinResponse response = downloadEvent.getResponse();
         try (OutputStream outputStream = downloadEvent.getOutputStream();
                 FileInputStream inputStream = new FileInputStream(file)) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/InMemoryUploadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/InMemoryUploadHandler.java
@@ -40,6 +40,7 @@ public class InMemoryUploadHandler
 
     @Override
     public void handleUploadRequest(UploadEvent event) throws IOException {
+        setTransferUI(event.getUI());
         byte[] data;
         try {
             try (InputStream inputStream = event.getInputStream();

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/InputStreamDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/InputStreamDownloadHandler.java
@@ -49,6 +49,7 @@ public class InputStreamDownloadHandler
     public void handleDownloadRequest(DownloadEvent downloadEvent)
             throws IOException {
         VaadinResponse response = downloadEvent.getResponse();
+        setTransferUI(downloadEvent.getUI());
         DownloadResponse download;
         try {
             download = callback.complete(downloadEvent);

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandler.java
@@ -76,6 +76,7 @@ public class ServletResourceDownloadHandler
     @Override
     public void handleDownloadRequest(DownloadEvent downloadEvent)
             throws IOException {
+        setTransferUI(downloadEvent.getUI());
         VaadinService service = downloadEvent.getRequest().getService();
         VaadinResponse response = downloadEvent.getResponse();
         if (service instanceof VaadinServletService servletService) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/AbstractDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/AbstractDownloadHandlerTest.java
@@ -62,6 +62,7 @@ public class AbstractDownloadHandlerTest {
     private DownloadEvent downloadEvent;
     private ByteArrayOutputStream outputStream;
     private Element owner;
+    private UI ui;
 
     @Before
     public void setUp() throws IOException {
@@ -69,7 +70,7 @@ public class AbstractDownloadHandlerTest {
         response = Mockito.mock(VaadinResponse.class);
         session = Mockito.mock(VaadinSession.class);
 
-        UI ui = Mockito.mock(UI.class);
+        ui = Mockito.mock(UI.class);
         // run the command immediately
         Mockito.doAnswer(invocation -> {
             Command command = invocation.getArgument(0);
@@ -90,6 +91,7 @@ public class AbstractDownloadHandlerTest {
             public void handleDownloadRequest(DownloadEvent event) {
             }
         };
+        handler.setTransferUI(ui);
         mockContext = Mockito.mock(TransferContext.class);
         Mockito.when(mockContext.contentLength()).thenReturn(TOTAL_BYTES);
         listener = Mockito.mock(TransferProgressListener.class);
@@ -195,6 +197,7 @@ public class AbstractDownloadHandlerTest {
             successAtomic.set(success);
         });
 
+        customHandler.setTransferUI(ui);
         customHandler.handleDownloadRequest(downloadEvent);
 
         Assert.assertTrue(successAtomic.get());

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/ClassDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/ClassDownloadHandlerTest.java
@@ -48,6 +48,7 @@ public class ClassDownloadHandlerTest {
     private DownloadEvent downloadEvent;
     private OutputStream outputStream;
     private Element owner;
+    private UI ui;
 
     @Before
     public void setUp() throws IOException {
@@ -56,7 +57,7 @@ public class ClassDownloadHandlerTest {
         session = Mockito.mock(VaadinSession.class);
         service = Mockito.mock(VaadinService.class);
 
-        UI ui = Mockito.mock(UI.class);
+        ui = Mockito.mock(UI.class);
         // run the command immediately
         Mockito.doAnswer(invocation -> {
             Command command = invocation.getArgument(0);
@@ -137,6 +138,7 @@ public class ClassDownloadHandlerTest {
         Mockito.when(event.getSession()).thenReturn(session);
         Mockito.when(event.getResponse()).thenReturn(response);
         Mockito.when(event.getOwningElement()).thenReturn(owner);
+        Mockito.when(event.getUI()).thenReturn(ui);
         OutputStream outputStreamMock = Mockito.mock(OutputStream.class);
         Mockito.doThrow(new IOException("I/O exception")).when(outputStreamMock)
                 .write(Mockito.any(byte[].class), Mockito.anyInt(),

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/InputStreamDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/InputStreamDownloadHandlerTest.java
@@ -49,6 +49,7 @@ public class InputStreamDownloadHandlerTest {
     private DownloadEvent downloadEvent;
     private OutputStream outputStream;
     private Element owner;
+    private UI ui;
 
     @Before
     public void setUp() throws IOException {
@@ -57,7 +58,7 @@ public class InputStreamDownloadHandlerTest {
         session = Mockito.mock(VaadinSession.class);
         service = Mockito.mock(VaadinService.class);
 
-        UI ui = Mockito.mock(UI.class);
+        ui = Mockito.mock(UI.class);
         // run the command immediately
         Mockito.doAnswer(invocation -> {
             Command command = invocation.getArgument(0);
@@ -140,6 +141,7 @@ public class InputStreamDownloadHandlerTest {
         Mockito.when(event.getSession()).thenReturn(session);
         Mockito.when(event.getResponse()).thenReturn(response);
         Mockito.when(event.getOwningElement()).thenReturn(owner);
+        Mockito.when(event.getUI()).thenReturn(ui);
         OutputStream outputStreamMock = Mockito.mock(OutputStream.class);
         Mockito.doThrow(new IOException("I/O exception")).when(outputStreamMock)
                 .write(Mockito.any(byte[].class), Mockito.anyInt(),
@@ -178,6 +180,7 @@ public class InputStreamDownloadHandlerTest {
         Mockito.when(event.getSession()).thenReturn(session);
         Mockito.when(event.getResponse()).thenReturn(response);
         Mockito.when(event.getOwningElement()).thenReturn(owner);
+        Mockito.when(event.getUI()).thenReturn(ui);
         OutputStream outputStreamMock = Mockito.mock(OutputStream.class);
         Mockito.when(event.getOutputStream()).thenReturn(outputStreamMock);
 
@@ -209,6 +212,7 @@ public class InputStreamDownloadHandlerTest {
         Mockito.when(event.getSession()).thenReturn(session);
         Mockito.when(event.getResponse()).thenReturn(response);
         Mockito.when(event.getOwningElement()).thenReturn(owner);
+        Mockito.when(event.getUI()).thenReturn(ui);
         OutputStream outputStreamMock = Mockito.mock(OutputStream.class);
         Mockito.when(event.getOutputStream()).thenReturn(outputStreamMock);
 
@@ -241,6 +245,7 @@ public class InputStreamDownloadHandlerTest {
         Mockito.when(event.getSession()).thenReturn(session);
         Mockito.when(event.getResponse()).thenReturn(response);
         Mockito.when(event.getOwningElement()).thenReturn(owner);
+        Mockito.when(event.getUI()).thenReturn(ui);
         OutputStream outputStreamMock = Mockito.mock(OutputStream.class);
         Mockito.when(event.getOutputStream()).thenReturn(outputStreamMock);
 
@@ -281,6 +286,7 @@ public class InputStreamDownloadHandlerTest {
         Mockito.when(event.getResponse()).thenReturn(response);
         Mockito.when(event.getOwningElement()).thenReturn(owner);
         Mockito.when(event.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(event.getUI()).thenReturn(ui);
         Mockito.when(response.getOutputStream()).thenReturn(outputStream);
         Mockito.when(response.getService()).thenReturn(service);
         Mockito.when(service.getMimeType(Mockito.anyString()))
@@ -307,6 +313,7 @@ public class InputStreamDownloadHandlerTest {
         Mockito.when(event.getResponse()).thenReturn(response);
         Mockito.when(event.getOwningElement()).thenReturn(owner);
         Mockito.when(event.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(event.getUI()).thenReturn(ui);
         Mockito.when(response.getOutputStream()).thenReturn(outputStream);
         Mockito.when(response.getService()).thenReturn(service);
         Mockito.when(service.getMimeType(Mockito.anyString()))

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandlerTest.java
@@ -52,6 +52,7 @@ public class ServletResourceDownloadHandlerTest {
     private DownloadEvent downloadEvent;
     private OutputStream outputStream;
     private Element owner;
+    private UI ui;
 
     @Before
     public void setUp() throws IOException, URISyntaxException {
@@ -72,7 +73,7 @@ public class ServletResourceDownloadHandlerTest {
         Mockito.when(servletContext.getResourceAsStream(Mockito.anyString()))
                 .thenReturn(stream);
 
-        UI ui = Mockito.mock(UI.class);
+        ui = Mockito.mock(UI.class);
         // run the command immediately
         Mockito.doAnswer(invocation -> {
             Command command = invocation.getArgument(0);
@@ -153,6 +154,7 @@ public class ServletResourceDownloadHandlerTest {
         Mockito.when(downloadEvent.getSession()).thenReturn(session);
         Mockito.when(downloadEvent.getResponse()).thenReturn(response);
         Mockito.when(downloadEvent.getOwningElement()).thenReturn(owner);
+        Mockito.when(downloadEvent.getUI()).thenReturn(ui);
         OutputStream outputStreamMock = Mockito.mock(OutputStream.class);
         Mockito.doThrow(new IOException("I/O exception")).when(outputStreamMock)
                 .write(Mockito.any(byte[].class), Mockito.anyInt(),
@@ -207,6 +209,7 @@ public class ServletResourceDownloadHandlerTest {
         Mockito.when(event.getResponse()).thenReturn(response);
         Mockito.when(event.getOwningElement()).thenReturn(owner);
         Mockito.when(event.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(event.getUI()).thenReturn(ui);
         Mockito.when(response.getOutputStream()).thenReturn(outputStream);
         Mockito.when(response.getService()).thenReturn(service);
         Mockito.when(service.getMimeType(Mockito.anyString()))
@@ -229,6 +232,7 @@ public class ServletResourceDownloadHandlerTest {
         Mockito.when(event.getResponse()).thenReturn(response);
         Mockito.when(event.getOwningElement()).thenReturn(owner);
         Mockito.when(event.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(event.getUI()).thenReturn(ui);
         Mockito.when(response.getOutputStream()).thenReturn(outputStream);
         Mockito.when(response.getService()).thenReturn(service);
         Mockito.when(service.getMimeType(Mockito.anyString()))

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DetachedTransferProgressListenerView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DetachedTransferProgressListenerView.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import java.io.ByteArrayInputStream;
+
+import com.vaadin.flow.component.html.Anchor;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.page.Push;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.streams.DownloadHandler;
+import com.vaadin.flow.server.streams.DownloadResponse;
+import com.vaadin.flow.server.streams.InputStreamDownloadHandler;
+
+@Push
+@Route(value = "com.vaadin.flow.uitest.ui.DetachedTransferProgressListenerView")
+public class DetachedTransferProgressListenerView extends Div {
+
+    static final String REMOVED_COMPONENT_DONE = "removed-component-resource-uploaded";
+    static final String DOWNLOAD_AND_REMOVE = "download-and-remove-component";
+
+    public DetachedTransferProgressListenerView() {
+        Anchor anchor = new Anchor();
+        InputStreamDownloadHandler downloadHandler = DownloadHandler
+                .fromInputStream(event -> {
+                    event.getSession()
+                            .accessSynchronously(() -> remove(anchor));
+                    return new DownloadResponse(
+                            new ByteArrayInputStream(new byte[] { 'a' }),
+                            "test.txt", null, 1);
+                }).whenComplete(ignore -> {
+                    Span completedSpan = new Span("Done");
+                    completedSpan.setId(REMOVED_COMPONENT_DONE);
+                    add(completedSpan);
+                });
+        anchor.setText("Download");
+        anchor.setHref(downloadHandler);
+        anchor.setId(DOWNLOAD_AND_REMOVE);
+        add(anchor);
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DetachedTransferProgressListenerIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DetachedTransferProgressListenerIT.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import java.io.IOException;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.WebElement;
+
+import static com.vaadin.flow.uitest.ui.DetachedTransferProgressListenerView.DOWNLOAD_AND_REMOVE;
+import static com.vaadin.flow.uitest.ui.DetachedTransferProgressListenerView.REMOVED_COMPONENT_DONE;
+
+public class DetachedTransferProgressListenerIT
+        extends AbstractStreamResourceIT {
+
+    @Test
+    public void downloadRemovesComponent_successfullyUpdatesUI()
+            throws IOException {
+        open();
+
+        WebElement link = findElement(By.id(DOWNLOAD_AND_REMOVE));
+        link.click();
+
+        try {
+            waitUntil(
+                    driver -> isElementPresent(By.id(REMOVED_COMPONENT_DONE)));
+        } catch (TimeoutException e) {
+            Assert.fail("Success element never present.");
+        }
+
+    }
+}


### PR DESCRIPTION
Store UI ref to have a correct ui
for TransferProgress even when
element is detached during transfer.

Fixes #22243
