### PR TITLE
chore(actions): print significat API changes in build summary

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -352,6 +352,7 @@ jobs:
 
           version_change="0.0.0"
 
+          summary=()
           for file in ${diff_files}
           do
               echo "  Verifying file '${file}'..."
@@ -360,9 +361,20 @@ jobs:
               if [[ "${version_change}" < "${temp_version_change}" ]]; then
                   version_change=${temp_version_change}
               fi
+          
+              if [[ "${temp_version_change}" > "0.0.1" ]]; then
+                summary+=("${file} :: ${temp_version_change}")
+              fi
           done
-
+          
           echo "Discovered version change: ${version_change}"
+          
+          if [[ "${version_change}" > "0.0.1" ]]; then
+            echo "### Significant API changes summary" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            printf '%s\n' "${summary[@]}" >> $GITHUB_STEP_SUMMARY
+          fi
 
           # Get current labels
           current_labels=$(gh api repos/${{ github.repository }}/issues/${{ env._PR_NUMBER }}/labels --jq '.[].name')


### PR DESCRIPTION
Prints a summary of the modules whose API changes are computed as 1.0.0 or 0.1.0.
