### PR TITLE
fix: update byte-buddy to support newer java versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
             <dependency>
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy</artifactId>
-                <version>1.17.8</version>
+                <version>1.14.8</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Fixes #22735

