### PR TITLE
fix: Prevent StackOverflowError on cyclic CSS @import statements

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/CssBundler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/CssBundler.java
@@ -191,6 +191,53 @@ public class CssBundler {
     private static String inlineImports(File baseFolder, File cssFile,
             Set<String> assetAliases, BundleFor bundleFor, String contextPath,
             File nodeModulesFolder) throws IOException {
+        List<String> cyclicImportWarnings = new ArrayList<>();
+        String result = inlineImports(baseFolder, cssFile, assetAliases,
+                bundleFor, contextPath, nodeModulesFolder, new HashSet<>(),
+                cyclicImportWarnings);
+
+        // Log single summary if cycles were detected
+        if (!cyclicImportWarnings.isEmpty()) {
+            getLogger().warn(
+                    "Cyclic CSS @import statements detected and skipped:{}  - {}",
+                    System.lineSeparator(),
+                    String.join(System.lineSeparator() + "  - ",
+                            cyclicImportWarnings));
+        }
+        return result;
+    }
+
+    /**
+     * Internal implementation with cycle detection support.
+     *
+     * @param baseFolder
+     *            base folder used for resolving relative paths
+     * @param cssFile
+     *            the CSS file to process
+     * @param assetAliases
+     *            theme asset aliases (only used when rewriting URLs)
+     * @param bundleFor
+     *            defines a way how bundler resolves url(...)
+     * @param contextPath
+     *            that url() are rewritten to and rebased onto
+     * @param nodeModulesFolder
+     *            the node_modules folder for resolving npm package imports
+     * @param visitedFiles
+     *            set of canonical paths already processed (for cycle detection)
+     * @param cyclicImportWarnings
+     *            list to collect cycle warnings for summary logging
+     */
+    private static String inlineImports(File baseFolder, File cssFile,
+            Set<String> assetAliases, BundleFor bundleFor, String contextPath,
+            File nodeModulesFolder, Set<String> visitedFiles,
+            List<String> cyclicImportWarnings) throws IOException {
+
+        // Track current file as visited using canonical path
+        String canonicalPath = cssFile.getCanonicalPath();
+        if (!visitedFiles.add(canonicalPath)) {
+            // Already processed - cycle detected, will be logged in summary
+            return "";
+        }
 
         String content = Files.readString(cssFile.toPath());
         if (bundleFor == BundleFor.THEMES) {
@@ -222,9 +269,22 @@ public class CssBundler {
                         cssFile.getParentFile(), nodeModulesFolder);
                 if (potentialFile != null && potentialFile.exists()) {
                     try {
+                        // Check for cycle before recursing
+                        String importedPath = potentialFile.getCanonicalPath();
+                        if (visitedFiles.contains(importedPath)) {
+                            // Cycle detected - file already inlined, just skip
+                            cyclicImportWarnings.add(String.format(
+                                    "'%s' imports already processed '%s'",
+                                    cssFile.toPath().normalize()
+                                            .toAbsolutePath(),
+                                    potentialFile.toPath().normalize()
+                                            .toAbsolutePath()));
+                            return "";
+                        }
                         return Matcher.quoteReplacement(inlineImports(
                                 baseFolder, potentialFile, assetAliases,
-                                bundleFor, contextPath, nodeModulesFolder));
+                                bundleFor, contextPath, nodeModulesFolder,
+                                visitedFiles, cyclicImportWarnings));
                     } catch (IOException e) {
                         getLogger().warn("Unable to inline import: {}",
                                 result.group());

--- a/flow-server/src/test/java/com/vaadin/flow/internal/CssBundlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/CssBundlerTest.java
@@ -558,4 +558,81 @@ public class CssBundlerTest {
         Assert.assertTrue("Should contain main CSS",
                 result.contains(".main { color: red; }"));
     }
+
+    @Test
+    public void cyclicImportsDoNotCauseStackOverflow() throws IOException {
+        // a.css imports b.css, b.css imports a.css
+        writeCss("@import 'b.css';\n.from-a { color: red; }", "a.css");
+        writeCss("@import 'a.css';\n.from-b { color: blue; }", "b.css");
+        writeCss("@import 'a.css';", "styles.css");
+
+        // Should not throw StackOverflowError
+        String result = CssBundler.inlineImportsForThemes(themeFolder,
+                getThemeFile("styles.css"), getThemeJson());
+
+        // Both CSS rules should be present (each file processed once)
+        Assert.assertTrue("Should contain .from-a", result.contains(".from-a"));
+        Assert.assertTrue("Should contain .from-b", result.contains(".from-b"));
+        // No @import statements should remain (all were inlined or skipped)
+        Assert.assertFalse("Should not contain any @import statements",
+                result.contains("@import"));
+    }
+
+    @Test
+    public void transitiveCyclicImportsDoNotCauseStackOverflow()
+            throws IOException {
+        // a.css -> b.css -> c.css -> a.css
+        writeCss("@import 'b.css';\n.from-a { color: red; }", "a.css");
+        writeCss("@import 'c.css';\n.from-b { color: blue; }", "b.css");
+        writeCss("@import 'a.css';\n.from-c { color: green; }", "c.css");
+        writeCss("@import 'a.css';", "styles.css");
+
+        String result = CssBundler.inlineImportsForThemes(themeFolder,
+                getThemeFile("styles.css"), getThemeJson());
+
+        Assert.assertTrue("Should contain .from-a", result.contains(".from-a"));
+        Assert.assertTrue("Should contain .from-b", result.contains(".from-b"));
+        Assert.assertTrue("Should contain .from-c", result.contains(".from-c"));
+        // No @import statements should remain (all were inlined or skipped)
+        Assert.assertFalse("Should not contain any @import statements",
+                result.contains("@import"));
+    }
+
+    @Test
+    public void selfImportDoesNotCauseStackOverflow() throws IOException {
+        // a.css imports itself
+        writeCss("@import 'a.css';\n.from-a { color: red; }", "a.css");
+        writeCss("@import 'a.css';", "styles.css");
+
+        String result = CssBundler.inlineImportsForThemes(themeFolder,
+                getThemeFile("styles.css"), getThemeJson());
+
+        Assert.assertTrue("Should contain .from-a", result.contains(".from-a"));
+        // No @import statements should remain (all were inlined or skipped)
+        Assert.assertFalse("Should not contain any @import statements",
+                result.contains("@import"));
+    }
+
+    @Test
+    public void cyclicImportsInNestedFoldersDoNotCauseStackOverflow()
+            throws IOException {
+        // styles.css imports sub/a.css
+        // sub/a.css imports ../b.css (back to root)
+        // b.css imports sub/a.css (creates cycle)
+        writeCss("@import 'sub/a.css';", "styles.css");
+        writeCss("@import '../b.css';\n.from-sub-a { color: red; }",
+                "sub/a.css");
+        writeCss("@import 'sub/a.css';\n.from-b { color: blue; }", "b.css");
+
+        String result = CssBundler.inlineImportsForThemes(themeFolder,
+                getThemeFile("styles.css"), getThemeJson());
+
+        // Both CSS rules should be present (each file processed once)
+        Assert.assertTrue("Should contain .from-sub-a",
+                result.contains(".from-sub-a"));
+        Assert.assertTrue("Should contain .from-b", result.contains(".from-b"));
+        // No @import statements should remain (all were inlined or skipped)
+        Assert.assertFalse("Should not contain any @import statements",
+                result.contains("@import"));
+    }
 }


### PR DESCRIPTION
Add cycle detection to CssBundler.inlineImports() to handle circular CSS imports gracefully. When a cycle is detected, the import is skipped since the file content has already been inlined, and a warning is logged.

Fixes #23237