### PR TITLE
fix: Add junit-vintage-engine to flow-server to restore JUnit 4 test discovery

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -147,6 +147,12 @@
       <version>6.0.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>6.0.2</version>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
   <build>


### PR DESCRIPTION
The signals module merge (be2f0b2253) added JUnit 5 Jupiter dependencies to flow-server, causing Surefire to use the JUnit Platform provider which only discovers JUnit 5 tests. Without junit-vintage-engine, the ~271 JUnit 4 test classes were silently skipped.
