### PR TITLE
chore: rename ambiguous 'current' variable to 'signalNames' in group bind

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/ThemeListImpl.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/ThemeListImpl.java
@@ -128,10 +128,10 @@ public class ThemeListImpl implements ThemeList, Serializable {
 
         Registration registration = ElementEffect
                 .effect(Element.get(element.getNode()), () -> {
-                    List<String> current = names.get();
+                    List<String> signalNames = names.get();
                     Set<String> newNames = new HashSet<>();
-                    if (current != null) {
-                        for (String name : current) {
+                    if (signalNames != null) {
+                        for (String name : signalNames) {
                             if (name != null && !name.isEmpty()) {
                                 newNames.add(name);
                             }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ElementClassList.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ElementClassList.java
@@ -122,10 +122,10 @@ public class ElementClassList extends SerializableNodeList<String> {
 
             Registration registration = ElementEffect
                     .effect(Element.get(getNode()), () -> {
-                        List<String> current = names.get();
+                        List<String> signalNames = names.get();
                         Set<String> newNames = new HashSet<>();
-                        if (current != null) {
-                            for (String name : current) {
+                        if (signalNames != null) {
+                            for (String name : signalNames) {
                                 if (name != null && !name.isEmpty()) {
                                     newNames.add(name);
                                 }


### PR DESCRIPTION
Clarifies that this is the raw list from the signal, distinct from the filtered 'newNames' set. Applied consistently in both ElementClassList and ThemeListImpl.
