### PR TITLE
feat: Add usage statistics for signals and shared signals

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/signals/impl/Effect.java
+++ b/flow-server/src/main/java/com/vaadin/flow/signals/impl/Effect.java
@@ -25,6 +25,7 @@ import org.jspecify.annotations.Nullable;
 
 import com.vaadin.flow.function.SerializableExecutor;
 import com.vaadin.flow.function.SerializableRunnable;
+import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.signals.MissingSignalUsageException;
 import com.vaadin.flow.signals.SignalEnvironment;
@@ -39,6 +40,10 @@ import com.vaadin.flow.signals.function.EffectAction;
  * based the signals read during the most recent invocation.
  */
 public class Effect implements Serializable {
+    static {
+        UsageStatistics.markAsUsed("flow/signal", null);
+    }
+
     private static final ThreadLocal<LinkedList<Effect>> activeEffects = ThreadLocal
             .withInitial(() -> new LinkedList<>());
 

--- a/flow-server/src/main/java/com/vaadin/flow/signals/local/AbstractLocalSignal.java
+++ b/flow-server/src/main/java/com/vaadin/flow/signals/local/AbstractLocalSignal.java
@@ -21,7 +21,6 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import org.jspecify.annotations.Nullable;
 
-import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.signals.Signal;
@@ -52,7 +51,6 @@ public abstract class AbstractLocalSignal<T extends @Nullable Object>
      *            the initial value
      */
     protected AbstractLocalSignal(T initialValue) {
-        UsageStatistics.markAsUsed("flow/signal", null);
         this.signalValue = initialValue;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/signals/shared/AbstractSignal.java
+++ b/flow-server/src/main/java/com/vaadin/flow/signals/shared/AbstractSignal.java
@@ -103,6 +103,7 @@ public abstract class AbstractSignal<T extends @Nullable Object>
     private static final ObjectMapper OBJECT_MAPPER;
     static {
         OBJECT_MAPPER = new ObjectMapper();
+        UsageStatistics.markAsUsed("flow/shared-signal", null);
     }
 
     /**
@@ -128,8 +129,6 @@ public abstract class AbstractSignal<T extends @Nullable Object>
      */
     protected AbstractSignal(SignalTree tree, Id id,
             CommandValidator validator) {
-        UsageStatistics.markAsUsed("flow/signal", null);
-        UsageStatistics.markAsUsed("flow/shared-signal", null);
         this.tree = Objects.requireNonNull(tree);
         this.validator = Objects.requireNonNull(validator);
         this.id = Objects.requireNonNull(id);


### PR DESCRIPTION
Track signal and shared signal usage through UsageStatistics to understand adoption of the signals API.
