### PR TITLE
feat: build-frontent to propagate build info

### DIFF
--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -141,6 +141,12 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo
             throws MojoExecutionException, MojoFailureException {
         long start = System.nanoTime();
 
+        if (!BuildFrontendUtil.getTokenFile(this).exists()) {
+            // if not prepare-frontend token file exists propagate build info
+            // to token file
+            File tokenFile = BuildFrontendUtil.propagateBuildInfo(this);
+        }
+
         Options options = new Options(null, getClassFinder(), npmFolder())
                 .withFrontendDirectory(frontendDirectory())
                 .withFrontendGeneratedFolder(generatedTsFolder());

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
@@ -149,6 +149,7 @@ public class BuildFrontendMojoTest {
                 "flow_resources");
 
         defaultJavaSource = new File(".", "src/test/java");
+        File defaultJavaResource = new File(".", "src/test/resources");
         openApiJsonFile = new File(npmFolder,
                 "target/classes/com/vaadin/hilla/openapi.json");
         generatedTsFolder = new File(npmFolder, "src/main/frontend/generated");
@@ -185,6 +186,8 @@ public class BuildFrontendMojoTest {
                         "src/main/resources/application.properties"));
         ReflectionUtils.setVariableValueInObject(mojo, "javaSourceFolder",
                 defaultJavaSource);
+        ReflectionUtils.setVariableValueInObject(mojo, "javaResourceFolder",
+                defaultJavaResource);
         ReflectionUtils.setVariableValueInObject(mojo, "generatedTsFolder",
                 generatedTsFolder);
         ReflectionUtils.setVariableValueInObject(mojo, "nodeVersion",
@@ -671,11 +674,11 @@ public class BuildFrontendMojoTest {
     }
 
     @Test
-    public void noTokenFile_noTokenFileShouldBeCreated()
+    public void noTokenFile_tokenFileShouldBeCreated()
             throws MojoExecutionException, MojoFailureException {
         mojo.execute();
 
-        Assert.assertFalse(tokenFile.exists());
+        Assert.assertTrue(tokenFile.exists());
     }
 
     @Test


### PR DESCRIPTION
Add build info propagation to
build-frontend goal so it can
be executed also without
prepare-frontend

Closes #22679
