### PR TITLE
fix: improve npm resolution for non-windows

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/NodeResolver.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/NodeResolver.java
@@ -587,6 +587,7 @@ class NodeResolver implements java.io.Serializable {
         } else {
             searchPaths.add("lib/node_modules/npm/bin/npm-cli.js");
             searchPaths.add("../lib/node_modules/npm/bin/npm-cli.js");
+            searchPaths.add("node_modules/npm/bin/npm-cli.js");
         }
 
         for (String path : searchPaths) {


### PR DESCRIPTION
Adds another potential path to the npm resolver algorithm to make it compatible with node installation performed by frontend-maven-plugin
