### PR TITLE
Add @NullMarked to com.vaadin.flow.theme package

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/theme/package-info.java
+++ b/flow-server/src/main/java/com/vaadin/flow/theme/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+@NullMarked
+package com.vaadin.flow.theme;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
Enable NullAway compile-time null-safety checks for the theme package. No nullable annotations needed as the API is already null-safe.
