### PR TITLE
fix: Fall back to InternalServerError when error view rendering fails (#23177)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -74,7 +74,6 @@ import com.vaadin.flow.router.RouteParameters;
 import com.vaadin.flow.router.Router;
 import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.router.internal.ErrorStateRenderer;
-import com.vaadin.flow.router.internal.ErrorTargetEntry;
 import com.vaadin.flow.router.internal.HasUrlParameterFormat;
 import com.vaadin.flow.router.internal.PathUtil;
 import com.vaadin.flow.server.Command;
@@ -2065,36 +2064,11 @@ public class UI extends Component
             adjustPageTitle();
 
         } catch (Exception exception) {
-            handleExceptionNavigation(location, exception);
+            getInternals().getRouter().handleExceptionNavigation(this, location,
+                    exception, NavigationTrigger.CLIENT_SIDE, null);
         } finally {
             getInternals().clearLastHandledNavigation();
         }
-    }
-
-    private boolean handleExceptionNavigation(Location location,
-            Exception exception) {
-        Optional<ErrorTargetEntry> maybeLookupResult = getInternals()
-                .getRouter().getErrorNavigationTarget(exception);
-        if (maybeLookupResult.isPresent()) {
-            ErrorTargetEntry lookupResult = maybeLookupResult.get();
-
-            ErrorParameter<?> errorParameter = new ErrorParameter<>(
-                    lookupResult.getHandledExceptionType(), exception,
-                    exception.getMessage());
-            ErrorStateRenderer errorStateRenderer = new ErrorStateRenderer(
-                    new NavigationStateBuilder(getInternals().getRouter())
-                            .withTarget(lookupResult.getNavigationTarget())
-                            .build());
-
-            ErrorNavigationEvent errorNavigationEvent = new ErrorNavigationEvent(
-                    getInternals().getRouter(), location, this,
-                    NavigationTrigger.CLIENT_SIDE, errorParameter);
-
-            errorStateRenderer.handle(errorNavigationEvent);
-        } else {
-            throw new RuntimeException(exception);
-        }
-        return isPostponed();
     }
 
     private boolean isPostponed() {

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
@@ -2983,14 +2983,11 @@ public class RouterTest extends RoutingTestBase {
         setNavigationTargets(FailOnException.class);
         setErrorNavigationTargets(FailingErrorHandler.class);
 
-        try {
-            ui.navigate("exception");
-            Assert.fail("No runtime exception was thrown from navigation");
-        } catch (Exception re) {
-            Assert.assertNull(
-                    "Last handled location should have been cleared even though navigation failed",
-                    ui.getInternals().getLastHandledLocation());
-        }
+        ui.navigate("exception");
+
+        Assert.assertNull(
+                "Last handled location should have been cleared even though navigation failed",
+                ui.getInternals().getLastHandledLocation());
     }
 
     @Test
@@ -4697,6 +4694,66 @@ public class RouterTest extends RoutingTestBase {
 
     private void navigate(String url) {
         router.navigate(ui, new Location(url), NavigationTrigger.PROGRAMMATIC);
+    }
+
+    // Test classes for exception in error view's parent layout afterNavigation
+    @Tag(Tag.DIV)
+    @Layout
+    public static class ThrowingMainLayout extends Component
+            implements RouterLayout, AfterNavigationObserver {
+
+        static List<AfterNavigationEvent> events = new ArrayList<>();
+
+        @Override
+        public void afterNavigation(AfterNavigationEvent event) {
+            events.add(event);
+            throw new RuntimeException(
+                    "Exception in MainLayout afterNavigation");
+        }
+    }
+
+    @Route(value = "error", layout = ThrowingMainLayout.class)
+    @Tag(Tag.DIV)
+    public static class TriggerErrorView extends Component {
+    }
+
+    @Tag(Tag.DIV)
+    @ParentLayout(ThrowingMainLayout.class)
+    public static class ErrorViewWithThrowingLayout extends Component
+            implements HasErrorParameter<RuntimeException> {
+
+        @Override
+        public int setErrorParameter(BeforeEnterEvent event,
+                ErrorParameter<RuntimeException> parameter) {
+            getElement().setText("An unexpected error occurred");
+            return HttpStatusCode.INTERNAL_SERVER_ERROR.getCode();
+        }
+    }
+
+    @Test
+    public void exception_in_error_view_parent_layout_afterNavigation_falls_back_to_InternalServerError()
+            throws InvalidRouteConfigurationException {
+        ThrowingMainLayout.events.clear();
+        setNavigationTargets(TriggerErrorView.class);
+        setErrorNavigationTargets(ErrorViewWithThrowingLayout.class);
+
+        int result = router.navigate(ui, new Location("error"),
+                NavigationTrigger.PROGRAMMATIC);
+
+        Assert.assertEquals(
+                "Navigation should complete with internal server error status.",
+                HttpStatusCode.INTERNAL_SERVER_ERROR.getCode(), result);
+
+        // Should fall back to InternalServerError instead of the custom error
+        // view
+        assertExceptionComponent(InternalServerError.class,
+                "There was an exception while trying to navigate to 'error' with the exception message 'Exception in MainLayout afterNavigation'");
+
+        // Verify that MainLayout's afterNavigation was called two times.
+        // Once for navigation and once for error view.
+        Assert.assertEquals(
+                "MainLayout's afterNavigation should have been called twice", 2,
+                ThrowingMainLayout.events.size());
     }
 
 }


### PR DESCRIPTION
Prevents navigation corruption when error view's parent layout throws an exception during afterNavigation by catching the exception and rendering InternalServerError as fallback.

Fixes #22146
