### PR TITLE
fix: Unpack production bundle eagerly

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -60,6 +60,7 @@ public class NodeTasks implements FallibleCommand {
     // without depending on when they are added.
     private static final List<Class<? extends FallibleCommand>> commandOrder =
         Collections.unmodifiableList(Arrays.asList(
+            TaskPrepareProdBundle.class,
             TaskGeneratePackageJson.class,
             TaskGenerateIndexHtml.class,
             TaskGenerateIndexTs.class,
@@ -91,7 +92,6 @@ public class NodeTasks implements FallibleCommand {
             TaskCopyTemplateFiles.class,
             TaskGenerateBootstrap.class,
             TaskRunDevBundleBuild.class,
-            TaskPrepareProdBundle.class,
             TaskProcessStylesheetCss.class,
             TaskCleanFrontendFiles.class,
             TaskRemoveOldFrontendGeneratedFiles.class


### PR DESCRIPTION
Unpack the production bunlde eagerly
before any generate tasks.
This way generation can override
bundle files if necessary.

fixes #23108