### PR TITLE
chore: Enable sourcemap generation in Vite config

### DIFF
--- a/vaadin-dev-server/vite.config.js
+++ b/vaadin-dev-server/vite.config.js
@@ -4,6 +4,7 @@ import typescript from '@rollup/plugin-typescript';
 
 export default defineConfig({
   build: {
+    sourcemap: true,
     // Write output to resources to include it in Maven package
     outDir: 'src/main/resources/META-INF/frontend/vaadin-dev-tools',
     // Clear output directory


### PR DESCRIPTION
This would help debug JS/TS code in browser when using dev mode.
