### PR TITLE
fix: fix JSON handling in ReactAdapterComponent change listener support (24.9)

### DIFF
--- a/flow-react/src/main/java/com/vaadin/flow/component/react/ReactAdapterComponent.java
+++ b/flow-react/src/main/java/com/vaadin/flow/component/react/ReactAdapterComponent.java
@@ -27,12 +27,15 @@ import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.internal.JacksonCodec;
 import com.vaadin.flow.internal.JacksonUtils;
 
+import com.vaadin.flow.internal.JsonCodec;
 import com.vaadin.flow.internal.JsonUtils;
 import com.vaadin.flow.internal.nodefeature.NodeProperties;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
+import elemental.json.JsonObject;
 import elemental.json.JsonValue;
 
 /**
@@ -285,8 +288,12 @@ public abstract class ReactAdapterComponent extends Component {
             SerializableConsumer<T> listener) {
         return getElement().addPropertyChangeListener(stateName,
                 stateName + "-changed", (event -> {
+                    Serializable value = event.getValue();
+                    if (value instanceof JsonValue elemental) {
+                        value = JacksonUtils.mapElemental(elemental);
+                    }
                     JsonNode newStateJson = JacksonCodec
-                            .encodeWithoutTypeInfo(event.getValue());
+                            .encodeWithoutTypeInfo(value);
                     T newState = jsonReader.apply(newStateJson);
                     listener.accept(newState);
                 }));


### PR DESCRIPTION
The property change listener registered by the ReactAdapterComponent expects a Jackson JSON object as input, but it is actually getting an Elemental object. This change makes sure the Elemental JSON values are properly mapped to Jackson before conversion to Java objects happens.
