### PR TITLE
feat: apply ElementEffect once when created (#23824) (CP: 25.1)

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -1727,20 +1727,35 @@ public class Binder<BEAN> implements Serializable {
         private void initInternalSignalEffectForValidators() {
             if (signalRegistration == null
                     && getField() instanceof Component component) {
-                // Constant signal that is only read and never modified.
-                // Satisfies the signal usage requirement for bindings
-                // without signal-using validators in the chain.
-                var usageGuard = new ValueSignal<Void>(null);
-                signalRegistration = Signal.effect(component, ctx -> {
-                    usageGuard.get();
-                    Result<TARGET> result = executeConversionChain();
-                    if (!ctx.isInitialRun()) {
-                        BindingValidationStatus<TARGET> status = toValidationStatus(
-                                result);
-                        fireValidationEvents(status);
-                    }
-                });
+                if (component.isAttached()) {
+                    initInternalSignalEffectForValidators(component);
+                } else {
+                    component.addAttachListener(event -> {
+                        if (event.isInitialAttach()) {
+                            event.unregisterListener();
+                        }
+                        initInternalSignalEffectForValidators(
+                                event.getSource());
+                    });
+                }
             }
+        }
+
+        private void initInternalSignalEffectForValidators(
+                Component component) {
+            // Constant signal that is only read and never modified.
+            // Satisfies the signal usage requirement for bindings
+            // without signal-using validators in the chain.
+            var usageGuard = new ValueSignal<Void>(null);
+            signalRegistration = Signal.effect(component, ctx -> {
+                usageGuard.get();
+                Result<TARGET> result = executeConversionChain();
+                if (!ctx.isInitialRun()) {
+                    BindingValidationStatus<TARGET> status = toValidationStatus(
+                            result);
+                    fireValidationEvents(status);
+                }
+            });
         }
 
         /**

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderSignalTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderSignalTest.java
@@ -630,6 +630,7 @@ public class BinderSignalTest extends SignalsUnitTest {
         assertFalse(firstNameField.isInvalid());
         assertTrue(binder.isValid());
 
+        lastNameSignal.set("Smith");
         // Now attach the fields
         UI.getCurrent().add(firstNameField, lastNameField);
 

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorBindTextTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorBindTextTest.java
@@ -43,12 +43,12 @@ public class AnchorBindTextTest extends SignalsUnitTest {
         // Detached: binding inactive
         var signal = new ValueSignal<>("one");
         Anchor anchor = new Anchor("/path", signal);
-        // no propagation while detached
-        assertEquals("", anchor.getText());
+        // Initial value is applied
+        assertEquals("one", anchor.getText());
 
         // Update before attach is ignored
         signal.set("two");
-        assertEquals("", anchor.getText());
+        assertEquals("one", anchor.getText());
 
         // Attach -> latest value applied
         UI.getCurrent().add(anchor);

--- a/flow-server/src/main/java/com/vaadin/flow/component/Component.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Component.java
@@ -594,10 +594,11 @@ public abstract class Component
 
     /**
      * Binds a {@link Signal}'s value to the <code>visible</code> property of
-     * this component and keeps property synchronized with the signal value
-     * while the component is in attached state. When the element is in detached
-     * state, signal value changes have no effect. <code>null</code> signal
-     * unbinds the existing binding.
+     * this component. The visibility is set immediately with the current signal
+     * value when the binding is created, and is kept synchronized with any
+     * subsequent signal value changes while the component is in attached state.
+     * When the element is in detached state, signal value changes have no
+     * effect. <code>null</code> signal unbinds the existing binding.
      * <p>
      * While a Signal is bound to a property, any attempt to set the visibility
      * manually with {@link #setVisible(boolean)} throws

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasEnabled.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasEnabled.java
@@ -102,11 +102,12 @@ public interface HasEnabled extends HasElement {
     }
 
     /**
-     * Binds a {@link Signal}'s value to the enabled state of this component and
-     * keeps the state synchronized with the signal value while the element is
-     * in attached state. When the element is in detached state, signal value
-     * changes have no effect. <code>null</code> signal unbinds the existing
-     * binding.
+     * Binds a {@link Signal}'s value to the enabled state of this component.
+     * The enabled state is set immediately with the current signal value when
+     * the binding is created, and is kept synchronized with any subsequent
+     * signal value changes while the element is in attached state. When the
+     * element is in detached state, signal value changes have no effect.
+     * <code>null</code> signal unbinds the existing binding.
      * <p>
      * While a Signal is bound to an enabled state, any attempt to set the state
      * manually with {@link #setEnabled(boolean)} throws

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasHelper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasHelper.java
@@ -74,8 +74,10 @@ public interface HasHelper extends HasElement {
     }
 
     /**
-     * Binds a signal's value to the component's helper text so that the helper
-     * text is updated when the signal's value is updated.
+     * Binds a signal's value to the component's helper text. The helper text is
+     * set immediately with the current signal value when the binding is
+     * created, and is kept synchronized with any subsequent signal value
+     * changes while the component is in attached state.
      * <p>
      * Passing {@code null} as the {@code signal} removes any existing binding
      * for the given helper text. When unbinding, the current helper text is
@@ -86,9 +88,8 @@ public interface HasHelper extends HasElement {
      * {@link com.vaadin.flow.signals.BindingActiveException}. The same happens
      * when trying to bind a new Signal while one is already bound.
      * <p>
-     * Bindings are lifecycle-aware and only active while this component is in
-     * the attached state; they are deactivated while the component is in the
-     * detached state.
+     * When the component is in the detached state, signal value changes have no
+     * effect.
      *
      * @param helperTextSignal
      *            the signal to bind, not <code>null</code>

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasPlaceholder.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasPlaceholder.java
@@ -55,8 +55,10 @@ public interface HasPlaceholder extends HasElement {
     }
 
     /**
-     * Binds a signal's value to the component's placeholder so that the
-     * placeholder is updated when the signal's value is updated.
+     * Binds a signal's value to the component's placeholder. The placeholder is
+     * set immediately with the current signal value when the binding is
+     * created, and is kept synchronized with any subsequent signal value
+     * changes while the component is in attached state.
      * <p>
      * Passing {@code null} as the {@code signal} removes any existing binding
      * for the given placeholder. When unbinding, the current placeholder is
@@ -67,9 +69,8 @@ public interface HasPlaceholder extends HasElement {
      * {@link com.vaadin.flow.signals.BindingActiveException}. The same happens
      * when trying to bind a new signal while one is already bound.
      * <p>
-     * Bindings are lifecycle-aware and only active while this component is in
-     * the attached state; they are deactivated while the component is in the
-     * detached state.
+     * When the component is in the detached state, signal value changes have no
+     * effect.
      *
      * @param placeholderSignal
      *            the signal to bind, not <code>null</code>

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasSize.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasSize.java
@@ -421,11 +421,12 @@ public interface HasSize extends HasElement {
     }
 
     /**
-     * Binds a {@link Signal}'s value to the width of this component and keeps
-     * the width synchronized with the signal value while the component is in
-     * attached state. When the component is in detached state, signal value
-     * changes have no effect. <code>null</code> signal unbinds the existing
-     * binding.
+     * Binds a {@link Signal}'s value to the width of this component. The width
+     * is set immediately with the current signal value when the binding is
+     * created, and is kept synchronized with any subsequent signal value
+     * changes while the component is in attached state. When the component is
+     * in detached state, signal value changes have no effect. <code>null</code>
+     * signal unbinds the existing binding.
      * <p>
      * The width should be in a format understood by the browser, e.g. "100px"
      * or "2.5em".
@@ -462,10 +463,11 @@ public interface HasSize extends HasElement {
     }
 
     /**
-     * Binds a {@link Signal}'s value to the height of this component and keeps
-     * the height synchronized with the signal value while the component is in
-     * attached state. When the component is in detached state, signal value
-     * changes have no effect.
+     * Binds a {@link Signal}'s value to the height of this component. The
+     * height is set immediately with the current signal value when the binding
+     * is created, and is kept synchronized with any subsequent signal value
+     * changes while the component is in attached state. When the component is
+     * in detached state, signal value changes have no effect.
      * <p>
      * The height should be in a format understood by the browser, e.g. "100px"
      * or "2.5em".

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasStyle.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasStyle.java
@@ -165,12 +165,15 @@ public interface HasStyle extends HasElement {
     }
 
     /**
-     * Binds the presence of the given CSS class name to a {@link Signal}. When
-     * the signal's value is {@code true}, the class name is added; when
-     * {@code false}, the class name is removed.
+     * Binds the presence of the given CSS class name to a {@link Signal}. The
+     * class name is immediately added or removed based on the current signal
+     * value when the binding is created. When the signal's value is
+     * {@code true}, the class name is added; when {@code false}, the class name
+     * is removed.
      * <p>
-     * The binding is active while the component is attached to a UI. When
-     * detached, signal value changes have no effect.
+     * The binding is kept synchronized with any subsequent signal value changes
+     * while the component is attached to a UI. When detached, signal value
+     * changes have no effect.
      *
      * @param className
      *            the CSS class name to toggle, not {@code null} or blank
@@ -185,9 +188,11 @@ public interface HasStyle extends HasElement {
     }
 
     /**
-     * Binds the CSS class names of this component to a {@link Signal} so that
-     * the class list is dynamically updated to match the signal's value. Only
-     * one group binding is allowed per component.
+     * Binds the CSS class names of this component to a {@link Signal}. The
+     * class list is immediately updated to match the current signal value when
+     * the binding is created, and is kept synchronized with any subsequent
+     * signal value changes while the component is attached. Only one group
+     * binding is allowed per component.
      * <p>
      * The group binding coexists with static values and individual toggle
      * bindings.

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasText.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasText.java
@@ -167,11 +167,12 @@ public interface HasText extends HasElement {
     }
 
     /**
-     * Binds a {@link Signal}'s value to the text content of this component and
-     * keeps the text content synchronized with the signal value while the
-     * element is in attached state. When the element is in detached state,
-     * signal value changes have no effect. <code>null</code> signal unbinds the
-     * existing binding.
+     * Binds a {@link Signal}'s value to the text content of this component. The
+     * text content is set immediately with the current signal value when the
+     * binding is created, and is kept synchronized with any subsequent signal
+     * value changes while the element is in attached state. When the element is
+     * in detached state, signal value changes have no effect. <code>null</code>
+     * signal unbinds the existing binding.
      * <p>
      * While a Signal is bound, any attempt to set the text content manually
      * throws {@link com.vaadin.flow.signals.BindingActiveException}. Same

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasValue.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasValue.java
@@ -235,10 +235,11 @@ public interface HasValue<E extends ValueChangeEvent<V>, V>
     boolean isRequiredIndicatorVisible();
 
     /**
-     * Binds a {@link Signal}'s value to the value state of this component and
-     * keeps the state synchronized with the signal value while the element is
-     * in attached state. When the element is in detached state, signal value
-     * changes have no effect.
+     * Binds a {@link Signal}'s value to the value state of this component. The
+     * value is set immediately with the current signal value when the binding
+     * is created, and is kept synchronized with any subsequent signal value
+     * changes while the element is in attached state. When the element is in
+     * detached state, signal value changes have no effect.
      * <p>
      * While a Signal is bound to a value state, any attempt to bind a new
      * Signal while one is already bound throws
@@ -312,10 +313,11 @@ public interface HasValue<E extends ValueChangeEvent<V>, V>
     }
 
     /**
-     * Binds a {@link Signal}'s value to the read-only state of this component
-     * and keeps the state synchronized with the signal value while the
-     * component is in attached state. When the component is in detached state,
-     * signal value changes have no effect.
+     * Binds a {@link Signal}'s value to the read-only state of this component.
+     * The read-only state is set immediately with the current signal value when
+     * the binding is created, and is kept synchronized with any subsequent
+     * signal value changes while the component is in attached state. When the
+     * component is in detached state, signal value changes have no effect.
      * <p>
      * While a Signal is bound to the read-only state, any attempt to set the
      * read-only state manually with {@link #setReadOnly(boolean)} throws
@@ -347,9 +349,11 @@ public interface HasValue<E extends ValueChangeEvent<V>, V>
 
     /**
      * Binds a {@link Signal}'s value to the required indicator visible state of
-     * this component and keeps the state synchronized with the signal value
-     * while the component is in attached state. When the component is in
-     * detached state, signal value changes have no effect.
+     * this component. The required indicator state is set immediately with the
+     * current signal value when the binding is created, and is kept
+     * synchronized with any subsequent signal value changes while the component
+     * is in attached state. When the component is in detached state, signal
+     * value changes have no effect.
      * <p>
      * While a Signal is bound to the required indicator visible state, any
      * attempt to set the state manually with

--- a/flow-server/src/main/java/com/vaadin/flow/component/Html.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Html.java
@@ -240,9 +240,11 @@ public class Html extends Component {
 
     /**
      * Binds a {@link com.vaadin.flow.signals.Signal}'s value to this
-     * component's HTML content (outer HTML) and keeps the content synchronized
-     * with the signal value while the component is attached. When the component
-     * is detached, signal value changes have no effect.
+     * component's HTML content (outer HTML). The content is set immediately
+     * with the current signal value when the binding is created, and is kept
+     * synchronized with any subsequent signal value changes while the component
+     * is attached. When the component is detached, signal value changes have no
+     * effect.
      * <p>
      * While a Signal is bound to the HTML content, any attempt to set the HTML
      * content manually via {@link #setHtmlContent(String)} throws

--- a/flow-server/src/main/java/com/vaadin/flow/component/SignalPropertySupport.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/SignalPropertySupport.java
@@ -116,10 +116,11 @@ public class SignalPropertySupport<T extends @Nullable Object>
     }
 
     /**
-     * Binds a {@link Signal}'s value to this property support and keeps the
-     * value synchronized with the signal value while the component is in
-     * attached state. When the component is in detached state, signal value
-     * changes have no effect.
+     * Binds a {@link Signal}'s value to this property support. The value is set
+     * immediately with the current signal value when the binding is created,
+     * and is kept synchronized with any subsequent signal value changes while
+     * the component is in attached state. When the component is in detached
+     * state, signal value changes have no effect.
      * <p>
      * While a Signal is bound to a property support, any attempt to set value
      * manually throws {@link com.vaadin.flow.signals.BindingActiveException}.
@@ -147,9 +148,13 @@ public class SignalPropertySupport<T extends @Nullable Object>
             T oldValue = previousValue[0];
             value = newValue;
             valueChangeConsumer.accept(newValue);
-            if (binding.hasCallbacks()) {
-                binding.fireOnChange(new BindingContext<>(ctx.isInitialRun(),
-                        ctx.isBackgroundChange(), oldValue, newValue, element));
+            if (ctx.isInitialRun() || binding.hasCallbacks()) {
+                var bindingContext = new BindingContext<>(ctx.isInitialRun(),
+                        ctx.isBackgroundChange(), oldValue, newValue, element);
+                binding.setInitialContext(bindingContext);
+                if (binding.hasCallbacks()) {
+                    binding.fireOnChange(bindingContext);
+                }
             }
             previousValue[0] = newValue;
         });

--- a/flow-server/src/main/java/com/vaadin/flow/dom/ClassList.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/ClassList.java
@@ -49,16 +49,18 @@ public interface ClassList extends Set<String>, Serializable {
     }
 
     /**
-     * Binds the presence of the given class name to the provided signal so that
-     * the class is added when the signal value is {@code true} and removed when
-     * the value is {@code false}.
+     * Binds the presence of the given class name to the provided signal. The
+     * class name is immediately added or removed based on the current signal
+     * value when the binding is created. The class is added when the signal
+     * value is {@code true} and removed when the value is {@code false}.
      * <p>
-     * While a binding for the given class name is active, manual calls to
-     * {@link #add(Object)}, {@link #remove(Object)} or
+     * After the initial application, the binding is kept synchronized with any
+     * subsequent signal value changes while the owning {@link Element} is in
+     * attached state. While a binding for the given class name is active,
+     * manual calls to {@link #add(Object)}, {@link #remove(Object)} or
      * {@link #set(String, boolean)} for that name will throw a
-     * {@link BindingActiveException}. Bindings are lifecycle-aware and only
-     * active while the owning {@link Element} is in attached state; they are
-     * deactivated while the element is in detached state.
+     * {@link BindingActiveException}. When the element is in detached state,
+     * signal value changes have no effect.
      * <p>
      * Bulk operations that indiscriminately replace or clear the class list
      * (for example {@link #clear()} or setting the {@code class} attribute via
@@ -79,9 +81,11 @@ public interface ClassList extends Set<String>, Serializable {
     };
 
     /**
-     * Binds the class names to the provided signal so that the class list is
-     * dynamically updated to match the signal's value. Only one group binding
-     * is allowed per class list.
+     * Binds the class names to the provided signal. The class list is
+     * immediately updated to match the current signal value when the binding is
+     * created, and is kept synchronized with any subsequent signal value
+     * changes while the element is attached. Only one group binding is allowed
+     * per class list.
      * <p>
      * The group binding coexists with static values and individual toggle
      * bindings. Names that appear in both sources are deduplicated by the

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -250,11 +250,12 @@ public class Element extends Node<Element> {
     }
 
     /**
-     * Binds a {@link Signal}'s value to a given attribute and keeps the
-     * attribute value synchronized with the signal value while the element is
-     * in attached state. When the element is in detached state, signal value
-     * changes have no effect. <code>null</code> signal unbinds existing
-     * binding.
+     * Binds a {@link Signal}'s value to a given attribute. The attribute is set
+     * immediately with the current signal value when the binding is created,
+     * and is kept synchronized with any subsequent signal value changes while
+     * the element is in attached state. When the element is in detached state,
+     * signal value changes have no effect. <code>null</code> signal unbinds
+     * existing binding.
      * <p>
      * Same rules applies for the attribute name and value from the bound Signal
      * as in {@link #setAttribute(String, String)}.
@@ -880,10 +881,11 @@ public class Element extends Node<Element> {
     }
 
     /**
-     * Binds a {@link Signal}'s value to the given property and keeps the
-     * property value synchronized with the signal value while the element is in
-     * attached state. When the element is in detached state, signal value
-     * changes have no effect.
+     * Binds a {@link Signal}'s value to the given property. The property is set
+     * immediately with the current signal value when the binding is created,
+     * and is kept synchronized with any subsequent signal value changes while
+     * the element is in attached state. When the element is in detached state,
+     * signal value changes have no effect.
      * <p>
      * Same rules apply for the property name and value from the bound Signal as
      * in {@link #setProperty(String, String)}.
@@ -1381,10 +1383,11 @@ public class Element extends Node<Element> {
     }
 
     /**
-     * Binds a {@link Signal}'s value to the text content of this element and
-     * keeps the text content synchronized with the signal value while the
-     * element is in attached state. When the element is in detached state,
-     * signal value changes have no effect.
+     * Binds a {@link Signal}'s value to the text content of this element. The
+     * text content is set immediately with the current signal value when the
+     * binding is created, and is kept synchronized with any subsequent signal
+     * value changes while the element is in attached state. When the element is
+     * in detached state, signal value changes have no effect.
      * <p>
      * While a Signal is bound to a property, any attempt to set the text
      * content manually throws
@@ -1896,9 +1899,11 @@ public class Element extends Node<Element> {
 
     /**
      * Binds a {@link Signal}'s value to the <code>visible</code> property of
-     * this element and keeps property synchronized with the signal value while
-     * the element is in attached state. When the element is in detached state,
-     * signal value changes have no effect.
+     * this element. The visibility is set immediately with the current signal
+     * value when the binding is created, and is kept synchronized with any
+     * subsequent signal value changes while the element is in attached state.
+     * When the element is in detached state, signal value changes have no
+     * effect.
      * <p>
      * While a Signal is bound to a property, any attempt to set the visibility
      * manually with {@link #setVisible(boolean)} throws
@@ -1952,10 +1957,11 @@ public class Element extends Node<Element> {
     }
 
     /**
-     * Binds a {@link Signal}'s value to the enabled state of this element and
-     * keeps the state synchronized with the signal value while the element is
-     * in attached state. When the element is in detached state, signal value
-     * changes have no effect.
+     * Binds a {@link Signal}'s value to the enabled state of this element. The
+     * enabled state is set immediately with the current signal value when the
+     * binding is created, and is kept synchronized with any subsequent signal
+     * value changes while the element is in attached state. When the element is
+     * in detached state, signal value changes have no effect.
      * <p>
      * While a Signal is bound to an enabled state, any attempt to set the state
      * manually with {@link #setEnabled(boolean)} throws

--- a/flow-server/src/main/java/com/vaadin/flow/dom/ElementEffect.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/ElementEffect.java
@@ -30,6 +30,7 @@ import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.UIDetachedException;
 import com.vaadin.flow.function.SerializableBiConsumer;
+import com.vaadin.flow.function.SerializableExecutor;
 import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.server.ErrorEvent;
 import com.vaadin.flow.shared.Registration;
@@ -56,9 +57,15 @@ import com.vaadin.flow.signals.impl.Effect;
  */
 public final class ElementEffect implements Serializable {
     private final ContextualEffectAction effectFunction;
+    private final Element owner;
     private Effect effect = null;
     private Registration attachRegistration;
     private Registration detachRegistration;
+    /**
+     * Error handler used by the active effect action. {@code null} means
+     * exceptions are re-thrown (probe / unattached mode).
+     */
+    private @Nullable SerializableBiConsumer<Exception, Element> errorHandler = null;
 
     public ElementEffect(Element owner, EffectAction effectFunction) {
         this(owner, (ContextualEffectAction) ctx -> effectFunction.execute());
@@ -69,6 +76,31 @@ public final class ElementEffect implements Serializable {
         Objects.requireNonNull(effectFunction,
                 "Effect function cannot be null");
         this.effectFunction = effectFunction;
+        this.owner = owner;
+
+        if (owner.getNode().isAttached()) {
+            // Element is already attached: set up the error handler and
+            // UI-locked dispatcher before creating the Effect so that the
+            // initial (synchronous) run uses the proper error-routing and
+            // execution context.
+            enableEffect(owner);
+
+            detachRegistration = owner.addDetachListener(detach -> {
+                disableEffect();
+                detachRegistration.remove();
+                detachRegistration = null;
+            });
+        } else {
+            // Element is not yet attached: run a probe immediately so that
+            // structural errors (e.g. MissingSignalUsageException) are reported
+            // at the call site rather than delayed until attach. The probe uses
+            // Runnable::run so the first revalidation is synchronous. The
+            // effect is then passivated so it does not actively listen for
+            // changes while the element is detached.
+            effect = new Effect(this::executeAction, Runnable::run);
+            effect.passivate();
+        }
+
         attachRegistration = owner.addAttachListener(attach -> {
             enableEffect(attach.getSource());
 
@@ -78,15 +110,26 @@ public final class ElementEffect implements Serializable {
                 detachRegistration = null;
             });
         });
+    }
 
-        if (owner.getNode().isAttached()) {
-            enableEffect(owner);
-
-            detachRegistration = owner.addDetachListener(detach -> {
-                disableEffect();
-                detachRegistration.remove();
-                detachRegistration = null;
-            });
+    /**
+     * Executes the effect function, routing exceptions through the
+     * {@link #errorHandler} when attached (active mode) or re-throwing them
+     * when no error handler is set (probe/unattached mode). This is a named
+     * method rather than a lambda to ensure reliable serialization.
+     */
+    private void executeAction(EffectContext ctx) {
+        try {
+            effectFunction.execute(ctx);
+        } catch (RuntimeException e) {
+            SerializableBiConsumer<Exception, Element> handler = errorHandler;
+            if (handler != null) {
+                handler.accept(e, owner);
+            } else {
+                // Probe run: re-throw so the exception surfaces at the
+                // call site (e.g. inside bindText / Signal.effect).
+                throw e;
+            }
         }
     }
 
@@ -206,38 +249,32 @@ public final class ElementEffect implements Serializable {
             T newValue = signal.get();
             T oldValue = previousValue[0];
             setter.accept(owner, newValue);
-            if (binding.hasCallbacks()) {
-                binding.fireOnChange(new BindingContext<>(ctx.isInitialRun(),
-                        ctx.isBackgroundChange(), oldValue, newValue, owner));
+            if (ctx.isInitialRun() || binding.hasCallbacks()) {
+                var bindingContext = new BindingContext<>(ctx.isInitialRun(),
+                        ctx.isBackgroundChange(), oldValue, newValue, owner);
+                binding.setInitialContext(bindingContext);
+                if (binding.hasCallbacks()) {
+                    binding.fireOnChange(bindingContext);
+                }
             }
+
             previousValue[0] = newValue;
         });
         return binding;
     }
 
     private void enableEffect(Element owner) {
-        if (effect != null) {
-            effect.activate();
-        } else {
-            createEffect(owner);
-        }
-    }
-
-    private void createEffect(Element owner) {
         Component parentComponent = ComponentUtil.findParentComponent(owner)
                 .get();
         UI ui = parentComponent.getUI().get();
 
-        ContextualEffectAction errorHandlingEffectFunction = ctx -> {
-            try {
-                effectFunction.execute(ctx);
-            } catch (Exception e) {
-                ui.getSession().getErrorHandler()
-                        .error(new ErrorEvent(e, owner.getNode()));
-            }
-        };
+        // Install the UI error handler so that exceptions during active
+        // (post-attach) runs are routed to the session error handler instead
+        // of being re-thrown.
+        errorHandler = (e, elem) -> ui.getSession().getErrorHandler()
+                .error(new ErrorEvent(e, elem.getNode()));
 
-        effect = new Effect(errorHandlingEffectFunction, command -> {
+        SerializableExecutor uiDispatcher = command -> {
             if (UI.getCurrent() == ui) {
                 // Run immediately if on the same UI
                 command.run();
@@ -253,7 +290,20 @@ public final class ElementEffect implements Serializable {
                     }
                 });
             }
-        });
+        };
+
+        if (effect == null) {
+            // First attach for the already-attached path (effect not yet
+            // created): create the Effect directly with the UI dispatcher so
+            // that the initial run uses the proper execution context.
+            effect = new Effect(this::executeAction, uiDispatcher);
+        } else {
+            // Re-attach after detach (or the not-attached probe path):
+            // swap the dispatcher and activate. activate() will only re-run
+            // the callback if a signal changed while the element was detached.
+            effect.setDispatcher(uiDispatcher);
+            effect.activate();
+        }
     }
 
     private void disableEffect() {

--- a/flow-server/src/main/java/com/vaadin/flow/dom/SignalBinding.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/SignalBinding.java
@@ -44,6 +44,7 @@ import com.vaadin.flow.function.SerializableConsumer;
  */
 public class SignalBinding<T extends @Nullable Object> implements Serializable {
 
+    private BindingContext<T> initialContext;
     private List<SerializableConsumer<BindingContext<T>>> changeCallbacks;
 
     /**
@@ -85,6 +86,9 @@ public class SignalBinding<T extends @Nullable Object> implements Serializable {
             changeCallbacks = new ArrayList<>();
         }
         changeCallbacks.add(action);
+        if (initialContext != null && initialContext.isInitialRun()) {
+            action.accept(initialContext);
+        }
         return this;
     }
 
@@ -115,5 +119,18 @@ public class SignalBinding<T extends @Nullable Object> implements Serializable {
         for (SerializableConsumer<BindingContext<T>> callback : changeCallbacks) {
             callback.accept(context);
         }
+    }
+
+    /**
+     * Stores the context from the initial effect run so that callbacks
+     * registered after the initial run can still be invoked immediately.
+     * <p>
+     * For internal use only. May be renamed or removed in a future release.
+     *
+     * @param context
+     *            the context from the initial run, not {@code null}
+     */
+    public void setInitialContext(BindingContext<T> context) {
+        this.initialContext = context;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Style.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Style.java
@@ -197,16 +197,18 @@ public interface Style extends Serializable {
     Stream<String> getNames();
 
     /**
-     * Binds the given style property to the provided string signal and keeps
-     * the style property value synchronized with the signal.
+     * Binds the given style property to the provided string signal. The style
+     * property is set immediately with the current signal value when the
+     * binding is created, and is kept synchronized with any subsequent signal
+     * value changes.
      * <p>
      * When a binding is in place, the style signal mirrors
      * {@code signal.get()}. If the signal value is {@code null}, the style
      * property is removed; otherwise it is set to the string value.
      * <p>
-     * The binding effect is active only while the owner element is in the
-     * attached state. While the owner is in the detached state, updates from
-     * the signal have no effect.
+     * After the initial application, the binding is active only while the owner
+     * element is in the attached state. While the owner is in the detached
+     * state, updates from the signal have no effect.
      * <p>
      * While a binding for a specific style name is active, any attempt to bind
      * another signal for the same name throws a {@link BindingActiveException}.

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/ThemeListImpl.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/ThemeListImpl.java
@@ -158,10 +158,14 @@ public class ThemeListImpl implements ThemeList, Serializable {
             previousNames.clear();
             previousNames.addAll(newNames);
 
-            if (binding.hasCallbacks()) {
-                binding.fireOnChange(new BindingContext<>(ctx.isInitialRun(),
+            if (ctx.isInitialRun() || binding.hasCallbacks()) {
+                var bindingContext = new BindingContext<>(ctx.isInitialRun(),
                         ctx.isBackgroundChange(), previousValue[0], signalNames,
-                        ownerElement));
+                        ownerElement);
+                binding.setInitialContext(bindingContext);
+                if (binding.hasCallbacks()) {
+                    binding.fireOnChange(bindingContext);
+                }
             }
             previousValue[0] = signalNames;
         });

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ElementClassList.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ElementClassList.java
@@ -153,10 +153,14 @@ public class ElementClassList extends SerializableNodeList<String> {
                 previousNames.clear();
                 previousNames.addAll(newNames);
 
-                if (binding.hasCallbacks()) {
-                    binding.fireOnChange(new BindingContext<>(
+                if (ctx.isInitialRun() || binding.hasCallbacks()) {
+                    var bindingContext = new BindingContext<>(
                             ctx.isInitialRun(), ctx.isBackgroundChange(),
-                            previousValue[0], signalNames, element));
+                            previousValue[0], signalNames, element);
+                    binding.setInitialContext(bindingContext);
+                    if (binding.hasCallbacks()) {
+                        binding.fireOnChange(bindingContext);
+                    }
                 }
                 previousValue[0] = signalNames;
             });

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/NodeMap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/NodeMap.java
@@ -201,6 +201,11 @@ public abstract class NodeMap extends NodeFeature {
      */
     protected Serializable put(String key, Serializable value,
             boolean emitChange) {
+        return putInternal(key, value, emitChange);
+    }
+
+    private Serializable putInternal(String key, Serializable value,
+            boolean emitChange) {
         Serializable oldValue = get(key);
         if (!producePutChange(key, contains(key), value)) {
             return oldValue;
@@ -581,10 +586,13 @@ public abstract class NodeMap extends NodeFeature {
             throw new BindingActiveException();
         }
 
-        SignalBinding<T> domBinding = ElementEffect.bind(owner, signal, setter);
-        put(key, new InternalSignalBinding(signal, get(key), writeCallback),
+        // Setter might trigger an immediate value update which requires the
+        // signal to be registered before ElementEffect.bind call.
+        putInternal(key,
+                new InternalSignalBinding(signal, get(key), writeCallback),
                 false);
-        return domBinding;
+
+        return ElementEffect.bind(owner, signal, setter);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/signals/impl/Effect.java
+++ b/flow-server/src/main/java/com/vaadin/flow/signals/impl/Effect.java
@@ -242,6 +242,19 @@ public class Effect implements Serializable {
     }
 
     /**
+     * Sets the dispatcher to use for subsequent invalidation callbacks. This
+     * can be used to change the execution context before re-activating a
+     * passivated effect.
+     *
+     * @param dispatcher
+     *            the new dispatcher to use, not <code>null</code>
+     */
+    public synchronized void setDispatcher(SerializableExecutor dispatcher) {
+        assert dispatcher != null;
+        this.dispatcher = dispatcher;
+    }
+
+    /**
      * Passivates this effect by removing all dependency listeners while
      * preserving the tracked usages. The effect can later be re-activated with
      * {@link #activate()}, which will check if any tracked values have changed

--- a/flow-server/src/test/java/com/vaadin/flow/component/AbstractCompositeFieldBindValueTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/AbstractCompositeFieldBindValueTest.java
@@ -74,9 +74,9 @@ class AbstractCompositeFieldBindValueTest extends SignalsUnitTest {
 
         ValueSignal<String> signal = new ValueSignal<>("Hello Cool World");
         field.bindValue(signal, signal::set);
-        // not attached yet, so presentation value not used from the signal
-        assertEquals("", field.start.getValue());
-        assertEquals("", field.rest.getValue());
+        // Probe runs immediately at bind time even when detached
+        assertEquals("Hello", field.start.getValue());
+        assertEquals("Cool World", field.rest.getValue());
 
         // setValue doesn't update the bound signal when detached
         field.setValue("Hey You");
@@ -90,9 +90,9 @@ class AbstractCompositeFieldBindValueTest extends SignalsUnitTest {
 
         ValueSignal<String> signal = new ValueSignal<>("Hello Cool World");
         field.bindValue(signal, signal::set);
-        // not attached yet, so presentation value not used from the signal
-        assertEquals("", field.start.getValue());
-        assertEquals("", field.rest.getValue());
+        // Probe runs immediately at bind time even when detached
+        assertEquals("Hello", field.start.getValue());
+        assertEquals("Cool World", field.rest.getValue());
 
         // setModelValue doesn't update the bound signal when detached
         field.start.setValue("Hey");

--- a/flow-server/src/test/java/com/vaadin/flow/component/AbstractFieldBindValueTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/AbstractFieldBindValueTest.java
@@ -83,9 +83,13 @@ class AbstractFieldBindValueTest extends SignalsUnitTest {
         TestInput input = new TestInput();
         ValueSignal<String> signal = new ValueSignal<>("foo");
         input.bindValue(signal, signal::set);
-        signal.set("bar");
 
-        assertEquals("", input.getValue());
+        // Probe runs immediately at bind time, setting the initial value
+        assertEquals("foo", input.getValue());
+
+        // Signal change while detached is ignored (effect is passivated)
+        signal.set("bar");
+        assertEquals("foo", input.getValue());
     }
 
     @Test
@@ -213,9 +217,10 @@ class AbstractFieldBindValueTest extends SignalsUnitTest {
             counter.incrementAndGet();
         });
 
-        assertEquals(0, counter.get());
+        // Both effects probe immediately at creation time
+        assertEquals(1, counter.get());
         UI.getCurrent().add(input);
-        // effect run once on attach
+        // Nothing changed since probe, so no re-run on attach
         assertEquals(1, counter.get());
 
         input.setValue("bar");

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasPlaceholderBindTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasPlaceholderBindTest.java
@@ -22,7 +22,6 @@ import com.vaadin.flow.signals.BindingActiveException;
 import com.vaadin.flow.signals.local.ValueSignal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -62,10 +61,11 @@ class HasPlaceholderBindTest extends SignalsUnitTest {
         // Not attached yet
         ValueSignal<String> signal = new ValueSignal<>("foo");
         component.bindPlaceholder(signal);
-        // No propagation while detached
-        assertNull(component.getPlaceholder());
+        // Probe runs immediately at bind time even when not attached
+        assertEquals("foo", component.getPlaceholder());
+        // Signal changes while detached are ignored (effect is passivated)
         signal.set("bar");
-        assertNull(component.getPlaceholder());
+        assertEquals("foo", component.getPlaceholder());
     }
 
     @Test
@@ -73,10 +73,12 @@ class HasPlaceholderBindTest extends SignalsUnitTest {
         TestComponent component = new TestComponent();
         ValueSignal<String> signal = new ValueSignal<>("foo");
         component.bindPlaceholder(signal);
-        // Update before attach
+        // Probe applied "foo" immediately
+        assertEquals("foo", component.getPlaceholder());
+        // Update before attach - ignored while detached
         signal.set("bar");
-        assertNull(component.getPlaceholder());
-        // Attach -> latest value is applied
+        assertEquals("foo", component.getPlaceholder());
+        // Attach -> latest value is applied because signal changed since probe
         UI.getCurrent().add(component);
         assertEquals("bar", component.getPlaceholder());
     }

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasSizeBindWidthHeightTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasSizeBindWidthHeightTest.java
@@ -84,9 +84,13 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
         HasSizeComponent component = new HasSizeComponent();
         ValueSignal<String> signal = new ValueSignal<>("200px");
         component.bindWidth(signal);
-        signal.set("300px");
 
-        assertNull(component.getWidth());
+        // Probe runs immediately at bind time even when not attached
+        assertEquals("200px", component.getWidth());
+
+        // Signal changes while detached are ignored
+        signal.set("300px");
+        assertEquals("200px", component.getWidth());
     }
 
     @Test
@@ -258,9 +262,13 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
         HasSizeComponent component = new HasSizeComponent();
         ValueSignal<String> signal = new ValueSignal<>("200px");
         component.bindHeight(signal);
-        signal.set("300px");
 
-        assertNull(component.getHeight());
+        // Probe runs immediately at bind time even when not attached
+        assertEquals("200px", component.getHeight());
+
+        // Signal changes while detached are ignored
+        signal.set("300px");
+        assertEquals("200px", component.getHeight());
     }
 
     @Test
@@ -393,13 +401,13 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
 
         component.bindWidth(signal).onChange(contexts::add);
 
-        // Initial run already happened before onChange was registered
-        assertEquals(0, contexts.size());
+        // onChange should have been called once initially
+        assertEquals(1, contexts.size());
 
         signal.set("300px");
 
-        assertEquals(1, contexts.size());
-        BindingContext<?> ctx = contexts.get(0);
+        assertEquals(2, contexts.size());
+        BindingContext<?> ctx = contexts.get(1);
         assertFalse(ctx.isInitialRun());
         assertEquals("200px", ctx.getOldValue());
         assertEquals("300px", ctx.getNewValue());
@@ -416,13 +424,13 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
 
         component.bindHeight(signal).onChange(contexts::add);
 
-        // Initial run already happened before onChange was registered
-        assertEquals(0, contexts.size());
+        // onChange should have been called once initially
+        assertEquals(1, contexts.size());
 
         signal.set("300px");
 
-        assertEquals(1, contexts.size());
-        BindingContext<?> ctx = contexts.get(0);
+        assertEquals(2, contexts.size());
+        BindingContext<?> ctx = contexts.get(1);
         assertFalse(ctx.isInitialRun());
         assertEquals("200px", ctx.getOldValue());
         assertEquals("300px", ctx.getNewValue());

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasValueBindReadOnlyTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasValueBindReadOnlyTest.java
@@ -81,9 +81,13 @@ class HasValueBindReadOnlyTest extends SignalsUnitTest {
         TestComponent component = new TestComponent();
         ValueSignal<Boolean> signal = new ValueSignal<>(true);
         component.bindReadOnly(signal);
-        signal.set(false);
 
-        assertFalse(component.isReadOnly());
+        // Probe runs immediately at bind time even when not attached
+        assertTrue(component.isReadOnly());
+
+        // Signal changes while detached are ignored
+        signal.set(false);
+        assertTrue(component.isReadOnly());
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasValueBindRequiredIndicatorVisibleTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasValueBindRequiredIndicatorVisibleTest.java
@@ -79,9 +79,13 @@ class HasValueBindRequiredIndicatorVisibleTest extends SignalsUnitTest {
         TestComponent component = new TestComponent();
         ValueSignal<Boolean> signal = new ValueSignal<>(true);
         component.bindRequiredIndicatorVisible(signal);
-        signal.set(false);
 
-        assertFalse(component.isRequiredIndicatorVisible());
+        // Probe runs immediately at bind time even when not attached
+        assertTrue(component.isRequiredIndicatorVisible());
+
+        // Signal changes while detached are ignored
+        signal.set(false);
+        assertTrue(component.isRequiredIndicatorVisible());
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/component/HtmlBindHtmlContentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HtmlBindHtmlContentTest.java
@@ -81,11 +81,14 @@ class HtmlBindHtmlContentTest extends SignalsUnitTest {
                 "<div id='b'>after</div>");
         html.bindHtmlContent(signal);
 
-        // change ignored while not attached
-        signal.set("<div id='c'>ignored</div>");
+        // Probe runs immediately at bind time, applying the signal value
+        assertEquals("after", html.getInnerHtml());
+        assertEquals("b", html.getElement().getAttribute("id"));
 
-        assertEquals("init", html.getInnerHtml());
-        assertEquals("a", html.getElement().getAttribute("id"));
+        // Changes while detached are ignored (effect is passivated)
+        signal.set("<div id='c'>ignored</div>");
+        assertEquals("after", html.getInnerHtml());
+        assertEquals("b", html.getElement().getAttribute("id"));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/component/SignalPropertySupportTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/SignalPropertySupportTest.java
@@ -110,7 +110,7 @@ class SignalPropertySupportTest {
     }
 
     @Test
-    public void get_boundButNotAttached_valueNotSetInitially() {
+    public void get_boundButNotAttached_valueSetInitially() {
         var component = new TestComponent();
 
         ValueSignal<String> signal = new ValueSignal<>("foo");
@@ -120,8 +120,9 @@ class SignalPropertySupportTest {
                 });
         signalPropertySupport.bind(signal);
 
-        assertNull(signalPropertySupport.get());
-        assertEquals(0, callCount.get());
+        // Probe runs immediately at bind time even when not attached
+        assertEquals("foo", signalPropertySupport.get());
+        assertEquals(1, callCount.get());
     }
 
     @Test
@@ -181,7 +182,8 @@ class SignalPropertySupportTest {
 
         assertThrows(BindingActiveException.class,
                 () -> signalPropertySupport.set("bar"));
-        assertEquals(0, callCount.get());
+        // Probe ran once at bind time
+        assertEquals(1, callCount.get());
     }
 
     @Test
@@ -269,13 +271,13 @@ class SignalPropertySupportTest {
 
         signalPropertySupport.bind(signal).onChange(contexts::add);
 
-        // Initial run already happened before onChange was registered
-        assertEquals(0, contexts.size());
+        // onChange run once initially
+        assertEquals(1, contexts.size());
 
         signal.set("updated");
 
-        assertEquals(1, contexts.size());
-        BindingContext<String> ctx = contexts.get(0);
+        assertEquals(2, contexts.size());
+        BindingContext<String> ctx = contexts.get(1);
         assertFalse(ctx.isInitialRun());
         assertEquals("initial", ctx.getOldValue());
         assertEquals("updated", ctx.getNewValue());
@@ -293,15 +295,43 @@ class SignalPropertySupportTest {
         List<BindingContext<String>> contexts = new ArrayList<>();
 
         signalPropertySupport.bind(signal).onChange(contexts::add);
-        assertEquals(0, contexts.size());
+        // Probe ran at bind time; onChange run initially
+        assertEquals(1, contexts.size());
 
-        // Attach — effect runs and fires initial callback
+        // Attach — nothing changed since probe, no additional callback
         UI.getCurrent().add(component);
+
+        assertEquals(1, contexts.size());
+    }
+
+    @Test
+    public void bind_onChange_bindThenChangeAndAttach() {
+        var component = new TestComponent();
+
+        ValueSignal<String> signal = new ValueSignal<>("initial");
+        SignalPropertySupport<String> signalPropertySupport = SignalPropertySupport
+                .create(component, value -> {
+                });
+        List<BindingContext<String>> contexts = new ArrayList<>();
+        signalPropertySupport.bind(signal).onChange(contexts::add);
 
         assertEquals(1, contexts.size());
         BindingContext<String> initialCtx = contexts.get(0);
         assertTrue(initialCtx.isInitialRun());
+        assertEquals("initial", initialCtx.getOldValue());
         assertEquals("initial", initialCtx.getNewValue());
+
+        // Change value before attach
+        signal.set("updated");
+
+        // Attach — changed since probe, run onChange
+        UI.getCurrent().add(component);
+
+        assertEquals(2, contexts.size());
+        initialCtx = contexts.get(1);
+        assertTrue(initialCtx.isInitialRun());
+        assertEquals("initial", initialCtx.getOldValue());
+        assertEquals("updated", initialCtx.getNewValue());
     }
 
     @Tag("div")

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ClassListGroupBindTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ClassListGroupBindTest.java
@@ -238,13 +238,13 @@ class ClassListGroupBindTest extends SignalsUnitTest {
 
         element.getClassList().bind(signal).onChange(contexts::add);
 
-        // Initial run already happened before onChange was registered
-        assertEquals(0, contexts.size());
+        // onChange should have been called once initially
+        assertEquals(1, contexts.size());
 
         signal.set(List.of("c"));
 
-        assertEquals(1, contexts.size());
-        BindingContext<List<String>> ctx = contexts.get(0);
+        assertEquals(2, contexts.size());
+        BindingContext<List<String>> ctx = contexts.get(1);
         assertFalse(ctx.isInitialRun());
         assertEquals(List.of("a", "b"), ctx.getOldValue());
         assertEquals(List.of("c"), ctx.getNewValue());

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementBindAttributeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementBindAttributeTest.java
@@ -105,7 +105,12 @@ class ElementBindAttributeTest {
 
         component.getElement().bindAttribute("foo", signal);
 
-        assertNull(component.getElement().getAttribute("foo"));
+        // Probe runs immediately at bind time even when not attached
+        assertEquals("bar", component.getElement().getAttribute("foo"));
+
+        // Signal changes while detached are ignored (effect is passivated)
+        signal.set("changed");
+        assertEquals("bar", component.getElement().getAttribute("foo"));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementBindPropertyTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementBindPropertyTest.java
@@ -56,7 +56,6 @@ import com.vaadin.tests.util.MockUI;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -407,7 +406,12 @@ class ElementBindPropertyTest {
 
         component.getElement().bindProperty("foo", signal, signal::set);
 
-        assertNull(component.getElement().getProperty("foo"));
+        // Probe runs immediately at bind time even when not attached
+        assertTrue(component.getElement().getProperty("foo", false));
+
+        // Changes while detached are ignored
+        signal.set(false);
+        assertTrue(component.getElement().getProperty("foo", false));
     }
 
     @Test
@@ -472,7 +476,14 @@ class ElementBindPropertyTest {
 
         component.getElement().bindProperty("foo", signal, signal::set);
 
-        assertNull(component.getElement().getProperty("foo"));
+        // Probe runs immediately at bind time even when not attached
+        assertEquals(1.0d, component.getElement().getProperty("foo", -1.0d),
+                0.0d);
+
+        // Changes while detached are ignored
+        signal.set(2.0d);
+        assertEquals(1.0d, component.getElement().getProperty("foo", -1.0d),
+                0.0d);
     }
 
     @Test
@@ -542,7 +553,12 @@ class ElementBindPropertyTest {
 
         component.getElement().bindProperty("foo", signal, signal::set);
 
-        assertNull(component.getElement().getProperty("foo"));
+        // Probe runs immediately at bind time even when not attached
+        assertEquals(1, component.getElement().getProperty("foo", -1));
+
+        // Changes while detached are ignored
+        signal.set(2);
+        assertEquals(1, component.getElement().getProperty("foo", -1));
     }
 
     @Test
@@ -607,7 +623,12 @@ class ElementBindPropertyTest {
 
         component.getElement().bindProperty("foo", signal, signal::set);
 
-        assertNull(component.getElement().getProperty("foo", null));
+        // Probe runs immediately at bind time even when not attached
+        assertEquals("bar", component.getElement().getProperty("foo", null));
+
+        // Changes while detached are ignored
+        signal.set("changed");
+        assertEquals("bar", component.getElement().getProperty("foo", null));
     }
 
     @Test
@@ -673,11 +694,18 @@ class ElementBindPropertyTest {
     public void bindBeanProperty_componentNotAttached_bindingIgnored() {
         TestComponent component = new TestComponent();
 
-        ValueSignal<JacksonUtilsTest.Person> signal = new ValueSignal<>(
-                createJohn());
+        JacksonUtilsTest.Person john = createJohn();
+        ValueSignal<JacksonUtilsTest.Person> signal = new ValueSignal<>(john);
         component.getElement().bindProperty("foo", signal, signal::set);
 
-        assertNull(component.getElement().getProperty("foo", null));
+        // Probe runs immediately at bind time even when not attached
+        assertPersonEquals(john,
+                (JsonNode) component.getElement().getPropertyRaw("foo"));
+
+        // Changes while detached are ignored
+        signal.set(createJack());
+        assertPersonEquals(john,
+                (JsonNode) component.getElement().getPropertyRaw("foo"));
     }
 
     @Test
@@ -750,7 +778,16 @@ class ElementBindPropertyTest {
                 Arrays.asList(createJohn(), createJack()));
         component.getElement().bindProperty("foo", signal, null);
 
-        assertNull(component.getElement().getProperty("foo", null));
+        // Probe runs immediately at bind time even when not attached
+        assertEquals("John",
+                getFromList(component, "foo", 0).get("name").asString());
+        assertEquals("Jack",
+                getFromList(component, "foo", 1).get("name").asString());
+
+        // Changes while detached are ignored
+        signal.set(Arrays.asList(createJack(), createJohn()));
+        assertEquals("John",
+                getFromList(component, "foo", 0).get("name").asString());
     }
 
     @Test
@@ -840,7 +877,16 @@ class ElementBindPropertyTest {
                 createPersonMap(createJohn(), createJack()));
         component.getElement().bindProperty("foo", signal, null);
 
-        assertNull(component.getElement().getProperty("foo", null));
+        // Probe runs immediately at bind time even when not attached
+        assertEquals("John",
+                getFromMap(component, "foo", "0").get("name").asString());
+        assertEquals("Jack",
+                getFromMap(component, "foo", "1").get("name").asString());
+
+        // Changes while detached are ignored
+        signal.set(createPersonMap(createJack(), createJohn()));
+        assertEquals("John",
+                getFromMap(component, "foo", "0").get("name").asString());
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementBindTextTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementBindTextTest.java
@@ -207,7 +207,12 @@ class ElementBindTextTest {
         ValueSignal<String> signal = new ValueSignal<>("text");
         element.bindText(signal);
 
-        assertEquals("", element.getText());
+        // Probe runs immediately at bind time even when not attached
+        assertEquals("text", element.getText());
+
+        // Signal changes while detached are ignored (effect is passivated)
+        signal.set("changed");
+        assertEquals("text", element.getText());
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementEffectTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementEffectTest.java
@@ -232,17 +232,16 @@ class ElementEffectTest {
         ValueSignal<String> signal = new ValueSignal<>("initial");
         List<BindingContext<String>> contexts = new ArrayList<>();
 
-        // onChange is registered after bind, so the initial execution is missed
+        // onChange is registered after bind, executed once immediately
         span.bindText(signal).onChange(contexts::add);
 
-        // No callbacks yet since initial run already happened before onChange
-        assertEquals(0, contexts.size());
+        assertEquals(1, contexts.size());
 
         // Trigger a subsequent update
         signal.set("updated");
 
-        assertEquals(1, contexts.size());
-        BindingContext<String> ctx = contexts.get(0);
+        assertEquals(2, contexts.size());
+        BindingContext<String> ctx = contexts.get(1);
         assertFalse(ctx.isInitialRun());
         assertEquals("initial", ctx.getOldValue());
         assertEquals("updated", ctx.getNewValue());
@@ -251,8 +250,8 @@ class ElementEffectTest {
         // Trigger another update and verify context tracks correctly
         signal.set("final");
 
-        assertEquals(2, contexts.size());
-        BindingContext<String> ctx2 = contexts.get(1);
+        assertEquals(3, contexts.size());
+        BindingContext<String> ctx2 = contexts.get(2);
         assertFalse(ctx2.isInitialRun());
         assertEquals("updated", ctx2.getOldValue());
         assertEquals("final", ctx2.getNewValue());
@@ -268,26 +267,106 @@ class ElementEffectTest {
         ValueSignal<String> signal = new ValueSignal<>("initial");
         List<BindingContext<String>> contexts = new ArrayList<>();
 
-        // Bind before attaching to UI
+        // Bind before attaching to UI: the effect runs immediately as a probe,
+        // setting the initial text. The onChange callback fire for the initial
+        // run.
         span.bindText(signal).onChange(contexts::add);
-        assertEquals(0, contexts.size());
+        assertEquals(1, contexts.size(), "onChange should fire once initially");
+        BindingContext<String> ctx = contexts.get(0);
+        assertTrue(ctx.isInitialRun());
+        assertEquals("initial", ctx.getOldValue());
+        assertEquals("initial", ctx.getNewValue());
 
-        // Attach — effect runs and fires initial callback
+        // Attach with no signal change: no re-run, no onChange callback
         ui.getElement().appendChild(span);
-
-        assertEquals(1, contexts.size());
-        BindingContext<String> initialCtx = contexts.get(0);
-        assertTrue(initialCtx.isInitialRun());
-        assertEquals("initial", initialCtx.getNewValue());
+        assertEquals(1, contexts.size(),
+                "onChange should not fire on attach when nothing changed since probe");
 
         // Trigger an update after attach
         signal.set("updated");
 
         assertEquals(2, contexts.size());
-        BindingContext<String> ctx = contexts.get(1);
+        ctx = contexts.get(1);
         assertFalse(ctx.isInitialRun());
         assertEquals("initial", ctx.getOldValue());
         assertEquals("updated", ctx.getNewValue());
+    }
+
+    @Test
+    public void signalBinding_onChange_bindThenChangeAndAttach() {
+        CurrentInstance.clearAll();
+        MockUI ui = new MockUI();
+        Element span = new Element("span");
+
+        ValueSignal<String> signal = new ValueSignal<>("initial");
+        List<BindingContext<String>> contexts = new ArrayList<>();
+
+        span.bindText(signal).onChange(contexts::add);
+        assertEquals(1, contexts.size(),
+                "onChange should fire once immediately");
+
+        // Trigger an update after attach
+        signal.set("updated");
+
+        // Attach with signal change: run onChange callback with
+        // isInitialRun=true
+        ui.getElement().appendChild(span);
+
+        assertEquals(2, contexts.size(),
+                "onChange should fire on attach when changed since probe");
+        assertEquals(2, contexts.size());
+        BindingContext<String> ctx = contexts.get(1);
+        assertTrue(ctx.isInitialRun());
+        assertEquals("initial", ctx.getOldValue());
+        assertEquals("updated", ctx.getNewValue());
+    }
+
+    @Test
+    public void signalBinding_onChange_calledImmediatelyInitially() {
+        CurrentInstance.clearAll();
+        MockUI ui = new MockUI();
+        Element span = new Element("span");
+        ui.getElement().appendChild(span);
+
+        ValueSignal<String> signal = new ValueSignal<>("initial");
+        List<BindingContext<String>> contexts = new ArrayList<>();
+
+        // Bind before attaching to UI
+        // The onChange callback fire immediately for the initial run
+        var signalBinding = span.bindText(signal).onChange(contexts::add);
+        assertEquals(1, contexts.size(), "onChange should fire once initially");
+        BindingContext<String> ctx = contexts.get(0);
+        assertTrue(ctx.isInitialRun());
+        assertEquals("initial", ctx.getOldValue());
+        assertEquals("initial", ctx.getNewValue());
+
+        // The second onChange callback fire immediately for the initial run
+        signalBinding.onChange(contexts::add);
+        assertEquals(2, contexts.size(),
+                "another onChange should fire once initially");
+        ctx = contexts.get(1);
+        assertTrue(ctx.isInitialRun());
+        assertEquals("initial", ctx.getOldValue());
+        assertEquals("initial", ctx.getNewValue());
+
+        // Trigger an update
+        signal.set("updated");
+
+        // two onChange callbacks should fire for the update
+        assertEquals(4, contexts.size());
+        ctx = contexts.get(2);
+        assertFalse(ctx.isInitialRun());
+        assertEquals("initial", ctx.getOldValue());
+        assertEquals("updated", ctx.getNewValue());
+        ctx = contexts.get(3);
+        assertFalse(ctx.isInitialRun());
+        assertEquals("initial", ctx.getOldValue());
+        assertEquals("updated", ctx.getNewValue());
+
+        // The new onChange callback doesn't fire immediately for the
+        // non-initial run
+        signalBinding.onChange(contexts::add);
+        assertEquals(4, contexts.size());
     }
 
     @Test
@@ -430,6 +509,34 @@ class ElementEffectTest {
     }
 
     @Test
+    public void effect_notAttached_effectRunsImmediatelyAsProbe() {
+        CurrentInstance.clearAll();
+        TestComponent component = new TestComponent();
+        ValueSignal<String> signal = new ValueSignal<>("initial");
+        AtomicInteger count = new AtomicInteger();
+
+        Signal.effect(component, () -> {
+            signal.get();
+            count.incrementAndGet();
+        });
+
+        assertEquals(1, count.get(),
+                "Effect should run once immediately as a probe at construction even when not attached");
+    }
+
+    @Test
+    public void effect_notAttached_noSignalRead_throwsEagerly() {
+        CurrentInstance.clearAll();
+        TestComponent component = new TestComponent();
+
+        assertThrows(com.vaadin.flow.signals.MissingSignalUsageException.class,
+                () -> Signal.effect(component, () -> {
+                    // no signal read
+                }),
+                "MissingSignalUsageException should be thrown eagerly at construction when no signal is read");
+    }
+
+    @Test
     public void effect_componentAttachedAndDetached_effectEnabledAndDisabled() {
         CurrentInstance.clearAll();
         TestComponent component = new TestComponent();
@@ -440,34 +547,35 @@ class ElementEffectTest {
             count.incrementAndGet();
         });
 
-        assertEquals(0, count.get(),
-                "Effect should not be run until component is attached");
+        assertEquals(1, count.get(),
+                "Effect should be run once immediately as a probe even before component is attached");
 
         signal.set("test");
-        assertEquals(0, count.get(),
-                "Effect should not be run until component is attached even after signal value change");
+        assertEquals(1, count.get(),
+                "Effect should not be run while detached even after signal value change");
 
         MockUI ui = new MockUI();
         ui.add(component);
 
-        assertEquals(1, count.get(),
-                "Effect should be run once component is attached");
+        assertEquals(2, count.get(),
+                "Effect should re-run on attach because signal changed while detached");
 
         signal.set("test2");
-        assertEquals(2, count.get(),
-                "Effect should be run when signal value is chaged");
+        assertEquals(3, count.get(),
+                "Effect should be run when signal value is changed");
 
         ui.remove(component);
 
         signal.set("test3");
-        assertEquals(2, count.get(), "Effect should not be run after detach");
+        assertEquals(3, count.get(), "Effect should not be run after detach");
 
         ui.add(component);
-        assertEquals(3, count.get(), "Effect should be run after attach");
+        assertEquals(4, count.get(),
+                "Effect should re-run on reattach because signal changed while detached");
 
         registration.remove();
         signal.set("test4");
-        assertEquals(3, count.get(), "Effect should not be run after remove");
+        assertEquals(4, count.get(), "Effect should not be run after remove");
     }
 
     @Test
@@ -481,9 +589,13 @@ class ElementEffectTest {
             count.incrementAndGet();
         });
 
+        assertEquals(1, count.get(),
+                "Effect should run once immediately as a probe at construction");
+
         MockUI ui = new MockUI();
         ui.add(component);
-        assertEquals(1, count.get(), "Effect should run on attach");
+        assertEquals(1, count.get(),
+                "Effect should not re-run on attach when nothing changed since probe");
 
         ui.remove(component);
         ui.add(component);

--- a/flow-server/src/test/java/com/vaadin/flow/dom/StyleBindTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/StyleBindTest.java
@@ -173,12 +173,12 @@ class StyleBindTest {
         // present
         assertTrue(names.contains("margin-bottom"));
 
-        // Detach before any applying for c -> bind while detached -> no value
-        // applied yet, get returns null
+        // Detach before binding c -> probe runs immediately at bind time even
+        // while detached, so value IS applied right away
         ValueSignal<String> c = new ValueSignal<>("5px");
         UI.getCurrent().getElement().removeChild(element);
         element.getStyle().bind("padding-top", c);
-        assertNull(element.getStyle().get("paddingTop"));
+        assertEquals("5px", element.getStyle().get("paddingTop"));
         names = element.getStyle().getNames().collect(Collectors.toSet());
         // The current implementation records the binding name even before first
         // attach
@@ -220,13 +220,13 @@ class StyleBindTest {
         element.getStyle().bind("background-color", signal)
                 .onChange(contexts::add);
 
-        // Initial run already happened before onChange was registered
-        assertEquals(0, contexts.size());
+        // onChange should have been called once initially
+        assertEquals(1, contexts.size());
 
         signal.set("blue");
 
-        assertEquals(1, contexts.size());
-        BindingContext<?> ctx = contexts.get(0);
+        assertEquals(2, contexts.size());
+        BindingContext<?> ctx = contexts.get(1);
         assertFalse(ctx.isInitialRun());
         assertEquals("red", ctx.getOldValue());
         assertEquals("blue", ctx.getNewValue());

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ThemeListGroupBindTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ThemeListGroupBindTest.java
@@ -219,13 +219,13 @@ class ThemeListGroupBindTest extends SignalsUnitTest {
 
         component.getThemeNames().bind(signal).onChange(contexts::add);
 
-        // Initial run already happened before onChange was registered
-        assertEquals(0, contexts.size());
+        // onChange should have been called once initially
+        assertEquals(1, contexts.size());
 
         signal.set(List.of("c"));
 
-        assertEquals(1, contexts.size());
-        BindingContext<List<String>> ctx = contexts.get(0);
+        assertEquals(2, contexts.size());
+        BindingContext<List<String>> ctx = contexts.get(1);
         assertFalse(ctx.isInitialRun());
         assertEquals(List.of("a", "b"), ctx.getOldValue());
         assertEquals(List.of("c"), ctx.getNewValue());

--- a/flow-server/src/test/java/com/vaadin/flow/signals/impl/EffectTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/impl/EffectTest.java
@@ -549,6 +549,42 @@ public class EffectTest extends SignalTestBase {
     }
 
     @Test
+    void setDispatcher_changesDispatcherUsedForSubsequentRuns() {
+        SharedValueSignal<String> signal = new SharedValueSignal<>("initial");
+        ArrayList<String> dispatcherLog = new ArrayList<>();
+        ArrayList<String> invocations = new ArrayList<>();
+
+        Effect effect = new Effect(() -> {
+            invocations.add(signal.get());
+        }, Runnable::run);
+        assertEquals(List.of("initial"), invocations);
+
+        effect.passivate();
+
+        // Switch to a dispatcher that records calls
+        effect.setDispatcher(command -> {
+            dispatcherLog.add("dispatched");
+            command.run();
+        });
+
+        signal.set("updated");
+        effect.activate();
+        // activate() calls revalidate() directly (not via the dispatcher)
+        // when there are changes, so the dispatcher is not invoked here
+        assertEquals(List.of("initial", "updated"), invocations,
+                "Effect should re-run with new value after setDispatcher + activate");
+        assertEquals(0, dispatcherLog.size(),
+                "Dispatcher is not used by activate() directly");
+
+        // The new dispatcher IS used for subsequent signal change notifications
+        signal.set("final");
+        assertEquals(List.of("initial", "updated", "final"), invocations,
+                "Effect should continue using the new dispatcher");
+        assertEquals(1, dispatcherLog.size(),
+                "New dispatcher should have been used for signal change");
+    }
+
+    @Test
     void passivateActivate_noChanges_callbackNotReRun() {
         SharedValueSignal<String> signal = new SharedValueSignal<>("initial");
         ArrayList<String> invocations = new ArrayList<>();

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ElementPropertySignalBindingView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ElementPropertySignalBindingView.java
@@ -49,8 +49,6 @@ public class ElementPropertySignalBindingView extends AbstractDivView {
         Signal.effect(this, () -> {
             signalValue.setText("Signal value: " + signal.get());
         });
-        target.getElement().bindProperty(TEST_PROPERTY_NAME, signal,
-                signal::set);
 
         target.getElement().addPropertyChangeListener(TEST_PROPERTY_NAME,
                 "change", event -> {
@@ -60,6 +58,9 @@ public class ElementPropertySignalBindingView extends AbstractDivView {
                     listenerCountDiv.setText(String
                             .valueOf(listenerCallCounter.incrementAndGet()));
                 });
+
+        target.getElement().bindProperty(TEST_PROPERTY_NAME, signal,
+                signal::set);
 
         // Attempt to update a property value from client to a computed signal
         // should throw an exception


### PR DESCRIPTION
ElementEffect is executed immediately once when created. This affects all Signal.effect calls with an owner component. Immediate execution ensures that exceptions can be thrown eagerly when e.g. bindText(signal) is called, not later when component is attached.

Fixes #23813
