### PR TITLE
fix: allow local get() in computed signal in explicit StagedTransaction

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/signals/local/ListSignal.java
+++ b/flow-server/src/main/java/com/vaadin/flow/signals/local/ListSignal.java
@@ -26,6 +26,7 @@ import org.jspecify.annotations.Nullable;
 
 import com.vaadin.flow.function.SerializableBiPredicate;
 import com.vaadin.flow.signals.impl.Transaction;
+import com.vaadin.flow.signals.shared.impl.StagedTransaction;
 
 /**
  * A local list signal that holds a list of writable signals, enabling per-entry
@@ -94,7 +95,9 @@ public class ListSignal<T extends @Nullable Object>
         assertLockHeld();
         super.checkPreconditions();
 
-        if (Transaction.inExplicitTransaction()) {
+        if (Transaction.inExplicitTransaction() && !(Transaction
+                .getCurrent() instanceof StagedTransaction stagedTransaction
+                && stagedTransaction.isCommitting())) {
             throw new IllegalStateException(
                     "ListSignal cannot be used inside signal transactions because it can hold a reference to a mutable object that can be mutated directly, bypassing transaction control. Use SharedListSignal instead.");
         }

--- a/flow-server/src/main/java/com/vaadin/flow/signals/local/ValueSignal.java
+++ b/flow-server/src/main/java/com/vaadin/flow/signals/local/ValueSignal.java
@@ -29,6 +29,7 @@ import com.vaadin.flow.signals.function.SignalUpdater;
 import com.vaadin.flow.signals.function.ValueMerger;
 import com.vaadin.flow.signals.function.ValueModifier;
 import com.vaadin.flow.signals.impl.Transaction;
+import com.vaadin.flow.signals.shared.impl.StagedTransaction;
 
 /**
  * A local writable signal that holds a reference to an object.
@@ -98,7 +99,9 @@ public class ValueSignal<T extends @Nullable Object>
         assertLockHeld();
         super.checkPreconditions();
 
-        if (Transaction.inExplicitTransaction()) {
+        if (Transaction.inExplicitTransaction() && !(Transaction
+                .getCurrent() instanceof StagedTransaction stagedTransaction
+                && stagedTransaction.isCommitting())) {
             throw new IllegalStateException(
                     "ValueSignal cannot be used inside signal transactions because it can hold a reference to a mutable object that can be mutated directly, bypassing transaction control. Use SharedValueSignal instead.");
         }

--- a/flow-server/src/main/java/com/vaadin/flow/signals/shared/impl/StagedTransaction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/signals/shared/impl/StagedTransaction.java
@@ -47,6 +47,7 @@ import com.vaadin.flow.signals.shared.impl.SignalTree.PendingCommit;
  * commands.
  */
 public class StagedTransaction extends Transaction {
+
     /**
      * Submits a successful result if all registered dependencies submit
      * successful results and an error result if any dependency submits an
@@ -156,6 +157,16 @@ public class StagedTransaction extends Transaction {
     public StagedTransaction(Transaction outer) {
         assert outer != null;
         this.outer = outer;
+    }
+
+    /**
+     * Checks if this transaction is currently committing.
+     * 
+     * @return <code>true</code> if this transaction is currently committing,
+     *         <code>false</code> otherwise
+     */
+    public boolean isCommitting() {
+        return committing;
     }
 
     @Override

--- a/flow-server/src/test/java/com/vaadin/flow/signals/impl/ComputedSignalTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/impl/ComputedSignalTest.java
@@ -29,6 +29,8 @@ import com.vaadin.flow.signals.MissingSignalUsageException;
 import com.vaadin.flow.signals.Signal;
 import com.vaadin.flow.signals.SignalTestBase;
 import com.vaadin.flow.signals.function.EffectAction;
+import com.vaadin.flow.signals.local.ListSignal;
+import com.vaadin.flow.signals.local.ValueSignal;
 import com.vaadin.flow.signals.shared.AbstractSharedSignal;
 import com.vaadin.flow.signals.shared.SharedValueSignal;
 
@@ -401,6 +403,103 @@ public class ComputedSignalTest extends SignalTestBase {
         shouldThrow.set(false);
         assertFalse(computed.peek());
         assertEquals(3, count.get());
+    }
+
+    @Test
+    void lambda_getLocalValueSignalExplicitTransaction_doNotThrow() {
+        var shared = new SharedValueSignal<>(1);
+        var local = new ValueSignal<>(2);
+
+        Signal<Integer> computed = () -> shared.get() + local.get();
+
+        AtomicInteger count = new AtomicInteger();
+        Signal.unboundEffect(() -> {
+            count.set(computed.get());
+        });
+
+        assertEquals(3, count.get());
+
+        // ValueSignal update should not throw IllegalStateException.
+        // Update runs in an explicit transaction.
+        shared.update(x -> x + 1);
+        assertEquals(4, count.get());
+        // Verify that set also works
+        shared.set(shared.peek() + 1);
+        assertEquals(5, count.get());
+    }
+
+    @Test
+    void computed_getLocalValueSignalExplicitTransaction_doNotThrow() {
+        var shared = new SharedValueSignal<>(1);
+        var local = new ValueSignal<>(2);
+
+        Signal<Integer> computed = Signal
+                .computed(() -> shared.get() + local.get());
+
+        AtomicInteger count = new AtomicInteger();
+        Signal.unboundEffect(() -> {
+            count.set(computed.get());
+        });
+
+        assertEquals(3, count.get());
+
+        // ValueSignal update should not throw IllegalStateException.
+        // Update runs in an explicit transaction.
+        shared.update(x -> x + 1);
+        assertEquals(4, count.get());
+        // Verify that set also works
+        shared.set(shared.peek() + 1);
+        assertEquals(5, count.get());
+    }
+
+    @Test
+    void lambda_getLocalListSignalExplicitTransaction_doNotThrow() {
+        var shared = new SharedValueSignal<>(1);
+        var local = new ListSignal<Integer>();
+        local.insertFirst(2);
+
+        Signal<Integer> computed = () -> shared.get()
+                + local.get().get(0).get();
+
+        AtomicInteger count = new AtomicInteger();
+        Signal.unboundEffect(() -> {
+            count.set(computed.get());
+        });
+
+        assertEquals(3, count.get());
+
+        // ListSignal update should not throw IllegalStateException.
+        // Update runs in an explicit transaction.
+        shared.update(x -> x + 1);
+        assertEquals(4, count.get());
+        // Verify that set also works
+        shared.set(shared.peek() + 1);
+        assertEquals(5, count.get());
+    }
+
+    @Test
+    void computed_getLocalListSignalExplicitTransaction_doNotThrow() {
+        var shared = new SharedValueSignal<>(1);
+        var local = new ListSignal<Integer>();
+        local.insertFirst(2);
+
+        Signal<Integer> computed = Signal
+                .computed(() -> shared.get() + local.get().get(0).peek());
+
+        AtomicInteger count = new AtomicInteger();
+        Signal.unboundEffect(() -> {
+            count.set(computed.get());
+        });
+
+        assertEquals(3, count.get());
+
+        // ListSignal update should not throw IllegalStateException.
+        // Update runs in an explicit transaction.
+        shared.update(x -> x + 1);
+        assertEquals(4, count.get());
+        // Verify that set also works
+        shared.set(shared.peek() + 1);
+        assertEquals(5, count.get());
     }
 
     private static boolean waitForGarbageCollection(WeakReference<?> ref) {


### PR DESCRIPTION
With this change, computed signals don't throw anymore `IllegalStateException`, when local signal `get()` is called inside an explicit `StagedTransaction` that is commiting.

Fixes #23782