### PR TITLE
chore: Reduce logging for bean resolution failures

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringInstantiator.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringInstantiator.java
@@ -100,7 +100,7 @@ public class SpringInstantiator extends DefaultInstantiator {
         } catch (NoSuchBeanDefinitionException ignored) {
             if (loggingEnabled.compareAndSet(true, false)) {
                 LoggerFactory.getLogger(SpringInstantiator.class.getName())
-                        .info("The number of beans implementing '{}' is {} why spring could not provide a unique bean. "
+                        .debug("The number of beans implementing '{}' is {} why spring could not provide a unique bean. "
                                 + "Cannot use Spring beans for I18N, falling back to the default behavior",
                                 I18NProvider.class.getSimpleName(),
                                 context.getBeanNamesForType(
@@ -117,7 +117,7 @@ public class SpringInstantiator extends DefaultInstantiator {
         } catch (NoSuchBeanDefinitionException ignored) {
             if (loggingEnabled.compareAndSet(true, false)) {
                 LoggerFactory.getLogger(SpringInstantiator.class.getName())
-                        .info("The number of beans implementing '{}' is {} why spring could not provide a unique bean. "
+                        .debug("The number of beans implementing '{}' is {} why spring could not provide a unique bean. "
                                 + "Cannot use Spring beans for Menu Access Control, falling back to the default behavior",
                                 MenuAccessControl.class.getSimpleName(),
                                 context.getBeanNamesForType(


### PR DESCRIPTION
Each and every startup and ui test logs
```
2026-02-24T21:51:02.755+02:00  INFO 73022 --- [           main] c.vaadin.flow.spring.SpringInstantiator  : The number of beans implementing 'I18NProvider' is 0 why spring could not provide a unique bean. Cannot use Spring beans for I18N, falling back to the default behavior
```

and it is not clear why this particular feature should have other behavior than other features. There is no eager logging for other potential problems, as far as I know or have seen
