### PR TITLE
fix: Set required Java version to 1.8 in flow-maven-plugin

### DIFF
--- a/flow-maven-plugin/pom.xml
+++ b/flow-maven-plugin/pom.xml
@@ -98,7 +98,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.5.2</version>
+                    <version>3.15.2</version>
                     <configuration>
                         <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                         <requiredJavaVersion>1.8</requiredJavaVersion>


### PR DESCRIPTION
Adapted from: https://github.com/vaadin/maven-plugin/pull/176