### PR TITLE
fix: Pass javaResourceFolder to Options in DevModeInitializer (#23440) (CP: 25.0)

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
@@ -226,7 +226,7 @@ public class DevModeInitializer implements Serializable {
                 .withFrontendDirectory(frontendFolder)
                 .withFrontendGeneratedFolder(
                         new File(frontendFolder + GENERATED))
-                .withBuildDirectory(config.getBuildFolder());
+                .withBuildDirectory(config.getBuildFolder())
                 .setJavaResourceFolder(config.getJavaResourceFolder());
 
         log().info("Starting dev-mode updaters in {} folder.",


### PR DESCRIPTION
DevModeInitializer was creating an Options object without setting javaResourceFolder, causing TaskUpdateSettingsFile to overwrite it with an empty string. This broke legacy theme component styles in Gradle dev mode because the Vite theme plugin couldn't find vaadin-featureflags.properties in the correct location.

Fixes #23438
