### PR TITLE
chore: Update webpush library

### DIFF
--- a/flow-webpush/pom.xml
+++ b/flow-webpush/pom.xml
@@ -28,19 +28,7 @@
     <dependency>
       <groupId>com.interaso</groupId>
       <artifactId>webpush</artifactId>
-      <version>1.2.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jetbrains.kotlin</groupId>
-          <artifactId>kotlin-stdlib</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib</artifactId>
-      <version>2.3.0</version>
+      <version>1.3.0</version>
     </dependency>
 
     <!-- DefaultApplicationConfigurationFactory is declared as an OSGi


### PR DESCRIPTION
Update the interaso/webpush
to 1.3.0

Fixes #23231
