### PR TITLE
feat: remove ComponentEffect#bindChildren usage

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentEffect.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentEffect.java
@@ -16,15 +16,10 @@
 package com.vaadin.flow.component;
 
 import java.io.Serializable;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
-import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementEffect;
 import com.vaadin.flow.function.SerializableBiConsumer;
 import com.vaadin.flow.function.SerializableFunction;
@@ -177,6 +172,7 @@ public final class ComponentEffect implements Serializable {
      * @throws IllegalStateException
      *             thrown if parent component isn't empty
      */
+    @Deprecated(forRemoval = true)
     public static <T, S extends Signal<T>, P extends Component & HasComponents> Registration bindChildren(
             P parent, Signal<List<S>> list,
             SerializableFunction<S, Component> childFactory) {
@@ -184,7 +180,7 @@ public final class ComponentEffect implements Serializable {
         Objects.requireNonNull(list, "List signal cannot be null");
         Objects.requireNonNull(childFactory,
                 "Child component factory cannot be null");
-        return bindChildren(parent, parent.getElement(), list,
+        return ElementEffect.bindChildren(parent.getElement(), list,
                 // wrap childFactory to convert Component to Element
                 signalValue -> Optional
                         .ofNullable(childFactory.apply(signalValue))
@@ -193,211 +189,9 @@ public final class ComponentEffect implements Serializable {
                                 "ComponentEffect.bindChildren childFactory must not return null")));
     }
 
-    private static <T, S extends Signal<T>> Registration bindChildren(
-            Component parentComponent, Element parent, Signal<List<S>> list,
-            SerializableFunction<S, Element> childFactory) {
-        Objects.requireNonNull(parentComponent,
-                "Parent component cannot be null");
-        Objects.requireNonNull(parent, "Parent element cannot be null");
-        Objects.requireNonNull(list, "List signal cannot be null");
-        Objects.requireNonNull(childFactory,
-                "Child element factory cannot be null");
-
-        if (parent.getChildCount() > 0) {
-            throw new IllegalStateException(
-                    "Parent element must not have children when binding a list signal to it");
-        }
-        // Create a child element cache outside the effect to persist elements
-        // created by the child factory and avoid recreating them each time the
-        // effect runs due to signal changes.
-        HashMap<S, Element> valueSignalToChildCache = new HashMap<>();
-
-        return Effect.effect(parentComponent,
-                () -> runEffect(new BindChildrenEffectContext<T, S>(parent,
-                        list.get(), childFactory, valueSignalToChildCache)));
-    }
-
-    private static <T, S extends Signal<T>> void runEffect(
-            BindChildrenEffectContext<T, S> context) {
-        // Cache the children to avoid multiple traversals
-        LinkedList<Element> remainingChildren = context
-                .parentChildrenToLinkedList();
-        // Cache the children in a HashSet for O(1) lookups and removals
-        HashSet<Element> remainingChildrenSet = new HashSet<>(
-                remainingChildren);
-
-        if (remainingChildren.size() != context.getCachedChildrenSize()) {
-            throw new IllegalStateException(
-                    "Parent element must have children matching the list signal. Unexpected child count: "
-                            + remainingChildren.size() + ", expected: "
-                            + context.getCachedChildrenSize());
-        }
-        removeNotPresentChildren(context, remainingChildrenSet);
-        updateByChildSignals(context, remainingChildren, remainingChildrenSet);
-
-        // Final validation to ensure no unexpected children are present. This
-        // will catch also wrong order and is run as a last to avoid running
-        // expensive validation in middle of the effect.
-        validate(context);
-    }
-
     private void close() {
         elementEffect.close();
         elementEffect = null;
     }
 
-    /**
-     * Validate that parent element has no children not belonging to the list of
-     * child signals.
-     */
-    private static <T, S extends Signal<T>> void validate(
-            BindChildrenEffectContext<T, S> context) {
-        LinkedList<Element> children = context.parentChildrenToLinkedList();
-        int index = 0;
-        for (Element actualElement : children) {
-            if (index >= context.childSignalsList.size()) {
-                throw new IllegalStateException(String.format(
-                        "Parent element must have children matching the list signal. Unexpected child at index %1$s: %2$s, expected: %3$s",
-                        index, actualElement, "none"));
-            }
-            Element expectedElement = context.valueSignalToChildCache
-                    .get(context.childSignalsList.get(index));
-            if (!Objects.equals(actualElement, expectedElement)) {
-                throw new IllegalStateException(String.format(
-                        "Parent element must have children matching the list signal. Unexpected child at index %1$s: %2$s, expected: %3$s",
-                        index, actualElement, expectedElement));
-            }
-            index++;
-        }
-        if (children.size() > context.getCachedChildrenSize()) {
-            throw new IllegalStateException(String.format(
-                    "Parent element must have children matching the list signal. Too many children: %1$s, expected: %2$s",
-                    children.size(), context.getCachedChildrenSize()));
-        }
-    }
-
-    /**
-     * Remove all existing children in valueSignalToChildCache map that are no
-     * longer present in the list of child signals.
-     */
-    private static <T, S extends Signal<T>> void removeNotPresentChildren(
-            BindChildrenEffectContext<T, S> context,
-            HashSet<Element> remainingChildrenSet) {
-        var toRemove = new HashSet<>(context.valueSignalToChildCache.keySet());
-        context.childSignalsList.forEach(toRemove::remove);
-        for (S removedItem : toRemove) {
-            Element element = context.valueSignalToChildCache
-                    .remove(removedItem);
-            element.removeFromParent();
-            remainingChildrenSet.remove(element);
-        }
-    }
-
-    /**
-     * Align parent element children with the list of child signals without
-     * removing any existing elements. Creates new elements with the element
-     * factory if not found from the cache.
-     */
-    private static <T, S extends Signal<T>> void updateByChildSignals(
-            BindChildrenEffectContext<T, S> context,
-            LinkedList<Element> remainingChildren,
-            HashSet<Element> remainingChildrenSet) {
-
-        for (int i = 0; i < context.childSignalsList.size(); i++) {
-            S item = context.childSignalsList.get(i);
-
-            Element expectedChild = context.getElement(item);
-            if (remainingChildrenSet.isEmpty() || !Objects
-                    .equals(expectedChild.getParent(), context.parentElement)) {
-                context.parentElement.insertChild(i, expectedChild);
-                continue;
-            }
-
-            // Use LinkedList for order
-            Element actualChild = remainingChildren.pollFirst();
-            // Skip children that have been removed already
-            while (actualChild != null
-                    && !remainingChildrenSet.contains(actualChild)) {
-                actualChild = remainingChildren.pollFirst();
-            }
-            if (actualChild == null) {
-                continue;
-            }
-            if (!Objects.equals(actualChild, expectedChild)) {
-                /*
-                 * A mismatch has been encountered and we need to adjust the
-                 * component children to match the expected order. This
-                 * algorithm optimized for cases where only a single item has
-                 * been moved to a new location and accepts that we might do
-                 * redundant operations in other cases.
-                 */
-                if (Objects.equals(expectedChild, remainingChildren.peek())) {
-                    // Move actual child to a later position
-                    // Remove from current pos. Will be added back later
-                    actualChild.removeFromParent();
-
-                    // Skip next child since that's the expected child
-                    remainingChildren.pollFirst();
-                } else {
-                    // Move expected child from a later position
-                    context.parentElement.insertChild(i, expectedChild);
-
-                    remainingChildrenSet.remove(expectedChild);
-
-                    // Restore previous actual child for next round
-                    remainingChildren.addFirst(actualChild);
-                }
-            }
-        }
-    }
-
-    /**
-     * Record for {@link #bindChildren(Component, Signal, SerializableFunction)}
-     * effect to update children of a parent element according to a list of
-     * child signals.
-     *
-     * @param parentElement
-     *            parent element to update children for
-     * @param childSignalsList
-     *            list of child signals to update by
-     * @param childElementFactory
-     *            factory to create new child element
-     * @param valueSignalToChildCache
-     *            map to store existing child elements by value signal
-     * @param <T>
-     *            the value type of the list signal to update by
-     * @param <S>
-     *            the type of the signal in the list
-     */
-    private record BindChildrenEffectContext<T, S extends Signal<T>>(
-            Element parentElement, List<S> childSignalsList,
-            SerializableFunction<S, Element> childElementFactory,
-            HashMap<S, Element> valueSignalToChildCache)
-            implements
-                Serializable {
-
-        /**
-         * Return existing element or generate new by child element factory.
-         *
-         * @throws IllegalStateException
-         *             if child factory adds or removes unexpected child
-         */
-        private Element getElement(S item) {
-            return valueSignalToChildCache.computeIfAbsent(item,
-                    childElementFactory);
-        }
-
-        /**
-         * Returns size of the <code>valueSignalToChildCache</code> map holding
-         * cached child elements by value signal.
-         */
-        private int getCachedChildrenSize() {
-            return valueSignalToChildCache.size();
-        }
-
-        private LinkedList<Element> parentChildrenToLinkedList() {
-            return parentElement.getChildren()
-                    .collect(Collectors.toCollection(LinkedList::new));
-        }
-    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasComponents.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasComponents.java
@@ -20,10 +20,12 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.ElementEffect;
 import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.internal.nodefeature.SignalBindingFeature;
 import com.vaadin.flow.signals.BindingActiveException;
@@ -242,8 +244,6 @@ public interface HasComponents extends HasElement, HasEnabled {
      *             thrown if this component isn't empty
      * @throws BindingActiveException
      *             thrown if a binding for children already exists
-     * @see ComponentEffect#bindChildren(Component, Signal,
-     *      SerializableFunction)
      */
     default <T, S extends Signal<T>> void bindChildren(Signal<List<S>> list,
             SerializableFunction<S, Component> childFactory) {
@@ -256,7 +256,14 @@ public interface HasComponents extends HasElement, HasEnabled {
         Objects.requireNonNull(list, "Signal cannot be null");
         Objects.requireNonNull(childFactory,
                 "Child component factory cannot be null");
-        var binding = ComponentEffect.bindChildren(self, list, childFactory);
+        var binding = ElementEffect.bindChildren(self.getElement(), list,
+                // wrap childFactory to convert Component to Element
+                signalValue -> Optional
+                        .ofNullable(childFactory.apply(signalValue))
+                        .map(Component::getElement)
+                        .orElseThrow(() -> new IllegalStateException(
+                                "HasComponents.bindChildren childFactory must not return null")));
+
         feature.setBinding(SignalBindingFeature.CHILDREN, binding, list);
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/dom/ElementEffect.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/ElementEffect.java
@@ -16,13 +16,19 @@
 package com.vaadin.flow.dom;
 
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.UIDetachedException;
 import com.vaadin.flow.function.SerializableBiConsumer;
+import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.function.SerializableRunnable;
 import com.vaadin.flow.server.ErrorEvent;
 import com.vaadin.flow.shared.Registration;
@@ -193,5 +199,245 @@ public final class ElementEffect implements Serializable {
     public void close() {
         disableEffect();
         closed = true;
+    }
+
+    /**
+     * Binds a list signal containing child signals to a parent component using
+     * a child component factory. Each signal in the list corresponds to a child
+     * component within the parent.
+     * <p>
+     * The parent component is automatically updated to reflect the structure of
+     * the list signal. Changes to the list, such as additions, removals, or
+     * reordering, will update the parent's children accordingly.
+     * <p>
+     * The parent component must not contain any children that are not part of
+     * the list signal. If the parent has existing children when this method is
+     * called, or if it contains unrelated children after the list changes, an
+     * {@link IllegalStateException} will be thrown.
+     * <p>
+     * New child components are created using the provided
+     * <code>childFactory</code> function. This function takes a signal from the
+     * list and returns a corresponding {@link Component}. It shouldn't return
+     * <code>null</code>. The signal can be further bound to the returned
+     * component as needed. Note that <code>childFactory</code> is run inside a
+     * {@link Effect}, and therefore {@link Signal#get()} calls makes effect
+     * re-run automatically on signal value change.
+     * <p>
+     *
+     * @param parentElement
+     *            target parent element, must not be <code>null</code>
+     * @param list
+     *            list signal to bind to the parent, must not be
+     *            <code>null</code>
+     * @param childFactory
+     *            factory to create new element, must not be <code>null</code>
+     * @param <T>
+     *            the value type of the {@link Signal}s in the list
+     * @param <S>
+     *            the type of the {@link Signal}s in the list
+     * @throws IllegalStateException
+     *             thrown if parent element isn't empty
+     */
+    public static <T, S extends Signal<T>> Registration bindChildren(
+            Element parentElement, Signal<List<S>> list,
+            SerializableFunction<S, Element> childFactory) {
+        Objects.requireNonNull(parentElement, "Parent element cannot be null");
+        Objects.requireNonNull(parentElement, "Parent element cannot be null");
+        Objects.requireNonNull(list, "List signal cannot be null");
+        Objects.requireNonNull(childFactory,
+                "Child element factory cannot be null");
+
+        if (parentElement.getChildCount() > 0) {
+            throw new IllegalStateException(
+                    "Parent element must not have children when binding a list signal to it");
+        }
+        // Create a child element cache outside the effect to persist elements
+        // created by the child factory and avoid recreating them each time the
+        // effect runs due to signal changes.
+        HashMap<S, Element> valueSignalToChildCache = new HashMap<>();
+
+        return new ElementEffect(parentElement,
+                () -> runEffect(new BindChildrenEffectContext<T, S>(
+                        parentElement, list.get(), childFactory,
+                        valueSignalToChildCache)))::close;
+    }
+
+    private static <T, S extends Signal<T>> void runEffect(
+            BindChildrenEffectContext<T, S> context) {
+        // Cache the children to avoid multiple traversals
+        LinkedList<Element> remainingChildren = context
+                .parentChildrenToLinkedList();
+        // Cache the children in a HashSet for O(1) lookups and removals
+        HashSet<Element> remainingChildrenSet = new HashSet<>(
+                remainingChildren);
+
+        if (remainingChildren.size() != context.getCachedChildrenSize()) {
+            throw new IllegalStateException(
+                    "Parent element must have children matching the list signal. Unexpected child count: "
+                            + remainingChildren.size() + ", expected: "
+                            + context.getCachedChildrenSize());
+        }
+        removeNotPresentChildren(context, remainingChildrenSet);
+        updateByChildSignals(context, remainingChildren, remainingChildrenSet);
+
+        // Final validation to ensure no unexpected children are present. This
+        // will catch also wrong order and is run as a last to avoid running
+        // expensive validation in middle of the effect.
+        validate(context);
+    }
+
+    /**
+     * Validate that parent element has no children not belonging to the list of
+     * child signals.
+     */
+    private static <T, S extends Signal<T>> void validate(
+            BindChildrenEffectContext<T, S> context) {
+        LinkedList<Element> children = context.parentChildrenToLinkedList();
+        int index = 0;
+        for (Element actualElement : children) {
+            if (index >= context.childSignalsList.size()) {
+                throw new IllegalStateException(String.format(
+                        "Parent element must have children matching the list signal. Unexpected child at index %1$s: %2$s, expected: %3$s",
+                        index, actualElement, "none"));
+            }
+            Element expectedElement = context.valueSignalToChildCache
+                    .get(context.childSignalsList.get(index));
+            if (!Objects.equals(actualElement, expectedElement)) {
+                throw new IllegalStateException(String.format(
+                        "Parent element must have children matching the list signal. Unexpected child at index %1$s: %2$s, expected: %3$s",
+                        index, actualElement, expectedElement));
+            }
+            index++;
+        }
+        if (children.size() > context.getCachedChildrenSize()) {
+            throw new IllegalStateException(String.format(
+                    "Parent element must have children matching the list signal. Too many children: %1$s, expected: %2$s",
+                    children.size(), context.getCachedChildrenSize()));
+        }
+    }
+
+    /**
+     * Remove all existing children in valueSignalToChildCache map that are no
+     * longer present in the list of child signals.
+     */
+    private static <T, S extends Signal<T>> void removeNotPresentChildren(
+            BindChildrenEffectContext<T, S> context,
+            HashSet<Element> remainingChildrenSet) {
+        var toRemove = new HashSet<>(context.valueSignalToChildCache.keySet());
+        context.childSignalsList.forEach(toRemove::remove);
+        for (S removedItem : toRemove) {
+            Element element = context.valueSignalToChildCache
+                    .remove(removedItem);
+            element.removeFromParent();
+            remainingChildrenSet.remove(element);
+        }
+    }
+
+    /**
+     * Align parent element children with the list of child signals without
+     * removing any existing elements. Creates new elements with the element
+     * factory if not found from the cache.
+     */
+    private static <T, S extends Signal<T>> void updateByChildSignals(
+            BindChildrenEffectContext<T, S> context,
+            LinkedList<Element> remainingChildren,
+            HashSet<Element> remainingChildrenSet) {
+
+        for (int i = 0; i < context.childSignalsList.size(); i++) {
+            S item = context.childSignalsList.get(i);
+
+            Element expectedChild = context.getElement(item);
+            if (remainingChildrenSet.isEmpty() || !Objects
+                    .equals(expectedChild.getParent(), context.parentElement)) {
+                context.parentElement.insertChild(i, expectedChild);
+                continue;
+            }
+
+            // Use LinkedList for order
+            Element actualChild = remainingChildren.pollFirst();
+            // Skip children that have been removed already
+            while (actualChild != null
+                    && !remainingChildrenSet.contains(actualChild)) {
+                actualChild = remainingChildren.pollFirst();
+            }
+            if (actualChild == null) {
+                continue;
+            }
+            if (!Objects.equals(actualChild, expectedChild)) {
+                /*
+                 * A mismatch has been encountered and we need to adjust the
+                 * component children to match the expected order. This
+                 * algorithm optimized for cases where only a single item has
+                 * been moved to a new location and accepts that we might do
+                 * redundant operations in other cases.
+                 */
+                if (Objects.equals(expectedChild, remainingChildren.peek())) {
+                    // Move actual child to a later position
+                    // Remove from current pos. Will be added back later
+                    actualChild.removeFromParent();
+
+                    // Skip next child since that's the expected child
+                    remainingChildren.pollFirst();
+                } else {
+                    // Move expected child from a later position
+                    context.parentElement.insertChild(i, expectedChild);
+
+                    remainingChildrenSet.remove(expectedChild);
+
+                    // Restore previous actual child for next round
+                    remainingChildren.addFirst(actualChild);
+                }
+            }
+        }
+    }
+
+    /**
+     * Record for {@link #bindChildren(Element, Signal, SerializableFunction)}
+     * effect to update children of a parent element according to a list of
+     * child signals.
+     *
+     * @param parentElement
+     *            parent element to update children for
+     * @param childSignalsList
+     *            list of child signals to update by
+     * @param childElementFactory
+     *            factory to create new child element
+     * @param valueSignalToChildCache
+     *            map to store existing child elements by value signal
+     * @param <T>
+     *            the value type of the list signal to update by
+     * @param <S>
+     *            the type of the signal in the list
+     */
+    private record BindChildrenEffectContext<T, S extends Signal<T>>(
+            Element parentElement, List<S> childSignalsList,
+            SerializableFunction<S, Element> childElementFactory,
+            HashMap<S, Element> valueSignalToChildCache)
+            implements
+                Serializable {
+
+        /**
+         * Return existing element or generate new by child element factory.
+         *
+         * @throws IllegalStateException
+         *             if child factory adds or removes unexpected child
+         */
+        private Element getElement(S item) {
+            return valueSignalToChildCache.computeIfAbsent(item,
+                    childElementFactory);
+        }
+
+        /**
+         * Returns size of the <code>valueSignalToChildCache</code> map holding
+         * cached child elements by value signal.
+         */
+        private int getCachedChildrenSize() {
+            return valueSignalToChildCache.size();
+        }
+
+        private LinkedList<Element> parentChildrenToLinkedList() {
+            return parentElement.getChildren()
+                    .collect(Collectors.toCollection(LinkedList::new));
+        }
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentEffectTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentEffectTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.ElementEffect;
 import com.vaadin.flow.dom.Node;
 import com.vaadin.flow.internal.CurrentInstance;
 import com.vaadin.flow.server.ErrorEvent;
@@ -341,12 +342,10 @@ public class ComponentEffectTest {
         TestLayout parentComponent = new TestLayout();
         new MockUI();
 
-        assertThrows(NullPointerException.class, () -> ComponentEffect
-                .bindChildren(null, taskList, valueSignal -> null));
-        assertThrows(NullPointerException.class, () -> ComponentEffect
-                .bindChildren(parentComponent, null, valueSignal -> null));
-        assertThrows(NullPointerException.class, () -> ComponentEffect
-                .bindChildren(parentComponent, taskList, null));
+        assertThrows(NullPointerException.class,
+                () -> parentComponent.bindChildren(null, valueSignal -> null));
+        assertThrows(NullPointerException.class,
+                () -> parentComponent.bindChildren(taskList, null));
     }
 
     @Test
@@ -356,7 +355,7 @@ public class ComponentEffectTest {
                 String.class);
         TestLayout parentComponent = new TestLayout();
         new MockUI().add(parentComponent);
-        ComponentEffect.bindChildren(parentComponent, taskList,
+        parentComponent.bindChildren(taskList,
                 valueSignal -> new TestComponent(valueSignal.get()));
         assertEquals(0, parentComponent.getComponentCount());
     }
@@ -373,11 +372,10 @@ public class ComponentEffectTest {
 
         new MockUI().add(parentComponent);
         assertThrows(IllegalStateException.class, () -> {
-            ComponentEffect.bindChildren(parentComponent, taskList,
-                    valueSignal -> {
-                        fail("Should not call element factory");
-                        return null;
-                    });
+            parentComponent.bindChildren(taskList, valueSignal -> {
+                fail("Should not call element factory");
+                return null;
+            });
         });
         assertEquals(1, parentComponent.getComponentCount());
     }
@@ -393,7 +391,7 @@ public class ComponentEffectTest {
         var expectedComponent = new TestComponent();
         new MockUI().add(parentComponent);
 
-        ComponentEffect.bindChildren(parentComponent, taskList, valueSignal -> {
+        parentComponent.bindChildren(taskList, valueSignal -> {
             expectedComponent.setValue(valueSignal.get());
             return expectedComponent;
         });
@@ -415,7 +413,7 @@ public class ComponentEffectTest {
         TestLayout parentComponent = new TestLayout();
         new MockUI().add(parentComponent);
 
-        ComponentEffect.bindChildren(parentComponent, taskList,
+        parentComponent.bindChildren(taskList,
                 valueSignal -> new TestComponent(valueSignal.get()));
 
         assertEquals("Parent component children count is wrong", 1,
@@ -450,7 +448,7 @@ public class ComponentEffectTest {
         TestLayout parentComponent = new TestLayout();
         new MockUI().add(parentComponent);
 
-        ComponentEffect.bindChildren(parentComponent, taskList,
+        parentComponent.bindChildren(taskList,
                 valueSignal -> new TestComponent(valueSignal.get()));
 
         assertEquals("Parent component children count is wrong", 3,
@@ -489,7 +487,7 @@ public class ComponentEffectTest {
         TestLayout parentComponent = new TestLayout();
         new MockUI().add(parentComponent);
 
-        ComponentEffect.bindChildren(parentComponent, taskList,
+        parentComponent.bindChildren(taskList,
                 valueSignal -> new TestComponent(valueSignal.get()));
 
         assertEquals("Parent component children count is wrong", 3,
@@ -613,8 +611,9 @@ public class ComponentEffectTest {
 
         ui.add(parentComponent);
 
-        ComponentEffect.bindChildren(parentComponent, taskList,
-                valueSignal -> new TestComponent(valueSignal.get()));
+        ElementEffect.bindChildren(parentComponent.getElement(), taskList,
+                valueSignal -> new TestComponent(valueSignal.get())
+                        .getElement());
 
         var expectedComponent = new TestComponent("added directly");
         // doing wrong
@@ -655,8 +654,9 @@ public class ComponentEffectTest {
 
         ui.add(parentComponent);
 
-        ComponentEffect.bindChildren(parentComponent, taskList,
-                valueSignal -> new TestComponent(valueSignal.get()));
+        ElementEffect.bindChildren(parentComponent.getElement(), taskList,
+                valueSignal -> new TestComponent(valueSignal.get())
+                        .getElement());
 
         var directlyAddedComponent1 = new TestComponent("added directly 1");
         var directlyAddedComponent2 = new TestComponent("added directly 2");
@@ -706,7 +706,7 @@ public class ComponentEffectTest {
 
         ui.add(parentComponent);
 
-        ComponentEffect.bindChildren(parentComponent, taskList, valueSignal -> {
+        parentComponent.bindChildren(taskList, valueSignal -> {
             String value = valueSignal.get();
             var component = new TestComponent(value);
             if ("middle".equals(value)) {
@@ -754,7 +754,7 @@ public class ComponentEffectTest {
 
         ui.add(parentComponent);
 
-        ComponentEffect.bindChildren(parentComponent, taskList, valueSignal -> {
+        parentComponent.bindChildren(taskList, valueSignal -> {
             String value = valueSignal.get();
             var component = new TestComponent(value);
             if ("middle".equals(value)) {
@@ -805,7 +805,7 @@ public class ComponentEffectTest {
 
         ui.add(parentComponent);
 
-        ComponentEffect.bindChildren(parentComponent, taskList, valueSignal -> {
+        parentComponent.bindChildren(taskList, valueSignal -> {
             String value = valueSignal.get();
             var component = new TestComponent(value);
             component.getElement().setText(value);
@@ -845,7 +845,7 @@ public class ComponentEffectTest {
         TestLayout parentComponent = new TestLayout(expectedMockedElements);
         new MockUI().add(parentComponent);
 
-        ComponentEffect.bindChildren(parentComponent, taskList, valueSignal -> {
+        parentComponent.bindChildren(taskList, valueSignal -> {
             var component = new TestComponent(valueSignal.get(),
                     parentComponent.getElement(), null);
             expectedMockedElements.add(component.getElement());
@@ -891,8 +891,7 @@ public class ComponentEffectTest {
 
         ui.add(parentComponent);
 
-        ComponentEffect.bindChildren(parentComponent, taskList,
-                valueSignal -> null);
+        parentComponent.bindChildren(taskList, valueSignal -> null);
 
         ErrorEvent event = events.pollFirst();
 
@@ -900,7 +899,7 @@ public class ComponentEffectTest {
         assertEquals(IllegalStateException.class,
                 event.getThrowable().getClass());
         assertEquals(
-                "ComponentEffect.bindChildren childFactory must not return null",
+                "HasComponents.bindChildren childFactory must not return null",
                 event.getThrowable().getMessage());
     }
 
@@ -915,9 +914,10 @@ public class ComponentEffectTest {
         TestLayout parentComponent = new TestLayout();
         new MockUI().add(parentComponent);
 
-        Registration registration = ComponentEffect.bindChildren(
-                parentComponent, taskList,
-                valueSignal -> new TestComponent(valueSignal.get()));
+        Registration registration = ElementEffect.bindChildren(
+                parentComponent.getElement(), taskList,
+                valueSignal -> new TestComponent(valueSignal.get())
+                        .getElement());
 
         assertEquals("Parent should have initial children", 2,
                 parentComponent.getComponentCount());
@@ -957,7 +957,7 @@ public class ComponentEffectTest {
         TestLayout parentComponent = new TestLayout();
         new MockUI().add(parentComponent);
 
-        ComponentEffect.bindChildren(parentComponent, listSignal,
+        parentComponent.bindChildren(listSignal,
                 valueSignal -> new TestComponent(valueSignal.get()));
 
         assertEquals(1, parentComponent.getComponentCount());
@@ -994,7 +994,7 @@ public class ComponentEffectTest {
         TestLayout parentComponent = new TestLayout();
         new MockUI().add(parentComponent);
 
-        ComponentEffect.bindChildren(parentComponent, listSignal,
+        parentComponent.bindChildren(listSignal,
                 valueSignal -> new TestComponent(valueSignal.get()));
 
         parentComponent.getChildren().map(TestComponent.class::cast)


### PR DESCRIPTION
Deprecates ComponentEffect#bindChildren. Remove all calls to it by using HasComponents#bindChildren.

Part of #23534