### PR TITLE
ci: enable Maven caching in Sonar workflow

### DIFF
--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Run Sonar analysis
         run: |
           mvn clean install sonar:sonar \
-            -U -B -e -V \
+            -B -e -V \
             -DskipTests \
             -Dsonar.projectKey=vaadin_flow \
             -Dsonar.organization=vaadin \


### PR DESCRIPTION
The -U flag forces Maven to check remote repositories for updates, bypassing the cache configured with 'cache: maven'. Removing it allows the workflow to use cached dependencies, significantly reducing build time and network usage.
