### PR TITLE
fix: move import statements to top in generated web component imports file (#23817) (CP: 25.0)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -267,7 +267,18 @@ abstract class AbstractUpdateImports implements Runnable {
                 Collections.emptyList()));
         merged.addAll(outputFiles.getOrDefault(generatedFlowImports,
                 Collections.emptyList()));
-        return merged.stream().distinct().toList();
+        List<String> result = new ArrayList<>(
+                merged.stream().distinct().toList());
+        moveImportsToTop(result);
+        return result;
+    }
+
+    // Move all import lines to the top, before any non-import lines
+    private static void moveImportsToTop(List<String> lines) {
+        List<String> imports = new ArrayList<>(lines);
+        imports.removeIf(line -> !line.startsWith("import "));
+        lines.removeIf(line -> line.startsWith("import "));
+        lines.addAll(0, imports);
     }
 
     private void writeWebComponentImports(List<String> lines) {
@@ -441,11 +452,7 @@ abstract class AbstractUpdateImports implements Runnable {
                     getCssLines(webComponentCssData, cssLineOffset));
         }
 
-        // Move all imports to the top
-        List<String> copy = new ArrayList<>(mainLines);
-        copy.removeIf(line -> !line.startsWith("import "));
-        mainLines.removeIf(line -> line.startsWith("import "));
-        mainLines.addAll(0, copy);
+        moveImportsToTop(mainLines);
 
         mainLines.addAll(chunkLoader);
         mainLines.add("window.Vaadin = window.Vaadin || {};");

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
@@ -48,10 +48,12 @@ import org.slf4j.Logger;
 import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.WebComponentExporter;
 import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.page.AppShellConfigurator;
+import com.vaadin.flow.component.webcomponent.WebComponent;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.LoadDependenciesOnStartup;
@@ -106,6 +108,19 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
     @Theme(themeClass = LumoTest.class)
     @CssImport("./foo.css")
     public static class ThemeCssImport implements AppShellConfigurator {
+    }
+
+    @CssImport("./foo.css")
+    public static class CssImportExporter
+            extends WebComponentExporter<FooCssImport> {
+        public CssImportExporter() {
+            super("css-import-exporter");
+        }
+
+        @Override
+        public void configureInstance(WebComponent<FooCssImport> webComponent,
+                FooCssImport component) {
+        }
     }
 
     protected File tmpRoot;
@@ -873,6 +888,47 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
             assertTrue("import '" + prefixed + "' appears in the wrong order",
                     curIndex <= nextIndex);
             curIndex = nextIndex;
+        }
+    }
+
+    @Test
+    public void generatedFlowImports_importsAreOnTopBeforeOtherInstructions() {
+        updater.run();
+
+        List<String> lines = updater.getOutput()
+                .get(updater.generatedFlowImports);
+        assertImportsBeforeNonImportLines(lines);
+    }
+
+    @Test
+    public void generatedFlowWebComponentImports_importsAreOnTopBeforeOtherInstructions()
+            throws Exception {
+        Class<?>[] testClasses = { CssImportExporter.class, FooCssImport.class,
+                UI.class, AllEagerAppConf.class };
+        ClassFinder classFinder = getClassFinder(testClasses);
+        updater = new UpdateImports(getScanner(classFinder), options);
+        updater.run();
+
+        List<String> lines = updater.webComponentImports;
+        Assert.assertNotNull("Web component imports should have been generated",
+                lines);
+        assertImportsBeforeNonImportLines(lines);
+    }
+
+    private void assertImportsBeforeNonImportLines(List<String> lines) {
+        boolean seenNonImport = false;
+        for (String line : lines) {
+            if (line.isBlank()) {
+                continue;
+            }
+            if (!line.startsWith("import ")) {
+                seenNonImport = true;
+            } else if (seenNonImport) {
+                Assert.fail("Import line found after non-import line. "
+                        + "All import lines should be at the top.\n"
+                        + "Offending line: " + line + "\n" + "Full output:\n"
+                        + String.join("\n", lines));
+            }
         }
     }
 


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #23817 to branch 25.0.

#### Original PR description
> `AbstractUpdateImports.process()` already reorders `import` lines to
> the top for `generatedFlowImports`, but the same sorting was not
> applied to `generatedFlowWebComponentImports`. This caused interleaved
> `import` and non-import lines (e.g. `injectGlobalWebcomponentCss()`
> calls mixed with `import` statements) in the web component output.
>
> Extract a reusable `moveImportsToTop()` method and apply it both in
> `process()` for main imports and in `mergeWebComponentOutputLines()`
> after merging and deduplicating the web component sources.
>
> Related to https://github.com/vaadin/flow/issues/23689#issuecomment-4026714714
