### PR TITLE
fix: make flattened TreeDataProvider consider entire hierarchy when filtering

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/TreeDataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/TreeDataProvider.java
@@ -202,20 +202,22 @@ public class TreeDataProvider<T>
         }
 
         for (T child : children) {
+            boolean isExpanded = expandedItemIds.contains(getId(child));
             List<T> descendants = Collections.emptyList();
             if (getHierarchyFormat().equals(HierarchyFormat.NESTED)
-                    || expandedItemIds.contains(getId(child))) {
+                    || isExpanded || combinedFilter.isPresent()) {
                 descendants = flatten(child, expandedItemIds, combinedFilter,
                         comparator);
             }
 
-            boolean shouldInclude = combinedFilter.map(f -> f.test(child))
-                    .orElse(true) || descendants.size() > 0;
-            if (shouldInclude) {
+            boolean matchesFilter = combinedFilter.map(f -> f.test(child))
+                    .orElse(true) || !descendants.isEmpty();
+            if (matchesFilter) {
                 result.add(child);
             }
-            if (shouldInclude
-                    && getHierarchyFormat().equals(HierarchyFormat.FLATTENED)) {
+            if (matchesFilter
+                    && getHierarchyFormat().equals(HierarchyFormat.FLATTENED)
+                    && isExpanded) {
                 result.addAll(descendants);
             }
         }


### PR DESCRIPTION
## Summary
When filtering in FLATTENED hierarchy format, ancestors were not shown if a filter matched a collapsed descendant. Now TreeDataProvider recurses into collapsed subtrees to check for matching descendants, so ancestors appear in the result even when the matching descendant is not expanded. This aligns filtering behavior with NESTED format.

Fixes https://github.com/vaadin/flow-components/issues/8784