### PR TITLE
fix: Only throw if a ListSignal is used in an explicit transaction

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/signals/local/ListSignal.java
+++ b/flow-server/src/main/java/com/vaadin/flow/signals/local/ListSignal.java
@@ -66,7 +66,7 @@ public class ListSignal<T>
         assertLockHeld();
         super.checkPreconditions();
 
-        if (Transaction.inTransaction()) {
+        if (Transaction.inExplicitTransaction()) {
             throw new IllegalStateException(
                     "ListSignal cannot be used inside signal transactions because it can hold a reference to a mutable object that can be mutated directly, bypassing transaction control. Use SharedListSignal instead.");
         }

--- a/flow-server/src/test/java/com/vaadin/flow/signals/local/ListSignalTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/local/ListSignalTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.signals.SignalTestBase;
+import com.vaadin.flow.signals.impl.Transaction;
 import com.vaadin.flow.signals.impl.UsageTracker;
 import com.vaadin.flow.signals.impl.UsageTracker.Usage;
 
@@ -383,6 +384,87 @@ public class ListSignalTest extends SignalTestBase {
         signal.insertLast("two");
 
         assertEquals("ListSignal[one, two]", signal.toString());
+    }
+
+    @Test
+    void get_insideExplicitTransaction_throwsException() {
+        ListSignal<String> signal = new ListSignal<>();
+        signal.insertLast("value");
+
+        assertThrows(IllegalStateException.class, () -> {
+            Transaction.runInTransaction(() -> {
+                signal.get();
+            });
+        });
+    }
+
+    @Test
+    void peek_insideExplicitTransaction_throwsException() {
+        ListSignal<String> signal = new ListSignal<>();
+        signal.insertLast("value");
+
+        assertThrows(IllegalStateException.class, () -> {
+            Transaction.runInTransaction(() -> {
+                signal.peek();
+            });
+        });
+    }
+
+    @Test
+    void insertFirst_insideExplicitTransaction_throwsException() {
+        ListSignal<String> signal = new ListSignal<>();
+
+        assertThrows(IllegalStateException.class, () -> {
+            Transaction.runInTransaction(() -> {
+                signal.insertFirst("value");
+            });
+        });
+    }
+
+    @Test
+    void insertLast_insideExplicitTransaction_throwsException() {
+        ListSignal<String> signal = new ListSignal<>();
+
+        assertThrows(IllegalStateException.class, () -> {
+            Transaction.runInTransaction(() -> {
+                signal.insertLast("value");
+            });
+        });
+    }
+
+    @Test
+    void insertAt_insideExplicitTransaction_throwsException() {
+        ListSignal<String> signal = new ListSignal<>();
+
+        assertThrows(IllegalStateException.class, () -> {
+            Transaction.runInTransaction(() -> {
+                signal.insertAt(0, "value");
+            });
+        });
+    }
+
+    @Test
+    void remove_insideExplicitTransaction_throwsException() {
+        ListSignal<String> signal = new ListSignal<>();
+        ValueSignal<String> entry = signal.insertLast("value");
+
+        assertThrows(IllegalStateException.class, () -> {
+            Transaction.runInTransaction(() -> {
+                signal.remove(entry);
+            });
+        });
+    }
+
+    @Test
+    void clear_insideExplicitTransaction_throwsException() {
+        ListSignal<String> signal = new ListSignal<>();
+        signal.insertLast("value");
+
+        assertThrows(IllegalStateException.class, () -> {
+            Transaction.runInTransaction(() -> {
+                signal.clear();
+            });
+        });
     }
 
     private static void assertValues(ListSignal<String> signal,

--- a/flow-server/src/test/java/com/vaadin/flow/signals/local/ValueSignalTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/local/ValueSignalTest.java
@@ -429,6 +429,51 @@ public class ValueSignalTest extends SignalTestBase {
     }
 
     @Test
+    void transactions_peekSignalInTransaction_throws() {
+        ValueSignal<String> signal = new ValueSignal<>("initial");
+
+        assertThrows(IllegalStateException.class, () -> {
+            Signal.runInTransaction(() -> {
+                signal.peek();
+            });
+        });
+    }
+
+    @Test
+    void transactions_replaceSignalInTransaction_throws() {
+        ValueSignal<String> signal = new ValueSignal<>("initial");
+
+        assertThrows(IllegalStateException.class, () -> {
+            Signal.runInTransaction(() -> {
+                signal.replace("initial", "update");
+            });
+        });
+    }
+
+    @Test
+    void transactions_updateSignalInTransaction_throws() {
+        ValueSignal<String> signal = new ValueSignal<>("initial");
+
+        assertThrows(IllegalStateException.class, () -> {
+            Signal.runInTransaction(() -> {
+                signal.update(x -> "update");
+            });
+        });
+    }
+
+    @Test
+    void transactions_modifySignalInTransaction_throws() {
+        ValueSignal<String[]> signal = new ValueSignal<>(
+                new String[] { "initial" });
+
+        assertThrows(IllegalStateException.class, () -> {
+            Signal.runInTransaction(() -> {
+                signal.modify(x -> x[0] = "update");
+            });
+        });
+    }
+
+    @Test
     void toString_includesValue() {
         ValueSignal<String> signal = new ValueSignal<>("signal value");
 


### PR DESCRIPTION
Uses `Transaction.inExplicitTransaction()` for checking local signals usage in transactions.

Without this fix the ListSignal is broken, i.e. throws in most of the calls, e.g. `listSignal.insertLast()`.
