### PR TITLE
feat: Binder throws error on invalid signal usage

### DIFF
--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderSignalTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderSignalTest.java
@@ -670,4 +670,30 @@ public class BinderSignalTest extends SignalsUnitTest {
         firstNameSignal.value("");
         Assert.assertFalse(lastNameField.isInvalid());
     }
+
+    @Test
+    public void beanLevelValidator_throwWhenSignalIsUsed() {
+        item.setFirstName("Alice");
+        var firstNameSignal = new ValueSignal<>("");
+        UI.getCurrent().add(firstNameField);
+        binder.forField(firstNameField).bind("firstName");
+        binder.setBean(item);
+
+        binder.withValidator(bean -> {
+            firstNameSignal.peek(); // ok
+            return true;
+        }, "Bean level validation failed");
+
+        Assert.assertTrue(binder.isValid());
+
+        binder.withValidator(bean -> {
+            firstNameSignal.value(); // causes error
+            return true;
+        }, "Bean level validation with a signal failed");
+
+        Assert.assertThrows(Binder.InvalidSignalUsageError.class,
+                () -> binder.validate());
+        Assert.assertThrows(Binder.InvalidSignalUsageError.class,
+                () -> binder.isValid());
+    }
 }

--- a/signals/src/main/java/com/vaadin/signals/impl/UsageTracker.java
+++ b/signals/src/main/java/com/vaadin/signals/impl/UsageTracker.java
@@ -17,6 +17,7 @@ package com.vaadin.signals.impl;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.function.Supplier;
 
 import com.vaadin.signals.function.CleanupCallback;
 import com.vaadin.signals.function.ValueSupplier;
@@ -196,11 +197,34 @@ public class UsageTracker {
         assert task != null;
         assert tracker != null;
 
+        track(() -> {
+            task.run();
+            return null;
+        }, tracker);
+    }
+
+    /**
+     * Runs the given task with return value while reacting to all cases where a
+     * managed value is used.
+     *
+     * @param task
+     *            the task to run, not <code>null</code>
+     * @param tracker
+     *            a consumer that receives all usages as they happen, not
+     *            <code>null</code>
+     * @param <T>
+     *            the task return type
+     * @return the value returned from the task
+     */
+    public static <T> T track(Supplier<T> task, UsageRegistrar tracker) {
+        assert task != null;
+        assert tracker != null;
+
         var previousTracker = currentTracker.get();
         try {
             currentTracker.set(tracker);
 
-            task.run();
+            return task.get();
         } finally {
             currentTracker.set(previousTracker);
         }


### PR DESCRIPTION
Bean level validators throws Binder.InvalidSignalUsageError error when Signal.value() is called in them.

Fixes: #23364