### PR TITLE
chore: Remove jna exclusion

### DIFF
--- a/vaadin-dev-server/pom.xml
+++ b/vaadin-dev-server/pom.xml
@@ -52,12 +52,6 @@
       <groupId>io.methvin</groupId>
       <artifactId>directory-watcher</artifactId>
       <version>0.19.1</version>
-      <exclusions>
-        <exclusion>
-          <groupId>net.java.dev.jna</groupId>
-          <artifactId>jna</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <!-- API dependencies -->


### PR DESCRIPTION
License checker no longer brings JNA so we cannot exclude it
