### PR TITLE
chore: update generated README file for bundles folder

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuild.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuild.java
@@ -58,7 +58,7 @@ public class TaskRunDevBundleBuild implements FallibleCommand {
             "- Custom theme imports/assets added into 'theme.json' file\n" +
             "- Exported web component is added.\n\n" +
             "If your project development needs a hot deployment of the frontend changes, \n" +
-            "you can switch Flow to use Vite development server (default in Vaadin 23.3 and earlier versions):\n" +
+            "you can switch Flow to use Vite development server:\n" +
             "- set `vaadin.frontend.hotdeploy=true` in `application.properties`\n" +
             "- configure `vaadin-maven-plugin`:\n" +
             "```\n" +
@@ -74,7 +74,7 @@ public class TaskRunDevBundleBuild implements FallibleCommand {
             "       </systemProperties>\n" +
             "   </configuration>\n" +
             "```\n\n" +
-            "Read more [about Vaadin development mode](https://vaadin.com/docs/next/flow/configuration/development-mode#precompiled-bundle).";
+            "Read more [about Vaadin development mode](https://vaadin.com/docs/latest/flow/configuration/development-mode#precompiled-bundle).";
     //@formatter:on
 
     public static final String VAADIN_JSON = "vaadin.json";


### PR DESCRIPTION
## Description

Fixed the docs link to use `latest` branch, as `next` redirects to docs home page. 
Also removed mention of Vaadin 23 - that seems outdated and no longer relevant.

## Type of change

- Internal change / Docs