### PR TITLE
fix: Update tailwind path

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -96,9 +96,6 @@ abstract class AbstractUpdateImports implements Runnable {
             .compile("^\\s*injectGlobalCss\\(([^,]+),.*$");
     private static final String INJECT_WC_CSS = "injectGlobalWebcomponentCss(%s);";
 
-    private static final String TAILWIND_IMPORT = "./"
-            + FrontendUtils.TAILWIND_JS;
-
     private static final String THEMABLE_MIXIN_IMPORT = "import { css, unsafeCSS, registerStyles } from '@vaadin/vaadin-themable-mixin';";
     private static final String REGISTER_STYLES_FOR_TEMPLATE = CSS_IMPORT_AND_MAKE_LIT_CSS
             + "%n" + "registerStyles('%s', $css_%1$d%s);";
@@ -148,7 +145,7 @@ abstract class AbstractUpdateImports implements Runnable {
         generatedFlowDefinitions = new File(
                 generatedFlowImports.getParentFile(),
                 FrontendUtils.IMPORTS_D_TS_NAME);
-        var generatedFolder = FrontendUtils
+        File generatedFolder = FrontendUtils
                 .getFrontendGeneratedFolder(options.getFrontendDirectory());
         appShellImports = new File(generatedFolder,
                 FrontendUtils.APP_SHELL_IMPORTS_NAME);
@@ -418,7 +415,13 @@ abstract class AbstractUpdateImports implements Runnable {
             appShellLines.addAll(appShellCssLines);
         }
         if (FrontendBuildUtils.isTailwindCssEnabled(options)) {
-            appShellLines.add(String.format(IMPORT_TEMPLATE, TAILWIND_IMPORT));
+            String importPath = "Frontend/"
+                    + options.getFrontendDirectory().toPath()
+                            .relativize(options.getFrontendGeneratedFolder()
+                                    .toPath())
+                            .toString()
+                    + "/" + FrontendUtils.TAILWIND_JS;
+            appShellLines.add(String.format(IMPORT_TEMPLATE, importPath));
         }
         files.put(appShellImports, appShellLines);
         files.put(appShellDefinitions, Collections.singletonList("export {}"));


### PR DESCRIPTION
Make the tailwind templat
import target not ./ but
from Frontend so we do not
get faulty imports in generated.

Fixes #23466
