### PR TITLE
chore: Revert to Vite 7.1

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
@@ -9,7 +9,7 @@
   "license": "Apache-2.0",
   "dependencies": {},
   "devDependencies": {
-    "vite": "7.2.0",
+    "vite": "7.1.12",
     "@vitejs/plugin-react": "5.1.0",
     "@preact/signals-react-transform": "0.6.0",
     "@rollup/plugin-replace": "6.0.3",


### PR DESCRIPTION
Vite 7.2 seems to have some issues according to platform tests