### PR TITLE
fix: Support base protocol in stylesheet hot-reload

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/StyleSheetHotswapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/StyleSheetHotswapper.java
@@ -521,7 +521,7 @@ public class StyleSheetHotswapper implements VaadinHotswapper {
         }
     }
 
-    private static String normalizeStylesheetUrl(String url) {
+    static String normalizeStylesheetUrl(String url) {
         if (url == null || url.isBlank()) {
             return null;
         }
@@ -529,6 +529,10 @@ public class StyleSheetHotswapper implements VaadinHotswapper {
         if (url.startsWith(ApplicationConstants.CONTEXT_PROTOCOL_PREFIX)) {
             url = url.substring(
                     ApplicationConstants.CONTEXT_PROTOCOL_PREFIX.length());
+        }
+        if (url.startsWith(ApplicationConstants.BASE_PROTOCOL_PREFIX)) {
+            url = url.substring(
+                    ApplicationConstants.BASE_PROTOCOL_PREFIX.length());
         }
         if (url.startsWith("/")) {
             url = url.substring(1);

--- a/flow-server/src/main/java/com/vaadin/flow/server/AppShellRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AppShellRegistry.java
@@ -266,8 +266,10 @@ public class AppShellRegistry implements Serializable {
         String contextPath = request.getContextPath();
         if (!contextPath.isEmpty()) {
             String contextProtocol = ApplicationConstants.CONTEXT_PROTOCOL_PREFIX;
-            if (!lower.startsWith(contextProtocol)) {
-                // Prepend context protocol so URL is resolved with context path
+            if (!lower.startsWith(contextProtocol) && !lower
+                    .startsWith(ApplicationConstants.BASE_PROTOCOL_PREFIX)) {
+                // Prepend context protocol so URL is resolved with a context
+                // path
                 href = contextProtocol + href;
             }
         }
@@ -389,6 +391,11 @@ public class AppShellRegistry implements Serializable {
                     source = source.substring(
                             ApplicationConstants.CONTEXT_PROTOCOL_PREFIX
                                     .length());
+                }
+                if (source.startsWith(
+                        ApplicationConstants.BASE_PROTOCOL_PREFIX)) {
+                    source = source.substring(
+                            ApplicationConstants.BASE_PROTOCOL_PREFIX.length());
                 }
                 return source;
             });

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/StyleSheetHotswapperTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/StyleSheetHotswapperTest.java
@@ -63,6 +63,18 @@ import static org.mockito.Mockito.verify;
 
 public class StyleSheetHotswapperTest {
 
+    @Test
+    public void normalizeStylesheetUrl_stripsBaseAndContextAndPrefixes() {
+        Assert.assertEquals("css/app.css", StyleSheetHotswapper
+                .normalizeStylesheetUrl("context://css/app.css"));
+        Assert.assertEquals("css/app.css", StyleSheetHotswapper
+                .normalizeStylesheetUrl("base://css/app.css"));
+        Assert.assertEquals("css/app.css",
+                StyleSheetHotswapper.normalizeStylesheetUrl("/css/app.css"));
+        Assert.assertEquals("css/app.css",
+                StyleSheetHotswapper.normalizeStylesheetUrl("./css/app.css"));
+    }
+
     private StyleSheetHotswapper hotswapper;
     private MockVaadinServletService service;
     private VaadinSession session;

--- a/flow-server/src/test/java/com/vaadin/flow/server/AppShellRegistryStyleSheetDataFilePathTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/AppShellRegistryStyleSheetDataFilePathTest.java
@@ -33,6 +33,7 @@ public class AppShellRegistryStyleSheetDataFilePathTest {
     @StyleSheet("/absolute.css")
     @StyleSheet("./relative/path.css")
     @StyleSheet("context://from-context.css")
+    @StyleSheet("base://from-base.css")
     @StyleSheet("https://cdn.example.com/remote.css")
     public static class MyShell implements AppShellConfigurator {
     }
@@ -68,7 +69,7 @@ public class AppShellRegistryStyleSheetDataFilePathTest {
         registry.modifyIndexHtml(document, request);
 
         List<Element> links = document.head().select("link[rel=stylesheet]");
-        Assert.assertEquals(4, links.size());
+        Assert.assertEquals(5, links.size());
 
         // 1) Absolute path: href preserved, data-file-path drops leading '/'
         Element abs = links.get(0);
@@ -87,8 +88,14 @@ public class AppShellRegistryStyleSheetDataFilePathTest {
         Assert.assertEquals("/ctx/from-context.css", ctx.attr("href"));
         Assert.assertEquals("from-context.css", ctx.attr("data-file-path"));
 
-        // 4) Remote http(s) URL unchanged, data-file-path remains original
-        Element remote = links.get(3);
+        // 4) base:// should resolve to "" in href, and
+        // data-file-path strips base protocol prefix
+        Element base = links.get(3);
+        Assert.assertEquals("from-base.css", base.attr("href"));
+        Assert.assertEquals("from-base.css", base.attr("data-file-path"));
+
+        // 5) Remote http(s) URL unchanged, data-file-path remains original
+        Element remote = links.get(4);
         Assert.assertEquals("https://cdn.example.com/remote.css",
                 remote.attr("href"));
         Assert.assertEquals("https://cdn.example.com/remote.css",

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/PublicStyleSheetBundler.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/PublicStyleSheetBundler.java
@@ -114,6 +114,10 @@ public final class PublicStyleSheetBundler {
             url = url.substring(
                     ApplicationConstants.CONTEXT_PROTOCOL_PREFIX.length());
         }
+        if (url.startsWith(ApplicationConstants.BASE_PROTOCOL_PREFIX)) {
+            url = url.substring(
+                    ApplicationConstants.BASE_PROTOCOL_PREFIX.length());
+        }
         if (url.startsWith("/")) {
             url = url.substring(1);
         }

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/PublicStyleSheetBundlerTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/PublicStyleSheetBundlerTest.java
@@ -109,9 +109,37 @@ public class PublicStyleSheetBundlerTest {
     }
 
     @Test
+    public void bundle_supportsBaseProtocol() throws IOException {
+        File project = temporaryFolder.newFolder("project2_base");
+        File publicRoot = new File(project, "src/main/resources/public");
+        assertTrue(publicRoot.mkdirs());
+
+        Files.writeString(new File(publicRoot, "imported.css").toPath(),
+                ".im{b:1;}", StandardCharsets.UTF_8);
+        Files.writeString(new File(publicRoot, "main.css").toPath(),
+                "@import './imported.css';\n.m{c:2;}", StandardCharsets.UTF_8);
+
+        PublicStyleSheetBundler bundler = PublicStyleSheetBundler
+                .forResourceLocations(java.util.List.of(publicRoot));
+
+        Optional<String> bundled = bundler.bundle("base://main.css", "");
+        assertTrue(bundled.isPresent());
+        String result = normalizeWhitespace(bundled.get());
+        assertTrue(result.contains(".im{b:1;}"));
+        assertTrue(result.contains(".m{c:2;}"));
+        assertTrue(result.indexOf(".im{b:1;}") < result.indexOf(".m{c:2;}"));
+    }
+
+    @Test
     public void normalize_contextProtocol_isStripped() {
         assertEquals("css/app.css",
                 PublicStyleSheetBundler.normalizeUrl("context://css/app.css"));
+    }
+
+    @Test
+    public void normalize_baseProtocol_isStripped() {
+        assertEquals("css/app.css",
+                PublicStyleSheetBundler.normalizeUrl("base://css/app.css"));
     }
 
     @Test


### PR DESCRIPTION
`StyleSheet` hot-reload uses normalized urls, where `ApplicationConstants.BASE_PROTOCOL_PREFIX` should be resolved.