### PR TITLE
test: fix CDP WebSocket connection leaks in DevToolsWrapper

### DIFF
--- a/flow-test-util/src/main/java/com/vaadin/flow/testutil/ChromeDeviceTest.java
+++ b/flow-test-util/src/main/java/com/vaadin/flow/testutil/ChromeDeviceTest.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
@@ -32,6 +33,8 @@ import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.testcategory.ChromeTests;
 import com.vaadin.testbench.TestBench;
@@ -56,6 +59,8 @@ import com.vaadin.testbench.parallel.Browser;
  */
 @Category(ChromeTests.class)
 public class ChromeDeviceTest extends ViewOrUITest {
+    private static final Logger log = LoggerFactory
+            .getLogger(ChromeDeviceTest.class);
     private DevToolsWrapper devTools = null;
 
     protected DevToolsWrapper getDevTools() {
@@ -77,6 +82,11 @@ public class ChromeDeviceTest extends ViewOrUITest {
         if (Browser.CHROME == getRunLocallyBrowser()) {
             driver = new ChromeDriver(chromeOptions);
         } else {
+            // Temporary workaround for dev tools websocket connection errors
+            // in the CI environment.
+            log.warn(
+                    "Forcing Chrome 143.0 for tests using Selenium dev tools to avoid websocket connection issues in CI");
+            chromeOptions.setBrowserVersion("143.0");
             URL remoteURL = new URL(getHubURL());
             driver = new RemoteWebDriver(remoteURL, chromeOptions);
             setDevToolsRuntimeCapabilities((RemoteWebDriver) driver, remoteURL);
@@ -85,6 +95,11 @@ public class ChromeDeviceTest extends ViewOrUITest {
         devTools = new DevToolsWrapper(driver);
 
         setDriver(TestBench.createDriver(driver));
+    }
+
+    @After
+    public void closeDevTools() {
+        devTools.close();
     }
 
     /**

--- a/flow-test-util/src/main/java/com/vaadin/flow/testutil/DevToolsWrapper.java
+++ b/flow-test-util/src/main/java/com/vaadin/flow/testutil/DevToolsWrapper.java
@@ -30,13 +30,15 @@ import org.openqa.selenium.devtools.idealized.target.model.SessionID;
 import org.openqa.selenium.devtools.idealized.target.model.TargetID;
 import org.openqa.selenium.devtools.v142.network.Network;
 import org.openqa.selenium.remote.Augmenter;
-import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.http.ClientConfig;
 
 public class DevToolsWrapper {
     private final WebDriver driver;
     private final Duration timeout = Duration.ofSeconds(3);
     private final HashMap<TargetID, SessionID> attachedTargets = new HashMap<TargetID, SessionID>();
     private Connection connection = null;
+    private DevTools devTools = null;
+    private Domains domains = null;
 
     public DevToolsWrapper(WebDriver driver) {
         this.driver = driver;
@@ -70,9 +72,18 @@ public class DevToolsWrapper {
         sendToAllTargets(Network.setCacheDisabled(isDisabled));
     }
 
+    public void close() {
+        if (devTools != null) {
+            devTools.close();
+        }
+        if (connection != null) {
+            connection.close();
+        }
+    }
+
     /**
      * Creates a custom DevTools CDP connection if there is not one yet.
-     *
+     * <p>
      * Note, there is already a CDP connection provided by {@link DevTools} but
      * it allows sending commands only to the page session whereas we need to
      * also send commands to service workers. Therefore a custom connection is
@@ -80,7 +91,8 @@ public class DevToolsWrapper {
      */
     private void createConnectionIfThereIsNotOne() {
         if (connection == null) {
-            connection = SeleniumCdpConnection.create(driver).get();
+            connection = SeleniumCdpConnection
+                    .create(driver, ClientConfig.defaultConfig()).get();
         }
     }
 
@@ -88,9 +100,9 @@ public class DevToolsWrapper {
      * Attaches to all the available targets by creating a session per each.
      * These sessions can be later used for sending commands to the
      * corresponding targets.
-     *
+     * <p>
      * Every target represents a certain browser page, service worker and etc.
-     *
+     * <p>
      * Read more about targets and sessions here:
      * https://github.com/aslushnikov/getting-started-with-cdp#targets--sessions
      */
@@ -100,8 +112,9 @@ public class DevToolsWrapper {
         connection
                 .sendAndWait(null, getDomains().target().getTargets(), timeout)
                 .stream()
-                .filter((target) -> !attachedTargets
-                        .containsKey(target.getTargetId()))
+                .filter((target) -> attachedTargets.keySet().stream()
+                        .noneMatch(t -> t.toString()
+                                .equals(target.getTargetId().toString())))
                 .forEach((target) -> {
                     TargetID targetId = target.getTargetId();
                     SessionID sessionId = connection.sendAndWait(null,
@@ -123,12 +136,17 @@ public class DevToolsWrapper {
     }
 
     private DevTools getDevTools() {
-        WebDriver driver = new Augmenter()
-                .augment((RemoteWebDriver) this.driver);
-        return ((HasDevTools) driver).getDevTools();
+        if (devTools == null) {
+            WebDriver augmented = new Augmenter().augment(this.driver);
+            devTools = ((HasDevTools) augmented).getDevTools();
+        }
+        return devTools;
     }
 
     private Domains getDomains() {
-        return getDevTools().getDomains();
+        if (domains == null) {
+            domains = getDevTools().getDomains();
+        }
+        return domains;
     }
 }


### PR DESCRIPTION
Cache DevTools and Domains instances with lazy initialization so only
one CDP WebSocket is opened per wrapper lifetime, instead of creating
a new Augmenter and connection on every call to getDevTools()/getDomains().

Add close() method to DevToolsWrapper and call it from an `@After` hook
in ChromeDeviceTest to ensure the WebSocket is properly closed after
each test.

Fix TargetID filtering in attachToTargets() to compare by string value
instead of object identity, which could cause duplicate session
attachments.

Pass ClientConfig.defaultConfig() to SeleniumCdpConnection.create()
for correct connection configuration.

Pin Chrome 143.0 for remote Grid tests as a temporary workaround for
CDP WebSocket connection issues in CI.