### PR TITLE
fix: skip validation on signal effect initial run in Binder

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -1734,7 +1734,7 @@ public class Binder<BEAN> implements Serializable {
                 signalRegistration = Signal.effect(component, ctx -> {
                     usageGuard.get();
                     Result<TARGET> result = executeConversionChain();
-                    if (!valueInit && !ctx.isInitialRun()) {
+                    if (!ctx.isInitialRun()) {
                         BindingValidationStatus<TARGET> status = toValidationStatus(
                                 result);
                         fireValidationEvents(status);

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderSignalTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderSignalTest.java
@@ -956,4 +956,16 @@ public class BinderSignalTest extends SignalsUnitTest {
         binderSetup.accept(person);
         assertFalse(prevStatus.get());
     }
+
+    @Test
+    public void asRequired_setBeanBeforeBind_fieldNotInvalidOnAttach() {
+        var field = new TestTextField();
+        binder.setBean(item);
+        binder.forField(field).asRequired("Required field")
+                .bind(Person::getFirstName, Person::setFirstName);
+
+        UI.getCurrent().add(field);
+
+        assertFalse(field.isInvalid());
+    }
 }

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -1833,23 +1833,6 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
     }
 
     @Test
-    public void asRequired_setBeanBeforeBind_fieldNotInvalidOnAttach() {
-        TestTextField field = new TestTextField();
-        // Do not attach the field yet — binding is created before attach
-        Binder<Person> freshBinder = new Binder<>(Person.class);
-        freshBinder.setBean(item);
-        freshBinder.forField(field).asRequired("Required field")
-                .bind(Person::getFirstName, Person::setFirstName);
-
-        // Simulate attach
-        UI ui = new UI();
-        ui.add(field);
-
-        assertFalse("Field should not be invalid after attach",
-                field.isInvalid());
-    }
-
-    @Test
     public void two_asRequired_fields_without_initial_values_readBean() {
         binder.forField(nameField).asRequired("Empty name").bind(p -> "",
                 (p, s) -> {


### PR DESCRIPTION
## Summary

Fixes vaadin/flow#23754

- The reactive `Signal.effect()` created by `initInternalSignalEffectForValidators()` was firing validation on its initial run when deferred to component attach, causing required fields (Select, ComboBox, MultiSelectComboBox, TextField) to be marked invalid immediately on navigation
- Use the context-aware `Signal.effect(component, ctx -> ...)` variant and skip `fireValidationEvents` when `ctx.isInitialRun()` is true, so validation only triggers on actual value changes

## Test plan

- [x] Added unit test `asRequired_setBeanBeforeBind_fieldNotInvalidOnAttach` verifying that a required field bound before attach is not marked invalid on attach
- [x] All existing `BinderTest` tests pass (130 tests)