### PR TITLE
fix: add replace option to copy tasks

### DIFF
--- a/flow-polymer2lit/src/main/java/com/vaadin/flow/polymer2lit/FrontendConverter.java
+++ b/flow-polymer2lit/src/main/java/com/vaadin/flow/polymer2lit/FrontendConverter.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -48,7 +49,7 @@ public class FrontendConverter implements AutoCloseable {
         this.tempDirPath = Files.createTempDirectory("converter");
         this.converterTempPath = tempDirPath.resolve("converter.js");
         Files.copy(getClass().getResourceAsStream(CONVERTER_EXECUTABLE_PATH),
-                converterTempPath);
+                converterTempPath, StandardCopyOption.REPLACE_EXISTING);
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleUtils.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -199,7 +200,8 @@ public final class BundleUtils {
         if (devBundleFolder.exists()) {
             File devPackageLock = new File(devBundleFolder, packageLockFile);
             if (devPackageLock.exists()) {
-                Files.copy(devPackageLock.toPath(), packageLock.toPath());
+                Files.copy(devPackageLock.toPath(), packageLock.toPath(),
+                        StandardCopyOption.REPLACE_EXISTING);
                 return;
             }
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCopyNpmAssetsFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCopyNpmAssetsFiles.java
@@ -24,6 +24,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.List;
@@ -159,7 +160,8 @@ public class TaskCopyNpmAssetsFiles
                     destFile.getAbsolutePath());
             try {
                 Files.createDirectories(destFile.toPath().getParent());
-                Files.copy(file.toPath(), destFile.toPath());
+                Files.copy(file.toPath(), destFile.toPath(),
+                        StandardCopyOption.REPLACE_EXISTING);
             } catch (IOException e) {
                 throw new UncheckedIOException(String.format(
                         "Failed to copy project frontend resources from '%s' to '%s'",

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCopyTemplateFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCopyTemplateFiles.java
@@ -21,6 +21,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -86,7 +87,8 @@ public class TaskCopyTemplateFiles implements FallibleCommand {
                 Path targetFile = templateDirectory.toPath().resolve(path);
                 try {
                     Files.createDirectories(targetFile.getParent());
-                    Files.copy(source.toPath(), targetFile);
+                    Files.copy(source.toPath(), targetFile,
+                            StandardCopyOption.REPLACE_EXISTING);
                 } catch (IOException e) {
                     throw new ExecutionFailedException(e);
                 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuild.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuild.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -241,7 +242,8 @@ public class TaskRunDevBundleBuild implements FallibleCommand {
         if (packageLockJson.exists()) {
             try {
                 Files.copy(packageLockJson.toPath(),
-                        new File(devBundleFolder, packageLockFile).toPath());
+                        new File(devBundleFolder, packageLockFile).toPath(),
+                        StandardCopyOption.REPLACE_EXISTING);
             } catch (IOException e) {
                 getLogger().error("Failed to copy '" + packageLockFile + "' to "
                         + getDevBundleFolderInTarget(), e);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateVite.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateVite.java
@@ -22,6 +22,7 @@ import java.io.Serializable;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -95,7 +96,8 @@ public class TaskUpdateVite implements FallibleCommand, Serializable {
 
         InputStream resource = this.getClass().getClassLoader()
                 .getResourceAsStream(FrontendUtils.VITE_CONFIG);
-        Files.copy(resource, configFile.toPath());
+        Files.copy(resource, configFile.toPath(),
+                StandardCopyOption.REPLACE_EXISTING);
         log().debug("Created vite configuration file: '{}'", configFile);
 
     }


### PR DESCRIPTION
Add REPLACE_EXISTING options flag
to copy tasks where we can expect
previous files to be available.
