### PR TITLE
fix: use AnnotatedPackages for test NullAway config to avoid split packages

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -241,7 +241,7 @@
                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
                 <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
                 <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
-                <arg>-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NullAway:ERROR -XepOpt:NullAway:JSpecifyMode=true -XepOpt:NullAway:OnlyNullMarked=true</arg>
+                <arg>-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NullAway:ERROR -XepOpt:NullAway:JSpecifyMode=true -XepOpt:NullAway:AnnotatedPackages=com.vaadin.flow.signals</arg>
               </compilerArgs>
               <annotationProcessorPaths>
                 <path>

--- a/flow-server/src/test/java/com/vaadin/flow/signals/impl/package-info.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/impl/package-info.java
@@ -1,4 +1,0 @@
-@NullMarked
-package com.vaadin.flow.signals.impl;
-
-import org.jspecify.annotations.NullMarked;

--- a/flow-server/src/test/java/com/vaadin/flow/signals/local/package-info.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/local/package-info.java
@@ -1,4 +1,0 @@
-@NullMarked
-package com.vaadin.flow.signals.local;
-
-import org.jspecify.annotations.NullMarked;

--- a/flow-server/src/test/java/com/vaadin/flow/signals/package-info.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/package-info.java
@@ -1,4 +1,0 @@
-@NullMarked
-package com.vaadin.flow.signals;
-
-import org.jspecify.annotations.NullMarked;

--- a/flow-server/src/test/java/com/vaadin/flow/signals/shared/impl/package-info.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/shared/impl/package-info.java
@@ -1,4 +1,0 @@
-@NullMarked
-package com.vaadin.flow.signals.shared.impl;
-
-import org.jspecify.annotations.NullMarked;

--- a/flow-server/src/test/java/com/vaadin/flow/signals/shared/package-info.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/shared/package-info.java
@@ -1,4 +1,0 @@
-@NullMarked
-package com.vaadin.flow.signals.shared;
-
-import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
Switch the test-compile NullAway configuration from OnlyNullMarked to AnnotatedPackages=com.vaadin.flow.signals, which covers all subpackages via prefix matching. This eliminates the need for duplicate package-info.java files in test sources, resolving Eclipse split-package errors while preserving null checking in tests.

Fixes #23683
