### PR TITLE
fix: add default success URL configuration for authentication (#22979) (CP: 24.9)

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinSecurityConfigurer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinSecurityConfigurer.java
@@ -147,6 +147,10 @@ public final class VaadinSecurityConfigurer
 
     private String oauth2LoginPage;
 
+    private String defaultSuccessUrl;
+
+    private boolean alwaysUseDefaultSuccessUrl;
+
     private String logoutSuccessUrl;
 
     private String postLogoutRedirectUri;
@@ -305,6 +309,43 @@ public final class VaadinSecurityConfigurer
             String postLogoutRedirectUri) {
         this.oauth2LoginPage = oauth2LoginPage;
         this.postLogoutRedirectUri = postLogoutRedirectUri;
+        return this;
+    }
+
+    /**
+     * Sets the default success URL after authentication. Redirected only when
+     * no protected page was previously accessed. Works only together with
+     * {@link #loginView(String)} or {@link #oauth2LoginPage(String)} and their
+     * variants.
+     * 
+     * @param defaultSuccessUrl
+     *            the default success url
+     * @return the current configurer instance for method chaining
+     * @see #defaultSuccessUrl(String, boolean)
+     */
+    public VaadinSecurityConfigurer defaultSuccessUrl(
+            String defaultSuccessUrl) {
+        return defaultSuccessUrl(defaultSuccessUrl, false);
+    }
+
+    /**
+     * Sets the default success URL after authentication. If alwaysUse is true,
+     * always redirects to this URL; otherwise, only when no protected page was
+     * previously accessed. Works only together with {@link #loginView(String)}
+     * or {@link #oauth2LoginPage(String)} and their variants.
+     * 
+     * @param defaultSuccessUrl
+     *            the default success url
+     * @param alwaysUse
+     *            if true, always redirect to {@code defaultSuccessUrl} after
+     *            authentication, even when a protected page was previously
+     *            accessed
+     * @return the current configurer instance for method chaining
+     */
+    public VaadinSecurityConfigurer defaultSuccessUrl(String defaultSuccessUrl,
+            boolean alwaysUse) {
+        this.defaultSuccessUrl = defaultSuccessUrl;
+        this.alwaysUseDefaultSuccessUrl = alwaysUse;
         return this;
     }
 
@@ -626,7 +667,12 @@ public final class VaadinSecurityConfigurer
 
     private VaadinSavedRequestAwareAuthenticationSuccessHandler createAuthenticationSuccessHandler() {
         var handler = new VaadinSavedRequestAwareAuthenticationSuccessHandler();
-        handler.setDefaultTargetUrl(getRequestUtil().applyUrlMapping(""));
+        if (defaultSuccessUrl != null) {
+            handler.setDefaultTargetUrl(defaultSuccessUrl);
+            handler.setAlwaysUseDefaultTargetUrl(alwaysUseDefaultSuccessUrl);
+        } else {
+            handler.setDefaultTargetUrl(getRequestUtil().applyUrlMapping(""));
+        }
         getSharedObject(RequestCache.class).ifPresent(handler::setRequestCache);
         getBuilder().setSharedObject(
                 VaadinSavedRequestAwareAuthenticationSuccessHandler.class,


### PR DESCRIPTION
Adds defaultSuccessUrl(String) and defaultSuccessUrl(String, boolean) methods to VaadinSecurityConfigurer. Similar API as with Spring FormLoginConfigurer.

Fixes: #22928
