### PR TITLE
chore: bindValue effect calls setValue

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/AbstractFieldSupport.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/AbstractFieldSupport.java
@@ -223,8 +223,8 @@ public class AbstractFieldSupport<C extends Component & HasValue<ComponentValueC
     private void setValueFromSignal(T value) {
         try {
             valueSetFromSignal = true;
-            // call setValue(T) to support overrides
-            setValue(value);
+            // call component's setValue(T) to support overrides
+            component.setValue(value);
         } finally {
             valueSetFromSignal = false;
         }

--- a/flow-server/src/test/java/com/vaadin/flow/component/AbstractFieldBindValueTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/AbstractFieldBindValueTest.java
@@ -73,6 +73,7 @@ public class AbstractFieldBindValueTest extends SignalsUnitTest {
 
         signal.value(null);
         assertNull(input.getValue());
+        assertEquals(3, input.setValueCounter);
     }
 
     @Test
@@ -289,6 +290,8 @@ public class AbstractFieldBindValueTest extends SignalsUnitTest {
     @Tag(Tag.INPUT)
     private static class TestInput extends AbstractField<TestInput, String> {
 
+        int setValueCounter = 0;
+
         public TestInput() {
             this("");
         }
@@ -300,6 +303,12 @@ public class AbstractFieldBindValueTest extends SignalsUnitTest {
         @Override
         protected void setPresentationValue(String newPresentationValue) {
             // NOP
+        }
+
+        @Override
+        public void setValue(String value) {
+            super.setValue(value);
+            setValueCounter++;
         }
     }
 


### PR DESCRIPTION
Changes bindValue to call setValue to support overrides. Removed automatic null conversion to empty value.

Related to #23038
