### PR TITLE
fix: allow non-Serializable beans in Element.callJsFunction

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -1634,11 +1634,11 @@ public class Element extends Node<Element> {
         String paramPlaceholderString = IntStream.range(1, arguments.length + 1)
                 .mapToObj(i -> "$" + i).collect(Collectors.joining(","));
         // Inject the element as $0
-        Serializable[] jsParameters;
+        Object[] jsParameters;
         if (arguments.length == 0) {
-            jsParameters = new Serializable[] { this };
+            jsParameters = new Object[] { this };
         } else {
-            jsParameters = new Serializable[arguments.length + 1];
+            jsParameters = new Object[arguments.length + 1];
             jsParameters[0] = this;
             System.arraycopy(arguments, 0, jsParameters, 1, arguments.length);
         }

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementJacksonTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementJacksonTest.java
@@ -2343,6 +2343,18 @@ public class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
+    public void callFunctionWithBean() {
+        UI ui = new MockUI();
+        Element element = ElementFactory.createDiv();
+        SimpleBean bean = new SimpleBean();
+        element.callJsFunction("method", bean);
+        ui.getElement().appendChild(element);
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        assertPendingJs(ui, "return $0.method($1)", element, bean);
+    }
+
+    @Test
     public void callFunctionOnProperty() {
         UI ui = new MockUI();
         Element element = ElementFactory.createDiv();


### PR DESCRIPTION
Element.callJsFunction was incorrectly using Serializable[] for parameter storage and System.arraycopy to copy Object[] arguments. This caused ArrayStoreException when passing non-Serializable objects like plain beans or records.

Changed to use Object[] instead, matching the implementation pattern used in Element.executeJs and Page.executeJs, which correctly support all Jackson-serializable types including non-Serializable beans.

Added test to verify beans can be passed to callJsFunction.
