### PR TITLE
feat: add bindWidth(Signal) and bindHeight(Signal)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/HasSize.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasSize.java
@@ -20,6 +20,10 @@ import java.util.Optional;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementConstants;
 import com.vaadin.flow.server.Constants;
+import com.vaadin.signals.Signal;
+
+import static com.vaadin.flow.dom.ElementConstants.STYLE_HEIGHT;
+import static com.vaadin.flow.dom.ElementConstants.STYLE_WIDTH;
 
 /**
  * Any component implementing this interface supports setting the size of the
@@ -412,6 +416,86 @@ public interface HasSize extends HasElement {
     default void setSizeUndefined() {
         setWidth(null);
         setHeight(null);
+    }
+
+    /**
+     * Binds a {@link Signal}'s value to the width of this component and keeps
+     * the width synchronized with the signal value while the component is in
+     * attached state. When the component is in detached state, signal value
+     * changes have no effect. <code>null</code> signal unbinds the existing
+     * binding.
+     * <p>
+     * The width should be in a format understood by the browser, e.g. "100px"
+     * or "2.5em".
+     * <p>
+     * While a Signal is bound to the width, any attempt to set the width
+     * manually throws {@link com.vaadin.signals.BindingActiveException}. Same
+     * happens when trying to bind a new Signal while one is already bound.
+     * <p>
+     * Example of usage:
+     *
+     * <pre>
+     * ValueSignal&lt;String&gt; signal = new ValueSignal&lt;&gt;("200px");
+     * Div component = new Div();
+     * add(component);
+     * component.bindWidth(signal);
+     * signal.value("300px"); // The component width is set to "300px"
+     * </pre>
+     *
+     * @param widthSignal
+     *            the signal to bind or <code>null</code> to unbind any existing
+     *            binding
+     * @throws com.vaadin.signals.BindingActiveException
+     *             thrown when there is already an existing binding
+     * @see #setWidth(String)
+     */
+    default void bindWidth(Signal<String> widthSignal) {
+        getElement().getStyle().bind(STYLE_WIDTH, widthSignal);
+        getElement().bindAttribute(Constants.ATTRIBUTE_WIDTH_FULL,
+                widthSignal != null
+                        ? widthSignal
+                                .map(value -> "100%".equals(value) ? "" : null)
+                        : null);
+    }
+
+    /**
+     * Binds a {@link Signal}'s value to the height of this component and keeps
+     * the height synchronized with the signal value while the component is in
+     * attached state. When the component is in detached state, signal value
+     * changes have no effect. <code>null</code> signal unbinds the existing
+     * binding.
+     * <p>
+     * The height should be in a format understood by the browser, e.g. "100px"
+     * or "2.5em".
+     * <p>
+     * While a Signal is bound to the height, any attempt to set the height
+     * manually throws {@link com.vaadin.signals.BindingActiveException}. Same
+     * happens when trying to bind a new Signal while one is already bound.
+     * <p>
+     * Example of usage:
+     *
+     * <pre>
+     * ValueSignal&lt;String&gt; signal = new ValueSignal&lt;&gt;("200px");
+     * Div component = new Div();
+     * add(component);
+     * component.bindHeight(signal);
+     * signal.value("300px"); // The component height is set to "300px"
+     * </pre>
+     *
+     * @param heightSignal
+     *            the signal to bind or <code>null</code> to unbind any existing
+     *            binding
+     * @throws com.vaadin.signals.BindingActiveException
+     *             thrown when there is already an existing binding
+     * @see #setHeight(String)
+     */
+    default void bindHeight(Signal<String> heightSignal) {
+        getElement().getStyle().bind(STYLE_HEIGHT, heightSignal);
+        getElement().bindAttribute(Constants.ATTRIBUTE_HEIGHT_FULL,
+                heightSignal != null
+                        ? heightSignal
+                                .map(value -> "100%".equals(value) ? "" : null)
+                        : null);
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasSizeBindWidthHeightTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasSizeBindWidthHeightTest.java
@@ -1,0 +1,414 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component;
+
+import org.junit.Test;
+
+import com.vaadin.flow.dom.SignalsUnitTest;
+import com.vaadin.flow.server.Constants;
+import com.vaadin.signals.BindingActiveException;
+import com.vaadin.signals.ValueSignal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
+public class HasSizeBindWidthHeightTest extends SignalsUnitTest {
+
+    @Tag("div")
+    public static class HasSizeComponent extends Component implements HasSize {
+    }
+
+    @Test
+    public void bindWidth_elementAttachedBefore_bindingActive() {
+        HasSizeComponent component = new HasSizeComponent();
+        UI.getCurrent().add(component);
+        assertNull(component.getWidth());
+
+        ValueSignal<String> signal = new ValueSignal<>("200px");
+        component.bindWidth(signal);
+
+        assertEquals("200px", component.getWidth());
+    }
+
+    @Test
+    public void bindWidth_elementAttachedAfter_bindingActive() {
+        HasSizeComponent component = new HasSizeComponent();
+        assertNull(component.getWidth());
+
+        ValueSignal<String> signal = new ValueSignal<>("200px");
+        component.bindWidth(signal);
+        UI.getCurrent().add(component);
+
+        assertEquals("200px", component.getWidth());
+    }
+
+    @Test
+    public void bindWidth_elementAttached_bindingActive() {
+        HasSizeComponent component = new HasSizeComponent();
+        UI.getCurrent().add(component);
+        ValueSignal<String> signal = new ValueSignal<>("200px");
+        component.bindWidth(signal);
+
+        // initially "200px"
+        assertEquals("200px", component.getWidth());
+
+        // "200px" -> "300px"
+        signal.value("300px");
+        assertEquals("300px", component.getWidth());
+
+        signal.value(null);
+        assertNull(component.getWidth());
+    }
+
+    @Test
+    public void bindWidth_elementNotAttached_bindingInactive() {
+        HasSizeComponent component = new HasSizeComponent();
+        ValueSignal<String> signal = new ValueSignal<>("200px");
+        component.bindWidth(signal);
+        signal.value("300px");
+
+        assertNull(component.getWidth());
+    }
+
+    @Test
+    public void bindWidth_elementDetached_bindingInactive() {
+        HasSizeComponent component = new HasSizeComponent();
+        UI.getCurrent().add(component);
+        ValueSignal<String> signal = new ValueSignal<>("200px");
+        component.bindWidth(signal);
+        component.removeFromParent();
+        signal.value("300px"); // ignored
+
+        assertEquals("200px", component.getWidth());
+    }
+
+    @Test
+    public void bindWidth_elementReAttached_bindingActivate() {
+        HasSizeComponent component = new HasSizeComponent();
+        UI.getCurrent().add(component);
+        ValueSignal<String> signal = new ValueSignal<>("200px");
+        component.bindWidth(signal);
+        component.removeFromParent();
+        signal.value("300px");
+        UI.getCurrent().add(component);
+
+        assertEquals("300px", component.getWidth());
+    }
+
+    @Test
+    public void bindWidth_setWidthWhileBindingIsActive_throwException() {
+        HasSizeComponent component = new HasSizeComponent();
+        UI.getCurrent().add(component);
+        component.bindWidth(new ValueSignal<>("200px"));
+
+        assertThrows(BindingActiveException.class,
+                () -> component.setWidth("300px"));
+        assertThrows(BindingActiveException.class, component::setWidthFull);
+        assertThrows(BindingActiveException.class,
+                () -> component.setWidth(300, Unit.PIXELS));
+        assertThrows(BindingActiveException.class, component::setSizeFull);
+        assertThrows(BindingActiveException.class,
+                () -> component.getElement().getStyle().setWidth("300px"));
+        assertThrows(BindingActiveException.class, () -> component.getElement()
+                .setAttribute(Constants.ATTRIBUTE_WIDTH_FULL, true));
+        assertEquals("200px", component.getWidth());
+    }
+
+    @Test
+    public void bindWidth_bindWidthWhileBindingIsActive_throwException() {
+        HasSizeComponent component = new HasSizeComponent();
+        UI.getCurrent().add(component);
+        component.bindWidth(new ValueSignal<>("200px"));
+
+        assertThrows(BindingActiveException.class,
+                () -> component.bindWidth(new ValueSignal<>("300px")));
+        assertThrows(BindingActiveException.class,
+                () -> component.setWidth("300px"));
+        assertEquals("200px", component.getWidth());
+    }
+
+    @Test
+    public void bindWidth_withNullBinding_removesBinding() {
+        HasSizeComponent component = new HasSizeComponent();
+        UI.getCurrent().add(component);
+        ValueSignal<String> signal = new ValueSignal<>("200px");
+        component.bindWidth(signal);
+        assertEquals("200px", component.getWidth());
+
+        component.bindWidth(null);
+        signal.value("300px");
+        assertEquals("200px", component.getWidth());
+    }
+
+    @Test
+    public void bindWidth_withNullBinding_allowsSetWidth() {
+        HasSizeComponent component = new HasSizeComponent();
+        UI.getCurrent().add(component);
+        ValueSignal<String> signal = new ValueSignal<>("200px");
+        component.bindWidth(signal);
+        assertEquals("200px", component.getWidth());
+
+        component.bindWidth(null);
+        component.setWidth("300px");
+        assertEquals("300px", component.getWidth());
+    }
+
+    @Test
+    public void bindWidth_fullWidth_widthFullAttributeSet() {
+        HasSizeComponent component = new HasSizeComponent();
+        UI.getCurrent().add(component);
+        ValueSignal<String> signal = new ValueSignal<>("100%");
+        component.bindWidth(signal);
+
+        assertEquals("100%", component.getWidth());
+        assertEquals("", component.getElement()
+                .getAttribute(Constants.ATTRIBUTE_WIDTH_FULL));
+    }
+
+    @Test
+    public void bindWidth_notFullWidth_widthFullAttributeNotSet() {
+        HasSizeComponent component = new HasSizeComponent();
+        UI.getCurrent().add(component);
+        ValueSignal<String> signal = new ValueSignal<>("200px");
+        component.bindWidth(signal);
+
+        assertEquals("200px", component.getWidth());
+        assertNull(component.getElement()
+                .getAttribute(Constants.ATTRIBUTE_WIDTH_FULL));
+    }
+
+    @Test
+    public void bindWidth_changeFromFullWidthToOther_widthFullAttributeRemoved() {
+        HasSizeComponent component = new HasSizeComponent();
+        UI.getCurrent().add(component);
+        ValueSignal<String> signal = new ValueSignal<>("100%");
+        component.bindWidth(signal);
+
+        assertEquals("", component.getElement()
+                .getAttribute(Constants.ATTRIBUTE_WIDTH_FULL));
+
+        signal.value("200px");
+        assertEquals("200px", component.getWidth());
+        assertNull(component.getElement()
+                .getAttribute(Constants.ATTRIBUTE_WIDTH_FULL));
+    }
+
+    @Test
+    public void bindWidth_changeFromOtherToFullWidth_widthFullAttributeSet() {
+        HasSizeComponent component = new HasSizeComponent();
+        UI.getCurrent().add(component);
+        ValueSignal<String> signal = new ValueSignal<>("200px");
+        component.bindWidth(signal);
+
+        assertNull(component.getElement()
+                .getAttribute(Constants.ATTRIBUTE_WIDTH_FULL));
+
+        signal.value("100%");
+        assertEquals("100%", component.getWidth());
+        assertEquals("", component.getElement()
+                .getAttribute(Constants.ATTRIBUTE_WIDTH_FULL));
+    }
+
+    @Test
+    public void bindHeight_elementAttachedBefore_bindingActive() {
+        HasSizeComponent component = new HasSizeComponent();
+        UI.getCurrent().add(component);
+        assertNull(component.getHeight());
+
+        ValueSignal<String> signal = new ValueSignal<>("200px");
+        component.bindHeight(signal);
+
+        assertEquals("200px", component.getHeight());
+    }
+
+    @Test
+    public void bindHeight_elementAttachedAfter_bindingActive() {
+        HasSizeComponent component = new HasSizeComponent();
+        assertNull(component.getHeight());
+
+        ValueSignal<String> signal = new ValueSignal<>("200px");
+        component.bindHeight(signal);
+        UI.getCurrent().add(component);
+
+        assertEquals("200px", component.getHeight());
+    }
+
+    @Test
+    public void bindHeight_elementAttached_bindingActive() {
+        HasSizeComponent component = new HasSizeComponent();
+        UI.getCurrent().add(component);
+        ValueSignal<String> signal = new ValueSignal<>("200px");
+        component.bindHeight(signal);
+
+        // initially "200px"
+        assertEquals("200px", component.getHeight());
+
+        // "200px" -> "300px"
+        signal.value("300px");
+        assertEquals("300px", component.getHeight());
+
+        signal.value(null);
+        assertNull(component.getHeight());
+    }
+
+    @Test
+    public void bindHeight_elementNotAttached_bindingInactive() {
+        HasSizeComponent component = new HasSizeComponent();
+        ValueSignal<String> signal = new ValueSignal<>("200px");
+        component.bindHeight(signal);
+        signal.value("300px");
+
+        assertNull(component.getHeight());
+    }
+
+    @Test
+    public void bindHeight_elementDetached_bindingInactive() {
+        HasSizeComponent component = new HasSizeComponent();
+        UI.getCurrent().add(component);
+        ValueSignal<String> signal = new ValueSignal<>("200px");
+        component.bindHeight(signal);
+        component.removeFromParent();
+        signal.value("300px"); // ignored
+
+        assertEquals("200px", component.getHeight());
+    }
+
+    @Test
+    public void bindHeight_elementReAttached_bindingActivate() {
+        HasSizeComponent component = new HasSizeComponent();
+        UI.getCurrent().add(component);
+        ValueSignal<String> signal = new ValueSignal<>("200px");
+        component.bindHeight(signal);
+        component.removeFromParent();
+        signal.value("300px");
+        UI.getCurrent().add(component);
+
+        assertEquals("300px", component.getHeight());
+    }
+
+    @Test
+    public void bindHeight_setHeightWhileBindingIsActive_throwException() {
+        HasSizeComponent component = new HasSizeComponent();
+        UI.getCurrent().add(component);
+        component.bindHeight(new ValueSignal<>("200px"));
+
+        assertThrows(BindingActiveException.class,
+                () -> component.setHeight("300px"));
+        assertThrows(BindingActiveException.class, component::setHeightFull);
+        assertThrows(BindingActiveException.class,
+                () -> component.setHeight(300, Unit.PIXELS));
+        assertThrows(BindingActiveException.class, component::setSizeFull);
+        assertThrows(BindingActiveException.class,
+                () -> component.getElement().getStyle().setHeight("300px"));
+        assertThrows(BindingActiveException.class, () -> component.getElement()
+                .setAttribute(Constants.ATTRIBUTE_HEIGHT_FULL, true));
+        assertEquals("200px", component.getHeight());
+    }
+
+    @Test
+    public void bindHeight_bindHeightWhileBindingIsActive_throwException() {
+        HasSizeComponent component = new HasSizeComponent();
+        UI.getCurrent().add(component);
+        component.bindHeight(new ValueSignal<>("200px"));
+
+        assertThrows(BindingActiveException.class,
+                () -> component.bindHeight(new ValueSignal<>("300px")));
+        assertEquals("200px", component.getHeight());
+    }
+
+    @Test
+    public void bindHeight_withNullBinding_removesBinding() {
+        HasSizeComponent component = new HasSizeComponent();
+        UI.getCurrent().add(component);
+        ValueSignal<String> signal = new ValueSignal<>("200px");
+        component.bindHeight(signal);
+        assertEquals("200px", component.getHeight());
+
+        component.bindHeight(null);
+        signal.value("300px");
+        assertEquals("200px", component.getHeight());
+    }
+
+    @Test
+    public void bindHeight_withNullBinding_allowsSetHeight() {
+        HasSizeComponent component = new HasSizeComponent();
+        UI.getCurrent().add(component);
+        ValueSignal<String> signal = new ValueSignal<>("200px");
+        component.bindHeight(signal);
+        assertEquals("200px", component.getHeight());
+
+        component.bindHeight(null);
+        component.setHeight("300px");
+        assertEquals("300px", component.getHeight());
+    }
+
+    @Test
+    public void bindHeight_fullHeight_heightFullAttributeSet() {
+        HasSizeComponent component = new HasSizeComponent();
+        UI.getCurrent().add(component);
+        ValueSignal<String> signal = new ValueSignal<>("100%");
+        component.bindHeight(signal);
+
+        assertEquals("100%", component.getHeight());
+        assertEquals("", component.getElement()
+                .getAttribute(Constants.ATTRIBUTE_HEIGHT_FULL));
+    }
+
+    @Test
+    public void bindHeight_notFullHeight_heightFullAttributeNotSet() {
+        HasSizeComponent component = new HasSizeComponent();
+        UI.getCurrent().add(component);
+        ValueSignal<String> signal = new ValueSignal<>("200px");
+        component.bindHeight(signal);
+
+        assertEquals("200px", component.getHeight());
+        assertNull(component.getElement()
+                .getAttribute(Constants.ATTRIBUTE_HEIGHT_FULL));
+    }
+
+    @Test
+    public void bindHeight_changeFromFullHeightToOther_heightFullAttributeRemoved() {
+        HasSizeComponent component = new HasSizeComponent();
+        UI.getCurrent().add(component);
+        ValueSignal<String> signal = new ValueSignal<>("100%");
+        component.bindHeight(signal);
+
+        assertEquals("", component.getElement()
+                .getAttribute(Constants.ATTRIBUTE_HEIGHT_FULL));
+
+        signal.value("200px");
+        assertEquals("200px", component.getHeight());
+        assertNull(component.getElement()
+                .getAttribute(Constants.ATTRIBUTE_HEIGHT_FULL));
+    }
+
+    @Test
+    public void bindHeight_changeFromOtherToFullHeight_heightFullAttributeSet() {
+        HasSizeComponent component = new HasSizeComponent();
+        UI.getCurrent().add(component);
+        ValueSignal<String> signal = new ValueSignal<>("200px");
+        component.bindHeight(signal);
+
+        assertNull(component.getElement()
+                .getAttribute(Constants.ATTRIBUTE_HEIGHT_FULL));
+
+        signal.value("100%");
+        assertEquals("100%", component.getHeight());
+        assertEquals("", component.getElement()
+                .getAttribute(Constants.ATTRIBUTE_HEIGHT_FULL));
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/signal/BindWidthHeightView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/signal/BindWidthHeightView.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.signal;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.dom.Style;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+import com.vaadin.signals.ValueSignal;
+
+/**
+ * View for testing binding width and height state to a Signal.
+ */
+@Route(value = "com.vaadin.flow.uitest.ui.signal.BindWidthHeightView", layout = ViewTestLayout.class)
+public class BindWidthHeightView extends Div {
+
+    private final ValueSignal<String> widthSignal = new ValueSignal<>("300px");
+    private final ValueSignal<String> heightSignal = new ValueSignal<>("300px");
+
+    public BindWidthHeightView() {
+        setWidth("500px");
+        setHeight("500px");
+        getStyle().setBorder("1px dotted green");
+
+        Span target = new Span();
+        target.getStyle().setDisplay(Style.Display.INLINE_BLOCK);
+        target.getStyle().setBackground("lightgray");
+        target.getStyle().setBorder("2px solid black");
+        target.setId("target");
+
+        Span widthInfo = new Span();
+        Span heightInfo = new Span();
+        target.add(widthInfo, new Span(" x "), heightInfo);
+
+        widthInfo.bindText(widthSignal);
+        heightInfo.bindText(heightSignal);
+
+        target.bindWidth(widthSignal);
+        target.bindHeight(heightSignal);
+
+        NativeButton setWidth100Button = new NativeButton(
+                "widthSignal.value(\"100%\")", e -> widthSignal.value("100%"));
+        setWidth100Button.setId("width-100-pct");
+
+        NativeButton setWidthNullButton = new NativeButton(
+                "widthSignal.value(null)", e -> widthSignal.value(null));
+        setWidthNullButton.setId("width-null");
+
+        NativeButton setHeight100Button = new NativeButton(
+                "heightSignal.value(\"100%\")",
+                e -> heightSignal.value("100%"));
+        setHeight100Button.setId("height-100-pct");
+
+        NativeButton setHeightNullButton = new NativeButton(
+                "heightSignal.value(null)", e -> heightSignal.value(null));
+        setHeightNullButton.setId("height-null");
+
+        add(target, new Div(setWidth100Button, setWidthNullButton,
+                setHeight100Button, setHeightNullButton));
+    }
+
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/signal/BindWidthHeightIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/signal/BindWidthHeightIT.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.signal;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.component.Unit;
+import com.vaadin.flow.component.html.testbench.NativeButtonElement;
+import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+/**
+ * Integration tests for binding width and height to signals.
+ */
+public class BindWidthHeightIT extends ChromeBrowserTest {
+
+    @Test
+    public void bindWidthAndHeight_changeSignalValues() {
+        open();
+
+        NativeButtonElement setWidth100Pct = $(NativeButtonElement.class)
+                .id("width-100-pct");
+        NativeButtonElement setHeight100Pct = $(NativeButtonElement.class)
+                .id("height-100-pct");
+
+        NativeButtonElement setWidthNull = $(NativeButtonElement.class)
+                .id("width-null");
+        NativeButtonElement setHeightNull = $(NativeButtonElement.class)
+                .id("height-null");
+
+        // Initially 300px x 300px span box inside a 500px x 500px container.
+        WebElement target = getTarget();
+        Assert.assertEquals("300px", target.getCssValue("width"));
+        Assert.assertEquals("300px", target.getCssValue("height"));
+        Assert.assertNull(
+                target.getDomAttribute(Constants.ATTRIBUTE_WIDTH_FULL));
+        Assert.assertNull(
+                target.getDomAttribute(Constants.ATTRIBUTE_HEIGHT_FULL));
+
+        setWidth100Pct.click();
+        setHeight100Pct.click();
+        Assert.assertEquals("500px", target.getCssValue("width"));
+        Assert.assertEquals("500px", target.getCssValue("height"));
+        Assert.assertNotNull(
+                target.getDomAttribute(Constants.ATTRIBUTE_WIDTH_FULL));
+        Assert.assertNotNull(
+                target.getDomAttribute(Constants.ATTRIBUTE_HEIGHT_FULL));
+
+        setWidthNull.click();
+        setHeightNull.click();
+        Assert.assertTrue(Unit.getSize(target.getCssValue("width")) < 20);
+        Assert.assertTrue(Unit.getSize(target.getCssValue("height")) < 20);
+        Assert.assertNull(
+                target.getDomAttribute(Constants.ATTRIBUTE_WIDTH_FULL));
+        Assert.assertNull(
+                target.getDomAttribute(Constants.ATTRIBUTE_HEIGHT_FULL));
+    }
+
+    private WebElement getTarget() {
+        return findElement(By.id("target"));
+    }
+}


### PR DESCRIPTION
Adds HasSize::bindWidth(Signal<String>) and HasSize::bindHeight(Signal<String>).

Fixes: #23256
