### PR TITLE
chore: add autoMerge check to GHA

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -263,6 +263,29 @@ jobs:
         run: |
           echo "🚫 THERE ARE TEST MODULES WITH FAILURES or BEEN CANCELLED" | tee -a $GITHUB_STEP_SUMMARY
           exit 1
+  auto-merge:
+    needs: api-diff-labeling
+    if: github.event_name == 'pull_request' && github.base_ref != 'main'
+    timeout-minutes: 5
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: vaadin/platform-build-script
+          ref: main
+          token: ${{ secrets.VAADIN_BOT_TOKEN }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24.9.0'
+      - name: Auto-merge PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.VAADIN_BOT_TOKEN }}
+          GITHUB_REVIEW_TOKEN: ${{ secrets.REVIEW_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
+        run: node scripts/autoMerge.js
   api-diff-labeling:
     environment: ${{ github.event.pull_request.head.repo.fork && 'pr-tests' || '' }}
     if: github.event_name == 'pull_request_target'


### PR DESCRIPTION
Automerge is meant to work only in maintenance branches, not main.