### PR TITLE
fix(gradle): Add nodeFolder to PrepareFrontendInputProperties

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/PrepareFrontendInputProperties.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/PrepareFrontendInputProperties.kt
@@ -93,6 +93,10 @@ internal class PrepareFrontendInputProperties(
         config.requireHomeNodeExec
 
     @Input
+    @Optional
+    fun getNodeFolder(): Provider<String> = config.nodeFolder
+
+    @Input
     fun getEagerServerLoad(): Provider<Boolean> = config.eagerServerLoad
 
     @InputFile


### PR DESCRIPTION
Adds the nodeFolder property as an @Input parameter to ensure proper Gradle configuration cache support. This property was introduced in commit 4b4b6be1fb but was missing from the input properties tracking.
