### PR TITLE
fix: Set required Java and Maven versions in flow-maven-plugin (24.10)

### DIFF
--- a/flow-plugins/flow-maven-plugin/pom.xml
+++ b/flow-plugins/flow-maven-plugin/pom.xml
@@ -80,10 +80,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.15.1</version>
+                    <version>3.15.2</version>
                     <configuration>
                         <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                         <goalPrefix>flow</goalPrefix>
+                        <requiredMavenVersion>3.5</requiredMavenVersion>
+                        <requiredJavaVersion>${maven.compiler.release}</requiredJavaVersion>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
Prevents potential issues with Maven versions >= 3.9.12 if a Java version newer than the supported one is used to package the Maven plugin.
