### PR TITLE
fix: Handle BaseJsonNode type in WebComponentGenerator JS type mapping (24.10)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentGenerator.java
@@ -26,6 +26,7 @@ import java.util.Set;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.BaseJsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.io.IOUtils;
 
@@ -310,7 +311,8 @@ public class WebComponentGenerator {
                 || ArrayNode.class.isAssignableFrom(propertyData.getType())) {
             return "Array";
         } else if (JsonValue.class.isAssignableFrom(propertyData.getType())
-                || ObjectNode.class.isAssignableFrom(propertyData.getType())) {
+                || BaseJsonNode.class
+                        .isAssignableFrom(propertyData.getType())) {
             return "Object";
         } else {
             throw new IllegalStateException(


### PR DESCRIPTION
Use BaseJsonNode.class.isAssignableFrom() in getJSTypeName() to match the approach already used in getDefaultJsValue(), so that properties added via addProperty with a Jackson ObjectNode default value are correctly mapped to the "Object" JS type.

Fixes #23488