### PR TITLE
fix: detect router-link attribute in ancestor elements during click navigation (#23786)

### DIFF
--- a/flow-client/src/main/frontend/Flow.ts
+++ b/flow-client/src/main/frontend/Flow.ts
@@ -179,13 +179,9 @@ export class Flow {
       'click',
       (_e) => {
         if (_e.target) {
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          if (_e.target.hasAttribute('router-link')) {
+          if (_e.composedPath().some((node) => node instanceof HTMLElement && node.hasAttribute('router-link'))) {
             this.navigation = 'link';
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-          } else if (_e.composedPath().some((node) => node.nodeName === 'A')) {
+          } else if (_e.composedPath().some((node) => (node as Element).nodeName === 'A')) {
             this.navigation = 'client';
           }
         }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/NavigationTriggerView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/NavigationTriggerView.java
@@ -39,6 +39,14 @@ public class NavigationTriggerView extends AbstractDivView
                 .createRouterLink(CLASS_NAME + "/routerlink/", "Router link");
         routerLink.setAttribute("id", "routerlink");
 
+        Element routerLinkWithButton = ElementFactory
+                .createRouterLink(CLASS_NAME + "/routerlink-button/", null);
+        routerLinkWithButton.setAttribute("id", "routerlink-with-button");
+        Element nestedButton = ElementFactory
+                .createButton("Router link button");
+        nestedButton.setAttribute("id", "routerlink-button");
+        routerLinkWithButton.appendChild(nestedButton);
+
         Element navigateButton = ElementFactory.createButton("UI.navigate");
         navigateButton.addEventListener("click",
                 e -> getUI().get().navigate(CLASS_NAME + "/navigate"));
@@ -54,8 +62,8 @@ public class NavigationTriggerView extends AbstractDivView
                 .navigate(NavigationTriggerView.class, "reroute"));
         rerouteButton.setAttribute("id", "rerouteButton");
 
-        getElement().appendChild(routerLink, navigateButton, forwardButton,
-                rerouteButton);
+        getElement().appendChild(routerLink, routerLinkWithButton,
+                navigateButton, forwardButton, rerouteButton);
     }
 
     public static String buildMessage(String path, NavigationTrigger trigger,

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/NavigationTriggerIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/NavigationTriggerIT.java
@@ -44,27 +44,32 @@ public class NavigationTriggerIT extends ChromeBrowserTest {
         assertLastMessage("/routerlink", NavigationTrigger.ROUTER_LINK,
                 "routerlink");
 
-        findElement(By.id("navigate")).click();
+        findElement(By.id("routerlink-button")).click();
         assertMessageCount(3);
+        assertLastMessage("/routerlink-button", NavigationTrigger.ROUTER_LINK,
+                "routerlink-button");
+
+        findElement(By.id("navigate")).click();
+        assertMessageCount(4);
         assertLastMessage("/navigate", NavigationTrigger.UI_NAVIGATE,
                 "navigate");
 
         getDriver().navigate().back();
-        assertMessageCount(4);
-        assertLastMessage("/routerlink", NavigationTrigger.HISTORY,
-                "routerlink");
+        assertMessageCount(5);
+        assertLastMessage("/routerlink-button", NavigationTrigger.HISTORY,
+                "routerlink-button");
 
         getDriver().navigate().forward();
-        assertMessageCount(5);
+        assertMessageCount(6);
         assertLastMessage("/navigate", NavigationTrigger.HISTORY, "navigate");
 
         findElement(By.id("forwardButton")).click();
-        assertMessageCount(6);
+        assertMessageCount(7);
         assertLastMessage("/forwarded", NavigationTrigger.PROGRAMMATIC,
                 "forwarded");
 
         findElement(By.id("rerouteButton")).click();
-        assertMessageCount(7);
+        assertMessageCount(8);
         assertLastMessage("/rerouted", NavigationTrigger.PROGRAMMATIC,
                 "rerouted");
     }


### PR DESCRIPTION
When a nested element (e.g., Button) inside a RouterLink is clicked, the navigation trigger was incorrectly reported as CLIENT_SIDE because only the direct click target was checked for the router-link attribute. Traverse the composed path instead so any ancestor with router-link is correctly identified as a ROUTER_LINK trigger.
