### PR TITLE
test: clean vite files in deepClean profile

### DIFF
--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -466,6 +466,8 @@
                     <include>tsconfig.json</include>
                     <include>pnpm-lock.yaml</include>
                     <include>bun.lockb</include>
+                    <include>vite.config.ts</include>
+                    <include>vite.generated.ts</include>
                     <include>node_modules/**</include>
                   </includes>
                 </fileset>


### PR DESCRIPTION
Also clean up vite files in test
modules when running the
deepClean profile for removing
frontend files.

Closes #12380
