### PR TITLE
fix: restore backwards-compatible 2-parameter constructors for BlurEvent and FocusEvent

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/BlurNotifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/BlurNotifier.java
@@ -72,9 +72,28 @@ public interface BlurNotifier<T extends Component> extends Serializable {
          *            side, <code>false</code> otherwise
          * @see ComponentEvent
          */
+        public BlurEvent(C source, boolean fromClient) {
+            super(source, fromClient);
+        }
+
+        /**
+         * BlurEvent constructor with event data for tracking whether the blur
+         * originated from a client-side interaction.
+         *
+         * @param source
+         *            the source component
+         * @param fromClient
+         *            <code>true</code> if the event originated from the client
+         *            side, <code>false</code> otherwise
+         * @param eventFromClient
+         *            value read from
+         *            {@code event.target._nextBlurIsFromClient}, overrides
+         *            {@code fromClient} when non-null
+         * @see ComponentEvent
+         */
         public BlurEvent(C source, boolean fromClient,
                 @EventData("event.target._nextBlurIsFromClient") Boolean eventFromClient) {
-            super(source,
+            this(source,
                     eventFromClient != null ? eventFromClient : fromClient);
         }
     }

--- a/flow-server/src/main/java/com/vaadin/flow/component/FocusNotifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/FocusNotifier.java
@@ -72,9 +72,28 @@ public interface FocusNotifier<T extends Component> extends Serializable {
          *            side, <code>false</code> otherwise
          * @see ComponentEvent
          */
+        public FocusEvent(C source, boolean fromClient) {
+            super(source, fromClient);
+        }
+
+        /**
+         * FocusEvent constructor with event data for tracking whether the focus
+         * originated from a client-side interaction.
+         *
+         * @param source
+         *            the source component
+         * @param fromClient
+         *            <code>true</code> if the event originated from the client
+         *            side, <code>false</code> otherwise
+         * @param eventFromClient
+         *            value read from
+         *            {@code event.target._nextFocusIsFromClient}, overrides
+         *            {@code fromClient} when non-null
+         * @see ComponentEvent
+         */
         public FocusEvent(C source, boolean fromClient,
                 @EventData("event.target._nextFocusIsFromClient") Boolean eventFromClient) {
-            super(source,
+            this(source,
                     eventFromClient != null ? eventFromClient : fromClient);
         }
     }


### PR DESCRIPTION
The 3-parameter constructors with @EventData broke backwards compatibility for code that directly instantiates these events. Re-add the original (Component, boolean) constructors alongside the @EventData variants, matching the pattern used by ClickEvent, KeyDownEvent, etc.
