### PR TITLE
chore: run API diff check after permissions check

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -265,6 +265,7 @@ jobs:
           echo "🚫 THERE ARE TEST MODULES WITH FAILURES or BEEN CANCELLED" | tee -a $GITHUB_STEP_SUMMARY
           exit 1
   api-diff-labeling:
+    needs: check-permissions
     if: github.event_name == 'pull_request_target'
     timeout-minutes: 10
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Make api-diff-labeling job depend on check-permissions to ensure it runs after the permissions check, consistent with other jobs in the workflow.
