### PR TITLE
feat: add bindReadOnly(Signal)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/HasValue.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasValue.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 
 import com.vaadin.flow.component.HasValue.ValueChangeEvent;
 import com.vaadin.flow.shared.Registration;
+import com.vaadin.signals.Signal;
 import com.vaadin.signals.WritableSignal;
 
 /**
@@ -267,6 +268,41 @@ public interface HasValue<E extends ValueChangeEvent<V>, V>
     default void bindValue(WritableSignal<V> valueSignal) {
         throw new UnsupportedOperationException(
                 "Binding value to a Signal is not supported by "
+                        + getClass().getSimpleName());
+    }
+
+    /**
+     * Binds a {@link Signal}'s value to the read-only state of this component
+     * and keeps the state synchronized with the signal value while the
+     * component is in attached state. When the component is in detached state,
+     * signal value changes have no effect. <code>null</code> signal unbinds the
+     * existing binding.
+     * <p>
+     * While a Signal is bound to the read-only state, any attempt to set the
+     * read-only state manually with {@link #setReadOnly(boolean)} throws
+     * {@link com.vaadin.signals.BindingActiveException}. Same happens when
+     * trying to bind a new Signal while one is already bound.
+     * <p>
+     * Example of usage:
+     *
+     * <pre>
+     * ValueSignal&lt;Boolean&gt; signal = new ValueSignal&lt;&gt;(false);
+     * Input component = new Input();
+     * add(component);
+     * component.bindReadOnly(signal);
+     * signal.value(true); // The input becomes read-only
+     * </pre>
+     *
+     * @param readOnlySignal
+     *            the signal to bind or <code>null</code> to unbind any existing
+     *            binding
+     * @throws com.vaadin.signals.BindingActiveException
+     *             thrown when there is already an existing binding
+     * @see #setReadOnly(boolean)
+     */
+    default void bindReadOnly(Signal<Boolean> readOnlySignal) {
+        throw new UnsupportedOperationException(
+                "Binding read only state to a Signal is not supported by "
                         + getClass().getSimpleName());
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasValueAndElement.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasValueAndElement.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component;
 
 import com.vaadin.flow.component.HasValue.ValueChangeEvent;
+import com.vaadin.signals.Signal;
 
 /**
  * A component that has a value.
@@ -48,5 +49,10 @@ public interface HasValueAndElement<E extends ValueChangeEvent<V>, V>
     @Override
     default boolean isReadOnly() {
         return getElement().getProperty("readonly", false);
+    }
+
+    @Override
+    default void bindReadOnly(Signal<Boolean> readOnlySignal) {
+        getElement().bindProperty("readonly", readOnlySignal);
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasValueBindReadOnlyTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasValueBindReadOnlyTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component;
+
+import org.junit.Test;
+
+import com.vaadin.flow.dom.SignalsUnitTest;
+import com.vaadin.signals.BindingActiveException;
+import com.vaadin.signals.Signal;
+import com.vaadin.signals.ValueSignal;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link HasValue#bindReadOnly(Signal)}.
+ */
+public class HasValueBindReadOnlyTest extends SignalsUnitTest {
+
+    @Test
+    public void bindReadOnly_elementAttachedBefore_bindingActive() {
+        TestComponent component = new TestComponent();
+        // attach before bindReadOnly
+        UI.getCurrent().add(component);
+        assertFalse(component.isReadOnly());
+
+        ValueSignal<Boolean> signal = new ValueSignal<>(true);
+        component.bindReadOnly(signal);
+
+        assertTrue(component.isReadOnly());
+    }
+
+    @Test
+    public void bindReadOnly_elementAttachedAfter_bindingActive() {
+        TestComponent component = new TestComponent();
+        assertFalse(component.isReadOnly());
+
+        ValueSignal<Boolean> signal = new ValueSignal<>(true);
+        component.bindReadOnly(signal);
+        // attach after bindReadOnly
+        UI.getCurrent().add(component);
+
+        assertTrue(component.isReadOnly());
+    }
+
+    @Test
+    public void bindReadOnly_elementAttached_bindingActive() {
+        TestComponent component = new TestComponent();
+        UI.getCurrent().add(component);
+        ValueSignal<Boolean> signal = new ValueSignal<>(true);
+        component.bindReadOnly(signal);
+
+        // initially true
+        assertTrue(component.isReadOnly());
+
+        // true -> false
+        signal.value(false);
+        assertFalse(component.isReadOnly());
+
+        // false -> true
+        signal.value(true);
+        assertTrue(component.isReadOnly());
+    }
+
+    @Test
+    public void bindReadOnly_elementNotAttached_bindingInactive() {
+        TestComponent component = new TestComponent();
+        ValueSignal<Boolean> signal = new ValueSignal<>(true);
+        component.bindReadOnly(signal);
+        signal.value(false);
+
+        assertFalse(component.isReadOnly());
+    }
+
+    @Test
+    public void bindReadOnly_elementDetached_bindingInactive() {
+        TestComponent component = new TestComponent();
+        UI.getCurrent().add(component);
+        ValueSignal<Boolean> signal = new ValueSignal<>(true);
+        component.bindReadOnly(signal);
+        component.removeFromParent();
+        signal.value(false); // ignored
+
+        assertTrue(component.isReadOnly());
+    }
+
+    @Test
+    public void bindReadOnly_elementReAttached_bindingActivate() {
+        TestComponent component = new TestComponent();
+        UI.getCurrent().add(component);
+        ValueSignal<Boolean> signal = new ValueSignal<>(true);
+        component.bindReadOnly(signal);
+        component.removeFromParent();
+        signal.value(false);
+        UI.getCurrent().add(component);
+
+        assertFalse(component.isReadOnly());
+    }
+
+    @Test
+    public void bindReadOnly_bindOrSetReadOnlyWhileBindingIsActive_throwException() {
+        TestComponent component = new TestComponent();
+        UI.getCurrent().add(component);
+        component.bindReadOnly(new ValueSignal<>(true));
+
+        assertThrows(BindingActiveException.class,
+                () -> component.bindReadOnly(new ValueSignal<>(false)));
+        assertThrows(BindingActiveException.class,
+                () -> component.setReadOnly(false));
+        assertTrue(component.isReadOnly());
+    }
+
+    @Test
+    public void bindReadOnly_withNullBinding_removesBinding() {
+        TestComponent component = new TestComponent();
+        UI.getCurrent().add(component);
+        ValueSignal<Boolean> signal = new ValueSignal<>(true);
+        component.bindReadOnly(signal);
+        assertTrue(component.isReadOnly());
+
+        component.bindReadOnly(null); // remove binding
+        signal.value(false); // no effect
+        assertTrue(component.isReadOnly());
+
+        component.setReadOnly(false);
+        assertFalse(component.isReadOnly());
+    }
+
+    @Test
+    public void bindReadOnly_withNullBinding_allowsSetReadOnly() {
+        TestComponent component = new TestComponent();
+        UI.getCurrent().add(component);
+        ValueSignal<Boolean> signal = new ValueSignal<>(true);
+        component.bindReadOnly(signal);
+        assertTrue(component.isReadOnly());
+
+        component.bindReadOnly(null); // remove binding
+
+        component.setReadOnly(false);
+        assertFalse(component.isReadOnly());
+    }
+
+    @Test
+    public void bindReadOnly_nullSignalValue_setsReadOnlyToFalse() {
+        TestComponent component = new TestComponent();
+        UI.getCurrent().add(component);
+        ValueSignal<Boolean> signal = new ValueSignal<>(true);
+        component.bindReadOnly(signal);
+        assertTrue(component.isReadOnly());
+
+        // null transforms to false (default value for boolean property)
+        signal.value(null);
+        assertFalse(component.isReadOnly());
+    }
+
+    @Test
+    public void bindReadOnly_toggleSignalValue_readOnlyUpdates() {
+        TestComponent component = new TestComponent();
+        UI.getCurrent().add(component);
+        ValueSignal<Boolean> signal = new ValueSignal<>(false);
+        component.bindReadOnly(signal);
+        assertFalse(component.isReadOnly());
+
+        signal.value(true);
+        assertTrue(component.isReadOnly());
+
+        signal.value(false);
+        assertFalse(component.isReadOnly());
+
+        signal.value(true);
+        assertTrue(component.isReadOnly());
+    }
+
+    /**
+     * Test component implementing {@link HasValueAndElement}.
+     */
+    @Tag(Tag.INPUT)
+    private static class TestComponent
+            extends AbstractField<TestComponent, String> {
+
+        public TestComponent() {
+            super("");
+        }
+
+        @Override
+        protected void setPresentationValue(String newPresentationValue) {
+            // NOP
+        }
+    }
+}


### PR DESCRIPTION
Adds HasValue::bindReadOnly(Signal<Boolean>).

Fixes: #23263
