### PR TITLE
fix: Do not serve reserved folders (#22998) (#23037)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -582,6 +582,10 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                     + invalidLocationException.getMessage());
             return true;
         }
+        if(LocationUtil.ensureRelativeNonNull(request.getPathInfo()).startsWith("VAADIN")) {
+            response.sendError(400, "Invalid UI location: VAADIN is for static files");
+            return true;
+        }
         return false;
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
@@ -1676,6 +1676,30 @@ public class BootstrapHandlerTest {
     }
 
     @Test
+    public void synchronizedHandleRequest_requestTargetVAADINFolder_noUiCreated()
+            throws IOException {
+        final BootstrapHandler bootstrapHandler = new BootstrapHandler();
+
+        final VaadinServletRequest request = Mockito
+                .mock(VaadinServletRequest.class);
+        Mockito.doAnswer(invocation -> "/VAADIN").when(request).getPathInfo();
+
+        final MockServletServiceSessionSetup.TestVaadinServletResponse response = mocks
+                .createResponse();
+
+        final boolean value = bootstrapHandler.synchronizedHandleRequest(
+                mocks.getSession(), request, response);
+        Assert.assertTrue("No further request handlers should be called",
+                value);
+
+        Assert.assertEquals("Invalid status code reported", 400,
+                response.getErrorCode());
+        Assert.assertEquals("Invalid message reported",
+                "Invalid UI location: VAADIN is for static files",
+                response.getErrorMessage());
+    }
+
+    @Test
     public void synchronizedHandleRequest_requestPathInfoStartsWithSlash_stripped()
             throws IOException {
         final BootstrapHandler bootstrapHandler = new BootstrapHandler();


### PR DESCRIPTION
Do not run BootstrapHandler
for requests to vaadin reserved
folder return 404 with message.
