### PR TITLE
fix: use pull_request in build files

### DIFF
--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -1,7 +1,7 @@
 name: Sonar PR Analysis
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
 
 concurrency:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,9 +1,9 @@
 name: Flow Validation
 on:
   push:
-    branches: [main, '24.9', '24.8', '24.7', '23.6']
+    branches: [main, '25.0', '24.9', '24.8', '24.7', '23.6']
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, edited]
 permissions:
   contents: read
@@ -266,7 +266,7 @@ jobs:
           exit 1
   api-diff-labeling:
     needs: check-permissions-validation
-    if: github.event_name == 'pull_request_target'
+    if: github.event_name == 'pull_request'
     timeout-minutes: 10
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
use pull_request instead of
pull_request_target as
pull_request_target environment rules
evaluate against the default branch.
