### PR TITLE
test: Replace exact dimension matching with threshold check

### DIFF
--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ExtendedClientDetailsIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ExtendedClientDetailsIT.java
@@ -96,10 +96,12 @@ public class ExtendedClientDetailsIT extends ChromeBrowserTest {
             int jsValue = ((Number) executionResult).intValue();
 
             Assert.assertTrue(
-                    "reported value for " + elementId + " should be > 50, but was: " + reportedValue,
+                    "reported value for " + elementId
+                            + " should be > 50, but was: " + reportedValue,
                     reportedValue > 50);
             Assert.assertTrue(
-                    "js execution value for " + elementId + " should be > 50, but was: " + jsValue,
+                    "js execution value for " + elementId
+                            + " should be > 50, but was: " + jsValue,
                     jsValue > 50);
         } catch (NumberFormatException nfe) {
             Assert.fail("Could not parse dimension value for " + elementId);


### PR DESCRIPTION
The test was flaky due to exact value matching on window/screen dimensions that could vary between test runs (e.g., window height 441 vs 493).

Changed to verify dimensions are > 50 instead of exact equality, which validates reasonable values are reported without being sensitive to browser window size variations.
