### PR TITLE
fix: Set required Java and Maven versions in flow-maven-plugin

### DIFF
--- a/flow-plugins/flow-maven-plugin/pom.xml
+++ b/flow-plugins/flow-maven-plugin/pom.xml
@@ -83,6 +83,8 @@
           <configuration>
             <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
             <goalPrefix>flow</goalPrefix>
+            <requiredJavaVersion>${maven.compiler.release}</requiredJavaVersion>
+            <requiredMavenVersion>3.8</requiredMavenVersion>
           </configuration>
           <executions>
             <execution>


### PR DESCRIPTION
Prevents potential issues with Maven versions >= 3.9.12 if a Java version newer than the supported one is used to package the Maven plugin.
