### PR TITLE
fix: Propagate build info in vaadinBuildFrontend when token file is missing

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
@@ -750,4 +750,62 @@ class MiscSingleModuleTest : AbstractGradleTest() {
         expect(true, buildResult.output) { buildResult.output.contains("!!!effective1.productionMode=true!!!") }
         expect(true, buildResult.output) { buildResult.output.contains("!!!effective2.productionMode=true!!!") }
     }
+
+    /**
+     * Tests https://github.com/vaadin/flow/issues/22679
+     * Verifies that vaadinBuildFrontend can propagate build info
+     * if the token file doesn't exist, making it possible to run
+     * without vaadinPrepareFrontend in edge cases.
+     */
+    @Test
+    fun testBuildFrontendPropagatesBuildInfo() {
+        testProject.buildFile.writeText(
+            """
+            plugins {
+                id 'war'
+                id 'org.gretty' version '4.0.3'
+                id("com.vaadin.flow")
+            }
+            repositories {
+                mavenLocal()
+                mavenCentral()
+                maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
+            }
+            dependencies {
+                implementation("com.vaadin:flow:$flowVersion")
+                providedCompile("jakarta.servlet:jakarta.servlet-api:6.0.0")
+                implementation("org.slf4j:slf4j-simple:$slf4jVersion")
+            }
+        """.trimIndent()
+        )
+
+        // First, run prepare and build to ensure everything works normally
+        val build1: BuildResult = testProject.build("-Pvaadin.productionMode", "build")
+        build1.expectTaskSucceded("vaadinPrepareFrontend")
+        build1.expectTaskSucceded("vaadinBuildFrontend")
+
+        // Verify token file was created
+        val tokenFile = File(testProject.dir, "build/resources/main/META-INF/VAADIN/config/flow-build-info.json")
+        expect(true) { tokenFile.exists() }
+        val tokenFileContent = JacksonUtils.readTree(tokenFile.readText())
+        expect("app-" + StringUtil.getHash(testProject.dir.name,
+            java.nio.charset.StandardCharsets.UTF_8
+        )) { tokenFileContent.get(InitParameters.APPLICATION_IDENTIFIER).textValue() }
+
+        // Clean the token file to simulate it not existing
+        tokenFile.delete()
+        expect(false) { tokenFile.exists() }
+
+        // Run vaadinBuildFrontend again - it should propagate build info
+        // even though the token file doesn't exist
+        val build2: BuildResult = testProject.build("-Pvaadin.productionMode", "vaadinBuildFrontend")
+        build2.expectTaskSucceded("vaadinBuildFrontend")
+
+        // Verify token file was re-created by propagation
+        expect(true) { tokenFile.exists() }
+        val newTokenFileContent = JacksonUtils.readTree(tokenFile.readText())
+        expect("app-" + StringUtil.getHash(testProject.dir.name,
+            java.nio.charset.StandardCharsets.UTF_8
+        )) { newTokenFileContent.get(InitParameters.APPLICATION_IDENTIFIER).textValue() }
+    }
 }

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinBuildFrontendTask.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinBuildFrontendTask.kt
@@ -81,9 +81,13 @@ public abstract class VaadinBuildFrontendTask : DefaultTask() {
     public fun vaadinBuildFrontend() {
         val config = adapter.get().config
         logger.info("Running the vaadinBuildFrontend task with effective configuration $config")
-        // sanity check
         val tokenFile = BuildFrontendUtil.getTokenFile(adapter.get())
-        check(tokenFile.exists()) { "token file $tokenFile doesn't exist!" }
+        if (!tokenFile.exists()) {
+            // if prepare-frontend token file doesn't exist, propagate build info
+            // to token file
+            logger.info("Token file does not exist, propagating build info")
+            BuildFrontendUtil.propagateBuildInfo(adapter.get())
+        }
 
         val options = Options(null, adapter.get().classFinder, config.npmFolder.get())
             .withFrontendDirectory(BuildFrontendUtil.getFrontendDirectory(adapter.get()))


### PR DESCRIPTION
Add defensive build info propagation to the vaadinBuildFrontend task, mirroring the fix from PR #22726 for the Maven plugin. Instead of failing with a hard check when the token file doesn't exist, the task now automatically propagates build info to create it.

This makes the Gradle plugin more resilient in edge cases where the token file might be missing, such as after incremental builds or when task dependencies are bypassed.

Related to #22679
