### PR TITLE
feat: Add Image constructor for byte array content

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
@@ -145,11 +145,43 @@ public class Image extends HtmlContainer
      * @see #setAlt(String)
      */
     public Image(byte[] imageContent, String imageName) {
+        this(imageContent, imageName,
+                URLConnection.guessContentTypeFromName(imageName));
+    }
+
+    /**
+     * Creates an image from byte array content with the given image name and
+     * MIME type.
+     *
+     * This convenience constructor simplifies the creation of images from
+     * in-memory byte data by automatically handling the creation of a
+     * {@link DownloadHandler} with a {@link DownloadResponse}.
+     *
+     * Use this constructor when you need to explicitly specify the MIME type,
+     * either because {@link URLConnection#guessContentTypeFromName(String)}
+     * does not recognize the file extension or when you want explicit control
+     * over the content type.
+     *
+     * The alternative text is set to the provided image name.
+     *
+     * Sets the <code>Content-Disposition</code> header to <code>inline</code>
+     * to ensure the image is displayed in the browser rather than downloaded.
+     *
+     * @param imageContent
+     *            the image data as a byte array, not null
+     * @param imageName
+     *            the image name, not null
+     * @param mimeType
+     *            the MIME type of the image (e.g., "image/png", "image/webp"),
+     *            or null to let the browser determine it
+     *
+     * @see #setSrc(DownloadHandler)
+     * @see #setAlt(String)
+     */
+    public Image(byte[] imageContent, String imageName, String mimeType) {
         this(DownloadHandler.fromInputStream(event -> {
             return new DownloadResponse(new ByteArrayInputStream(imageContent),
-                    imageName,
-                    URLConnection.guessContentTypeFromName(imageName),
-                    imageContent.length);
+                    imageName, mimeType, imageContent.length);
         }).inline(), imageName);
     }
 

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/ImageTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/ImageTest.java
@@ -15,13 +15,21 @@
  */
 package com.vaadin.flow.component.html;
 
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
 import java.util.Optional;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinResponse;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.server.streams.DownloadEvent;
 import com.vaadin.flow.server.streams.DownloadHandler;
 import com.vaadin.flow.server.streams.DownloadResponse;
 import com.vaadin.flow.server.streams.InputStreamDownloadHandler;
@@ -72,8 +80,44 @@ public class ImageTest extends ComponentTest {
         Assert.assertTrue(handler.isInline());
     }
 
+    /**
+     * Helper method to capture and invoke a DownloadHandler, returning the
+     * captured content type.
+     */
+    private String captureAndInvokeDownloadHandler(Element element)
+            throws Exception {
+        ArgumentCaptor<DownloadHandler> handlerCaptor = ArgumentCaptor
+                .forClass(DownloadHandler.class);
+        Mockito.verify(element).setAttribute(Mockito.eq("src"),
+                handlerCaptor.capture());
+
+        DownloadHandler handler = handlerCaptor.getValue();
+        Assert.assertTrue("Handler should be InputStreamDownloadHandler",
+                handler instanceof InputStreamDownloadHandler);
+
+        // Create mock event and response to capture content type
+        VaadinRequest request = Mockito.mock(VaadinRequest.class);
+        VaadinResponse response = Mockito.mock(VaadinResponse.class);
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        VaadinService service = Mockito.mock(VaadinService.class);
+        OutputStream outputStream = new ByteArrayOutputStream();
+        Mockito.when(response.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(response.getService()).thenReturn(service);
+        Mockito.when(service.getMimeType(Mockito.anyString()))
+                .thenReturn("application/octet-stream");
+
+        DownloadEvent event = new DownloadEvent(request, response, session,
+                element);
+        handler.handleDownloadRequest(event);
+
+        ArgumentCaptor<String> contentTypeCaptor = ArgumentCaptor
+                .forClass(String.class);
+        Mockito.verify(response).setContentType(contentTypeCaptor.capture());
+        return contentTypeCaptor.getValue();
+    }
+
     @Test
-    public void byteArrayConstructor_typicalUseCase() {
+    public void byteArrayConstructor_typicalUseCase() throws Exception {
         Element element = Mockito.mock(Element.class);
         byte[] imageData = new byte[] { 1, 2, 3, 4, 5 };
 
@@ -88,9 +132,57 @@ public class ImageTest extends ComponentTest {
             }
         }
 
-        TestImage image = new TestImage(imageData, "test.png");
+        new TestImage(imageData, "test.png");
         Mockito.verify(element).setAttribute("alt", "test.png");
-        Mockito.verify(element).setAttribute(Mockito.eq("src"),
-                Mockito.any(DownloadHandler.class));
+
+        String contentType = captureAndInvokeDownloadHandler(element);
+        Assert.assertEquals("image/png", contentType);
+    }
+
+    @Test
+    public void byteArrayConstructor_withExplicitMimeType() throws Exception {
+        Element element = Mockito.mock(Element.class);
+        byte[] imageData = new byte[] { 1, 2, 3, 4, 5 };
+
+        class TestImage extends Image {
+            public TestImage(byte[] content, String name, String mimeType) {
+                super(content, name, mimeType);
+            }
+
+            @Override
+            public Element getElement() {
+                return element;
+            }
+        }
+
+        new TestImage(imageData, "test.webp", "image/webp");
+        Mockito.verify(element).setAttribute("alt", "test.webp");
+
+        String contentType = captureAndInvokeDownloadHandler(element);
+        Assert.assertEquals("image/webp", contentType);
+    }
+
+    @Test
+    public void byteArrayConstructor_withNullMimeType() throws Exception {
+        Element element = Mockito.mock(Element.class);
+        byte[] imageData = new byte[] { 1, 2, 3, 4, 5 };
+
+        class TestImage extends Image {
+            public TestImage(byte[] content, String name, String mimeType) {
+                super(content, name, mimeType);
+            }
+
+            @Override
+            public Element getElement() {
+                return element;
+            }
+        }
+
+        new TestImage(imageData, "test.img", null);
+        Mockito.verify(element).setAttribute("alt", "test.img");
+
+        String contentType = captureAndInvokeDownloadHandler(element);
+        // When MIME type is null, it falls back to the service's getMimeType
+        Assert.assertEquals("application/octet-stream", contentType);
     }
 }


### PR DESCRIPTION
Add a convenience constructor to Image class that accepts byte array content and an image name, simplifying the creation of images from in-memory data. The constructor automatically handles DownloadHandler creation, MIME type detection via URLConnection, and sets inline content disposition for proper browser display.

Fixes #21967
