### PR TITLE
chore: update 'vaadin-dev-server missing' message

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -541,7 +541,7 @@ public class VaadinServletContextInitializer
                                     dependencies {
                                         developmentOnly('com.vaadin:vaadin-dev')
                                     }
-                                
+
                                 See https://vaadin.com/docs/latest/flow/configuration/development-mode#development-mode for more details.
                                 """);
             }


### PR DESCRIPTION
Updates the "vaadin-dev-server missing" error message for Spring Boot app. Cleaned up and added a link for more info. `optional=true` for Maven and `developmentOnly` for Gradle for Spring Boot app is recommended approach.
