### PR TITLE
fix: ReflectionClassFinder should not exclued Vaadin packages

### DIFF
--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/server/scanner/ReflectionsClassFinder.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/server/scanner/ReflectionsClassFinder.java
@@ -82,9 +82,7 @@ public class ReflectionsClassFinder implements ClassFinder {
             "com.vaadin.external.gwt", "javassist.*", "io.methvin",
             "com.github.javaparser", "oshi.*", "io.micrometer", "jakarta.*",
             "com.nimbusds", "elemental.util", "org.reflections",
-            "org.aopalliance", "org.objectweb",
-
-            "com.vaadin.hilla", "com.vaadin.copilot" };
+            "org.aopalliance", "org.objectweb" };
 
     private static final Logger LOGGER = LoggerFactory
             .getLogger(ReflectionsClassFinder.class);


### PR DESCRIPTION
Rejecting Hilla packages prevents TS endpoints to be generated.
