### PR TITLE
fix: Pass javaResourceFolder to Options in DevModeInitializer

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
@@ -225,7 +225,8 @@ public class DevModeInitializer implements Serializable {
                 .withFrontendDirectory(frontendFolder)
                 .withFrontendGeneratedFolder(
                         new File(frontendFolder + FrontendUtils.GENERATED))
-                .withBuildDirectory(config.getBuildFolder());
+                .withBuildDirectory(config.getBuildFolder())
+                .setJavaResourceFolder(config.getJavaResourceFolder());
 
         log().info("Starting dev-mode updaters in {} folder.",
                 options.getNpmFolder());


### PR DESCRIPTION
DevModeInitializer was creating an Options object without setting javaResourceFolder, causing TaskUpdateSettingsFile to overwrite it with an empty string. This broke legacy theme component styles in Gradle dev mode because the Vite theme plugin couldn't find vaadin-featureflags.properties in the correct location.

Fixes #23438
