### PR TITLE
fix: use absolute path for Aura CSS resource availability check

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/AppShellRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AppShellRegistry.java
@@ -242,7 +242,7 @@ public class AppShellRegistry implements Serializable {
             String defaultStylesheet = ApplicationConstants.CONTEXT_PROTOCOL_PREFIX
                     + AURA_STYLESHEET;
             VaadinService service = request.getService();
-            if (service.isResourceAvailable(AURA_STYLESHEET)) {
+            if (service.isResourceAvailable("/" + AURA_STYLESHEET)) {
                 String auraHref = resolveStyleSheetHref(defaultStylesheet,
                         request);
                 if (auraHref != null) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/AppShellRegistryAuraAutoLoadTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/AppShellRegistryAuraAutoLoadTest.java
@@ -88,7 +88,7 @@ class AppShellRegistryAuraAutoLoadTest {
         AppShellRegistry registry = AppShellRegistry.getInstance(context);
 
         // Mock Aura resource availability
-        Mockito.when(service.isResourceAvailable("aura/aura.css"))
+        Mockito.when(service.isResourceAvailable("/aura/aura.css"))
                 .thenReturn(true);
 
         VaadinServletRequest request = createRequest("/", "");
@@ -110,7 +110,7 @@ class AppShellRegistryAuraAutoLoadTest {
         AppShellRegistry registry = AppShellRegistry.getInstance(context);
 
         // Mock Aura resource NOT available
-        Mockito.when(service.isResourceAvailable("aura/aura.css"))
+        Mockito.when(service.isResourceAvailable("/aura/aura.css"))
                 .thenReturn(false);
 
         VaadinServletRequest request = createRequest("/", "");


### PR DESCRIPTION
The isResourceAvailable call used the relative path "aura/aura.css" which, after URI resolution, was passed unchanged to ServletContext.getResource(). The Servlet specification requires paths to start with "/" and threw MalformedURLException, causing the check to always fail and flooding logs with warnings on every page load.
