### PR TITLE
fix: add registerStyles import for @CssImport(themeFor) on AppShellConfigurator

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -412,6 +412,10 @@ abstract class AbstractUpdateImports implements Runnable {
         cssLineOffset += appShellCssLines.size();
         if (!appShellCssLines.isEmpty()) {
             appShellLines.add(IMPORT_INJECT);
+            if (appShellCssData.stream().anyMatch(
+                    d -> d.getThemefor() != null || d.getId() != null)) {
+                appShellLines.add(THEMABLE_MIXIN_IMPORT);
+            }
             appShellLines.addAll(appShellCssLines);
         }
         if (FrontendBuildUtils.isTailwindCssEnabled(options)) {

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
@@ -110,6 +110,12 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
     public static class ThemeCssImport implements AppShellConfigurator {
     }
 
+    @Theme(themeClass = LumoTest.class)
+    @CssImport(value = "./foo.css", themeFor = "custom-component")
+    public static class ThemeForAppShellCssImport
+            implements AppShellConfigurator {
+    }
+
     protected File tmpRoot;
     protected File frontendDirectory;
     protected File nodeModulesPath;

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/UpdateImportsWithByteCodeScannerTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/UpdateImportsWithByteCodeScannerTest.java
@@ -332,6 +332,27 @@ public class UpdateImportsWithByteCodeScannerTest
     }
 
     @Test
+    public void themeForCssImportFromAppShell_includesRegisterStylesImport()
+            throws Exception {
+        Class<?>[] testClasses = { ThemeForAppShellCssImport.class, UI.class };
+        ClassFinder classFinder = getClassFinder(testClasses);
+        updater = new UpdateImports(getScanner(classFinder), options);
+        updater.run();
+
+        Map<File, List<String>> output = updater.getOutput();
+
+        Optional<File> appShellFile = output.keySet().stream()
+                .filter(file -> file.getName().endsWith("app-shell-imports.js"))
+                .findAny();
+        Assert.assertTrue(appShellFile.isPresent());
+        List<String> appShellLines = output.get(appShellFile.get());
+
+        assertOnce("registerStyles('custom-component',", appShellLines);
+        assertOnce("registerStyles } from '@vaadin/vaadin-themable-mixin'",
+                appShellLines);
+    }
+
+    @Test
     public void cssInLazyChunkWorks() throws Exception {
         Class<?>[] testClasses = { FooCssImport.class, UI.class };
         ClassFinder classFinder = getClassFinder(testClasses);


### PR DESCRIPTION
The generated app-shell-imports.js calls registerStyles() when @CssImport has themeFor set, but the import providing registerStyles was only added for eager and lazy CSS paths, not for the appShell path. This causes "registerStyles is not defined" at runtime.
