### PR TITLE
test: fix flaky test in PublicResourcesLiveUpdaterTest

### DIFF
--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/PublicResourcesLiveUpdaterTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/PublicResourcesLiveUpdaterTest.java
@@ -369,11 +369,11 @@ public class PublicResourcesLiveUpdaterTest {
                 // Wait until the non-Lumo URL is processed (bundled at least
                 // once)
                 Awaitility.await().untilAsserted(() -> {
-                    Mockito.verify(bundler, Mockito.times(1))
+                    Mockito.verify(bundler, Mockito.atLeastOnce())
                             .bundle(eq("/css/app.css"), anyString());
-                    Mockito.verify(bundler, Mockito.times(1))
+                    Mockito.verify(bundler, Mockito.atLeastOnce())
                             .bundle(eq("context://css/app.css"), anyString());
-                    Mockito.verify(bundler, Mockito.times(1))
+                    Mockito.verify(bundler, Mockito.atLeastOnce())
                             .bundle(eq("base://css/app.css"), anyString());
                 });
 


### PR DESCRIPTION
The test expected the file watcher to be engaged once when a CSS file is created, but actually it gets two events (CREATE and MODIFY).
This change updates the verification to expect at least one call instead of exactly one.
