### PR TITLE
ci: convert API diff workflow to opt-out approach with all public modules

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -273,21 +273,6 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    env:
-      # Opt-out: Modules to exclude from API diff checking
-      # These are excluded because they are not public APIs or are infrastructure/test modules
-      EXCLUDED_MODULES: |
-        flow-client
-        flow-test-util
-        flow-test-generic
-        flow-tests
-        flow-html-components-testbench
-        flow-server-production-mode
-        flow-plugins
-        flow-bom
-        vaadin-dev-server
-        flow-jandex
-        flow-polymer2lit
     steps:
       - uses: actions/checkout@v4
         with:
@@ -308,14 +293,6 @@ jobs:
             !~/.m2/repository/com/vaadin
           key: ${{ runner.os }}-maven-api-diff-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-
-      - name: Prepare Maven exclusion list
-        run: |
-          echo "Excluded modules:"
-          echo "$EXCLUDED_MODULES"
-          # Transform newline-separated list to Maven exclusion format (!module1,!module2,...)
-          EXCLUSION_LIST=$(echo "$EXCLUDED_MODULES" | tr '\n' ',' | sed 's/,$//' | sed 's/,/,!/g;s/^/!/')
-          echo "Maven exclusion list: $EXCLUSION_LIST"
-          echo "MAVEN_EXCLUSION_LIST=$EXCLUSION_LIST" >> $GITHUB_ENV
       - name: Checkout base branch for API comparison
         run: |
           echo "Checking out base branch: ${{ env.BASE_REF }}"
@@ -332,8 +309,7 @@ jobs:
         run: |
           echo "Building base version ${{ steps.base-version.outputs.BASE_API_VERSION }} from branch ${{ env.BASE_REF }}"
           echo "Running in $(pwd)"
-          echo "Using Maven exclusion list: $MAVEN_EXCLUSION_LIST"
-          mvn clean install -B -ntp -DskipTests -pl "$MAVEN_EXCLUSION_LIST" -am
+          mvn clean install -B -ntp -DskipTests
       - name: Use temporary flow version for PR
         # working-directory is not set, so it defaults back to the PR branch checkout
         run: |
@@ -342,15 +318,13 @@ jobs:
       - name: Calculate API version difference
         run: |
           echo "Running in $(pwd)"
-          echo "Using Maven exclusion list: $MAVEN_EXCLUSION_LIST"
-          mvn clean install -B -ntp -e -V -pl "$MAVEN_EXCLUSION_LIST" -am -Papicmp -DskipTests -Dapi.reference.version=${{ steps.base-version.outputs.BASE_API_VERSION }} -Dtest.use.hub=true -Djapicmp.maven.plugin.version=0.22.0
+          mvn clean install -B -ntp -e -V -Papicmp -DskipTests -Dapi.reference.version=${{ steps.base-version.outputs.BASE_API_VERSION }} -Dtest.use.hub=true -Djapicmp.maven.plugin.version=0.22.0
       - name: Move API diff results
         run: |
           #!/bin/bash
           set -e
           mkdir -p apidiff
           # Find all japicmp output directories and move them
-          # Excluding the excluded modules
           for module_dir in */target/japicmp; do
             if [ -d "$module_dir" ]; then
               module_name=$(dirname $(dirname "$module_dir"))

--- a/flow-bom/pom.xml
+++ b/flow-bom/pom.xml
@@ -11,6 +11,10 @@
   <name>Flow Bill of Materials</name>
   <description>Flow Bill of Materials</description>
 
+  <properties>
+    <flow.apicmp.skip>true</flow.apicmp.skip>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/flow-client/pom.xml
+++ b/flow-client/pom.xml
@@ -23,6 +23,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <testListener/>
+    <flow.apicmp.skip>true</flow.apicmp.skip>
   </properties>
 
   <dependencyManagement>

--- a/flow-html-components-testbench/pom.xml
+++ b/flow-html-components-testbench/pom.xml
@@ -11,7 +11,9 @@
   <name>TestBench elements for Flow HTML Components</name>
   <description>${project.name}</description>
 
-  <properties/>
+  <properties>
+    <flow.apicmp.skip>true</flow.apicmp.skip>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/flow-jandex/pom.xml
+++ b/flow-jandex/pom.xml
@@ -28,6 +28,10 @@
   <name>Flow Jandex index</name>
   <description>Jandex index for flow packages for when the vaadin platform is not used</description>
 
+  <properties>
+    <flow.apicmp.skip>true</flow.apicmp.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.vaadin</groupId>

--- a/flow-plugins/pom.xml
+++ b/flow-plugins/pom.xml
@@ -18,6 +18,7 @@
   <properties>
     <bnd.skip>true</bnd.skip>
     <testListener/>
+    <flow.apicmp.skip>true</flow.apicmp.skip>
   </properties>
   <profiles>
     <profile>

--- a/flow-polymer2lit/pom.xml
+++ b/flow-polymer2lit/pom.xml
@@ -13,6 +13,7 @@
 
   <properties>
     <version.roaster>2.30.1.Final</version.roaster>
+    <flow.apicmp.skip>true</flow.apicmp.skip>
   </properties>
 
   <dependencies>

--- a/flow-server-production-mode/pom.xml
+++ b/flow-server-production-mode/pom.xml
@@ -17,4 +17,8 @@
     https://vaadin.com/docs/v10/flow/web-components/tutorial-webcomponents-es5.html for more
     information.</description>
 
+  <properties>
+    <flow.apicmp.skip>true</flow.apicmp.skip>
+  </properties>
+
 </project>

--- a/flow-test-generic/pom.xml
+++ b/flow-test-generic/pom.xml
@@ -10,6 +10,11 @@
   <artifactId>flow-test-generic</artifactId>
   <name>Flow Generic Test Utilities</name>
   <description>${project.name}</description>
+
+  <properties>
+    <flow.apicmp.skip>true</flow.apicmp.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>junit</groupId>

--- a/flow-test-util/pom.xml
+++ b/flow-test-util/pom.xml
@@ -15,6 +15,7 @@
   <properties>
     <license.skipDownloadLicenses>true</license.skipDownloadLicenses>
     <sonar.skip>true</sonar.skip>
+    <flow.apicmp.skip>true</flow.apicmp.skip>
   </properties>
 
   <dependencies>

--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -28,6 +28,7 @@
     <license.skipDownloadLicenses>true</license.skipDownloadLicenses>
 
     <maven.deploy.skip>true</maven.deploy.skip>
+    <flow.apicmp.skip>true</flow.apicmp.skip>
     <!-- Used in the tests, should be overridden for each module to support
             concurrent running of test modules. -->
     <server.port>8888</server.port>

--- a/pom.xml
+++ b/pom.xml
@@ -771,5 +771,48 @@
         <sonar.issuesReport.html.enable/>
       </properties>
     </profile>
+    <profile>
+      <id>apicmp</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.siom79.japicmp</groupId>
+            <artifactId>japicmp-maven-plugin</artifactId>
+            <version>${japicmp.maven.plugin.version}</version>
+            <configuration>
+              <oldVersion>
+                <dependency>
+                  <groupId>${project.groupId}</groupId>
+                  <artifactId>${project.artifactId}</artifactId>
+                  <version>${api.reference.version}</version>
+                  <type>jar</type>
+                </dependency>
+              </oldVersion>
+              <newVersion>
+                <file>
+                  <path>${project.build.directory}/${project.artifactId}-${project.version}.jar</path>
+                </file>
+              </newVersion>
+              <parameter>
+                <onlyModified>true</onlyModified>
+                <ignoreMissingClasses>true</ignoreMissingClasses>
+                <skipXmlReport>true</skipXmlReport>
+                <skipDiffReport>true</skipDiffReport>
+                <ignoreMissingOldVersion>true</ignoreMissingOldVersion>
+              </parameter>
+              <skip>${flow.apicmp.skip}</skip>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>cmp</goal>
+                </goals>
+                <phase>verify</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>

--- a/vaadin-dev-server/pom.xml
+++ b/vaadin-dev-server/pom.xml
@@ -16,6 +16,7 @@
     <!-- Allows to skip running NPM tests via exec-maven-plugin with both -Dmaven.test.skip=true and -DskipTests=true -->
     <maven.test.skip>false</maven.test.skip>
     <skipTests>${maven.test.skip}</skipTests>
+    <flow.apicmp.skip>true</flow.apicmp.skip>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Changed the API diff workflow from opt-in (4 modules) to opt-out approach, checking API compatibility for all public modules except infrastructure/test modules.

Previously checked (4 modules):
- flow-server, flow-data, flow-html-components, vaadin-spring

Now checked (12 modules):
- All above plus: flow, flow-react, flow-polymer-template, flow-lit-template, flow-push, flow-webpush, flow-dnd, signals
