### PR TITLE
chore: Switch NullAway from AnnotatedPackages to OnlyNullMarked mode

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -207,7 +207,7 @@
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
                 <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
                 <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
-                <arg>-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NullAway:ERROR -XepOpt:NullAway:AnnotatedPackages=com.vaadin.flow.signals -XepOpt:NullAway:JSpecifyMode=true</arg>
+                <arg>-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NullAway:ERROR -XepOpt:NullAway:JSpecifyMode=true -XepOpt:NullAway:OnlyNullMarked=true</arg>
               </compilerArgs>
               <annotationProcessorPaths>
                 <path>


### PR DESCRIPTION
This enables NullAway to automatically check any package that has @NullMarked in its package-info.java, instead of requiring an explicit package list in the pom.xml configuration. No functional change since the signals packages already have @NullMarked annotations.
