### PR TITLE
chore: limit the branch for formatter only in main

### DIFF
--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -4,7 +4,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
     # spotless available in 25.x
-    branches: [main, '25.0']
+    branches: [main]
 
 # Cancel previous runs if a new one is triggered
 concurrency:


### PR DESCRIPTION
having the 25.0 branch in the collection will cause the behavior like in https://github.com/vaadin/flow/pull/23316

from maintenance branch, it can run the workflow from its own branch