### PR TITLE
fix: Reuse view instance when forwarding to same view with different parameters

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -136,15 +137,20 @@ public abstract class AbstractNavigationStateRenderer
         boolean forceInstantiation = lastElement ? event.isForceInstantiation()
                 : (event.isForceInstantiation()
                         && event.isRecreateLayoutChain());
+        Predicate<HasElement> isRouteTargetType = component -> instantiator
+                .getApplicationClass(component).equals(routeTargetType);
         Optional<HasElement> currentInstance = forceInstantiation
                 ? Optional.empty()
-                : ui.getInternals().getActiveRouterTargetsChain().stream()
-                        .filter(component -> instantiator
-                                .getApplicationClass(component)
-                                .equals(routeTargetType))
-                        .findAny();
+                : findActiveRouteTarget(event, isRouteTargetType);
         return (T) currentInstance.orElseGet(
                 () -> instantiator.createRouteTarget(routeTargetType, event));
+    }
+
+    protected Optional<HasElement> findActiveRouteTarget(NavigationEvent event,
+            Predicate<HasElement> isRouteTargetType) {
+
+        return event.getUI().getInternals().getActiveRouterTargetsChain()
+                .stream().filter(isRouteTargetType).findAny();
     }
 
     @Override
@@ -515,7 +521,6 @@ public abstract class AbstractNavigationStateRenderer
      *            component type that will be shown
      * @param router
      *            used router instance
-     *
      * @return a list of parent {@link RouterLayout} types, not
      *         <code>null</code>
      */
@@ -627,7 +632,7 @@ public abstract class AbstractNavigationStateRenderer
      * event is sent first to the {@link BeforeEnterHandler}s registered within
      * the {@link UI}, then to any element in the chain and to any of its child
      * components in the hierarchy which implements {@link BeforeEnterHandler}
-     *
+     * <p>
      * If the <code>chain</code> argument is empty <code>chainClasses</code> is
      * going to be used and populate <code>chain</code> with new created
      * instance.
@@ -904,6 +909,9 @@ public abstract class AbstractNavigationStateRenderer
 
     private int forward(NavigationEvent event, BeforeEvent beforeNavigation) {
         NavigationHandler handler = beforeNavigation.getForwardTarget();
+        if (handler instanceof NavigationStateRenderer renderer) {
+            renderer.setOngoingLocationChangeEvent(locationChangeEvent);
+        }
 
         NavigationEvent newNavigationEvent = getNavigationEvent(event,
                 beforeNavigation);
@@ -916,6 +924,9 @@ public abstract class AbstractNavigationStateRenderer
 
     private int reroute(NavigationEvent event, BeforeEvent beforeNavigation) {
         NavigationHandler handler = beforeNavigation.getRerouteTarget();
+        if (handler instanceof NavigationStateRenderer renderer) {
+            renderer.setOngoingLocationChangeEvent(locationChangeEvent);
+        }
 
         NavigationEvent newNavigationEvent = getNavigationEvent(event,
                 beforeNavigation);

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/RedirectToSameViewView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/RedirectToSameViewView.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import java.util.Map;
+import java.util.Set;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.BeforeEnterObserver;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouteParameters;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+/**
+ * Test view for issue #23232: StackOverflowError when forwarding to the same
+ * view with different route parameters.
+ */
+@Route(value = "com.vaadin.flow.uitest.ui.RedirectToSameViewView/:redirectType((forward|reroute))/:id", layout = ViewTestLayout.class)
+public class RedirectToSameViewView extends Div implements BeforeEnterObserver {
+
+    enum RedirectType {
+        forward, reroute
+    }
+
+    static final String VALID_ID = "valid-id";
+    static final Set<String> VALID_IDS = Set.of(VALID_ID, "other-valid-id");
+
+    public static final String ID_LABEL = "id-label";
+    public static final String ENTER_COUNT_LABEL = "enter-count-label";
+    public static final String INSTANCE_ID_LABEL = "instance-id-label";
+
+    private static int instanceCounter = 0;
+    private int enterCount = 0;
+    private final int instanceId;
+
+    private final Span idLabel;
+    private final Span enterCountLabel;
+    private final Span instanceIdLabel;
+
+    public static void resetStatic() {
+        instanceCounter = 0;
+    }
+
+    public RedirectToSameViewView() {
+        instanceId = ++instanceCounter;
+
+        idLabel = new Span();
+        idLabel.setId(ID_LABEL);
+
+        enterCountLabel = new Span();
+        enterCountLabel.setId(ENTER_COUNT_LABEL);
+
+        instanceIdLabel = new Span();
+        instanceIdLabel.setId(INSTANCE_ID_LABEL);
+        instanceIdLabel.setText(String.valueOf(instanceId));
+
+        add(new Div(new Span("ID: "), idLabel));
+        add(new Div(new Span("Enter count: "), enterCountLabel));
+        add(new Div(new Span("Instance ID: "), instanceIdLabel));
+    }
+
+    @Override
+    public void beforeEnter(BeforeEnterEvent event) {
+        enterCount++;
+        RedirectType redirectType = RedirectType.valueOf(event
+                .getRouteParameters().get("redirectType").orElse("forward"));
+        String id = event.getRouteParameters().get("id").orElse("");
+        idLabel.setText(id);
+        enterCountLabel.setText(String.valueOf(enterCount));
+
+        // If the ID is not valid, forward to the same view with a valid ID
+        // This simulates the scenario from issue #23232
+        if (!VALID_IDS.contains(id)) {
+            Class<? extends Component> targetViewClass = (Class<? extends Component>) event
+                    .getNavigationTarget();
+            RouteParameters parameters = new RouteParameters(Map
+                    .of("redirectType", redirectType.name(), "id", VALID_ID));
+
+            switch (redirectType) {
+            case forward -> event.forwardTo(targetViewClass, parameters);
+            case reroute -> event.rerouteTo(targetViewClass, parameters);
+            }
+        }
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/RedirectToSameViewIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/RedirectToSameViewIT.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+/**
+ * Integration test for issue #23232: StackOverflowError when forwarding to the
+ * same view with different route parameters.
+ * <p>
+ * This test verifies that:
+ * <ul>
+ * <li>Navigating to a view with an invalid ID forwards to the same view with a
+ * valid ID</li>
+ * <li>No StackOverflowError occurs</li>
+ * <li>The view instance is reused (same instance ID)</li>
+ * <li>beforeEnter is called twice (once for original, once for forward)</li>
+ * </ul>
+ */
+public class RedirectToSameViewIT extends ChromeBrowserTest {
+
+    private static final String BASE_PATH = "/view/com.vaadin.flow.uitest.ui.RedirectToSameViewView";
+
+    @Test
+    public void forwardToSameView_withDifferentParameter_noStackOverflow() {
+        redirectToSameView_withDifferentParameter_noStackOverflow(
+                RedirectToSameViewView.RedirectType.forward);
+    }
+
+    @Test
+    public void rerouteToSameView_withDifferentParameter_noStackOverflow() {
+        redirectToSameView_withDifferentParameter_noStackOverflow(
+                RedirectToSameViewView.RedirectType.reroute);
+    }
+
+    private void redirectToSameView_withDifferentParameter_noStackOverflow(
+            RedirectToSameViewView.RedirectType redirectType) {
+        // Navigate to the view with an invalid ID
+        // This should trigger a forward to the same view with a valid ID
+        getDriver().get(
+                getRootURL() + BASE_PATH + "/" + redirectType + "/unknown-id");
+        waitForDevServer();
+
+        // Wait for the view to load
+        waitForElementPresent(By.id(RedirectToSameViewView.ID_LABEL));
+
+        // Verify the ID was changed to the valid one
+        String displayedId = findElement(By.id(RedirectToSameViewView.ID_LABEL))
+                .getText();
+        Assert.assertEquals("ID should be the valid ID after " + redirectType,
+                RedirectToSameViewView.VALID_ID, displayedId);
+
+        // Verify beforeEnter was called twice (original + forward)
+        String enterCount = findElement(
+                By.id(RedirectToSameViewView.ENTER_COUNT_LABEL)).getText();
+        Assert.assertEquals("beforeEnter should be called twice (original + "
+                + redirectType + ")", "2", enterCount);
+
+        // Verify URL was updated (only forward, reroute doesn't change URL)'
+        if (redirectType == RedirectToSameViewView.RedirectType.forward) {
+            String currentUrl = getDriver().getCurrentUrl();
+            Assert.assertTrue("URL should be updated to valid-id",
+                    currentUrl.endsWith(BASE_PATH + "/" + redirectType + "/"
+                            + RedirectToSameViewView.VALID_ID));
+        }
+    }
+
+    @Test
+    public void navigateToValidId_noForward() {
+        // Navigate directly to a valid ID - no forward should occur
+        getDriver().get(getRootURL() + BASE_PATH + "/forward/"
+                + RedirectToSameViewView.VALID_ID);
+        waitForDevServer();
+
+        waitForElementPresent(By.id(RedirectToSameViewView.ID_LABEL));
+
+        // Verify the ID is displayed
+        String displayedId = findElement(By.id(RedirectToSameViewView.ID_LABEL))
+                .getText();
+        Assert.assertEquals("ID should be the valid ID",
+                RedirectToSameViewView.VALID_ID, displayedId);
+
+        // Verify beforeEnter was called only once (no forward)
+        String enterCount = findElement(
+                By.id(RedirectToSameViewView.ENTER_COUNT_LABEL)).getText();
+        Assert.assertEquals("beforeEnter should be called once (no forward)",
+                "1", enterCount);
+    }
+}


### PR DESCRIPTION
When a BeforeEnterObserver forwards or reroutes to the same view class with different route parameters, the view instance is now reused instead of creating a new one. This prevents StackOverflowError that occurred when the framework kept creating new instances in a loop.

The fix passes the ongoing navigation context to forward/reroute handlers, allowing them to find the current view instance before it's added to the UI's active router chain.

Fixes #23232