### PR TITLE
fix: warn less eagerly about denied access

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/AnnotatedViewAccessChecker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/AnnotatedViewAccessChecker.java
@@ -84,9 +84,7 @@ public class AnnotatedViewAccessChecker implements NavigationAccessChecker {
                 boolean hasAccess = accessAnnotationChecker.hasAccess(layout,
                         context.getPrincipal(), context::hasRole);
                 if (!hasAccess) {
-                    LOGGER.warn(
-                            "Denied access to view due to layout '{}' access rules",
-                            layout.getSimpleName());
+                    logDeniedByLayoutAccessRules(context, targetView);
                     return context.deny("Denied access to view due to layout '"
                             + targetView.getSimpleName() + "' access rules."
                             + "Consider adding one of the following annotations "
@@ -107,9 +105,8 @@ public class AnnotatedViewAccessChecker implements NavigationAccessChecker {
                     boolean hasAccess = accessAnnotationChecker.hasAccess(
                             parent, context.getPrincipal(), context::hasRole);
                     if (!hasAccess) {
-                        LOGGER.warn(
-                                "Denied access to view due to parent layout '{}' access rules",
-                                parent.getSimpleName());
+                        logDeniedByLayoutAccessRules(context, parent,
+                                "Denied access to view due to parent layout '{}' access rules");
                         return context.deny(
                                 "Denied access to view due to parent layout '"
                                         + targetView.getSimpleName()
@@ -141,9 +138,7 @@ public class AnnotatedViewAccessChecker implements NavigationAccessChecker {
                             .getTargetUrl(
                                     (Class<? extends Component>) targetView)
                             .isEmpty()) {
-                LOGGER.warn(
-                        "Denied access to view due to layout '{}' access rules",
-                        targetView.getSimpleName());
+                logDeniedByLayoutAccessRules(context, targetView);
                 denyReason = "Denied access to view due to layout '"
                         + targetView.getSimpleName() + "' access rules."
                         + "Consider adding one of the following annotations "
@@ -154,6 +149,21 @@ public class AnnotatedViewAccessChecker implements NavigationAccessChecker {
             denyReason = "Access is denied by annotations on the view.";
         }
         return context.deny(denyReason);
+    }
+
+    private void logDeniedByLayoutAccessRules(NavigationContext context,
+            Class<?> viewClass) {
+        logDeniedByLayoutAccessRules(context, viewClass,
+                "Denied access to view due to layout '{}' access rules");
+    }
+
+    private void logDeniedByLayoutAccessRules(NavigationContext context,
+            Class<?> viewClass, String msg) {
+        if (context.isNavigating()) {
+            LOGGER.warn(msg, viewClass.getSimpleName());
+        } else {
+            LOGGER.trace(msg, viewClass.getSimpleName());
+        }
     }
 
     private boolean isImplicitlyDenyAllAnnotated(Class<?> targetView) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/NavigationAccessControl.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/NavigationAccessControl.java
@@ -447,6 +447,6 @@ public class NavigationAccessControl implements BeforeEnterListener {
         return new NavigationContext(vaadinService.getRouter(),
                 navigationTarget, new Location(path), RouteParameters.empty(),
                 getPrincipal(vaadinRequest), getRolesChecker(vaadinRequest),
-                false);
+                false, false);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/NavigationContext.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/NavigationContext.java
@@ -60,9 +60,51 @@ public final class NavigationContext {
     private final Predicate<String> roleChecker;
 
     private final boolean errorHandling;
+    private final boolean navigating;
 
     /**
      * Creates a new navigation context instance.
+     *
+     * @param router
+     *            the router that triggered the change, not {@literal null}
+     * @param navigationTarget
+     *            navigation target class, not {@literal null}
+     * @param location
+     *            the requested location, not {@literal null}
+     * @param parameters
+     *            route parameters, not {@literal null}
+     * @param principal
+     *            the principal of the user
+     * @param roleChecker
+     *            a function that can answer if a user has a given role
+     * @param errorHandling
+     *            {@literal true} if the current navigation is related to an
+     *            error handling phase, {@literal false} for a regular
+     *            navigation to a target view
+     * @param navigating
+     *            {@literal true} if the navigation is ongoing, {@literal false}
+     *            if not (e.g. during access checks outside of navigation)
+     */
+    public NavigationContext(Router router, Class<?> navigationTarget,
+            Location location, RouteParameters parameters, Principal principal,
+            Predicate<String> roleChecker, boolean errorHandling,
+            boolean navigating) {
+        this.router = Objects.requireNonNull(router, "router must no be null");
+        this.navigationTarget = Objects.requireNonNull(navigationTarget,
+                "navigationTarget must no be null");
+        this.location = Objects.requireNonNull(location,
+                "location must no be null");
+        this.parameters = Objects.requireNonNull(parameters,
+                "parameters must no be null");
+        this.roleChecker = Objects.requireNonNull(roleChecker,
+                "roleChecker must no be null");
+        this.principal = principal;
+        this.errorHandling = errorHandling;
+        this.navigating = navigating;
+    }
+
+    /**
+     * Creates a new navigation context instance for ongoing navigation.
      *
      * @param router
      *            the router that triggered the change, not {@literal null}
@@ -84,17 +126,8 @@ public final class NavigationContext {
     public NavigationContext(Router router, Class<?> navigationTarget,
             Location location, RouteParameters parameters, Principal principal,
             Predicate<String> roleChecker, boolean errorHandling) {
-        this.router = Objects.requireNonNull(router, "router must no be null");
-        this.navigationTarget = Objects.requireNonNull(navigationTarget,
-                "navigationTarget must no be null");
-        this.location = Objects.requireNonNull(location,
-                "location must no be null");
-        this.parameters = Objects.requireNonNull(parameters,
-                "parameters must no be null");
-        this.roleChecker = Objects.requireNonNull(roleChecker,
-                "roleChecker must no be null");
-        this.principal = principal;
-        this.errorHandling = errorHandling;
+        this(router, navigationTarget, location, parameters, principal,
+                roleChecker, errorHandling, true);
     }
 
     /**
@@ -181,6 +214,17 @@ public final class NavigationContext {
      */
     public boolean isErrorHandling() {
         return errorHandling;
+    }
+
+    /**
+     * Gets if navigation is ongoing or not. If not, navigation context is not
+     * expected to produce access denial warnings in the logs eagerly.
+     * 
+     * @return {@literal true} if the navigation is ongoing, {@literal false} if
+     *         not
+     */
+    public boolean isNavigating() {
+        return navigating;
     }
 
     /**

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/RequestUtil.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/RequestUtil.java
@@ -366,7 +366,7 @@ public class RequestUtil {
                 targetView,
                 new Location(path,
                         QueryParameters.full(request.getParameterMap())),
-                target.getRouteParameters(), null, role -> false, false);
+                target.getRouteParameters(), null, role -> false, false, false);
 
         AccessCheckResult result = navigationAccessControl
                 .checkAccess(navigationContext, productionMode);


### PR DESCRIPTION
Updates `AnnotatedViewAccessChecker` to log a warning about denied access, based on `Layout` permissions, only when navigation is ongoing. Logs with trace level otherwise.

Fixes: #22737
