### PR TITLE
chore: fix bindThemeName with multiple bindings

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/ThemeListImpl.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/ThemeListImpl.java
@@ -78,7 +78,11 @@ public class ThemeListImpl implements ThemeList, Serializable {
      */
     public ThemeListImpl(Element element) {
         this.element = element;
-        themes = Optional.ofNullable(element.getAttribute(THEME_ATTRIBUTE_NAME))
+        themes = readThemesFromAttribute();
+    }
+
+    private Set<String> readThemesFromAttribute() {
+        return Optional.ofNullable(element.getAttribute(THEME_ATTRIBUTE_NAME))
                 .map(value -> value.split(THEME_NAMES_DELIMITER))
                 .map(Stream::of)
                 .map(stream -> stream.filter(themeName -> !themeName.isEmpty())
@@ -109,6 +113,12 @@ public class ThemeListImpl implements ThemeList, Serializable {
     }
 
     private void internalSetPresence(String name, boolean set) {
+        // Constructor reads the initial themes state only once.
+        // Refresh themes from the attribute to ensure multiple ElementEffect
+        // bindings work correctly with the latest themes.
+        themes.clear();
+        themes.addAll(readThemesFromAttribute());
+
         boolean changed;
         if (set) {
             changed = themes.add(name);

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ThemeListBindTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ThemeListBindTest.java
@@ -25,6 +25,7 @@ import com.vaadin.flow.component.HasTheme;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
 import com.vaadin.signals.BindingActiveException;
+import com.vaadin.signals.Signal;
 import com.vaadin.signals.ValueSignal;
 
 /**
@@ -198,6 +199,38 @@ public class ThemeListBindTest extends SignalsUnitTest {
         signal.value(false);
         signal.value(false); // no-op update
         Assert.assertFalse(component.hasThemeName("spin"));
+    }
+
+    @Test
+    public void bindMultipleSignals() {
+        TestComponent component = new TestComponent();
+        UI.getCurrent().add(component);
+
+        enum DummyEnum {
+            ONE, TWO, THREE
+        }
+        ValueSignal<DummyEnum> signal = new ValueSignal<>(DummyEnum.ONE);
+
+        Signal<Boolean> a = signal.map(v -> v == DummyEnum.ONE);
+        Signal<Boolean> b = signal.map(v -> v == DummyEnum.TWO);
+        Signal<Boolean> c = signal.map(v -> v == DummyEnum.THREE);
+        component.bindThemeName("a", a);
+        component.bindThemeName("b", b);
+        component.bindThemeName("c", c);
+
+        Assert.assertTrue(component.hasThemeName("a"));
+        Assert.assertFalse(component.hasThemeName("b"));
+        Assert.assertFalse(component.hasThemeName("b"));
+
+        signal.value(DummyEnum.TWO);
+        Assert.assertFalse(component.hasThemeName("a"));
+        Assert.assertTrue(component.hasThemeName("b"));
+        Assert.assertFalse(component.hasThemeName("c"));
+
+        signal.value(DummyEnum.THREE);
+        Assert.assertFalse(component.hasThemeName("a"));
+        Assert.assertFalse(component.hasThemeName("b"));
+        Assert.assertTrue(component.hasThemeName("c"));
     }
 
     @Tag("span")


### PR DESCRIPTION
Multiple bindThemeName bindings didn't use the latest updated themes since themes Set is build once in the constructor of ThemeListImpl. This change fixes effect execution to read fresh themes from the updated attribute.

Related to #23211