### PR TITLE
test: prevent ComponentEffectTest flakyness

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentEffectTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentEffectTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import net.jcip.annotations.NotThreadSafe;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -58,6 +59,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@NotThreadSafe
 public class ComponentEffectTest {
 
     private static MockVaadinServletService service;


### PR DESCRIPTION
Marks the ComponentEffectTest as not thread safe so that it would get executed at the end, preventing thread pool starvation caused by multiple tests running in parallel
