### PR TITLE
feat: add Element.flashClass() for CSS animation-based visual feedback

### DIFF
--- a/flow-client/src/main/frontend/FlowBootstrap.js
+++ b/flow-client/src/main/frontend/FlowBootstrap.js
@@ -57,6 +57,27 @@ const init = function (appInitResponse) {
   /*
    * Needed for wrapping custom javascript functionality in the components (i.e. connectors)
    */
+  window.Vaadin.Flow.flashClass = function (element, className) {
+    element.classList.remove(className);
+    void element.offsetWidth;
+    element.classList.add(className);
+    function onAnimationEnd(e) {
+      if (e.target === element) {
+        element.classList.remove(className);
+        element.removeEventListener('animationend', onAnimationEnd);
+      }
+    }
+    element.addEventListener('animationend', onAnimationEnd);
+    requestAnimationFrame(function () {
+      var style = getComputedStyle(element);
+      var animName = style.animationName;
+      if (!animName || animName === 'none') {
+        element.classList.remove(className);
+        element.removeEventListener('animationend', onAnimationEnd);
+      }
+    });
+  };
+
   window.Vaadin.Flow.tryCatchWrapper = function (originalFunction, component) {
     return function () {
       try {

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -1441,6 +1441,38 @@ public class Element extends Node<Element> {
     }
 
     /**
+     * Temporarily adds a CSS class to this element to trigger a CSS animation,
+     * then automatically removes it when the animation ends. This is useful for
+     * "flash" effects such as highlighting a value that changed in the
+     * background.
+     * <p>
+     * The method works by removing the class (if present), forcing a DOM
+     * reflow, and then re-adding it. This restarts any CSS animation associated
+     * with the class. An {@code animationend} listener automatically removes
+     * the class when the animation completes. If no CSS animation is defined
+     * for the class, it is removed immediately.
+     * <p>
+     * Example CSS to define a flash animation:
+     *
+     * <pre>
+     * .highlight {
+     *     animation: flash 0.5s ease-out;
+     * }
+     * &#64;keyframes flash {
+     *     from { background-color: yellow; }
+     *     to { background-color: transparent; }
+     * }
+     * </pre>
+     *
+     * @param className
+     *            the CSS class name to flash, not <code>null</code>
+     */
+    public void flashClass(String className) {
+        Objects.requireNonNull(className, "className cannot be null");
+        executeJs("window.Vaadin.Flow.flashClass(this, $0)", className);
+    }
+
+    /**
      * Gets the set of the theme names applied to the corresponding element in
      * {@code theme} attribute. The set returned can be modified to add or
      * remove the theme names, changes to the set will be reflected in the

--- a/flow-server/src/main/resources/com/vaadin/flow/server/BootstrapHandler.js
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/BootstrapHandler.js
@@ -45,6 +45,27 @@
   /*
    * Needed for wrapping custom javascript functionality in the components (i.e. connectors)
    */
+  window.Vaadin.Flow.flashClass = function(element, className) {
+    element.classList.remove(className);
+    void element.offsetWidth;
+    element.classList.add(className);
+    function onAnimationEnd(e) {
+      if (e.target === element) {
+        element.classList.remove(className);
+        element.removeEventListener('animationend', onAnimationEnd);
+      }
+    }
+    element.addEventListener('animationend', onAnimationEnd);
+    requestAnimationFrame(function() {
+      var style = getComputedStyle(element);
+      var animName = style.animationName;
+      if (!animName || animName === 'none') {
+        element.classList.remove(className);
+        element.removeEventListener('animationend', onAnimationEnd);
+      }
+    });
+  };
+
   window.Vaadin.Flow.tryCatchWrapper = function(originalFunction, component, repo) {
     return function() {
       try {

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementJacksonTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementJacksonTest.java
@@ -178,6 +178,9 @@ class ElementJacksonTest extends AbstractNodeTest {
         ignore.add("bindText");
         ignore.add("bindVisible");
 
+        // returns void
+        ignore.add("flashClass");
+
         assertMethodsReturnType(Element.class, ignore);
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
@@ -180,6 +180,9 @@ class ElementTest extends AbstractNodeTest {
         ignore.add("bindText");
         ignore.add("bindVisible");
 
+        // returns void
+        ignore.add("flashClass");
+
         assertMethodsReturnType(Element.class, ignore);
     }
 


### PR DESCRIPTION
Add a flashClass(String) method to Element that temporarily applies a CSS class to trigger an animation, then auto-removes it when the animation ends. This enables easy "flash" effects for highlighting background data updates.

The client-side implementation lives in both BootstrapHandler.js and FlowBootstrap.js on window.Vaadin.Flow.flashClass, handling DOM reflow restart, animationend cleanup, and fallback for elements without CSS animations defined.
