### PR TITLE
feat: Add Web Share API support via Page.share() and Page.isShareSupported()

### DIFF
--- a/flow-client/src/main/frontend/Flow.ts
+++ b/flow-client/src/main/frontend/Flow.ts
@@ -550,6 +550,9 @@ export class Flow {
     }
     params['v-tn'] = themeName;
 
+    /* Web Share API support */
+    params['v-ns'] = !!navigator.share;
+
     /* Stringify each value (they are parsed on the server side) */
     const stringParams: Record<string, string> = {};
     Object.keys(params).forEach((key) => {

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -1387,7 +1387,7 @@ public class UIInternals implements Serializable {
             // Create placeholder with default values
             extendedClientDetails = new ExtendedClientDetails(ui, null, null,
                     null, null, null, null, null, null, null, null, null, null,
-                    null, null, null, null, null, null);
+                    null, null, null, null, null, null, null);
         }
         return extendedClientDetails;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
@@ -60,6 +60,7 @@ public class ExtendedClientDetails implements Serializable {
     private String navigatorPlatform;
     private ColorScheme.Value colorScheme = ColorScheme.Value.NORMAL;
     private String themeName;
+    private boolean webShareSupported;
 
     /**
      * For internal use only. Updates all properties in the class according to
@@ -104,6 +105,8 @@ public class ExtendedClientDetails implements Serializable {
      *            the current color scheme
      * @param themeName
      *            the theme name (e.g., "lumo", "aura")
+     * @param webShareSupported
+     *            whether the browser supports the Web Share API
      */
     public ExtendedClientDetails(UI ui, String screenWidth, String screenHeight,
             String windowInnerWidth, String windowInnerHeight,
@@ -111,7 +114,8 @@ public class ExtendedClientDetails implements Serializable {
             String rawTzOffset, String dstShift, String dstInEffect,
             String tzId, String curDate, String touchDevice,
             String devicePixelRatio, String windowName,
-            String navigatorPlatform, String colorScheme, String themeName) {
+            String navigatorPlatform, String colorScheme, String themeName,
+            String webShareSupported) {
         this.ui = ui;
         if (screenWidth != null) {
             try {
@@ -190,6 +194,9 @@ public class ExtendedClientDetails implements Serializable {
         this.navigatorPlatform = navigatorPlatform;
         setColorScheme(ColorScheme.Value.fromString(colorScheme));
         this.themeName = themeName;
+        if (webShareSupported != null) {
+            this.webShareSupported = Boolean.parseBoolean(webShareSupported);
+        }
     }
 
     /**
@@ -430,6 +437,16 @@ public class ExtendedClientDetails implements Serializable {
     }
 
     /**
+     * Returns whether the browser supports the Web Share API
+     * ({@code navigator.share}).
+     *
+     * @return {@code true} if the browser supports the Web Share API
+     */
+    public boolean isWebShareSupported() {
+        return webShareSupported;
+    }
+
+    /**
      * Updates the color scheme. For internal use only.
      *
      * @param colorScheme
@@ -491,7 +508,8 @@ public class ExtendedClientDetails implements Serializable {
                 getStringElseNull.apply("v-wn"),
                 getStringElseNull.apply("v-np"),
                 getStringElseNull.apply("v-cs"),
-                getStringElseNull.apply("v-tn"));
+                getStringElseNull.apply("v-tn"),
+                getStringElseNull.apply("v-ns"));
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -674,6 +674,45 @@ public class Page implements Serializable {
         });
     }
 
+    /**
+     * Returns whether the browser supports the
+     * <a href="https://developer.mozilla.org/en-US/docs/Web/API/Web_Share_API">
+     * Web Share API</a> ({@code navigator.share}).
+     *
+     * @return {@code true} if the browser supports the Web Share API
+     */
+    public boolean isShareSupported() {
+        return getExtendedClientDetails().isWebShareSupported();
+    }
+
+    /**
+     * Invokes the browser's native share dialog using the <a href=
+     * "https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share"> Web
+     * Share API</a>.
+     *
+     * @param title
+     *            the title to share
+     * @param text
+     *            the text to share
+     * @param url
+     *            the URL to share
+     * @return a pending result that resolves when the share completes or
+     *         rejects if the user cancels or sharing fails
+     * @throws UnsupportedOperationException
+     *             if the browser does not support the Web Share API
+     */
+    public PendingJavaScriptResult share(String title, String text,
+            String url) {
+        if (!isShareSupported()) {
+            throw new UnsupportedOperationException(
+                    "The browser does not support the Web Share API. "
+                            + "Check isShareSupported() before calling share().");
+        }
+        return executeJs(
+                "return navigator.share({title: $0, text: $1, url: $2})", title,
+                text, url);
+    }
+
     private Direction getDirectionByClientName(String directionClientName) {
         return Arrays.stream(Direction.values())
                 .filter(direction -> direction.getClientName()

--- a/flow-server/src/main/resources/com/vaadin/flow/server/BootstrapHandler.js
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/BootstrapHandler.js
@@ -268,7 +268,10 @@ Please submit an issue to https://github.com/vaadin/flow-components/issues/new/c
       if(navigator.platform) {
         params['v-np'] = navigator.platform;
       }
-      
+
+      /* Web Share API support */
+      params['v-ns'] = !!navigator.share;
+
       /* Stringify each value (they are parsed on the server side) */
       Object.keys(params).forEach(function(key) {
         var value = params[key];

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/ExtendedClientDetailsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/ExtendedClientDetailsTest.java
@@ -56,6 +56,7 @@ class ExtendedClientDetailsTest {
         assertFalse(details.isIPad());
         assertEquals(ColorScheme.Value.LIGHT, details.getColorScheme());
         assertEquals("aura", details.getThemeName());
+        assertTrue(details.isWebShareSupported());
 
         // Don't test getCurrentDate() and time delta due to the dependency on
         // server-side time
@@ -167,6 +168,7 @@ class ExtendedClientDetailsTest {
         private String navigatorPlatform = "Linux i686";
         private String colorScheme = "light";
         private String themeName = "aura";
+        private String webShareSupported = "true";
 
         public ExtendedClientDetails buildDetails() {
             return new ExtendedClientDetails(null, screenWidth, screenHeight,
@@ -174,7 +176,8 @@ class ExtendedClientDetailsTest {
                     bodyClientHeight, timezoneOffset, rawTimezoneOffset,
                     dstSavings, dstInEffect, timeZoneId, clientServerTimeDelta,
                     touchDevice, devicePixelRatio, windowName,
-                    navigatorPlatform, colorScheme, themeName);
+                    navigatorPlatform, colorScheme, themeName,
+                    webShareSupported);
         }
 
         public ExtendBuilder setScreenWidth(String screenWidth) {

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
@@ -464,11 +464,52 @@ class PageTest {
         // Set up ExtendedClientDetails with color scheme
         ExtendedClientDetails details = new ExtendedClientDetails(mockUI, null,
                 null, null, null, null, null, null, null, null, null, null,
-                null, null, null, null, null, "dark", null);
+                null, null, null, null, null, "dark", null, null);
         mockUI.getInternals().setExtendedClientDetails(details);
 
         Page page = new Page(mockUI);
         assertEquals(ColorScheme.Value.DARK, page.getColorScheme());
+    }
+
+    @Test
+    void share_passesCorrectJsAndParameters() {
+        MockUI mockUI = new MockUI();
+        ExtendedClientDetails details = new ExtendedClientDetails(mockUI, null,
+                null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, "true");
+        mockUI.getInternals().setExtendedClientDetails(details);
+
+        TestPage sharePage = new TestPage(mockUI);
+        sharePage.share("My Title", "Some text", "https://example.com");
+
+        assertEquals("return navigator.share({title: $0, text: $1, url: $2})",
+                sharePage.expression);
+        assertEquals("My Title", sharePage.firstParam);
+    }
+
+    @Test
+    void share_throwsWhenNotSupported() {
+        MockUI mockUI = new MockUI();
+        ExtendedClientDetails details = new ExtendedClientDetails(mockUI, null,
+                null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, "false");
+        mockUI.getInternals().setExtendedClientDetails(details);
+
+        Page sharePage = new Page(mockUI);
+        assertThrows(UnsupportedOperationException.class,
+                () -> sharePage.share("title", "text", "url"));
+    }
+
+    @Test
+    void isShareSupported_delegatesToExtendedClientDetails() {
+        MockUI mockUI = new MockUI();
+        ExtendedClientDetails details = new ExtendedClientDetails(mockUI, null,
+                null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, "true");
+        mockUI.getInternals().setExtendedClientDetails(details);
+
+        Page page = new Page(mockUI);
+        assertTrue(page.isShareSupported());
     }
 
     @Test
@@ -477,7 +518,7 @@ class PageTest {
         // Set up ExtendedClientDetails
         ExtendedClientDetails details = new ExtendedClientDetails(mockUI, null,
                 null, null, null, null, null, null, null, null, null, null,
-                null, null, null, null, null, null, null);
+                null, null, null, null, null, null, null, null);
         mockUI.getInternals().setExtendedClientDetails(details);
 
         Page page = new Page(mockUI) {


### PR DESCRIPTION
Detect navigator.share support during browser details collection and expose it through ExtendedClientDetails.isWebShareSupported(). Add Page.isShareSupported() for checking support and Page.share() for invoking the native share dialog. The share() method throws UnsupportedOperationException if the browser lacks support.
