### PR TITLE
refactor: consolidate window.name initialization to Flow.ts

### DIFF
--- a/flow-client/src/main/frontend/Flow.ts
+++ b/flow-client/src/main/frontend/Flow.ts
@@ -102,6 +102,12 @@ export class Flow {
   private navigation: string = '';
 
   constructor(config?: FlowConfig) {
+    // Set window.name early so @PreserveOnRefresh can use it to identify the browser tab
+    // Only set if not already set to preserve any existing value
+    if (!window.name) {
+      window.name = `v-${Math.random()}`;
+    }
+
     flowRoot.$ = flowRoot.$ || [];
     this.config = config || {};
 

--- a/flow-client/src/main/frontend/FlowBootstrap.js
+++ b/flow-client/src/main/frontend/FlowBootstrap.js
@@ -144,10 +144,6 @@ Please submit an issue to https://github.com/vaadin/flow-components/issues/new/c
       };
       apps[appId] = app;
 
-      if (!window.name) {
-        window.name = appId + '-' + Math.random();
-      }
-
       var widgetset = 'client';
       widgetsets[widgetset] = {
         pendingApps: []

--- a/flow-server/src/main/resources/com/vaadin/flow/server/BootstrapHandler.js
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/BootstrapHandler.js
@@ -102,11 +102,7 @@ Please submit an issue to https://github.com/vaadin/flow-components/issues/new/c
         getConfig: getConfig
       };
       apps[appId] = app;
-      
-      if (!window.name) {
-        window.name =  appId + '-' + Math.random();
-      }
-  
+
       var widgetset = "client";
       if (!window.Vaadin.Flow.pendingStartup[widgetset]) {
         window.Vaadin.Flow.pendingStartup[widgetset] = {


### PR DESCRIPTION
Move window.name initialization from two bootstrap files (FlowBootstrap.js and BootstrapHandler.js) to a single location in Flow.ts constructor. This ensures window.name is set earlier in the application lifecycle and eliminates code duplication.
