### PR TITLE
chore: cache stats.json parsing to avoid repeated I/O

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleUtils.java
@@ -53,6 +53,14 @@ public final class BundleUtils {
     }
 
     /**
+     * Cached stats.json content to avoid repeated file I/O and parsing.
+     * Volatile ensures visibility across threads. The stats.json is a classpath
+     * resource that cannot change at runtime, making it safe to cache
+     * indefinitely.
+     */
+    private static volatile ObjectNode cachedStatsJson = null;
+
+    /**
      * Loads stats.json from the classpath (from the production bundle) and
      * returns the "bundleImports" part of it.
      *
@@ -85,24 +93,34 @@ public final class BundleUtils {
     }
 
     /**
-     * Loads stats.json from the classpath (from the production bundle).
+     * Loads stats.json from the classpath (from the production bundle). The
+     * result is cached after first load since stats.json is immutable at
+     * runtime.
      *
      * @return the stats json as a json object
      */
     static ObjectNode loadStatsJson() {
+        ObjectNode cached = cachedStatsJson;
+        if (cached != null) {
+            return cached;
+        }
+
         InputStream stats = BundleUtils.class.getClassLoader()
                 .getResourceAsStream("META-INF/VAADIN/config/stats.json");
         if (stats == null) {
-            return JacksonUtils.createObjectNode();
+            cached = JacksonUtils.createObjectNode();
+        } else {
+            try {
+                cached = JacksonUtils.readTree(StringUtil.toUTF8String(stats));
+            } catch (IOException e) {
+                getLogger().warn(
+                        "Unable to parse META-INF/VAADIN/config/stats.json", e);
+                cached = JacksonUtils.createObjectNode();
+            }
         }
 
-        try {
-            return JacksonUtils.readTree(StringUtil.toUTF8String(stats));
-        } catch (IOException e) {
-            getLogger().warn(
-                    "Unable to parse META-INF/VAADIN/config/stats.json", e);
-            return JacksonUtils.createObjectNode();
-        }
+        cachedStatsJson = cached;
+        return cached;
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/BundleUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/BundleUtilsTest.java
@@ -379,4 +379,36 @@ public class BundleUtilsTest {
         Assert.assertEquals("Existing file should not be overwritten",
                 existingLockFile, packageLockContents);
     }
+
+    @Test
+    public void loadStatsJson_cachesResult_returnsSameInstance() {
+        // First call loads and caches
+        ObjectNode first = BundleUtils.loadStatsJson();
+        // Second call returns cached instance
+        ObjectNode second = BundleUtils.loadStatsJson();
+        Assert.assertSame("Should return cached instance on second call", first,
+                second);
+    }
+
+    @Test
+    public void loadStatsJson_cachedResultIsConsistent() {
+        ObjectNode first = BundleUtils.loadStatsJson();
+        ObjectNode second = BundleUtils.loadStatsJson();
+
+        // Verify both have same content (whether same instance or not)
+        Assert.assertEquals("Cached result should be consistent",
+                first.toString(), second.toString());
+    }
+
+    @Test
+    public void isPreCompiledProductionBundle_usesCachedStats() {
+        // Call multiple times
+        boolean first = BundleUtils.isPreCompiledProductionBundle();
+        boolean second = BundleUtils.isPreCompiledProductionBundle();
+        boolean third = BundleUtils.isPreCompiledProductionBundle();
+
+        // All should return same result
+        Assert.assertEquals("Should return consistent results", first, second);
+        Assert.assertEquals("Should return consistent results", second, third);
+    }
 }


### PR DESCRIPTION
BundleUtils.loadStatsJson() was repeatedly reading and parsing the stats.json file from classpath on every call. Since this file is immutable at runtime, the parsed result is now cached using a volatile field for thread-safe publication.

Thread safety is ensured via volatile semantics with benign race condition - multiple threads may parse the file once at startup, but all produce identical results.

Fixes #21397

🤖 Generated with [Claude Code](https://claude.com/claude-code)