### PR TITLE
fix: add default success URL configuration for authentication

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinSecurityConfigurer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinSecurityConfigurer.java
@@ -149,6 +149,10 @@ public final class VaadinSecurityConfigurer
 
     private String oauth2LoginPage;
 
+    private String defaultSuccessUrl;
+
+    private boolean alwaysUseDefaultSuccessUrl;
+
     private String logoutSuccessUrl;
 
     private String postLogoutRedirectUri;
@@ -307,6 +311,43 @@ public final class VaadinSecurityConfigurer
             String postLogoutRedirectUri) {
         this.oauth2LoginPage = oauth2LoginPage;
         this.postLogoutRedirectUri = postLogoutRedirectUri;
+        return this;
+    }
+
+    /**
+     * Sets the default success URL after authentication. Redirected only when
+     * no protected page was previously accessed. Works only together with
+     * {@link #loginView(String)} or {@link #oauth2LoginPage(String)} and their
+     * variants.
+     * 
+     * @param defaultSuccessUrl
+     *            the default success url
+     * @return the current configurer instance for method chaining
+     * @see #defaultSuccessUrl(String, boolean)
+     */
+    public VaadinSecurityConfigurer defaultSuccessUrl(
+            String defaultSuccessUrl) {
+        return defaultSuccessUrl(defaultSuccessUrl, false);
+    }
+
+    /**
+     * Sets the default success URL after authentication. If alwaysUse is true,
+     * always redirects to this URL; otherwise, only when no protected page was
+     * previously accessed. Works only together with {@link #loginView(String)}
+     * or {@link #oauth2LoginPage(String)} and their variants.
+     * 
+     * @param defaultSuccessUrl
+     *            the default success url
+     * @param alwaysUse
+     *            if true, always redirect to {@code defaultSuccessUrl} after
+     *            authentication, even when a protected page was previously
+     *            accessed
+     * @return the current configurer instance for method chaining
+     */
+    public VaadinSecurityConfigurer defaultSuccessUrl(String defaultSuccessUrl,
+            boolean alwaysUse) {
+        this.defaultSuccessUrl = defaultSuccessUrl;
+        this.alwaysUseDefaultSuccessUrl = alwaysUse;
         return this;
     }
 
@@ -697,7 +738,12 @@ public final class VaadinSecurityConfigurer
 
     private VaadinSavedRequestAwareAuthenticationSuccessHandler createAuthenticationSuccessHandler() {
         var handler = new VaadinSavedRequestAwareAuthenticationSuccessHandler();
-        handler.setDefaultTargetUrl(getRequestUtil().applyUrlMapping(""));
+        if (defaultSuccessUrl != null) {
+            handler.setDefaultTargetUrl(defaultSuccessUrl);
+            handler.setAlwaysUseDefaultTargetUrl(alwaysUseDefaultSuccessUrl);
+        } else {
+            handler.setDefaultTargetUrl(getRequestUtil().applyUrlMapping(""));
+        }
         getSharedObject(RequestCache.class).ifPresent(handler::setRequestCache);
         getBuilder().setSharedObject(
                 VaadinSavedRequestAwareAuthenticationSuccessHandler.class,

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/VaadinSecurityConfigurerTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/VaadinSecurityConfigurerTest.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.spring.security;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletResponse;
 
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
 
@@ -57,6 +58,7 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.web.access.ExceptionTranslationFilter;
 import org.springframework.security.web.access.intercept.AuthorizationFilter;
+import org.springframework.security.web.authentication.AbstractAuthenticationTargetUrlRequestHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
@@ -392,6 +394,110 @@ class VaadinSecurityConfigurerTest {
                             () -> filter.doFilter(request, response, chain))
                             .doesNotThrowAnyException());
         }
+    }
+
+    @Test
+    void defaultSuccessUrl_withLoginView_successHandlerIsConfigured()
+            throws Exception {
+        http.with(configurer,
+                c -> c.loginView("/login").defaultSuccessUrl("/dashboard"))
+                .build();
+
+        var handler = http.getSharedObject(
+                VaadinSavedRequestAwareAuthenticationSuccessHandler.class);
+
+        assertThat(handler).isNotNull();
+        assertThat(getDefaultTargetUrl(handler)).isEqualTo("/dashboard");
+        assertThat(isAlwaysUseDefaultTargetUrl(handler)).isFalse();
+    }
+
+    @Test
+    void defaultSuccessUrl_withLoginViewClass_successHandlerIsConfigured()
+            throws Exception {
+        http.with(configurer, c -> c.loginView(TestLoginView.class)
+                .defaultSuccessUrl("/home")).build();
+
+        var handler = http.getSharedObject(
+                VaadinSavedRequestAwareAuthenticationSuccessHandler.class);
+
+        assertThat(handler).isNotNull();
+        assertThat(getDefaultTargetUrl(handler)).isEqualTo("/home");
+        assertThat(isAlwaysUseDefaultTargetUrl(handler)).isFalse();
+    }
+
+    @Test
+    void defaultSuccessUrl_withOAuth2LoginPage_successHandlerIsConfigured()
+            throws Exception {
+        http.with(configurer,
+                c -> c.oauth2LoginPage("/oauth2/authorization/google")
+                        .defaultSuccessUrl("/main"))
+                .build();
+
+        var handler = http.getSharedObject(
+                VaadinSavedRequestAwareAuthenticationSuccessHandler.class);
+
+        assertThat(handler).isNotNull();
+        assertThat(getDefaultTargetUrl(handler)).isEqualTo("/main");
+        assertThat(isAlwaysUseDefaultTargetUrl(handler)).isFalse();
+    }
+
+    @Test
+    void defaultSuccessUrl_withAlwaysUseTrue_alwaysRedirectsToDefaultUrl()
+            throws Exception {
+        http.with(configurer, c -> c.loginView("/login")
+                .defaultSuccessUrl("/dashboard", true)).build();
+
+        var handler = http.getSharedObject(
+                VaadinSavedRequestAwareAuthenticationSuccessHandler.class);
+
+        assertThat(handler).isNotNull();
+        assertThat(getDefaultTargetUrl(handler)).isEqualTo("/dashboard");
+        assertThat(isAlwaysUseDefaultTargetUrl(handler)).isTrue();
+    }
+
+    @Test
+    void defaultSuccessUrl_withAlwaysUseFalse_redirectsToSavedRequest()
+            throws Exception {
+        http.with(configurer, c -> c.loginView("/login")
+                .defaultSuccessUrl("/dashboard", false)).build();
+
+        var handler = http.getSharedObject(
+                VaadinSavedRequestAwareAuthenticationSuccessHandler.class);
+
+        assertThat(handler).isNotNull();
+        assertThat(getDefaultTargetUrl(handler)).isEqualTo("/dashboard");
+        assertThat(isAlwaysUseDefaultTargetUrl(handler)).isFalse();
+    }
+
+    @Test
+    void defaultSuccessUrl_notSet_usesRootPath() throws Exception {
+        http.with(configurer, c -> c.loginView("/login")).build();
+
+        var handler = http.getSharedObject(
+                VaadinSavedRequestAwareAuthenticationSuccessHandler.class);
+
+        assertThat(handler).isNotNull();
+        assertThat(getDefaultTargetUrl(handler)).isEqualTo("/");
+        assertThat(isAlwaysUseDefaultTargetUrl(handler)).isFalse();
+    }
+
+    // Helper methods to access protected fields using reflection
+    private String getDefaultTargetUrl(
+            VaadinSavedRequestAwareAuthenticationSuccessHandler handler)
+            throws Exception {
+        Method method = AbstractAuthenticationTargetUrlRequestHandler.class
+                .getDeclaredMethod("getDefaultTargetUrl");
+        method.setAccessible(true);
+        return (String) method.invoke(handler);
+    }
+
+    private boolean isAlwaysUseDefaultTargetUrl(
+            VaadinSavedRequestAwareAuthenticationSuccessHandler handler)
+            throws Exception {
+        Method method = AbstractAuthenticationTargetUrlRequestHandler.class
+                .getDeclaredMethod("isAlwaysUseDefaultTargetUrl");
+        method.setAccessible(true);
+        return (boolean) method.invoke(handler);
     }
 
     @Route


### PR DESCRIPTION
Adds defaultSuccessUrl(String) and defaultSuccessUrl(String, boolean) methods to VaadinSecurityConfigurer. Similar API as with Spring FormLoginConfigurer.

Fixes: #22928
