### PR TITLE
fix: refresh error views automatically on hotswap (#23272) (#23311) (CP: 24.9)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -1177,6 +1177,21 @@ public class UIInternals implements Serializable {
     }
 
     /**
+     * Checks if an error view is currently being displayed. An error view is a
+     * component that implements HasErrorParameter.
+     *
+     * @return true if showing an error view, false otherwise
+     */
+    public boolean isShowingErrorView() {
+        if (routerTargetChain.isEmpty()) {
+            return false;
+        }
+        // The first element in the chain is the actual view component
+        HasElement target = routerTargetChain.get(0);
+        return target instanceof com.vaadin.flow.router.HasErrorParameter;
+    }
+
+    /**
      * Check if we have already started navigation to some location on this
      * roundtrip.
      *

--- a/flow-server/src/main/java/com/vaadin/flow/hotswap/impl/ErrorViewHotswapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/hotswap/impl/ErrorViewHotswapper.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.hotswap.impl;
+
+import jakarta.annotation.Priority;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.hotswap.VaadinHotswapper;
+import com.vaadin.flow.server.VaadinSession;
+
+import java.util.Set;
+
+/**
+ * Triggers UI refresh when hotswap occurs while an error view is displayed.
+ * This ensures that fixing a broken class during development will refresh the
+ * error page and attempt to re-navigate to the original location.
+ * <p>
+ * For internal use only. May be renamed or removed in a future release.
+ *
+ * @since 25.0
+ */
+@Priority(100)
+public class ErrorViewHotswapper implements VaadinHotswapper {
+
+    @Override
+    public boolean onClassLoadEvent(VaadinSession session,
+            Set<Class<?>> classes, boolean redefined) {
+        // Only process redefined classes (not first-time loads)
+        if (!redefined) {
+            return false;
+        }
+
+        // Check each UI in the session
+        for (UI ui : session.getUIs()) {
+            if (ui.isClosing()) {
+                continue;
+            }
+
+            // If showing error view, trigger page reload
+            if (ui.getInternals().isShowingErrorView()) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/flow-server/src/main/resources/META-INF/services/com.vaadin.flow.hotswap.VaadinHotswapper
+++ b/flow-server/src/main/resources/META-INF/services/com.vaadin.flow.hotswap.VaadinHotswapper
@@ -16,3 +16,4 @@
 
 com.vaadin.flow.router.internal.RouteRegistryHotswapper
 com.vaadin.flow.internal.ReflectionCacheHotswapper
+com.vaadin.flow.hotswap.impl.ErrorViewHotswapper

--- a/flow-server/src/test/java/com/vaadin/flow/hotswap/impl/ErrorViewHotswapperTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/hotswap/impl/ErrorViewHotswapperTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.hotswap.impl;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.internal.CurrentInstance;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.ErrorParameter;
+import com.vaadin.flow.router.HasErrorParameter;
+import com.vaadin.flow.router.Location;
+import com.vaadin.flow.server.MockVaadinServletService;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.tests.util.AlwaysLockedVaadinSession;
+import com.vaadin.tests.util.MockUI;
+
+public class ErrorViewHotswapperTest {
+
+    private ErrorViewHotswapper hotswapper;
+    private MockVaadinServletService service;
+    private VaadinSession session;
+    private MockUI ui;
+
+    @Before
+    public void setUp() {
+        CurrentInstance.clearAll();
+        service = new MockVaadinServletService();
+        session = new AlwaysLockedVaadinSession(service);
+        session.setConfiguration(service.getDeploymentConfiguration());
+        ui = new MockUI(session);
+        ui.doInit(null, 42, "test");
+        session.addUI(ui);
+        hotswapper = new ErrorViewHotswapper();
+    }
+
+    private Location createMockLocation(String path) {
+        Location location = Mockito.mock(Location.class);
+        Mockito.when(location.getPath()).thenReturn(path);
+        return location;
+    }
+
+    @Test
+    public void onClassesChange_errorViewShown_redefined_triggersRefresh() {
+        // Simulate an error view being displayed
+        TestErrorView errorView = new TestErrorView();
+        ui.getInternals().showRouteTarget(createMockLocation("error"),
+                errorView, Collections.emptyList());
+
+        // Verify error view is actually showing
+        Assert.assertTrue("Error view should be showing",
+                ui.getInternals().isShowingErrorView());
+
+        // Simulate a class being redefined (hotswap)
+        boolean reload = hotswapper.onClassLoadEvent(session,
+                Set.of(String.class), true);
+
+        // Verify refresh was triggered
+        Assert.assertTrue("Should trigger refresh when error view is shown",
+                reload);
+    }
+
+    @Test
+    public void onClassesChange_normalViewShown_redefined_noRefresh() {
+        // Simulate a normal view being displayed
+        TestNormalView normalView = new TestNormalView();
+        ui.getInternals().showRouteTarget(createMockLocation("normal"),
+                normalView, Collections.emptyList());
+
+        // Verify error view is not showing
+        Assert.assertFalse("Normal view should not be an error view",
+                ui.getInternals().isShowingErrorView());
+
+        // Simulate a class being redefined (hotswap)
+        boolean reload = hotswapper.onClassLoadEvent(session,
+                Set.of(String.class), true);
+
+        // Verify refresh was not triggered
+        Assert.assertFalse("Should not trigger refresh for normal view",
+                reload);
+    }
+
+    // Test classes
+
+    @Tag("div")
+    public static class TestErrorView extends Component
+            implements HasErrorParameter<Exception> {
+        @Override
+        public int setErrorParameter(BeforeEnterEvent event,
+                ErrorParameter<Exception> parameter) {
+            return 500;
+        }
+    }
+
+    @Tag("div")
+    public static class TestNormalView extends Component {
+    }
+}

--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
@@ -119,6 +119,8 @@ public abstract class ClassesSerializableTest extends ClassFinder {
                 "com\\.vaadin\\.flow\\.hotswap\\.HotswapCompleteEvent",
                 "com\\.vaadin\\.flow\\.hotswap\\.Hotswapper",
                 "com\\.vaadin\\.flow\\.hotswap\\.VaadinHotswapper",
+                "com\\.vaadin\\.flow\\.hotswap\\.impl\\.ErrorViewHotswapper",
+                "com\\.vaadin\\.flow\\.i18n\\.DefaultTranslationsHotswapper",
                 "com\\.vaadin\\.flow\\.internal\\.BrowserLiveReloadAccessor",
                 "com\\.vaadin\\.flow\\.internal\\.BrowserLiveReloadAccess",
                 "com\\.vaadin\\.flow\\.internal\\.BrowserLiveReload",


### PR DESCRIPTION
When a class breaks during development, Flow shows an error view. Previously, when the class was fixed and hotswapped, the error view remained visible because the hotswap system only refreshed views that used the changed class in their route chain.

This fix adds ErrorViewHotswapper plugin that detects when an error view is displayed (by checking if the current view implements HasErrorParameter) and triggers a browser reload on any hotswap. The page is reloaded to the original URL, allowing the fixed code to be properly loaded.

Adds unit tests to verify that ErrorViewHotswapper correctly:
- Triggers UI reload when an error view is shown during hotswap
- Does not trigger reload for normal views during hotswap
