### PR TITLE
Add "shared" to abstract signal class name

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/signals/impl/ComputedSignal.java
+++ b/flow-server/src/main/java/com/vaadin/flow/signals/impl/ComputedSignal.java
@@ -32,7 +32,7 @@ import com.vaadin.flow.signals.SignalCommand;
 import com.vaadin.flow.signals.function.EffectAction;
 import com.vaadin.flow.signals.function.SignalComputation;
 import com.vaadin.flow.signals.impl.UsageTracker.Usage;
-import com.vaadin.flow.signals.shared.AbstractSignal;
+import com.vaadin.flow.signals.shared.AbstractSharedSignal;
 import com.vaadin.flow.signals.shared.SharedNodeSignal;
 import com.vaadin.flow.signals.shared.impl.SynchronousSignalTree;
 
@@ -50,7 +50,7 @@ import com.vaadin.flow.signals.shared.impl.SynchronousSignalTree;
  *            the value type
  */
 public class ComputedSignal<T extends @Nullable Object>
-        extends AbstractSignal<T> {
+        extends AbstractSharedSignal<T> {
 
     /*
      * This state is never supposed to be synchronized across a cluster or to

--- a/flow-server/src/main/java/com/vaadin/flow/signals/shared/AbstractSharedSignal.java
+++ b/flow-server/src/main/java/com/vaadin/flow/signals/shared/AbstractSharedSignal.java
@@ -56,7 +56,7 @@ import com.vaadin.flow.signals.shared.impl.TreeRevision;
  * @param <T>
  *            the signal value type
  */
-public abstract class AbstractSignal<T extends @Nullable Object>
+public abstract class AbstractSharedSignal<T extends @Nullable Object>
         implements Signal<T> {
     /**
      * Converts a command result into a specific value type.
@@ -85,7 +85,7 @@ public abstract class AbstractSignal<T extends @Nullable Object>
      *            the child signal type
      */
     @FunctionalInterface
-    protected interface ChildSignalFactory<I extends AbstractSignal<?>> {
+    protected interface ChildSignalFactory<I extends AbstractSharedSignal<?>> {
         /**
          * Creates a child signal instance for the given node ID.
          *
@@ -127,7 +127,7 @@ public abstract class AbstractSignal<T extends @Nullable Object>
      *            the validator to check operations submitted to this singal,
      *            not <code>null</code>
      */
-    protected AbstractSignal(SignalTree tree, Id id,
+    protected AbstractSharedSignal(SignalTree tree, Id id,
             CommandValidator validator) {
         this.tree = Objects.requireNonNull(tree);
         this.validator = Objects.requireNonNull(validator);
@@ -372,7 +372,7 @@ public abstract class AbstractSignal<T extends @Nullable Object>
      *            operation, not <code>null</code>
      * @return the created insert operation, not <code>null</code>
      */
-    protected <I extends AbstractSignal<?>> InsertOperation<I> submitInsert(
+    protected <I extends AbstractSharedSignal<?>> InsertOperation<I> submitInsert(
             SignalCommand command, ChildSignalFactory<I> childFactory) {
         return submitVoidOperation(command, new InsertOperation<>(
                 childFactory.create(command.commandId())));
@@ -556,7 +556,7 @@ public abstract class AbstractSignal<T extends @Nullable Object>
      *
      * @return the created signal operation instance, not <code>null</code>
      */
-    protected SignalOperation<Void> remove(AbstractSignal<?> child) {
+    protected SignalOperation<Void> remove(AbstractSharedSignal<?> child) {
         return submit(
                 new SignalCommand.RemoveCommand(Id.random(), child.id(), id()));
     }

--- a/flow-server/src/main/java/com/vaadin/flow/signals/shared/SharedListSignal.java
+++ b/flow-server/src/main/java/com/vaadin/flow/signals/shared/SharedListSignal.java
@@ -44,7 +44,7 @@ import com.vaadin.flow.signals.shared.impl.SignalTree;
  *            the element type
  */
 public class SharedListSignal<T extends @Nullable Object>
-        extends AbstractSignal<@NonNull List<SharedValueSignal<T>>> {
+        extends AbstractSharedSignal<@NonNull List<SharedValueSignal<T>>> {
 
     /**
      * A list insertion position before and/or after the referenced entries. If
@@ -97,7 +97,8 @@ public class SharedListSignal<T extends @Nullable Object>
          *            first
          * @return a list position after the given signal, not <code>null</code>
          */
-        public static ListPosition after(@Nullable AbstractSignal<?> after) {
+        public static ListPosition after(
+                @Nullable AbstractSharedSignal<?> after) {
             return new ListPosition(idOf(after), null);
         }
 
@@ -111,7 +112,8 @@ public class SharedListSignal<T extends @Nullable Object>
          *            insert last
          * @return a list position after the given signal, not <code>null</code>
          */
-        public static ListPosition before(@Nullable AbstractSignal<?> before) {
+        public static ListPosition before(
+                @Nullable AbstractSharedSignal<?> before) {
             return new ListPosition(null, idOf(before));
         }
 
@@ -131,12 +133,13 @@ public class SharedListSignal<T extends @Nullable Object>
          * @return a list position between the given signals, not
          *         <code>null</code>
          */
-        public static ListPosition between(@Nullable AbstractSignal<?> after,
-                @Nullable AbstractSignal<?> before) {
+        public static ListPosition between(
+                @Nullable AbstractSharedSignal<?> after,
+                @Nullable AbstractSharedSignal<?> before) {
             return new ListPosition(idOf(after), idOf(before));
         }
 
-        private static Id idOf(@Nullable AbstractSignal<?> signal) {
+        private static Id idOf(@Nullable AbstractSharedSignal<?> signal) {
             if (signal == null) {
                 return Id.EDGE;
             } else {
@@ -286,7 +289,7 @@ public class SharedListSignal<T extends @Nullable Object>
      *            the position to move to, not <code>null</code>
      * @return an operation containing the eventual result
      */
-    public SignalOperation<Void> moveTo(AbstractSignal<T> child,
+    public SignalOperation<Void> moveTo(AbstractSharedSignal<T> child,
             ListPosition to) {
         var verifyChild = new SignalCommand.PositionCondition(Id.random(), id(),
                 child.id(), new ListPosition(null, null));
@@ -336,7 +339,7 @@ public class SharedListSignal<T extends @Nullable Object>
      *            the expected position of the child, not <code>null</code>
      * @return an operation containing the eventual result
      */
-    public SignalOperation<Void> verifyPosition(AbstractSignal<?> child,
+    public SignalOperation<Void> verifyPosition(AbstractSharedSignal<?> child,
             ListPosition expectedPosition) {
         return submit(new SignalCommand.PositionCondition(Id.random(), id(),
                 child.id(), Objects.requireNonNull(expectedPosition)));
@@ -354,7 +357,7 @@ public class SharedListSignal<T extends @Nullable Object>
      *            the child to look for test, not <code>null</code>
      * @return an operation containing the eventual result
      */
-    public SignalOperation<Void> verifyChild(AbstractSignal<?> child) {
+    public SignalOperation<Void> verifyChild(AbstractSharedSignal<?> child) {
         return verifyPosition(child, new ListPosition(null, null));
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/signals/shared/SharedMapSignal.java
+++ b/flow-server/src/main/java/com/vaadin/flow/signals/shared/SharedMapSignal.java
@@ -46,8 +46,8 @@ import com.vaadin.flow.signals.shared.impl.SignalTree;
  * @param <T>
  *            the element type
  */
-public class SharedMapSignal<T extends @Nullable Object>
-        extends AbstractSignal<@NonNull Map<String, SharedValueSignal<T>>> {
+public class SharedMapSignal<T extends @Nullable Object> extends
+        AbstractSharedSignal<@NonNull Map<String, SharedValueSignal<T>>> {
 
     private Class<T> elementType;
 
@@ -250,7 +250,7 @@ public class SharedMapSignal<T extends @Nullable Object>
      * @return an operation containing the eventual result
      */
     public SignalOperation<Void> verifyKey(String key,
-            AbstractSignal<?> expectedChild) {
+            AbstractSharedSignal<?> expectedChild) {
         return submitKeyCondition(Objects.requireNonNull(key),
                 expectedChild.id());
     }

--- a/flow-server/src/main/java/com/vaadin/flow/signals/shared/SharedNodeSignal.java
+++ b/flow-server/src/main/java/com/vaadin/flow/signals/shared/SharedNodeSignal.java
@@ -56,7 +56,7 @@ import com.vaadin.flow.signals.shared.impl.SignalTree;
  * applying some specific operation.
  */
 public class SharedNodeSignal
-        extends AbstractSignal<SharedNodeSignal.SharedNodeSignalState> {
+        extends AbstractSharedSignal<SharedNodeSignal.SharedNodeSignalState> {
     /**
      * The snapshot of the state of a node signal. Gives access to the value and
      * child nodes.
@@ -345,7 +345,7 @@ public class SharedNodeSignal
      *            the target list location, not <code>null</code>
      * @return an operation containing the eventual result
      */
-    public SignalOperation<Void> adoptAt(AbstractSignal<?> node,
+    public SignalOperation<Void> adoptAt(AbstractSharedSignal<?> node,
             ListPosition at) {
         return submit(new SignalCommand.AdoptAtCommand(Id.random(), id(),
                 node.id(), Objects.requireNonNull(at)));
@@ -363,7 +363,8 @@ public class SharedNodeSignal
      *            the key to use, not <code>null</code>
      * @return an operation containing the eventual result
      */
-    public SignalOperation<Void> adoptAs(AbstractSignal<?> signal, String key) {
+    public SignalOperation<Void> adoptAs(AbstractSharedSignal<?> signal,
+            String key) {
         return submit(new SignalCommand.AdoptAsCommand(Id.random(), id(),
                 signal.id(), Objects.requireNonNull(key)));
     }

--- a/flow-server/src/main/java/com/vaadin/flow/signals/shared/SharedValueSignal.java
+++ b/flow-server/src/main/java/com/vaadin/flow/signals/shared/SharedValueSignal.java
@@ -44,7 +44,7 @@ import com.vaadin.flow.signals.shared.impl.SignalTree;
  *            the signal value type
  */
 public class SharedValueSignal<T extends @Nullable Object>
-        extends AbstractSignal<T> {
+        extends AbstractSharedSignal<T> {
     private final Class<T> valueType;
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/signals/shared/SignalUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/signals/shared/SignalUtils.java
@@ -41,7 +41,7 @@ public class SignalUtils {
      *            the signal to get the tree of, not <code>null</code>
      * @return the signal tree instance, not <code>null</code>
      */
-    public static SignalTree treeOf(AbstractSignal<?> signal) {
+    public static SignalTree treeOf(AbstractSharedSignal<?> signal) {
         return signal.tree();
     }
 
@@ -61,7 +61,7 @@ public class SignalUtils {
      * @return <code>true</code> if the command is valid, <code>false</code>
      *         otherwise
      */
-    public static boolean isValid(AbstractSignal<?> signal,
+    public static boolean isValid(AbstractSharedSignal<?> signal,
             SignalCommand command) {
         return signal.isValid(command);
     }

--- a/flow-server/src/test/java/com/vaadin/flow/signals/TestUtil.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/TestUtil.java
@@ -25,7 +25,7 @@ import com.vaadin.flow.signals.impl.Transaction;
 import com.vaadin.flow.signals.operations.SignalOperation;
 import com.vaadin.flow.signals.operations.SignalOperation.Result;
 import com.vaadin.flow.signals.operations.SignalOperation.ResultOrError;
-import com.vaadin.flow.signals.shared.AbstractSignal;
+import com.vaadin.flow.signals.shared.AbstractSharedSignal;
 import com.vaadin.flow.signals.shared.SignalUtils;
 import com.vaadin.flow.signals.shared.impl.SignalTree;
 
@@ -90,7 +90,7 @@ public class TestUtil {
     /*
      * Helper to run package-private tree getter from tests in sub packages.
      */
-    public static SignalTree tree(AbstractSignal<?> signal) {
+    public static SignalTree tree(AbstractSharedSignal<?> signal) {
         return SignalUtils.treeOf(signal);
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/signals/impl/ComputedSignalTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/impl/ComputedSignalTest.java
@@ -29,7 +29,7 @@ import com.vaadin.flow.signals.MissingSignalUsageException;
 import com.vaadin.flow.signals.Signal;
 import com.vaadin.flow.signals.SignalTestBase;
 import com.vaadin.flow.signals.function.EffectAction;
-import com.vaadin.flow.signals.shared.AbstractSignal;
+import com.vaadin.flow.signals.shared.AbstractSharedSignal;
 import com.vaadin.flow.signals.shared.SharedValueSignal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -343,7 +343,7 @@ public class ComputedSignalTest extends SignalTestBase {
 
     @Test
     void unsuppotedOperations_runOperations_throws() {
-        AbstractSignal<Object> signal = (AbstractSignal<Object>) Signal
+        AbstractSharedSignal<Object> signal = (AbstractSharedSignal<Object>) Signal
                 .computed(() -> null);
 
         assertThrows(UnsupportedOperationException.class, () -> {

--- a/flow-server/src/test/java/com/vaadin/flow/signals/shared/SignalUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/shared/SignalUtilsTest.java
@@ -31,7 +31,8 @@ public class SignalUtilsTest {
     @Test
     void treeOf_returnsSignalsUnderlyingTree() {
         SignalTree tree = Mockito.mock(SignalTree.class);
-        AbstractSignal<?> signal = Mockito.mock(AbstractSignal.class);
+        AbstractSharedSignal<?> signal = Mockito
+                .mock(AbstractSharedSignal.class);
         Mockito.when(signal.tree()).thenReturn(tree);
         assertSame(tree, SignalUtils.treeOf(signal));
         Mockito.verify(signal, Mockito.times(1)).tree();
@@ -40,7 +41,8 @@ public class SignalUtilsTest {
 
     @Test
     void isValid_callsSignalsIsValid() {
-        AbstractSignal<?> signal = Mockito.mock(AbstractSignal.class);
+        AbstractSharedSignal<?> signal = Mockito
+                .mock(AbstractSharedSignal.class);
         SignalCommand command = TestUtil.writeRootValueCommand();
         Mockito.when(signal.isValid(any())).thenReturn(true);
         assertTrue(SignalUtils.isValid(signal, command));


### PR DESCRIPTION
When renaming e.g. ValueSignal to SharedValueSignal, the base class was still left with the original name that gives the impression that it should be used for all signal types.