### PR TITLE
fix: Flush outputStream after write

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/TransferUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/TransferUtil.java
@@ -116,6 +116,7 @@ public final class TransferUtil {
                 }
             }
         }
+        outputStream.flush();
         long finalTransferred = transferred;
         listeners.forEach(listener -> listener.onComplete(transferContext,
                 finalTransferred));


### PR DESCRIPTION
transfer() method should call flush() on the OutputStream before 
returning to ensure all buffered data is actually written
