### PR TITLE
test: Migrate flow-html-components tests to JUnit 5

### DIFF
--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/AbbrTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/AbbrTest.java
@@ -15,9 +15,9 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class AbbrTest extends ComponentTest {
+class AbbrTest extends ComponentTest {
     // Actual test methods in super class
 
     @Override
@@ -27,7 +27,7 @@ public class AbbrTest extends ComponentTest {
 
     @Test
     @Override
-    public void testHasAriaLabelIsNotImplemented() {
+    protected void testHasAriaLabelIsNotImplemented() {
         // Don't use aria-label or aria-labelledby on any other non-interactive
         // content such as p, legend, li, or ul, because it is ignored.
         // Source: https://www.w3.org/TR/using-aria/#label-support

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTargetValueTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTargetValueTest.java
@@ -15,25 +15,26 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class AnchorTargetValueTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AnchorTargetValueTest {
 
     @Test
-    public void fromString_notEnum_objectHasValueAndEquals() {
+    void fromString_notEnum_objectHasValueAndEquals() {
         AnchorTargetValue value = AnchorTargetValue.forString("foo");
-        Assert.assertEquals("foo", value.getValue());
+        assertEquals("foo", value.getValue());
 
         AnchorTargetValue value1 = AnchorTargetValue.forString("foo");
-        Assert.assertEquals(value, value1);
-        Assert.assertEquals(value.hashCode(), value1.hashCode());
+        assertEquals(value, value1);
+        assertEquals(value.hashCode(), value1.hashCode());
     }
 
     @Test
-    public void fromString_enumValue_resultIsEnum() {
+    void fromString_enumValue_resultIsEnum() {
         AnchorTargetValue value = AnchorTargetValue
                 .forString(AnchorTarget.TOP.getValue());
-        Assert.assertEquals(AnchorTarget.TOP, value);
+        assertEquals(AnchorTarget.TOP, value);
     }
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
@@ -19,9 +19,9 @@ import java.beans.IntrospectionException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Optional;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.UI;
@@ -29,18 +29,24 @@ import com.vaadin.flow.server.AbstractStreamResource;
 import com.vaadin.flow.server.streams.DownloadHandler;
 import com.vaadin.flow.server.streams.ServletResourceDownloadHandler;
 
-public class AnchorTest extends ComponentTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AnchorTest extends ComponentTest {
 
     private UI ui;
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         ui = null;
         UI.setCurrent(null);
     }
 
+    @BeforeEach
     @Override
-    public void setup() throws IntrospectionException, InstantiationException,
+    void setup() throws IntrospectionException, InstantiationException,
             IllegalAccessException, ClassNotFoundException,
             InvocationTargetException, NoSuchMethodException {
         whitelistProperty("download");
@@ -48,100 +54,98 @@ public class AnchorTest extends ComponentTest {
     }
 
     @Test
-    public void removeHref() {
+    void removeHref() {
         Anchor anchor = new Anchor();
         anchor.setHref("foo");
-        Assert.assertTrue(anchor.getElement().hasAttribute("href"));
+        assertTrue(anchor.getElement().hasAttribute("href"));
 
         anchor.removeHref();
-        Assert.assertFalse(anchor.getElement().hasAttribute("href"));
+        assertFalse(anchor.getElement().hasAttribute("href"));
     }
 
     @Test
-    public void createWithComponent() {
+    void createWithComponent() {
         Anchor anchor = new Anchor("#", new Text("Home"));
-        Assert.assertEquals(anchor.getElement().getAttribute("href"), "#");
-        Assert.assertEquals(anchor.getHref(), "#");
-        Assert.assertEquals(anchor.getElement().getText(), "Home");
-        Assert.assertEquals(anchor.getText(), "Home");
+        assertEquals(anchor.getElement().getAttribute("href"), "#");
+        assertEquals(anchor.getHref(), "#");
+        assertEquals(anchor.getElement().getText(), "Home");
+        assertEquals(anchor.getText(), "Home");
     }
 
     @Test
-    public void createWithTarget() {
+    void createWithTarget() {
         Anchor anchor = new Anchor("#", "Home");
-        Assert.assertEquals(anchor.getTargetValue(), AnchorTarget.DEFAULT);
-        Assert.assertEquals(anchor.getTarget(), Optional.empty());
+        assertEquals(anchor.getTargetValue(), AnchorTarget.DEFAULT);
+        assertEquals(anchor.getTarget(), Optional.empty());
 
         anchor.setTarget(AnchorTarget.BLANK);
 
-        Assert.assertEquals(anchor.getTargetValue(), AnchorTarget.BLANK);
-        Assert.assertEquals(anchor.getTarget(),
+        assertEquals(anchor.getTargetValue(), AnchorTarget.BLANK);
+        assertEquals(anchor.getTarget(),
                 Optional.of(AnchorTarget.BLANK.getValue()));
 
-        Assert.assertEquals(anchor.getTargetValue(),
+        assertEquals(anchor.getTargetValue(),
                 new Anchor("#", "Home", AnchorTarget.BLANK).getTargetValue());
-        Assert.assertEquals(anchor.getTarget(),
+        assertEquals(anchor.getTarget(),
                 new Anchor("#", "Home", AnchorTarget.BLANK).getTarget());
     }
 
     @Test
-    public void shouldNotRemoveRouterIgnoreAttributeWhenRemoveHref() {
+    void shouldNotRemoveRouterIgnoreAttributeWhenRemoveHref() {
         Anchor anchor = new Anchor();
         anchor.getElement().setAttribute("router-ignore", true);
         anchor.removeHref();
 
-        Assert.assertEquals(
-                "Anchor element should have router-ignore " + "attribute", "",
-                anchor.getElement().getAttribute("router-ignore"));
+        assertEquals("", anchor.getElement().getAttribute("router-ignore"),
+                "Anchor element should have router-ignore " + "attribute");
     }
 
     @Test
-    public void shouldNotBreakBehaviorIfSetHrefWhenHavingRouterIgnoreAttributeBefore() {
+    void shouldNotBreakBehaviorIfSetHrefWhenHavingRouterIgnoreAttributeBefore() {
         Anchor anchor = new Anchor();
         anchor.getElement().setAttribute("router-ignore", true);
         anchor.setHref("/logout");
 
-        Assert.assertEquals(
-                "Anchor element should have router-ignore " + "attribute", "",
-                anchor.getElement().getAttribute("router-ignore"));
+        assertEquals("", anchor.getElement().getAttribute("router-ignore"),
+                "Anchor element should have router-ignore " + "attribute");
     }
 
     @Test
-    public void setTargetValue_useEnum_targetIsSet() {
+    void setTargetValue_useEnum_targetIsSet() {
         Anchor anchor = new Anchor();
         anchor.setTarget(AnchorTarget.PARENT);
 
-        Assert.assertEquals(Optional.of(AnchorTarget.PARENT.getValue()),
+        assertEquals(Optional.of(AnchorTarget.PARENT.getValue()),
                 anchor.getTarget());
-        Assert.assertEquals(AnchorTarget.PARENT, anchor.getTargetValue());
+        assertEquals(AnchorTarget.PARENT, anchor.getTargetValue());
     }
 
     @Test
-    public void setTargetValue_useObject_targetIsSet() {
+    void setTargetValue_useObject_targetIsSet() {
         Anchor anchor = new Anchor();
         anchor.setTarget(AnchorTargetValue.forString("foo"));
 
-        Assert.assertEquals(Optional.of("foo"), anchor.getTarget());
-        Assert.assertEquals("foo", anchor.getTargetValue().getValue());
+        assertEquals(Optional.of("foo"), anchor.getTarget());
+        assertEquals("foo", anchor.getTargetValue().getValue());
     }
 
     @Test
-    public void getTargetValue_useEnumStringValue_targetIsReturned() {
+    void getTargetValue_useEnumStringValue_targetIsReturned() {
         Anchor anchor = new Anchor();
         anchor.setTarget(AnchorTarget.SELF.getValue());
 
-        Assert.assertEquals(Optional.of(AnchorTarget.SELF.getValue()),
+        assertEquals(Optional.of(AnchorTarget.SELF.getValue()),
                 anchor.getTarget());
-        Assert.assertEquals(AnchorTarget.SELF, anchor.getTargetValue());
+        assertEquals(AnchorTarget.SELF, anchor.getTargetValue());
     }
 
     @Test
-    public void getTargetValue_useSomeStringValue_targetIsReturned() {
+    void getTargetValue_useSomeStringValue_targetIsReturned() {
         Anchor anchor = new Anchor();
         anchor.setTarget("foo");
 
-        Assert.assertEquals(Optional.of("foo"), anchor.getTarget());
-        Assert.assertEquals("foo", anchor.getTargetValue().getValue());
+        assertEquals(Optional.of("foo"), anchor.getTarget());
+        assertEquals("foo", anchor.getTargetValue().getValue());
     }
 
     // Other test methods in super class
@@ -156,17 +160,17 @@ public class AnchorTest extends ComponentTest {
 
     @Test
     @Override
-    public void testHasAriaLabelIsImplemented() {
+    protected void testHasAriaLabelIsImplemented() {
         super.testHasAriaLabelIsImplemented();
     }
 
     @Test
-    public void setEnabled_anchorWithoutHref_doesNotThrow() {
+    void setEnabled_anchorWithoutHref_doesNotThrow() {
         Anchor anchor = new Anchor();
         anchor.setEnabled(false);
 
         anchor.setEnabled(true);
-        Assert.assertTrue(anchor.isEnabled());
+        assertTrue(anchor.isEnabled());
 
         anchor.setHref("foo");
         anchor.setEnabled(false);
@@ -175,33 +179,33 @@ public class AnchorTest extends ComponentTest {
     }
 
     @Test
-    public void disabledAnchor_removeHref_hrefIsEmpty() {
+    void disabledAnchor_removeHref_hrefIsEmpty() {
         Anchor anchor = new Anchor();
         anchor.setHref("foo");
         anchor.setEnabled(false);
-        Assert.assertEquals("foo", anchor.getHref());
+        assertEquals("foo", anchor.getHref());
         anchor.setHref("bar");
-        Assert.assertEquals("bar", anchor.getHref());
+        assertEquals("bar", anchor.getHref());
         anchor.removeHref();
-        Assert.assertEquals("", anchor.getHref());
+        assertEquals("", anchor.getHref());
         anchor.setEnabled(true);
-        Assert.assertEquals("", anchor.getHref());
+        assertEquals("", anchor.getHref());
     }
 
     @Test
-    public void disabledAnchor_hrefIsRemoved_enableAnchor_hrefIsRestored() {
+    void disabledAnchor_hrefIsRemoved_enableAnchor_hrefIsRestored() {
         Anchor anchor = new Anchor("foo", "bar");
         anchor.setEnabled(false);
 
-        Assert.assertFalse(anchor.getElement().hasAttribute("href"));
+        assertFalse(anchor.getElement().hasAttribute("href"));
 
         anchor.setEnabled(true);
-        Assert.assertTrue(anchor.getElement().hasAttribute("href"));
-        Assert.assertEquals("foo", anchor.getHref());
+        assertTrue(anchor.getElement().hasAttribute("href"));
+        assertEquals("foo", anchor.getHref());
     }
 
     @Test
-    public void disabledAnchor_setHrefWhenDisabled_enableAnchor_hrefIsPreserved() {
+    void disabledAnchor_setHrefWhenDisabled_enableAnchor_hrefIsPreserved() {
         Anchor anchor = new Anchor("foo", "bar");
         anchor.setEnabled(false);
 
@@ -209,12 +213,12 @@ public class AnchorTest extends ComponentTest {
 
         anchor.setEnabled(true);
 
-        Assert.assertTrue(anchor.getElement().hasAttribute("href"));
-        Assert.assertEquals("baz", anchor.getHref());
+        assertTrue(anchor.getElement().hasAttribute("href"));
+        assertEquals("baz", anchor.getHref());
     }
 
     @Test
-    public void disabledAnchor_setResourceWhenDisabled_enableAnchor_resourceIsPreserved() {
+    void disabledAnchor_setResourceWhenDisabled_enableAnchor_resourceIsPreserved() {
         Anchor anchor = new Anchor("foo", "bar");
         anchor.setEnabled(false);
 
@@ -228,11 +232,11 @@ public class AnchorTest extends ComponentTest {
         });
         anchor.setEnabled(true);
 
-        Assert.assertTrue(anchor.getElement().hasAttribute("href"));
+        assertTrue(anchor.getElement().hasAttribute("href"));
     }
 
     @Test
-    public void disabledAnchor_setResource_hrefIsRemoved_enableAnchor_hrefIsRestored() {
+    void disabledAnchor_setResource_hrefIsRemoved_enableAnchor_hrefIsRestored() {
         mockUI();
         AbstractStreamResource resource = new AbstractStreamResource() {
 
@@ -246,15 +250,15 @@ public class AnchorTest extends ComponentTest {
         String href = anchor.getHref();
         anchor.setEnabled(false);
 
-        Assert.assertFalse(anchor.getElement().hasAttribute("href"));
-        Assert.assertEquals(href, anchor.getHref());
+        assertFalse(anchor.getElement().hasAttribute("href"));
+        assertEquals(href, anchor.getHref());
 
         anchor.setEnabled(true);
-        Assert.assertEquals(href, anchor.getHref());
+        assertEquals(href, anchor.getHref());
     }
 
     @Test
-    public void disabledAnchor_setResourceWhenDisabled_hrefIsPreserved() {
+    void disabledAnchor_setResourceWhenDisabled_hrefIsPreserved() {
         mockUI();
         AbstractStreamResource resource = new AbstractStreamResource() {
 
@@ -278,12 +282,12 @@ public class AnchorTest extends ComponentTest {
 
         anchor.setEnabled(true);
 
-        Assert.assertTrue(anchor.getElement().hasAttribute("href"));
-        Assert.assertNotEquals(href, anchor.getHref());
+        assertTrue(anchor.getElement().hasAttribute("href"));
+        assertNotEquals(href, anchor.getHref());
     }
 
     @Test
-    public void disabledAnchor_setDownload_hrefIsRemoved_enableAnchor_hrefIsRestored() {
+    void disabledAnchor_setDownload_hrefIsRemoved_enableAnchor_hrefIsRestored() {
         mockUI();
         DownloadHandler downloadHandler = event -> event.getWriter()
                 .write("foo");
@@ -291,15 +295,15 @@ public class AnchorTest extends ComponentTest {
         String href = anchor.getHref();
         anchor.setEnabled(false);
 
-        Assert.assertFalse(anchor.getElement().hasAttribute("href"));
-        Assert.assertEquals(href, anchor.getHref());
+        assertFalse(anchor.getElement().hasAttribute("href"));
+        assertEquals(href, anchor.getHref());
 
         anchor.setEnabled(true);
-        Assert.assertEquals(href, anchor.getHref());
+        assertEquals(href, anchor.getHref());
     }
 
     @Test
-    public void disabledAnchor_setDownloadWhenDisabled_hrefIsPreserved() {
+    void disabledAnchor_setDownloadWhenDisabled_hrefIsPreserved() {
         mockUI();
         DownloadHandler downloadHandler = event -> event.getWriter()
                 .write("foo");
@@ -317,121 +321,111 @@ public class AnchorTest extends ComponentTest {
 
         anchor.setEnabled(true);
 
-        Assert.assertTrue(anchor.getElement().hasAttribute("href"));
-        Assert.assertNotEquals(href, anchor.getHref());
+        assertTrue(anchor.getElement().hasAttribute("href"));
+        assertNotEquals(href, anchor.getHref());
     }
 
     @Test
-    public void anchorWithDownloadHandler_downloadAttributeIsSet() {
+    void anchorWithDownloadHandler_downloadAttributeIsSet() {
         mockUI();
         DownloadHandler downloadHandler = DownloadHandler
                 .forServletResource("null/path");
         Anchor anchor = new Anchor(downloadHandler, "bar");
 
-        Assert.assertTrue(
-                "Pre-built download handlers should set download attribute",
-                anchor.isDownload());
+        assertTrue(anchor.isDownload(),
+                "Pre-built download handlers should set download attribute");
     }
 
     @Test
-    public void anchorWithDownloadAttributeSet_newHandler_downloadAttributeCleared() {
+    void anchorWithDownloadAttributeSet_newHandler_downloadAttributeCleared() {
         mockUI();
         ServletResourceDownloadHandler downloadHandler = DownloadHandler
                 .forServletResource("null/path");
         Anchor anchor = new Anchor(downloadHandler, "bar");
 
-        Assert.assertTrue(
-                "Pre-built download handlers should set download attribute",
-                anchor.isDownload());
+        assertTrue(anchor.isDownload(),
+                "Pre-built download handlers should set download attribute");
 
         downloadHandler.inline();
 
         anchor.setHref(downloadHandler);
 
-        Assert.assertFalse(
-                "Setting inline download handler should clear download attribute",
-                anchor.isDownload());
+        assertFalse(anchor.isDownload(),
+                "Setting inline download handler should clear download attribute");
     }
 
     @Test
-    public void anchorWithDownloadAttributeSet_newCustomHandler_downloadAttributeNotTouched() {
+    void anchorWithDownloadAttributeSet_newCustomHandler_downloadAttributeNotTouched() {
         mockUI();
         Anchor anchor = new Anchor("/home", "bar");
         anchor.getElement().setAttribute("download", true);
 
-        Assert.assertTrue(
-                "Pre-built download handlers should set download attribute",
-                anchor.isDownload());
+        assertTrue(anchor.isDownload(),
+                "Pre-built download handlers should set download attribute");
 
         anchor.setHref(event -> event.getWriter().write("foo"));
 
-        Assert.assertTrue(
-                "Setting custom download handler should not clear download attribute",
-                anchor.isDownload());
+        assertTrue(anchor.isDownload(),
+                "Setting custom download handler should not clear download attribute");
     }
 
     @Test
-    public void anchorWithDownloadHandler_inlineSet_downloadAttributeIsNotSet() {
+    void anchorWithDownloadHandler_inlineSet_downloadAttributeIsNotSet() {
         mockUI();
         DownloadHandler downloadHandler = DownloadHandler
                 .forServletResource("null/path").inline();
         Anchor anchor = new Anchor(downloadHandler, "bar");
 
-        Assert.assertFalse(
-                "Inline download handlers should not add download attribute",
-                anchor.isDownload());
+        assertFalse(anchor.isDownload(),
+                "Inline download handlers should not add download attribute");
     }
 
     @Test
-    public void anchorWithLinkModeDownload_downloadAttributeIsSet() {
+    void anchorWithLinkModeDownload_downloadAttributeIsSet() {
         mockUI();
         DownloadHandler downloadHandler = DownloadHandler
                 .forServletResource("null/path").inline();
         Anchor anchor = new Anchor(downloadHandler, AttachmentType.DOWNLOAD,
                 "bar");
 
-        Assert.assertTrue(
-                "Inline download handlers should not add download attribute",
-                anchor.isDownload());
+        assertTrue(anchor.isDownload(),
+                "Inline download handlers should not add download attribute");
     }
 
     @Test
-    public void anchorWithLinkModeInline_downloadAttributeIsNotSet() {
+    void anchorWithLinkModeInline_downloadAttributeIsNotSet() {
         mockUI();
         DownloadHandler downloadHandler = DownloadHandler
                 .forServletResource("null/path");
         Anchor anchor = new Anchor(downloadHandler, AttachmentType.INLINE,
                 "bar");
 
-        Assert.assertFalse(
-                "Inline download handlers should not add download attribute",
-                anchor.isDownload());
+        assertFalse(anchor.isDownload(),
+                "Inline download handlers should not add download attribute");
     }
 
     @Test
-    public void customDownloadHandler_constructorSetsDownloadMode() {
+    void customDownloadHandler_constructorSetsDownloadMode() {
         mockUI();
         DownloadHandler downloadHandler = DownloadHandler
                 .forServletResource("null/path");
         Anchor anchor = new Anchor(event -> {
         }, "bar");
 
-        Assert.assertTrue(
-                "Custom download handlers should by default add download attribute",
-                anchor.isDownload());
+        assertTrue(anchor.isDownload(),
+                "Custom download handlers should by default add download attribute");
     }
 
     @Test
-    public void customDownloadHandler_nullType_constructorSetsDownloadMode() {
+    void customDownloadHandler_nullType_constructorSetsDownloadMode() {
         mockUI();
         DownloadHandler downloadHandler = DownloadHandler
                 .forServletResource("null/path");
         Anchor anchor = new Anchor(event -> {
         }, null, "bar");
 
-        Assert.assertTrue(
-                "Custom download handlers should by default add download attribute",
-                anchor.isDownload());
+        assertTrue(anchor.isDownload(),
+                "Custom download handlers should by default add download attribute");
     }
 
     private void mockUI() {

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/ArticleTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/ArticleTest.java
@@ -15,9 +15,9 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ArticleTest extends ComponentTest {
+class ArticleTest extends ComponentTest {
     // Actual test methods in super class
 
     @Override
@@ -27,13 +27,13 @@ public class ArticleTest extends ComponentTest {
 
     @Test
     @Override
-    public void testHasOrderedComponents() {
+    protected void testHasOrderedComponents() {
         super.testHasOrderedComponents();
     }
 
     @Test
     @Override
-    public void testHasAriaLabelIsNotImplemented() {
+    protected void testHasAriaLabelIsNotImplemented() {
         // For most assistive technology it's fine to use aria-label or
         // aria-labelledby on the <nav>, and <main> elements but not
         // on <footer>, <section>, <article>, or <header>.

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/AsideTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/AsideTest.java
@@ -15,9 +15,9 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class AsideTest extends ComponentTest {
+class AsideTest extends ComponentTest {
     // Actual test methods in super class
 
     @Override
@@ -27,13 +27,13 @@ public class AsideTest extends ComponentTest {
 
     @Test
     @Override
-    public void testHasOrderedComponents() {
+    protected void testHasOrderedComponents() {
         super.testHasOrderedComponents();
     }
 
     @Test
     @Override
-    public void testHasAriaLabelIsNotImplemented() {
+    protected void testHasAriaLabelIsNotImplemented() {
         // There is mixed support for aria-label or aria-labelledby on <aside>.
         // Source: https://www.w3.org/TR/using-aria/#label-support
         super.testHasAriaLabelIsNotImplemented();

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/AssertUtils.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/AssertUtils.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.component.html;
 
 import java.util.Optional;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 /**
  * Assert utility class.
@@ -32,19 +32,18 @@ class AssertUtils {
      *
      * If both <code>expected</code> and <code>actual</code> are arrays or are
      * <code>Optional</code>s wrapping arrays,
-     * <code>Assert#assertArrayEquals</code> is used to assert that the arrays
-     * content is equal.
+     * <code>Assertions#assertArrayEquals</code> is used to assert that the
+     * arrays content is equal.
      *
-     * @param message
-     *            the identifying message for the {@link AssertionError}
-     *            (<code>null</code> okay)
      * @param expected
      *            expected value
      * @param actual
      *            actual value
+     * @param message
+     *            the identifying message for the {@link AssertionError}
+     *            (<code>null</code> okay)
      */
-    static public void assertEquals(String message, Object expected,
-            Object actual) {
+    static void assertEquals(Object expected, Object actual, String message) {
 
         if (expected instanceof Optional && actual instanceof Optional) {
             expected = ((Optional) expected).orElseGet(() -> null);
@@ -56,15 +55,15 @@ class AssertUtils {
             return;
 
         } else if (expected == null || actual == null) {
-            Assert.assertEquals(message, expected, actual);
+            Assertions.assertEquals(expected, actual, message);
         }
 
         if (expected.getClass().isArray() && actual.getClass().isArray()) {
-            Assert.assertArrayEquals(message, (Object[]) expected,
-                    (Object[]) actual);
+            Assertions.assertArrayEquals((Object[]) expected, (Object[]) actual,
+                    message);
 
         } else {
-            Assert.assertEquals(message, expected, actual);
+            Assertions.assertEquals(expected, actual, message);
         }
     }
 

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/CodeTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/CodeTest.java
@@ -15,9 +15,9 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class CodeTest extends ComponentTest {
+class CodeTest extends ComponentTest {
     // Actual test methods in super class
 
     @Override
@@ -27,7 +27,7 @@ public class CodeTest extends ComponentTest {
 
     @Test
     @Override
-    public void testHasAriaLabelIsNotImplemented() {
+    protected void testHasAriaLabelIsNotImplemented() {
         // Don't use aria-label or aria-labelledby on any other non-interactive
         // content such as p, legend, li, or ul, because it is ignored.
         // Source: https://www.w3.org/TR/using-aria/#label-support

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/ComponentTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/ComponentTest.java
@@ -29,9 +29,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasAriaLabel;
@@ -39,15 +38,21 @@ import com.vaadin.flow.component.HasOrderedComponents;
 import com.vaadin.flow.component.HtmlComponent;
 import com.vaadin.flow.dom.Element;
 
-public abstract class ComponentTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+abstract class ComponentTest {
 
     private Component component;
     private List<ComponentProperty> properties = new ArrayList<>();
 
     private Set<String> WHITE_LIST = new HashSet<>();
 
-    @Before
-    public void setup() throws IntrospectionException, InstantiationException,
+    @BeforeEach
+    void setup() throws IntrospectionException, InstantiationException,
             IllegalAccessException, ClassNotFoundException,
             InvocationTargetException, NoSuchMethodException {
         component = createComponent();
@@ -136,69 +141,71 @@ public abstract class ComponentTest {
 
     protected void testHasOrderedComponents() {
         if (!(component instanceof HasOrderedComponents)) {
-            Assert.fail("Component " + component.getClass()
+            fail("Component " + component.getClass()
                     + " did not implement HasOrderedComponents anymore.");
         }
 
         HasOrderedComponents component = (HasOrderedComponents) this.component;
-        Assert.assertEquals(0, component.getComponentCount());
+        assertEquals(0, component.getComponentCount());
 
         Paragraph firstChildren = new Paragraph("first children");
         component.add(firstChildren);
-        Assert.assertEquals(firstChildren, component.getComponentAt(0));
+        assertEquals(firstChildren, component.getComponentAt(0));
 
         Paragraph newFirstChildren = new Paragraph("new first children");
         component.addComponentAtIndex(0, newFirstChildren);
-        Assert.assertEquals(newFirstChildren, component.getComponentAt(0));
+        assertEquals(newFirstChildren, component.getComponentAt(0));
 
-        Assert.assertEquals(1, component.indexOf(firstChildren));
+        assertEquals(1, component.indexOf(firstChildren));
     }
 
     protected void testHasAriaLabelIsImplemented() {
         if (!(component instanceof HasAriaLabel)) {
-            Assert.fail("Component " + component.getClass()
+            fail("Component " + component.getClass()
                     + " did not implement HasAriaLabel anymore.");
         }
     }
 
     protected void testHasAriaLabelIsNotImplemented() {
         if (component instanceof HasAriaLabel) {
-            Assert.fail("Component " + component.getClass()
+            fail("Component " + component.getClass()
                     + " implemented HasAriaLabel. This is not valid."
                     + " See test case for more information.");
         }
     }
 
     @Test
-    public void setAriaLabel() {
+    void setAriaLabel() {
         if (!(component instanceof HasAriaLabel)) {
             return; // test should only run for components that implement
                     // HasAriaLabel
         }
 
         HasAriaLabel component = (HasAriaLabel) this.component;
-        Assert.assertFalse(component.getAriaLabel().isPresent());
+        assertFalse(component.getAriaLabel().isPresent());
 
         component.setAriaLabel("new AriaLabel");
-        Assert.assertEquals("new AriaLabel", component.getAriaLabel().get());
+        assertEquals("new AriaLabel", component.getAriaLabel().get());
     }
 
     @Test
-    public void testSetterGetterTypes() throws Exception {
+    void testSetterGetterTypes() throws Exception {
         for (ComponentProperty property : properties) {
             Class<?> getterType = property.getGetter().getReturnType();
             if (property.optional) {
                 String message = "Getter for " + property.name
                         + " should return Optional<"
                         + property.type.getSimpleName() + ">";
-                Assert.assertEquals(message, Optional.class, getterType);
-                Assert.assertEquals(message, property.type, getOptionalType(
-                        property.getGetter().getGenericReturnType()));
+                assertEquals(Optional.class, getterType, message);
+                assertEquals(property.type,
+                        getOptionalType(
+                                property.getGetter().getGenericReturnType()),
+                        message);
             } else {
-                Assert.assertEquals(property.type, getterType);
+                assertEquals(property.type, getterType);
             }
 
-            Assert.assertEquals(property.type,
+            assertEquals(property.type,
                     property.getSetter().getParameterTypes()[0]);
         }
     }
@@ -209,25 +216,25 @@ public abstract class ComponentTest {
     }
 
     @Test
-    public void testDefaultValues() throws Exception {
+    void testDefaultValues() throws Exception {
         setDefaultValues();
     }
 
     @Test
-    public void testNonDefaultValues() throws Exception {
+    void testNonDefaultValues() throws Exception {
         setNonDefaultValues();
         assertNonDefaultValues();
     }
 
     @Test
-    public void setAndResetValues() throws Exception {
+    void setAndResetValues() throws Exception {
         setNonDefaultValues();
         setDefaultValues();
         assertDefaultValues();
     }
 
     @Test
-    public void testNullForOptionalNonStringProperties() {
+    void testNullForOptionalNonStringProperties() {
         Stream<ComponentProperty> optionalNonStringProperties = properties
                 .stream().filter(ComponentProperty::isOptional)
                 .filter(p -> p.type != String.class);
@@ -237,19 +244,19 @@ public abstract class ComponentTest {
     }
 
     @Test
-    public void testNullForOptionalStringProperties() {
+    void testNullForOptionalStringProperties() {
         getOptionalStringProperties()
                 .forEach(this::testNullForOptionalStringProperty);
     }
 
     @Test
-    public void testEmptyStringForOptionalStringProperties() {
+    void testEmptyStringForOptionalStringProperties() {
         getOptionalStringProperties()
                 .forEach(this::testEmptyStringForOptionalStringProperty);
     }
 
     @Test
-    public void testNullForStringPropertiesWithEmptyStringDefault() {
+    void testNullForStringPropertiesWithEmptyStringDefault() {
         properties.stream().filter(p -> !p.isOptional())
                 .filter(p -> p.type == String.class)
                 .forEach(p -> testNullForStringPropertyWithEmptyStringDefault(
@@ -257,32 +264,32 @@ public abstract class ComponentTest {
     }
 
     @Test
-    public void setTitle() {
+    void setTitle() {
         if (!(component instanceof HtmlComponent)) {
             return;
         }
 
         HtmlComponent component = (HtmlComponent) this.component;
-        Assert.assertFalse(component.getTitle().isPresent());
+        assertFalse(component.getTitle().isPresent());
 
         component.setTitle("myTitle");
 
-        Assert.assertEquals("myTitle",
-                component.getElement().getAttribute("title"));
-        Assert.assertEquals("myTitle", component.getTitle().orElse(null));
-        Assert.assertFalse(component.getElement().hasProperty("title"));
+        assertEquals("myTitle", component.getElement().getAttribute("title"));
+        assertEquals("myTitle", component.getTitle().orElse(null));
+        assertFalse(component.getElement().hasProperty("title"));
 
         component.setTitle("");
-        Assert.assertFalse(component.getTitle().isPresent());
+        assertFalse(component.getTitle().isPresent());
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void setTitle_nullDisallowed() {
+    @Test
+    void setTitle_nullDisallowed() {
         if (!(component instanceof HtmlComponent)) {
-            throw new IllegalArgumentException();
+            return;
         }
 
-        ((HtmlComponent) component).setTitle(null);
+        assertThrows(IllegalArgumentException.class,
+                () -> ((HtmlComponent) component).setTitle(null));
     }
 
     private Stream<ComponentProperty> getOptionalStringProperties() {
@@ -294,11 +301,11 @@ public abstract class ComponentTest {
             ComponentProperty p) {
         try {
             p.setUsingSetter(component, null);
-            Assert.fail("Setting '" + p.name
+            fail("Setting '" + p.name
                     + "' with \"\" default to null should throw an exception");
         } catch (InvocationTargetException e) {
             // OK, should throw
-            Assert.assertEquals(IllegalArgumentException.class,
+            assertEquals(IllegalArgumentException.class,
                     e.getCause().getClass());
         } catch (IllegalAccessException | IllegalArgumentException
                 | NoSuchMethodException | SecurityException e) {
@@ -309,9 +316,9 @@ public abstract class ComponentTest {
     private void testEmptyStringForOptionalStringProperty(ComponentProperty p) {
         try {
             p.setUsingSetter(component, "");
-            Assert.assertEquals("The getter for '" + p.name
-                    + "' should return an empty optional after setting \"\"",
-                    Optional.empty(), p.getUsingGetter(component));
+            assertEquals(Optional.empty(), p.getUsingGetter(component),
+                    "The getter for '" + p.name
+                            + "' should return an empty optional after setting \"\"");
         } catch (Exception e) {
             throw new AssertionError(e);
         }
@@ -320,9 +327,9 @@ public abstract class ComponentTest {
     private void testNullForOptionalNonStringProperty(ComponentProperty p) {
         try {
             p.setUsingSetter(component, null);
-            Assert.assertEquals("Setting the property " + p.name
-                    + " to null should cause an empty optional to be returned by the getter",
-                    Optional.empty(), p.getUsingGetter(component));
+            assertEquals(Optional.empty(), p.getUsingGetter(component),
+                    "Setting the property " + p.name
+                            + " to null should cause an empty optional to be returned by the getter");
         } catch (Exception e) {
             throw new AssertionError(
                     "The optional property '" + p.name
@@ -335,10 +342,9 @@ public abstract class ComponentTest {
     private void testNullForOptionalStringProperty(ComponentProperty p) {
         try {
             p.setUsingSetter(component, null);
-            Assert.fail(
-                    "Setting an optional String attribute to null should throw an exception");
+            fail("Setting an optional String attribute to null should throw an exception");
         } catch (InvocationTargetException e) {
-            Assert.assertEquals(IllegalArgumentException.class,
+            assertEquals(IllegalArgumentException.class,
                     e.getCause().getClass());
         } catch (IllegalAccessException | IllegalArgumentException
                 | NoSuchMethodException | SecurityException e) {
@@ -358,10 +364,10 @@ public abstract class ComponentTest {
             if (property.optional) {
                 String message = "Default value for " + property.name
                         + " should be an empty Optional";
-                Assert.assertEquals(message, Optional.empty(),
-                        property.getUsingGetter(component));
+                assertEquals(Optional.empty(),
+                        property.getUsingGetter(component), message);
             } else {
-                Assert.assertEquals(property.defaultValue,
+                assertEquals(property.defaultValue,
                         property.getUsingGetter(component));
             }
             if (property.removeDefault) {
@@ -376,13 +382,13 @@ public abstract class ComponentTest {
         for (ComponentProperty property : properties) {
             if (property.optional) {
                 AssertUtils.assertEquals(
+                        Optional.ofNullable(property.otherValue),
+                        property.getUsingGetter(component),
                         "Getter for " + property.name
                                 + " should return Optional<"
-                                + property.type.getSimpleName() + ">",
-                        Optional.ofNullable(property.otherValue),
-                        property.getUsingGetter(component));
+                                + property.type.getSimpleName() + ">");
             } else {
-                Assert.assertEquals(property.otherValue,
+                assertEquals(property.otherValue,
                         property.getUsingGetter(component));
             }
             assertPropertyOrAttribute(component,
@@ -396,16 +402,14 @@ public abstract class ComponentTest {
 
     private static void assertProperty(Component component, String property,
             boolean present) {
-        Assert.assertEquals(present,
-                component.getElement().hasProperty(property));
+        assertEquals(present, component.getElement().hasProperty(property));
     }
 
     private static void assertAttribute(Component component, String attribute,
             boolean present) {
-        Assert.assertEquals(
+        assertEquals(present, component.getElement().hasAttribute(attribute),
                 "Component should " + (present ? "" : "not ")
-                        + "have the attribute " + attribute,
-                present, component.getElement().hasAttribute(attribute));
+                        + "have the attribute " + attribute);
     }
 
     private static void assertNoPropertyOrAttribute(Component component,
@@ -424,11 +428,12 @@ public abstract class ComponentTest {
     private static void assertPropertyOrAttribute(Component component,
             String propertyOrAttribute) {
         Element element = component.getElement();
-        Assert.assertNotEquals(propertyOrAttribute + ": attribute="
-                + element.hasAttribute(propertyOrAttribute) + ", property="
-                + element.hasProperty(propertyOrAttribute),
-                element.hasAttribute(propertyOrAttribute),
-                element.hasProperty(propertyOrAttribute));
+        assertNotEquals(element.hasAttribute(propertyOrAttribute),
+                element.hasProperty(propertyOrAttribute),
+                propertyOrAttribute + ": attribute="
+                        + element.hasAttribute(propertyOrAttribute)
+                        + ", property="
+                        + element.hasProperty(propertyOrAttribute));
     }
 
     private void assertProperty(PropertyDescriptor descriptor) {

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/DivTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/DivTest.java
@@ -15,10 +15,11 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class DivTest extends ComponentTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DivTest extends ComponentTest {
 
     // Actual test methods in super class
 
@@ -29,13 +30,13 @@ public class DivTest extends ComponentTest {
 
     @Test
     @Override
-    public void testHasOrderedComponents() {
+    protected void testHasOrderedComponents() {
         super.testHasOrderedComponents();
     }
 
     @Test
     @Override
-    public void testHasAriaLabelIsNotImplemented() {
+    protected void testHasAriaLabelIsNotImplemented() {
         // Don't use aria-label or aria-labelledby on a span or div unless
         // its given a role. When aria-label or aria-labelledby are on
         // interactive roles (such as a link or button) or an img role,
@@ -46,7 +47,7 @@ public class DivTest extends ComponentTest {
     }
 
     @Test
-    public void testNonDefaultConstructor() {
-        Assert.assertEquals("text", new Div("text").getText());
+    void testNonDefaultConstructor() {
+        assertEquals("text", new Div("text").getText());
     }
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/EmphasisTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/EmphasisTest.java
@@ -15,9 +15,9 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class EmphasisTest extends ComponentTest {
+class EmphasisTest extends ComponentTest {
     // Actual test methods in super class
 
     @Override
@@ -27,7 +27,7 @@ public class EmphasisTest extends ComponentTest {
 
     @Test
     @Override
-    public void testHasAriaLabelIsNotImplemented() {
+    protected void testHasAriaLabelIsNotImplemented() {
         // Don't use aria-label or aria-labelledby on any other non-interactive
         // content such as p, legend, li, or ul, because it is ignored.
         // Source: https://www.w3.org/TR/using-aria/#label-support

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/FieldSetTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/FieldSetTest.java
@@ -15,10 +15,12 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class FieldSetTest extends ComponentTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class FieldSetTest extends ComponentTest {
 
     @Override
     protected void addProperties() {
@@ -28,54 +30,54 @@ public class FieldSetTest extends ComponentTest {
     }
 
     @Test
-    public void testConstructorParams() {
+    void testConstructorParams() {
         FieldSet fieldset = new FieldSet("sample-legend");
-        Assert.assertEquals("sample-legend", fieldset.getLegend().getText());
-        Assert.assertEquals(0, fieldset.getContent().count());
+        assertEquals("sample-legend", fieldset.getLegend().getText());
+        assertEquals(0, fieldset.getContent().count());
 
         fieldset = new FieldSet(new Paragraph("sample-content"));
-        Assert.assertNull(fieldset.getLegend());
-        Assert.assertEquals("sample-content",
+        assertNull(fieldset.getLegend());
+        assertEquals("sample-content",
                 ((Paragraph) fieldset.getContent().findFirst().get())
                         .getText());
 
         Paragraph content = new Paragraph("content");
         fieldset = new FieldSet("sample-legend", content);
-        Assert.assertEquals("sample-legend", fieldset.getLegend().getText());
-        Assert.assertEquals(content, fieldset.getContent().findFirst().get());
+        assertEquals("sample-legend", fieldset.getLegend().getText());
+        assertEquals(content, fieldset.getContent().findFirst().get());
     }
 
     @Test
-    public void testSetLegendReplacesLegendText() {
+    void testSetLegendReplacesLegendText() {
         FieldSet fieldset = new FieldSet("legend1", new Paragraph("content"));
-        Assert.assertEquals("legend1", fieldset.getLegend().getText());
+        assertEquals("legend1", fieldset.getLegend().getText());
 
         fieldset.setLegendText("legend2");
-        Assert.assertEquals("legend2", fieldset.getLegend().getText());
+        assertEquals("legend2", fieldset.getLegend().getText());
 
         fieldset.setLegendText(null);
-        Assert.assertNull(fieldset.getLegend());
+        assertNull(fieldset.getLegend());
     }
 
     @Test
-    public void testSetContentReplacesContent() {
+    void testSetContentReplacesContent() {
         Paragraph content1 = new Paragraph("content1");
         Paragraph content2 = new Paragraph("content2");
         FieldSet fieldset = new FieldSet("text-legend", content1);
-        Assert.assertEquals(content1, fieldset.getContent().findFirst().get());
+        assertEquals(content1, fieldset.getContent().findFirst().get());
 
         fieldset.remove(content1);
         fieldset.add(content2);
-        Assert.assertEquals(content2, fieldset.getContent().findFirst().get());
+        assertEquals(content2, fieldset.getContent().findFirst().get());
 
-        Assert.assertNull(content1.getElement().getParent());
+        assertNull(content1.getElement().getParent());
     }
 
     @Test
-    public void testFieldSetLegendTextSetting() {
+    void testFieldSetLegendTextSetting() {
         String expectedText = "Test Legend";
         FieldSet fieldSet = new FieldSet(expectedText);
-        Assert.assertEquals("The legend text should be set correctly.",
-                expectedText, fieldSet.getLegend().getText());
+        assertEquals(expectedText, fieldSet.getLegend().getText(),
+                "The legend text should be set correctly.");
     }
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/FooterTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/FooterTest.java
@@ -15,9 +15,9 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class FooterTest extends ComponentTest {
+class FooterTest extends ComponentTest {
     // Actual test methods in super class
 
     @Override
@@ -27,13 +27,13 @@ public class FooterTest extends ComponentTest {
 
     @Test
     @Override
-    public void testHasOrderedComponents() {
+    protected void testHasOrderedComponents() {
         super.testHasOrderedComponents();
     }
 
     @Test
     @Override
-    public void testHasAriaLabelIsNotImplemented() {
+    protected void testHasAriaLabelIsNotImplemented() {
         // For most assistive technology it's fine to use aria-label or
         // aria-labelledby on the <nav>, and <main> elements but not
         // on <footer>, <section>, <article>, or <header>.

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/H1Test.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/H1Test.java
@@ -15,9 +15,9 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class H1Test extends ComponentTest {
+class H1Test extends ComponentTest {
     // Actual test methods in super class
 
     @Override
@@ -27,7 +27,7 @@ public class H1Test extends ComponentTest {
 
     @Test
     @Override
-    public void testHasAriaLabelIsNotImplemented() {
+    protected void testHasAriaLabelIsNotImplemented() {
         // Don't use aria-label or aria-labelledby on any heading elements
         // because it overrides them on NVDA, VoiceOver and Talkback.
         // JAWS ignores them.

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/H2Test.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/H2Test.java
@@ -15,9 +15,9 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class H2Test extends ComponentTest {
+class H2Test extends ComponentTest {
     // Actual test methods in super class
 
     @Override
@@ -27,7 +27,7 @@ public class H2Test extends ComponentTest {
 
     @Test
     @Override
-    public void testHasAriaLabelIsNotImplemented() {
+    protected void testHasAriaLabelIsNotImplemented() {
         // Don't use aria-label or aria-labelledby on any heading elements
         // because it overrides them on NVDA, VoiceOver and Talkback.
         // JAWS ignores them.

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/H3Test.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/H3Test.java
@@ -15,9 +15,9 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class H3Test extends ComponentTest {
+class H3Test extends ComponentTest {
     // Actual test methods in super class
 
     @Override
@@ -27,7 +27,7 @@ public class H3Test extends ComponentTest {
 
     @Test
     @Override
-    public void testHasAriaLabelIsNotImplemented() {
+    protected void testHasAriaLabelIsNotImplemented() {
         // Don't use aria-label or aria-labelledby on any heading elements
         // because it overrides them on NVDA, VoiceOver and Talkback.
         // JAWS ignores them.

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/H4Test.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/H4Test.java
@@ -15,9 +15,9 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class H4Test extends ComponentTest {
+class H4Test extends ComponentTest {
     // Actual test methods in super class
 
     @Override
@@ -27,7 +27,7 @@ public class H4Test extends ComponentTest {
 
     @Test
     @Override
-    public void testHasAriaLabelIsNotImplemented() {
+    protected void testHasAriaLabelIsNotImplemented() {
         // Don't use aria-label or aria-labelledby on any heading elements
         // because it overrides them on NVDA, VoiceOver and Talkback.
         // JAWS ignores them.

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/H5Test.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/H5Test.java
@@ -15,9 +15,9 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class H5Test extends ComponentTest {
+class H5Test extends ComponentTest {
     // Actual test methods in super class
 
     @Override
@@ -27,7 +27,7 @@ public class H5Test extends ComponentTest {
 
     @Test
     @Override
-    public void testHasAriaLabelIsNotImplemented() {
+    protected void testHasAriaLabelIsNotImplemented() {
         // Don't use aria-label or aria-labelledby on any heading elements
         // because it overrides them on NVDA, VoiceOver and Talkback.
         // JAWS ignores them.

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/H6Test.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/H6Test.java
@@ -15,9 +15,9 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class H6Test extends ComponentTest {
+class H6Test extends ComponentTest {
     // Actual test methods in super class
 
     @Override
@@ -27,7 +27,7 @@ public class H6Test extends ComponentTest {
 
     @Test
     @Override
-    public void testHasAriaLabelIsNotImplemented() {
+    protected void testHasAriaLabelIsNotImplemented() {
         // Don't use aria-label or aria-labelledby on any heading elements
         // because it overrides them on NVDA, VoiceOver and Talkback.
         // JAWS ignores them.

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/HeaderTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/HeaderTest.java
@@ -15,9 +15,9 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class HeaderTest extends ComponentTest {
+class HeaderTest extends ComponentTest {
     // Actual test methods in super class
 
     @Override
@@ -27,13 +27,13 @@ public class HeaderTest extends ComponentTest {
 
     @Test
     @Override
-    public void testHasOrderedComponents() {
+    protected void testHasOrderedComponents() {
         super.testHasOrderedComponents();
     }
 
     @Test
     @Override
-    public void testHasAriaLabelIsNotImplemented() {
+    protected void testHasAriaLabelIsNotImplemented() {
         // For most assistive technology it's fine to use aria-label or
         // aria-labelledby on the <nav>, and <main> elements but not
         // on <footer>, <section>, <article>, or <header>.

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/HrTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/HrTest.java
@@ -15,10 +15,11 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class HrTest extends ComponentTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HrTest extends ComponentTest {
 
     // Actual test methods in super class
 
@@ -28,9 +29,8 @@ public class HrTest extends ComponentTest {
     }
 
     @Test
-    public void ariaHiddenSetByDefault() {
+    void ariaHiddenSetByDefault() {
         Hr hr = new Hr();
-        Assert.assertEquals("true",
-                hr.getElement().getAttribute("aria-hidden"));
+        assertEquals("true", hr.getElement().getAttribute("aria-hidden"));
     }
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
@@ -36,8 +36,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasEnabled;
@@ -52,7 +51,10 @@ import com.vaadin.flow.internal.change.NodeChange;
 import com.vaadin.flow.server.AbstractStreamResource;
 import com.vaadin.flow.server.streams.DownloadHandler;
 
-public class HtmlComponentSmokeTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HtmlComponentSmokeTest {
 
     // Custom logic for components without a no-args constructor
     private static final Map<Class<? extends HtmlComponent>, Supplier<HtmlComponent>> customConstructors = new HashMap<>();
@@ -105,9 +107,9 @@ public class HtmlComponentSmokeTest {
     }
 
     @Test
-    public void testAllHtmlComponents() throws IOException {
+    void testAllHtmlComponents() throws IOException {
         URL divClassLocationLocation = Div.class.getResource("Div.class");
-        Assert.assertEquals(divClassLocationLocation.getProtocol(), "file");
+        assertEquals(divClassLocationLocation.getProtocol(), "file");
 
         Path componentClassesLocation = new File(
                 divClassLocationLocation.getPath()).getParentFile().toPath();
@@ -158,13 +160,13 @@ public class HtmlComponentSmokeTest {
             HtmlComponent instance = constructor.newInstance(parameterValue);
 
             if (clazz.getAnnotation(Tag.class) == null) {
-                Assert.assertEquals(constructor
-                        + " should set the tag for a class without @Tag",
-                        parameterValue, instance.getElement().getTag());
+                assertEquals(parameterValue, instance.getElement().getTag(),
+                        constructor
+                                + " should set the tag for a class without @Tag");
             } else {
-                Assert.assertEquals(constructor
-                        + " should set the text content for a class with @Tag",
-                        parameterValue, instance.getElement().getText());
+                assertEquals(parameterValue, instance.getElement().getText(),
+                        constructor
+                                + " should set the text content for a class with @Tag");
             }
         } catch (NoSuchMethodException e) {
             // No constructor to test
@@ -289,8 +291,8 @@ public class HtmlComponentSmokeTest {
             getterType = (Class<?>) ((ParameterizedType) gen)
                     .getActualTypeArguments()[0];
         }
-        Assert.assertEquals(setter + " should have the same type as its getter",
-                propertyType, getterType);
+        assertEquals(propertyType, getterType,
+                setter + " should have the same type as its getter");
 
         Map<Class<?>, Object> specialValueMap = specialTestValues
                 .get(instance.getClass());
@@ -330,9 +332,8 @@ public class HtmlComponentSmokeTest {
 
             // Might have to add a blacklist for this logic at some point
             if (!testValue.equals(originalGetterValue)) {
-                Assert.assertTrue(
-                        setter + " should update the underlying state node",
-                        hasPendingChanges(elementNode));
+                assertTrue(hasPendingChanges(elementNode),
+                        setter + " should update the underlying state node");
             }
 
             Object getterValue = getter.invoke(instance);
@@ -340,8 +341,8 @@ public class HtmlComponentSmokeTest {
                 getterValue = ((Optional<?>) getterValue).get();
             }
 
-            AssertUtils.assertEquals(getter + " should return the set value",
-                    testValue, getterValue);
+            AssertUtils.assertEquals(testValue, getterValue,
+                    getter + " should return the set value");
 
         } catch (IllegalAccessException | IllegalArgumentException
                 | InvocationTargetException e) {

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlObjectTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlObjectTest.java
@@ -18,9 +18,8 @@ package com.vaadin.flow.component.html;
 import java.net.URI;
 import java.util.Optional;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.UI;
@@ -34,10 +33,14 @@ import com.vaadin.flow.server.streams.DownloadHandler;
 import com.vaadin.flow.server.streams.DownloadResponse;
 import com.vaadin.flow.server.streams.InputStreamDownloadHandler;
 
-public class HtmlObjectTest extends ComponentTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-    @After
-    public void tearDown() {
+class HtmlObjectTest extends ComponentTest {
+
+    @AfterEach
+    void tearDown() {
         CurrentInstance.clearAll();
     }
 
@@ -49,12 +52,12 @@ public class HtmlObjectTest extends ComponentTest {
 
     @Test
     @Override
-    public void testHasOrderedComponents() {
+    protected void testHasOrderedComponents() {
         super.testHasOrderedComponents();
     }
 
     @Test
-    public void setData_dataAsAResource() {
+    void setData_dataAsAResource() {
         UI ui = new UI();
         UI.setCurrent(ui);
         HtmlObject object = new HtmlObject();
@@ -64,12 +67,12 @@ public class HtmlObjectTest extends ComponentTest {
 
         URI uri = StreamResourceRegistry.getURI(resource);
 
-        Assert.assertEquals(uri.toASCIIString(),
+        assertEquals(uri.toASCIIString(),
                 object.getElement().getAttribute("data"));
     }
 
     @Test
-    public void setData_dataAsAResourceinCTOR() {
+    void setData_dataAsAResourceinCTOR() {
         UI ui = new UI();
         UI.setCurrent(ui);
         StreamResource resource = new StreamResource("foo",
@@ -79,37 +82,39 @@ public class HtmlObjectTest extends ComponentTest {
 
         URI uri = StreamResourceRegistry.getURI(resource);
 
-        Assert.assertEquals(uri.toASCIIString(),
+        assertEquals(uri.toASCIIString(),
                 object.getElement().getAttribute("data"));
     }
 
     @Test
-    public void setDownloadHandlerData_dataAsAResource() {
+    void setDownloadHandlerData_dataAsAResource() {
         UI ui = new UI();
         UI.setCurrent(ui);
         HtmlObject object = new HtmlObject();
         object.setData(event -> event.getWriter().write("foo"));
 
-        Assert.assertTrue("Data should be set as dynamic resource.",
+        assertTrue(
                 object.getElement().getAttribute("data")
-                        .startsWith("VAADIN/dynamic/resource/-1/"));
+                        .startsWith("VAADIN/dynamic/resource/-1/"),
+                "Data should be set as dynamic resource.");
     }
 
     @Test
-    public void setDownloadHandlerData_dataAsAResourceinCTOR() {
+    void setDownloadHandlerData_dataAsAResourceinCTOR() {
         UI ui = new UI();
         UI.setCurrent(ui);
 
         HtmlObject object = new HtmlObject(
                 event -> event.getWriter().write("foo"), "foo");
 
-        Assert.assertTrue("Data should be set as dynamic resource.",
+        assertTrue(
                 object.getElement().getAttribute("data")
-                        .startsWith("VAADIN/dynamic/resource/-1/"));
+                        .startsWith("VAADIN/dynamic/resource/-1/"),
+                "Data should be set as dynamic resource.");
     }
 
     @Test
-    public void downloadHandler_isSetToInline() {
+    void downloadHandler_isSetToInline() {
         Element element = Mockito.mock(Element.class);
         StateNode node = Mockito.mock(StateNode.class);
         Mockito.when(element.getNode()).thenReturn(node);
@@ -141,21 +146,21 @@ public class HtmlObjectTest extends ComponentTest {
             }
         }
         InputStreamDownloadHandler handler = createDummyDownloadHandler();
-        Assert.assertFalse(handler.isInline());
+        assertFalse(handler.isInline());
         new TestHtmlObject(handler);
-        Assert.assertTrue(handler.isInline());
+        assertTrue(handler.isInline());
 
         handler = createDummyDownloadHandler();
         new TestHtmlObject(handler, "type");
-        Assert.assertTrue(handler.isInline());
+        assertTrue(handler.isInline());
 
         handler = createDummyDownloadHandler();
         new TestHtmlObject(handler, "type", new Param("param", "paramValue"));
-        Assert.assertTrue(handler.isInline());
+        assertTrue(handler.isInline());
 
         handler = createDummyDownloadHandler();
         new TestHtmlObject(handler, new Param("param", "paramValue"));
-        Assert.assertTrue(handler.isInline());
+        assertTrue(handler.isInline());
     }
 
     private InputStreamDownloadHandler createDummyDownloadHandler() {

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/IFrameTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/IFrameTest.java
@@ -17,8 +17,7 @@ package com.vaadin.flow.component.html;
 
 import java.lang.reflect.Field;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
@@ -27,7 +26,10 @@ import com.vaadin.flow.server.streams.DownloadHandler;
 import com.vaadin.flow.server.streams.DownloadResponse;
 import com.vaadin.flow.server.streams.InputStreamDownloadHandler;
 
-public class IFrameTest extends ComponentTest {
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class IFrameTest extends ComponentTest {
 
     // Actual test methods mostly in super class
 
@@ -49,7 +51,7 @@ public class IFrameTest extends ComponentTest {
     }
 
     @Test
-    public void reload() throws Exception {
+    void reload() throws Exception {
         Element element = Mockito.mock(Element.class);
         IFrame iframe = new IFrame();
         Field f = Component.class.getDeclaredField("element");
@@ -64,12 +66,12 @@ public class IFrameTest extends ComponentTest {
 
     @Test
     @Override
-    public void testHasAriaLabelIsImplemented() {
+    protected void testHasAriaLabelIsImplemented() {
         super.testHasAriaLabelIsImplemented();
     }
 
     @Test
-    public void downloadHandler_isSetToInline() {
+    void downloadHandler_isSetToInline() {
         Element element = Mockito.mock(Element.class);
         class TestIFrame extends IFrame {
             public TestIFrame(DownloadHandler downloadHandler) {
@@ -84,8 +86,8 @@ public class IFrameTest extends ComponentTest {
         // dummy handler
         InputStreamDownloadHandler handler = DownloadHandler
                 .fromInputStream(event -> DownloadResponse.error(500));
-        Assert.assertFalse(handler.isInline());
+        assertFalse(handler.isInline());
         new TestIFrame(handler);
-        Assert.assertTrue(handler.isInline());
+        assertTrue(handler.isInline());
     }
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/ImageTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/ImageTest.java
@@ -19,8 +19,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.util.Optional;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
@@ -34,7 +33,11 @@ import com.vaadin.flow.server.streams.DownloadHandler;
 import com.vaadin.flow.server.streams.DownloadResponse;
 import com.vaadin.flow.server.streams.InputStreamDownloadHandler;
 
-public class ImageTest extends ComponentTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ImageTest extends ComponentTest {
 
     // Actual test methods in super class
 
@@ -45,22 +48,22 @@ public class ImageTest extends ComponentTest {
 
     @Test
     @Override
-    public void testHasAriaLabelIsImplemented() {
+    protected void testHasAriaLabelIsImplemented() {
         super.testHasAriaLabelIsImplemented();
     }
 
     @Test
-    public void emptyAltKeepsAttribute() {
+    void emptyAltKeepsAttribute() {
         Image img = new Image("test.png", "");
-        Assert.assertEquals("", img.getAlt().get());
-        Assert.assertTrue(img.getElement().hasAttribute("alt"));
+        assertEquals("", img.getAlt().get());
+        assertTrue(img.getElement().hasAttribute("alt"));
         img.setAlt(null);
-        Assert.assertEquals(Optional.empty(), img.getAlt());
-        Assert.assertFalse(img.getElement().hasAttribute("alt"));
+        assertEquals(Optional.empty(), img.getAlt());
+        assertFalse(img.getElement().hasAttribute("alt"));
     }
 
     @Test
-    public void downloadHandler_isSetToInline() {
+    void downloadHandler_isSetToInline() {
         Element element = Mockito.mock(Element.class);
         class TestImage extends Image {
             public TestImage(DownloadHandler downloadHandler, String alt) {
@@ -75,9 +78,9 @@ public class ImageTest extends ComponentTest {
         // dummy handler
         InputStreamDownloadHandler handler = DownloadHandler
                 .fromInputStream(event -> DownloadResponse.error(500));
-        Assert.assertFalse(handler.isInline());
+        assertFalse(handler.isInline());
         new TestImage(handler, "test.png");
-        Assert.assertTrue(handler.isInline());
+        assertTrue(handler.isInline());
     }
 
     /**
@@ -92,8 +95,8 @@ public class ImageTest extends ComponentTest {
                 handlerCaptor.capture());
 
         DownloadHandler handler = handlerCaptor.getValue();
-        Assert.assertTrue("Handler should be InputStreamDownloadHandler",
-                handler instanceof InputStreamDownloadHandler);
+        assertTrue(handler instanceof InputStreamDownloadHandler,
+                "Handler should be InputStreamDownloadHandler");
 
         // Create mock event and response to capture content type
         VaadinRequest request = Mockito.mock(VaadinRequest.class);
@@ -117,7 +120,7 @@ public class ImageTest extends ComponentTest {
     }
 
     @Test
-    public void byteArrayConstructor_typicalUseCase() throws Exception {
+    void byteArrayConstructor_typicalUseCase() throws Exception {
         Element element = Mockito.mock(Element.class);
         byte[] imageData = new byte[] { 1, 2, 3, 4, 5 };
 
@@ -136,11 +139,11 @@ public class ImageTest extends ComponentTest {
         Mockito.verify(element).setAttribute("alt", "test.png");
 
         String contentType = captureAndInvokeDownloadHandler(element);
-        Assert.assertEquals("image/png", contentType);
+        assertEquals("image/png", contentType);
     }
 
     @Test
-    public void byteArrayConstructor_withExplicitMimeType() throws Exception {
+    void byteArrayConstructor_withExplicitMimeType() throws Exception {
         Element element = Mockito.mock(Element.class);
         byte[] imageData = new byte[] { 1, 2, 3, 4, 5 };
 
@@ -159,11 +162,11 @@ public class ImageTest extends ComponentTest {
         Mockito.verify(element).setAttribute("alt", "test.webp");
 
         String contentType = captureAndInvokeDownloadHandler(element);
-        Assert.assertEquals("image/webp", contentType);
+        assertEquals("image/webp", contentType);
     }
 
     @Test
-    public void byteArrayConstructor_withNullMimeType() throws Exception {
+    void byteArrayConstructor_withNullMimeType() throws Exception {
         Element element = Mockito.mock(Element.class);
         byte[] imageData = new byte[] { 1, 2, 3, 4, 5 };
 
@@ -183,6 +186,6 @@ public class ImageTest extends ComponentTest {
 
         String contentType = captureAndInvokeDownloadHandler(element);
         // When MIME type is null, it falls back to the service's getMimeType
-        Assert.assertEquals("application/octet-stream", contentType);
+        assertEquals("application/octet-stream", contentType);
     }
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/InputTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/InputTest.java
@@ -18,14 +18,16 @@ package com.vaadin.flow.component.html;
 import java.beans.IntrospectionException;
 import java.lang.reflect.InvocationTargetException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class InputTest extends ComponentTest {
+class InputTest extends ComponentTest {
 
     // Actual test methods in super class
 
+    @BeforeEach
     @Override
-    public void setup() throws IntrospectionException, InstantiationException,
+    void setup() throws IntrospectionException, InstantiationException,
             IllegalAccessException, ClassNotFoundException,
             InvocationTargetException, NoSuchMethodException {
         whitelistProperty("valueChangeMode");
@@ -43,7 +45,7 @@ public class InputTest extends ComponentTest {
 
     @Test
     @Override
-    public void testHasAriaLabelIsImplemented() {
+    protected void testHasAriaLabelIsImplemented() {
         super.testHasAriaLabelIsImplemented();
     }
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/ListItemTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/ListItemTest.java
@@ -15,9 +15,9 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ListItemTest extends ComponentTest {
+class ListItemTest extends ComponentTest {
     // Actual test methods in super class
 
     @Override
@@ -27,7 +27,7 @@ public class ListItemTest extends ComponentTest {
 
     @Test
     @Override
-    public void testHasAriaLabelIsNotImplemented() {
+    protected void testHasAriaLabelIsNotImplemented() {
         // Don't use aria-label or aria-labelledby on any other non-interactive
         // content such as p, legend, li, or ul, because it is ignored.
         // Source: https://www.w3.org/TR/using-aria/#label-support

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/MainTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/MainTest.java
@@ -15,9 +15,9 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class MainTest extends ComponentTest {
+class MainTest extends ComponentTest {
     // Actual test methods in super class
 
     @Override
@@ -27,13 +27,13 @@ public class MainTest extends ComponentTest {
 
     @Test
     @Override
-    public void testHasOrderedComponents() {
+    protected void testHasOrderedComponents() {
         super.testHasOrderedComponents();
     }
 
     @Test
     @Override
-    public void testHasAriaLabelIsImplemented() {
+    protected void testHasAriaLabelIsImplemented() {
         super.testHasAriaLabelIsImplemented();
     }
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeButtonTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeButtonTest.java
@@ -15,9 +15,9 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class NativeButtonTest extends ComponentTest {
+class NativeButtonTest extends ComponentTest {
 
     // Actual test methods in super class
 
@@ -28,7 +28,7 @@ public class NativeButtonTest extends ComponentTest {
 
     @Test
     @Override
-    public void testHasAriaLabelIsImplemented() {
+    protected void testHasAriaLabelIsImplemented() {
         super.testHasAriaLabelIsImplemented();
     }
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeDetailsTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeDetailsTest.java
@@ -15,10 +15,14 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class NativeDetailsTest extends ComponentTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NativeDetailsTest extends ComponentTest {
     // Actual test methods in super class
 
     @Override
@@ -32,50 +36,50 @@ public class NativeDetailsTest extends ComponentTest {
     }
 
     @Test
-    public void testConstructorParams() {
+    void testConstructorParams() {
         NativeDetails details = new NativeDetails("text-summary");
-        Assert.assertEquals("text-summary", details.getSummaryText());
-        Assert.assertNull(details.getContent());
+        assertEquals("text-summary", details.getSummaryText());
+        assertNull(details.getContent());
 
         details = new NativeDetails(new Paragraph("text-summary"));
-        Assert.assertEquals("", details.getSummaryText());
-        Assert.assertEquals("text-summary",
+        assertEquals("", details.getSummaryText());
+        assertEquals("text-summary",
                 details.getSummary().getElement().getTextRecursively());
-        Assert.assertNull(details.getContent());
+        assertNull(details.getContent());
 
         Paragraph content = new Paragraph("content");
         details = new NativeDetails("text-summary", content);
-        Assert.assertEquals("text-summary", details.getSummaryText());
-        Assert.assertEquals(content, details.getContent());
+        assertEquals("text-summary", details.getSummaryText());
+        assertEquals(content, details.getContent());
     }
 
     @Test
-    public void testSetSummaryReplacesSummary() {
+    void testSetSummaryReplacesSummary() {
         Paragraph summmary2 = new Paragraph("summary2");
         NativeDetails details = new NativeDetails("summary1",
                 new Paragraph("content"));
-        Assert.assertEquals("summary1", details.getSummaryText());
+        assertEquals("summary1", details.getSummaryText());
 
         details.setSummary(summmary2);
-        Assert.assertEquals("summary2",
+        assertEquals("summary2",
                 details.getSummary().getElement().getTextRecursively());
 
         details.setSummaryText("summary3");
-        Assert.assertEquals("summary3", details.getSummaryText());
+        assertEquals("summary3", details.getSummaryText());
     }
 
     @Test
-    public void testSetContentReplacesContent() {
+    void testSetContentReplacesContent() {
         Paragraph content1 = new Paragraph("content1");
         Paragraph content2 = new Paragraph("content2");
         NativeDetails details = new NativeDetails("text-summary", content1);
-        Assert.assertEquals(content1, details.getContent());
-        Assert.assertTrue(content1.getParent().isPresent());
-        Assert.assertFalse(content2.getParent().isPresent());
+        assertEquals(content1, details.getContent());
+        assertTrue(content1.getParent().isPresent());
+        assertFalse(content2.getParent().isPresent());
 
         details.setContent(content2);
-        Assert.assertEquals(content2, details.getContent());
-        Assert.assertTrue(content2.getParent().isPresent());
-        Assert.assertFalse(content1.getParent().isPresent());
+        assertEquals(content2, details.getContent());
+        assertTrue(content2.getParent().isPresent());
+        assertFalse(content1.getParent().isPresent());
     }
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeLabelTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeLabelTest.java
@@ -15,10 +15,11 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class NativeLabelTest extends ComponentTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class NativeLabelTest extends ComponentTest {
 
     // Actual test methods in super class
 
@@ -28,12 +29,12 @@ public class NativeLabelTest extends ComponentTest {
     }
 
     @Test
-    public void setForComponent() {
+    void setForComponent() {
         NativeLabel otherComponent = new NativeLabel();
         otherComponent.setId("otherC");
         NativeLabel l = (NativeLabel) getComponent();
         l.setFor(otherComponent);
-        Assert.assertEquals(otherComponent.getId().get(), l.getFor().get());
+        assertEquals(otherComponent.getId().get(), l.getFor().get());
     }
 
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableCellTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableCellTest.java
@@ -15,12 +15,13 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static com.vaadin.flow.component.html.AssertUtils.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class NativeTableCellTest extends ComponentTest {
+class NativeTableCellTest extends ComponentTest {
     // Actual test methods in super class
 
     @Override
@@ -29,78 +30,78 @@ public class NativeTableCellTest extends ComponentTest {
         addProperty("rowspan", int.class, 1, 2, false, false);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void colspanMustBeNonNegative() {
+    @Test
+    void colspanMustBeNonNegative() {
         NativeTableCell cell = (NativeTableCell) getComponent();
-        cell.setColspan(-1);
+        assertThrows(IllegalArgumentException.class, () -> cell.setColspan(-1));
     }
 
     @Test
-    public void setColspan() {
+    void setColspan() {
         NativeTableCell cell = (NativeTableCell) getComponent();
         cell.setColspan(2);
-        assertEquals("Colspan should be 2", "2",
-                cell.getElement().getAttribute("colspan"));
+        assertEquals("2", cell.getElement().getAttribute("colspan"),
+                "Colspan should be 2");
     }
 
     @Test
-    public void getDefaultColspan() {
+    void getDefaultColspan() {
         NativeTableCell cell = (NativeTableCell) getComponent();
         int colspan = cell.getColspan();
-        assertEquals("Default colspan should be 1", 1, colspan);
+        assertEquals(1, colspan, "Default colspan should be 1");
     }
 
     @Test
-    public void getColspan() {
+    void getColspan() {
         NativeTableCell cell = (NativeTableCell) getComponent();
         cell.getElement().setAttribute("colspan", "2");
-        assertEquals("Colspan should be 2", 2, cell.getColspan());
+        assertEquals(2, cell.getColspan(), "Colspan should be 2");
     }
 
     @Test
-    public void resetColspan() {
+    void resetColspan() {
         NativeTableCell cell = (NativeTableCell) getComponent();
         cell.getElement().setAttribute("colspan", "2");
         cell.resetColspan();
-        assertNull("Element should not have colspan attribute",
-                cell.getElement().getAttribute("colspan"));
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void rowspanMustNonNegative() {
-        NativeTableCell cell = (NativeTableCell) getComponent();
-        cell.setRowspan(-1);
+        assertNull(cell.getElement().getAttribute("colspan"),
+                "Element should not have colspan attribute");
     }
 
     @Test
-    public void setRowspan() {
+    void rowspanMustNonNegative() {
+        NativeTableCell cell = (NativeTableCell) getComponent();
+        assertThrows(IllegalArgumentException.class, () -> cell.setRowspan(-1));
+    }
+
+    @Test
+    void setRowspan() {
         NativeTableCell cell = (NativeTableCell) getComponent();
         cell.setRowspan(2);
-        assertEquals("Rowspan should be 2", "2",
-                cell.getElement().getAttribute("rowspan"));
+        assertEquals("2", cell.getElement().getAttribute("rowspan"),
+                "Rowspan should be 2");
     }
 
     @Test
-    public void getDefaultRowspan() {
+    void getDefaultRowspan() {
         NativeTableCell cell = (NativeTableCell) getComponent();
         int rowspan = cell.getRowspan();
-        assertEquals("Default rowspan should be 1", 1, rowspan);
+        assertEquals(1, rowspan, "Default rowspan should be 1");
     }
 
     @Test
-    public void getRowspan() {
+    void getRowspan() {
         NativeTableCell cell = (NativeTableCell) getComponent();
         cell.getElement().setAttribute("rowspan", "2");
-        assertEquals("Rowspan should be 2", 2, cell.getRowspan());
+        assertEquals(2, cell.getRowspan(), "Rowspan should be 2");
     }
 
     @Test
-    public void resetRowspan() {
+    void resetRowspan() {
         NativeTableCell cell = (NativeTableCell) getComponent();
         cell.setRowspan(2);
         cell.resetRowspan();
-        assertNull("Element should not have rowspan attribute",
-                cell.getElement().getAttribute("rowspan"));
+        assertNull(cell.getElement().getAttribute("rowspan"),
+                "Element should not have rowspan attribute");
     }
 
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableRowContainerTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableRowContainerTest.java
@@ -15,79 +15,79 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class NativeTableRowContainerTest {
+class NativeTableRowContainerTest {
 
     private RowContainer container;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         container = new RowContainer();
     }
 
     @Test
-    public void addRow() {
+    void addRow() {
         var children = container.getChildren().toList();
         assertEquals(0, children.size());
         var row = container.addRow();
         children = container.getChildren().toList();
         assertEquals(1, children.size());
-        AssertUtils.assertEquals("Child is not added row", children.get(0),
-                row);
+        AssertUtils.assertEquals(children.get(0), row,
+                "Child is not added row");
         row = container.addRow();
         children = container.getChildren().toList();
         assertEquals(2, children.size());
-        AssertUtils.assertEquals("Child is not added row", children.get(1),
-                row);
+        AssertUtils.assertEquals(children.get(1), row,
+                "Child is not added row");
         for (var child : children) {
             assertTrue(child instanceof NativeTableRow);
         }
     }
 
     @Test
-    public void getRows() {
+    void getRows() {
         for (int i = 0; i < 10; i++) {
             container.addRow();
         }
         var rows = container.getRows();
         var children = container.getChildren().toList();
         for (int i = 0; i < 10; i++) {
-            AssertUtils.assertEquals("row does not match", children.get(i),
-                    rows.get(i));
+            AssertUtils.assertEquals(children.get(i), rows.get(i),
+                    "row does not match");
         }
     }
 
     @Test
-    public void getRow() {
+    void getRow() {
         var row0 = new NativeTableRow();
         var row1 = new NativeTableRow();
         var row2 = new NativeTableRow();
         container.addRows(row0, row1, row2);
-        AssertUtils.assertEquals("Row 0 does not match", row0,
-                container.getRow(0).orElseThrow());
-        AssertUtils.assertEquals("Row 1 does not match", row1,
-                container.getRow(1).orElseThrow());
-        AssertUtils.assertEquals("Row 2 does not match", row2,
-                container.getRow(2).orElseThrow());
+        AssertUtils.assertEquals(row0, container.getRow(0).orElseThrow(),
+                "Row 0 does not match");
+        AssertUtils.assertEquals(row1, container.getRow(1).orElseThrow(),
+                "Row 1 does not match");
+        AssertUtils.assertEquals(row2, container.getRow(2).orElseThrow(),
+                "Row 2 does not match");
     }
 
     @Test
-    public void getNonExistentRow() {
+    void getNonExistentRow() {
         container.addRow();
         assertTrue(container.getRow(0).isPresent());
         assertTrue(container.getRow(1).isEmpty());
     }
 
     @Test
-    public void getRowIndex() {
+    void getRowIndex() {
         for (int i = 0; i < 10; i++) {
             container.addRow();
             var row = container.getRow(i).orElseThrow();
@@ -97,7 +97,7 @@ public class NativeTableRowContainerTest {
     }
 
     @Test
-    public void insertRow() {
+    void insertRow() {
         var row0 = new NativeTableRow();
         var row1 = new NativeTableRow();
         var row2 = new NativeTableRow();
@@ -105,12 +105,12 @@ public class NativeTableRowContainerTest {
         var newRow = container.insertRow(1);
         var children = container.getChildren().toList();
         assertEquals(4, children.size());
-        AssertUtils.assertEquals("New row must be inserted at given position",
-                newRow, children.get(1));
+        AssertUtils.assertEquals(newRow, children.get(1),
+                "New row must be inserted at given position");
     }
 
     @Test
-    public void removeAllRows() {
+    void removeAllRows() {
         container.addRow();
         container.addRow();
         container.addRow();
@@ -119,7 +119,7 @@ public class NativeTableRowContainerTest {
     }
 
     @Test
-    public void removeRowByIndex() {
+    void removeRowByIndex() {
         var row0 = container.addRow();
         var row1 = container.addRow();
         var row2 = container.addRow();
@@ -127,14 +127,14 @@ public class NativeTableRowContainerTest {
         assertTrue(row1.getParent().isEmpty());
         var children = container.getChildren().toList();
         assertEquals(2, children.size());
-        AssertUtils.assertEquals("row0 must not be removed", row0,
-                children.get(0));
-        AssertUtils.assertEquals("row2 must not be removed", row2,
-                children.get(1));
+        AssertUtils.assertEquals(row0, children.get(0),
+                "row0 must not be removed");
+        AssertUtils.assertEquals(row2, children.get(1),
+                "row2 must not be removed");
     }
 
     @Test
-    public void removeRowsByReference() {
+    void removeRowsByReference() {
         var row0 = container.addRow();
         var row1 = container.addRow();
         var row2 = container.addRow();
@@ -145,28 +145,28 @@ public class NativeTableRowContainerTest {
         assertTrue(row3.getParent().isEmpty());
         var children = container.getChildren().toList();
         assertEquals(3, children.size());
-        AssertUtils.assertEquals("row0 must not be removed", container,
-                row0.getParent().orElseThrow());
-        AssertUtils.assertEquals("row2 must not be removed", container,
-                row2.getParent().orElseThrow());
-        AssertUtils.assertEquals("row4 must not be removed", container,
-                row4.getParent().orElseThrow());
+        AssertUtils.assertEquals(container, row0.getParent().orElseThrow(),
+                "row0 must not be removed");
+        AssertUtils.assertEquals(container, row2.getParent().orElseThrow(),
+                "row2 must not be removed");
+        AssertUtils.assertEquals(container, row4.getParent().orElseThrow(),
+                "row4 must not be removed");
     }
 
     @Test
-    public void replaceRow() {
+    void replaceRow() {
         container.addRow();
         container.addRow();
         container.addRow();
         var newRow = new NativeTableRow();
         container.replaceRow(1, newRow);
         assertEquals(3, container.getChildren().count());
-        AssertUtils.assertEquals("Row must be replaced with new row", newRow,
-                container.getRow(1).orElseThrow());
+        AssertUtils.assertEquals(newRow, container.getRow(1).orElseThrow(),
+                "Row must be replaced with new row");
     }
 
     @Test
-    public void getRowCount() {
+    void getRowCount() {
         assertEquals(0, container.getRowCount());
         container.addRow();
         assertEquals(1, container.getRowCount());

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableTest.java
@@ -19,16 +19,19 @@ import java.beans.IntrospectionException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class NativeTableTest extends ComponentTest {
+class NativeTableTest extends ComponentTest {
     // Actual test methods in super class
 
+    @BeforeEach
     @Override
-    public void setup() throws IntrospectionException, InstantiationException,
+    void setup() throws IntrospectionException, InstantiationException,
             IllegalAccessException, ClassNotFoundException,
             InvocationTargetException, NoSuchMethodException {
         whitelistProperty("captionText");
@@ -36,15 +39,15 @@ public class NativeTableTest extends ComponentTest {
     }
 
     @Test
-    public void getCaption() {
+    void getCaption() {
         var component = (NativeTable) getComponent();
         NativeTableCaption caption = component.getCaption();
-        AssertUtils.assertEquals("Caption does not match",
-                component.getChildren().toList().get(0), caption);
+        AssertUtils.assertEquals(component.getChildren().toList().get(0),
+                caption, "Caption does not match");
     }
 
     @Test
-    public void addsCaptionAsFirstChild() {
+    void addsCaptionAsFirstChild() {
         var component = (NativeTable) getComponent();
         assertEquals(0, component.getChildren().count());
         component.getHead();
@@ -52,15 +55,16 @@ public class NativeTableTest extends ComponentTest {
         component.getFoot();
         var caption = component.getCaption();
         assertEquals(4, component.getChildren().count());
-        AssertUtils.assertEquals("Caption is not the first child", caption,
-                component.getChildren().findFirst().orElseThrow());
-        AssertUtils.assertEquals("Table is not the caption's father",
-                caption.getParent().orElseThrow(), component);
+        AssertUtils.assertEquals(caption,
+                component.getChildren().findFirst().orElseThrow(),
+                "Caption is not the first child");
+        AssertUtils.assertEquals(caption.getParent().orElseThrow(), component,
+                "Table is not the caption's father");
 
     }
 
     @Test
-    public void setCaptionText() {
+    void setCaptionText() {
         var component = (NativeTable) getComponent();
         String expectedText = "Test caption text.";
         component.setCaptionText(expectedText);
@@ -69,7 +73,7 @@ public class NativeTableTest extends ComponentTest {
     }
 
     @Test
-    public void getCaptionText() {
+    void getCaptionText() {
         var component = (NativeTable) getComponent();
         String expectedText = "Test caption text.";
         var caption = component.getCaption();
@@ -78,7 +82,7 @@ public class NativeTableTest extends ComponentTest {
     }
 
     @Test
-    public void removeCaption() {
+    void removeCaption() {
         var component = (NativeTable) getComponent();
         var caption = component.getCaption();
         component.removeCaption();
@@ -86,16 +90,16 @@ public class NativeTableTest extends ComponentTest {
     }
 
     @Test
-    public void getHead() {
+    void getHead() {
         var component = (NativeTable) getComponent();
         assertEquals(0, component.getChildren().count());
         NativeTableHeader head = component.getHead();
-        AssertUtils.assertEquals("head was not added", component,
-                head.getParent().orElseThrow());
+        AssertUtils.assertEquals(component, head.getParent().orElseThrow(),
+                "head was not added");
     }
 
     @Test
-    public void addHeadAfterCaption() {
+    void addHeadAfterCaption() {
         var component = (NativeTable) getComponent();
         component.getCaption();
         var head = component.getHead();
@@ -105,7 +109,7 @@ public class NativeTableTest extends ComponentTest {
     }
 
     @Test
-    public void removeHead() {
+    void removeHead() {
         var component = (NativeTable) getComponent();
         NativeTableHeader head = component.getHead();
         component.removeHead();
@@ -113,16 +117,16 @@ public class NativeTableTest extends ComponentTest {
     }
 
     @Test
-    public void getFoot() {
+    void getFoot() {
         var component = (NativeTable) getComponent();
         assertEquals(0, component.getChildren().count());
         NativeTableFooter footer = component.getFoot();
-        AssertUtils.assertEquals("footer was not added", component,
-                footer.getParent().orElseThrow());
+        AssertUtils.assertEquals(component, footer.getParent().orElseThrow(),
+                "footer was not added");
     }
 
     @Test
-    public void removeFoot() {
+    void removeFoot() {
         var component = (NativeTable) getComponent();
         NativeTableFooter footer = component.getFoot();
         component.removeFoot();
@@ -130,7 +134,7 @@ public class NativeTableTest extends ComponentTest {
     }
 
     @Test
-    public void addBody() {
+    void addBody() {
         var component = (NativeTable) getComponent();
         component.addBody();
         assertEquals(1, component.getChildren().count());
@@ -139,7 +143,7 @@ public class NativeTableTest extends ComponentTest {
     }
 
     @Test
-    public void addBodyAfterCaption() {
+    void addBodyAfterCaption() {
         var component = (NativeTable) getComponent();
         component.getCaption();
         var body = component.addBody();
@@ -147,7 +151,7 @@ public class NativeTableTest extends ComponentTest {
     }
 
     @Test
-    public void addBodyAfterHeader() {
+    void addBodyAfterHeader() {
         var component = (NativeTable) getComponent();
         component.getHead();
         var body = component.addBody();
@@ -155,7 +159,7 @@ public class NativeTableTest extends ComponentTest {
     }
 
     @Test
-    public void addBodyAfterBothCaptionAndHeader() {
+    void addBodyAfterBothCaptionAndHeader() {
         var component = (NativeTable) getComponent();
         component.getCaption();
         component.getHead();
@@ -164,7 +168,7 @@ public class NativeTableTest extends ComponentTest {
     }
 
     @Test
-    public void getBody() {
+    void getBody() {
         var component = (NativeTable) getComponent();
         var body = component.getBody();
         assertEquals(1, component.getChildren().count());
@@ -173,42 +177,43 @@ public class NativeTableTest extends ComponentTest {
         assertEquals(2, component.getChildren().count());
         // subsequent calls should return the same first body
         var secondCallBody = component.getBody();
-        AssertUtils.assertEquals("No new body should've been created", body,
-                secondCallBody);
+        AssertUtils.assertEquals(body, secondCallBody,
+                "No new body should've been created");
     }
 
     @Test
-    public void getBodyByIndex() {
+    void getBodyByIndex() {
         var component = (NativeTable) getComponent();
         var body = component.getBody(0);
         assertEquals(1, component.getChildren().count());
         var secondCallBody = component.getBody(0);
         assertEquals(1, component.getChildren().count());
-        AssertUtils.assertEquals("No new body should've been created", body,
-                secondCallBody);
-    }
-
-    @Test(expected = IndexOutOfBoundsException.class)
-    public void getNonExistentBodyByIndex() {
-        var component = (NativeTable) getComponent();
-        component.getBody(1);
+        AssertUtils.assertEquals(body, secondCallBody,
+                "No new body should've been created");
     }
 
     @Test
-    public void getBodies() {
+    void getNonExistentBodyByIndex() {
+        var component = (NativeTable) getComponent();
+        assertThrows(IndexOutOfBoundsException.class,
+                () -> component.getBody(1));
+    }
+
+    @Test
+    void getBodies() {
         var component = (NativeTable) getComponent();
         for (int i = 0; i < 10; i++) {
             component.addBody();
         }
         List<NativeTableBody> bodies = component.getBodies();
         for (NativeTableBody body : bodies) {
-            AssertUtils.assertEquals("Body is not a child of table", component,
-                    body.getParent().orElseThrow());
+            AssertUtils.assertEquals(component, body.getParent().orElseThrow(),
+                    "Body is not a child of table");
         }
     }
 
     @Test
-    public void removeBody() {
+    void removeBody() {
         var component = (NativeTable) getComponent();
         for (int i = 0; i < 10; i++) {
             component.addBody();
@@ -221,7 +226,7 @@ public class NativeTableTest extends ComponentTest {
     }
 
     @Test
-    public void removeBodyByIndex() {
+    void removeBodyByIndex() {
         var component = (NativeTable) getComponent();
         var body0 = component.addBody();
         var body1 = component.addBody();
@@ -233,7 +238,7 @@ public class NativeTableTest extends ComponentTest {
     }
 
     @Test
-    public void removeBodyByReference() {
+    void removeBodyByReference() {
         var component = (NativeTable) getComponent();
         var body0 = component.addBody();
         var body1 = component.addBody();

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NavTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NavTest.java
@@ -15,9 +15,9 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class NavTest extends ComponentTest {
+class NavTest extends ComponentTest {
     // Actual test methods in super class
 
     @Override
@@ -27,13 +27,13 @@ public class NavTest extends ComponentTest {
 
     @Test
     @Override
-    public void testHasOrderedComponents() {
+    protected void testHasOrderedComponents() {
         super.testHasOrderedComponents();
     }
 
     @Test
     @Override
-    public void testHasAriaLabelIsImplemented() {
+    protected void testHasAriaLabelIsImplemented() {
         super.testHasAriaLabelIsImplemented();
     }
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/OrderedListTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/OrderedListTest.java
@@ -15,11 +15,11 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.component.html.OrderedList.NumberingType;
 
-public class OrderedListTest extends ComponentTest {
+class OrderedListTest extends ComponentTest {
 
     // Actual test methods in super class
 
@@ -31,7 +31,7 @@ public class OrderedListTest extends ComponentTest {
 
     @Test
     @Override
-    public void testHasAriaLabelIsNotImplemented() {
+    protected void testHasAriaLabelIsNotImplemented() {
         // Don't use aria-label or aria-labelledby on any other non-interactive
         // content such as p, legend, li, or ul, because it is ignored.
         // Source: https://www.w3.org/TR/using-aria/#label-support

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/ParagraphTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/ParagraphTest.java
@@ -15,9 +15,9 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ParagraphTest extends ComponentTest {
+class ParagraphTest extends ComponentTest {
     // Actual test methods in super class
 
     @Override
@@ -27,7 +27,7 @@ public class ParagraphTest extends ComponentTest {
 
     @Test
     @Override
-    public void testHasAriaLabelIsNotImplemented() {
+    protected void testHasAriaLabelIsNotImplemented() {
         // Don't use aria-label or aria-labelledby on any other non-interactive
         // content such as p, legend, li, or ul, because it is ignored.
         // Source: https://www.w3.org/TR/using-aria/#label-support

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/PreTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/PreTest.java
@@ -15,9 +15,9 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class PreTest extends ComponentTest {
+class PreTest extends ComponentTest {
     // Actual test methods in super class
 
     @Override
@@ -27,7 +27,7 @@ public class PreTest extends ComponentTest {
 
     @Test
     @Override
-    public void testHasAriaLabelIsNotImplemented() {
+    protected void testHasAriaLabelIsNotImplemented() {
         // Don't use aria-label or aria-labelledby on any other non-interactive
         // content such as p, legend, li, or ul, because it is ignored.
         // Source: https://www.w3.org/TR/using-aria/#label-support

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/RangeInputTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/RangeInputTest.java
@@ -18,15 +18,19 @@ package com.vaadin.flow.component.html;
 import java.beans.IntrospectionException;
 import java.lang.reflect.InvocationTargetException;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class RangeInputTest extends ComponentTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class RangeInputTest extends ComponentTest {
 
     // Actual test methods in super class
 
+    @BeforeEach
     @Override
-    public void setup() throws IntrospectionException, InstantiationException,
+    void setup() throws IntrospectionException, InstantiationException,
             IllegalAccessException, ClassNotFoundException,
             InvocationTargetException, NoSuchMethodException {
         whitelistProperty("valueChangeMode");
@@ -51,31 +55,31 @@ public class RangeInputTest extends ComponentTest {
 
     @Test
     @Override
-    public void testHasAriaLabelIsImplemented() {
+    protected void testHasAriaLabelIsImplemented() {
         super.testHasAriaLabelIsImplemented();
     }
 
     @Test
-    public void settingOrientationUpdatesStylesProperly() {
+    void settingOrientationUpdatesStylesProperly() {
         final RangeInput rangeInput = new RangeInput();
-        Assert.assertNull(rangeInput.getStyle().get("-webkit-appearance"));
-        Assert.assertNull(rangeInput.getStyle().get("appearance"));
-        Assert.assertNull(rangeInput.getStyle().get("writing-mode"));
-        Assert.assertEquals(RangeInput.Orientation.HORIZONTAL,
+        assertNull(rangeInput.getStyle().get("-webkit-appearance"));
+        assertNull(rangeInput.getStyle().get("appearance"));
+        assertNull(rangeInput.getStyle().get("writing-mode"));
+        assertEquals(RangeInput.Orientation.HORIZONTAL,
                 rangeInput.getOrientation());
         rangeInput.setOrientation(RangeInput.Orientation.VERTICAL);
-        Assert.assertEquals("slider-vertical",
+        assertEquals("slider-vertical",
                 rangeInput.getStyle().get("-webkit-appearance"));
-        Assert.assertEquals("slider-vertical",
+        assertEquals("slider-vertical",
                 rangeInput.getStyle().get("appearance"));
-        Assert.assertEquals("bt-lr", rangeInput.getStyle().get("writing-mode"));
-        Assert.assertEquals(RangeInput.Orientation.VERTICAL,
+        assertEquals("bt-lr", rangeInput.getStyle().get("writing-mode"));
+        assertEquals(RangeInput.Orientation.VERTICAL,
                 rangeInput.getOrientation());
         rangeInput.setOrientation(RangeInput.Orientation.HORIZONTAL);
-        Assert.assertNull(rangeInput.getStyle().get("-webkit-appearance"));
-        Assert.assertNull(rangeInput.getStyle().get("appearance"));
-        Assert.assertNull(rangeInput.getStyle().get("writing-mode"));
-        Assert.assertEquals(RangeInput.Orientation.HORIZONTAL,
+        assertNull(rangeInput.getStyle().get("-webkit-appearance"));
+        assertNull(rangeInput.getStyle().get("appearance"));
+        assertNull(rangeInput.getStyle().get("writing-mode"));
+        assertEquals(RangeInput.Orientation.HORIZONTAL,
                 rangeInput.getOrientation());
     }
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/SectionTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/SectionTest.java
@@ -15,9 +15,9 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class SectionTest extends ComponentTest {
+class SectionTest extends ComponentTest {
     // Actual test methods in super class
 
     @Override
@@ -27,13 +27,13 @@ public class SectionTest extends ComponentTest {
 
     @Test
     @Override
-    public void testHasAriaLabelIsImplemented() {
+    protected void testHasAriaLabelIsImplemented() {
         super.testHasAriaLabelIsImplemented();
     }
 
     @Test
     @Override
-    public void testHasOrderedComponents() {
+    protected void testHasOrderedComponents() {
         // According to this article:
         // https://www.scottohara.me/blog/2021/07/16/section.html
         // aria-label and aria-labelled-by are the best way to provide an

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/SpanTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/SpanTest.java
@@ -15,9 +15,9 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class SpanTest extends ComponentTest {
+class SpanTest extends ComponentTest {
     // Actual test methods in super class
 
     @Override
@@ -27,7 +27,7 @@ public class SpanTest extends ComponentTest {
 
     @Test
     @Override
-    public void testHasAriaLabelIsNotImplemented() {
+    protected void testHasAriaLabelIsNotImplemented() {
         // Don't use aria-label or aria-labelledby on any other non-interactive
         // content such as p, legend, li, or ul, because it is ignored.
         // Source: https://www.w3.org/TR/using-aria/#label-support

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/UnorderedListTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/UnorderedListTest.java
@@ -15,9 +15,9 @@
  */
 package com.vaadin.flow.component.html;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class UnorderedListTest extends ComponentTest {
+class UnorderedListTest extends ComponentTest {
     // Actual test methods in super class
 
     @Override
@@ -27,7 +27,7 @@ public class UnorderedListTest extends ComponentTest {
 
     @Test
     @Override
-    public void testHasAriaLabelIsNotImplemented() {
+    protected void testHasAriaLabelIsNotImplemented() {
         // Don't use aria-label or aria-labelledby on any other non-interactive
         // content such as p, legend, li, or ul, because it is ignored.
         // Source: https://www.w3.org/TR/using-aria/#label-support


### PR DESCRIPTION
Migrate all test files in flow-html-components from JUnit 4 to JUnit 5:
- Replace JUnit 4 imports with JUnit 5 equivalents
- Convert @Before/@After to @BeforeEach/@AfterEach
- Add @BeforeEach to setup() overrides in subclasses
- Change test class and method visibility to package-private
- Replace Assert.xxx() with static imports from Assertions
- Reorder message arguments to JUnit 5 convention (message last)
- Convert @Test(expected=...) to assertThrows
- Update AssertUtils to use JUnit 5 Assertions with message-last signature
