### PR TITLE
Original felix/feat/dual based locking

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -854,7 +854,7 @@ public class UI extends Component
         if (session == null) {
             throw new UIDetachedException("Cannot push a detached UI");
         }
-        session.checkHasLock();
+        this.checkHasLock();
 
         if (!getPushConfiguration().getPushMode().isEnabled()) {
             throw new IllegalStateException("Push not enabled");
@@ -868,7 +868,7 @@ public class UI extends Component
          * when the push would otherwise be ignored because there are no changes
          * to push.
          */
-        session.getService().runPendingAccessTasks(session);
+        this.runPendingAccessTasks();
 
         if (!getInternals().isDirty()
                 || getInternals().getStateTree().isPreparingForResync()) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -16,16 +16,13 @@
 package com.vaadin.flow.component;
 
 import java.net.URI;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.server.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import tools.jackson.databind.JsonNode;
@@ -72,14 +69,6 @@ import com.vaadin.flow.router.Router;
 import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.router.internal.HasUrlParameterFormat;
 import com.vaadin.flow.router.internal.PathUtil;
-import com.vaadin.flow.server.Command;
-import com.vaadin.flow.server.ErrorEvent;
-import com.vaadin.flow.server.ErrorHandlingCommand;
-import com.vaadin.flow.server.VaadinRequest;
-import com.vaadin.flow.server.VaadinService;
-import com.vaadin.flow.server.VaadinServlet;
-import com.vaadin.flow.server.VaadinSession;
-import com.vaadin.flow.server.VaadinSessionState;
 import com.vaadin.flow.server.auth.AnonymousAllowed;
 import com.vaadin.flow.server.communication.PushConnection;
 import com.vaadin.flow.shared.Registration;
@@ -108,7 +97,9 @@ import com.vaadin.flow.shared.Registration;
  */
 @JsModule("@vaadin/common-frontend/ConnectionIndicator.js")
 public class UI extends Component
-        implements PollNotifier, HasComponents, RouterLayout {
+        implements PollNotifier, HasComponents, RouterLayout, AccessSupport {
+
+    private static final String UI_NOT_LOCKED_MESSAGE = "Cannot access state in UI without locking the UI.";
 
     private static final String NULL_LISTENER = "Listener can not be 'null'";
 
@@ -138,6 +129,17 @@ public class UI extends Component
      * generator.
      */
     private final String csrfToken = UUID.randomUUID().toString();
+
+    private long lastUnlocked;
+
+    private long lastLocked;
+
+    private transient Lock lock = new ReentrantLock();
+
+    private transient ConcurrentLinkedQueue<AbstractFutureAccess> pendingAccessQueue = new ConcurrentLinkedQueue<>();
+
+    private UILockCheckStrategy uiLockCheckStrategy = UILockCheckStrategy.ASSERT;
+
 
     /**
      * Creates a new empty UI.
@@ -372,9 +374,7 @@ public class UI extends Component
             // the UI is detached and cleaned up.
 
             // Can't use UI.push() directly since it checks for a valid session
-            if (getSession() != null) {
-                getSession().getService().runPendingAccessTasks(getSession());
-            }
+            this.runPendingAccessTasks();
             pushConnection.push();
         }
 
@@ -477,36 +477,141 @@ public class UI extends Component
      */
     private void accessSynchronously(Command command,
             SerializableRunnable detachHandler) {
-
-        Map<Class<?>, CurrentInstance> old = null;
-
-        VaadinSession session = getSession();
-
-        if (session == null) {
+        if (!this.isAttached()) {
             handleAccessDetach(detachHandler);
             return;
         }
-
-        VaadinService.verifyNoOtherSessionLocked(session);
-
-        session.lock();
+        this.checkHasLock();
+        this.getLockInstance().lock();
         try {
-            if (getSession() == null) {
+            if (!this.isAttached()) {
                 // UI was detached after fetching the session but before we
                 // acquired the lock.
                 handleAccessDetach(detachHandler);
                 return;
             }
-            old = CurrentInstance.setCurrent(this);
             command.execute();
         } finally {
-            session.unlock();
-            if (old != null) {
-                CurrentInstance.restoreInstances(old);
-            }
+            this.getLockInstance().unlock();
         }
 
     }
+
+
+    @Override
+    public Lock getLockInstance() {
+        return this.lock;
+    }
+
+
+    @Override
+    public void lock() {
+        this.getLockInstance().lock();
+        this.lastLocked = System.currentTimeMillis();
+    }
+
+
+    @Override
+    public void unlock() {
+        this.checkHasLock();
+        boolean ultimateRelease = false;
+        try {
+            /*
+             * Run pending tasks and push if the reentrant lock will actually be
+             * released by this unlock() invocation.
+             */
+            if (((ReentrantLock) getLockInstance()).getHoldCount() == 1) {
+                ultimateRelease = true;
+                runPendingAccessTasks();
+                this.push();
+                this.lastUnlocked = System.currentTimeMillis();
+            }
+        } finally {
+            getLockInstance().unlock();
+        }
+
+        /*
+         * If the session is locked when a new access task is added, it is
+         * assumed that the queue will be purged when the lock is released. This
+         * might however not happen if a task is enqueued between the moment
+         * when unlock() purges the queue and the moment when the lock is
+         * actually released. This means that the queue should be purged again
+         * if it is not empty after unlocking.
+         */
+        if (ultimateRelease && !getPendingAccessQueue().isEmpty()) {
+            this.ensureAccessQueuePurged();
+        }
+    }
+
+
+    @Override
+    public void checkHasLock() {
+        checkHasLock(UI_NOT_LOCKED_MESSAGE);
+    }
+
+
+    @Override
+    public void checkHasLock(String message) {
+        uiLockCheckStrategy.checkHasLock(this, message);
+    }
+
+
+    @Override
+    public void runPendingAccessTasks() {
+        this.checkHasLock();
+
+        if (this.getPendingAccessQueue().isEmpty()) {
+            return;
+        }
+
+        AbstractFutureAccess pendingAccess;
+        while ((pendingAccess = this.getPendingAccessQueue()
+                .poll()) != null) {
+            if (!pendingAccess.isCancelled()) {
+                pendingAccess.run();
+
+                try {
+                    pendingAccess.get();
+
+                } catch (CancellationException ignored) { // NOSONAR
+                    // Ignore canceled UI access tasks exceptions and don't
+                    // let it to be processed by the error handler and shown
+                    // on the UI
+                } catch (Exception exception) {
+                    pendingAccess.handleError(exception);
+                }
+            }
+        }
+    }
+
+
+    @Override
+    public void ensureAccessQueuePurged() {
+        /*
+         * If no thread is currently holding the lock, pending changes for UIs
+         * with automatic push would not be processed and pushed until the next
+         * time there is a request or someone does an explicit push call.
+         *
+         * To remedy this, we try to get the lock at this point. If the lock is
+         * currently held by another thread, we just back out as the queue will
+         * get purged once it is released. If the lock is held by the current
+         * thread, we just release it knowing that the queue gets purged once
+         * the lock is ultimately released. If the lock is not held by any
+         * thread and we acquire it, we just release it again to purge the queue
+         * right away.
+         */
+        try {
+            // tryLock() would be shorter, but it does not guarantee fairness
+            if (this.getLockInstance().tryLock(0, TimeUnit.SECONDS)) {
+                // unlock triggers runPendingAccessTasks
+                this.unlock();
+            }
+        } catch (InterruptedException e) {
+            // Restore the interrupted flag
+            Thread.currentThread().interrupt();
+        }
+    }
+
 
     /**
      * Provides exclusive access to this UI from outside a request handling
@@ -547,10 +652,30 @@ public class UI extends Component
      * @return a future that can be used to check for task completion and to
      *         cancel the task
      */
+    @Override
     public Future<Void> access(final Command command) {
         // null detach handler -> throw UIDetachEvent
         return access(command, null);
     }
+
+
+    @Override
+    public Queue<AbstractFutureAccess> getPendingAccessQueue() {
+        return this.pendingAccessQueue;
+    }
+
+
+    @Override
+    public long getLastLocked() {
+        return this.lastLocked;
+    }
+
+
+    @Override
+    public long getLastUnlocked() {
+        return this.lastUnlocked;
+    }
+
 
     /*
      * Yes, we are mixing legacy Command with newer SerializableRunnable. This
@@ -559,14 +684,7 @@ public class UI extends Component
      */
     private Future<Void> access(Command command,
             SerializableRunnable detachHandler) {
-        VaadinSession session = getSession();
-
-        if (session == null) {
-            handleAccessDetach(detachHandler);
-            return null;
-        }
-
-        return session.access(new ErrorHandlingCommand() {
+        UIFutureAccess uiFutureAccess = new UIFutureAccess(this, new ErrorHandlingCommand() {
             @Override
             public void execute() {
                 accessSynchronously(command, detachHandler);
@@ -607,6 +725,9 @@ public class UI extends Component
                 }
             }
         });
+        pendingAccessQueue.add(uiFutureAccess);
+        ensureAccessQueuePurged();
+        return uiFutureAccess;
     }
 
     /**
@@ -782,7 +903,7 @@ public class UI extends Component
         return getNode().getFeature(ReconnectDialogConfigurationMap.class);
     }
 
-    Logger getLogger() {
+    public Logger getLogger() {
         return LoggerFactory.getLogger(UI.class.getName());
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/AbstractFutureAccess.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AbstractFutureAccess.java
@@ -1,0 +1,12 @@
+package com.vaadin.flow.server;
+
+import java.util.concurrent.FutureTask;
+
+public abstract class AbstractFutureAccess extends FutureTask<Void> {
+
+	public AbstractFutureAccess(Runnable runnable, Void result) {
+		super(runnable, result);
+	}
+
+	public abstract void handleError(Exception exception);
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/AccessSupport.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AccessSupport.java
@@ -1,0 +1,39 @@
+package com.vaadin.flow.server;
+
+import java.util.Queue;
+import java.util.concurrent.Future;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+public interface AccessSupport {
+
+	Lock getLockInstance();
+
+	void lock();
+
+	void unlock();
+
+	void checkHasLock();
+
+	void checkHasLock(String message);
+
+	void runPendingAccessTasks();
+
+	void ensureAccessQueuePurged();
+
+	Future<Void> access(Command command);
+
+	void accessSynchronously(Command command);
+
+	Queue<AbstractFutureAccess> getPendingAccessQueue();
+
+	long getLastLocked();
+
+	long getLastUnlocked();
+
+	default boolean hasLock() {
+		ReentrantLock l = ((ReentrantLock) getLockInstance());
+		return l.isHeldByCurrentThread();
+	}
+
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/FutureAccess.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/FutureAccess.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  * @author Vaadin Ltd
  * @since 1.0
  */
-public class FutureAccess extends FutureTask<Void> {
+public class FutureAccess extends AbstractFutureAccess {
     private final VaadinSession session;
     private final Command command;
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/UIFutureAccess.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/UIFutureAccess.java
@@ -37,7 +37,7 @@ public class UIFutureAccess extends AbstractFutureAccess{
 		 * the check is always done as the deterministic behavior makes it
 		 * easier to detect potential problems.
 		 */
-		ui.checkHasLock();
+		VaadinService.isOtherUILocked(this.ui);
 		return super.get();
 	}
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/UIFutureAccess.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/UIFutureAccess.java
@@ -1,0 +1,76 @@
+package com.vaadin.flow.server;
+
+import com.vaadin.flow.component.UI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ExecutionException;
+
+public class UIFutureAccess extends AbstractFutureAccess{
+
+	private final UI ui;
+	private final Command command;
+
+	/**
+	 * Creates an instance for the given command.
+	 *
+	 * @param ui
+	 *            the UI to which the task belongs
+	 * @param command
+	 *            the command to run when this task is purged from the queue
+	 */
+	public UIFutureAccess(UI ui, Command command) {
+		super(command::execute, null);
+		this.ui = ui;
+		this.command = command;
+	}
+
+	@Override
+	public Void get() throws InterruptedException, ExecutionException {
+		/*
+		 * Help the developer avoid programming patterns that cause deadlocks
+		 * unless implemented very carefully. get(long, TimeUnit) does not have
+		 * the same detection since a sensible timeout should avoid completely
+		 * locking up the application.
+		 *
+		 * Even though no deadlock could occur after the command has been run,
+		 * the check is always done as the deterministic behavior makes it
+		 * easier to detect potential problems.
+		 */
+		ui.checkHasLock();
+		return super.get();
+	}
+
+	/**
+	 * Handles exceptions thrown during the execution of this task.
+	 *
+	 * @param exception
+	 *            the thrown exception.
+	 */
+	public void handleError(Exception exception) {
+		try {
+			if (command instanceof ErrorHandlingCommand) {
+				ErrorHandlingCommand errorHandlingCommand = (ErrorHandlingCommand) command;
+
+				errorHandlingCommand.handleError(exception);
+			} else {
+				ErrorEvent errorEvent = new ErrorEvent(exception);
+
+				ErrorHandler errorHandler = ErrorEvent
+						.findErrorHandler(ui.getSession());
+
+				if (errorHandler == null) {
+					errorHandler = new DefaultErrorHandler();
+				}
+
+				errorHandler.error(errorEvent);
+			}
+		} catch (Exception e) {
+			getLogger().error(e.getMessage(), e);
+		}
+	}
+
+	private static Logger getLogger() {
+		return LoggerFactory.getLogger(FutureAccess.class.getName());
+	}
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/UILockCheckStrategy.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/UILockCheckStrategy.java
@@ -61,8 +61,8 @@ public enum UILockCheckStrategy {
      * Potentially checks whether this session is currently locked by the
      * current thread
      *
-     * @param session
-     *            the session to check the lock for, not null.
+     * @param ui
+     *            the UI to check the lock for, not null.
      * @param message
      *            the error message to include when failing if the check is done
      *            and the session is not locked

--- a/flow-server/src/main/java/com/vaadin/flow/server/UILockCheckStrategy.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/UILockCheckStrategy.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server;
+
+import com.vaadin.flow.component.UI;
+
+/**
+ * Available strategies for session lock checking.
+ */
+public enum UILockCheckStrategy {
+    /**
+     * The default strategy, runs Java `assert` statement. Does nothing when
+     * assertions are disabled (the default for JVM).
+     */
+    ASSERT {
+        @Override
+        public void checkHasLock(UI ui, String message) {
+            assert ui.hasLock() : message;
+        }
+    },
+    /**
+     * If the session doesn't have a lock, a warning message is logged to the
+     * log but the code execution continues normally.
+     */
+    LOG {
+        @Override
+        public void checkHasLock(UI ui, String message) {
+            if (!ui.hasLock()) {
+                ui.getLogger().warn(message,
+                        new IllegalStateException(message));
+            }
+        }
+    },
+    /**
+     * If the session doesn't have a lock, an {@link IllegalStateException} is
+     * thrown.
+     */
+    THROW {
+        @Override
+        public void checkHasLock(UI ui, String message) {
+            if (!ui.hasLock()) {
+                throw new IllegalStateException(message);
+            }
+        }
+    };
+
+    /**
+     * Potentially checks whether this session is currently locked by the
+     * current thread
+     *
+     * @param session
+     *            the session to check the lock for, not null.
+     * @param message
+     *            the error message to include when failing if the check is done
+     *            and the session is not locked
+     */
+    public abstract void checkHasLock(UI ui, String message);
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -2203,6 +2203,23 @@ public abstract class VaadinService implements Serializable {
     }
 
     /**
+     * Checks that another {@link UI} instance is not locked. This is
+     * internally used by {@link UI#accessSynchronously(Command)} and
+     * {@link UI#accessSynchronously(Command)} to help avoid causing deadlocks.
+     *
+     * @param ui
+     *            the session that is being locked
+     * @throws IllegalStateException
+     *             if the current thread holds the lock for another session
+     */
+    public static void verifyNoOtherUILocked(UI ui) {
+        if (isOtherUILocked(ui)) {
+            throw new IllegalStateException(
+                    "Can't access UI while another UI is locked by the same thread. This restriction is intended to help avoid deadlocks.");
+        }
+    }
+
+    /**
      * Checks whether there might be some {@link VaadinSession} other than the
      * provided one for which the current thread holds a lock. This method might
      * not detect all cases where some other session is locked, but it should
@@ -2219,6 +2236,25 @@ public abstract class VaadinService implements Serializable {
             return false;
         }
         return otherSession.hasLock();
+    }
+
+    /**
+     * Checks whether there might be some {@link UI} other than the
+     * provided one for which the current thread holds a lock. This method might
+     * not detect all cases where some other UI is locked, but it should
+     * cover the most typical situations.
+     *
+     * @param ui
+     *            the UI that is expected to be locked
+     * @return <code>true</code> if another session is also locked by the
+     *         current thread; <code>false</code> if no such session was found
+     */
+    public static boolean isOtherUILocked(UI ui) {
+        UI otherUI = UI.getCurrent();
+        if (otherUI == null || otherUI == ui) {
+            return false;
+        }
+        return otherUI.hasLock();
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -2330,7 +2330,7 @@ public abstract class VaadinService implements Serializable {
             return;
         }
 
-        FutureAccess pendingAccess;
+        AbstractFutureAccess pendingAccess;
 
         // Dump all current instances, not only the ones dumped by setCurrent
         Map<Class<?>, CurrentInstance> oldInstances = CurrentInstance

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
@@ -758,13 +758,9 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable, 
                             .getPushMode() == PushMode.AUTOMATIC) {
                         Map<Class<?>, CurrentInstance> oldCurrent = CurrentInstance
                                 .setCurrent(ui);
-                        ui.runPendingAccessTasks();
                         try {
-                            ui.push();
+                            ui.accessSynchronously(()->{});
                         } finally {
-                            if (!ui.getPendingAccessQueue().isEmpty()) {
-                                ui.ensureAccessQueuePurged();
-                            }
                             CurrentInstance.restoreInstances(oldCurrent);
                         }
                     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
@@ -762,6 +762,9 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable, 
                         try {
                             ui.push();
                         } finally {
+                            if (!ui.getPendingAccessQueue().isEmpty()) {
+                                ui.ensureAccessQueuePurged();
+                            }
                             CurrentInstance.restoreInstances(oldCurrent);
                         }
                     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
@@ -154,7 +154,7 @@ public class JavaScriptBootstrapHandler extends BootstrapHandler {
             VaadinRequest request, VaadinResponse response,
             VaadinSession session) {
 
-        BootstrapContext context = super.createAndInitUI(UI.class, request,
+        BootstrapContext context = super.createAndInitUI(uiClass, request,
                 response, session);
         ObjectNode config = context.getApplicationParameters();
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
@@ -261,7 +261,7 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
 
         final String serviceUrl = getServiceUrl(request, response);
 
-        BootstrapContext context = super.createAndInitUI(WebComponentUI.class,
+        BootstrapContext context = super.createAndInitUI(uiClass,
                 request, response, session);
         ObjectNode config = context.getApplicationParameters();
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/UITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/UITest.java
@@ -196,7 +196,7 @@ public class UITest {
             }
 
             @Override
-            Logger getLogger() {
+            public Logger getLogger() {
                 return mockLogger;
             }
         };


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description
- Separated UI and Session Locking
- Fixed a Bug where whenever another UI-Class has been Configured the Configuration was ignored.

Fixes # (issue)
The issue was whenever a UI was freezing, all other UIs in the same VaadinSession were freezed as well.

## Type of change

- [X] Bugfix
- [X] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [X] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
