### PR TITLE
fix: Update tailwind path (#23481)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -412,7 +412,7 @@ abstract class AbstractUpdateImports implements Runnable {
             appShellLines.add(IMPORT_INJECT);
             appShellLines.addAll(appShellCssLines);
         }
-        if (FrontendBuildUtils.isTailwindCssEnabled(options)) {
+        if (FrontendUtils.isTailwindCssEnabled(options)) {
             String importPath = "Frontend/"
                     + options.getFrontendDirectory().toPath()
                             .relativize(options.getFrontendGeneratedFolder()


### PR DESCRIPTION
Make the tailwind templat
import target not ./ but
from Frontend so we do not
get faulty imports in generated.

Fixes #23466
