### PR TITLE
fix: Prevent Vite reload from canceling logout redirect (#23375) (CP: 24.9)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -393,8 +393,12 @@ public class Page implements Serializable {
      *            the name of the window.
      */
     public void open(String url, String windowName) {
+        // The vaadin-redirect-pending event might be useful to block other
+        // client side
+        // reload/redirection triggered by other components, for example Vite.
         executeJs(
-                "if ($1 == '_self') this.stopApplication(); window.open($0, $1)",
+                "window.dispatchEvent(new CustomEvent('vaadin-redirect-pending', {detail: {url: $0}})); "
+                        + "if ($1 == '_self') this.stopApplication(); window.open($0, $1)",
                 url, windowName);
     }
 

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/vite-devmode.ts
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/vite-devmode.ts
@@ -14,13 +14,63 @@ if (import.meta.hot) {
   };
 
   let pendingNavigationTo: string | undefined = undefined;
+  let redirectPending: boolean = false;
 
   window.addEventListener('vaadin-router-go', (routerEvent: any) => {
     pendingNavigationTo = routerEvent.detail.pathname + routerEvent.detail.search;
   });
+
+  // Listen for server-initiated redirects via Page.setLocation()
+  window.addEventListener('vaadin-redirect-pending', () => {
+    redirectPending = true;
+  });
+
+  // Register a close event listener and store a Promise on the WebSocket.
+  // The Promise resolves with the close code when our listener runs.
+  // This allows vite:ws:disconnect to await the close code even though
+  // Vite's close listener runs before ours (due to registration order).
+  hot.on('vite:ws:connect', (payload: any) => {
+    const ws = payload.webSocket;
+
+    // Create Promise with resolver scoped to this closure.
+    // Store on WebSocket so vite:ws:disconnect can access it.
+    (ws as any)._closeCodePromise = new Promise<number>((resolve) => {
+      ws.addEventListener('close', (event: any) => {
+        resolve(event.code);
+      });
+    });
+  });
+
+  // Async handler that waits for the close listener to run.
+  // Vite's close handler calls notifyListeners which awaits this handler.
+  // By awaiting the closeCodePromise, we ensure our close listener has
+  // run and we can check the close code before Vite checks willUnload.
+  hot.on('vite:ws:disconnect', async (payload: any) => {
+    const ws = payload.webSocket;
+    const closeCodePromise = (ws as any)?._closeCodePromise;
+
+    if (closeCodePromise) {
+      const closeCode = await closeCodePromise;
+
+      // Close code 1008 (VIOLATED_POLICY) indicates authenticated HTTP session invalidation
+      // that usually corresponds also to a server-initiated redirect.
+      if (closeCode === 1008) {
+        redirectPending = true;
+        // Dispatch beforeunload to set Vite's internal willUnload flag,
+        // which prevents Vite from reloading the page after reconnecting.
+        window.dispatchEvent(new Event('beforeunload'));
+      }
+    }
+  });
+
   hot.on('vite:beforeFullReload', (payload: any) => {
     if (isLiveReloadDisabled()) {
       preventViteReload(payload);
+    }
+    // Prevent reload when a server-initiated redirect is pending
+    if (redirectPending) {
+      preventViteReload(payload);
+      return;
     }
     if (pendingNavigationTo) {
       // Force reload with the new URL

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
@@ -364,7 +364,59 @@ public class PageTest {
         // self check
         Assert.assertEquals("_self", params.get(1));
 
-        MatcherAssert.assertThat(capture.get(), CoreMatchers
-                .startsWith("if ($1 == '_self') this.stopApplication();"));
+        MatcherAssert.assertThat(capture.get(),
+                CoreMatchers.containsString("this.stopApplication();"));
+    }
+
+    @Test
+    public void setLocation_dispatchesRedirectPendingEvent() {
+        AtomicReference<String> capture = new AtomicReference<>();
+        List<Object> params = new ArrayList<>();
+        Page page = new Page(new MockUI()) {
+            @Override
+            public PendingJavaScriptResult executeJs(String expression,
+                    Serializable... parameters) {
+                capture.set(expression);
+                params.addAll(Arrays.asList(parameters));
+                return Mockito.mock(PendingJavaScriptResult.class);
+            }
+        };
+
+        page.setLocation("/logout-landing");
+
+        String expression = capture.get();
+        Assert.assertTrue("Should dispatch vaadin-redirect-pending event",
+                expression.contains("vaadin-redirect-pending"));
+        Assert.assertTrue("Should call window.open",
+                expression.contains("window.open"));
+        Assert.assertEquals("URL parameter should be passed", "/logout-landing",
+                params.get(0));
+    }
+
+    @Test
+    public void open_dispatchesRedirectPendingEventBeforeRedirect() {
+        AtomicReference<String> capture = new AtomicReference<>();
+        Page page = new Page(new MockUI()) {
+            @Override
+            public PendingJavaScriptResult executeJs(String expression,
+                    Serializable... parameters) {
+                capture.set(expression);
+                return Mockito.mock(PendingJavaScriptResult.class);
+            }
+        };
+
+        page.open("https://example.com", "_blank");
+
+        String expression = capture.get();
+        // Verify event dispatch comes before window.open
+        int eventDispatchIndex = expression.indexOf("vaadin-redirect-pending");
+        int windowOpenIndex = expression.indexOf("window.open");
+        Assert.assertTrue("Event dispatch should be present",
+                eventDispatchIndex >= 0);
+        Assert.assertTrue("window.open should be present",
+                windowOpenIndex >= 0);
+        Assert.assertTrue(
+                "Event dispatch should come before window.open in the script",
+                eventDispatchIndex < windowOpenIndex);
     }
 }

--- a/flow-tests/test-dev-mode/src/main/java/com/vaadin/flow/uitest/ui/vitelogout/CloseViteWebsocketOnSessionExpiration.java
+++ b/flow-tests/test-dev-mode/src/main/java/com/vaadin/flow/uitest/ui/vitelogout/CloseViteWebsocketOnSessionExpiration.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.vitelogout;
+
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
+import jakarta.servlet.annotation.WebListener;
+import jakarta.servlet.http.HttpSessionEvent;
+import jakarta.servlet.http.HttpSessionListener;
+
+import com.vaadin.base.devserver.viteproxy.ViteSessionTracker;
+
+/**
+ * Replicates Tomcat's behavior of closing WebSocket connections when an
+ * authenticated HTTP session is invalidated. Jetty doesn't do this by default,
+ * so this listener is needed to properly test the logout redirect fix in the
+ * test environment.
+ * <p>
+ * Implements both ServletContextListener (to initialize the ViteSessionTracker)
+ * and HttpSessionListener (to notify tracker when sessions are destroyed).
+ */
+@WebListener
+public class CloseViteWebsocketOnSessionExpiration
+        implements HttpSessionListener, ServletContextListener {
+
+    private ViteSessionTracker tracker;
+
+    @Override
+    public void contextInitialized(ServletContextEvent sce) {
+        tracker = new ViteSessionTracker();
+        sce.getServletContext().setAttribute(ViteSessionTracker.class.getName(),
+                tracker);
+    }
+
+    @Override
+    public void sessionDestroyed(HttpSessionEvent se) {
+        if (tracker != null) {
+            // Simulate Tomcat behavior
+            // Close code 1008 is VIOLATED_POLICY per WebSocket RFC
+            tracker.close(se.getSession().getId(), 1008,
+                    "This connection was established under an authenticated HTTP session that has ended");
+        }
+    }
+}

--- a/flow-tests/test-dev-mode/src/main/java/com/vaadin/flow/uitest/ui/vitelogout/LoginView.java
+++ b/flow-tests/test-dev-mode/src/main/java/com/vaadin/flow/uitest/ui/vitelogout/LoginView.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.vitelogout;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.router.Route;
+
+/**
+ * Login view for testing Vite logout redirect behavior.
+ * <p>
+ * Contains a native HTML form that posts to the login route, which is
+ * intercepted by {@link MockAuthenticationFilter}.
+ */
+@Route("com.vaadin.flow.uitest.ui.vitelogout.LoginView")
+public class LoginView extends Div {
+
+    public LoginView() {
+        Element form = new Element("form");
+        form.setAttribute("action",
+                "/view/com.vaadin.flow.uitest.ui.vitelogout.LoginView");
+        form.setAttribute("method", "POST");
+
+        NativeButton submit = new NativeButton("Login");
+        submit.setId("login-button");
+        submit.getElement().setAttribute("type", "submit");
+
+        getElement().appendChild(form);
+        form.appendChild(submit.getElement());
+    }
+}

--- a/flow-tests/test-dev-mode/src/main/java/com/vaadin/flow/uitest/ui/vitelogout/LogoutTestView.java
+++ b/flow-tests/test-dev-mode/src/main/java/com/vaadin/flow/uitest/ui/vitelogout/LogoutTestView.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.vitelogout;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.VaadinSession;
+
+/**
+ * View for testing Vite logout redirect behavior.
+ * <p>
+ * Contains a logout button that sets the location to the session-ended route
+ * and invalidates the session. The test verifies that Vite's page reload
+ * doesn't cancel the server-initiated redirect when the session is invalidated.
+ */
+@Route("com.vaadin.flow.uitest.ui.vitelogout.LogoutTestView")
+public class LogoutTestView extends Div {
+
+    public LogoutTestView() {
+        Span marker = new Span("Logout Test View");
+        marker.setId("logout-test-marker");
+
+        NativeButton logoutButton = new NativeButton("Logout", e -> {
+            UI.getCurrent().getPage().setLocation(
+                    "/view/com.vaadin.flow.uitest.ui.vitelogout.SessionEndedView");
+            VaadinSession.getCurrent().getSession().invalidate();
+        });
+        logoutButton.setId("logout-button");
+
+        add(marker, logoutButton);
+    }
+}

--- a/flow-tests/test-dev-mode/src/main/java/com/vaadin/flow/uitest/ui/vitelogout/MockAuthenticationFilter.java
+++ b/flow-tests/test-dev-mode/src/main/java/com/vaadin/flow/uitest/ui/vitelogout/MockAuthenticationFilter.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.vitelogout;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.annotation.WebFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+
+import java.io.IOException;
+import java.security.Principal;
+
+/**
+ * Mock authentication filter for testing Vite logout redirect behavior.
+ * <p>
+ * Intercepts login POST requests, sets an authenticated session attribute, and
+ * wraps subsequent requests with a principal when authenticated.
+ */
+@WebFilter(urlPatterns = { "/view/*" })
+public class MockAuthenticationFilter implements Filter {
+
+    public static final String AUTHENTICATED_ATTR = "mock.authenticated";
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response,
+            FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+        HttpSession session = httpRequest.getSession();
+        String path = httpRequest.getRequestURI();
+
+        // On POST to login route, mark as authenticated and redirect
+        if (path.endsWith(".LoginView")
+                && "POST".equals(httpRequest.getMethod())) {
+            session.setAttribute(AUTHENTICATED_ATTR, true);
+            httpResponse.sendRedirect(
+                    "/view/com.vaadin.flow.uitest.ui.vitelogout.LogoutTestView");
+            return;
+        }
+
+        // If authenticated, wrap request with principal
+        if (Boolean.TRUE.equals(session.getAttribute(AUTHENTICATED_ATTR))) {
+            chain.doFilter(new AuthenticatedRequestWrapper(httpRequest),
+                    response);
+        } else {
+            chain.doFilter(request, response);
+        }
+    }
+
+    private static class AuthenticatedRequestWrapper
+            extends HttpServletRequestWrapper {
+
+        AuthenticatedRequestWrapper(HttpServletRequest request) {
+            super(request);
+        }
+
+        @Override
+        public Principal getUserPrincipal() {
+            return () -> "testuser";
+        }
+    }
+}

--- a/flow-tests/test-dev-mode/src/main/java/com/vaadin/flow/uitest/ui/vitelogout/SessionEndedView.java
+++ b/flow-tests/test-dev-mode/src/main/java/com/vaadin/flow/uitest/ui/vitelogout/SessionEndedView.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.vitelogout;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.Route;
+
+/**
+ * View displayed after successful logout.
+ * <p>
+ * Used to verify that the browser correctly navigated to this page after
+ * session invalidation, instead of being redirected by Vite's page reload.
+ */
+@Route("com.vaadin.flow.uitest.ui.vitelogout.SessionEndedView")
+public class SessionEndedView extends Div {
+
+    public SessionEndedView() {
+        Span marker = new Span("Session Ended Successfully");
+        marker.setId("session-ended-marker");
+        add(marker);
+    }
+}

--- a/flow-tests/test-dev-mode/src/test/java/com/vaadin/flow/uitest/ui/vitelogout/ViteLogoutRedirectIT.java
+++ b/flow-tests/test-dev-mode/src/test/java/com/vaadin/flow/uitest/ui/vitelogout/ViteLogoutRedirectIT.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.vitelogout;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.html.testbench.NativeButtonElement;
+import com.vaadin.flow.component.html.testbench.SpanElement;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+/**
+ * Integration test for issue #20819: Vite page reload should not cancel
+ * server-initiated redirect when session is invalidated.
+ * <p>
+ * Test scenario:
+ * <ol>
+ * <li>Navigate to login page</li>
+ * <li>Submit login form (POST to login route)</li>
+ * <li>Filter intercepts, sets authenticated flag, redirects to logout-test
+ * route</li>
+ * <li>Click logout button which sets location to session-ended route and
+ * invalidates session</li>
+ * <li>Verify user lands on session-ended page (not reloaded by Vite)</li>
+ * </ol>
+ */
+public class ViteLogoutRedirectIT extends ChromeBrowserTest {
+
+    @Override
+    protected String getTestPath() {
+        return "/view/com.vaadin.flow.uitest.ui.vitelogout.LoginView";
+    }
+
+    @Test
+    public void logoutRedirect_sessionInvalidated_redirectsToSessionEndedPage() {
+        // Navigate to login page
+        open();
+
+        // Submit the login form
+        $(NativeButtonElement.class).id("login-button").click();
+
+        // Verify redirected to logout-test page
+        waitUntil(driver -> $(SpanElement.class).id("logout-test-marker")
+                .isDisplayed());
+
+        // Click logout button
+        $(NativeButtonElement.class).id("logout-button").click();
+
+        // Verify redirected to session-ended page (not reloaded by Vite)
+        waitUntil(driver -> $(SpanElement.class).id("session-ended-marker")
+                .isDisplayed());
+
+        // Verify we're on the correct URL
+        Assert.assertTrue("Should be on SessionEndedView page",
+                getDriver().getCurrentUrl().contains(
+                        "/view/com.vaadin.flow.uitest.ui.vitelogout.SessionEndedView"));
+    }
+}

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/viteproxy/ViteSessionTracker.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/viteproxy/ViteSessionTracker.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.base.devserver.viteproxy;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import com.vaadin.flow.shared.Registration;
+
+/**
+ * Tracks HTTP session closures and notifies registered listeners.
+ * <p>
+ * This allows WebSocket connections to be notified when their associated HTTP
+ * session is invalidated, enabling them to close the WebSocket with an
+ * appropriate close code that the client can detect.
+ * <p>
+ * This class is meant only for testing purposes. Do not use it in production.
+ * <p>
+ * For internal use only. May be renamed or removed in a future release.
+ */
+public class ViteSessionTracker {
+
+    /**
+     * Listener interface for HTTP session close events.
+     */
+    @FunctionalInterface
+    public interface SessionCloseListener {
+        /**
+         * Called when an HTTP session is closed.
+         *
+         * @param httpSessionId
+         *            the ID of the HTTP session that was closed
+         * @param closeCode
+         *            the WebSocket close code to use (e.g., 1008 for
+         *            VIOLATED_POLICY)
+         * @param closeMessage
+         *            the close message to send with the WebSocket close
+         */
+        void onSessionClose(String httpSessionId, int closeCode,
+                String closeMessage);
+    }
+
+    private final List<SessionCloseListener> listeners = new CopyOnWriteArrayList<>();
+
+    /**
+     * Adds a listener that will be notified when an HTTP session is closed.
+     *
+     * @param listener
+     *            a listener that receives the HTTP session ID, close code, and
+     *            close message
+     * @return a registration that can be used to remove the listener
+     */
+    public Registration addListener(SessionCloseListener listener) {
+        listeners.add(listener);
+        return () -> listeners.remove(listener);
+    }
+
+    /**
+     * Notifies all registered listeners that the given HTTP session has closed.
+     *
+     * @param httpSessionId
+     *            the ID of the HTTP session that was closed
+     * @param closeCode
+     *            the WebSocket close code to use (e.g., 1008 for
+     *            VIOLATED_POLICY)
+     * @param closeMessage
+     *            the close message to send with the WebSocket close
+     */
+    public void close(String httpSessionId, int closeCode,
+            String closeMessage) {
+        for (SessionCloseListener listener : listeners) {
+            listener.onSessionClose(httpSessionId, closeCode, closeMessage);
+        }
+    }
+}

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketEndpoint.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/viteproxy/ViteWebsocketEndpoint.java
@@ -15,11 +15,21 @@
  */
 package com.vaadin.base.devserver.viteproxy;
 
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpSession;
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.CloseReason.CloseCodes;
+import jakarta.websocket.DeploymentException;
+import jakarta.websocket.Endpoint;
+import jakarta.websocket.EndpointConfig;
+import jakarta.websocket.HandshakeResponse;
+import jakarta.websocket.Session;
+import jakarta.websocket.server.HandshakeRequest;
+import jakarta.websocket.server.ServerContainer;
+import jakarta.websocket.server.ServerEndpointConfig;
+
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,15 +37,7 @@ import org.slf4j.LoggerFactory;
 import com.vaadin.base.devserver.ViteHandler;
 import com.vaadin.flow.server.VaadinContext;
 import com.vaadin.flow.server.VaadinServletContext;
-
-import jakarta.servlet.ServletContext;
-import jakarta.websocket.CloseReason;
-import jakarta.websocket.DeploymentException;
-import jakarta.websocket.Endpoint;
-import jakarta.websocket.EndpointConfig;
-import jakarta.websocket.Session;
-import jakarta.websocket.server.ServerContainer;
-import jakarta.websocket.server.ServerEndpointConfig;
+import com.vaadin.flow.shared.Registration;
 
 /**
  * The websocket endpoint for Vite.
@@ -43,9 +45,29 @@ import jakarta.websocket.server.ServerEndpointConfig;
 public class ViteWebsocketEndpoint extends Endpoint {
 
     public static final String VITE_HANDLER = "viteServer";
+    static final String TRACKER_KEY = "viteSessionTracker";
+    private static final String HTTP_SESSION_ID = "httpSessionId";
 
-    private final static Map<String, ViteWebsocketProxy> proxies = Collections
-            .synchronizedMap(new HashMap<>());
+    private ViteWebsocketProxy proxy;
+    private Registration listenerRegistration;
+
+    /**
+     * Configurator that captures the HTTP session ID during the WebSocket
+     * handshake. This allows tracking which WebSocket sessions are associated
+     * with which HTTP sessions.
+     */
+    public static class HttpSessionConfigurator
+            extends ServerEndpointConfig.Configurator {
+        @Override
+        public void modifyHandshake(ServerEndpointConfig config,
+                HandshakeRequest request, HandshakeResponse response) {
+            Object httpSessionObject = request.getHttpSession();
+            if (httpSessionObject instanceof HttpSession httpSession) {
+                config.getUserProperties().put(HTTP_SESSION_ID,
+                        httpSession.getId());
+            }
+        }
+    }
 
     /**
      * Creates the websocket endpoint that Vite connects to.
@@ -70,9 +92,19 @@ public class ViteWebsocketEndpoint extends Endpoint {
             ServerEndpointConfig endpointConfig = ServerEndpointConfig.Builder
                     .create(ViteWebsocketEndpoint.class,
                             viteHandler.getPathToVaadinInContext())
-                    .subprotocols(subProtocols).build();
+                    .subprotocols(subProtocols)
+                    .configurator(new HttpSessionConfigurator()).build();
             endpointConfig.getUserProperties()
                     .put(ViteWebsocketEndpoint.VITE_HANDLER, viteHandler);
+
+            // Get tracker from servlet context if it exists (set by test
+            // listener)
+            ViteSessionTracker tracker = (ViteSessionTracker) servletContext
+                    .getAttribute(ViteSessionTracker.class.getName());
+            if (tracker != null) {
+                endpointConfig.getUserProperties().put(TRACKER_KEY, tracker);
+            }
+
             container.addEndpoint(endpointConfig);
         } catch (DeploymentException e) {
             getLogger().error("Error deploying Vite websocket proxy endpoint",
@@ -93,11 +125,31 @@ public class ViteWebsocketEndpoint extends Endpoint {
 
         ViteHandler viteHandler = (ViteHandler) config.getUserProperties()
                 .get(VITE_HANDLER);
-        ViteWebsocketProxy proxy;
+
+        String httpSessionId = (String) config.getUserProperties()
+                .get(HTTP_SESSION_ID);
+        ViteSessionTracker tracker = (ViteSessionTracker) config
+                .getUserProperties().get(TRACKER_KEY);
+        if (tracker != null && httpSessionId != null) {
+            listenerRegistration = tracker
+                    .addListener((sessionId, closeCode, closeMessage) -> {
+                        if (sessionId.equals(httpSessionId)) {
+                            try {
+                                if (session.isOpen()) {
+                                    session.close(new CloseReason(
+                                            CloseCodes.getCloseCode(closeCode),
+                                            closeMessage));
+                                }
+                            } catch (IOException e) {
+                                getLogger().debug("Error closing session", e);
+                            }
+                        }
+                    });
+        }
+
         try {
             proxy = new ViteWebsocketProxy(session, viteHandler.getPort(),
                     viteHandler.getPathToVaadin());
-            proxies.put(session.getId(), proxy);
             session.addMessageHandler(proxy);
         } catch (Exception e) {
             getLogger().error("Error creating Vite proxy connection", e);
@@ -113,7 +165,11 @@ public class ViteWebsocketEndpoint extends Endpoint {
     public void onClose(Session session, CloseReason closeReason) {
         getLogger().debug("Browser ({}) closed the connection",
                 session.getId());
-        ViteWebsocketProxy proxy = proxies.remove(session.getId());
+
+        if (listenerRegistration != null) {
+            listenerRegistration.remove();
+        }
+
         if (proxy != null) {
             proxy.close();
         }


### PR DESCRIPTION
When a user logs out and the session is invalidated, the server closes WebSocket connections with close code 1008 (VIOLATED_POLICY). Vite detects this disconnection and starts polling for reconnection, then reloads the page - canceling any server-initiated redirect.

The fix uses a Promise-based synchronization between Vite's HMR events:

1. On vite:ws:connect, we register a close listener and store a Promise on the WebSocket that resolves with the close code when triggered.

2. On vite:ws:disconnect, we await this Promise to get the close code. Since Vite's notifyListeners awaits our async handler, this creates a synchronization point before Vite checks its willUnload flag.

3. When close code is 1008, we dispatch a beforeunload event to set Vite's internal willUnload flag, preventing the reload.

This approach works because Vite's close handler does not await the Promise returned by onMessage/handleMessage, so our async disconnect handler can complete (setting willUnload) before Vite's willUnload check runs.

Fixes #20819