### PR TITLE
feat: Add Screen Orientation API support to Page

### DIFF
--- a/flow-client/src/main/frontend/Flow.ts
+++ b/flow-client/src/main/frontend/Flow.ts
@@ -6,6 +6,7 @@ import {
 } from '@vaadin/common-frontend';
 import './Geolocation';
 import { currentVisibility } from './PageVisibility';
+import { currentScreenOrientationAngle, currentScreenOrientationType } from './ScreenOrientation';
 
 export interface FlowConfig {
   imports?: () => Promise<any>;
@@ -544,6 +545,11 @@ export class Flow {
     params['v-cs'] = colorScheme && colorScheme !== 'normal' ? colorScheme : '';
     /* Page visibility — initial state of document.hidden / document.hasFocus() */
     params['v-pv'] = currentVisibility();
+
+    /* Screen orientation — initial state of screen.orientation, empty
+       when the Screen Orientation API is unavailable. */
+    params['v-so'] = currentScreenOrientationType();
+    params['v-soa'] = currentScreenOrientationAngle();
 
     /* Theme name - detect which theme is in use */
     const computedStyle = getComputedStyle(document.documentElement);

--- a/flow-client/src/main/frontend/ScreenOrientation.ts
+++ b/flow-client/src/main/frontend/ScreenOrientation.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+type VaadinScreenOrientationType =
+  | 'portrait-primary'
+  | 'portrait-secondary'
+  | 'landscape-primary'
+  | 'landscape-secondary';
+
+interface VaadinScreenOrientationDetail {
+  type: VaadinScreenOrientationType | '';
+  angle: number;
+}
+
+/**
+ * Returns the current screen orientation type synchronously, or the empty
+ * string if the Screen Orientation API is unavailable. Used by the bootstrap
+ * path to seed the server-side signal without waiting for a DOM event.
+ */
+export function currentScreenOrientationType(): string {
+  return screen.orientation?.type ?? '';
+}
+
+/**
+ * Returns the current screen orientation angle synchronously, or 0 if the
+ * Screen Orientation API is unavailable.
+ */
+export function currentScreenOrientationAngle(): number {
+  return screen.orientation?.angle ?? 0;
+}
+
+// Dispatch on document.body so the server-side Page facade (listening on the
+// UI element, which is body) can update its signal.
+function dispatch(detail: VaadinScreenOrientationDetail): void {
+  document.body.dispatchEvent(new CustomEvent('vaadin-screen-orientation-change', { detail }));
+}
+
+if (screen.orientation) {
+  screen.orientation.addEventListener('change', () => {
+    dispatch({
+      type: screen.orientation.type as VaadinScreenOrientationType,
+      angle: screen.orientation.angle
+    });
+  });
+}
+
+const $wnd = window as any;
+$wnd.Vaadin ??= {};
+$wnd.Vaadin.Flow ??= {};
+$wnd.Vaadin.Flow.screenOrientation = {
+  lock(type: string): Promise<void> {
+    return screen.orientation.lock(type as OrientationLockType);
+  },
+  unlock(): void {
+    screen.orientation.unlock();
+  }
+};

--- a/flow-client/src/main/frontend/ScreenOrientation.ts
+++ b/flow-client/src/main/frontend/ScreenOrientation.ts
@@ -26,12 +26,13 @@ interface VaadinScreenOrientationDetail {
 }
 
 /**
- * Returns the current screen orientation type synchronously, or the empty
- * string if the Screen Orientation API is unavailable. Used by the bootstrap
- * path to seed the server-side signal without waiting for a DOM event.
+ * Returns the current screen orientation type synchronously, or
+ * {@code 'unsupported'} if the Screen Orientation API is unavailable. Used by
+ * the bootstrap path to seed the server-side signal without waiting for a DOM
+ * event.
  */
 export function currentScreenOrientationType(): string {
-  return screen.orientation?.type ?? '';
+  return screen.orientation?.type ?? 'unsupported';
 }
 
 /**
@@ -60,11 +61,35 @@ if (screen.orientation) {
 const $wnd = window as any;
 $wnd.Vaadin ??= {};
 $wnd.Vaadin.Flow ??= {};
+interface VaadinScreenOrientationLockResult {
+  success: boolean;
+  name?: string;
+  message?: string;
+}
+
 $wnd.Vaadin.Flow.screenOrientation = {
-  lock(type: string): Promise<void> {
-    return screen.orientation.lock(type as OrientationLockType);
+  // Always resolves so the server-side .then(success, error) chain only
+  // receives the "error" branch on a bridge failure (lost connection, etc.).
+  // Rejected DOMExceptions are folded into the resolved result so the server
+  // can decode them as a record without forfeiting the JS-bridge error arm.
+  lock(type: string): Promise<VaadinScreenOrientationLockResult> {
+    if (!screen.orientation || typeof screen.orientation.lock !== 'function') {
+      return Promise.resolve({
+        success: false,
+        name: 'NotSupportedError',
+        message: 'Screen Orientation API is not supported in this browser.'
+      });
+    }
+    return screen.orientation
+      .lock(type as OrientationLockType)
+      .then(() => ({ success: true }))
+      .catch((e: DOMException) => ({
+        success: false,
+        name: e.name ?? 'UnknownError',
+        message: e.message ?? ''
+      }));
   },
   unlock(): void {
-    screen.orientation.unlock();
+    screen.orientation?.unlock();
   }
 };

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
@@ -499,6 +499,8 @@ public class ExtendedClientDetails implements Serializable {
                 getStringElseNull.apply("v-tn"));
         ui.getInternals().setExtendedClientDetails(details);
         ui.getPage().setPageVisibility(getStringElseNull.apply("v-pv"));
+        ui.getPage().setScreenOrientation(getStringElseNull.apply("v-so"),
+                getStringElseNull.apply("v-soa"));
         String ga = getStringElseNull.apply("v-ga");
         if (ga != null) {
             try {

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -38,6 +38,7 @@ import com.vaadin.flow.component.internal.UIInternals.JavaScriptInvocation;
 import com.vaadin.flow.dom.DomListenerRegistration;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.function.SerializableRunnable;
 import com.vaadin.flow.internal.UrlUtil;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.shared.ui.Dependency;
@@ -509,10 +510,10 @@ public class Page implements Serializable {
      * The signal is seeded from the initial client bootstrap, so user code
      * always sees a real value when the browser supports the <a href=
      * "https://developer.mozilla.org/en-US/docs/Web/API/Screen_Orientation_API">Screen
-     * Orientation API</a>. On browsers that do not implement the API (or until
-     * the first bootstrap arrives) the value is
-     * {@link ScreenOrientation#UNKNOWN} with angle 0; once a real value has
-     * arrived, the signal never returns to {@code UNKNOWN}.
+     * Orientation API</a>. Browsers that do not implement the API report
+     * {@link ScreenOrientation#UNSUPPORTED} after bootstrap; the initial value
+     * before bootstrap is {@link ScreenOrientation#UNKNOWN}. Once a real value
+     * has arrived, the signal never returns to {@code UNKNOWN}.
      * <p>
      * Subscribe with {@code Signal.effect(owner, ...)} to react to changes;
      * call {@code screenOrientationSignal().peek()} for a snapshot outside a
@@ -530,28 +531,82 @@ public class Page implements Serializable {
      * fullscreen mode, and locking is generally only honored on devices where a
      * physical orientation actually exists (mobile, tablet).
      * <p>
-     * The returned result resolves when the lock succeeds, or completes
-     * exceptionally if the browser denies the request.
+     * This overload is fire-and-forget: failures are logged at {@code DEBUG}
+     * but not otherwise surfaced. Use
+     * {@link #lockOrientation(ScreenOrientation, SerializableRunnable, SerializableConsumer)}
+     * to react to success or to the specific lock error.
      *
      * @param orientation
      *            the orientation to lock to, not {@code null} and not
-     *            {@link ScreenOrientation#UNKNOWN}
-     * @return a pending result that resolves when the lock is applied
+     *            {@link ScreenOrientation#UNKNOWN} or
+     *            {@link ScreenOrientation#UNSUPPORTED}
      */
-    public PendingJavaScriptResult lockOrientation(
-            ScreenOrientation orientation) {
-        Objects.requireNonNull(orientation);
-        if (orientation == ScreenOrientation.UNKNOWN) {
-            throw new IllegalArgumentException(
-                    "Cannot lock to ScreenOrientation.UNKNOWN");
-        }
-        return executeJs("return window.Vaadin.Flow.screenOrientation.lock($0)",
-                orientation.getClientValue());
+    public void lockOrientation(ScreenOrientation orientation) {
+        lockOrientation(orientation, () -> {
+        }, error -> LOGGER.debug("Screen orientation lock failed: {} ({})",
+                error.message(), error.name()));
     }
 
     /**
-     * Releases a previous {@link #lockOrientation(ScreenOrientation) lock},
-     * allowing the screen to follow the device orientation again.
+     * Locks the screen orientation to the given type and notifies the matching
+     * callback when the browser resolves the request. Mirrors the
+     * {@link com.vaadin.flow.component.geolocation.Geolocation#getPosition
+     * Geolocation.getPosition} pattern so applications can bind UI to lock
+     * success and failure without having to write JavaScript glue.
+     * <p>
+     * The browser dispatches exactly one of the two callbacks on the UI thread.
+     * A lock typically requires fullscreen and a device that physically rotates
+     * — see {@link ScreenOrientationLockError} for the {@code DOMException}
+     * names you can expect on failure.
+     *
+     * @param orientation
+     *            the orientation to lock to, not {@code null} and not
+     *            {@link ScreenOrientation#UNKNOWN} or
+     *            {@link ScreenOrientation#UNSUPPORTED}
+     * @param onSuccess
+     *            invoked when the browser confirms the lock; not {@code null}
+     * @param onError
+     *            invoked when the browser rejects the request, or when the
+     *            Screen Orientation API is not available; not {@code null}
+     */
+    public void lockOrientation(ScreenOrientation orientation,
+            SerializableRunnable onSuccess,
+            SerializableConsumer<ScreenOrientationLockError> onError) {
+        Objects.requireNonNull(orientation, "orientation cannot be null");
+        Objects.requireNonNull(onSuccess, "onSuccess callback cannot be null");
+        Objects.requireNonNull(onError, "onError callback cannot be null");
+        if (orientation == ScreenOrientation.UNKNOWN
+                || orientation == ScreenOrientation.UNSUPPORTED) {
+            throw new IllegalArgumentException(
+                    "Cannot lock to ScreenOrientation." + orientation.name());
+        }
+        ui.getElement()
+                .executeJs(
+                        "return window.Vaadin.Flow.screenOrientation.lock($0)",
+                        orientation.getClientValue())
+                .then(LockResult.class, result -> {
+                    if (result.success()) {
+                        onSuccess.run();
+                    } else {
+                        onError.accept(new ScreenOrientationLockError(
+                                result.name() == null ? "UnknownError"
+                                        : result.name(),
+                                result.message() == null ? ""
+                                        : result.message()));
+                    }
+                }, bridgeError -> onError.accept(new ScreenOrientationLockError(
+                        "BridgeError", bridgeError)));
+    }
+
+    private record LockResult(boolean success, String name,
+            String message) implements Serializable {
+    }
+
+    /**
+     * Releases a previous
+     * {@link #lockOrientation(ScreenOrientation, SerializableRunnable, SerializableConsumer)
+     * lock}, allowing the screen to follow the device orientation again. A
+     * no-op on browsers that do not implement the Screen Orientation API.
      */
     public void unlockOrientation() {
         executeJs("window.Vaadin.Flow.screenOrientation.unlock()");
@@ -559,10 +614,13 @@ public class Page implements Serializable {
 
     /**
      * Sets the screen orientation from raw client-side values (e.g. from the
-     * bootstrap parameters). {@code null} or empty type means the browser does
-     * not implement the Screen Orientation API and the previous value is
-     * preserved. Unknown type values are logged at debug level so a
-     * forward-compatible client value does not silently disappear.
+     * bootstrap parameters). {@code null} type means the bootstrap parameters
+     * are absent (e.g. in a unit-test scenario) and the previous value is
+     * preserved. The client reports {@code "unsupported"} when the browser does
+     * not implement the Screen Orientation API, which maps to
+     * {@link ScreenOrientation#UNSUPPORTED}. Unknown type values are logged at
+     * debug level so a forward-compatible client value does not silently
+     * disappear.
      *
      * @param type
      *            the raw orientation type from the client, or {@code null}

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -66,6 +66,10 @@ public class Page implements Serializable {
             PageVisibility.UNKNOWN);
     private final Signal<PageVisibility> pageVisibilityReadOnly = pageVisibilitySignal
             .asReadonly();
+    private final ValueSignal<ScreenOrientationData> screenOrientationSignal = new ValueSignal<>(
+            new ScreenOrientationData(ScreenOrientation.UNKNOWN, 0));
+    private final Signal<ScreenOrientationData> screenOrientationReadOnly = screenOrientationSignal
+            .asReadonly();
 
     /**
      * Creates a page instance for the given UI.
@@ -80,6 +84,14 @@ public class Page implements Serializable {
                 .addEventListener("vaadin-page-visibility-change",
                         e -> setPageVisibility(e.getEventDetail(String.class)))
                 .addEventDetail().debounce(100).allowInert();
+        ui.getElement().addEventListener("vaadin-screen-orientation-change",
+                e -> setScreenOrientation(
+                        e.getEventDetail(ScreenOrientationDetail.class)))
+                .addEventDetail().allowInert();
+    }
+
+    private record ScreenOrientationDetail(String type,
+            int angle) implements Serializable {
     }
 
     /**
@@ -487,6 +499,102 @@ public class Page implements Serializable {
                         }
                     }).addEventData("event.w").addEventData("event.h")
                     .debounce(300).allowInert();
+        }
+    }
+
+    /**
+     * Returns a read-only signal that tracks the current screen orientation and
+     * its rotation angle.
+     * <p>
+     * The signal is seeded from the initial client bootstrap, so user code
+     * always sees a real value when the browser supports the <a href=
+     * "https://developer.mozilla.org/en-US/docs/Web/API/Screen_Orientation_API">Screen
+     * Orientation API</a>. On browsers that do not implement the API (or until
+     * the first bootstrap arrives) the value is
+     * {@link ScreenOrientation#UNKNOWN} with angle 0; once a real value has
+     * arrived, the signal never returns to {@code UNKNOWN}.
+     * <p>
+     * Subscribe with {@code Signal.effect(owner, ...)} to react to changes;
+     * call {@code screenOrientationSignal().peek()} for a snapshot outside a
+     * reactive context, and {@code .get()} inside one.
+     *
+     * @return the read-only screen orientation signal
+     */
+    public Signal<ScreenOrientationData> screenOrientationSignal() {
+        return screenOrientationReadOnly;
+    }
+
+    /**
+     * Locks the screen orientation to the given type for as long as the user
+     * remains on the current page. Most browsers require the document to be in
+     * fullscreen mode, and locking is generally only honored on devices where a
+     * physical orientation actually exists (mobile, tablet).
+     * <p>
+     * The returned result resolves when the lock succeeds, or completes
+     * exceptionally if the browser denies the request.
+     *
+     * @param orientation
+     *            the orientation to lock to, not {@code null} and not
+     *            {@link ScreenOrientation#UNKNOWN}
+     * @return a pending result that resolves when the lock is applied
+     */
+    public PendingJavaScriptResult lockOrientation(
+            ScreenOrientation orientation) {
+        Objects.requireNonNull(orientation);
+        if (orientation == ScreenOrientation.UNKNOWN) {
+            throw new IllegalArgumentException(
+                    "Cannot lock to ScreenOrientation.UNKNOWN");
+        }
+        return executeJs("return window.Vaadin.Flow.screenOrientation.lock($0)",
+                orientation.getClientValue());
+    }
+
+    /**
+     * Releases a previous {@link #lockOrientation(ScreenOrientation) lock},
+     * allowing the screen to follow the device orientation again.
+     */
+    public void unlockOrientation() {
+        executeJs("window.Vaadin.Flow.screenOrientation.unlock()");
+    }
+
+    /**
+     * Sets the screen orientation from raw client-side values (e.g. from the
+     * bootstrap parameters). {@code null} or empty type means the browser does
+     * not implement the Screen Orientation API and the previous value is
+     * preserved. Unknown type values are logged at debug level so a
+     * forward-compatible client value does not silently disappear.
+     *
+     * @param type
+     *            the raw orientation type from the client, or {@code null}
+     * @param angle
+     *            the raw orientation angle from the client, or {@code null}
+     */
+    void setScreenOrientation(String type, String angle) {
+        if (type == null || type.isEmpty()) {
+            return;
+        }
+        try {
+            int angleValue = angle == null ? 0 : Integer.parseInt(angle);
+            screenOrientationSignal.set(new ScreenOrientationData(
+                    ScreenOrientation.fromClientValue(type), angleValue));
+        } catch (IllegalArgumentException e) {
+            LOGGER.debug("Unknown screen orientation value from client: "
+                    + "type={} angle={}", type, angle);
+        }
+    }
+
+    private void setScreenOrientation(ScreenOrientationDetail detail) {
+        if (detail == null || detail.type() == null
+                || detail.type().isEmpty()) {
+            return;
+        }
+        try {
+            screenOrientationSignal.set(new ScreenOrientationData(
+                    ScreenOrientation.fromClientValue(detail.type()),
+                    detail.angle()));
+        } catch (IllegalArgumentException e) {
+            LOGGER.debug("Unknown screen orientation value from client: {}",
+                    detail.type());
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/ScreenOrientation.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/ScreenOrientation.java
@@ -21,21 +21,29 @@ package com.vaadin.flow.component.page;
  * Mirrors the values reported by the browser's <a href=
  * "https://developer.mozilla.org/en-US/docs/Web/API/Screen_Orientation_API">Screen
  * Orientation API</a>, plus an {@link #UNKNOWN} sentinel used before the first
- * value has arrived from the client and on browsers that do not implement the
- * API.
+ * value has arrived from the client and an {@link #UNSUPPORTED} sentinel for
+ * browsers that do not implement the API.
  *
  * @see Page#screenOrientationSignal()
  */
 public enum ScreenOrientation {
 
     /**
-     * No value has been reported by the browser yet, or the browser does not
-     * implement the Screen Orientation API. Used as the initial value of the
-     * signal before the first client handshake delivers a real one. In normal
-     * request handling the signal is seeded before any user code runs, so this
-     * value is observed only when the API itself is unavailable.
+     * No value has been reported by the browser yet. Used as the initial value
+     * of the signal before the first client handshake delivers a real one. In
+     * normal request handling the signal is seeded before any user code runs,
+     * so this value is essentially never observed in practice; once a real
+     * value has arrived, the signal never returns to {@code UNKNOWN}.
      */
     UNKNOWN(""),
+
+    /**
+     * The browser does not implement the <a href=
+     * "https://developer.mozilla.org/en-US/docs/Web/API/Screen_Orientation_API">Screen
+     * Orientation API</a>. Distinct from {@link #UNKNOWN} so callers can tell
+     * "no data yet" apart from "the platform will never produce data."
+     */
+    UNSUPPORTED("unsupported"),
 
     /**
      * The screen is in primary portrait orientation (the device is held upright
@@ -74,6 +82,28 @@ public enum ScreenOrientation {
      */
     public String getClientValue() {
         return clientValue;
+    }
+
+    /**
+     * Returns {@code true} for the two landscape orientations
+     * ({@link #LANDSCAPE_PRIMARY}, {@link #LANDSCAPE_SECONDARY}).
+     * {@link #UNKNOWN} and {@link #UNSUPPORTED} return {@code false}.
+     *
+     * @return whether this is a landscape orientation
+     */
+    public boolean isLandscape() {
+        return this == LANDSCAPE_PRIMARY || this == LANDSCAPE_SECONDARY;
+    }
+
+    /**
+     * Returns {@code true} for the two portrait orientations
+     * ({@link #PORTRAIT_PRIMARY}, {@link #PORTRAIT_SECONDARY}).
+     * {@link #UNKNOWN} and {@link #UNSUPPORTED} return {@code false}.
+     *
+     * @return whether this is a portrait orientation
+     */
+    public boolean isPortrait() {
+        return this == PORTRAIT_PRIMARY || this == PORTRAIT_SECONDARY;
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/ScreenOrientation.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/ScreenOrientation.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.page;
+
+/**
+ * Represents the orientation of the browser screen.
+ * <p>
+ * Mirrors the values reported by the browser's <a href=
+ * "https://developer.mozilla.org/en-US/docs/Web/API/Screen_Orientation_API">Screen
+ * Orientation API</a>, plus an {@link #UNKNOWN} sentinel used before the first
+ * value has arrived from the client and on browsers that do not implement the
+ * API.
+ *
+ * @see Page#screenOrientationSignal()
+ */
+public enum ScreenOrientation {
+
+    /**
+     * No value has been reported by the browser yet, or the browser does not
+     * implement the Screen Orientation API. Used as the initial value of the
+     * signal before the first client handshake delivers a real one. In normal
+     * request handling the signal is seeded before any user code runs, so this
+     * value is observed only when the API itself is unavailable.
+     */
+    UNKNOWN(""),
+
+    /**
+     * The screen is in primary portrait orientation (the device is held upright
+     * in its natural portrait position).
+     */
+    PORTRAIT_PRIMARY("portrait-primary"),
+
+    /**
+     * The screen is in secondary portrait orientation (the device is rotated
+     * 180° from {@link #PORTRAIT_PRIMARY}).
+     */
+    PORTRAIT_SECONDARY("portrait-secondary"),
+
+    /**
+     * The screen is in primary landscape orientation (the device is rotated 90°
+     * clockwise from its natural portrait position).
+     */
+    LANDSCAPE_PRIMARY("landscape-primary"),
+
+    /**
+     * The screen is in secondary landscape orientation (the device is rotated
+     * 90° counter-clockwise from its natural portrait position).
+     */
+    LANDSCAPE_SECONDARY("landscape-secondary");
+
+    private final String clientValue;
+
+    ScreenOrientation(String clientValue) {
+        this.clientValue = clientValue;
+    }
+
+    /**
+     * Returns the value as used by the browser's Screen Orientation API.
+     *
+     * @return the client-side orientation type string
+     */
+    public String getClientValue() {
+        return clientValue;
+    }
+
+    /**
+     * Returns the enum constant matching the given client-side orientation type
+     * string.
+     *
+     * @param clientValue
+     *            the orientation type string from the browser
+     * @return the corresponding enum value
+     * @throws IllegalArgumentException
+     *             if the value does not match any known orientation type
+     */
+    public static ScreenOrientation fromClientValue(String clientValue) {
+        for (ScreenOrientation orientation : values()) {
+            if (orientation.clientValue.equals(clientValue)) {
+                return orientation;
+            }
+        }
+        throw new IllegalArgumentException(
+                "Unknown screen orientation type: " + clientValue);
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/ScreenOrientationData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/ScreenOrientationData.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.page;
+
+import java.io.Serializable;
+
+/**
+ * Represents the current screen orientation state, including the orientation
+ * type and the angle of rotation.
+ *
+ * @param type
+ *            the screen orientation type
+ * @param angle
+ *            the screen orientation angle in degrees
+ *
+ * @author Vaadin Ltd
+ */
+public record ScreenOrientationData(ScreenOrientation type,
+        int angle) implements Serializable {
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/ScreenOrientationLockError.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/ScreenOrientationLockError.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.page;
+
+import java.io.Serializable;
+
+/**
+ * Describes a failed screen-orientation lock request.
+ * <p>
+ * Fields mirror the {@code DOMException} the browser rejects
+ * {@code screen.orientation.lock()} with. The most common values for
+ * {@code name} are:
+ * <ul>
+ * <li>{@code "NotSupportedError"} — the browser does not implement the Screen
+ * Orientation API at all, or does not allow locking on this device.</li>
+ * <li>{@code "SecurityError"} — the document is not in fullscreen, which most
+ * browsers require for locking.</li>
+ * <li>{@code "AbortError"} — a newer lock or unlock call superseded this
+ * one.</li>
+ * </ul>
+ *
+ * @param name
+ *            the {@code DOMException} name, e.g. {@code "SecurityError"}
+ * @param message
+ *            the {@code DOMException} message, suitable for logging
+ */
+public record ScreenOrientationLockError(String name,
+        String message) implements Serializable {
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/PageScreenOrientationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/PageScreenOrientationTest.java
@@ -16,6 +16,8 @@
 package com.vaadin.flow.component.page;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.node.ObjectNode;
@@ -33,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class PageScreenOrientationTest {
 
@@ -137,6 +140,46 @@ class PageScreenOrientationTest {
     }
 
     @Test
+    void lockOrientation_unsupportedIsRejected() {
+        Page page = new MockUI().getPage();
+        assertThrows(IllegalArgumentException.class,
+                () -> page.lockOrientation(ScreenOrientation.UNSUPPORTED));
+    }
+
+    @Test
+    void lockOrientation_successCallbackFires() {
+        MockUI ui = new MockUI();
+        AtomicBoolean success = new AtomicBoolean();
+        ui.getPage().lockOrientation(ScreenOrientation.LANDSCAPE_PRIMARY,
+                () -> success.set(true),
+                error -> fail("onError should not fire: " + error.message()));
+
+        ObjectNode result = JacksonUtils.createObjectNode();
+        result.put("success", true);
+        resolveLockPromise(ui, result);
+
+        assertTrue(success.get(),
+                "onSuccess must fire when the client resolves with success");
+    }
+
+    @Test
+    void lockOrientation_errorCallbackFires() {
+        MockUI ui = new MockUI();
+        AtomicReference<ScreenOrientationLockError> captured = new AtomicReference<>();
+        ui.getPage().lockOrientation(ScreenOrientation.LANDSCAPE_PRIMARY,
+                () -> fail("onSuccess should not fire"), captured::set);
+
+        ObjectNode result = JacksonUtils.createObjectNode();
+        result.put("success", false);
+        result.put("name", "SecurityError");
+        result.put("message", "Must be in fullscreen");
+        resolveLockPromise(ui, result);
+
+        assertEquals("SecurityError", captured.get().name());
+        assertEquals("Must be in fullscreen", captured.get().message());
+    }
+
+    @Test
     void unlockOrientation_executesCorrectJs() {
         MockUI ui = new MockUI();
         ui.getPage().unlockOrientation();
@@ -154,8 +197,44 @@ class PageScreenOrientationTest {
                 ScreenOrientation.fromClientValue("portrait-primary"));
         assertEquals(ScreenOrientation.LANDSCAPE_SECONDARY,
                 ScreenOrientation.fromClientValue("landscape-secondary"));
+        assertEquals(ScreenOrientation.UNSUPPORTED,
+                ScreenOrientation.fromClientValue("unsupported"));
         assertThrows(IllegalArgumentException.class,
-                () -> ScreenOrientation.fromClientValue("unknown"));
+                () -> ScreenOrientation.fromClientValue("diagonal-future"));
+    }
+
+    @Test
+    void isLandscape_isPortrait() {
+        assertTrue(ScreenOrientation.LANDSCAPE_PRIMARY.isLandscape());
+        assertTrue(ScreenOrientation.LANDSCAPE_SECONDARY.isLandscape());
+        assertFalse(ScreenOrientation.PORTRAIT_PRIMARY.isLandscape());
+        assertFalse(ScreenOrientation.UNKNOWN.isLandscape());
+        assertFalse(ScreenOrientation.UNSUPPORTED.isLandscape());
+
+        assertTrue(ScreenOrientation.PORTRAIT_PRIMARY.isPortrait());
+        assertTrue(ScreenOrientation.PORTRAIT_SECONDARY.isPortrait());
+        assertFalse(ScreenOrientation.LANDSCAPE_PRIMARY.isPortrait());
+        assertFalse(ScreenOrientation.UNKNOWN.isPortrait());
+        assertFalse(ScreenOrientation.UNSUPPORTED.isPortrait());
+    }
+
+    @Test
+    void setScreenOrientation_unsupportedFromBootstrap() {
+        MockUI ui = new MockUI();
+        ui.getPage().setScreenOrientation("unsupported", "0");
+        assertEquals(ScreenOrientation.UNSUPPORTED,
+                ui.getPage().screenOrientationSignal().peek().type(),
+                "Client-side 'unsupported' must be observable distinctly "
+                        + "from the pre-bootstrap UNKNOWN state");
+    }
+
+    private static void resolveLockPromise(MockUI ui, ObjectNode result) {
+        PendingJavaScriptInvocation invocation = ui.dumpPendingJsInvocations()
+                .stream()
+                .filter(inv -> inv.getInvocation().getExpression()
+                        .contains("screenOrientation.lock"))
+                .reduce((a, b) -> b).orElseThrow();
+        invocation.complete(result);
     }
 
     private void fireOrientationEvent(MockUI ui, String type, int angle) {

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/PageScreenOrientationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/PageScreenOrientationTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.page;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.node.ObjectNode;
+
+import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
+import com.vaadin.flow.dom.DomEvent;
+import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
+import com.vaadin.flow.signals.Signal;
+import com.vaadin.flow.signals.local.ValueSignal;
+import com.vaadin.tests.util.MockUI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PageScreenOrientationTest {
+
+    @Test
+    void screenOrientationSignal_isReadOnly() {
+        MockUI ui = new MockUI();
+        Signal<ScreenOrientationData> signal = ui.getPage()
+                .screenOrientationSignal();
+        assertFalse(signal instanceof ValueSignal,
+                "screenOrientationSignal() should return a read-only signal");
+    }
+
+    @Test
+    void screenOrientationSignal_defaultsToUnknownBeforeBootstrap() {
+        MockUI ui = new MockUI();
+        Signal<ScreenOrientationData> signal = ui.getPage()
+                .screenOrientationSignal();
+        assertEquals(ScreenOrientation.UNKNOWN, signal.peek().type(),
+                "Before bootstrap the type should be UNKNOWN so callers can "
+                        + "distinguish 'no data yet' from a real value");
+        assertEquals(0, signal.peek().angle());
+    }
+
+    @Test
+    void screenOrientationSignal_readonlyWrapperIsCached() {
+        Page page = new MockUI().getPage();
+        assertSame(page.screenOrientationSignal(),
+                page.screenOrientationSignal(),
+                "Repeated calls must return the same read-only wrapper so "
+                        + "subscriber identity stays stable");
+    }
+
+    @Test
+    void screenOrientationSignal_tracksOrientationChanges() {
+        MockUI ui = new MockUI();
+        Signal<ScreenOrientationData> signal = ui.getPage()
+                .screenOrientationSignal();
+
+        fireOrientationEvent(ui, "landscape-primary", 90);
+        assertEquals(ScreenOrientation.LANDSCAPE_PRIMARY, signal.peek().type());
+        assertEquals(90, signal.peek().angle());
+
+        fireOrientationEvent(ui, "portrait-secondary", 180);
+        assertEquals(ScreenOrientation.PORTRAIT_SECONDARY,
+                signal.peek().type());
+        assertEquals(180, signal.peek().angle());
+    }
+
+    @Test
+    void screenOrientationSignal_unknownTypeKeepsPreviousValue() {
+        MockUI ui = new MockUI();
+        Signal<ScreenOrientationData> signal = ui.getPage()
+                .screenOrientationSignal();
+
+        fireOrientationEvent(ui, "landscape-primary", 90);
+        fireOrientationEvent(ui, "diagonal-future", 45);
+
+        assertEquals(ScreenOrientation.LANDSCAPE_PRIMARY, signal.peek().type(),
+                "Unknown type values from a newer client should not reset "
+                        + "the signal");
+        assertEquals(90, signal.peek().angle());
+    }
+
+    @Test
+    void setScreenOrientation_fromBootstrapSeedsSignal() {
+        MockUI ui = new MockUI();
+        ui.getPage().setScreenOrientation("landscape-secondary", "270");
+
+        ScreenOrientationData data = ui.getPage().screenOrientationSignal()
+                .peek();
+        assertEquals(ScreenOrientation.LANDSCAPE_SECONDARY, data.type());
+        assertEquals(270, data.angle());
+    }
+
+    @Test
+    void setScreenOrientation_emptyTypeIsIgnored() {
+        MockUI ui = new MockUI();
+        ui.getPage().setScreenOrientation("", "0");
+        assertEquals(ScreenOrientation.UNKNOWN,
+                ui.getPage().screenOrientationSignal().peek().type(),
+                "Empty type from a browser without the Screen Orientation API "
+                        + "must keep UNKNOWN, not crash");
+    }
+
+    @Test
+    void lockOrientation_executesCorrectJs() {
+        MockUI ui = new MockUI();
+        ui.getPage().lockOrientation(ScreenOrientation.LANDSCAPE_PRIMARY);
+
+        List<PendingJavaScriptInvocation> invocations = ui
+                .dumpPendingJsInvocations();
+        assertTrue(invocations.stream()
+                .anyMatch(i -> i.getInvocation().getExpression().contains(
+                        "window.Vaadin.Flow.screenOrientation.lock(")));
+    }
+
+    @Test
+    void lockOrientation_unknownIsRejected() {
+        Page page = new MockUI().getPage();
+        assertThrows(IllegalArgumentException.class,
+                () -> page.lockOrientation(ScreenOrientation.UNKNOWN));
+    }
+
+    @Test
+    void unlockOrientation_executesCorrectJs() {
+        MockUI ui = new MockUI();
+        ui.getPage().unlockOrientation();
+
+        List<PendingJavaScriptInvocation> invocations = ui
+                .dumpPendingJsInvocations();
+        assertTrue(invocations.stream()
+                .anyMatch(i -> i.getInvocation().getExpression().contains(
+                        "window.Vaadin.Flow.screenOrientation.unlock()")));
+    }
+
+    @Test
+    void screenOrientation_fromClientValue() {
+        assertEquals(ScreenOrientation.PORTRAIT_PRIMARY,
+                ScreenOrientation.fromClientValue("portrait-primary"));
+        assertEquals(ScreenOrientation.LANDSCAPE_SECONDARY,
+                ScreenOrientation.fromClientValue("landscape-secondary"));
+        assertThrows(IllegalArgumentException.class,
+                () -> ScreenOrientation.fromClientValue("unknown"));
+    }
+
+    private void fireOrientationEvent(MockUI ui, String type, int angle) {
+        ObjectNode detail = JacksonUtils.createObjectNode();
+        detail.put("type", type);
+        detail.put("angle", angle);
+        ObjectNode eventData = JacksonUtils.createObjectNode();
+        eventData.set("event.detail", detail);
+        ui.getElement().getNode().getFeature(ElementListenerMap.class)
+                .fireEvent(new DomEvent(ui.getElement(),
+                        "vaadin-screen-orientation-change", eventData));
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ScreenOrientationView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ScreenOrientationView.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.page.ScreenOrientationData;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.signals.Signal;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+@Route(value = "com.vaadin.flow.uitest.ui.ScreenOrientationView", layout = ViewTestLayout.class)
+public class ScreenOrientationView extends AbstractDivView {
+
+    @Override
+    protected void onShow() {
+        Div type = new Div();
+        type.setId("type");
+        Div angle = new Div();
+        angle.setId("angle");
+        Div updates = new Div();
+        updates.setId("updates");
+        updates.setText("0");
+        add(type, angle, updates);
+
+        Signal<ScreenOrientationData> signal = UI.getCurrent().getPage()
+                .screenOrientationSignal();
+        AtomicInteger count = new AtomicInteger();
+        Signal.effect(this, () -> {
+            ScreenOrientationData data = signal.get();
+            type.setText(data.type().name());
+            angle.setText(String.valueOf(data.angle()));
+            updates.setText(String.valueOf(count.incrementAndGet()));
+        });
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ScreenOrientationIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ScreenOrientationIT.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class ScreenOrientationIT extends ChromeBrowserTest {
+
+    @Test
+    public void initialState_isReportedFromBootstrap() {
+        open();
+        // The bootstrap parameters v-so/v-soa must seed the signal to a real
+        // value before the view renders. Headless Chrome reports a portrait
+        // orientation by default; the contract is only that the type is no
+        // longer UNKNOWN.
+        waitUntil(d -> {
+            String t = findElement(By.id("type")).getText();
+            return t.startsWith("PORTRAIT") || t.startsWith("LANDSCAPE");
+        });
+    }
+
+    @Test
+    public void orientationChange_isPropagatedToSignal() {
+        open();
+
+        // Fake a change event by overriding screen.orientation and dispatching
+        // the change event the client listener subscribes to. Headless Chrome
+        // does not actually rotate, so the values are spoofed.
+        executeScript("""
+                Object.defineProperty(screen.orientation, 'type', \
+                {value: 'landscape-primary', configurable: true});
+                Object.defineProperty(screen.orientation, 'angle', \
+                {value: 90, configurable: true});
+                screen.orientation.dispatchEvent(new Event('change'));
+                """);
+
+        waitUntil(d -> "LANDSCAPE_PRIMARY"
+                .equals(findElement(By.id("type")).getText())
+                && "90".equals(findElement(By.id("angle")).getText()));
+    }
+}


### PR DESCRIPTION
Expose the browser Screen Orientation API through Page methods, providing a read-only signal for tracking orientation changes and methods to lock/unlock screen orientation for tablet and mobile apps.
