### PR TITLE
ci: rename check-permissions jobs to avoid workflow grouping issues

### DIFF
--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -18,11 +18,11 @@ permissions:
   issues: write
 
 jobs:
-  check-permissions:
+  check-permissions-formatter:
     uses: ./.github/workflows/check-permissions.yml
 
   formatter:
-    needs: check-permissions
+    needs: check-permissions-formatter
     name: Verify Java code format
     runs-on: ubuntu-latest
     timeout-minutes: 120

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -18,11 +18,11 @@ env:
   PR_NUMBER: ${{ github.event.number }}
   JAVA_VERSION: '21'
 jobs:
-  check-permissions:
+  check-permissions-validation:
     uses: ./.github/workflows/check-permissions.yml
 
   build:
-    needs: check-permissions
+    needs: check-permissions-validation
     timeout-minutes: 30
     runs-on: ubuntu-24.04
     outputs:
@@ -265,7 +265,7 @@ jobs:
           echo "🚫 THERE ARE TEST MODULES WITH FAILURES or BEEN CANCELLED" | tee -a $GITHUB_STEP_SUMMARY
           exit 1
   api-diff-labeling:
-    needs: check-permissions
+    needs: check-permissions-validation
     if: github.event_name == 'pull_request_target'
     timeout-minutes: 10
     runs-on: ubuntu-24.04


### PR DESCRIPTION
The Formatter and Flow Validation workflows both had a job named `check-permissions`, causing GitHub Actions UI to incorrectly group jobs from different workflows together. This resulted in the test-results job from Flow Validation appearing under the Formatter workflow section.

Renamed the jobs to be workflow-specific:
- formatter.yml: check-permissions -> check-permissions-formatter
- validation.yml: check-permissions -> check-permissions-validation

Updated all job dependencies accordingly to ensure proper workflow execution.
