### PR TITLE
test: Clear leaked VaadinService state in CompositeTest setup

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/component/CompositeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/CompositeTest.java
@@ -21,7 +21,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import net.jcip.annotations.NotThreadSafe;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;


### PR DESCRIPTION
Replace assertNull with setCurrent(null) to actively clean any VaadinService leaked by a prior test, avoiding flaky failures when surefire test ordering varies between environments.
