### PR TITLE
fix: add missing reflection hints for type used with ReflectTools

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/springnative/VaadinBeanFactoryInitializationAotProcessor.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/springnative/VaadinBeanFactoryInitializationAotProcessor.java
@@ -43,7 +43,9 @@ import org.springframework.core.type.filter.AssignableTypeFilter;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.WebComponentExporter;
 import com.vaadin.flow.component.page.AppShellConfigurator;
+import com.vaadin.flow.i18n.I18NProvider;
 import com.vaadin.flow.router.HasErrorParameter;
 import com.vaadin.flow.router.HasUrlParameter;
 import com.vaadin.flow.router.Layout;
@@ -51,6 +53,7 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteAlias;
 import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.server.PWA;
+import com.vaadin.flow.server.auth.MenuAccessControl;
 
 /**
  * Bean factory initialization AOT processor for Vaadin applications.
@@ -122,6 +125,9 @@ public class VaadinBeanFactoryInitializationAotProcessor
                 registerSubTypes(hints, pkg, HasUrlParameter.class);
                 registerSubTypes(hints, pkg,
                         "com.vaadin.flow.data.converter.Converter");
+                registerSubTypes(hints, pkg, WebComponentExporter.class);
+                registerSubTypes(hints, pkg, I18NProvider.class);
+                registerSubTypes(hints, pkg, MenuAccessControl.class);
             }
         };
     }


### PR DESCRIPTION
WebComponentExporter, I18NProvider, and MenuAccessControl might be instantiated via ReflectTools.createInstance and were missing reflection hints in VaadinBeanFactoryInitializationAotProcessor, which could cause issues at runtime in native executables.

Fixes #23060
