### PR TITLE
fix: stabilize reflection class implementation

### DIFF
--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/Reflector.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/Reflector.java
@@ -29,7 +29,6 @@ import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -310,21 +309,19 @@ public final class Reflector {
         record FilterableArtifact(Artifact artifact, boolean scan) {
         }
 
-        Map<String, FilterableArtifact> projectDependencies = 
-                project.getArtifacts().stream()
-                        // Exclude all maven artifacts to prevent class loading
-                        // clash
-                        // with maven.api class realm
-                        .filter(artifact -> !DEPENDENCIES_GROUP_EXCLUSIONS
-                                .contains(artifact.getGroupId()))
-                        .filter(Reflector::isProductionDependency)
-                        .map(artifact -> new FilterableArtifact(artifact,
-                                shouldScan.test(artifact)))
-                        .collect(Collectors.toMap(
-                                item -> keyMapper.apply(item.artifact),
-                                Function.identity(),
-                                (a, b) -> a,
-                                LinkedHashMap::new));
+        Map<String, FilterableArtifact> projectDependencies = project
+                .getArtifacts().stream()
+                // Exclude all maven artifacts to prevent class loading
+                // clash
+                // with maven.api class realm
+                .filter(artifact -> !DEPENDENCIES_GROUP_EXCLUSIONS
+                        .contains(artifact.getGroupId()))
+                .filter(Reflector::isProductionDependency)
+                .map(artifact -> new FilterableArtifact(artifact,
+                        shouldScan.test(artifact)))
+                .collect(Collectors.toMap(
+                        item -> keyMapper.apply(item.artifact),
+                        Function.identity(), (a, b) -> a, LinkedHashMap::new));
 
         if (mojoExecution != null) {
 


### PR DESCRIPTION
## Description

Part of #22767

In the module `flow-plugins/flow-maven-plugin` , the test `com.vaadin.flow.plugin.maven.CleanFrontendMojoTest` contains flaky tests:

- `should_notRemoveNpmPackageLockFile_hilla`
- `should_notRemoveNodeModulesFolder_hilla`

## Root Cause
`Reflector.createIsolatedClassLoader `collected project dependencies into a `HashMap` and then iterated over `projectDependencies.values()` to build the URL array for the isolated classloader. Because `HashMap` does not preserve insertion order, the classpath URL order became nondeterministic under certain JVMs and under NonDex’s shuffled iteration, causing different JARs to load first and leading to intermittent `MojoFailureException` during plugin initialization.

## Fix
The dependency map is now built directly as a `LinkedHashMap` using the 4-argument `Collectors.toMap` collector, which preserves the original Maven artifact order and ensures the classpath URLs are produced deterministically across all runs.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
