### PR TITLE
fix: clean comments from content

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/CssBundler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/CssBundler.java
@@ -204,6 +204,7 @@ public class CssBundler {
             content = rewriteCssUrlsForStaticResources(baseFolder, cssFile,
                     contextPath, content);
         }
+        content = StringUtil.removeComments(content, true);
         List<String> unhandledImports = new ArrayList<>();
         Matcher importMatcher = IMPORT_PATTERN.matcher(content);
         content = importMatcher.replaceAll(result -> {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/CssBundlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/CssBundlerTest.java
@@ -293,6 +293,24 @@ public class CssBundlerTest {
                 """, actualCss);
     }
 
+    @Test
+    public void ignoreCommentedRules() throws Exception {
+        File cssFile = writeCss("""
+                /*
+                @import url('a.css');
+                */
+                @import url('b.css');
+                /*@import url('c.css');*/
+                @import url('d.css');
+                """, "styles.css");
+        String output = CssBundler.inlineImportsForPublicResources(
+                cssFile.getParentFile(), cssFile, null);
+        Assert.assertFalse(output.contains("a.css"));
+        Assert.assertTrue(output.contains("b.css"));
+        Assert.assertFalse(output.contains("c.css"));
+        Assert.assertTrue(output.contains("d.css"));
+    }
+
     private boolean createThemeFile(String filename) throws IOException {
         File f = getThemeFile(filename);
         f.getParentFile().mkdirs();


### PR DESCRIPTION
Clean the comments from the css content
before collecting imports to not
handle commented out imports.

Fixes #22903
