### PR TITLE
chore: simplify NoRoutesError_dev.html to show only Flow option

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/router/NoRoutesError_dev.html
+++ b/flow-server/src/main/resources/com/vaadin/flow/router/NoRoutesError_dev.html
@@ -1,13 +1,8 @@
 <div style="margin: 2rem;">
     <h3>No views found</h3>
-    <p>To get started, you can either</p>
-    <ul>
-        <li><a href onclick="window.Vaadin.copilot.initEmptyApp('flow')">Create a view for coding the UI in Java with Flow</a></li>
-        <li><a href onclick="window.Vaadin.copilot.initEmptyApp('hilla')">Create a view for coding the UI in TypeScript with Hilla and React</a></li>
-    </ul>
+    <p>To get started, <a href onclick="window.Vaadin.copilot.initEmptyApp('flow')">create a view</a>.</p>
     <p>
         You can also create a view manually in your IDE, see <a target="_blank" href="https://vaadin.com/docs/latest/tutorial">the tutorial</a>
     </p>
-
     <p>Learn more at <a target="_blank" href="https://vaadin.com/docs">https://vaadin.com/docs</a>.</p>
 </div>


### PR DESCRIPTION
Remove the Hilla/React option from the "No views found" development error page, leaving only the Flow option for creating a new view.
