### PR TITLE
deps: bump javaparser to 3.28.0

### DIFF
--- a/vaadin-dev-server/pom.xml
+++ b/vaadin-dev-server/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>com.github.javaparser</groupId>
       <artifactId>javaparser-core</artifactId>
-      <version>3.27.1</version>
+      <version>3.28.0</version>
     </dependency>
     <dependency>
       <groupId>io.methvin</groupId>


### PR DESCRIPTION
Bumps javaparser, fixes issues related to usage of unnamed variables `_`