### PR TITLE
test: Fix flaky ComponentEffectTest with FlushableExecutor

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentEffectTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentEffectTest.java
@@ -23,7 +23,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -102,8 +101,8 @@ public class ComponentEffectTest {
 
         /**
          * Flushes all pending async tasks. This executes tasks queued in the
-         * executor and then processes any UI access tasks that were queued as
-         * a result.
+         * executor and then processes any UI access tasks that were queued as a
+         * result.
          */
         public void flushExecutorAndAccessTasks(VaadinSession session) {
             // Flush executor tasks (effect dispatcher)


### PR DESCRIPTION
Replace async thread pool execution with a flushable executor that runs tasks synchronously on the test thread. This eliminates race conditions that caused intermittent test failures.

Root cause: Tests created effects dispatched to VaadinTaskExecutor thread pool and waited with CountDownLatch.await(1000ms). If the thread pool was busy, tasks wouldn't execute within timeout, causing flaky failures.

Solution: Implemented FlushableExecutor that queues tasks and executes them synchronously when flushed. This makes tests deterministic and fast.

Changes:
- Add FlushableExecutor class that implements Executor interface
- Add TestService that uses FlushableExecutor instead of thread pool
- Add flushExecutorAndAccessTasks() helper to process queued tasks
- Refactor three flaky tests to use flush instead of CountDownLatch
- Remove unused imports (CountDownLatch, LinkedBlockingQueue, TimeUnit)

Fixes #22572
