### PR TITLE
refactor: remove from reflection cache only changed classes

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/hotswap/Hotswapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/hotswap/Hotswapper.java
@@ -15,12 +15,15 @@
  */
 package com.vaadin.flow.hotswap;
 
+import jakarta.annotation.Priority;
+
 import java.io.Serializable;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -125,8 +128,15 @@ public class Hotswapper implements ServiceDestroyListener, SessionInitListener,
             throw new IllegalStateException(
                     "Lookup not found in VaadinContext");
         }
-        Collection<VaadinHotswapper> hotSwappers = lookup
-                .lookupAll(VaadinHotswapper.class);
+        List<VaadinHotswapper> hotSwappers = new ArrayList<>(
+                lookup.lookupAll(VaadinHotswapper.class));
+        hotSwappers.sort(Comparator.comparingInt(plugin -> {
+            Priority priority = plugin.getClass().getAnnotation(Priority.class);
+            if (priority == null) {
+                return 0;
+            }
+            return priority.value();
+        }));
         for (VaadinHotswapper hotSwapper : hotSwappers) {
             try {
                 hotSwapper.onInit(vaadinService);

--- a/flow-server/src/main/java/com/vaadin/flow/internal/ReflectionCache.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/ReflectionCache.java
@@ -20,10 +20,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
+import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableFunction;
-import com.vaadin.flow.function.SerializableRunnable;
 import com.vaadin.flow.shared.Registration;
 
 /**
@@ -41,7 +42,7 @@ import com.vaadin.flow.shared.Registration;
  *            the cached value type
  */
 public class ReflectionCache<C, T> {
-    private static final Set<Runnable> clearAllActions = Collections
+    private static final Set<Consumer<Class<?>>> clearAllActions = Collections
             .synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
 
     private final ConcurrentHashMap<Class<? extends C>, T> values = new ConcurrentHashMap<>();
@@ -52,7 +53,7 @@ public class ReflectionCache<C, T> {
      * Capture the action in a field to prevent garbage collection. This is
      * necessary because the actions are stored with weak references.
      */
-    private final SerializableRunnable clearAction = this::clear;
+    private final SerializableConsumer<Class<? extends C>> clearAction = this::clear;
 
     /**
      * Creates a new reflection cache with the given value provider. The value
@@ -71,7 +72,8 @@ public class ReflectionCache<C, T> {
         }
         this.valueProvider = wrapValueProvider(valueProvider);
 
-        addClearAllAction(clearAction);
+        // noinspection rawtypes,unchecked
+        addClearAllAction((Consumer) clearAction);
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -130,6 +132,20 @@ public class ReflectionCache<C, T> {
     }
 
     /**
+     * Removes mappings for the given type.
+     *
+     * @param type
+     *            the type to remove; {@literal null} means all mappings.
+     */
+    public void clear(Class<? extends C> type) {
+        if (type != null) {
+            values.remove(type);
+        } else {
+            values.clear();
+        }
+    }
+
+    /**
      * Adds an action that will be run when all reflection caches are cleared.
      * <p>
      * The actions are held with a weak reference, which typically means that
@@ -143,6 +159,24 @@ public class ReflectionCache<C, T> {
      * @return a registration for removing the action
      */
     public static Registration addClearAllAction(Runnable action) {
+        return Registration.addAndRemove(clearAllActions, k -> action.run());
+    }
+
+    /**
+     * Adds an action that will be run when all reflection caches are cleared
+     * for a specific type.
+     * <p>
+     * The actions are held with a weak reference, which typically means that
+     * the action will be ignored if the returned registration is garbage
+     * collected.
+     *
+     * @see #clearAll(Class)
+     *
+     * @param action
+     *            the action to run
+     * @return a registration for removing the action
+     */
+    public static Registration addClearAllAction(Consumer<Class<?>> action) {
         return Registration.addAndRemove(clearAllActions, action);
     }
 
@@ -150,6 +184,15 @@ public class ReflectionCache<C, T> {
      * Clears all mappings from all reflection caches and related resources.
      */
     public static void clearAll() {
-        clearAllActions.forEach(Runnable::run);
+        clearAll(null);
     }
+
+    /**
+     * Clears mappings for give type from all reflection caches and related
+     * resources.
+     */
+    public static void clearAll(Class<?> type) {
+        clearAllActions.forEach(action -> action.accept(type));
+    }
+
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/ReflectionCacheHotswapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/ReflectionCacheHotswapper.java
@@ -15,17 +15,23 @@
  */
 package com.vaadin.flow.internal;
 
+import jakarta.annotation.Priority;
+
 import com.vaadin.flow.hotswap.HotswapClassEvent;
 import com.vaadin.flow.hotswap.VaadinHotswapper;
 
 /**
  * Clears all mappings from all reflection caches and related resources when one
  * or more classes has been changed.
+ * <p>
+ * Should run as last, so other hotswappers can still query
+ * {@link ReflectionCache} to get previous data before the cache is cleared.
  */
+@Priority(Integer.MAX_VALUE)
 public class ReflectionCacheHotswapper implements VaadinHotswapper {
 
     @Override
     public void onClassesChange(HotswapClassEvent event) {
-        ReflectionCache.clearAll();
+        event.getChangedClasses().forEach(ReflectionCache::clearAll);
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/ReflectionCacheHotswapperTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/ReflectionCacheHotswapperTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.internal;
+
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.hotswap.HotswapClassEvent;
+import com.vaadin.flow.server.MockVaadinServletService;
+
+public class ReflectionCacheHotswapperTest {
+
+    private MockVaadinServletService service = new MockVaadinServletService(
+            false);
+    private ReflectionCacheHotswapper hotswapper = new ReflectionCacheHotswapper();
+    private ReflectionCache<CacheKey, CacheValue> cache = new ReflectionCache<>(
+            CacheValue::new);
+
+    @Test
+    public void onClassesChange_classCached_clearCache() {
+        cache.get(CacheKey.class).value = "BASE";
+        cache.get(CacheSubKey.class).value = "SUBCLASS";
+        hotswapper.onClassesChange(
+                new HotswapClassEvent(service, Set.of(CacheKey.class), true));
+
+        Assert.assertNull("Should have clean cache for cached class change",
+                cache.get(CacheKey.class).value);
+        Assert.assertEquals(
+                "Should not have cleared cache for other cached class",
+                "SUBCLASS", cache.get(CacheSubKey.class).value);
+    }
+
+    @Test
+    public void onClassesChange_classNotCached_doNotClearCache() {
+        cache.get(CacheKey.class).value = "BEFORE";
+        hotswapper.onClassesChange(
+                new HotswapClassEvent(service, Set.of(String.class), true));
+
+        Assert.assertEquals(
+                "Should not have cleared cache for non cached class change",
+                "BEFORE", cache.get(CacheKey.class).value);
+    }
+
+    static class CacheKey {
+    }
+
+    static class CacheSubKey extends CacheKey {
+    }
+
+    static class CacheValue {
+        private final Class<CacheKey> key;
+        private String value;
+
+        CacheValue(Class<CacheKey> key) {
+            this.key = key;
+        }
+
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/internal/ReflectionCacheTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/ReflectionCacheTest.java
@@ -67,6 +67,35 @@ public class ReflectionCacheTest {
     }
 
     @Test
+    public void cacheClearEntry() {
+        ReflectionCache<Number, Object> cache = new ReflectionCache<>(
+                type -> type);
+
+        cache.get(Integer.class);
+        cache.get(Double.class);
+        cache.get(Long.class);
+        Assert.assertTrue(cache.contains(Integer.class));
+        Assert.assertTrue(cache.contains(Double.class));
+        Assert.assertTrue(cache.contains(Long.class));
+
+        cache.clear(Double.class);
+        Assert.assertTrue(cache.contains(Integer.class));
+        Assert.assertFalse(cache.contains(Double.class));
+        Assert.assertTrue(cache.contains(Long.class));
+
+        cache.clear(Integer.class);
+        Assert.assertFalse(cache.contains(Integer.class));
+        Assert.assertFalse(cache.contains(Double.class));
+        Assert.assertTrue(cache.contains(Long.class));
+
+        cache.clear(Long.class);
+        Assert.assertFalse(cache.contains(Integer.class));
+        Assert.assertFalse(cache.contains(Double.class));
+        Assert.assertFalse(cache.contains(Long.class));
+
+    }
+
+    @Test
     public void clearAll() {
         ReflectionCache<Object, Object> cache1 = new ReflectionCache<>(
                 type -> type);
@@ -80,6 +109,32 @@ public class ReflectionCacheTest {
 
         Assert.assertFalse(cache1.contains(Object.class));
         Assert.assertFalse(cache2.contains(Object.class));
+    }
+
+    @Test
+    public void clearAllForGivenType() {
+        ReflectionCache<Number, Object> cache1 = new ReflectionCache<>(
+                type -> type);
+
+        ReflectionCache<Number, Object> cache2 = new ReflectionCache<>(
+                type -> type);
+
+        cache1.get(Integer.class);
+        cache1.get(Double.class);
+        cache2.get(Float.class);
+        cache2.get(Double.class);
+
+        ReflectionCache.clearAll(Integer.class);
+
+        Assert.assertFalse(cache1.contains(Integer.class));
+        Assert.assertTrue(cache1.contains(Double.class));
+        Assert.assertTrue(cache2.contains(Float.class));
+        Assert.assertTrue(cache2.contains(Double.class));
+
+        ReflectionCache.clearAll(Double.class);
+        Assert.assertFalse(cache1.contains(Double.class));
+        Assert.assertTrue(cache2.contains(Float.class));
+        Assert.assertFalse(cache2.contains(Double.class));
     }
 
     @Test


### PR DESCRIPTION
Refactors ReflectionCache hotswapper to selectively clean the caches based on the changed classes.
Also introduces hotswappers load sorting based on Priority annotation to allow developers to prioritize execution.
This is needed to ensure that ReflectionCache hotswapper is executed as the last one (or one of the latest) to allow other plugins to be able to query the cache to get previous state.