### PR TITLE
test: exclude duplicate flow-build-tools JAR from WAR packaging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -431,6 +431,7 @@
                 <Implementation-Version>${project.version}</Implementation-Version>
               </manifestEntries>
             </archive>
+            <packagingExcludes>%regex[WEB-INF/lib/flow-build-tools-.*(?&lt;!-shaded)\.jar]</packagingExcludes>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
The maven-shade-plugin replaces the main artifact's file reference with shaded content during reactor builds, causing both flow-build-tools.jar and flow-build-tools-shaded.jar (byte-identical) to end up in test WAR WEB-INF/lib directories. This produces hundreds of duplicate-class warnings from Jetty's AnnotationParser.

Add a packagingExcludes regex to the maven-war-plugin configuration in the root POM's pluginManagement to exclude the non-shaded JAR while keeping the shaded one.
