### PR TITLE
fix: do not try to compute hash for frontend folders

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/BundleValidationUtil.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/BundleValidationUtil.java
@@ -721,11 +721,12 @@ public final class BundleValidationUtil {
                 getLogger().info("No file found for '{}'", projectImport);
                 return false;
             }
-
-            String frontendFileContent = Files
-                    .readString(frontendFile.toPath());
-            compareFrontendHashes(frontendHashes, faultyContent, projectImport,
-                    frontendFileContent);
+            if (!frontendFile.isDirectory()) {
+                String frontendFileContent = Files
+                        .readString(frontendFile.toPath());
+                compareFrontendHashes(frontendHashes, faultyContent,
+                        projectImport, frontendFileContent);
+            }
         }
 
         if (!faultyContent.isEmpty()) {


### PR DESCRIPTION
Fixes an error in Flow tests with frontend files importing a folder instead of a file.
