### PR TITLE
fix: use direct VAADIN path for push script URL

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/BootstrapHandlerHelper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/BootstrapHandlerHelper.java
@@ -61,36 +61,6 @@ public final class BootstrapHandlerHelper implements Serializable {
     }
 
     /**
-     * Resolves a resource path relative to the context root.
-     * <p>
-     * This method properly handles servlet context paths by using
-     * {@link com.vaadin.flow.server.VaadinService#getContextRootRelativePath}
-     * to construct the correct relative URL.
-     *
-     * @param vaadinRequest
-     *            the request
-     * @param resourcePath
-     *            the resource path relative to context root (e.g.,
-     *            "VAADIN/static/push/vaadinPush.js")
-     * @return the resolved URL relative to the current request
-     */
-    public static String resolveContextRootRelativeUrl(
-            VaadinRequest vaadinRequest, String resourcePath) {
-        String contextRootPath = vaadinRequest.getService()
-                .getContextRootRelativePath(vaadinRequest);
-
-        // Ensure proper path joining
-        if (contextRootPath.endsWith("/") && resourcePath.startsWith("/")) {
-            resourcePath = resourcePath.substring(1);
-        } else if (!contextRootPath.endsWith("/")
-                && !resourcePath.startsWith("/")) {
-            contextRootPath = contextRootPath + "/";
-        }
-
-        return contextRootPath + resourcePath;
-    }
-
-    /**
      * Gets the push URL as a URL relative to the request URI.
      *
      * @param vaadinSession

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -1518,8 +1518,9 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             pushJs = ApplicationConstants.VAADIN_PUSH_DEBUG_JS;
         }
 
-        return BootstrapHandlerHelper.resolveContextRootRelativeUrl(request,
-                pushJs) + versionQueryParam;
+        // Use direct path - the <base href> already points to the servlet root,
+        // so VAADIN/... resolves correctly to {context}/{servlet}/VAADIN/...
+        return pushJs + versionQueryParam;
     }
 
     protected static void setupErrorDialogs(Element style) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
@@ -445,9 +445,9 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
 
         indexDocument.body().appendChild(new Element("vaadin-dev-tools"));
 
-        String pushUrl = BootstrapHandlerHelper.resolveContextRootRelativeUrl(
-                request, ApplicationConstants.VAADIN_PUSH_DEBUG_JS);
-        addScriptSrc(indexDocument, pushUrl);
+        // Use direct path - the <base href> already points to the servlet root,
+        // so VAADIN/... resolves correctly to {context}/{servlet}/VAADIN/...
+        addScriptSrc(indexDocument, ApplicationConstants.VAADIN_PUSH_DEBUG_JS);
     }
 
     static boolean isAllowedDevToolsHost(AbstractConfiguration configuration,

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandlerTest.java
@@ -170,7 +170,7 @@ public class JavaScriptBootstrapHandlerTest {
 
         // Using regex, because version depends on the build
         Assert.assertTrue(json.get("pushScript").asString().matches(
-                "^\\./VAADIN/static/push/vaadinPush\\.js\\?v=[\\w\\.\\-]+$"));
+                "^VAADIN/static/push/vaadinPush\\.js\\?v=[\\w\\.\\-]+$"));
     }
 
     @Test
@@ -187,10 +187,8 @@ public class JavaScriptBootstrapHandlerTest {
         JsonNode json = JacksonUtils.readTree(response.getPayload());
 
         // Using regex, because version depends on the build
-        // When servlet is mapped to /vaadin/, the context root is one level up,
-        // so the relative path needs to go up one level (./..)
         Assert.assertTrue(json.get("pushScript").asString().matches(
-                "^\\./../VAADIN/static/push/vaadinPush\\.js\\?v=[\\w\\.\\-]+$"));
+                "^VAADIN/static/push/vaadinPush\\.js\\?v=[\\w\\.\\-]+$"));
     }
 
     @Test
@@ -225,7 +223,7 @@ public class JavaScriptBootstrapHandlerTest {
 
         // Using regex, because version depends on the build
         Assert.assertTrue(json.get("pushScript").asString().matches(
-                "^\\./VAADIN/static/push/vaadinPush\\.js\\?v=[\\w\\.\\-]+$"));
+                "^VAADIN/static/push/vaadinPush\\.js\\?v=[\\w\\.\\-]+$"));
     }
 
     @Test


### PR DESCRIPTION
The correct approach is to use the direct VAADIN/... path without any
navigation prefix. This works because the <base href> already points
to the servlet root, so relative URLs resolve correctly to
{context-path}/{servlet-path}/VAADIN/...

Fixes #22826