### PR TITLE
test: use waitUntil in NavigationIT to avoid async flakiness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,3 +170,4 @@ Components extend `Component` and use:
 - When creating a commit that will resolve an issue in the same repository, add "Fixes #issuenumber" to the commit message
 - Don't add @since to javadocs
 - When adding unit tests, add only the essential ones and not more than that
+- Use test: instead of fix: when fixing only tests

--- a/flow-tests/test-react-router/src/test/java/com/vaadin/flow/NavigationIT.java
+++ b/flow-tests/test-react-router/src/test/java/com/vaadin/flow/NavigationIT.java
@@ -278,18 +278,18 @@ public class NavigationIT extends ChromeBrowserTest {
                 $(SpanElement.class).first().getText());
 
         $(NativeButtonElement.class).id(NavigationView.REACT_ID).click();
-        Assert.assertEquals("This is a simple view for a React route",
-                $(ParagraphElement.class).id("react").getText());
+        waitUntil(driver -> "This is a simple view for a React route"
+                .equals($(ParagraphElement.class).id("react").getText()));
         getDriver().navigate().back();
-        Assert.assertEquals("NavigationView",
-                $(SpanElement.class).first().getText());
+        waitUntil(driver -> "NavigationView"
+                .equals($(SpanElement.class).first().getText()));
 
         $(NativeButtonElement.class).id(NavigationView.REACT_ID).click();
-        Assert.assertEquals("This is a simple view for a React route",
-                $(ParagraphElement.class).id("react").getText());
+        waitUntil(driver -> "This is a simple view for a React route"
+                .equals($(ParagraphElement.class).id("react").getText()));
         getDriver().navigate().back();
-        Assert.assertEquals("NavigationView",
-                $(SpanElement.class).first().getText());
+        waitUntil(driver -> "NavigationView"
+                .equals($(SpanElement.class).first().getText()));
     }
 
     @Test


### PR DESCRIPTION
Replace immediate assertions with waitUntil polling after server-side navigation and browser history back in the React navigation test, as the React component may not have finished rendering by the time the assertion runs.
