### PR TITLE
Pass --no-frozen-lockfile in pnpm dev mode to prevent CI failures

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -110,6 +110,8 @@ public class TaskRunNpmInstall implements FallibleCommand {
             } else {
                 command = "ci";
             }
+        } else if (options.isEnablePnpm()) {
+            command += " --no-frozen-lockfile";
         }
 
         if (packageUpdater.modified || shouldRunNpmInstall()) {
@@ -282,6 +284,9 @@ public class TaskRunNpmInstall implements FallibleCommand {
             }
         } else {
             npmInstallCommand.add("install");
+            if (options.isEnablePnpm()) {
+                npmInstallCommand.add("--no-frozen-lockfile");
+            }
         }
 
         postinstallCommand.add("run");

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -586,6 +586,8 @@ class TaskRunNpmInstallTest {
             } else {
                 command = "ci";
             }
+        } else if ("pnpm".equals(getToolName())) {
+            command += " --no-frozen-lockfile";
         }
         return command;
     }

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import tools.jackson.databind.JsonNode;
@@ -394,6 +395,41 @@ class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         TaskRunNpmInstall ciTask = createCiTask();
         ciTask.execute();
         Mockito.verify(logger).info(getRunningMsg());
+    }
+
+    @Test
+    public void runPnpmInstall_devMode_usesNoFrozenLockfile()
+            throws ExecutionFailedException, IOException {
+        TaskRunNpmInstall task = createTask();
+        getNodeUpdater().modified = true;
+
+        task.execute();
+
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(logger).info(
+                Mockito.eq("using '{}' for frontend package installation"),
+                captor.capture());
+        assertTrue(captor.getValue().contains("--no-frozen-lockfile"),
+                "pnpm install in dev mode should use --no-frozen-lockfile");
+    }
+
+    @Test
+    public void runPnpmInstall_ciBuild_usesFrozenLockfile()
+            throws ExecutionFailedException, IOException {
+        TaskRunNpmInstall ciTask = createCiTask();
+        getNodeUpdater().modified = true;
+
+        ciTask.execute();
+
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(logger).info(
+                Mockito.eq("using '{}' for frontend package installation"),
+                captor.capture());
+        String command = captor.getValue();
+        assertTrue(command.contains("--frozen-lockfile"),
+                "pnpm install in CI build should use --frozen-lockfile");
+        assertFalse(command.contains("--no-frozen-lockfile"),
+                "pnpm install in CI build should not use --no-frozen-lockfile");
     }
 
     @Override


### PR DESCRIPTION
## Summary

- pnpm 10 auto-enables `--frozen-lockfile` when it detects CI environments
  (via `ci-info`, checking `GITHUB_ACTIONS`, `CI`, etc.)
- Flow never requests this: `ciBuild` defaults to `false` in dev mode
- When a user bumps `vaadin.version` and pushes, the stale `pnpm-lock.yaml`
  causes `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` in CI but works locally
- Fix: explicitly pass `--no-frozen-lockfile` when running pnpm install
  in dev mode (`ciBuild==false`), since Flow is resolving dependencies,
  not reproducing a locked build

## Context

When `ciBuild==true`, Flow already passes `--frozen-lockfile` explicitly.
This change makes the non-CI path equally explicit, preventing pnpm from
silently inheriting a stricter mode based on environment detection.

Fixes #23530


