### PR TITLE
fix!: update old browser check to verify compatibility with Vaadin 25+

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
@@ -320,7 +320,7 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
 
     private void redirectToOldBrowserPageWhenNeeded(Document indexDocument) {
         addScript(indexDocument, """
-                if (!Object.hasOwn(HTMLElement.prototype, "popover") {
+                if (!Object.hasOwn(HTMLElement.prototype, "popover")) {
                     window.location.search='v-r=oldbrowser';
                 }
                 """);


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Update old browser check to ensure that Vaadin 25 compatible application can be detected. Vaadin's web-components require `popover` to be available.

Fixes #23026 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
