### PR TITLE
chore: setValue updates signal value

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/HasValue.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasValue.java
@@ -239,10 +239,13 @@ public interface HasValue<E extends ValueChangeEvent<V>, V>
      * signal value changes have no effect. <code>null</code> signal unbinds the
      * existing binding.
      * <p>
-     * While a Signal is bound to a value state, any attempt to set the state
-     * manually with {@link #setValue(Object)} throws
-     * {@link com.vaadin.signals.BindingActiveException}. Same happens when
-     * trying to bind a new Signal while one is already bound.
+     * While a Signal is bound to a value state, any attempt to bind a new
+     * Signal while one is already bound throws
+     * {@link com.vaadin.signals.BindingActiveException}.
+     * <p>
+     * While a Signal is bound to a value state and the element is in attached
+     * state, setting the value with {@link #setValue(Object)} or when a change
+     * originates from the client, will update the signal value.
      * <p>
      * Example of usage:
      *

--- a/flow-server/src/test/java/com/vaadin/flow/component/AbstractCompositeFieldBindValueTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/AbstractCompositeFieldBindValueTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 import com.vaadin.flow.component.AbstractSinglePropertyFieldTest.StringField;
 import com.vaadin.flow.component.ComponentTest.TestDiv;
 import com.vaadin.flow.dom.SignalsUnitTest;
-import com.vaadin.signals.BindingActiveException;
 import com.vaadin.signals.ValueSignal;
 import com.vaadin.signals.WritableSignal;
 
@@ -69,7 +68,7 @@ public class AbstractCompositeFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void multipleFieldsField_bindValue_detached_setModalValueDoesNotUpdateSignal() {
+    public void multipleFieldsField_bindValue_detached_setValueDoesNotUpdateSignal() {
         MultipleFieldsField field = new MultipleFieldsField();
 
         WritableSignal<String> signal = new ValueSignal<>("Hello Cool World");
@@ -78,7 +77,23 @@ public class AbstractCompositeFieldBindValueTest extends SignalsUnitTest {
         Assert.assertEquals("", field.start.getValue());
         Assert.assertEquals("", field.rest.getValue());
 
-        // test that setModelValue updates the bound signal even when detached
+        // setValue doesn't update the bound signal when detached
+        field.setValue("Hey You");
+        Assert.assertEquals("Hey You", field.getValue());
+        Assert.assertEquals("Hello Cool World", signal.peek());
+    }
+
+    @Test
+    public void multipleFieldsField_bindValue_detached_setModelValueDoesNotUpdateSignal() {
+        MultipleFieldsField field = new MultipleFieldsField();
+
+        WritableSignal<String> signal = new ValueSignal<>("Hello Cool World");
+        field.bindValue(signal);
+        // not attached yet, so presentation value not used from the signal
+        Assert.assertEquals("", field.start.getValue());
+        Assert.assertEquals("", field.rest.getValue());
+
+        // setModelValue doesn't update the bound signal when detached
         field.start.setValue("Hey");
         field.rest.setValue("You");
         Assert.assertEquals("Hey You", field.getValue());
@@ -95,12 +110,14 @@ public class AbstractCompositeFieldBindValueTest extends SignalsUnitTest {
         Assert.assertEquals("Hello", field.start.getValue());
         Assert.assertEquals("Cool World", field.rest.getValue());
 
-        // test that setValue fails when bound
-        Assert.assertThrows(BindingActiveException.class,
-                () -> field.setValue(""));
+        // test that setValue updates the signal
+        field.setValue("");
+        Assert.assertEquals("", field.getValue());
+        Assert.assertEquals("", signal.peek());
 
-        // setValue for CompositeField's components is allowed since their value
-        // change listeners update the value by internal setModelValue method
+        signal.value("Hello Cool World");
+        // setValue for CompositeField's components value change listeners
+        // update the value by internal setModelValue method
         field.rest.setValue("");
         Assert.assertEquals("Hello", field.getValue());
         Assert.assertEquals("Hello", signal.peek());

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/signal/BindValueView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/signal/BindValueView.java
@@ -20,7 +20,6 @@ import com.vaadin.flow.component.html.Input;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.uitest.servlet.ViewTestLayout;
-import com.vaadin.signals.BindingActiveException;
 import com.vaadin.signals.ValueSignal;
 
 /**
@@ -56,11 +55,7 @@ public class BindValueView extends Div {
 
         NativeButton changeInputValueButton = new NativeButton(
                 "setValue(\"foo\")", e -> {
-                    try {
-                        target.setValue("foo");
-                    } catch (BindingActiveException ex) {
-                        valueInfoDiv.setText("BindingActiveException");
-                    }
+                    target.setValue("foo");
                 });
         changeInputValueButton.setId("change-value-button");
 

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/signal/BindValueIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/signal/BindValueIT.java
@@ -29,16 +29,18 @@ import com.vaadin.flow.testutil.ChromeBrowserTest;
 public class BindValueIT extends ChromeBrowserTest {
 
     @Test
-    public void setValue_throwBindingActiveException() {
+    public void setValue_updatesInputAndSignalValue() {
         open();
 
-        NativeButtonElement changeSignalValue = $(NativeButtonElement.class)
+        NativeButtonElement changeValue = $(NativeButtonElement.class)
                 .id("change-value-button");
 
-        changeSignalValue.click();
+        changeValue.click();
 
-        Assert.assertEquals("BindingActiveException",
-                $(DivElement.class).id("value-info").getText());
+        Assert.assertEquals("foo", getTargetInput().getValue());
+        Assert.assertEquals("foo", getSignalValueText());
+        Assert.assertEquals("foo", getSignalValueText());
+        Assert.assertEquals("1", getCounterNumber());
     }
 
     @Test
@@ -63,6 +65,31 @@ public class BindValueIT extends ChromeBrowserTest {
         Assert.assertEquals("bar", getValueText());
         Assert.assertEquals("bar", getSignalValueText());
         Assert.assertEquals("1", getCounterNumber());
+    }
+
+    @Test
+    public void setValueAndChangeSignalValueMixed_updatesInputAndSignalValue() {
+        open();
+
+        NativeButtonElement changeSignalValue = $(NativeButtonElement.class)
+                .id("change-signal-value-button");
+        NativeButtonElement changeValue = $(NativeButtonElement.class)
+                .id("change-value-button");
+
+        changeSignalValue.click();
+        changeValue.click();
+        Assert.assertEquals("foo", getTargetInput().getValue());
+        Assert.assertEquals("foo", getSignalValueText());
+        Assert.assertEquals("foo", getSignalValueText());
+        Assert.assertEquals("2", getCounterNumber());
+
+        changeSignalValue.click();
+        changeValue.click();
+        changeSignalValue.click();
+        Assert.assertEquals("bar", getTargetInput().getValue());
+        Assert.assertEquals("bar", getValueText());
+        Assert.assertEquals("bar", getSignalValueText());
+        Assert.assertEquals("5", getCounterNumber());
     }
 
     // This simulates internal value change via subclassing or similar


### PR DESCRIPTION
Changes bindValue(Signal) to not throw BindingActiveException when trying to call setValue while value is bound to signal. setValue updates the signal value making the two-way binding more consistent. Earlier signal was updated only for a value change coming from the client, or from the component's internal setModelValue API.

Related to #23038