### PR TITLE
chore: bump vite to 6.4.1 (24.9)

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
@@ -9,7 +9,7 @@
   "license": "Apache-2.0",
   "dependencies": {},
   "devDependencies": {
-    "vite": "6.3.7",
+    "vite": "6.4.1",
     "@vitejs/plugin-react": "4.7.0",
     "@preact/signals-react-transform": "0.6.0",
     "@rollup/plugin-replace": "6.0.2",


### PR DESCRIPTION
resolve https://github.com/advisories/GHSA-93m4-6634-74q7