### PR TITLE
chore: bump byte-buddy to support recent Java versions (23.6)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
             <dependency>
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy</artifactId>
-                <version>1.17.8</version>
+                <version>1.14.8</version>
             </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>


### PR DESCRIPTION
Fixes #22595
