### PR TITLE
fix: check binding not binder status (#23093)

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/BinderValidationStatus.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/BinderValidationStatus.java
@@ -69,7 +69,7 @@ public class BinderValidationStatus<BEAN> implements Serializable {
     public BinderValidationStatus(Binder<BEAN> source,
             List<BindingValidationStatus<?>> bindingStatuses,
             List<ValidationResult> binderStatuses) {
-        Objects.requireNonNull(binderStatuses,
+        Objects.requireNonNull(bindingStatuses,
                 "binding statuses cannot be null");
         Objects.requireNonNull(binderStatuses,
                 "binder statuses cannot be null");

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderValidationStatusTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderValidationStatusTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.data.binder;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -480,4 +481,14 @@ public class BinderValidationStatusTest
         }
     }
 
+    @Test
+    public void binderValidationStatus_nullBindingStatuses() {
+        try {
+            new BinderValidationStatus<>(new Binder<Person>(), null,
+                    Collections.emptyList());
+            Assert.fail("Binder should throw an NPE");
+        } catch (NullPointerException npe) {
+            Assert.assertNotNull(npe.getMessage());
+        }
+    }
 }


### PR DESCRIPTION
Check the correct statuses for non null. Backported from main.

Fixes #23081
