### PR TITLE
chore: change build-frontend default phase to prepare-package

### DIFF
--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -66,7 +66,7 @@ import com.vaadin.pro.licensechecker.MissingLicenseKeyException;
  *
  * @since 2.0
  */
-@Mojo(name = "build-frontend", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, defaultPhase = LifecyclePhase.PROCESS_CLASSES)
+@Mojo(name = "build-frontend", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, defaultPhase = LifecyclePhase.PREPARE_PACKAGE)
 public class BuildFrontendMojo extends FlowModeAbstractMojo
         implements PluginAdapterBuild {
 

--- a/flow-tests/test-express-build/test-flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/TestBuildFrontendMojo.java
+++ b/flow-tests/test-express-build/test-flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/TestBuildFrontendMojo.java
@@ -19,7 +19,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
-@Mojo(name = "build-frontend", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, defaultPhase = LifecyclePhase.PROCESS_CLASSES)
+@Mojo(name = "build-frontend", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, defaultPhase = LifecyclePhase.PREPARE_PACKAGE)
 public class TestBuildFrontendMojo extends BuildFrontendMojo {
 
 }


### PR DESCRIPTION
If build-frontend is run in the process-classes phase, it will run for all development builds and everything