### PR TITLE
chore: Log missing @vaadin/bundles as debug info

### DIFF
--- a/flow-server/src/main/resources/plugins/vite-plugin-vaadin-bundles/index.ts
+++ b/flow-server/src/main/resources/plugins/vite-plugin-vaadin-bundles/index.ts
@@ -97,7 +97,7 @@ export default function vaadinBundlesPlugin({ nodeModulesFolder }: { nodeModules
       } catch (e: unknown) {
         if (typeof e === 'object' && (e as { code: string }).code === 'MODULE_NOT_FOUND') {
           vaadinBundleJson = { packages: {} };
-          console.info(`@vaadin/bundles npm package is not found, ${disabledMessage}`);
+          console.debug(`@vaadin/bundles npm package is not found, ${disabledMessage}`);
           return false;
         } else {
           throw e;


### PR DESCRIPTION
The bundle is excluded by default