### PR TITLE
Fix race condition when closing CombineUsage subscriptions

### DIFF
--- a/signals/src/main/java/com/vaadin/signals/impl/UsageTracker.java
+++ b/signals/src/main/java/com/vaadin/signals/impl/UsageTracker.java
@@ -80,10 +80,14 @@ public class UsageTracker {
 
                 private void close() {
                     synchronized (lock) {
+                        if (closed) {
+                            return;
+                        }
                         closed = true;
-                        cleanups.forEach(CleanupCallback::cleanup);
-                        cleanups.clear();
                     }
+                    // Important release the lock before calling signal methods
+                    cleanups.forEach(CleanupCallback::cleanup);
+                    cleanups.clear();
                 }
 
                 @Override


### PR DESCRIPTION
There's a race between the signal tree lock and the UsageTracker subscription lock because notifying about a change holds the signal lock when trying to acquire the subscription lock. Closing the subscription does on the other hand hold the subscription lock while trying to acquire the signal lock.

This is fixed by releasing the subscription lock in the close() code path before calling into signal code. This remains safe by ensuring that only one thread actually performs the close operation.