### PR TITLE
chore: Update PushHandler log messages with current issue link

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PushHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PushHandler.java
@@ -477,13 +477,13 @@ public class PushHandler {
                     getLogger()
                             .debug("Could not get UI. This should never happen,"
                                     + " except when reloading in Firefox and Chrome -"
-                                    + " see http://dev.vaadin.com/ticket/14251.");
+                                    + " see https://github.com/vaadin/framework/issues/5449.");
                     return session;
                 } else {
                     getLogger().info(
                             "No UI was found based on data in the request,"
                                     + " but a slower lookup based on the AtmosphereResource succeeded."
-                                    + " See http://dev.vaadin.com/ticket/14251 for more details.");
+                                    + " See https://github.com/vaadin/framework/issues/5449 for more details.");
                 }
             }
 


### PR DESCRIPTION
Updated PushHandler log messages to reference GitHub issues instead of old Trac issues.

As a more advanced fix someone might look for a better reference than a Vaadin 7.2.6 issue from 2016 to refer to here, but updating the links to their current location is at least a start.
