### PR TITLE
fix: propagate forceInstantiation and recreateLayoutChain flags on forward/reroute

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -983,7 +983,8 @@ public abstract class AbstractNavigationStateRenderer
         Location location = new Location(url, queryParameters);
 
         return new NavigationEvent(event.getSource(), location, event.getUI(),
-                NavigationTrigger.PROGRAMMATIC, (BaseJsonNode) null, true);
+                NavigationTrigger.PROGRAMMATIC, (BaseJsonNode) null, true,
+                event.isForceInstantiation(), event.isRecreateLayoutChain());
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
@@ -171,6 +171,10 @@ class NavigationStateRendererTest {
         RouteRegistry registry = ApplicationRouteRegistry
                 .getInstance(new MockVaadinContext());
         router = new Router(registry);
+
+        RouteParentLayout.creationCount.set(0);
+        ConditionalForwardView.shouldForward = false;
+        ConditionalRerouteView.shouldReroute = false;
     }
 
     @Test
@@ -305,7 +309,10 @@ class NavigationStateRendererTest {
     @Tag("div")
     private static class RouteParentLayout extends Component
             implements RouterLayout {
+        private static final AtomicInteger creationCount = new AtomicInteger(0);
+
         RouteParentLayout() {
+            creationCount.incrementAndGet();
             addAttachListener(e -> layoutAttachCount.getAndIncrement());
             layoutUUID = UUID.randomUUID().toString();
         }
@@ -1203,6 +1210,118 @@ class NavigationStateRendererTest {
                     (Class<? extends Component>) event.getNavigationTarget(),
                     new RouteParameters("id", id));
         }
+    }
+
+    @Route(value = "forward-target", layout = RouteParentLayout.class)
+    @Tag("div")
+    private static class ForwardTargetView extends Component {
+    }
+
+    @Route(value = "conditional-forward", layout = RouteParentLayout.class)
+    @Tag("div")
+    private static class ConditionalForwardView extends Component
+            implements BeforeEnterObserver {
+        static boolean shouldForward = false;
+
+        @Override
+        public void beforeEnter(BeforeEnterEvent event) {
+            if (shouldForward) {
+                event.forwardTo(ForwardTargetView.class);
+            }
+        }
+    }
+
+    @Route(value = "reroute-target", layout = RouteParentLayout.class)
+    @Tag("div")
+    private static class RerouteTargetView extends Component {
+    }
+
+    @Route(value = "conditional-reroute", layout = RouteParentLayout.class)
+    @Tag("div")
+    private static class ConditionalRerouteView extends Component
+            implements BeforeEnterObserver {
+        static boolean shouldReroute = false;
+
+        @Override
+        public void beforeEnter(BeforeEnterEvent event) {
+            if (shouldReroute) {
+                event.rerouteTo(RerouteTargetView.class);
+            }
+        }
+    }
+
+    @Test
+    public void handle_refreshCurrentRouteWithForward_recreatesLayout() {
+        layoutAttachCount = new AtomicInteger();
+        viewAttachCount = new AtomicInteger();
+
+        MockVaadinServletService service = createMockServiceWithInstantiator();
+        MockVaadinSession session = new AlwaysLockedVaadinSession(service);
+
+        router = session.getService().getRouter();
+        NavigationStateRenderer renderer = new NavigationStateRenderer(
+                new NavigationStateBuilder(router)
+                        .withTarget(ConditionalForwardView.class)
+                        .withPath("conditional-forward").build());
+        router.getRegistry().setRoute("conditional-forward",
+                ConditionalForwardView.class, List.of(RouteParentLayout.class));
+        router.getRegistry().setRoute("forward-target", ForwardTargetView.class,
+                List.of(RouteParentLayout.class));
+
+        MockUI ui = new MockUI(session);
+
+        // Initial navigation without forward
+        renderer.handle(
+                new NavigationEvent(router, new Location("conditional-forward"),
+                        ui, NavigationTrigger.PAGE_LOAD));
+
+        ui.getInternals().clearLastHandledNavigation();
+
+        // Enable forwarding and refresh with recreateLayoutChain=true
+        RouteParentLayout.creationCount.set(0);
+        ConditionalForwardView.shouldForward = true;
+        ui.refreshCurrentRoute(true);
+
+        // layout should be recreated by both refresh and forward
+        assertEquals(2, RouteParentLayout.creationCount.get(),
+                "Layout should be recreated by both refresh and forward");
+    }
+
+    @Test
+    public void handle_refreshCurrentRouteWithReroute_recreatesLayout() {
+        layoutAttachCount = new AtomicInteger();
+        viewAttachCount = new AtomicInteger();
+
+        MockVaadinServletService service = createMockServiceWithInstantiator();
+        MockVaadinSession session = new AlwaysLockedVaadinSession(service);
+
+        router = session.getService().getRouter();
+        NavigationStateRenderer renderer = new NavigationStateRenderer(
+                new NavigationStateBuilder(router)
+                        .withTarget(ConditionalRerouteView.class)
+                        .withPath("conditional-reroute").build());
+        router.getRegistry().setRoute("conditional-reroute",
+                ConditionalRerouteView.class, List.of(RouteParentLayout.class));
+        router.getRegistry().setRoute("reroute-target", RerouteTargetView.class,
+                List.of(RouteParentLayout.class));
+
+        MockUI ui = new MockUI(session);
+
+        // Initial navigation without reroute
+        renderer.handle(
+                new NavigationEvent(router, new Location("conditional-reroute"),
+                        ui, NavigationTrigger.PAGE_LOAD));
+
+        ui.getInternals().clearLastHandledNavigation();
+
+        // Enable rerouting and refresh with recreateLayoutChain=true
+        RouteParentLayout.creationCount.set(0);
+        ConditionalRerouteView.shouldReroute = true;
+        ui.refreshCurrentRoute(true);
+
+        // layout should be recreated by both refresh and reroute
+        assertEquals(2, RouteParentLayout.creationCount.get(),
+                "Layout should be recreated by both refresh and reroute");
     }
 
     @Test

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/RefreshCurrentRouteLayout.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/RefreshCurrentRouteLayout.java
@@ -17,13 +17,17 @@ package com.vaadin.flow.uitest.ui;
 
 import java.util.UUID;
 
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.router.RouterLayout;
+import com.vaadin.flow.uitest.ui.RefreshCurrentRouteRedirectView.RedirectData;
 
 public class RefreshCurrentRouteLayout implements RouterLayout {
 
     final static String ROUTER_LAYOUT_ID = "routerlayoutid";
+    final static String LAYOUT_CREATION_COUNT_ID = "layout-creation-count";
 
     private Div layout = new Div();
 
@@ -32,6 +36,18 @@ public class RefreshCurrentRouteLayout implements RouterLayout {
         Div routerLayoutId = new Div(uniqueId);
         routerLayoutId.setId(ROUTER_LAYOUT_ID);
         layout.add(routerLayoutId);
+
+        UI ui = UI.getCurrent();
+        if (ui != null) {
+            RedirectData data = ComponentUtil.getData(ui, RedirectData.class);
+            if (data != null) {
+                data.layoutCreationCount++;
+                Div countDiv = new Div(
+                        String.valueOf(data.layoutCreationCount));
+                countDiv.setId(LAYOUT_CREATION_COUNT_ID);
+                layout.add(countDiv);
+            }
+        }
     }
 
     @Override

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/RefreshCurrentRouteRedirectTargetView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/RefreshCurrentRouteRedirectTargetView.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import java.util.UUID;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "com.vaadin.flow.uitest.ui.RefreshCurrentRouteRedirectTargetView", layout = RefreshCurrentRouteLayout.class)
+public class RefreshCurrentRouteRedirectTargetView extends Div {
+
+    static final String VIEW_ID = "forward-target-id";
+
+    public RefreshCurrentRouteRedirectTargetView() {
+        Div id = new Div(UUID.randomUUID().toString());
+        id.setId(VIEW_ID);
+        add(id);
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/RefreshCurrentRouteRedirectView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/RefreshCurrentRouteRedirectView.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.BeforeEnterObserver;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "com.vaadin.flow.uitest.ui.RefreshCurrentRouteRedirectView", layout = RefreshCurrentRouteLayout.class)
+public class RefreshCurrentRouteRedirectView extends Div
+        implements BeforeEnterObserver {
+
+    enum RedirectMode {
+        FORWARD, REROUTE
+    }
+
+    static class RedirectData {
+        RedirectMode mode;
+        int layoutCreationCount;
+
+        RedirectData(RedirectMode mode) {
+            this.mode = mode;
+            this.layoutCreationCount = 0;
+        }
+    }
+
+    static final String FORWARD_AND_REFRESH_LAYOUTS = "forward-refresh-layouts";
+    static final String FORWARD_AND_REFRESH = "forward-refresh";
+    static final String REROUTE_AND_REFRESH_LAYOUTS = "reroute-refresh-layouts";
+    static final String REROUTE_AND_REFRESH = "reroute-refresh";
+
+    @Override
+    public void beforeEnter(BeforeEnterEvent event) {
+        RedirectData data = ComponentUtil.getData(event.getUI(),
+                RedirectData.class);
+        if (data == null) {
+            return;
+        }
+        switch (data.mode) {
+        case FORWARD ->
+            event.forwardTo(RefreshCurrentRouteRedirectTargetView.class);
+        case REROUTE ->
+            event.rerouteTo(RefreshCurrentRouteRedirectTargetView.class);
+        }
+    }
+
+    public RefreshCurrentRouteRedirectView() {
+        addButton(FORWARD_AND_REFRESH_LAYOUTS, "Forward + refresh layouts",
+                RedirectMode.FORWARD, true);
+        addButton(FORWARD_AND_REFRESH, "Forward + refresh view only",
+                RedirectMode.FORWARD, false);
+        addButton(REROUTE_AND_REFRESH_LAYOUTS, "Reroute + refresh layouts",
+                RedirectMode.REROUTE, true);
+        addButton(REROUTE_AND_REFRESH, "Reroute + refresh view only",
+                RedirectMode.REROUTE, false);
+    }
+
+    private void addButton(String id, String text, RedirectMode mode,
+            boolean recreateLayouts) {
+        NativeButton button = new NativeButton(text, e -> {
+            UI ui = UI.getCurrent();
+            ComponentUtil.setData(ui, RedirectData.class,
+                    new RedirectData(mode));
+            ui.refreshCurrentRoute(recreateLayouts);
+        });
+        button.setId(id);
+        add(button);
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/RefreshCurrentRouteRedirectIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/RefreshCurrentRouteRedirectIT.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.component.html.testbench.NativeButtonElement;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+import static com.vaadin.flow.uitest.ui.RefreshCurrentRouteLayout.LAYOUT_CREATION_COUNT_ID;
+import static com.vaadin.flow.uitest.ui.RefreshCurrentRouteLayout.ROUTER_LAYOUT_ID;
+import static com.vaadin.flow.uitest.ui.RefreshCurrentRouteRedirectTargetView.VIEW_ID;
+import static com.vaadin.flow.uitest.ui.RefreshCurrentRouteRedirectView.FORWARD_AND_REFRESH;
+import static com.vaadin.flow.uitest.ui.RefreshCurrentRouteRedirectView.FORWARD_AND_REFRESH_LAYOUTS;
+import static com.vaadin.flow.uitest.ui.RefreshCurrentRouteRedirectView.REROUTE_AND_REFRESH;
+import static com.vaadin.flow.uitest.ui.RefreshCurrentRouteRedirectView.REROUTE_AND_REFRESH_LAYOUTS;
+
+public class RefreshCurrentRouteRedirectIT extends ChromeBrowserTest {
+
+    @Test
+    public void refreshCurrentRouteAndLayouts_withForward_recreatesTargetAndLayout() {
+        open();
+        waitForElementPresent(By.id(FORWARD_AND_REFRESH_LAYOUTS));
+
+        $(NativeButtonElement.class).id(FORWARD_AND_REFRESH_LAYOUTS).click();
+
+        // Should now be on the forward target view
+        waitForElementPresent(By.id(VIEW_ID));
+
+        // Layout should be created twice: once for the refresh, once for the
+        // forward. This verifies that the forceInstantiation flag is propagated
+        // during forward.
+        Assert.assertEquals(
+                "Layout should be created twice when forwarding with refreshCurrentRoute(true)",
+                "2", getString(LAYOUT_CREATION_COUNT_ID));
+    }
+
+    @Test
+    public void refreshCurrentRouteViewOnly_withForward_recreatesTargetOnly() {
+        open();
+        waitForElementPresent(By.id(FORWARD_AND_REFRESH));
+
+        String originalLayoutId = getString(ROUTER_LAYOUT_ID);
+
+        $(NativeButtonElement.class).id(FORWARD_AND_REFRESH).click();
+
+        // Should now be on the forward target view
+        waitForElementPresent(By.id(VIEW_ID));
+        String newLayoutId = getString(ROUTER_LAYOUT_ID);
+
+        // Layout should be the same (only view refresh, not layouts)
+        Assert.assertEquals(
+                "Layout should NOT be recreated after forward with refreshCurrentRoute(false)",
+                originalLayoutId, newLayoutId);
+    }
+
+    @Test
+    public void refreshCurrentRouteAndLayouts_withReroute_recreatesTargetAndLayout() {
+        open();
+        waitForElementPresent(By.id(REROUTE_AND_REFRESH_LAYOUTS));
+
+        $(NativeButtonElement.class).id(REROUTE_AND_REFRESH_LAYOUTS).click();
+
+        // Should now show the rerouted target view
+        waitForElementPresent(By.id(VIEW_ID));
+
+        // Layout should be created twice: once for the refresh, once for the
+        // reroute. This verifies that the recreateLayoutChain flag is
+        // propagated during reroute.
+        Assert.assertEquals(
+                "Layout should be created twice when rerouting with refreshCurrentRoute(true)",
+                "2", getString(LAYOUT_CREATION_COUNT_ID));
+    }
+
+    @Test
+    public void refreshCurrentRouteViewOnly_withReroute_recreatesTargetOnly() {
+        open();
+        waitForElementPresent(By.id(REROUTE_AND_REFRESH));
+
+        String originalLayoutId = getString(ROUTER_LAYOUT_ID);
+
+        $(NativeButtonElement.class).id(REROUTE_AND_REFRESH).click();
+
+        // Should now show the rerouted target view
+        waitForElementPresent(By.id(VIEW_ID));
+        String newLayoutId = getString(ROUTER_LAYOUT_ID);
+
+        // Layout should be the same (only view refresh, not layouts)
+        Assert.assertEquals(
+                "Layout should NOT be recreated after reroute with refreshCurrentRoute(false)",
+                originalLayoutId, newLayoutId);
+    }
+
+    private String getString(String id) {
+        waitForElementPresent(By.id(id));
+        return findElement(By.id(id)).getText();
+    }
+}


### PR DESCRIPTION
When `refreshCurrentRoute(true)` triggered a forward or reroute in `BeforeEnterObserver`, the `NavigationEvent` created for the redirect lost the `forceInstantiation` and `recreateLayoutChain` flags, causing layouts not to be recreated as expected.

Fixes #20988