### PR TITLE
fix: use raw request URI for baseHref calculation to support encoded slashes (#23569) (CP: 24.10)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/BootstrapHandlerHelper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/BootstrapHandlerHelper.java
@@ -25,8 +25,10 @@ import jakarta.servlet.ServletRegistration;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.HandlerHelper;
 import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.server.VaadinServletService;
 import com.vaadin.flow.server.VaadinSession;
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * Helper methods for use in bootstrapping.
@@ -54,10 +56,44 @@ public final class BootstrapHandlerHelper implements Serializable {
             /*
              * Make a relative URL to the servlet by adding one ../ for each
              * path segment in pathInfo (i.e. the part of the requested path
-             * that comes after the servlet mapping)
+             * that comes after the servlet mapping).
+             *
+             * Use the raw (percent-encoded) path from the request URI to count
+             * segments so that encoded slashes (%2F) in wildcard route
+             * parameters are not mistaken for path separators.
              */
-            return HandlerHelper.getCancelingRelativePath(pathInfo);
+            String rawPathInfo = getRawPathInfo(vaadinRequest);
+            return HandlerHelper.getCancelingRelativePath(
+                    rawPathInfo != null ? rawPathInfo : pathInfo);
         }
+    }
+
+    /**
+     * Returns the raw (percent-encoded) path info by stripping the context path
+     * and servlet path from the request URI. This preserves encoded characters
+     * like {@code %2F} that would be decoded in
+     * {@link HttpServletRequest#getPathInfo()}.
+     *
+     * @param vaadinRequest
+     *            the request
+     * @return the raw path info, or {@code null} if it cannot be determined
+     */
+    private static String getRawPathInfo(VaadinRequest vaadinRequest) {
+        if (vaadinRequest instanceof VaadinServletRequest servletRequest) {
+            HttpServletRequest httpRequest = servletRequest
+                    .getHttpServletRequest();
+            String requestURI = httpRequest.getRequestURI();
+            String contextPath = httpRequest.getContextPath();
+            String servletPath = httpRequest.getServletPath();
+            if (requestURI != null && contextPath != null
+                    && servletPath != null) {
+                int prefixLength = contextPath.length() + servletPath.length();
+                if (requestURI.length() >= prefixLength) {
+                    return requestURI.substring(prefixLength);
+                }
+            }
+        }
+        return null;
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/internal/BootstrapHandlerHelperTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/BootstrapHandlerHelperTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.internal;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.server.VaadinServletRequest;
+import com.vaadin.flow.server.VaadinServletService;
+
+import static org.junit.Assert.assertEquals;
+
+public class BootstrapHandlerHelperTest {
+
+    @Test
+    public void getServiceUrl_nullPathInfo_returnsDot() {
+        VaadinServletRequest request = createRequest(null, "", "/", "");
+        assertEquals(".", BootstrapHandlerHelper.getServiceUrl(request));
+    }
+
+    @Test
+    public void getServiceUrl_simplePath_returnsCorrectRelativePath() {
+        VaadinServletRequest request = createRequest("/some/path", "",
+                "/some/path", "");
+        assertEquals("./..", BootstrapHandlerHelper.getServiceUrl(request));
+    }
+
+    @Test
+    public void getServiceUrl_encodedSlashInPath_treatsAsOneSegment() {
+        // Simulates a wildcard route with %2F: /wild/a%2Fb
+        // getPathInfo() returns decoded /wild/a/b (2 slashes after root)
+        // but the raw URI has /wild/a%2Fb (1 slash after root)
+        // The baseHref should be ./.., not ./../..
+        VaadinServletRequest request = createRequest("/wild/a/b", "",
+                "/wild/a%2Fb", "");
+        assertEquals("./..", BootstrapHandlerHelper.getServiceUrl(request));
+    }
+
+    @Test
+    public void getServiceUrl_encodedSlashWithContextPath_treatsAsOneSegment() {
+        VaadinServletRequest request = createRequest("/wild/a/b", "",
+                "/ctx/wild/a%2Fb", "/ctx");
+        assertEquals("./..", BootstrapHandlerHelper.getServiceUrl(request));
+    }
+
+    @Test
+    public void getServiceUrl_multipleEncodedSlashes_countsCorrectly() {
+        // /wild/a%2Fb%2Fc has 1 real slash after root in the raw form
+        VaadinServletRequest request = createRequest("/wild/a/b/c", "",
+                "/wild/a%2Fb%2Fc", "");
+        assertEquals("./..", BootstrapHandlerHelper.getServiceUrl(request));
+    }
+
+    @Test
+    public void getServiceUrl_pathWithSpaces_unaffected() {
+        // Spaces (%20) don't affect slash counting
+        VaadinServletRequest request = createRequest("/file with spaces.js", "",
+                "/file%20with%20spaces.js", "");
+        assertEquals(".", BootstrapHandlerHelper.getServiceUrl(request));
+    }
+
+    @Test
+    public void getServiceUrl_normalPathWithServletPath_returnsCorrectPath() {
+        VaadinServletRequest request = createRequest("/view/sub", "/app",
+                "/app/view/sub", "");
+        assertEquals("./..", BootstrapHandlerHelper.getServiceUrl(request));
+    }
+
+    private VaadinServletRequest createRequest(String pathInfo,
+            String servletPath, String requestURI, String contextPath) {
+        HttpServletRequest httpRequest = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(httpRequest.getPathInfo()).thenReturn(pathInfo);
+        Mockito.when(httpRequest.getServletPath()).thenReturn(servletPath);
+        Mockito.when(httpRequest.getRequestURI()).thenReturn(requestURI);
+        Mockito.when(httpRequest.getContextPath()).thenReturn(contextPath);
+        VaadinServletService service = Mockito.mock(VaadinServletService.class);
+        return new VaadinServletRequest(httpRequest, service);
+    }
+}

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/ForwardingRequestWrapper.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/ForwardingRequestWrapper.java
@@ -38,11 +38,6 @@ public class ForwardingRequestWrapper extends HttpServletRequestWrapper {
 
     public ForwardingRequestWrapper(HttpServletRequest request) {
         super(request);
-        // Do not decode URLs to preserve encoded path separators (%2F).
-        // Decoding would cause incorrect baseHref calculation when paths
-        // contain encoded slashes (e.g., /a%2Fb should be one segment, not
-        // two).
-        urlPathHelper.setUrlDecode(false);
     }
 
     @Override


### PR DESCRIPTION
The previous fix for encoded slashes (%2F) in wildcard route parameters (commit b0c121b1a9) set urlPathHelper.setUrlDecode(false) in ForwardingRequestWrapper, which made getPathInfo() return percent-encoded paths for all requests. This broke static resource serving for files with spaces in their names and potentially affected other getPathInfo() consumers like DAUUtils.

Instead of disabling URL decoding globally, fix the actual site where the raw path matters: BootstrapHandlerHelper.getServiceUrl(). This method uses getCancelingRelativePath() to count path segments for the baseHref, which must use the raw URI so that %2F is not mistaken for a real path separator.

The fix computes the raw path info by stripping the context path and servlet path from the request URI, preserving the original encoding. This allows reverting setUrlDecode(false) so that getPathInfo() returns properly decoded paths for all consumers.

Fixes #23551