### PR TITLE
fix: Set required Java and Maven versions in flow-maven-plugin (23.7)

### DIFF
--- a/flow-plugins/flow-maven-plugin/pom.xml
+++ b/flow-plugins/flow-maven-plugin/pom.xml
@@ -91,9 +91,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.7.0</version>
+                    <version>3.15.2</version>
                     <configuration>
                         <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+                        <goalPrefix>flow</goalPrefix>
+                        <requiredJavaVersion>${maven.compiler.release}</requiredJavaVersion>
+                        <requiredMavenVersion>3.5</requiredMavenVersion>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
Prevents potential issues with Maven versions >= 3.9.12 if a Java version newer than the supported one is used to package the Maven plugin.
