### PR TITLE
chore: use SignalBindingFeature in ElementClassList

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/SignalBindingFeature.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/SignalBindingFeature.java
@@ -30,6 +30,7 @@ import com.vaadin.signals.Signal;
  */
 public class SignalBindingFeature extends ServerSideFeature {
 
+    public static final String CLASSES = "classes/";
     public static final String ENABLED = "enabled";
 
     private Map<String, SignalBinding> values;
@@ -78,6 +79,29 @@ public class SignalBindingFeature extends ServerSideFeature {
         SignalBinding binding = values.get(key);
         return binding != null && binding.signal != null
                 && binding.registration != null;
+    }
+
+    /**
+     * Clears all bindings with keys starting with the given prefix.
+     *
+     * @param keyPrefix
+     *            the key prefix
+     */
+    public void clearBindings(String keyPrefix) {
+        if (values == null) {
+            return;
+        }
+        values.entrySet().removeIf(entry -> {
+            String key = entry.getKey();
+            if (key.startsWith(keyPrefix)) {
+                SignalBinding binding = entry.getValue();
+                if (binding != null && binding.registration != null) {
+                    binding.registration.remove();
+                }
+                return true;
+            }
+            return false;
+        });
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ClassListBindTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ClassListBindTest.java
@@ -15,65 +15,18 @@
  */
 package com.vaadin.flow.dom;
 
-import java.util.LinkedList;
-
-import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
-import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.component.UI;
-import com.vaadin.flow.server.ErrorEvent;
-import com.vaadin.flow.server.MockVaadinServletService;
-import com.vaadin.flow.server.MockVaadinSession;
-import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.internal.nodefeature.SignalBindingFeature;
 import com.vaadin.signals.BindingActiveException;
 import com.vaadin.signals.ValueSignal;
-import com.vaadin.tests.util.MockUI;
-
-import static org.mockito.ArgumentMatchers.any;
 
 /**
  * Tests for binding CSS class presence to a Signal using ClassList.bind.
  */
-public class ClassListBindTest {
-
-    private static MockVaadinServletService service;
-
-    private MockedStatic<FeatureFlags> featureFlagStaticMock;
-
-    @BeforeClass
-    public static void init() {
-        MockedStatic<FeatureFlags> staticMock = Mockito
-                .mockStatic(FeatureFlags.class);
-        featureFlagEnabled(staticMock);
-        service = new MockVaadinServletService();
-        close(staticMock);
-    }
-
-    @AfterClass
-    public static void clean() {
-        VaadinService.setCurrent(null);
-        service.destroy();
-    }
-
-    @Before
-    public void before() {
-        featureFlagStaticMock = Mockito.mockStatic(FeatureFlags.class);
-        featureFlagEnabled(featureFlagStaticMock);
-        mockLockedSessionWithErrorHandler();
-    }
-
-    @After
-    public void after() {
-        close(featureFlagStaticMock);
-        VaadinService.setCurrent(null);
-    }
+public class ClassListBindTest extends SignalsUnitTest {
 
     @Test
     public void bindingMirrorsSignalWhileAttached_toggleAddsRemovesClass() {
@@ -230,27 +183,22 @@ public class ClassListBindTest {
         Assert.assertFalse(element.getClassList().contains("spin"));
     }
 
-    private void mockLockedSessionWithErrorHandler() {
-        VaadinService.setCurrent(service);
-        var session = new MockVaadinSession(service);
-        session.lock();
-        new MockUI(session);
-        var list = new LinkedList<ErrorEvent>();
-        session.setErrorHandler(list::add);
-    }
+    @Test
+    public void lazyInitSignalBindingFeature() {
+        Element element = new Element("div");
+        UI.getCurrent().getElement().appendChild(element);
+        element.getClassList().add("spin");
+        Assert.assertTrue(element.getClassList().contains("spin"));
 
-    private static void featureFlagEnabled(
-            MockedStatic<FeatureFlags> featureFlagStaticMock) {
-        FeatureFlags flags = Mockito.mock(FeatureFlags.class);
-        Mockito.when(
-                flags.isEnabled(FeatureFlags.FLOW_FULLSTACK_SIGNALS.getId()))
-                .thenReturn(true);
-        featureFlagStaticMock.when(() -> FeatureFlags.get(any()))
-                .thenReturn(flags);
-    }
+        element.getNode().getFeatureIfInitialized(SignalBindingFeature.class)
+                .ifPresent(feature -> Assert.fail(
+                        "SignalBindingFeature should not be initialized before binding a signal"));
 
-    private static void close(
-            MockedStatic<FeatureFlags> featureFlagStaticMock) {
-        featureFlagStaticMock.close();
+        ValueSignal<Boolean> signal = new ValueSignal<>(false);
+        element.getClassList().bind("spin", signal);
+
+        element.getNode().getFeatureIfInitialized(SignalBindingFeature.class)
+                .orElseThrow(() -> new AssertionError(
+                        "SignalBindingFeature should be initialized after binding a signal"));
     }
 }


### PR DESCRIPTION
Use lazy-initialized SignalBindingFeature instead of a Map in ElementClassList to store signal bindings.

Fixes: #23039