### PR TITLE
fix: wait for dev server in DevModeNoClassCacheIT to prevent flaky test

### DIFF
--- a/flow-tests/test-redeployment-no-cache/src/test/java/com/vaadin/flow/uitest/ui/DevModeNoClassCacheIT.java
+++ b/flow-tests/test-redeployment-no-cache/src/test/java/com/vaadin/flow/uitest/ui/DevModeNoClassCacheIT.java
@@ -36,6 +36,7 @@ public class DevModeNoClassCacheIT extends ChromeBrowserTest {
     @Test
     public void testDevModeClassCacheNotPopulated() {
         open();
+        waitForDevServer();
 
         waitForElementPresent(By.id("last-span"));
 


### PR DESCRIPTION
The test was timing out waiting for the "last-span" element because it didn't wait for the Vite dev server to fully initialize before checking for DOM elements. Adding waitForDevServer() ensures the dev server, Spring Boot app, and view rendering complete before assertions.
