### PR TITLE
feat: Add Fullscreen API wrapping the browser Fullscreen API

### DIFF
--- a/flow-client/src/main/frontend/Flow.ts
+++ b/flow-client/src/main/frontend/Flow.ts
@@ -4,6 +4,7 @@ import {
   type ConnectionStateChangeListener,
   type ConnectionStateStore
 } from '@vaadin/common-frontend';
+import { currentFullscreenState } from './Fullscreen';
 import './Geolocation';
 import { currentVisibility } from './PageVisibility';
 
@@ -544,6 +545,8 @@ export class Flow {
     params['v-cs'] = colorScheme && colorScheme !== 'normal' ? colorScheme : '';
     /* Page visibility — initial state of document.hidden / document.hasFocus() */
     params['v-pv'] = currentVisibility();
+    /* Fullscreen state — initial state of document.fullscreenEnabled / .fullscreenElement */
+    params['v-fs'] = currentFullscreenState();
 
     /* Theme name - detect which theme is in use */
     const computedStyle = getComputedStyle(document.documentElement);

--- a/flow-client/src/main/frontend/Fullscreen.ts
+++ b/flow-client/src/main/frontend/Fullscreen.ts
@@ -116,7 +116,3 @@ $wnd.Vaadin.Flow.fullscreen = {
     }
   }
 };
-
-// Empty export to ensure TypeScript emits this as an ES module,
-// which is required for Vite to load it via import.
-export {};

--- a/flow-client/src/main/frontend/Fullscreen.ts
+++ b/flow-client/src/main/frontend/Fullscreen.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+type VaadinFullscreenState = 'UNSUPPORTED' | 'NOT_FULLSCREEN' | 'FULLSCREEN';
+
+/**
+ * Returns the current fullscreen state synchronously. Used by the bootstrap
+ * path to seed the server-side signal without waiting for a DOM event.
+ */
+export function currentFullscreenState(): VaadinFullscreenState {
+  if (document.fullscreenEnabled !== true) {
+    return 'UNSUPPORTED';
+  }
+  return document.fullscreenElement ? 'FULLSCREEN' : 'NOT_FULLSCREEN';
+}
+
+// Dispatch on document.body so the server-side Page facade (listening on
+// the UI element, which is body) can update its signal.
+function dispatch(state: VaadinFullscreenState): void {
+  document.body.dispatchEvent(new CustomEvent('vaadin-fullscreen-change', { detail: state }));
+}
+
+// Tracks the most recent component-fullscreen setup so the wrapper can be
+// torn down when fullscreen exits (programmatically or via Escape) or when
+// a new fullscreen request supersedes it.
+let activeComponentReset: (() => void) | undefined;
+
+function resetComponentIfActive(): void {
+  if (activeComponentReset) {
+    const fn = activeComponentReset;
+    activeComponentReset = undefined;
+    fn();
+  }
+}
+
+document.addEventListener('fullscreenchange', () => {
+  if (!document.fullscreenElement) {
+    resetComponentIfActive();
+  }
+  dispatch(currentFullscreenState());
+});
+
+const $wnd = window as any;
+$wnd.Vaadin ??= {};
+$wnd.Vaadin.Flow ??= {};
+$wnd.Vaadin.Flow.fullscreen = {
+  /**
+   * Requests fullscreen for the entire page (document.documentElement).
+   * No-op if the browser does not support fullscreen.
+   */
+  requestPageFullscreen(): void {
+    resetComponentIfActive();
+    if (document.fullscreenEnabled !== true) {
+      return;
+    }
+    document.documentElement.requestFullscreen();
+  },
+
+  /**
+   * Requests fullscreen for a specific component by moving it into the
+   * given wrapper element and hiding the rest of the view. Fullscreens
+   * document.documentElement so that Vaadin theming and overlay
+   * components keep working. The component is restored to its original
+   * position on exit (programmatic, Escape, or a superseding request).
+   * No-op if the browser does not support fullscreen.
+   */
+  requestComponentFullscreen(element: HTMLElement, wrapper: HTMLElement): void {
+    resetComponentIfActive();
+    if (document.fullscreenEnabled !== true) {
+      return;
+    }
+    const originalParent = element.parentNode;
+    if (!originalParent) {
+      return;
+    }
+    const placeholder = document.createComment('vaadin-fullscreen-placeholder');
+    originalParent.insertBefore(placeholder, element);
+
+    wrapper.appendChild(element);
+    const viewRoot = wrapper.firstChild as HTMLElement | null;
+    const previousDisplay = viewRoot?.style.display ?? '';
+    if (viewRoot) {
+      viewRoot.style.display = 'none';
+    }
+
+    activeComponentReset = () => {
+      placeholder.parentNode?.insertBefore(element, placeholder);
+      placeholder.remove();
+      if (viewRoot) {
+        viewRoot.style.display = previousDisplay;
+      }
+    };
+
+    document.documentElement.requestFullscreen();
+  },
+
+  /**
+   * Exits fullscreen mode if the page is currently in fullscreen.
+   */
+  exitFullscreen(): void {
+    if (document.fullscreenElement) {
+      document.exitFullscreen();
+    }
+  }
+};
+
+// Empty export to ensure TypeScript emits this as an ES module,
+// which is required for Vite to load it via import.
+export {};

--- a/flow-client/src/main/frontend/Fullscreen.ts
+++ b/flow-client/src/main/frontend/Fullscreen.ts
@@ -16,6 +16,11 @@
 
 type VaadinFullscreenState = 'UNSUPPORTED' | 'NOT_FULLSCREEN' | 'FULLSCREEN';
 
+interface VaadinFullscreenOutcome {
+  ok: boolean;
+  error?: string;
+}
+
 /**
  * Returns the current fullscreen state synchronously. Used by the bootstrap
  * path to seed the server-side signal without waiting for a DOM event.
@@ -53,20 +58,34 @@ document.addEventListener('fullscreenchange', () => {
   dispatch(currentFullscreenState());
 });
 
+function errorMessage(e: unknown): string {
+  if (e instanceof Error) {
+    return e.message;
+  }
+  return String(e);
+}
+
 const $wnd = window as any;
 $wnd.Vaadin ??= {};
 $wnd.Vaadin.Flow ??= {};
 $wnd.Vaadin.Flow.fullscreen = {
   /**
    * Requests fullscreen for the entire page (document.documentElement).
-   * No-op if the browser does not support fullscreen.
+   * Resolves with { ok: true } once the browser has entered fullscreen, or
+   * { ok: false, error } if the browser rejected the request (no user
+   * activation, permissions policy, etc.) or fullscreen is not supported.
    */
-  requestPageFullscreen(): void {
+  async requestPageFullscreen(): Promise<VaadinFullscreenOutcome> {
     resetComponentIfActive();
     if (document.fullscreenEnabled !== true) {
-      return;
+      return { ok: false, error: 'unsupported' };
     }
-    document.documentElement.requestFullscreen();
+    try {
+      await document.documentElement.requestFullscreen();
+      return { ok: true };
+    } catch (e) {
+      return { ok: false, error: errorMessage(e) };
+    }
   },
 
   /**
@@ -75,16 +94,17 @@ $wnd.Vaadin.Flow.fullscreen = {
    * document.documentElement so that Vaadin theming and overlay
    * components keep working. The component is restored to its original
    * position on exit (programmatic, Escape, or a superseding request).
-   * No-op if the browser does not support fullscreen.
+   * If the browser rejects the request, the DOM is rolled back before
+   * resolving.
    */
-  requestComponentFullscreen(element: HTMLElement, wrapper: HTMLElement): void {
+  async requestComponentFullscreen(element: HTMLElement, wrapper: HTMLElement): Promise<VaadinFullscreenOutcome> {
     resetComponentIfActive();
     if (document.fullscreenEnabled !== true) {
-      return;
+      return { ok: false, error: 'unsupported' };
     }
     const originalParent = element.parentNode;
     if (!originalParent) {
-      return;
+      return { ok: false, error: 'detached' };
     }
     const placeholder = document.createComment('vaadin-fullscreen-placeholder');
     originalParent.insertBefore(placeholder, element);
@@ -104,7 +124,15 @@ $wnd.Vaadin.Flow.fullscreen = {
       }
     };
 
-    document.documentElement.requestFullscreen();
+    try {
+      await document.documentElement.requestFullscreen();
+      return { ok: true };
+    } catch (e) {
+      // Browser rejected the request — undo the DOM changes so the page
+      // does not end up looking fullscreened without actually being so.
+      resetComponentIfActive();
+      return { ok: false, error: errorMessage(e) };
+    }
   },
 
   /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/Component.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Component.java
@@ -904,6 +904,45 @@ public abstract class Component
     }
 
     /**
+     * Requests that the browser display this component in fullscreen mode.
+     * <p>
+     * Because of how Vaadin theming and overlay components work, this method
+     * does not call {@code requestFullscreen()} on the component's element
+     * directly. Instead, it fullscreens the entire page
+     * ({@code document.documentElement}), moves the component into a wrapper
+     * element, and hides the rest of the view. When fullscreen is exited
+     * (either programmatically via
+     * {@link com.vaadin.flow.component.page.Page#exitFullscreen()} or by the
+     * user pressing Escape), the component is automatically restored to its
+     * original position in the DOM.
+     * <p>
+     * Note that browsers require transient user activation (e.g. a button
+     * click) to enter fullscreen mode. Calling this method from a server push
+     * or view constructor will not work. The fullscreen state can be observed
+     * via {@link com.vaadin.flow.component.page.Page#fullscreenSignal()}; calls
+     * made while the state is
+     * {@link com.vaadin.flow.component.page.FullscreenState#UNSUPPORTED
+     * UNSUPPORTED} are no-ops on the client.
+     *
+     * @throws IllegalStateException
+     *             if the component is not attached to a UI
+     * @see com.vaadin.flow.component.page.Page#requestFullscreen()
+     * @see com.vaadin.flow.component.page.Page#exitFullscreen()
+     * @see com.vaadin.flow.component.page.Page#fullscreenSignal()
+     * @see <a href=
+     *      "https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API">MDN
+     *      Fullscreen API</a>
+     */
+    public void requestFullscreen() {
+        UI ui = getUI().orElseThrow(() -> new IllegalStateException(
+                "Component must be attached to the UI to request fullscreen"));
+        Element wrapperElement = ui.getInternals().getWrapperElement();
+        ui.getElement().executeJs(
+                "window.Vaadin.Flow.fullscreen.requestComponentFullscreen($0, $1)",
+                getElement(), wrapperElement);
+    }
+
+    /**
      * Traverses the component tree up and returns the first ancestor component
      * that matches the given type.
      *

--- a/flow-server/src/main/java/com/vaadin/flow/component/Component.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Component.java
@@ -911,35 +911,54 @@ public abstract class Component
      * directly. Instead, it fullscreens the entire page
      * ({@code document.documentElement}), moves the component into a wrapper
      * element, and hides the rest of the view. When fullscreen is exited
-     * (either programmatically via
-     * {@link com.vaadin.flow.component.page.Page#exitFullscreen()} or by the
-     * user pressing Escape), the component is automatically restored to its
+     * (either programmatically via {@link #exitFullscreen()},
+     * {@link com.vaadin.flow.component.page.FullscreenSession#exit()}, or by
+     * the user pressing Escape), the component is automatically restored to its
      * original position in the DOM.
      * <p>
      * Note that browsers require transient user activation (e.g. a button
      * click) to enter fullscreen mode. Calling this method from a server push
-     * or view constructor will not work. The fullscreen state can be observed
-     * via {@link com.vaadin.flow.component.page.Page#fullscreenSignal()}; calls
-     * made while the state is
-     * {@link com.vaadin.flow.component.page.FullscreenState#UNSUPPORTED
-     * UNSUPPORTED} are no-ops on the client.
+     * or view constructor will end up with the returned session in
+     * {@link com.vaadin.flow.component.page.FullscreenSessionState#REJECTED
+     * REJECTED}. The fullscreen state can be observed via
+     * {@link com.vaadin.flow.component.page.Page#fullscreenSignal()}, and the
+     * per-request lifecycle via the returned session.
+     * <p>
+     * The returned session's
+     * {@link com.vaadin.flow.component.page.FullscreenSession#owner() owner()}
+     * is this component, so a UI listening to multiple components' sessions can
+     * identify which one is fullscreen and react accordingly.
      *
+     * @return a session handle for the request, never {@code null}
      * @throws IllegalStateException
      *             if the component is not attached to a UI
+     * @see #exitFullscreen()
      * @see com.vaadin.flow.component.page.Page#requestFullscreen()
-     * @see com.vaadin.flow.component.page.Page#exitFullscreen()
      * @see com.vaadin.flow.component.page.Page#fullscreenSignal()
      * @see <a href=
      *      "https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API">MDN
      *      Fullscreen API</a>
      */
-    public void requestFullscreen() {
+    public com.vaadin.flow.component.page.FullscreenSession requestFullscreen() {
         UI ui = getUI().orElseThrow(() -> new IllegalStateException(
                 "Component must be attached to the UI to request fullscreen"));
-        Element wrapperElement = ui.getInternals().getWrapperElement();
-        ui.getElement().executeJs(
-                "window.Vaadin.Flow.fullscreen.requestComponentFullscreen($0, $1)",
-                getElement(), wrapperElement);
+        return ui.getPage().requestFullscreen(this);
+    }
+
+    /**
+     * Exits fullscreen mode if the page is currently in fullscreen. Equivalent
+     * to {@link com.vaadin.flow.component.page.Page#exitFullscreen()} so that
+     * component code does not need to reach for {@code getUI().getPage()} just
+     * to undo its own {@link #requestFullscreen()} call.
+     * <p>
+     * No-op if the component is not attached to a UI or if the page is not
+     * currently fullscreen.
+     *
+     * @see #requestFullscreen()
+     * @see com.vaadin.flow.component.page.Page#exitFullscreen()
+     */
+    public void exitFullscreen() {
+        getUI().ifPresent(ui -> ui.getPage().exitFullscreen());
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
@@ -499,6 +499,7 @@ public class ExtendedClientDetails implements Serializable {
                 getStringElseNull.apply("v-tn"));
         ui.getInternals().setExtendedClientDetails(details);
         ui.getPage().setPageVisibility(getStringElseNull.apply("v-pv"));
+        ui.getPage().setFullscreenState(getStringElseNull.apply("v-fs"));
         String ga = getStringElseNull.apply("v-ga");
         if (ga != null) {
             try {

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/FullscreenSession.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/FullscreenSession.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.page;
+
+import java.io.Serializable;
+import java.util.Optional;
+
+import org.jspecify.annotations.Nullable;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.signals.Signal;
+import com.vaadin.flow.signals.local.ValueSignal;
+
+/**
+ * A handle to a single fullscreen request, returned by
+ * {@link Page#requestFullscreen()} and {@link Component#requestFullscreen()}.
+ * <p>
+ * A session is the unit that ties together one {@link FullscreenSessionState
+ * lifecycle} (PENDING → ACTIVE or REJECTED → an EXITED state), the
+ * {@linkplain #owner() owner component} that asked for fullscreen (empty when
+ * the whole page was requested), and how it ended. Subscribe to
+ * {@link #stateSignal()} to react to lifecycle transitions; call
+ * {@link #exit()} to end the session from server code. The page-level
+ * {@link Page#fullscreenSignal()} answers the cross-session "is anything
+ * fullscreen right now" question and is independent of sessions.
+ * <p>
+ * Only one session can be active per page at a time. Starting a new request
+ * while one is active transitions the old session to
+ * {@link FullscreenSessionState#EXITED_BY_CODE EXITED_BY_CODE} before the new
+ * session is returned.
+ * <p>
+ * If a request is rejected (no user activation, permissions policy, etc.) or
+ * exits, the {@code error()} accessor returns the browser-provided error
+ * message when available, otherwise empty.
+ */
+public class FullscreenSession implements Serializable {
+
+    private final ValueSignal<FullscreenSessionState> stateSignal = new ValueSignal<>(
+            FullscreenSessionState.PENDING);
+    private final Signal<FullscreenSessionState> stateSignalReadOnly = stateSignal
+            .asReadonly();
+    private final @Nullable Component owner;
+    private final Page page;
+    private @Nullable String error;
+
+    FullscreenSession(Page page, @Nullable Component owner) {
+        this.page = page;
+        this.owner = owner;
+    }
+
+    /**
+     * Returns a read-only signal that tracks this session's
+     * {@linkplain FullscreenSessionState lifecycle state}.
+     * <p>
+     * The signal starts at {@link FullscreenSessionState#PENDING} and
+     * transitions through {@link FullscreenSessionState#ACTIVE} on a successful
+     * request, or directly to a terminal state on rejection or exit. Once in a
+     * terminal state the signal does not change again. Subscribe with
+     * {@code Signal.effect(owner, ...)} to react to transitions.
+     *
+     * @return the read-only session state signal
+     */
+    public Signal<FullscreenSessionState> stateSignal() {
+        return stateSignalReadOnly;
+    }
+
+    /**
+     * Returns the component that requested fullscreen, or empty if the entire
+     * page was requested via {@link Page#requestFullscreen()}. Useful for
+     * binding the active component's appearance (e.g. an {@code expanded} style
+     * class) only on the owner.
+     *
+     * @return the owner component, or empty for a page-level session
+     */
+    public Optional<Component> owner() {
+        return Optional.ofNullable(owner);
+    }
+
+    /**
+     * Returns the browser-provided error message when this session is in
+     * {@link FullscreenSessionState#REJECTED REJECTED}, or empty otherwise.
+     * Used for logging and surfacing diagnostics — the contents are
+     * browser-defined and not stable enough to drive logic.
+     *
+     * @return the error message, when available
+     */
+    public Optional<String> error() {
+        return Optional.ofNullable(error);
+    }
+
+    /**
+     * Ends this session. Equivalent to {@link Page#exitFullscreen()} when this
+     * session is active; a no-op if the session already ended.
+     */
+    public void exit() {
+        if (isTerminal()) {
+            return;
+        }
+        page.exitFullscreen();
+    }
+
+    boolean isTerminal() {
+        FullscreenSessionState state = stateSignal.peek();
+        return state != FullscreenSessionState.PENDING
+                && state != FullscreenSessionState.ACTIVE;
+    }
+
+    void setActive() {
+        if (stateSignal.peek() == FullscreenSessionState.PENDING) {
+            stateSignal.set(FullscreenSessionState.ACTIVE);
+        }
+    }
+
+    void setRejected(@Nullable String errorMessage) {
+        if (isTerminal()) {
+            return;
+        }
+        this.error = errorMessage;
+        stateSignal.set(FullscreenSessionState.REJECTED);
+    }
+
+    void setExited(boolean programmatic) {
+        if (isTerminal()) {
+            return;
+        }
+        stateSignal.set(programmatic ? FullscreenSessionState.EXITED_BY_CODE
+                : FullscreenSessionState.EXITED_BY_USER);
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/FullscreenSessionState.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/FullscreenSessionState.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.page;
+
+import com.vaadin.flow.component.Component;
+
+/**
+ * Lifecycle state of a single {@link FullscreenSession}.
+ * <p>
+ * Each call to {@link Page#requestFullscreen()} or
+ * {@link Component#requestFullscreen()} starts a new session in
+ * {@link #PENDING} and ends in one of the four terminal states:
+ * {@link #REJECTED} if the browser refused the request, {@link #EXITED_BY_CODE}
+ * if server code initiated the exit, or {@link #EXITED_BY_USER} if the browser
+ * exited fullscreen for any other reason (Escape key, browser close button,
+ * navigation, etc.). The intermediate {@link #ACTIVE} state means the browser
+ * accepted the request and fullscreen is currently in effect for this session.
+ *
+ * @see FullscreenSession#stateSignal()
+ */
+public enum FullscreenSessionState {
+
+    /**
+     * The request has been sent to the browser but no outcome has been reported
+     * yet. Sessions transition out of this state to either {@link #ACTIVE} or
+     * {@link #REJECTED}.
+     */
+    PENDING,
+
+    /**
+     * The browser has accepted the request and the page or component is
+     * currently fullscreen. Sessions in this state transition to
+     * {@link #EXITED_BY_CODE} or {@link #EXITED_BY_USER} when fullscreen ends.
+     */
+    ACTIVE,
+
+    /**
+     * The browser refused the request. Common causes are missing transient user
+     * activation (the request was not made from a direct user gesture), an
+     * iframe permissions policy that blocks fullscreen, or the document being
+     * detached. A {@code WARN} is logged with the browser-provided error
+     * message. Terminal state.
+     */
+    REJECTED,
+
+    /**
+     * The user ended fullscreen — Escape key, the browser's exit button,
+     * navigation, or any other browser-side cause that was not a server-side
+     * {@link Page#exitFullscreen()} or {@link Component#exitFullscreen()} or
+     * {@link FullscreenSession#exit()} call. Terminal state.
+     */
+    EXITED_BY_USER,
+
+    /**
+     * Server code ended fullscreen by calling {@link Page#exitFullscreen()},
+     * {@link Component#exitFullscreen()}, or {@link FullscreenSession#exit()}.
+     * Also reached when a new {@code requestFullscreen()} supersedes the
+     * session before the previous one exited. Terminal state.
+     */
+    EXITED_BY_CODE
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/FullscreenState.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/FullscreenState.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.page;
+
+import com.vaadin.flow.component.Component;
+
+/**
+ * Represents the fullscreen state of a browser page.
+ * <p>
+ * Wraps the browser's Fullscreen API ({@code document.fullscreenEnabled} and
+ * {@code document.fullscreenElement}) into four observable states: the browser
+ * does not support fullscreen at all, fullscreen is supported but the page is
+ * not in it, the page is currently fullscreen, and an {@link #UNKNOWN} sentinel
+ * used before the first value has arrived from the client.
+ *
+ * @see Page#fullscreenSignal()
+ * @see Page#requestFullscreen()
+ * @see Page#exitFullscreen()
+ * @see Component#requestFullscreen()
+ */
+public enum FullscreenState {
+
+    /**
+     * No value has been reported by the browser yet. Used only as the initial
+     * value of the signal before the first client handshake delivers the real
+     * one. In normal request handling the signal is seeded before any user code
+     * (UI initialization, {@code UIInitListener}, component attach) runs, so
+     * this value is essentially never observed in practice; once a real value
+     * has arrived, the signal never returns to {@code UNKNOWN}.
+     */
+    UNKNOWN,
+
+    /**
+     * The browser does not support fullscreen mode, or the document is not
+     * permitted to enter it. In the browser, this corresponds to
+     * {@code document.fullscreenEnabled} being {@code false}. Calls to
+     * {@link Page#requestFullscreen()} or {@link Component#requestFullscreen()}
+     * are no-ops in this state.
+     */
+    UNSUPPORTED,
+
+    /**
+     * Fullscreen mode is supported and the page is currently not in it. In the
+     * browser, this corresponds to {@code document.fullscreenEnabled} being
+     * {@code true} and {@code document.fullscreenElement} being {@code null}.
+     */
+    NOT_FULLSCREEN,
+
+    /**
+     * The page is currently in fullscreen mode. In the browser, this
+     * corresponds to {@code document.fullscreenElement} being non-{@code null}.
+     */
+    FULLSCREEN
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Direction;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JavaScript;
@@ -66,6 +67,10 @@ public class Page implements Serializable {
             PageVisibility.UNKNOWN);
     private final Signal<PageVisibility> pageVisibilityReadOnly = pageVisibilitySignal
             .asReadonly();
+    private final ValueSignal<FullscreenState> fullscreenSignal = new ValueSignal<>(
+            FullscreenState.UNKNOWN);
+    private final Signal<FullscreenState> fullscreenSignalReadOnly = fullscreenSignal
+            .asReadonly();
 
     /**
      * Creates a page instance for the given UI.
@@ -80,6 +85,10 @@ public class Page implements Serializable {
                 .addEventListener("vaadin-page-visibility-change",
                         e -> setPageVisibility(e.getEventDetail(String.class)))
                 .addEventDetail().debounce(100).allowInert();
+        ui.getElement()
+                .addEventListener("vaadin-fullscreen-change",
+                        e -> setFullscreenState(e.getEventDetail(String.class)))
+                .addEventDetail().allowInert();
     }
 
     /**
@@ -547,6 +556,100 @@ public class Page implements Serializable {
             pageVisibilitySignal.set(PageVisibility.valueOf(value));
         } catch (IllegalArgumentException e) {
             LOGGER.debug("Unknown page visibility value from client: {}",
+                    value);
+        }
+    }
+
+    /**
+     * Returns a read-only signal that tracks the browser's fullscreen state.
+     * <p>
+     * The signal distinguishes between {@link FullscreenState#FULLSCREEN
+     * FULLSCREEN} (the page is currently in fullscreen),
+     * {@link FullscreenState#NOT_FULLSCREEN NOT_FULLSCREEN} (fullscreen is
+     * supported but the page is not in it), {@link FullscreenState#UNSUPPORTED
+     * UNSUPPORTED} (the browser does not support fullscreen or the document is
+     * not permitted to enter it), and {@link FullscreenState#UNKNOWN UNKNOWN}
+     * (the initial value, replaced with a real one before any user code
+     * observes the signal).
+     * <p>
+     * The signal value is seeded from the initial client bootstrap, so user
+     * code always sees a real value. Subscribe with
+     * {@code Signal.effect(owner, ...)} to react to changes; call
+     * {@code fullscreenSignal().peek()} for a snapshot outside a reactive
+     * context, and {@code .get()} inside one. Use {@link #requestFullscreen()},
+     * {@link Component#requestFullscreen()}, or {@link #exitFullscreen()} to
+     * change the state.
+     * <p>
+     * Note that browsers require transient user activation (e.g. a button
+     * click) to enter fullscreen mode, so the signal will not transition to
+     * {@link FullscreenState#FULLSCREEN FULLSCREEN} in response to a request
+     * from a server push or view constructor.
+     *
+     * @return the read-only fullscreen signal
+     */
+    public Signal<FullscreenState> fullscreenSignal() {
+        return fullscreenSignalReadOnly;
+    }
+
+    /**
+     * Requests that the browser display the entire page in fullscreen mode.
+     * <p>
+     * This calls {@code document.documentElement.requestFullscreen()} on the
+     * browser. Themes and overlay components (such as Notification and ComboBox
+     * popups) work correctly in this mode. Use
+     * {@link Component#requestFullscreen()} to fullscreen a single component
+     * within the page.
+     * <p>
+     * Note that browsers require transient user activation (e.g. a button
+     * click) to enter fullscreen mode. Calling this method from a server push
+     * or view constructor will not work. The fullscreen state can be observed
+     * via {@link #fullscreenSignal()}; calls made while the state is
+     * {@link FullscreenState#UNSUPPORTED UNSUPPORTED} are no-ops on the client.
+     *
+     * @see Component#requestFullscreen()
+     * @see #exitFullscreen()
+     * @see #fullscreenSignal()
+     * @see <a href=
+     *      "https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API">MDN
+     *      Fullscreen API</a>
+     */
+    public void requestFullscreen() {
+        executeJs("window.Vaadin.Flow.fullscreen.requestPageFullscreen()");
+    }
+
+    /**
+     * Exits fullscreen mode if the page is currently in fullscreen, otherwise a
+     * no-op.
+     * <p>
+     * If a component was previously fullscreened via
+     * {@link Component#requestFullscreen()}, it is automatically restored to
+     * its original position in the DOM.
+     *
+     * @see #requestFullscreen()
+     * @see Component#requestFullscreen()
+     */
+    public void exitFullscreen() {
+        executeJs("window.Vaadin.Flow.fullscreen.exitFullscreen()");
+    }
+
+    /**
+     * Sets the fullscreen state from a raw client-side value (e.g. from the
+     * bootstrap parameters or from a {@code vaadin-fullscreen-change} DOM
+     * event). {@code null} and unknown values are ignored — the latter is
+     * logged at debug level so a forward-compatible client value does not
+     * silently disappear.
+     *
+     * @param value
+     *            the raw value, or {@code null}
+     */
+    void setFullscreenState(String value) {
+        if (value == null) {
+            return;
+        }
+        try {
+            fullscreenSignal.set(FullscreenState.valueOf(value));
+        } catch (IllegalArgumentException e) {
+            LOGGER.debug("Unknown fullscreen state value from client: {}",
                     value);
         }
     }

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -24,8 +24,10 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.UUID;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.databind.JsonNode;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Direction;
@@ -71,6 +73,8 @@ public class Page implements Serializable {
             FullscreenState.UNKNOWN);
     private final Signal<FullscreenState> fullscreenSignalReadOnly = fullscreenSignal
             .asReadonly();
+    private @Nullable FullscreenSession currentFullscreenSession;
+    private boolean expectProgrammaticFullscreenExit;
 
     /**
      * Creates a page instance for the given UI.
@@ -585,6 +589,29 @@ public class Page implements Serializable {
      * {@link FullscreenState#FULLSCREEN FULLSCREEN} in response to a request
      * from a server push or view constructor.
      *
+     * <h2>Example: bind a toggle button</h2>
+     *
+     * <pre>
+     * Button toggle = new Button();
+     * Page page = UI.getCurrent().getPage();
+     * Signal&lt;FullscreenState&gt; state = page.fullscreenSignal();
+     *
+     * toggle.bindText(state.map(s -&gt; switch (s) {
+     * case FULLSCREEN -&gt; "Exit fullscreen";
+     * case NOT_FULLSCREEN -&gt; "Enter fullscreen";
+     * default -&gt; "Fullscreen unavailable";
+     * }));
+     * toggle.bindEnabled(state.map(s -&gt; s == FullscreenState.FULLSCREEN
+     *         || s == FullscreenState.NOT_FULLSCREEN));
+     * toggle.addClickListener(e -&gt; {
+     *     if (state.peek() == FullscreenState.FULLSCREEN) {
+     *         page.exitFullscreen();
+     *     } else {
+     *         page.requestFullscreen();
+     *     }
+     * });
+     * </pre>
+     *
      * @return the read-only fullscreen signal
      */
     public Signal<FullscreenState> fullscreenSignal() {
@@ -602,10 +629,34 @@ public class Page implements Serializable {
      * <p>
      * Note that browsers require transient user activation (e.g. a button
      * click) to enter fullscreen mode. Calling this method from a server push
-     * or view constructor will not work. The fullscreen state can be observed
-     * via {@link #fullscreenSignal()}; calls made while the state is
-     * {@link FullscreenState#UNSUPPORTED UNSUPPORTED} are no-ops on the client.
+     * or view constructor will not work — the returned session will end up in
+     * {@link FullscreenSessionState#REJECTED REJECTED}. The fullscreen state
+     * can be observed via {@link #fullscreenSignal()}; calls made while the
+     * state is {@link FullscreenState#UNSUPPORTED UNSUPPORTED} resolve to
+     * {@link FullscreenSessionState#REJECTED REJECTED} immediately.
+     * <p>
+     * If a session is already active when this method is called, it is moved to
+     * {@link FullscreenSessionState#EXITED_BY_CODE EXITED_BY_CODE} before the
+     * new session is returned.
      *
+     * <h2>Example: react to lifecycle transitions</h2>
+     *
+     * <pre>
+     * FullscreenSession session = ui.getPage().requestFullscreen();
+     * Signal.effect(this, () -&gt; {
+     *     switch (session.stateSignal().get()) {
+     *     case ACTIVE -&gt; statusLabel.setText("Now fullscreen");
+     *     case REJECTED -&gt; statusLabel.setText("Could not enter fullscreen: "
+     *             + session.error().orElse("unknown"));
+     *     case EXITED_BY_USER -&gt; statusLabel.setText("You exited fullscreen");
+     *     case EXITED_BY_CODE -&gt; statusLabel.setText("Fullscreen ended");
+     *     default -&gt; {
+     *     }
+     *     }
+     * });
+     * </pre>
+     *
+     * @return a session handle for the request, never {@code null}
      * @see Component#requestFullscreen()
      * @see #exitFullscreen()
      * @see #fullscreenSignal()
@@ -613,8 +664,46 @@ public class Page implements Serializable {
      *      "https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API">MDN
      *      Fullscreen API</a>
      */
-    public void requestFullscreen() {
-        executeJs("window.Vaadin.Flow.fullscreen.requestPageFullscreen()");
+    public FullscreenSession requestFullscreen() {
+        return startFullscreenSession(null,
+                "return window.Vaadin.Flow.fullscreen.requestPageFullscreen()");
+    }
+
+    /**
+     * Requests that the browser display the given component in fullscreen mode.
+     * The component is moved into a wrapper element and the rest of the view is
+     * hidden so Vaadin theming and overlay components keep working; see
+     * {@link Component#requestFullscreen()} for the rationale.
+     * <p>
+     * This is the same operation as calling
+     * {@link Component#requestFullscreen()} directly; the static-style entry
+     * point is offered for code that already holds a {@link Page} reference and
+     * would rather not reach back through the component to start a fullscreen
+     * session.
+     *
+     * @param component
+     *            the component to fullscreen, not {@code null}
+     * @return a session handle for the request, never {@code null}
+     * @throws NullPointerException
+     *             if {@code component} is {@code null}
+     * @throws IllegalStateException
+     *             if the component is not attached to this page's UI
+     * @see Component#requestFullscreen()
+     * @see #requestFullscreen()
+     * @see #exitFullscreen()
+     */
+    public FullscreenSession requestFullscreen(Component component) {
+        Objects.requireNonNull(component, "component must not be null");
+        UI componentUi = component.getUI()
+                .orElseThrow(() -> new IllegalStateException(
+                        "Component must be attached to the UI to request fullscreen"));
+        if (componentUi != ui) {
+            throw new IllegalStateException(
+                    "Component is attached to a different UI than this page");
+        }
+        return startFullscreenSession(component,
+                "return window.Vaadin.Flow.fullscreen.requestComponentFullscreen($0, $1)",
+                component.getElement(), ui.getInternals().getWrapperElement());
     }
 
     /**
@@ -623,13 +712,69 @@ public class Page implements Serializable {
      * <p>
      * If a component was previously fullscreened via
      * {@link Component#requestFullscreen()}, it is automatically restored to
-     * its original position in the DOM.
+     * its original position in the DOM. The active session, if any, transitions
+     * to {@link FullscreenSessionState#EXITED_BY_CODE EXITED_BY_CODE}.
      *
      * @see #requestFullscreen()
      * @see Component#requestFullscreen()
      */
     public void exitFullscreen() {
+        expectProgrammaticFullscreenExit = true;
         executeJs("window.Vaadin.Flow.fullscreen.exitFullscreen()");
+    }
+
+    /**
+     * Starts a new fullscreen session by running the given JavaScript
+     * expression on the client and wiring its outcome (a {@code Promise<{ ok,
+     * error? }>}) to the session's state signal.
+     * <p>
+     * If a previous session is still active or pending it is transitioned to
+     * {@link FullscreenSessionState#EXITED_BY_CODE EXITED_BY_CODE} so that only
+     * one session is observable at a time.
+     */
+    FullscreenSession startFullscreenSession(@Nullable Component owner,
+            String requestExpression, Object... parameters) {
+        if (currentFullscreenSession != null
+                && !currentFullscreenSession.isTerminal()) {
+            currentFullscreenSession.setExited(true);
+        }
+        FullscreenSession session = new FullscreenSession(this, owner);
+        currentFullscreenSession = session;
+        executeJs(requestExpression, parameters).then(JsonNode.class,
+                result -> handleRequestOutcome(session, result),
+                errorMessage -> handleRequestError(session, errorMessage));
+        return session;
+    }
+
+    private void handleRequestOutcome(FullscreenSession session,
+            JsonNode result) {
+        if (session.isTerminal()) {
+            return;
+        }
+        JsonNode okNode = result.get("ok");
+        if (okNode != null && okNode.asBoolean()) {
+            session.setActive();
+            return;
+        }
+        JsonNode errorNode = result.get("error");
+        String errorText = errorNode == null || errorNode.isNull() ? null
+                : errorNode.asString();
+        LOGGER.warn(
+                "Fullscreen request was rejected by the browser{}. "
+                        + "Most likely the call was not made from a "
+                        + "user gesture (transient user activation).",
+                errorText == null ? "" : ": " + errorText);
+        session.setRejected(errorText);
+    }
+
+    private void handleRequestError(FullscreenSession session,
+            String errorMessage) {
+        if (session.isTerminal()) {
+            return;
+        }
+        LOGGER.warn("Fullscreen request failed on the client: {}",
+                errorMessage);
+        session.setRejected(errorMessage);
     }
 
     /**
@@ -647,11 +792,40 @@ public class Page implements Serializable {
             return;
         }
         try {
-            fullscreenSignal.set(FullscreenState.valueOf(value));
+            applyFullscreenState(FullscreenState.valueOf(value));
         } catch (IllegalArgumentException e) {
             LOGGER.debug("Unknown fullscreen state value from client: {}",
                     value);
         }
+    }
+
+    /**
+     * Drives {@link #fullscreenSignal()} from test code without going through
+     * the client bridge. Mirrors the effect of a
+     * {@code vaadin-fullscreen-change} DOM event, including transitioning the
+     * active {@link FullscreenSession} to its appropriate terminal state.
+     * <p>
+     * Intended for unit tests. Production code should not need to call this.
+     *
+     * @param newState
+     *            the state to set, not {@code null}
+     */
+    public void simulateFullscreenChange(FullscreenState newState) {
+        Objects.requireNonNull(newState, "newState must not be null");
+        applyFullscreenState(newState);
+    }
+
+    private void applyFullscreenState(FullscreenState newState) {
+        FullscreenState previous = fullscreenSignal.peek();
+        fullscreenSignal.set(newState);
+        if (previous == FullscreenState.FULLSCREEN
+                && newState != FullscreenState.FULLSCREEN
+                && currentFullscreenSession != null
+                && !currentFullscreenSession.isTerminal()) {
+            boolean programmatic = expectProgrammaticFullscreenExit;
+            currentFullscreenSession.setExited(programmatic);
+        }
+        expectProgrammaticFullscreenExit = false;
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
@@ -2068,6 +2068,22 @@ public class ComponentTest {
     }
 
     @Test
+    public void requestFullscreen_attachedComponent_executesJs() {
+        EnabledDiv div = new EnabledDiv();
+        testUI.add(div);
+        div.requestFullscreen();
+
+        assertPendingJs(
+                "window.Vaadin.Flow.fullscreen.requestComponentFullscreen");
+    }
+
+    @Test
+    public void requestFullscreen_detachedComponent_throws() {
+        EnabledDiv div = new EnabledDiv();
+        assertThrows(IllegalStateException.class, div::requestFullscreen);
+    }
+
+    @Test
     public void cannotMoveComponentsToOtherUI() {
         // tests https://github.com/vaadin/flow/issues/9376
         final UI otherUI = createMockedUI();

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/FullscreenSessionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/FullscreenSessionTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.page;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.tests.util.MockUI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FullscreenSessionTest {
+
+    @Tag("div")
+    private static class TestComponent extends Component {
+    }
+
+    private MockUI ui;
+    private TestPage page;
+
+    @BeforeEach
+    void setUp() {
+        ui = new MockUI();
+        page = new TestPage(ui);
+        ui.setPage(page);
+    }
+
+    @Test
+    void requestFullscreen_startsInPending() {
+        FullscreenSession session = page.requestFullscreen();
+        assertEquals(FullscreenSessionState.PENDING,
+                session.stateSignal().peek());
+        assertTrue(session.owner().isEmpty(),
+                "Page-level session has no owner");
+    }
+
+    @Test
+    void requestFullscreen_acceptedOutcome_transitionsToActive() {
+        FullscreenSession session = page.requestFullscreen();
+        page.lastResult.fireSuccess(outcome(true, null));
+        assertEquals(FullscreenSessionState.ACTIVE,
+                session.stateSignal().peek());
+    }
+
+    @Test
+    void requestFullscreen_rejectedOutcome_transitionsToRejectedAndCarriesError() {
+        FullscreenSession session = page.requestFullscreen();
+        page.lastResult.fireSuccess(outcome(false, "no user activation"));
+        assertEquals(FullscreenSessionState.REJECTED,
+                session.stateSignal().peek());
+        assertEquals("no user activation", session.error().orElse(null));
+    }
+
+    @Test
+    void requestFullscreen_clientError_transitionsToRejected() {
+        FullscreenSession session = page.requestFullscreen();
+        page.lastResult.fireError("script crash");
+        assertEquals(FullscreenSessionState.REJECTED,
+                session.stateSignal().peek());
+        assertEquals("script crash", session.error().orElse(null));
+    }
+
+    @Test
+    void requestFullscreen_userExit_transitionsToExitedByUser() {
+        FullscreenSession session = page.requestFullscreen();
+        page.lastResult.fireSuccess(outcome(true, null));
+        page.simulateFullscreenChange(FullscreenState.FULLSCREEN);
+        page.simulateFullscreenChange(FullscreenState.NOT_FULLSCREEN);
+        assertEquals(FullscreenSessionState.EXITED_BY_USER,
+                session.stateSignal().peek());
+    }
+
+    @Test
+    void exitFullscreen_transitionsActiveSessionToExitedByCode() {
+        FullscreenSession session = page.requestFullscreen();
+        page.lastResult.fireSuccess(outcome(true, null));
+        page.simulateFullscreenChange(FullscreenState.FULLSCREEN);
+
+        page.exitFullscreen();
+        page.simulateFullscreenChange(FullscreenState.NOT_FULLSCREEN);
+
+        assertEquals(FullscreenSessionState.EXITED_BY_CODE,
+                session.stateSignal().peek());
+    }
+
+    @Test
+    void newRequest_supersedesActiveSession() {
+        FullscreenSession first = page.requestFullscreen();
+        page.lastResult.fireSuccess(outcome(true, null));
+
+        FullscreenSession second = page.requestFullscreen();
+
+        assertEquals(FullscreenSessionState.EXITED_BY_CODE,
+                first.stateSignal().peek(),
+                "Superseded session should end in EXITED_BY_CODE");
+        assertEquals(FullscreenSessionState.PENDING,
+                second.stateSignal().peek());
+        assertNotSame(first, second);
+    }
+
+    @Test
+    void requestFullscreenForComponent_carriesOwner() {
+        TestComponent component = new TestComponent();
+        ui.add(component);
+
+        FullscreenSession session = page.requestFullscreen(component);
+
+        assertSame(component, session.owner().orElseThrow());
+    }
+
+    @Test
+    void requestFullscreenForComponent_nullThrows() {
+        assertThrows(NullPointerException.class,
+                () -> page.requestFullscreen(null));
+    }
+
+    @Test
+    void componentRequestFullscreen_returnsSession() {
+        TestComponent component = new TestComponent();
+        ui.add(component);
+
+        FullscreenSession session = component.requestFullscreen();
+
+        assertEquals(FullscreenSessionState.PENDING,
+                session.stateSignal().peek());
+        assertSame(component, session.owner().orElseThrow());
+    }
+
+    @Test
+    void componentExitFullscreen_callsPageExitFullscreen() {
+        TestComponent component = new TestComponent();
+        ui.add(component);
+        page.requestFullscreen(component);
+        page.lastResult.fireSuccess(outcome(true, null));
+        page.simulateFullscreenChange(FullscreenState.FULLSCREEN);
+
+        component.exitFullscreen();
+        page.simulateFullscreenChange(FullscreenState.NOT_FULLSCREEN);
+
+        FullscreenSession session = (FullscreenSession) page.lastSession;
+        assertEquals(FullscreenSessionState.EXITED_BY_CODE,
+                session.stateSignal().peek());
+    }
+
+    private static JsonNode outcome(boolean ok, String error) {
+        tools.jackson.databind.node.ObjectNode node = JacksonUtils
+                .createObjectNode();
+        node.put("ok", ok);
+        if (error != null) {
+            node.put("error", error);
+        }
+        return node;
+    }
+
+    /**
+     * Captures every executeJs invocation and lets the test fire the success or
+     * error callback synchronously, replacing the asynchronous client
+     * round-trip. Also records the most recent session returned from a
+     * fullscreen request so tests can assert on it after delegating through
+     * Component or Page-level overloads.
+     */
+    private static class TestPage extends Page {
+        CapturingPendingResult lastResult;
+        FullscreenSession lastSession;
+
+        TestPage(MockUI ui) {
+            super(ui);
+        }
+
+        @Override
+        public PendingJavaScriptResult executeJs(String expression,
+                Object... parameters) {
+            CapturingPendingResult result = new CapturingPendingResult();
+            lastResult = result;
+            return result;
+        }
+
+        @Override
+        public FullscreenSession requestFullscreen() {
+            FullscreenSession session = super.requestFullscreen();
+            lastSession = session;
+            return session;
+        }
+
+        @Override
+        public FullscreenSession requestFullscreen(Component component) {
+            FullscreenSession session = super.requestFullscreen(component);
+            lastSession = session;
+            return session;
+        }
+    }
+
+    private static class CapturingPendingResult
+            implements PendingJavaScriptResult {
+        private final List<SerializableConsumer<JsonNode>> successHandlers = new ArrayList<>();
+        private final List<SerializableConsumer<String>> errorHandlers = new ArrayList<>();
+
+        @Override
+        public boolean cancelExecution() {
+            return false;
+        }
+
+        @Override
+        public boolean isSentToBrowser() {
+            return false;
+        }
+
+        @Override
+        public void then(SerializableConsumer<JsonNode> resultHandler,
+                SerializableConsumer<String> errorHandler) {
+            if (resultHandler != null) {
+                successHandlers.add(resultHandler);
+            }
+            if (errorHandler != null) {
+                errorHandlers.add(errorHandler);
+            }
+        }
+
+        void fireSuccess(JsonNode json) {
+            successHandlers.forEach(h -> h.accept(json));
+        }
+
+        void fireError(String error) {
+            errorHandlers.forEach(h -> h.accept(error));
+        }
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/FullscreenSignalTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/FullscreenSignalTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.page;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.node.ObjectNode;
+
+import com.vaadin.flow.dom.DomEvent;
+import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
+import com.vaadin.flow.signals.Signal;
+import com.vaadin.flow.signals.local.ValueSignal;
+import com.vaadin.tests.util.MockUI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class FullscreenSignalTest {
+
+    @Test
+    void fullscreenSignal_isReadOnly() {
+        MockUI ui = new MockUI();
+        Signal<FullscreenState> signal = ui.getPage().fullscreenSignal();
+        assertFalse(signal instanceof ValueSignal,
+                "fullscreenSignal() should return a read-only signal");
+    }
+
+    @Test
+    void fullscreenSignal_defaultsToUnknownBeforeBootstrap() {
+        MockUI ui = new MockUI();
+        Signal<FullscreenState> signal = ui.getPage().fullscreenSignal();
+        assertEquals(FullscreenState.UNKNOWN, signal.peek(),
+                "Before bootstrap the value should be UNKNOWN so callers can "
+                        + "distinguish 'no data yet' from a real value");
+    }
+
+    @Test
+    void fullscreenSignal_readonlyWrapperIsCached() {
+        Page page = new MockUI().getPage();
+        assertSame(page.fullscreenSignal(), page.fullscreenSignal(),
+                "Repeated calls must return the same read-only wrapper so "
+                        + "subscriber identity stays stable");
+    }
+
+    @Test
+    void fullscreenSignal_tracksStateChanges() {
+        MockUI ui = new MockUI();
+        Signal<FullscreenState> signal = ui.getPage().fullscreenSignal();
+
+        fireFullscreenEvent(ui, "NOT_FULLSCREEN");
+        assertEquals(FullscreenState.NOT_FULLSCREEN, signal.peek());
+
+        fireFullscreenEvent(ui, "FULLSCREEN");
+        assertEquals(FullscreenState.FULLSCREEN, signal.peek());
+
+        fireFullscreenEvent(ui, "UNSUPPORTED");
+        assertEquals(FullscreenState.UNSUPPORTED, signal.peek());
+    }
+
+    @Test
+    void fullscreenSignal_unknownDetailKeepsPreviousValue() {
+        MockUI ui = new MockUI();
+        Signal<FullscreenState> signal = ui.getPage().fullscreenSignal();
+
+        fireFullscreenEvent(ui, "FULLSCREEN");
+        fireFullscreenEvent(ui, "SOMETHING_NEW");
+
+        assertEquals(FullscreenState.FULLSCREEN, signal.peek(),
+                "Unknown detail values from a newer client should not reset "
+                        + "the signal");
+    }
+
+    private void fireFullscreenEvent(MockUI ui, String state) {
+        ObjectNode eventData = JacksonUtils.createObjectNode();
+        eventData.put("event.detail", state);
+        // No debounce on the listener — DomEvent defaults to LEADING phase.
+        ui.getElement().getNode().getFeature(ElementListenerMap.class)
+                .fireEvent(new DomEvent(ui.getElement(),
+                        "vaadin-fullscreen-change", eventData));
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
@@ -517,7 +517,8 @@ class PageTest {
 
         page.requestFullscreen();
 
-        assertEquals("window.Vaadin.Flow.fullscreen.requestPageFullscreen()",
+        assertEquals(
+                "return window.Vaadin.Flow.fullscreen.requestPageFullscreen()",
                 capturedExpression.get());
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
@@ -502,4 +502,40 @@ class PageTest {
         page.setColorScheme(ColorScheme.Value.NORMAL);
         assertEquals(ColorScheme.Value.NORMAL, page.getColorScheme());
     }
+
+    @Test
+    void requestFullscreen_executesConnectorJs() {
+        AtomicReference<String> capturedExpression = new AtomicReference<>();
+        Page page = new Page(new MockUI()) {
+            @Override
+            public PendingJavaScriptResult executeJs(String expression,
+                    Object... parameters) {
+                capturedExpression.set(expression);
+                return Mockito.mock(PendingJavaScriptResult.class);
+            }
+        };
+
+        page.requestFullscreen();
+
+        assertEquals("window.Vaadin.Flow.fullscreen.requestPageFullscreen()",
+                capturedExpression.get());
+    }
+
+    @Test
+    void exitFullscreen_executesConnectorJs() {
+        AtomicReference<String> capturedExpression = new AtomicReference<>();
+        Page page = new Page(new MockUI()) {
+            @Override
+            public PendingJavaScriptResult executeJs(String expression,
+                    Object... parameters) {
+                capturedExpression.set(expression);
+                return Mockito.mock(PendingJavaScriptResult.class);
+            }
+        };
+
+        page.exitFullscreen();
+
+        assertEquals("window.Vaadin.Flow.fullscreen.exitFullscreen()",
+                capturedExpression.get());
+    }
 }


### PR DESCRIPTION
Adds Component.requestFullscreen() that uses a wrapper approach to handle Vaadin theming and overlay components correctly, along with Page.requestFullscreen() for whole-page fullscreen, Page.exitFullscreen(), Page.isFullscreenEnabled(), and Page.addFullscreenChangeListener().
