### PR TITLE
revert: Add HasValidation::bindErrorMessage and bindInvalid

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/HasValidation.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasValidation.java
@@ -17,8 +17,6 @@ package com.vaadin.flow.component;
 
 import java.io.Serializable;
 
-import com.vaadin.flow.signals.Signal;
-
 /**
  * A component that supports input validation.
  * <p>
@@ -72,14 +70,9 @@ public interface HasValidation extends Serializable {
      * invalid state for the Web Component. Which means that there is no need to
      * clean up the message when component becomes valid (otherwise it may lead
      * to undesired visual effects).
-     * <p>
-     * While a signal binding for the error message is active, calls to this
-     * method throw a {@code com.vaadin.flow.signals.BindingActiveException}.
      *
      * @param errorMessage
      *            a new error message
-     * @throws com.vaadin.flow.signals.BindingActiveException
-     *             thrown when there is already an existing signal binding
      */
     void setErrorMessage(String errorMessage);
 
@@ -89,31 +82,6 @@ public interface HasValidation extends Serializable {
      * @return current error message
      */
     String getErrorMessage();
-
-    /**
-     * Binds the component's error message to the provided signal so that the
-     * error message is kept in sync with the signal's current value.
-     * <p>
-     * Passing {@code null} as the {@code signal} removes any existing binding.
-     * When unbinding, the current error message is left unchanged.
-     * <p>
-     * While a binding is active, manual calls to
-     * {@link #setErrorMessage(String)} throw a
-     * {@code com.vaadin.flow.signals.BindingActiveException}. Bindings are
-     * lifecycle-aware and only active while the owning {@link Component} is in
-     * attached state; they are deactivated while the component is in detached
-     * state.
-     *
-     * @param signal
-     *            the signal providing error messages, not {@code null}
-     * @throws com.vaadin.flow.signals.BindingActiveException
-     *             thrown when there is already an existing binding
-     * @since 25.1
-     */
-    default void bindErrorMessage(Signal<String> signal) {
-        // experimental API, do not force implementation
-        throw new UnsupportedOperationException();
-    }
 
     /**
      * Sets the validity of the component input.
@@ -126,14 +94,9 @@ public interface HasValidation extends Serializable {
      * enabling manual validation mode with
      * {@link #setManualValidation(boolean)} to avoid potential conflicts
      * between your custom validation and the component's built-in validation.
-     * <p>
-     * While a signal binding for the invalid state is active, calls to this
-     * method throw a {@code com.vaadin.flow.signals.BindingActiveException}.
      *
      * @param invalid
      *            new value for component input validity
-     * @throws com.vaadin.flow.signals.BindingActiveException
-     *             thrown when there is already an existing signal binding
      */
     void setInvalid(boolean invalid);
 
@@ -144,29 +107,4 @@ public interface HasValidation extends Serializable {
      * @return whether the component input is valid
      */
     boolean isInvalid();
-
-    /**
-     * Binds the component's invalid state to the provided signal so that the
-     * invalid flag is kept in sync with the signal's current value.
-     * <p>
-     * Passing {@code null} as the {@code signal} removes any existing binding.
-     * When unbinding, the current invalid state is left unchanged.
-     * <p>
-     * While a binding is active, manual calls to {@link #setInvalid(boolean)}
-     * throw a {@code com.vaadin.flow.signals.BindingActiveException}. Bindings
-     * are lifecycle-aware and only active while the owning component is in the
-     * attached state; they are deactivated while the component is in the
-     * detached state.
-     *
-     * @param signal
-     *            the signal providing invalid state flags, or {@code null} to
-     *            unbind
-     * @throws com.vaadin.flow.signals.BindingActiveException
-     *             thrown when there is already an existing binding
-     * @since 25.1
-     */
-    default void bindInvalid(Signal<Boolean> signal) {
-        // experimental API, do not force implementation
-        throw new UnsupportedOperationException();
-    }
 }


### PR DESCRIPTION
Reverts https://github.com/vaadin/flow/pull/23258

Reverting for now as this API is not implemented in any Vaadin component, and we can assume that custom components may include their own validation logic that controls the invalid and error message properties, which conceptually does not align with the current one-way bindings.