### PR TITLE
fix: respect configured nodeFolder

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
@@ -311,8 +311,7 @@ public class DevModeInitializer implements Serializable {
                 .withNpmExcludeWebComponents(npmExcludeWebComponents)
                 .withNodeVersion(config.getStringProperty(NODE_VERSION,
                         DEFAULT_NODE_VERSION))
-                .withNodeFolder(config.getStringProperty(NODE_FOLDER,
-                        null))
+                .withNodeFolder(config.getStringProperty(NODE_FOLDER, null))
                 .withNodeDownloadRoot(
                         URI.create(config.getStringProperty(NODE_DOWNLOAD_ROOT,
                                 NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT)));


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

This change propagates the NODE_FOLDER init parameter into Options so that dev mode node tasks respect a custom node installation.

I did not add an automated test for this because:
- the change happens during dev mode initialization
- Options does not expose the resolved node folder
- verifying the behavior would require running actual node tasks

The fix is a straightforward configuration pass-through and can be manually verified by starting dev mode with a custom NODE_FOLDER configured.

This change is part of a fix that also requires a corresponding update in Hilla.

Fixes vaadin/flow#23291

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
