### PR TITLE
chore: Remove 'provided' scope from license-checker dependency

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -83,7 +83,6 @@
     <dependency>
       <groupId>com.vaadin</groupId>
       <artifactId>license-checker</artifactId>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
flow-server is using the dependency
