### PR TITLE
fix: clamp effectiveRequested range in DataCommunicator to prevent IndexOutOfBoundsException

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -1309,6 +1309,13 @@ public class DataCommunicator<T> implements Serializable {
         activeKeyOrder = activation.getActiveKeys();
         activeStart = effectiveRequested.getStart();
 
+        // Clamp range when data provider returns fewer items than expected
+        // (e.g. items deleted between count and fetch queries)
+        if (activeKeyOrder.size() < effectiveRequested.length()) {
+            effectiveRequested = Range.withLength(activeStart,
+                    activeKeyOrder.size());
+        }
+
         // Phase 2: Collect changes to send
         Update update = arrayUpdater.startUpdate(assumedSize);
         boolean updated = collectChangesToSend(previousActive,

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
@@ -445,6 +445,39 @@ public class DataCommunicatorTest {
     }
 
     @Test
+    public void dataProviderReturnsLessItemsThanSize_noIndexOutOfBounds() {
+        // Data provider where size() always returns 50 but fetch() only
+        // returns 45 items, simulating items deleted between count and fetch
+        AbstractDataProvider<Item, Object> dataProvider = new AbstractDataProvider<>() {
+            @Override
+            public int size(Query<Item, Object> query) {
+                return 50;
+            }
+
+            @Override
+            public Stream<Item> fetch(Query<Item, Object> query) {
+                int end = Math.min(query.getOffset() + query.getLimit(), 45);
+                if (end <= query.getOffset()) {
+                    return Stream.empty();
+                }
+                return asParallelIfRequired(
+                        IntStream.range(query.getOffset(), end))
+                        .mapToObj(Item::new);
+            }
+
+            @Override
+            public boolean isInMemory() {
+                return false;
+            }
+        };
+
+        dataCommunicator.setDataProvider(dataProvider, null);
+        dataCommunicator.setViewportRange(0, 50);
+        // Should not throw IndexOutOfBoundsException
+        fakeClientCommunication();
+    }
+
+    @Test
     public void setSizeCallback_usedForDataSize() {
         AbstractDataProvider<Item, Object> dataProvider = createDataProvider();
         dataProvider = Mockito.spy(dataProvider);


### PR DESCRIPTION
When a data provider returns fewer items than its size() reports (e.g. items deleted between the count and fetch queries), getJsonItems() would crash with an IndexOutOfBoundsException. Clamp effectiveRequested to match the actual number of fetched items before processing changes.

Fixes #5839
