### PR TITLE
fix: stablize test in flow-html-component

### DIFF
--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
@@ -40,6 +40,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasEnabled;
 import com.vaadin.flow.component.HasText;
 import com.vaadin.flow.component.HtmlComponent;
 import com.vaadin.flow.component.HtmlContainer;
@@ -174,8 +175,12 @@ public class HtmlComponentSmokeTest {
     private static void testSetters(HtmlComponent instance) {
         Arrays.stream(instance.getClass().getMethods())
                 .filter(HtmlComponentSmokeTest::isSetter)
-                .filter(m -> !isSpecialSetter(m))
-                .forEach(m -> testSetter(instance, m));
+                .filter(m -> !isSpecialSetter(m)).forEach(m -> {
+                    if (instance instanceof HasEnabled) {
+                        ((HasEnabled) instance).setEnabled(true);
+                    }
+                    testSetter(instance, m);
+                });
     }
 
     private static boolean isSetter(Method method) {


### PR DESCRIPTION
## Description

Part of #22767

Similar to PR #22808. This PR fixes 1 flaky test in `flow-html-component`:
- `HtmlComponentSmokeTest#testAllHtmlComponents`

## Root Cause
- `HtmlComponentSmokeTest#testAllHtmlComponents`: The smoke test incorrectly assumes setters behave the same regardless of component enabled/disabled state, but Anchor.setHref(String) is disabled-aware and won’t update the DOM attribute while disabled by `component.HasEnabled.setEnabled`.

## Fix
- `HtmlComponentSmokeTest#testAllHtmlComponents`: Add check before testing each setter method to make sure `isEnabled` is set to true for any instance with this attribute.

## Notes
- All fix in this PR modifies only test code but no Code-Under-Test.
- There are some more flaky tests in other modules, and they will be resolved with separate PRs

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
