### PR TITLE
fix: prevent AppShellRegistry validation failure for StyleSheet.Container

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/AppShellRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AppShellRegistry.java
@@ -176,6 +176,7 @@ public class AppShellRegistry implements Serializable {
         // StyleSheet is allowed on Components; do not treat it as an
         // AppShell-only annotation
         validOnlyForAppShell.remove(StyleSheet.class);
+        validOnlyForAppShell.remove(StyleSheet.Container.class);
         if (WebComponentExporter.class.isAssignableFrom(clz)) {
             // Webcomponent exporter should have the theme annotation
             // and Push annotation as it is not appShell configured.

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/VaadinAppShellInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/VaadinAppShellInitializerTest.java
@@ -208,6 +208,13 @@ public class VaadinAppShellInitializerTest {
     public static class ComponentWithStylesheet extends Component {
     }
 
+    @StyleSheet("./foo1.css")
+    @StyleSheet("./foo2.css")
+    @StyleSheet("./foo3.css")
+    @StyleSheet("./foo4.css")
+    public static class ComponentWithMultipleStylesheet extends Component {
+    }
+
     @StyleSheet("context://my-styles.css")
     @StyleSheet("https://cdn.example.com/ui.css")
     public static class MyAppShellWithStyleSheets
@@ -550,6 +557,13 @@ public class VaadinAppShellInitializerTest {
     @Test
     public void styleSheetOnComponent_notOffending() throws Exception {
         classes.add(ComponentWithStylesheet.class);
+        // Should not throw as @StyleSheet is allowed on Components
+        initializer.process(classes, servletContext);
+    }
+
+    @Test
+    public void multipleStyleSheetOnComponent_notOffending() throws Exception {
+        classes.add(ComponentWithMultipleStylesheet.class);
         // Should not throw as @StyleSheet is allowed on Components
         initializer.process(classes, servletContext);
     }


### PR DESCRIPTION
When AppShellRegistry validates offending annotation on other compoent classes it ignore the StyleSheet annotation. However, if a component has multiple StyleSheet annotations on it, the validation fails. This change also ignores StyleSheet.Container annotation during validation

Fixes #22629