### PR TITLE
test: Migrate flow-plugins tests to JUnit 6 (#23847) (CP: 25.1)

### DIFF
--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/TestUtils.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/TestUtils.java
@@ -27,7 +27,7 @@ import tools.jackson.databind.node.ObjectNode;
 
 import com.vaadin.flow.internal.JacksonUtils;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Shared code to use in the unit tests.
@@ -77,9 +77,9 @@ public final class TestUtils {
     public static URL getTestResource(String resourceName) {
         URL resourceUrl = TestUtils.class.getClassLoader()
                 .getResource(resourceName);
-        assertNotNull(String.format(
+        assertNotNull(resourceUrl, String.format(
                 "Expect the test resource to be present in test resource folder with name = '%s'",
-                resourceName), resourceUrl);
+                resourceName));
         return resourceUrl;
     }
 

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/ArtifactMatcherTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/ArtifactMatcherTest.java
@@ -18,13 +18,16 @@ package com.vaadin.flow.plugin.maven;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.artifact.handler.DefaultArtifactHandler;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ArtifactMatcherTest {
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ArtifactMatcherTest {
 
     @Test
-    public void setGroupId_wildcard_throwIfInInvalidPosition() {
+    void setGroupId_wildcard_throwIfInInvalidPosition() {
         FrontendScannerConfig.ArtifactMatcher matcher = new FrontendScannerConfig.ArtifactMatcher();
         matcher.setGroupId(null);
         matcher.setGroupId("");
@@ -33,24 +36,24 @@ public class ArtifactMatcherTest {
         matcher.setGroupId("*.vaadin");
         matcher.setGroupId("com.vaadin.*");
         matcher.setGroupId("*.vaadin.*");
-        Assert.assertThrows(IllegalArgumentException.class,
+        assertThrows(IllegalArgumentException.class,
                 () -> matcher.setGroupId("com.*.vaadin"));
-        Assert.assertThrows(IllegalArgumentException.class,
+        assertThrows(IllegalArgumentException.class,
                 () -> matcher.setGroupId("c*.vaadi*n"));
-        Assert.assertThrows(IllegalArgumentException.class,
+        assertThrows(IllegalArgumentException.class,
                 () -> matcher.setGroupId("*.vaa*din.*"));
-        Assert.assertThrows(IllegalArgumentException.class,
+        assertThrows(IllegalArgumentException.class,
                 () -> matcher.setGroupId("*.vaa*din"));
-        Assert.assertThrows(IllegalArgumentException.class,
+        assertThrows(IllegalArgumentException.class,
                 () -> matcher.setGroupId("**.vaadin"));
-        Assert.assertThrows(IllegalArgumentException.class,
+        assertThrows(IllegalArgumentException.class,
                 () -> matcher.setGroupId("com.vaa*din*"));
-        Assert.assertThrows(IllegalArgumentException.class,
+        assertThrows(IllegalArgumentException.class,
                 () -> matcher.setGroupId("com.vaadi**"));
     }
 
     @Test
-    public void setArtifactId_wildcard_throwIfInInvalidPosition() {
+    void setArtifactId_wildcard_throwIfInInvalidPosition() {
         FrontendScannerConfig.ArtifactMatcher matcher = new FrontendScannerConfig.ArtifactMatcher();
         matcher.setArtifactId(null);
         matcher.setArtifactId("");
@@ -59,221 +62,214 @@ public class ArtifactMatcherTest {
         matcher.setArtifactId("*vaadin");
         matcher.setArtifactId("vaadin*");
         matcher.setArtifactId("*vaadin*");
-        Assert.assertThrows(IllegalArgumentException.class,
+        assertThrows(IllegalArgumentException.class,
                 () -> matcher.setGroupId("va*din"));
-        Assert.assertThrows(IllegalArgumentException.class,
+        assertThrows(IllegalArgumentException.class,
                 () -> matcher.setGroupId("v*di*n"));
-        Assert.assertThrows(IllegalArgumentException.class,
+        assertThrows(IllegalArgumentException.class,
                 () -> matcher.setGroupId("v*d*i*n"));
-        Assert.assertThrows(IllegalArgumentException.class,
+        assertThrows(IllegalArgumentException.class,
                 () -> matcher.setGroupId("*di*n"));
-        Assert.assertThrows(IllegalArgumentException.class,
+        assertThrows(IllegalArgumentException.class,
                 () -> matcher.setGroupId("**din"));
-        Assert.assertThrows(IllegalArgumentException.class,
+        assertThrows(IllegalArgumentException.class,
                 () -> matcher.setGroupId("vadi**"));
-        Assert.assertThrows(IllegalArgumentException.class,
+        assertThrows(IllegalArgumentException.class,
                 () -> matcher.setGroupId("vadi*n*"));
     }
 
     @Test
-    public void matches_matchEverything_returnsTrue() {
+    void matches_matchEverything_returnsTrue() {
         Artifact artifact = fromString(
-                "com.vaadin:vaadin:jar:25.1-SNAPSHOT:compile");
-        Assert.assertTrue("Unspecified groups and artifacts",
-                new FrontendScannerConfig.ArtifactMatcher().matches(artifact));
-        Assert.assertTrue("Empty groups and artifacts",
-                new FrontendScannerConfig.ArtifactMatcher("", "")
-                        .matches(artifact));
-        Assert.assertTrue("All groups and artifacts",
-                new FrontendScannerConfig.ArtifactMatcher("*", "*")
-                        .matches(artifact));
-        Assert.assertTrue("All groups, unspecified artifacts",
-                new FrontendScannerConfig.ArtifactMatcher("*", null)
-                        .matches(artifact));
-        Assert.assertTrue("Unspecified groups, all artifacts",
-                new FrontendScannerConfig.ArtifactMatcher(null, "*")
-                        .matches(artifact));
-        Assert.assertTrue("Blank groups, all artifacts",
-                new FrontendScannerConfig.ArtifactMatcher("", "*")
-                        .matches(artifact));
-        Assert.assertTrue("All groups, unspecified artifacts",
-                new FrontendScannerConfig.ArtifactMatcher("*", null)
-                        .matches(artifact));
-        Assert.assertTrue("Unspecified groups, all artifacts",
-                new FrontendScannerConfig.ArtifactMatcher(null, "*")
-                        .matches(artifact));
-        Assert.assertTrue("Unspecified groups, blank artifacts",
-                new FrontendScannerConfig.ArtifactMatcher(null, "")
-                        .matches(artifact));
+                "com.vaadin:vaadin:jar:999.99-SNAPSHOT:compile");
+        assertTrue(
+                new FrontendScannerConfig.ArtifactMatcher().matches(artifact),
+                "Unspecified groups and artifacts");
+        assertTrue(new FrontendScannerConfig.ArtifactMatcher("", "")
+                .matches(artifact), "Empty groups and artifacts");
+        assertTrue(new FrontendScannerConfig.ArtifactMatcher("*", "*")
+                .matches(artifact), "All groups and artifacts");
+        assertTrue(new FrontendScannerConfig.ArtifactMatcher("*", null)
+                .matches(artifact), "All groups, unspecified artifacts");
+        assertTrue(new FrontendScannerConfig.ArtifactMatcher(null, "*")
+                .matches(artifact), "Unspecified groups, all artifacts");
+        assertTrue(new FrontendScannerConfig.ArtifactMatcher("", "*")
+                .matches(artifact), "Blank groups, all artifacts");
+        assertTrue(new FrontendScannerConfig.ArtifactMatcher("*", null)
+                .matches(artifact), "All groups, unspecified artifacts");
+        assertTrue(new FrontendScannerConfig.ArtifactMatcher(null, "*")
+                .matches(artifact), "Unspecified groups, all artifacts");
+        assertTrue(new FrontendScannerConfig.ArtifactMatcher(null, "")
+                .matches(artifact), "Unspecified groups, blank artifacts");
     }
 
     @Test
-    public void matches_exactGroup() {
+    void matches_exactGroup() {
         FrontendScannerConfig.ArtifactMatcher matcher = new FrontendScannerConfig.ArtifactMatcher(
                 "com.vaadin", null);
-        Assert.assertTrue(matcher.matches(
-                fromString("com.vaadin:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertTrue(matcher.matches(fromString(
-                "com.vaadin:flow-server:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertFalse(matcher.matches(fromString(
-                "com.vaadin.demo:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertFalse(matcher.matches(fromString(
-                "org.com.vaadin.demo:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertFalse(matcher.matches(
-                fromString("com.vaadindemo:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertFalse(matcher.matches(
-                fromString("org.example:vaadin:jar:25.1-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(
+                fromString("com.vaadin:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(fromString(
+                "com.vaadin:flow-server:jar:999.99-SNAPSHOT:compile")));
+        assertFalse(matcher.matches(fromString(
+                "com.vaadin.demo:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertFalse(matcher.matches(fromString(
+                "org.com.vaadin.demo:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertFalse(matcher.matches(fromString(
+                "com.vaadindemo:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertFalse(matcher.matches(
+                fromString("org.example:vaadin:jar:999.99-SNAPSHOT:compile")));
     }
 
     @Test
-    public void matches_wildcardGroup() {
+    void matches_wildcardGroup() {
         FrontendScannerConfig.ArtifactMatcher matcher = new FrontendScannerConfig.ArtifactMatcher(
                 "com.vaadin.*", null);
-        Assert.assertTrue(matcher.matches(fromString(
-                "com.vaadin.example:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertTrue(matcher.matches(fromString(
-                "com.vaadin.demo:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertTrue(matcher.matches(fromString(
-                "com.vaadin.demo.a:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertFalse(matcher.matches(
-                fromString("com.vaadin:vaadin:jar:25.1-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(fromString(
+                "com.vaadin.example:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(fromString(
+                "com.vaadin.demo:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(fromString(
+                "com.vaadin.demo.a:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertFalse(matcher.matches(
+                fromString("com.vaadin:vaadin:jar:999.99-SNAPSHOT:compile")));
 
         matcher.setGroupId("*.vaadin");
-        Assert.assertTrue(matcher.matches(
-                fromString("com.vaadin:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertTrue(matcher.matches(fromString(
-                "com.example.vaadin:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertTrue(matcher.matches(
-                fromString(".vaadin:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertFalse(matcher.matches(
-                fromString("vaadin:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertFalse(matcher.matches(
-                fromString("com.vaadindemo:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertFalse(matcher.matches(fromString(
-                "com.vaadin.example:vaadin:jar:25.1-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(
+                fromString("com.vaadin:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(fromString(
+                "com.example.vaadin:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(
+                fromString(".vaadin:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertFalse(matcher.matches(
+                fromString("vaadin:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertFalse(matcher.matches(fromString(
+                "com.vaadindemo:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertFalse(matcher.matches(fromString(
+                "com.vaadin.example:vaadin:jar:999.99-SNAPSHOT:compile")));
 
         matcher.setGroupId("*vaadin*");
-        Assert.assertTrue(matcher.matches(fromString(
-                "com.vaadin.example:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertTrue(matcher.matches(fromString(
-                "com.vaadin.demo:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertTrue(matcher.matches(fromString(
-                "com.vaadin.demo.a:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertTrue(matcher.matches(
-                fromString("com.vaadin:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertTrue(matcher.matches(
-                fromString("com.vaadin:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertTrue(matcher.matches(fromString(
-                "com.example.vaadin:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertTrue(matcher.matches(
-                fromString(".vaadin:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertTrue(matcher.matches(
-                fromString("vaadin:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertTrue(matcher.matches(
-                fromString("com.vaadindemo:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertTrue(matcher.matches(fromString(
-                "com.vaadin.example:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertFalse(matcher.matches(
-                fromString("com.example:vaadin:jar:25.1-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(fromString(
+                "com.vaadin.example:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(fromString(
+                "com.vaadin.demo:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(fromString(
+                "com.vaadin.demo.a:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(
+                fromString("com.vaadin:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(
+                fromString("com.vaadin:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(fromString(
+                "com.example.vaadin:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(
+                fromString(".vaadin:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(
+                fromString("vaadin:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(fromString(
+                "com.vaadindemo:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(fromString(
+                "com.vaadin.example:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertFalse(matcher.matches(
+                fromString("com.example:vaadin:jar:999.99-SNAPSHOT:compile")));
     }
 
     @Test
-    public void matches_wildcardArtifact() {
+    void matches_wildcardArtifact() {
         FrontendScannerConfig.ArtifactMatcher matcher = new FrontendScannerConfig.ArtifactMatcher(
                 null, "vaadin*");
-        Assert.assertTrue(matcher.matches(fromString(
-                "com.vaadin.example:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertTrue(matcher.matches(fromString(
-                "com.vaadin.demo:vaadin-demo:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertTrue(matcher.matches(fromString(
-                "com.vaadin.demo.a:vaadindemo:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertFalse(matcher.matches(
-                fromString("com.vaadin:demovaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertFalse(matcher.matches(
-                fromString("com.vaadin:example:jar:25.1-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(fromString(
+                "com.vaadin.example:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(fromString(
+                "com.vaadin.demo:vaadin-demo:jar:999.99-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(fromString(
+                "com.vaadin.demo.a:vaadindemo:jar:999.99-SNAPSHOT:compile")));
+        assertFalse(matcher.matches(fromString(
+                "com.vaadin:demovaadin:jar:999.99-SNAPSHOT:compile")));
+        assertFalse(matcher.matches(
+                fromString("com.vaadin:example:jar:999.99-SNAPSHOT:compile")));
 
         matcher.setArtifactId("*vaadin");
-        Assert.assertTrue(matcher.matches(fromString(
-                "com.vaadin.example:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertTrue(matcher.matches(fromString(
-                "com.vaadin.demo:demo-vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertTrue(matcher.matches(fromString(
-                "com.vaadin.demo.a:demovaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertFalse(matcher.matches(
-                fromString("com.vaadin:vaadindemo:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertFalse(matcher.matches(fromString(
-                "com.vaadin:vaadin-demo:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertFalse(matcher.matches(
-                fromString("com.vaadin:example:jar:25.1-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(fromString(
+                "com.vaadin.example:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(fromString(
+                "com.vaadin.demo:demo-vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(fromString(
+                "com.vaadin.demo.a:demovaadin:jar:999.99-SNAPSHOT:compile")));
+        assertFalse(matcher.matches(fromString(
+                "com.vaadin:vaadindemo:jar:999.99-SNAPSHOT:compile")));
+        assertFalse(matcher.matches(fromString(
+                "com.vaadin:vaadin-demo:jar:999.99-SNAPSHOT:compile")));
+        assertFalse(matcher.matches(
+                fromString("com.vaadin:example:jar:999.99-SNAPSHOT:compile")));
 
         matcher.setArtifactId("*vaadin*");
-        Assert.assertTrue(matcher.matches(fromString(
-                "com.vaadin.example:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertTrue(matcher.matches(fromString(
-                "com.vaadin.demo:vaadin-demo:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertTrue(matcher.matches(fromString(
-                "com.vaadin.demo.a:vaadindemo:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertTrue(matcher.matches(fromString(
-                "com.vaadin.demo:demo-vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertTrue(matcher.matches(fromString(
-                "com.vaadin.demo.a:demovaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertFalse(matcher.matches(
-                fromString("com.vaadin:example:jar:25.1-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(fromString(
+                "com.vaadin.example:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(fromString(
+                "com.vaadin.demo:vaadin-demo:jar:999.99-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(fromString(
+                "com.vaadin.demo.a:vaadindemo:jar:999.99-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(fromString(
+                "com.vaadin.demo:demo-vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(fromString(
+                "com.vaadin.demo.a:demovaadin:jar:999.99-SNAPSHOT:compile")));
+        assertFalse(matcher.matches(
+                fromString("com.vaadin:example:jar:999.99-SNAPSHOT:compile")));
     }
 
     @Test
-    public void matches_exactArtifact() {
+    void matches_exactArtifact() {
         FrontendScannerConfig.ArtifactMatcher matcher = new FrontendScannerConfig.ArtifactMatcher(
                 null, "vaadin");
-        Assert.assertTrue(matcher.matches(
-                fromString("com.vaadin:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertTrue(matcher.matches(
-                fromString("org.example:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertFalse(matcher.matches(
-                fromString("com.vaadin:vaadindemo:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertFalse(matcher.matches(
-                fromString("com.vaadin:demovaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertFalse(matcher.matches(fromString(
-                "com.vaadin:demovaadindemo:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertFalse(matcher.matches(
-                fromString("com.vaadin:example:jar:25.1-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(
+                fromString("com.vaadin:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(
+                fromString("org.example:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertFalse(matcher.matches(fromString(
+                "com.vaadin:vaadindemo:jar:999.99-SNAPSHOT:compile")));
+        assertFalse(matcher.matches(fromString(
+                "com.vaadin:demovaadin:jar:999.99-SNAPSHOT:compile")));
+        assertFalse(matcher.matches(fromString(
+                "com.vaadin:demovaadindemo:jar:999.99-SNAPSHOT:compile")));
+        assertFalse(matcher.matches(
+                fromString("com.vaadin:example:jar:999.99-SNAPSHOT:compile")));
 
     }
 
     @Test
-    public void matches_exactGroupAndArtifact() {
+    void matches_exactGroupAndArtifact() {
         FrontendScannerConfig.ArtifactMatcher matcher = new FrontendScannerConfig.ArtifactMatcher(
                 "com.vaadin", "vaadin");
-        Assert.assertTrue(matcher.matches(
-                fromString("com.vaadin:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertFalse(matcher.matches(fromString(
-                "com.vaadin:flow-server:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertFalse(matcher.matches(fromString(
-                "com.vaadin.demo:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertFalse(matcher.matches(fromString(
-                "org.com.vaadin.demo:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertFalse(matcher.matches(
-                fromString("com.vaadindemo:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertFalse(matcher.matches(
-                fromString("org.example:vaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertFalse(matcher.matches(
-                fromString("com.vaadin:vaadindemo:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertFalse(matcher.matches(
-                fromString("com.vaadin:demovaadin:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertFalse(matcher.matches(fromString(
-                "com.vaadin:demovaadindemo:jar:25.1-SNAPSHOT:compile")));
-        Assert.assertFalse(matcher.matches(
-                fromString("com.vaadin:example:jar:25.1-SNAPSHOT:compile")));
+        assertTrue(matcher.matches(
+                fromString("com.vaadin:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertFalse(matcher.matches(fromString(
+                "com.vaadin:flow-server:jar:999.99-SNAPSHOT:compile")));
+        assertFalse(matcher.matches(fromString(
+                "com.vaadin.demo:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertFalse(matcher.matches(fromString(
+                "org.com.vaadin.demo:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertFalse(matcher.matches(fromString(
+                "com.vaadindemo:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertFalse(matcher.matches(
+                fromString("org.example:vaadin:jar:999.99-SNAPSHOT:compile")));
+        assertFalse(matcher.matches(fromString(
+                "com.vaadin:vaadindemo:jar:999.99-SNAPSHOT:compile")));
+        assertFalse(matcher.matches(fromString(
+                "com.vaadin:demovaadin:jar:999.99-SNAPSHOT:compile")));
+        assertFalse(matcher.matches(fromString(
+                "com.vaadin:demovaadindemo:jar:999.99-SNAPSHOT:compile")));
+        assertFalse(matcher.matches(
+                fromString("com.vaadin:example:jar:999.99-SNAPSHOT:compile")));
     }
 
     @Test
-    public void matches_nullArtifact_returnsFalse() {
+    void matches_nullArtifact_returnsFalse() {
         FrontendScannerConfig.ArtifactMatcher matcher = new FrontendScannerConfig.ArtifactMatcher();
-        Assert.assertFalse(matcher.matches(null));
+        assertFalse(matcher.matches(null));
         matcher.setGroupId("com.vaadin");
-        Assert.assertFalse(matcher.matches(null));
+        assertFalse(matcher.matches(null));
         matcher.setArtifactId("vaadin");
-        Assert.assertFalse(matcher.matches(null));
+        assertFalse(matcher.matches(null));
     }
 
     /**

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
@@ -52,13 +52,11 @@ import org.codehaus.plexus.classworlds.ClassWorld;
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.ReflectionUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ObjectNode;
@@ -85,12 +83,18 @@ import static com.vaadin.flow.server.InitParameters.APPLICATION_IDENTIFIER;
 import static com.vaadin.flow.server.InitParameters.FRONTEND_HOTDEPLOY;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE;
 import static java.io.File.pathSeparator;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @NotThreadSafe
-public class BuildFrontendMojoTest {
+class BuildFrontendMojoTest {
     public static final String TEST_PROJECT_RESOURCE_JS = "test_project_resource.js";
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir
+    Path tempDir;
 
     private File importsFile;
     private File nodeModulesPath;
@@ -112,11 +116,11 @@ public class BuildFrontendMojoTest {
     private Lookup lookup;
     private File frontendDirectory;
 
-    @Before
-    public void setup() throws Exception {
-        projectBase = temporaryFolder.getRoot();
+    @BeforeEach
+    void setup() throws Exception {
+        projectBase = tempDir.toFile();
 
-        tokenFile = new File(temporaryFolder.getRoot(),
+        tokenFile = new File(tempDir.toFile(),
                 VAADIN_SERVLET_RESOURCES + FrontendUtils.TOKEN_FILE);
 
         File npmFolder = projectBase;
@@ -148,11 +152,12 @@ public class BuildFrontendMojoTest {
                 "target/classes/com/vaadin/hilla/openapi.json");
         generatedTsFolder = new File(npmFolder, "src/main/frontend/generated");
 
-        Assert.assertTrue("Failed to create a test project resources",
-                projectFrontendResourcesDirectory.mkdirs());
-        Assert.assertTrue("Failed to create a test project file",
+        assertTrue(projectFrontendResourcesDirectory.mkdirs(),
+                "Failed to create a test project resources");
+        assertTrue(
                 new File(projectFrontendResourcesDirectory,
-                        TEST_PROJECT_RESOURCE_JS).createNewFile());
+                        TEST_PROJECT_RESOURCE_JS).createNewFile(),
+                "Failed to create a test project file");
 
         ReflectionUtils.setVariableValueInObject(mojo,
                 "frontendResourcesDirectory",
@@ -216,8 +221,8 @@ public class BuildFrontendMojoTest {
         }).when(mojo).createLookup(Mockito.any(ClassFinder.class));
     }
 
-    @After
-    public void teardown() throws IOException {
+    @AfterEach
+    void teardown() throws IOException {
         if (FileUtils.fileExists(packageJson)) {
             FileUtils.fileDelete(packageJson);
         }
@@ -276,27 +281,29 @@ public class BuildFrontendMojoTest {
     }
 
     @Test
-    public void should_generateViteConfig() throws Exception {
-        Assert.assertFalse(FileUtils.fileExists(viteConfig));
+    void should_generateViteConfig() throws Exception {
+        assertFalse(FileUtils.fileExists(viteConfig));
         mojo.execute();
-        Assert.assertTrue(FileUtils.fileExists(viteConfig));
+        assertTrue(FileUtils.fileExists(viteConfig));
     }
 
     @Test
-    public void should_generateViteGeneratedConfig() throws Exception {
-        Assert.assertFalse(FileUtils.fileExists(viteGenerated));
+    void should_generateViteGeneratedConfig() throws Exception {
+        assertFalse(FileUtils.fileExists(viteGenerated));
         mojo.execute();
-        Assert.assertTrue(FileUtils.fileExists(viteGenerated));
+        assertTrue(FileUtils.fileExists(viteGenerated));
     }
 
     @Test
-    public void should_copyProjectFrontendResources()
+    void should_copyProjectFrontendResources()
             throws MojoExecutionException, MojoFailureException {
 
         List<File> initialFiles = gatherFiles(jarResourcesFolder);
-        initialFiles.forEach(file -> Assert.assertFalse(String.format(
-                "Test resource shouldn't exist before running mojo.", file),
-                TEST_PROJECT_RESOURCE_JS.equals(file.getName())));
+        initialFiles.forEach(file -> assertFalse(
+                TEST_PROJECT_RESOURCE_JS.equals(file.getName()),
+                String.format(
+                        "Test resource shouldn't exist before running mojo.",
+                        file)));
         mojo.execute();
 
         Set<String> projectFrontendResources = Stream
@@ -308,14 +315,15 @@ public class BuildFrontendMojoTest {
                 .collect(Collectors.toSet());
 
         projectFrontendResources.forEach(fileName -> {
-            Assert.assertTrue(String.format(
-                    "Expected the copied file '%s' to be in the project resources",
-                    fileName), filesInFlowResourcesFolder.contains(fileName));
+            assertTrue(filesInFlowResourcesFolder.contains(fileName),
+                    String.format(
+                            "Expected the copied file '%s' to be in the project resources",
+                            fileName));
         });
     }
 
     @Test
-    public void changedBuildDirectory_resourcesCopiedNoTargetFolderExists()
+    void changedBuildDirectory_resourcesCopiedNoTargetFolderExists()
             throws MojoExecutionException, MojoFailureException,
             IllegalAccessException, IOException {
         // Clean generated target folders.
@@ -332,9 +340,11 @@ public class BuildFrontendMojoTest {
                 "build");
 
         List<File> initialFiles = gatherFiles(jarResourcesFolder);
-        initialFiles.forEach(file -> Assert.assertFalse(String.format(
-                "Test resource shouldn't exist before running mojo.", file),
-                TEST_PROJECT_RESOURCE_JS.equals(file.getName())));
+        initialFiles.forEach(file -> assertFalse(
+                TEST_PROJECT_RESOURCE_JS.equals(file.getName()),
+                String.format(
+                        "Test resource shouldn't exist before running mojo.",
+                        file)));
         mojo.execute();
 
         Set<String> projectFrontendResources = Stream
@@ -346,9 +356,10 @@ public class BuildFrontendMojoTest {
                 .collect(Collectors.toSet());
 
         projectFrontendResources.forEach(fileName -> {
-            Assert.assertTrue(String.format(
-                    "Expected the copied file '%s' to be in the project resources",
-                    fileName), filesInFlowResourcesFolder.contains(fileName));
+            assertTrue(filesInFlowResourcesFolder.contains(fileName),
+                    String.format(
+                            "Expected the copied file '%s' to be in the project resources",
+                            fileName));
         });
 
         final Set<String> generatedFiles = Stream
@@ -358,19 +369,18 @@ public class BuildFrontendMojoTest {
 
         String generated = "'%s' should have been generated into 'build/frontend'";
 
-        Assert.assertTrue(String.format(generated, FrontendUtils.IMPORTS_NAME),
-                generatedFiles.contains(FrontendUtils.IMPORTS_NAME));
-        Assert.assertTrue(
-                String.format(generated, FrontendUtils.IMPORTS_D_TS_NAME),
-                generatedFiles.contains(FrontendUtils.IMPORTS_D_TS_NAME));
+        assertTrue(generatedFiles.contains(FrontendUtils.IMPORTS_NAME),
+                String.format(generated, FrontendUtils.IMPORTS_NAME));
+        assertTrue(generatedFiles.contains(FrontendUtils.IMPORTS_D_TS_NAME),
+                String.format(generated, FrontendUtils.IMPORTS_D_TS_NAME));
 
-        Assert.assertFalse("No 'target' directory should exist after build.",
-                target.exists());
+        assertFalse(target.exists(),
+                "No 'target' directory should exist after build.");
     }
 
     @Test
-    public void should_UpdateMainJsFile() throws Exception {
-        Assert.assertFalse(importsFile.exists());
+    void should_UpdateMainJsFile() throws Exception {
+        assertFalse(importsFile.exists());
 
         List<String> expectedLines = getExpectedImports();
 
@@ -378,12 +388,12 @@ public class BuildFrontendMojoTest {
 
         assertContainsImports(true, expectedLines.toArray(new String[0]));
 
-        Assert.assertTrue(
+        assertTrue(
                 new File(jarResourcesFolder, "/ExampleConnector.js").exists());
     }
 
     @Test
-    public void shouldNot_UpdateJsFile_when_NoChanges() throws Exception {
+    void shouldNot_UpdateJsFile_when_NoChanges() throws Exception {
 
         mojo.execute();
         long timestamp1 = importsFile.lastModified();
@@ -393,11 +403,11 @@ public class BuildFrontendMojoTest {
         mojo.execute();
         long timestamp2 = importsFile.lastModified();
 
-        Assert.assertEquals(timestamp1, timestamp2);
+        assertEquals(timestamp1, timestamp2);
     }
 
     @Test
-    public void should_ContainLumoThemeFiles() throws Exception {
+    void should_ContainLumoThemeFiles() throws Exception {
         mojo.execute();
 
         assertContainsImports(true, "@vaadin/vaadin-lumo-styles/color.js",
@@ -409,7 +419,7 @@ public class BuildFrontendMojoTest {
     }
 
     @Test
-    public void shouldNot_ContainExternalUrls() throws Exception {
+    void shouldNot_ContainExternalUrls() throws Exception {
         mojo.execute();
 
         assertContainsImports(false, "https://foo.com/bar.js");
@@ -417,7 +427,7 @@ public class BuildFrontendMojoTest {
     }
 
     @Test
-    public void should_AddImports() throws Exception {
+    void should_AddImports() throws Exception {
         mojo.execute();
         removeImports("@vaadin/vaadin-lumo-styles/sizing.js",
                 "./local-template.js");
@@ -430,7 +440,7 @@ public class BuildFrontendMojoTest {
     }
 
     @Test
-    public void should_removeImports() throws Exception {
+    void should_removeImports() throws Exception {
         mojo.execute();
         addImports("./added-import.js");
         assertContainsImports(true, "./added-import.js");
@@ -440,7 +450,7 @@ public class BuildFrontendMojoTest {
     }
 
     @Test
-    public void should_AddRemove_Imports() throws Exception {
+    void should_AddRemove_Imports() throws Exception {
         mojo.execute();
 
         removeImports("@vaadin/vaadin-lumo-styles/sizing.js",
@@ -459,7 +469,7 @@ public class BuildFrontendMojoTest {
     }
 
     @Test
-    public void mavenGoalWhenPackageJsonContainsDependencies_onlyFrameworkHandledDependencyIsTouched()
+    void mavenGoalWhenPackageJsonContainsDependencies_onlyFrameworkHandledDependencyIsTouched()
             throws Exception {
         ObjectNode json = TestUtils.getInitialPackageJson();
         ObjectNode dependencies = JacksonUtils.createObjectNode();
@@ -478,18 +488,18 @@ public class BuildFrontendMojoTest {
         assertContainsPackage(dependencies, "@vaadin/button",
                 "@vaadin/vaadin-element-mixin");
 
-        Assert.assertFalse("proj4 should have been removed",
-                dependencies.has("proj4"));
-        Assert.assertTrue("line-awesome should remain",
-                dependencies.has("line-awesome"));
+        assertFalse(dependencies.has("proj4"),
+                "proj4 should have been removed");
+        assertTrue(dependencies.has("line-awesome"),
+                "line-awesome should remain");
     }
 
     @Test
-    public void existingTokenFile_parametersShouldBeRemoved()
+    void existingTokenFile_parametersShouldBeRemoved()
             throws IOException, IllegalAccessException, MojoExecutionException,
             MojoFailureException {
 
-        File projectBase = temporaryFolder.getRoot();
+        File projectBase = tempDir.toFile();
         File webpackOutputDirectory = new File(projectBase,
                 VAADIN_WEBAPP_RESOURCES);
         File resourceOutputDirectory = new File(projectBase,
@@ -521,35 +531,32 @@ public class BuildFrontendMojoTest {
         String json = org.apache.commons.io.FileUtils
                 .readFileToString(tokenFile, "UTF-8");
         ObjectNode buildInfo = JacksonUtils.readTree(json);
-        Assert.assertNull(
-                "enable dev server token shouldn't be added " + "automatically",
-                buildInfo.get(FRONTEND_HOTDEPLOY));
-        Assert.assertNotNull("productionMode token should be available",
-                buildInfo.get(SERVLET_PARAMETER_PRODUCTION_MODE));
-        Assert.assertNull("npmFolder should have been removed",
-                buildInfo.get(Constants.NPM_TOKEN));
-        Assert.assertNull("frontendFolder should have been removed",
-                buildInfo.get(Constants.FRONTEND_TOKEN));
+        assertNull(buildInfo.get(FRONTEND_HOTDEPLOY),
+                "enable dev server token shouldn't be added "
+                        + "automatically");
+        assertNotNull(buildInfo.get(SERVLET_PARAMETER_PRODUCTION_MODE),
+                "productionMode token should be available");
+        assertNull(buildInfo.get(Constants.NPM_TOKEN),
+                "npmFolder should have been removed");
+        assertNull(buildInfo.get(Constants.FRONTEND_TOKEN),
+                "frontendFolder should have been removed");
 
-        Assert.assertNull(
+        assertNull(buildInfo.get(InitParameters.SERVLET_PARAMETER_ENABLE_PNPM),
                 InitParameters.SERVLET_PARAMETER_ENABLE_PNPM
-                        + "should have been removed",
-                buildInfo.get(InitParameters.SERVLET_PARAMETER_ENABLE_PNPM));
-        Assert.assertNull(InitParameters.CI_BUILD + "should have been removed",
-                buildInfo.get(InitParameters.CI_BUILD));
-        Assert.assertNull(
+                        + "should have been removed");
+        assertNull(buildInfo.get(InitParameters.CI_BUILD),
+                InitParameters.CI_BUILD + "should have been removed");
+        assertNull(buildInfo.get(InitParameters.REQUIRE_HOME_NODE_EXECUTABLE),
                 InitParameters.REQUIRE_HOME_NODE_EXECUTABLE
-                        + "should have been removed",
-                buildInfo.get(InitParameters.REQUIRE_HOME_NODE_EXECUTABLE));
-        Assert.assertNull(
+                        + "should have been removed");
+        assertNull(buildInfo
+                .get(InitParameters.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE),
                 InitParameters.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE
-                        + "should have been removed",
-                buildInfo.get(
-                        InitParameters.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE));
+                        + "should have been removed");
     }
 
     @Test
-    public void existingTokenFile_defaultApplicationIdentifierWritten()
+    void existingTokenFile_defaultApplicationIdentifierWritten()
             throws IOException, MojoExecutionException, MojoFailureException {
         String expectedAppId = "app-" + StringUtil.getHash(
                 "com.vaadin.testing:my-application", StandardCharsets.UTF_8);
@@ -571,19 +578,18 @@ public class BuildFrontendMojoTest {
                 initialBuildInfo.toPrettyString() + "\n", "UTF-8");
 
         mojo.execute();
-        Assert.assertTrue("No token file could be found", tokenFile.exists());
+        assertTrue(tokenFile.exists(), "No token file could be found");
 
         String json = org.apache.commons.io.FileUtils
                 .readFileToString(tokenFile, "UTF-8");
         ObjectNode buildInfo = JacksonUtils.readTree(json);
-        Assert.assertEquals(
-                "Custom application identifier not written on token file",
-                expectedAppId,
-                buildInfo.get(APPLICATION_IDENTIFIER).textValue());
+        assertEquals(expectedAppId,
+                buildInfo.get(APPLICATION_IDENTIFIER).textValue(),
+                "Custom application identifier not written on token file");
     }
 
     @Test
-    public void existingTokenFile_customApplicationIdentifierWritten()
+    void existingTokenFile_customApplicationIdentifierWritten()
             throws IOException, MojoExecutionException, MojoFailureException,
             IllegalAccessException {
         String appId = "MY-APP-ID";
@@ -607,18 +613,17 @@ public class BuildFrontendMojoTest {
                 initialBuildInfo.toPrettyString() + "\n", "UTF-8");
 
         mojo.execute();
-        Assert.assertTrue("No token file could be found", tokenFile.exists());
+        assertTrue(tokenFile.exists(), "No token file could be found");
 
         String json = org.apache.commons.io.FileUtils
                 .readFileToString(tokenFile, "UTF-8");
         ObjectNode buildInfo = JacksonUtils.readTree(json);
-        Assert.assertEquals(
-                "Custom application identifier not written on token file",
-                appId, buildInfo.get(APPLICATION_IDENTIFIER).textValue());
+        assertEquals(appId, buildInfo.get(APPLICATION_IDENTIFIER).textValue(),
+                "Custom application identifier not written on token file");
     }
 
     @Test
-    public void commercialComponent_noLicenseKey_commercialBannerEnabled_buildsWithCommercialBannerFlag()
+    void commercialComponent_noLicenseKey_commercialBannerEnabled_buildsWithCommercialBannerFlag()
             throws Throwable {
 
         ObjectNode initialBuildInfo = JacksonUtils.createObjectNode();
@@ -638,21 +643,20 @@ public class BuildFrontendMojoTest {
             String json = Files.readString(tokenFile.toPath(),
                     StandardCharsets.UTF_8);
             ObjectNode buildInfo = JacksonUtils.readTree(json);
-            Assert.assertTrue(
-                    "Commercial banner build token not written on token file",
-                    buildInfo.get(COMMERCIAL_BANNER_TOKEN).booleanValue());
+            assertTrue(buildInfo.get(COMMERCIAL_BANNER_TOKEN).booleanValue(),
+                    "Commercial banner build token not written on token file");
         });
     }
 
     @Test
-    public void commercialComponent_noLicenseKey_commercialBannerNotEnabled_buildFails()
+    void commercialComponent_noLicenseKey_commercialBannerNotEnabled_buildFails()
             throws Throwable {
         DefaultArtifact commercialComponent = createCommercialComponent();
         mojo.project.getArtifacts().add(commercialComponent);
 
         runWithoutLicenseKeys(() -> {
-            Throwable exception = Assert
-                    .assertThrows(MojoFailureException.class, mojo::execute);
+            Throwable exception = assertThrows(MojoFailureException.class,
+                    mojo::execute);
             exception = exception.getCause();
             // Checking exception type by name because classes are loaded from
             // different classloaders
@@ -660,24 +664,23 @@ public class BuildFrontendMojoTest {
                     .equals(LicenseException.class.getName())) {
                 exception = exception.getCause();
             }
-            Assert.assertNotNull(
-                    "Expected the build to fail because of LicenseException, but not found in stack trace",
-                    exception);
-            Assert.assertTrue(exception.getMessage()
+            assertNotNull(exception,
+                    "Expected the build to fail because of LicenseException, but not found in stack trace");
+            assertTrue(exception.getMessage()
                     .contains(InitParameters.COMMERCIAL_WITH_BANNER));
         });
     }
 
     @Test
-    public void noTokenFile_tokenFileShouldBeCreated()
+    void noTokenFile_tokenFileShouldBeCreated()
             throws MojoExecutionException, MojoFailureException {
         mojo.execute();
 
-        Assert.assertTrue(tokenFile.exists());
+        assertTrue(tokenFile.exists());
     }
 
     @Test
-    public void mavenGoal_generateOpenApiJson_when_itIsInClientSideMode()
+    void mavenGoal_generateOpenApiJson_when_itIsInClientSideMode()
             throws Exception {
         // Enable Hilla to generate openApi
         FileUtils.fileWrite(new File(frontendDirectory, "routes.tsx"), "UTF-8",
@@ -695,15 +698,13 @@ public class BuildFrontendMojoTest {
                         export const router = createBrowserRouter(...routes]);
                         """);
 
-        Assert.assertFalse(
-                FileUtils.fileExists(openApiJsonFile.getAbsolutePath()));
+        assertFalse(FileUtils.fileExists(openApiJsonFile.getAbsolutePath()));
         mojo.execute();
-        Assert.assertTrue(
-                FileUtils.fileExists(openApiJsonFile.getAbsolutePath()));
+        assertTrue(FileUtils.fileExists(openApiJsonFile.getAbsolutePath()));
     }
 
     @Test
-    public void mavenGoal_generateTsFiles_when_enabled() throws Exception {
+    void mavenGoal_generateTsFiles_when_enabled() throws Exception {
         // Enable Hilla to generate ts files
         FileUtils.fileWrite(new File(frontendDirectory, "routes.tsx"), "UTF-8",
                 """
@@ -724,23 +725,24 @@ public class BuildFrontendMojoTest {
                 "connect-client.default.ts");
         File endpointClientApi = new File(generatedTsFolder, "MyEndpoint.ts");
 
-        Assert.assertFalse(connectClientApi.exists());
-        Assert.assertFalse(endpointClientApi.exists());
+        assertFalse(connectClientApi.exists());
+        assertFalse(endpointClientApi.exists());
         mojo.execute();
-        Assert.assertTrue(connectClientApi.exists());
-        Assert.assertTrue(endpointClientApi.exists());
+        assertTrue(connectClientApi.exists());
+        assertTrue(endpointClientApi.exists());
     }
 
     static void assertContainsPackage(JsonNode dependencies,
             String... packages) {
-        Arrays.asList(packages).forEach(dep -> Assert
-                .assertTrue("Missing " + dep, dependencies.has(dep)));
+        Arrays.asList(packages).forEach(
+                dep -> assertTrue(dependencies.has(dep), "Missing " + dep));
     }
 
     static void assertNotContainingPackages(JsonNode dependencies,
             String... packages) {
-        Arrays.asList(packages).forEach(dep -> Assert
-                .assertFalse("Not expecting " + dep, dependencies.has(dep)));
+        Arrays.asList(packages)
+                .forEach(dep -> assertFalse(dependencies.has(dep),
+                        "Not expecting " + dep));
     }
 
     private void assertContainsImports(boolean contains, String... imports)
@@ -749,14 +751,14 @@ public class BuildFrontendMojoTest {
 
         if (contains) {
             Arrays.asList(imports)
-                    .forEach(s -> Assert.assertTrue(
-                            s + " not found in:\n" + content,
-                            content.contains(addFrontendPrefix(s))));
+                    .forEach(s -> assertTrue(
+                            content.contains(addFrontendPrefix(s)),
+                            s + " not found in:\n" + content));
         } else {
             Arrays.asList(imports)
-                    .forEach(s -> Assert.assertFalse(
-                            s + " found in:\n" + content,
-                            content.contains(addFrontendPrefix(s))));
+                    .forEach(s -> assertFalse(
+                            content.contains(addFrontendPrefix(s)),
+                            s + " found in:\n" + content));
         }
     }
 
@@ -823,12 +825,12 @@ public class BuildFrontendMojoTest {
             if (expectedImport.startsWith("./generated/jar-resources/")) {
                 File newFile = new File(jarResourcesSource, expectedImport
                         .substring("./generated/jar-resources/".length()));
-                Assert.assertTrue(newFile.createNewFile());
+                assertTrue(newFile.createNewFile());
             } else {
                 File newFile = resolveImportFile(directoryWithImportsJs,
                         nodeModulesPath, expectedImport);
                 newFile.getParentFile().mkdirs();
-                Assert.assertTrue(newFile.createNewFile());
+                assertTrue(newFile.createNewFile());
             }
         }
     }
@@ -908,12 +910,13 @@ public class BuildFrontendMojoTest {
         return commercialComponent;
     }
 
-    private void runWithoutLicenseKeys(ThrowingRunnable test) throws Throwable {
+    private void runWithoutLicenseKeys(Executable test) throws Throwable {
         String userHome = System.getProperty("user.home");
         File userHomeFolder = new File(userHome);
         Path vaadinHomeNodeFolder = userHomeFolder.toPath()
                 .resolve(Path.of(".vaadin", "node"));
-        File fakeUserHomeFolder = temporaryFolder.newFolder("fake-home");
+        File fakeUserHomeFolder = Files
+                .createDirectories(tempDir.resolve("fake-home")).toFile();
         // Try to speed up test by copying existing node into the fake home
         if (Files.isDirectory(vaadinHomeNodeFolder)) {
             File fakeVaadinHomeNode = fakeUserHomeFolder.toPath()
@@ -925,7 +928,7 @@ public class BuildFrontendMojoTest {
         try {
             System.setProperty("user.home",
                     fakeUserHomeFolder.getAbsolutePath());
-            test.run();
+            test.execute();
         } finally {
             System.setProperty("user.home", userHome);
         }

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/CleanFrontendMojoTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/CleanFrontendMojoTest.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.plugin.maven;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 
@@ -26,11 +27,9 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.ReflectionUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ObjectNode;
@@ -46,10 +45,12 @@ import static com.vaadin.flow.plugin.maven.BuildFrontendMojoTest.setProject;
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
 import static com.vaadin.flow.server.Constants.VAADIN_WEBAPP_RESOURCES;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class CleanFrontendMojoTest {
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+class CleanFrontendMojoTest {
+    @TempDir
+    Path tempDir;
 
     private final CleanFrontendMojo mojo = new CleanFrontendMojo();
     private String packageJson;
@@ -57,10 +58,10 @@ public class CleanFrontendMojoTest {
     private MavenProject project;
     private File frontendGenerated;
 
-    @Before
-    public void setup() throws Exception {
+    @BeforeEach
+    void setup() throws Exception {
 
-        projectBase = temporaryFolder.getRoot();
+        projectBase = tempDir.toFile();
 
         project = Mockito.mock(MavenProject.class);
         Mockito.when(project.getBasedir()).thenReturn(projectBase);
@@ -107,87 +108,82 @@ public class CleanFrontendMojoTest {
     }
 
     @Test
-    public void mavenGoal_when_packageJsonMissing() throws Exception {
-        Assert.assertFalse(FileUtils.fileExists(packageJson));
+    void mavenGoal_when_packageJsonMissing() throws Exception {
+        assertFalse(FileUtils.fileExists(packageJson));
         mojo.execute();
     }
 
     @Test
-    public void should_removeNodeModulesFolder()
+    void should_removeNodeModulesFolder()
             throws MojoFailureException, MojoExecutionException {
         final File nodeModules = new File(projectBase,
                 FrontendUtils.NODE_MODULES);
-        Assert.assertTrue("Failed to create 'node_modules'",
-                nodeModules.mkdirs());
+        assertTrue(nodeModules.mkdirs(), "Failed to create 'node_modules'");
         mojo.execute();
-        Assert.assertFalse("'node_modules' was not removed.",
-                nodeModules.exists());
+        assertFalse(nodeModules.exists(), "'node_modules' was not removed.");
     }
 
     @Test
-    public void should_notRemoveNodeModulesFolder_hilla()
+    void should_notRemoveNodeModulesFolder_hilla()
             throws MojoFailureException, IOException, MojoExecutionException {
         enableHilla();
         final File nodeModules = new File(projectBase,
                 FrontendUtils.NODE_MODULES);
-        Assert.assertTrue("Failed to create 'node_modules'",
-                nodeModules.mkdirs());
+        assertTrue(nodeModules.mkdirs(), "Failed to create 'node_modules'");
         mojo.execute();
-        Assert.assertTrue("'node_modules' should not be removed.",
-                nodeModules.exists());
+        assertTrue(nodeModules.exists(),
+                "'node_modules' should not be removed.");
     }
 
     @Test
-    public void should_removeCompressedDevBundle()
+    void should_removeCompressedDevBundle()
             throws MojoFailureException, IOException, MojoExecutionException {
         final File devBundleDir = new File(projectBase,
                 Constants.BUNDLE_LOCATION);
         final File devBundle = new File(projectBase,
                 Constants.DEV_BUNDLE_COMPRESSED_FILE_LOCATION);
-        Assert.assertTrue("Failed to create 'dev-bundle' folder",
-                devBundleDir.mkdirs());
-        Assert.assertTrue(devBundle.createNewFile());
+        assertTrue(devBundleDir.mkdirs(),
+                "Failed to create 'dev-bundle' folder");
+        assertTrue(devBundle.createNewFile());
         mojo.execute();
-        Assert.assertFalse("'dev.bundle' was not removed.", devBundle.exists());
-        Assert.assertFalse("Empty 'bundle' directory was not removed.",
-                devBundleDir.exists());
+        assertFalse(devBundle.exists(), "'dev.bundle' was not removed.");
+        assertFalse(devBundleDir.exists(),
+                "Empty 'bundle' directory was not removed.");
     }
 
     @Test
-    public void should_removeOldDevBundle()
+    void should_removeOldDevBundle()
             throws MojoFailureException, MojoExecutionException {
         final File devBundleDir = new File(projectBase, "src/main/dev-bundle/");
-        Assert.assertTrue("Failed to create 'dev-bundle' folder",
-                devBundleDir.mkdirs());
+        assertTrue(devBundleDir.mkdirs(),
+                "Failed to create 'dev-bundle' folder");
         mojo.execute();
-        Assert.assertFalse("Bundle directory was not removed.",
-                devBundleDir.exists());
+        assertFalse(devBundleDir.exists(), "Bundle directory was not removed.");
     }
 
     @Test
-    public void should_removeFrontendGeneratedFolder()
+    void should_removeFrontendGeneratedFolder()
             throws MojoFailureException, IOException, MojoExecutionException {
-        Assert.assertTrue("Failed to create 'frontend/generated'",
-                frontendGenerated.mkdirs());
+        assertTrue(frontendGenerated.mkdirs(),
+                "Failed to create 'frontend/generated'");
         FileUtils.fileWrite(new File(frontendGenerated, "my_theme.js"),
                 "fakeThemeFile");
 
         mojo.execute();
-        Assert.assertFalse(
-                "Generated frontend folder 'frontend/generated' was not removed.",
-                frontendGenerated.exists());
+        assertFalse(frontendGenerated.exists(),
+                "Generated frontend folder 'frontend/generated' was not removed.");
     }
 
     @Test
-    public void should_removeGeneratedFolderForCustomFrontendFolder()
+    void should_removeGeneratedFolderForCustomFrontendFolder()
             throws MojoFailureException, IOException, IllegalAccessException,
             MojoExecutionException {
 
         File customFrontendFolder = new File(projectBase, "src/main/frontend");
         File customFrontendGenerated = new File(customFrontendFolder,
                 "generated");
-        Assert.assertTrue("Failed to create 'src/main/frontend/generated'",
-                customFrontendGenerated.mkdirs());
+        assertTrue(customFrontendGenerated.mkdirs(),
+                "Failed to create 'src/main/frontend/generated'");
         FileUtils.fileWrite(new File(customFrontendFolder, "my_theme.js"),
                 "fakeThemeFile");
 
@@ -195,58 +191,55 @@ public class CleanFrontendMojoTest {
                 customFrontendFolder);
 
         mojo.execute();
-        Assert.assertTrue(
-                "Custom frontend folder 'src/main/frontend' has been removed.",
-                customFrontendFolder.exists());
-        Assert.assertFalse(
-                "Generated frontend folder 'src/main/frontend/generated' was not removed.",
-                customFrontendGenerated.exists());
+        assertTrue(customFrontendFolder.exists(),
+                "Custom frontend folder 'src/main/frontend' has been removed.");
+        assertFalse(customFrontendGenerated.exists(),
+                "Generated frontend folder 'src/main/frontend/generated' was not removed.");
     }
 
     @Test
-    public void should_removeNpmPackageLockFile()
+    void should_removeNpmPackageLockFile()
             throws MojoFailureException, IOException, MojoExecutionException {
         final File packageLock = new File(projectBase, "package-lock.json");
         FileUtils.fileWrite(packageLock, "{ \"fake\": \"lock\"}");
 
         mojo.execute();
-        Assert.assertFalse("package-lock.json was not removed",
-                packageLock.exists());
+        assertFalse(packageLock.exists(), "package-lock.json was not removed");
     }
 
     @Test
-    public void should_notRemoveNpmPackageLockFile_hilla()
+    void should_notRemoveNpmPackageLockFile_hilla()
             throws MojoFailureException, IOException, MojoExecutionException {
         enableHilla();
         final File packageLock = new File(projectBase, "package-lock.json");
         FileUtils.fileWrite(packageLock, "{ \"fake\": \"lock\"}");
 
         mojo.execute();
-        Assert.assertTrue("package-lock.json should not be removed",
-                packageLock.exists());
+        assertTrue(packageLock.exists(),
+                "package-lock.json should not be removed");
     }
 
     @Test
-    public void should_removePnpmFile()
+    void should_removePnpmFile()
             throws MojoFailureException, IOException, MojoExecutionException {
         final File pnpmFile = new File(projectBase, ".pnpmfile.cjs");
         FileUtils.fileWrite(pnpmFile, "{ \"fake\": \"pnpmfile\"}");
 
         mojo.execute();
-        Assert.assertFalse(".pnpmfile.cjs was not removed", pnpmFile.exists());
+        assertFalse(pnpmFile.exists(), ".pnpmfile.cjs was not removed");
     }
 
     @Test
-    public void should_removePnpmPackageLockFile()
+    void should_removePnpmPackageLockFile()
             throws MojoFailureException, IOException, MojoExecutionException {
         final File pnpmLock = new File(projectBase, "pnpm-lock.yaml");
         FileUtils.fileWrite(pnpmLock, "lockVersion: -1");
         mojo.execute();
-        Assert.assertFalse("pnpm-lock.yaml was not removed", pnpmLock.exists());
+        assertFalse(pnpmLock.exists(), "pnpm-lock.yaml was not removed");
     }
 
     @Test
-    public void should_cleanPackageJson_removeVaadinAndHashObjects()
+    void should_cleanPackageJson_removeVaadinAndHashObjects()
             throws MojoFailureException, IOException, MojoExecutionException {
         ObjectNode json = createInitialPackageJson();
         FileUtils.fileWrite(packageJson, json.toString());
@@ -255,14 +248,14 @@ public class CleanFrontendMojoTest {
 
         ObjectNode packageObjectNode = getPackageJson(packageJson);
 
-        Assert.assertFalse("'vaadin' object was left in package.json",
-                packageObjectNode.has("vaadin"));
-        Assert.assertFalse("'hash' object was left in package.json",
-                packageObjectNode.has("hash"));
+        assertFalse(packageObjectNode.has("vaadin"),
+                "'vaadin' object was left in package.json");
+        assertFalse(packageObjectNode.has("hash"),
+                "'hash' object was left in package.json");
     }
 
     @Test
-    public void should_cleanPackageJson_removeVaadinDependenciesInOverrides()
+    void should_cleanPackageJson_removeVaadinDependenciesInOverrides()
             throws MojoFailureException, IOException, MojoExecutionException {
         ObjectNode json = createInitialPackageJson(true);
         FileUtils.fileWrite(packageJson, json.toString());
@@ -277,7 +270,7 @@ public class CleanFrontendMojoTest {
     }
 
     @Test
-    public void should_keepUserDependencies_whenPackageJsonEdited()
+    void should_keepUserDependencies_whenPackageJsonEdited()
             throws MojoFailureException, IOException, MojoExecutionException {
         ObjectNode json = createInitialPackageJson();
         json.set("dependencies", JacksonUtils.createObjectNode());
@@ -316,13 +309,13 @@ public class CleanFrontendMojoTest {
     static void assertNotContainsPackage(JsonNode dependencies,
             String... packages) {
         Arrays.asList(packages).forEach(
-                dep -> Assert.assertFalse("Has " + dep, dependencies.has(dep)));
+                dep -> assertFalse(dependencies.has(dep), "Has " + dep));
     }
 
     static void assertContainsPackage(JsonNode dependencies,
             String... packages) {
-        Arrays.asList(packages).forEach(dep -> Assert
-                .assertTrue("Not Have " + dep, dependencies.has(dep)));
+        Arrays.asList(packages).forEach(
+                dep -> assertTrue(dependencies.has(dep), "Not Have " + dep));
     }
 
     static ObjectNode createInitialPackageJson() {

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/FrontendScannerConfigTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/FrontendScannerConfigTest.java
@@ -20,41 +20,43 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import org.apache.maven.artifact.Artifact;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class FrontendScannerConfigTest {
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FrontendScannerConfigTest {
 
     @Test
-    public void shouldScan_noRules_allArtifactsAccepted() {
+    void shouldScan_noRules_allArtifactsAccepted() {
         FrontendScannerConfig config = new FrontendScannerConfig();
-        Assert.assertTrue(artifacts().allMatch(config::shouldScan));
+        assertTrue(artifacts().allMatch(config::shouldScan));
     }
 
     @Test
-    public void shouldScan_includes_ruleApplied() {
+    void shouldScan_includes_ruleApplied() {
         FrontendScannerConfig config = new FrontendScannerConfig();
         config.addInclude(
                 new FrontendScannerConfig.ArtifactMatcher("com.vaadin", null));
-        Assert.assertTrue(artifacts().filter(config::shouldScan)
+        assertTrue(artifacts().filter(config::shouldScan)
                 .allMatch(a -> a.getGroupId().equals("com.vaadin")));
 
         config.addInclude(new FrontendScannerConfig.ArtifactMatcher(
                 "tools.jackson*", null));
-        Assert.assertTrue(artifacts().filter(config::shouldScan)
+        assertTrue(artifacts().filter(config::shouldScan)
                 .allMatch(a -> a.getGroupId().equals("com.vaadin")
                         || a.getGroupId().startsWith("tools.jackson")));
 
         config.addInclude(
                 new FrontendScannerConfig.ArtifactMatcher(null, "flow-server"));
-        Assert.assertTrue(artifacts().filter(config::shouldScan)
+        assertTrue(artifacts().filter(config::shouldScan)
                 .allMatch(a -> a.getGroupId().equals("com.vaadin")
                         || a.getGroupId().startsWith("tools.jackson")
                         || a.getArtifactId().equals("flow-server")));
 
         config.addInclude(
                 new FrontendScannerConfig.ArtifactMatcher("vaadin-*", null));
-        Assert.assertTrue(artifacts().filter(config::shouldScan)
+        assertTrue(artifacts().filter(config::shouldScan)
                 .allMatch(a -> a.getGroupId().equals("com.vaadin")
                         || a.getGroupId().startsWith("tools.jackson")
                         || a.getArtifactId().equals("flow-server")
@@ -62,29 +64,29 @@ public class FrontendScannerConfigTest {
     }
 
     @Test
-    public void shouldScan_excludes_ruleApplied() {
+    void shouldScan_excludes_ruleApplied() {
         FrontendScannerConfig config = new FrontendScannerConfig();
         config.addExclude(
                 new FrontendScannerConfig.ArtifactMatcher("com.vaadin", null));
-        Assert.assertTrue(artifacts().filter(config::shouldScan)
+        assertTrue(artifacts().filter(config::shouldScan)
                 .noneMatch(a -> a.getGroupId().equals("com.vaadin")));
 
         config.addExclude(new FrontendScannerConfig.ArtifactMatcher(
                 "tools.jackson*", null));
-        Assert.assertTrue(artifacts().filter(config::shouldScan)
+        assertTrue(artifacts().filter(config::shouldScan)
                 .noneMatch(a -> a.getGroupId().equals("com.vaadin")
                         || a.getGroupId().startsWith("tools.jackson")));
 
         config.addExclude(
                 new FrontendScannerConfig.ArtifactMatcher(null, "flow-server"));
-        Assert.assertTrue(artifacts().filter(config::shouldScan)
+        assertTrue(artifacts().filter(config::shouldScan)
                 .noneMatch(a -> a.getGroupId().equals("com.vaadin")
                         || a.getGroupId().startsWith("tools.jackson")
                         || a.getArtifactId().equals("flow-server")));
 
         config.addExclude(
                 new FrontendScannerConfig.ArtifactMatcher("vaadin-*", null));
-        Assert.assertTrue(artifacts().filter(config::shouldScan)
+        assertTrue(artifacts().filter(config::shouldScan)
                 .noneMatch(a -> a.getGroupId().equals("com.vaadin")
                         || a.getGroupId().startsWith("tools.jackson")
                         || a.getArtifactId().equals("flow-server")
@@ -92,11 +94,11 @@ public class FrontendScannerConfigTest {
     }
 
     @Test
-    public void shouldScan_excludeAndIncludeRules_exclusionsHaveHigherPriority() {
+    void shouldScan_excludeAndIncludeRules_exclusionsHaveHigherPriority() {
         FrontendScannerConfig config = new FrontendScannerConfig();
         config.addExclude(new FrontendScannerConfig.ArtifactMatcher("*", "*"));
         config.addInclude(new FrontendScannerConfig.ArtifactMatcher("*", "*"));
-        Assert.assertTrue(artifacts().noneMatch(config::shouldScan));
+        assertTrue(artifacts().noneMatch(config::shouldScan));
 
         config = new FrontendScannerConfig();
         config.addExclude(new FrontendScannerConfig.ArtifactMatcher(
@@ -106,20 +108,20 @@ public class FrontendScannerConfigTest {
 
         List<Artifact> artifacts = artifacts().filter(config::shouldScan)
                 .toList();
-        Assert.assertFalse(artifacts.isEmpty());
-        Assert.assertTrue(artifacts.stream()
+        assertFalse(artifacts.isEmpty());
+        assertTrue(artifacts.stream()
                 .allMatch(a -> a.getGroupId().equals("com.vaadin")
                         && !a.getArtifactId().startsWith("vaadin-")));
 
     }
 
     @Test
-    public void shouldScan_disabled_alwaysTrue() {
+    void shouldScan_disabled_alwaysTrue() {
         FrontendScannerConfig config = new FrontendScannerConfig();
         config.addExclude(new FrontendScannerConfig.ArtifactMatcher("*", "*"));
         config.addInclude(new FrontendScannerConfig.ArtifactMatcher("*", "*"));
         config.setEnabled(false);
-        Assert.assertTrue(artifacts().allMatch(config::shouldScan));
+        assertTrue(artifacts().allMatch(config::shouldScan));
     }
 
     private Stream<Artifact> artifacts() {

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/GenerateMavenBOMMojoTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/GenerateMavenBOMMojoTest.java
@@ -17,36 +17,37 @@ package com.vaadin.flow.plugin.maven;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.ReflectionUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class GenerateMavenBOMMojoTest {
+class GenerateMavenBOMMojoTest {
 
     private String bomFilename;
 
     private File resourceOutputDirectory;
 
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir
+    Path tempDir;
 
     private GenerateMavenBOMMojo mojo;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() throws Exception {
         this.mojo = new GenerateMavenBOMMojo();
 
         MavenProject project = Mockito.mock(MavenProject.class);
-        File projectBase = temporaryFolder.getRoot();
+        File projectBase = tempDir.toFile();
         Mockito.when(project.getBasedir()).thenReturn(projectBase);
         resourceOutputDirectory = new File(projectBase,
                 VAADIN_SERVLET_RESOURCES);
@@ -86,10 +87,10 @@ public class GenerateMavenBOMMojoTest {
     }
 
     @Test
-    public void shouldGenerateSBOM() throws Exception {
-        Assert.assertFalse(Files.exists(Paths.get(bomFilename)));
+    void shouldGenerateSBOM() throws Exception {
+        assertFalse(Files.exists(Paths.get(bomFilename)));
         mojo.execute();
-        Assert.assertTrue(Files.exists(Paths.get(bomFilename)));
+        assertTrue(Files.exists(Paths.get(bomFilename)));
     }
 
 }

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/GenerateNpmBOMMojoTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/GenerateNpmBOMMojoTest.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.plugin.maven;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Set;
@@ -24,11 +25,9 @@ import java.util.Set;
 import org.apache.maven.plugin.MojoFailureException;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.ReflectionUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.di.Lookup;
@@ -41,15 +40,19 @@ import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import static com.vaadin.flow.plugin.maven.BuildFrontendMojoTest.setProject;
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class GenerateNpmBOMMojoTest {
+class GenerateNpmBOMMojoTest {
 
     private String bomFilename;
 
     private File resourceOutputDirectory;
 
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir
+    Path tempDir;
 
     private File jarResourcesSource;
     private File nodeModulesDir;
@@ -58,11 +61,11 @@ public class GenerateNpmBOMMojoTest {
 
     private Lookup lookup;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() throws Exception {
         this.mojo = Mockito.spy(new GenerateNpmBOMMojo());
 
-        File projectBase = temporaryFolder.getRoot();
+        File projectBase = tempDir.toFile();
         File frontendDirectory = new File(projectBase,
                 FrontendUtils.DEFAULT_FRONTEND_DIR);
         resourceOutputDirectory = new File(projectBase,
@@ -73,9 +76,9 @@ public class GenerateNpmBOMMojoTest {
         bomFilename = new File(resourceOutputDirectory, "bom-npm.json")
                 .getAbsolutePath();
 
-        nodeModulesDir = new File(temporaryFolder.getRoot(), "node_modules");
+        nodeModulesDir = new File(tempDir.toFile(), "node_modules");
         boolean nodeModulesDirCreated = nodeModulesDir.mkdir();
-        Assert.assertTrue(nodeModulesDirCreated);
+        assertTrue(nodeModulesDirCreated);
 
         String manifestFilePath = new File(projectBase, PACKAGE_JSON)
                 .getAbsolutePath();
@@ -130,29 +133,30 @@ public class GenerateNpmBOMMojoTest {
     }
 
     @Test
-    public void shouldGenerateSBOM() throws Exception {
-        Assert.assertFalse(Files.exists(Paths.get(bomFilename)));
+    void shouldGenerateSBOM() throws Exception {
+        assertFalse(Files.exists(Paths.get(bomFilename)));
         mojo.execute();
-        Assert.assertTrue(Files.exists(Paths.get(bomFilename)));
+        assertTrue(Files.exists(Paths.get(bomFilename)));
     }
 
-    @Test(expected = MojoFailureException.class)
-    public void shouldFailWhenNoPackageJsonIsPresent() throws Exception {
+    @Test
+    void shouldFailWhenNoPackageJsonIsPresent() throws Exception {
         ReflectionUtils.setVariableValueInObject(mojo, "packageManifest", "");
-        mojo.execute();
+        assertThrows(MojoFailureException.class, () -> {
+            mojo.execute();
+        });
     }
 
     @Test
-    public void shouldRunNpmInstallIfNodeModulesIsNotPresent()
-            throws Exception {
-        Assert.assertTrue(nodeModulesDir.delete());
-        Assert.assertFalse(nodeModulesDir.exists());
+    void shouldRunNpmInstallIfNodeModulesIsNotPresent() throws Exception {
+        assertTrue(nodeModulesDir.delete());
+        assertFalse(nodeModulesDir.exists());
         mojo.execute();
-        Assert.assertTrue(nodeModulesDir.exists());
+        assertTrue(nodeModulesDir.exists());
     }
 
     @Test
-    public void shouldSkipNpmInstallIfNodeModulesIsPresent() throws Exception {
+    void shouldSkipNpmInstallIfNodeModulesIsPresent() throws Exception {
         List<String> originalContent = TestUtils
                 .listFilesRecursively(nodeModulesDir);
 
@@ -160,8 +164,7 @@ public class GenerateNpmBOMMojoTest {
 
         List<String> newContent = TestUtils
                 .listFilesRecursively(nodeModulesDir);
-        Assert.assertArrayEquals(originalContent.toArray(),
-                newContent.toArray());
+        assertArrayEquals(originalContent.toArray(), newContent.toArray());
     }
 
 }

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/InvocationRequestBuilderTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/InvocationRequestBuilderTest.java
@@ -18,10 +18,11 @@ package com.vaadin.flow.plugin.maven;
 import java.util.List;
 
 import org.apache.maven.shared.invoker.InvocationRequest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class InvocationRequestBuilderTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class InvocationRequestBuilderTest {
 
     private final String groupId = "group.id";
     private final String artifactId = "artifact.id";
@@ -29,18 +30,18 @@ public class InvocationRequestBuilderTest {
     private final String goal = "goal";
 
     @Test
-    public void createInvocationRequest() {
+    void createInvocationRequest() {
         InvocationRequestBuilder requestBuilder = new InvocationRequestBuilder();
         InvocationRequest request = requestBuilder.groupId(groupId)
                 .artifactId(artifactId).version(version).goal(goal)
                 .createInvocationRequest();
         List<String> goals = request.getGoals();
-        Assert.assertEquals(1, goals.size());
+        assertEquals(1, goals.size());
 
         String expectedGoal = String.format("%s:%s:%s:%s", groupId, artifactId,
                 version, goal);
         String actualGoal = goals.get(0);
-        Assert.assertEquals(expectedGoal, actualGoal);
+        assertEquals(expectedGoal, actualGoal);
     }
 
 }

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.plugin.maven;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.apache.maven.plugin.MojoExecutionException;
@@ -25,12 +26,9 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.ReflectionUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 import tools.jackson.databind.node.ObjectNode;
 
@@ -51,13 +49,15 @@ import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
 import static com.vaadin.flow.server.Constants.VAADIN_WEBAPP_RESOURCES;
 import static com.vaadin.flow.server.InitParameters.FRONTEND_HOTDEPLOY;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-public class PrepareFrontendMojoTest {
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
+class PrepareFrontendMojoTest {
+    @TempDir
+    Path tempDir;
 
     private final PrepareFrontendMojo mojo = new PrepareFrontendMojo();
     private String packageJson;
@@ -69,12 +69,12 @@ public class PrepareFrontendMojoTest {
     private File defaultJavaResource;
     private File generatedTsFolder;
 
-    @Before
-    public void setup() throws Exception {
+    @BeforeEach
+    void setup() throws Exception {
 
-        projectBase = temporaryFolder.getRoot();
+        projectBase = tempDir.toFile();
 
-        tokenFile = new File(temporaryFolder.getRoot(),
+        tokenFile = new File(tempDir.toFile(),
                 VAADIN_SERVLET_RESOURCES + FrontendUtils.TOKEN_FILE);
 
         packageJson = new File(projectBase, PACKAGE_JSON).getAbsolutePath();
@@ -125,40 +125,40 @@ public class PrepareFrontendMojoTest {
     }
 
     @Test
-    public void tokenFileShouldExist_noHotdeployTokenVisible()
+    void tokenFileShouldExist_noHotdeployTokenVisible()
             throws IOException, MojoExecutionException, MojoFailureException {
         mojo.execute();
-        Assert.assertTrue("No token file could be found", tokenFile.exists());
+        assertTrue(tokenFile.exists(), "No token file could be found");
 
         String json = org.apache.commons.io.FileUtils
                 .readFileToString(tokenFile, "UTF-8");
         ObjectNode buildInfo = JacksonUtils.readTree(json);
-        Assert.assertNull("Default HotDeploy token should not be available",
-                buildInfo.get(FRONTEND_HOTDEPLOY));
-        Assert.assertNotNull("productionMode token should be available",
-                buildInfo.get(SERVLET_PARAMETER_PRODUCTION_MODE));
+        assertNull(buildInfo.get(FRONTEND_HOTDEPLOY),
+                "Default HotDeploy token should not be available");
+        assertNotNull(buildInfo.get(SERVLET_PARAMETER_PRODUCTION_MODE),
+                "productionMode token should be available");
     }
 
     @Test
-    public void tokenFileShouldExist_hotdeployIsTrueTokenVisible()
+    void tokenFileShouldExist_hotdeployIsTrueTokenVisible()
             throws IOException, MojoExecutionException, MojoFailureException,
             IllegalAccessException {
         ReflectionUtils.setVariableValueInObject(mojo, "frontendHotdeploy",
                 Boolean.TRUE);
         mojo.execute();
-        Assert.assertTrue("No token file could be found", tokenFile.exists());
+        assertTrue(tokenFile.exists(), "No token file could be found");
 
         String json = org.apache.commons.io.FileUtils
                 .readFileToString(tokenFile, "UTF-8");
         ObjectNode buildInfo = JacksonUtils.readTree(json);
-        Assert.assertNotNull("HotDeploy should be written",
-                buildInfo.get(FRONTEND_HOTDEPLOY));
-        Assert.assertTrue("HotDeploy should be enabled",
-                buildInfo.get(FRONTEND_HOTDEPLOY).booleanValue());
+        assertNotNull(buildInfo.get(FRONTEND_HOTDEPLOY),
+                "HotDeploy should be written");
+        assertTrue(buildInfo.get(FRONTEND_HOTDEPLOY).booleanValue(),
+                "HotDeploy should be enabled");
     }
 
     @Test
-    public void existingTokenFile_defaultFrontendHotdeployShouldBeRemoved()
+    void existingTokenFile_defaultFrontendHotdeployShouldBeRemoved()
             throws IOException, MojoExecutionException, MojoFailureException {
 
         ObjectNode initialBuildInfo = JacksonUtils.createObjectNode();
@@ -173,14 +173,14 @@ public class PrepareFrontendMojoTest {
         String json = org.apache.commons.io.FileUtils
                 .readFileToString(tokenFile, "UTF-8");
         ObjectNode buildInfo = JacksonUtils.readTree(json);
-        Assert.assertNull("Default hotdeploy should not be added",
-                buildInfo.get(FRONTEND_HOTDEPLOY));
-        Assert.assertNotNull("productionMode token should be available",
-                buildInfo.get(SERVLET_PARAMETER_PRODUCTION_MODE));
+        assertNull(buildInfo.get(FRONTEND_HOTDEPLOY),
+                "Default hotdeploy should not be added");
+        assertNotNull(buildInfo.get(SERVLET_PARAMETER_PRODUCTION_MODE),
+                "productionMode token should be available");
     }
 
     @Test
-    public void writeTokenFile_devModePropertiesAreWritten()
+    void writeTokenFile_devModePropertiesAreWritten()
             throws IOException, MojoExecutionException, MojoFailureException {
 
         mojo.execute();
@@ -189,65 +189,60 @@ public class PrepareFrontendMojoTest {
                 .readFileToString(tokenFile, StandardCharsets.UTF_8);
         ObjectNode buildInfo = JacksonUtils.readTree(json);
 
-        Assert.assertTrue(
+        assertTrue(buildInfo.has(InitParameters.SERVLET_PARAMETER_ENABLE_PNPM),
                 InitParameters.SERVLET_PARAMETER_ENABLE_PNPM
-                        + "should have been written",
-                buildInfo.has(InitParameters.SERVLET_PARAMETER_ENABLE_PNPM));
-        Assert.assertFalse(
-                InitParameters.SERVLET_PARAMETER_ENABLE_PNPM
-                        + "should have been disabled",
+                        + "should have been written");
+        assertFalse(
                 buildInfo.get(InitParameters.SERVLET_PARAMETER_ENABLE_PNPM)
-                        .booleanValue());
+                        .booleanValue(),
+                InitParameters.SERVLET_PARAMETER_ENABLE_PNPM
+                        + "should have been disabled");
 
-        Assert.assertTrue(
+        assertTrue(buildInfo.has(InitParameters.REQUIRE_HOME_NODE_EXECUTABLE),
                 InitParameters.REQUIRE_HOME_NODE_EXECUTABLE
-                        + "should have been written",
-                buildInfo.has(InitParameters.REQUIRE_HOME_NODE_EXECUTABLE));
-        Assert.assertTrue(
-                InitParameters.REQUIRE_HOME_NODE_EXECUTABLE
-                        + "should have been enabled",
+                        + "should have been written");
+        assertTrue(
                 buildInfo.get(InitParameters.REQUIRE_HOME_NODE_EXECUTABLE)
-                        .booleanValue());
+                        .booleanValue(),
+                InitParameters.REQUIRE_HOME_NODE_EXECUTABLE
+                        + "should have been enabled");
 
-        Assert.assertFalse(
+        assertFalse(buildInfo
+                .has(InitParameters.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE),
                 InitParameters.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE
-                        + "should not have been written",
-                buildInfo.has(
-                        InitParameters.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE));
+                        + "should not have been written");
     }
 
     @Test
-    public void mavenGoal_when_packageJsonMissing_shouldNotGenerateDefault()
+    void mavenGoal_when_packageJsonMissing_shouldNotGenerateDefault()
             throws Exception {
-        Assert.assertFalse(FileUtils.fileExists(packageJson));
+        assertFalse(FileUtils.fileExists(packageJson));
         mojo.execute();
-        Assert.assertFalse(FileUtils.fileExists(packageJson));
+        assertFalse(FileUtils.fileExists(packageJson));
     }
 
     @Test
-    public void mavenGoal_when_frontendGeneratedExists_shouldClearFolder()
+    void mavenGoal_when_frontendGeneratedExists_shouldClearFolder()
             throws Exception {
         if (!generatedTsFolder.mkdirs()) {
-            Assert.fail("Failed to generate Frontend/generated folders.");
+            fail("Failed to generate Frontend/generated folders.");
         }
         final File flowFolder = new File(generatedTsFolder, "flow");
         if (!flowFolder.mkdir()) {
-            Assert.fail("Failed to generate flow folder");
+            fail("Failed to generate flow folder");
         }
         final File oldFile = new File(flowFolder, "old.js");
         if (!oldFile.createNewFile()) {
-            Assert.fail("Failed to generate old.js in Frontend/generated/flow");
+            fail("Failed to generate old.js in Frontend/generated/flow");
         }
 
         mojo.execute();
-        Assert.assertTrue("Missing generated folder",
-                generatedTsFolder.exists());
-        Assert.assertFalse("Old file should have been removed",
-                oldFile.exists());
+        assertTrue(generatedTsFolder.exists(), "Missing generated folder");
+        assertFalse(oldFile.exists(), "Old file should have been removed");
     }
 
     @Test
-    public void should_updateAndKeepDependencies_when_packageJsonExists()
+    void should_updateAndKeepDependencies_when_packageJsonExists()
             throws Exception {
         ObjectNode json = TestUtils.getInitialPackageJson();
         json.set("dependencies", JacksonUtils.createObjectNode());
@@ -261,7 +256,7 @@ public class PrepareFrontendMojoTest {
     }
 
     @Test
-    public void jarPackaging_copyProjectFrontendResources()
+    void jarPackaging_copyProjectFrontendResources()
             throws MojoExecutionException, MojoFailureException,
             IllegalAccessException {
         mojo.project.setPackaging("jar");

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/ReflectorTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/ReflectorTest.java
@@ -40,24 +40,28 @@ import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.classworlds.ClassWorld;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.utils.FlowFileUtils;
 
 import static com.vaadin.flow.plugin.maven.BuildFrontendMojoTest.getClassPath;
 import static com.vaadin.flow.utils.FlowFileUtils.convertToUrl;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ReflectorTest {
+class ReflectorTest {
 
     private static final String FLAT_MAVEN_REPO_PATH = "/some/flat/maven-repo/";
     public static final String PROJECT_TARGET_FOLDER = "/my/project/target";
 
     Reflector reflector;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         ClassLoader systemClassLoader = ClassLoader.getSystemClassLoader();
         URLClassLoader urlClassLoader = new URLClassLoader(
                 getClassPath(Path.of(".")).stream().distinct().map(File::new)
@@ -78,7 +82,7 @@ public class ReflectorTest {
     }
 
     @Test
-    public void createMojo_createInstanceAndCopyFields() throws Exception {
+    void createMojo_createInstanceAndCopyFields() throws Exception {
         MyMojo source = new MyMojo();
         source.fillFields();
         Mojo target = reflector.createMojo(source);
@@ -99,8 +103,7 @@ public class ReflectorTest {
     }
 
     @Test
-    public void createMojo_subclass_createInstanceAndCopyFields()
-            throws Exception {
+    void createMojo_subclass_createInstanceAndCopyFields() throws Exception {
         SubClassMojo source = new SubClassMojo();
         source.fillFields();
         Mojo target = reflector.createMojo(source);
@@ -124,19 +127,19 @@ public class ReflectorTest {
     }
 
     @Test
-    public void createMojo_incompatibleFields_fails() {
+    void createMojo_incompatibleFields_fails() {
         IncompatibleFieldsMojo source = new IncompatibleFieldsMojo();
         source.fillFields();
-        NoSuchFieldException exception = Assert.assertThrows(
+        NoSuchFieldException exception = assertThrows(
                 NoSuchFieldException.class, () -> reflector.createMojo(source));
-        Assert.assertTrue(
-                "Expected exception to be thrown because of class loader mismatch",
+        assertTrue(
                 exception.getMessage()
-                        .contains("loaded from different class loaders"));
+                        .contains("loaded from different class loaders"),
+                "Expected exception to be thrown because of class loader mismatch");
     }
 
     @Test
-    public void createMojo_cloneableFields_createInstanceAndCopyFields()
+    void createMojo_cloneableFields_createInstanceAndCopyFields()
             throws Exception {
         CloneableFieldsMojo source = new CloneableFieldsMojo();
         source.fillFields();
@@ -154,8 +157,7 @@ public class ReflectorTest {
     }
 
     @Test
-    public void reflector_fromProject_getsIsolatedClassLoader()
-            throws Exception {
+    void reflector_fromProject_getsIsolatedClassLoader() throws Exception {
         String outputDirectory = PROJECT_TARGET_FOLDER;
 
         MavenProject project = new MavenProject();
@@ -199,29 +201,28 @@ public class ReflectorTest {
 
         Set<String> urlSet = Arrays.stream(isolatedClassLoader.getURLs())
                 .map(URL::toExternalForm).collect(Collectors.toSet());
-        Assert.assertEquals(5, urlSet.size());
-        Assert.assertTrue(urlSet.contains(toURLExternalForm(outputDirectory)));
-        Assert.assertTrue(urlSet.contains(
+        assertEquals(5, urlSet.size());
+        assertTrue(urlSet.contains(toURLExternalForm(outputDirectory)));
+        assertTrue(urlSet.contains(
                 toURLExternalForm("com.vaadin.test-compile-1.0.jar")));
-        Assert.assertTrue(urlSet.contains(
+        assertTrue(urlSet.contains(
                 toURLExternalForm("com.vaadin.test-provided-1.0.jar")));
-        Assert.assertTrue(urlSet
+        assertTrue(urlSet
                 .contains(toURLExternalForm("com.vaadin.test-system-1.0.jar")));
-        Assert.assertTrue(urlSet
+        assertTrue(urlSet
                 .contains(toURLExternalForm("com.vaadin.test-plugin-1.0.jar")));
 
         // from platform class loader
-        Assert.assertNotNull(
+        assertNotNull(
                 isolatedClassLoader.loadClass("java.net.http.HttpClient"));
         // from maven.api class loader
-        Assert.assertNotNull(
+        assertNotNull(
                 isolatedClassLoader.getResource("org/json/CookieList.class"));
-        Assert.assertNotNull(
-                isolatedClassLoader.loadClass("org.json.CookieList"));
+        assertNotNull(isolatedClassLoader.loadClass("org.json.CookieList"));
     }
 
     @Test
-    public void reflector_frontendScannerConfigExclusions_getsFilteredIsolatedClassLoader()
+    void reflector_frontendScannerConfigExclusions_getsFilteredIsolatedClassLoader()
             throws Exception {
         FrontendScannerConfig scanner = new FrontendScannerConfig();
         scanner.addExclude(
@@ -241,7 +242,7 @@ public class ReflectorTest {
     }
 
     @Test
-    public void reflector_frontendScannerConfigInclusions_getsFilteredIsolatedClassLoader()
+    void reflector_frontendScannerConfigInclusions_getsFilteredIsolatedClassLoader()
             throws Exception {
         FrontendScannerConfig scanner = new FrontendScannerConfig();
         scanner.addInclude(
@@ -256,7 +257,7 @@ public class ReflectorTest {
     }
 
     @Test
-    public void reflector_frontendScannerConfigExclusionHigherPriority_getsFilteredIsolatedClassLoader()
+    void reflector_frontendScannerConfigExclusionHigherPriority_getsFilteredIsolatedClassLoader()
             throws Exception {
         FrontendScannerConfig scanner = new FrontendScannerConfig();
         scanner.addExclude(
@@ -284,7 +285,7 @@ public class ReflectorTest {
     }
 
     @Test
-    public void reflector_frontendScannerConfig_vaadinArtifactAlwaysIncluded()
+    void reflector_frontendScannerConfig_vaadinArtifactAlwaysIncluded()
             throws Exception {
         FrontendScannerConfig scanner = new FrontendScannerConfig();
         scanner.addExclude(new FrontendScannerConfig.ArtifactMatcher("*", "*"));
@@ -297,7 +298,7 @@ public class ReflectorTest {
     }
 
     @Test
-    public void reflector_disabledFrontendScannerConfig_getsFullIsolatedClassLoader()
+    void reflector_disabledFrontendScannerConfig_getsFullIsolatedClassLoader()
             throws Exception {
         FrontendScannerConfig scanner = new FrontendScannerConfig();
         scanner.addExclude(
@@ -321,8 +322,7 @@ public class ReflectorTest {
     }
 
     @Test
-    public void reflector_excludeTargetFolder_targetFolderExcluded()
-            throws Exception {
+    void reflector_excludeTargetFolder_targetFolderExcluded() throws Exception {
         FrontendScannerConfig scanner = new FrontendScannerConfig();
         scanner.setIncludeOutputDirectory(false);
 
@@ -414,42 +414,40 @@ public class ReflectorTest {
         // Ensure the classloader references all dependencies
         Set<String> urlSet = Arrays.stream(isolatedClassLoader.getURLs())
                 .map(URL::toExternalForm).collect(Collectors.toSet());
-        Assert.assertEquals(19, urlSet.size());
-        Assert.assertTrue(urlSet.contains(toURLExternalForm(outputDirectory)));
-        Assert.assertTrue(urlSet
+        assertEquals(19, urlSet.size());
+        assertTrue(urlSet.contains(toURLExternalForm(outputDirectory)));
+        assertTrue(urlSet
                 .contains(toURLExternalForm("com.vaadin-vaadin-core-1.0.jar")));
-        Assert.assertTrue(urlSet.contains(toURLExternalForm(
+        assertTrue(urlSet.contains(toURLExternalForm(
                 "org.springframework.boot-spring-boot-1.0.jar")));
-        Assert.assertTrue(urlSet.contains(
+        assertTrue(urlSet.contains(
                 toURLExternalForm("com.example.addon-alpha-1.0.jar")));
-        Assert.assertTrue(urlSet
+        assertTrue(urlSet
                 .contains(toURLExternalForm("com.example.addon-beta-1.0.jar")));
-        Assert.assertTrue(
+        assertTrue(
                 urlSet.contains(toURLExternalForm("org.test-alpha-1.0.jar")));
-        Assert.assertTrue(
-                urlSet.contains(toURLExternalForm("org.test-beta-1.0.jar")));
-        Assert.assertTrue(urlSet.contains(
+        assertTrue(urlSet.contains(toURLExternalForm("org.test-beta-1.0.jar")));
+        assertTrue(urlSet.contains(
                 toURLExternalForm("com.example.plugin-plugin-dep-1.0.jar")));
         for (String url : defaultVaadinDependencies) {
-            Assert.assertTrue(urlSet.contains(toURLExternalForm(url)));
+            assertTrue(urlSet.contains(toURLExternalForm(url)));
         }
 
         // Verify scan URLs
         urlSet = Arrays.stream(isolatedClassLoader.getUrlsToScan())
                 .map(URL::toExternalForm).collect(Collectors.toSet());
-        Assert.assertEquals(expectedScanURLs.size(), urlSet.size());
+        assertEquals(expectedScanURLs.size(), urlSet.size());
         for (String expectedUrl : expectedScanURLs) {
-            Assert.assertTrue("Scan URL missing in Reflector: " + expectedUrl,
-                    urlSet.contains(toURLExternalForm(expectedUrl)));
+            assertTrue(urlSet.contains(toURLExternalForm(expectedUrl)),
+                    "Scan URL missing in Reflector: " + expectedUrl);
         }
         // verify default excluded URLs are indeed excluded
         for (String expectedExcludedUrl : defaultVaadinDependencies) {
             if (expectedScanURLs.contains(expectedExcludedUrl)) {
                 continue; // already checked as included
             }
-            Assert.assertFalse(
-                    "Unexpected scan URL in Reflector: " + expectedExcludedUrl,
-                    urlSet.contains(toURLExternalForm(expectedExcludedUrl)));
+            assertFalse(urlSet.contains(toURLExternalForm(expectedExcludedUrl)),
+                    "Unexpected scan URL in Reflector: " + expectedExcludedUrl);
         }
 
     }

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/SkipExecutionTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/SkipExecutionTest.java
@@ -16,33 +16,33 @@
 package com.vaadin.flow.plugin.maven;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import org.apache.maven.plugin.logging.Log;
 import org.codehaus.plexus.util.ReflectionUtils;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 import static com.vaadin.flow.plugin.maven.BuildFrontendMojoTest.setProject;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-public class SkipExecutionTest {
+class SkipExecutionTest {
 
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir
+    Path tempDir;
 
     private PrepareFrontendMojo mojo;
     private Log mockLog;
     private File projectBase;
 
-    @Before
-    public void setup() throws Exception {
+    @BeforeEach
+    void setup() throws Exception {
         mojo = new PrepareFrontendMojo();
         mockLog = Mockito.mock(Log.class);
-        projectBase = temporaryFolder.getRoot();
+        projectBase = tempDir.toFile();
 
         // Set up the mojo with basic configuration
         ReflectionUtils.setVariableValueInObject(mojo, "projectBasedir",
@@ -57,7 +57,7 @@ public class SkipExecutionTest {
     }
 
     @Test
-    public void testSkipExecutionWhenVaadinSkipIsTrue() throws Exception {
+    void testSkipExecutionWhenVaadinSkipIsTrue() throws Exception {
         // Set the skip parameter to true
         ReflectionUtils.setVariableValueInObject(mojo, "skip", true);
 
@@ -69,7 +69,7 @@ public class SkipExecutionTest {
     }
 
     @Test
-    public void testNormalExecutionWhenVaadinSkipIsFalse() throws Exception {
+    void testNormalExecutionWhenVaadinSkipIsFalse() throws Exception {
         // Set the skip parameter to false (default)
         ReflectionUtils.setVariableValueInObject(mojo, "skip", false);
 

--- a/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
+++ b/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
@@ -37,11 +37,9 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Answers;
 import org.mockito.InOrder;
 import org.mockito.MockedConstruction;
@@ -76,10 +74,16 @@ import com.vaadin.pro.licensechecker.LicenseException;
 import com.vaadin.pro.licensechecker.MissingLicenseKeyException;
 import com.vaadin.pro.licensechecker.Product;
 
-public class BuildFrontendUtilTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-    @Rule
-    public TemporaryFolder tmpDir = new TemporaryFolder();
+class BuildFrontendUtilTest {
+
+    @TempDir
+    Path tmpDir;
     private File baseDir;
 
     private PluginAdapterBuild adapter;
@@ -89,10 +93,11 @@ public class BuildFrontendUtilTest {
     private File statsJson;
     private File resourceOutput;
 
-    @Before
-    public void setup() throws Exception {
-        baseDir = tmpDir.newFolder();
-        File frontendOutput = tmpDir.newFolder("frontend-output");
+    @BeforeEach
+    void setup() throws Exception {
+        baseDir = Files.createDirectories(tmpDir.resolve("baseDir")).toFile();
+        File frontendOutput = Files
+                .createDirectories(tmpDir.resolve("frontend-output")).toFile();
 
         adapter = Mockito.mock(PluginAdapterBuild.class);
         Mockito.when(adapter.frontendOutputDirectory())
@@ -100,8 +105,7 @@ public class BuildFrontendUtilTest {
         Mockito.when(adapter.npmFolder()).thenReturn(baseDir);
         Mockito.when(adapter.generatedTsFolder())
                 .thenReturn(new File(baseDir, "src/main/frontend/generated"));
-        Mockito.when(adapter.projectBaseDirectory())
-                .thenReturn(tmpDir.getRoot().toPath());
+        Mockito.when(adapter.projectBaseDirectory()).thenReturn(tmpDir);
         Mockito.when(adapter.applicationIdentifier()).thenReturn("TEST_APP_ID");
         ClassFinder classFinder = new ClassFinder.DefaultClassFinder(
                 getClass().getClassLoader());
@@ -111,9 +115,9 @@ public class BuildFrontendUtilTest {
 
         // setup: mock a vite executable
         File viteBin = new File(baseDir, "node_modules/vite/bin");
-        Assert.assertTrue(viteBin.mkdirs());
+        assertTrue(viteBin.mkdirs());
         File viteExecutableMock = new File(viteBin, "vite.js");
-        Assert.assertTrue(viteExecutableMock.createNewFile());
+        assertTrue(viteExecutableMock.createNewFile());
 
         resourceOutput = new File(baseDir, "resOut");
         Mockito.when(adapter.servletResourceOutputDirectory())
@@ -126,7 +130,7 @@ public class BuildFrontendUtilTest {
     }
 
     @Test
-    public void should_notUseHilla_inPrepareFrontend()
+    void should_notUseHilla_inPrepareFrontend()
             throws ExecutionFailedException, IOException, URISyntaxException {
         setupPluginAdapterDefaults();
 
@@ -147,7 +151,7 @@ public class BuildFrontendUtilTest {
     }
 
     @Test
-    public void should_useHillaEngine_withNodeUpdater()
+    void should_useHillaEngine_withNodeUpdater()
             throws URISyntaxException, ExecutionFailedException {
         setupPluginAdapterDefaults();
 
@@ -198,7 +202,7 @@ public class BuildFrontendUtilTest {
     }
 
     @Test
-    public void detectsUsedCommercialComponents() {
+    void detectsUsedCommercialComponents() {
 
         final FrontendDependenciesScanner scanner = Mockito
                 .mock(FrontendDependenciesScanner.class);
@@ -218,19 +222,19 @@ public class BuildFrontendUtilTest {
         List<Product> components = BuildFrontendUtil
                 .findCommercialFrontendComponents(scanner, statsJsonContents);
         // Two components are included, only one is used
-        Assert.assertEquals(1, components.size());
-        Assert.assertEquals("comm-comp", components.get(0).getName());
-        Assert.assertEquals("4.6.5", components.get(0).getVersion());
+        assertEquals(1, components.size());
+        assertEquals("comm-comp", components.get(0).getName());
+        assertEquals("4.6.5", components.get(0).getVersion());
     }
 
     @Test
-    public void propagateBuildInfo_tokenFileNotExisting_createTokenFile()
+    void propagateBuildInfo_tokenFileNotExisting_createTokenFile()
             throws Exception {
         prepareAndAssertTokenFile();
     }
 
     @Test
-    public void propagateBuildInfo_existingTokenFileWithDifferentContent_overwritesTokenFile()
+    void propagateBuildInfo_existingTokenFileWithDifferentContent_overwritesTokenFile()
             throws Exception {
         File tokenFile = prepareAndAssertTokenFile();
         long lastModified = tokenFile.lastModified();
@@ -239,12 +243,12 @@ public class BuildFrontendUtilTest {
         Mockito.when(adapter.nodeVersion()).thenReturn("v1.0.0");
         BuildFrontendUtil.propagateBuildInfo(adapter);
 
-        Assert.assertNotEquals("Expected token file to be updated, but was not",
-                lastModified, tokenFile.lastModified());
+        assertNotEquals(lastModified, tokenFile.lastModified(),
+                "Expected token file to be updated, but was not");
     }
 
     @Test
-    public void propagateBuildInfo_existingTokenFileWithSameContent_doesNotWriteTokenFile()
+    void propagateBuildInfo_existingTokenFileWithSameContent_doesNotWriteTokenFile()
             throws Exception {
         File tokenFile = prepareAndAssertTokenFile();
         long lastModified = tokenFile.lastModified();
@@ -252,17 +256,15 @@ public class BuildFrontendUtilTest {
         Thread.sleep(100);
 
         BuildFrontendUtil.propagateBuildInfo(adapter);
-        Assert.assertEquals(
-                "Expected token file not to be updated, but it has been written",
-                lastModified, tokenFile.lastModified());
+        assertEquals(lastModified, tokenFile.lastModified(),
+                "Expected token file not to be updated, but it has been written");
     }
 
     @Test
-    public void prepareFrontend_shouldCleanUnusedGeneratedFiles()
-            throws Exception {
+    void prepareFrontend_shouldCleanUnusedGeneratedFiles() throws Exception {
         fillAdapter();
         File frontendGeneratedFolder = new File(
-                new File(tmpDir.getRoot(), "frontend"), "generated");
+                new File(tmpDir.toFile(), "frontend"), "generated");
         Mockito.when(adapter.generatedTsFolder())
                 .thenReturn(frontendGeneratedFolder);
 
@@ -289,61 +291,59 @@ public class BuildFrontendUtilTest {
         Set<Path> generatedFiles = Files.walk(frontendGeneratedFolder.toPath())
                 .filter(Files::isRegularFile).collect(Collectors.toSet());
 
-        Assert.assertTrue(
-                "Files not generated by prepare frontend should not be present",
-                generatedFiles.stream().noneMatch(additionalFiles::contains));
-        Assert.assertEquals("Expecting same generated files to be present",
-                expectedGeneratedFiles, generatedFiles);
+        assertTrue(generatedFiles.stream().noneMatch(additionalFiles::contains),
+                "Files not generated by prepare frontend should not be present");
+        assertEquals(expectedGeneratedFiles, generatedFiles,
+                "Expecting same generated files to be present");
 
     }
 
     @Test
-    public void updateBuildFile_tokenFileNotExisting_doNothing()
-            throws Exception {
+    void updateBuildFile_tokenFileNotExisting_doNothing() throws Exception {
         fillAdapter();
 
         BuildFrontendUtil.updateBuildFile(adapter, false, false);
         File tokenFile = new File(resourceOutput, FrontendUtils.TOKEN_FILE);
-        Assert.assertFalse("Token file should not have been created",
-                tokenFile.exists());
+        assertFalse(tokenFile.exists(),
+                "Token file should not have been created");
     }
 
     @Test
-    public void updateBuildFile_tokenExisting_developmentEntriesRemoved()
+    void updateBuildFile_tokenExisting_developmentEntriesRemoved()
             throws Exception {
         File tokenFile = prepareAndAssertTokenFile();
         JsonNode buildInfoJsonDev = JacksonUtils
                 .readTree(Files.readString(tokenFile.toPath()));
 
         BuildFrontendUtil.updateBuildFile(adapter, false, false);
-        Assert.assertTrue("Token file should still exist", tokenFile.exists());
+        assertTrue(tokenFile.exists(), "Token file should still exist");
         JsonNode buildInfoJsonProd = JacksonUtils
                 .readTree(Files.readString(tokenFile.toPath()));
 
         Set<String> removedKeys = JacksonUtils.getKeys(buildInfoJsonDev)
                 .stream().filter(key -> !buildInfoJsonProd.has(key))
                 .collect(Collectors.toSet());
-        Assert.assertFalse(
-                "Development entries have not been removed from token file",
-                removedKeys.isEmpty());
+        assertFalse(removedKeys.isEmpty(),
+                "Development entries have not been removed from token file");
     }
 
     @Test
-    public void updateBuildFile_tokenExisting_applicationIdentifierAdded()
+    void updateBuildFile_tokenExisting_applicationIdentifierAdded()
             throws Exception {
         File tokenFile = prepareAndAssertTokenFile();
 
         BuildFrontendUtil.updateBuildFile(adapter, false, false);
-        Assert.assertTrue("Token file should still exist", tokenFile.exists());
+        assertTrue(tokenFile.exists(), "Token file should still exist");
         JsonNode buildInfoJsonProd = JacksonUtils
                 .readTree(Files.readString(tokenFile.toPath()));
-        Assert.assertEquals("Wrong application identifier in token file",
-                "TEST_APP_ID", buildInfoJsonProd
-                        .get(InitParameters.APPLICATION_IDENTIFIER).asString());
+        assertEquals("TEST_APP_ID",
+                buildInfoJsonProd.get(InitParameters.APPLICATION_IDENTIFIER)
+                        .asString(),
+                "Wrong application identifier in token file");
     }
 
     @Test
-    public void updateBuildFile_tokenExisting_licenseRequiredAndSubscriptionKey_dauFlagAdded()
+    void updateBuildFile_tokenExisting_licenseRequiredAndSubscriptionKey_dauFlagAdded()
             throws Exception {
         File tokenFile = prepareAndAssertTokenFile();
         withMockedLicenseChecker(false, () -> {
@@ -360,17 +360,17 @@ public class BuildFrontendUtilTest {
                     System.clearProperty("vaadin.subscriptionKey");
                 }
             }
-            Assert.assertTrue("Token file should still exist",
-                    tokenFile.exists());
+            assertTrue(tokenFile.exists(), "Token file should still exist");
             JsonNode buildInfoJsonProd = JacksonUtils
                     .readTree(Files.readString(tokenFile.toPath()));
-            Assert.assertTrue("DAU flag should be active in token file",
-                    buildInfoJsonProd.get(Constants.DAU_TOKEN).booleanValue());
+            assertTrue(
+                    buildInfoJsonProd.get(Constants.DAU_TOKEN).booleanValue(),
+                    "DAU flag should be active in token file");
         });
     }
 
     @Test
-    public void updateBuildFile_tokenExisting_licenseNotRequiredAndSubscriptionKey_dauFlagNotAdded()
+    void updateBuildFile_tokenExisting_licenseNotRequiredAndSubscriptionKey_dauFlagNotAdded()
             throws Exception {
         File tokenFile = prepareAndAssertTokenFile();
 
@@ -387,15 +387,15 @@ public class BuildFrontendUtilTest {
                 System.clearProperty("vaadin.subscriptionKey");
             }
         }
-        Assert.assertTrue("Token file should still exist", tokenFile.exists());
+        assertTrue(tokenFile.exists(), "Token file should still exist");
         JsonNode buildInfoJsonProd = JacksonUtils
                 .readTree(Files.readString(tokenFile.toPath()));
-        Assert.assertFalse("DAU flag should not be present in token file",
-                buildInfoJsonProd.has(Constants.DAU_TOKEN));
+        assertFalse(buildInfoJsonProd.has(Constants.DAU_TOKEN),
+                "DAU flag should not be present in token file");
     }
 
     @Test
-    public void updateBuildFile_tokenExisting_licenseRequiredNoSubscriptionKey_dauFlagNotAdded()
+    void updateBuildFile_tokenExisting_licenseRequiredNoSubscriptionKey_dauFlagNotAdded()
             throws Exception {
         File tokenFile = prepareAndAssertTokenFile();
         withMockedLicenseChecker(false, () -> {
@@ -412,17 +412,16 @@ public class BuildFrontendUtilTest {
                     System.clearProperty("vaadin.subscriptionKey");
                 }
             }
-            Assert.assertTrue("Token file should still exist",
-                    tokenFile.exists());
+            assertTrue(tokenFile.exists(), "Token file should still exist");
             JsonNode buildInfoJsonProd = JacksonUtils
                     .readTree(Files.readString(tokenFile.toPath()));
-            Assert.assertFalse("DAU flag should not be present in token file",
-                    buildInfoJsonProd.has(Constants.DAU_TOKEN));
+            assertFalse(buildInfoJsonProd.has(Constants.DAU_TOKEN),
+                    "DAU flag should not be present in token file");
         });
     }
 
     @Test
-    public void updateBuildFile_tokenExisting_licenseRequiredAndIsPremiumLike_premiumFeaturesFlagAdded()
+    void updateBuildFile_tokenExisting_licenseRequiredAndIsPremiumLike_premiumFeaturesFlagAdded()
             throws Exception {
         File tokenFile = prepareAndAssertTokenFile();
 
@@ -438,20 +437,19 @@ public class BuildFrontendUtilTest {
 
         withMockedLicenseChecker(true, () -> {
             BuildFrontendUtil.updateBuildFile(adapter, true, false);
-            Assert.assertTrue("Token file should still exist",
-                    tokenFile.exists());
+            assertTrue(tokenFile.exists(), "Token file should still exist");
             JsonNode buildInfoJsonProd = JacksonUtils
                     .readTree(Files.readString(tokenFile.toPath()));
-            Assert.assertTrue(
-                    Constants.PREMIUM_FEATURES
-                            + " flag should be active in token file",
+            assertTrue(
                     buildInfoJsonProd.get(Constants.PREMIUM_FEATURES)
-                            .booleanValue());
+                            .booleanValue(),
+                    Constants.PREMIUM_FEATURES
+                            + " flag should be active in token file");
         });
     }
 
     @Test
-    public void updateBuildFile_tokenExisting_licenseRequiredAndIsNotPremiumLike_premiumFeaturesFlagNotAdded()
+    void updateBuildFile_tokenExisting_licenseRequiredAndIsNotPremiumLike_premiumFeaturesFlagNotAdded()
             throws Exception {
         File tokenFile = prepareAndAssertTokenFile();
 
@@ -459,19 +457,17 @@ public class BuildFrontendUtilTest {
 
         withMockedLicenseChecker(false, () -> {
             BuildFrontendUtil.updateBuildFile(adapter, true, false);
-            Assert.assertTrue("Token file should still exist",
-                    tokenFile.exists());
+            assertTrue(tokenFile.exists(), "Token file should still exist");
             JsonNode buildInfoJsonProd = JacksonUtils
                     .readTree(Files.readString(tokenFile.toPath()));
-            Assert.assertFalse(
+            assertFalse(buildInfoJsonProd.has(Constants.PREMIUM_FEATURES),
                     Constants.PREMIUM_FEATURES
-                            + " flag should not be active in token file",
-                    buildInfoJsonProd.has(Constants.PREMIUM_FEATURES));
+                            + " flag should not be active in token file");
         });
     }
 
     @Test
-    public void updateBuildFile_tokenExisting_commercialBannerBuildRequiredAndIsPremiumLike_premiumFeaturesFlagAdded()
+    void updateBuildFile_tokenExisting_commercialBannerBuildRequiredAndIsPremiumLike_premiumFeaturesFlagAdded()
             throws Exception {
         Mockito.when(adapter.isCommercialBannerEnabled()).thenReturn(true);
         File tokenFile = prepareAndAssertTokenFile();
@@ -488,36 +484,34 @@ public class BuildFrontendUtilTest {
 
         withMockedLicenseChecker(false, () -> {
             BuildFrontendUtil.updateBuildFile(adapter, true, true);
-            Assert.assertTrue("Token file should still exist",
-                    tokenFile.exists());
+            assertTrue(tokenFile.exists(), "Token file should still exist");
             JsonNode buildInfoJsonProd = JacksonUtils
                     .readTree(Files.readString(tokenFile.toPath()));
-            Assert.assertTrue(
-                    Constants.PREMIUM_FEATURES
-                            + " flag should be active in token file",
+            assertTrue(
                     buildInfoJsonProd.get(Constants.PREMIUM_FEATURES)
-                            .booleanValue());
+                            .booleanValue(),
+                    Constants.PREMIUM_FEATURES
+                            + " flag should be active in token file");
         });
     }
 
     @Test
-    public void updateBuildFile_tokenExisting_commercialBannerBuildRequired_commercialBannerBuildEnabled_commercialBannerFlagAdded()
+    void updateBuildFile_tokenExisting_commercialBannerBuildRequired_commercialBannerBuildEnabled_commercialBannerFlagAdded()
             throws Exception {
         Mockito.when(adapter.isCommercialBannerEnabled()).thenReturn(true);
         File tokenFile = prepareAndAssertTokenFile();
 
         BuildFrontendUtil.updateBuildFile(adapter, true, true);
-        Assert.assertTrue("Token file should still exist", tokenFile.exists());
+        assertTrue(tokenFile.exists(), "Token file should still exist");
         JsonNode buildInfoJsonProd = JacksonUtils
                 .readTree(Files.readString(tokenFile.toPath()));
-        Assert.assertTrue(
+        assertTrue(buildInfoJsonProd.has(Constants.COMMERCIAL_BANNER_TOKEN),
                 Constants.COMMERCIAL_BANNER_TOKEN
-                        + " flag should be active in token file",
-                buildInfoJsonProd.has(Constants.COMMERCIAL_BANNER_TOKEN));
+                        + " flag should be active in token file");
     }
 
     @Test
-    public void updateBuildFile_tokenExisting_commercialBannerBuildRequired_commercialBannerBuildNotEnabled_throws()
+    void updateBuildFile_tokenExisting_commercialBannerBuildRequired_commercialBannerBuildNotEnabled_throws()
             throws Exception {
         Mockito.when(adapter.isCommercialBannerEnabled()).thenReturn(false);
         prepareAndAssertTokenFile();
@@ -525,44 +519,42 @@ public class BuildFrontendUtilTest {
         // If commercial banner is required but not enabled, it means there's an
         // issue
         // in the plugin license checking mechanism
-        Assert.assertThrows(IllegalStateException.class,
+        assertThrows(IllegalStateException.class,
                 () -> BuildFrontendUtil.updateBuildFile(adapter, true, true));
     }
 
     @Test
-    public void updateBuildFile_tokenExisting_commercialBannerBuildNotRequired_commercialBannerBuildEnabled_commercialBannerFlagNotAdded()
+    void updateBuildFile_tokenExisting_commercialBannerBuildNotRequired_commercialBannerBuildEnabled_commercialBannerFlagNotAdded()
             throws Exception {
         Mockito.when(adapter.isCommercialBannerEnabled()).thenReturn(true);
         File tokenFile = prepareAndAssertTokenFile();
 
         BuildFrontendUtil.updateBuildFile(adapter, true, false);
-        Assert.assertTrue("Token file should still exist", tokenFile.exists());
+        assertTrue(tokenFile.exists(), "Token file should still exist");
         JsonNode buildInfoJsonProd = JacksonUtils
                 .readTree(Files.readString(tokenFile.toPath()));
-        Assert.assertFalse(
+        assertFalse(buildInfoJsonProd.has(Constants.COMMERCIAL_BANNER_TOKEN),
                 Constants.COMMERCIAL_BANNER_TOKEN
-                        + " flag should not be active in token file",
-                buildInfoJsonProd.has(Constants.COMMERCIAL_BANNER_TOKEN));
+                        + " flag should not be active in token file");
     }
 
     @Test
-    public void updateBuildFile_tokenExisting_licenseNotRequired_commercialBannerBuildRequired_commercialBannerFlagNotAdded()
+    void updateBuildFile_tokenExisting_licenseNotRequired_commercialBannerBuildRequired_commercialBannerFlagNotAdded()
             throws Exception {
         Mockito.when(adapter.isCommercialBannerEnabled()).thenReturn(true);
         File tokenFile = prepareAndAssertTokenFile();
 
         BuildFrontendUtil.updateBuildFile(adapter, false, true);
-        Assert.assertTrue("Token file should still exist", tokenFile.exists());
+        assertTrue(tokenFile.exists(), "Token file should still exist");
         JsonNode buildInfoJsonProd = JacksonUtils
                 .readTree(Files.readString(tokenFile.toPath()));
-        Assert.assertFalse(
+        assertFalse(buildInfoJsonProd.has(Constants.COMMERCIAL_BANNER_TOKEN),
                 Constants.COMMERCIAL_BANNER_TOKEN
-                        + " flag should not be active in token file",
-                buildInfoJsonProd.has(Constants.COMMERCIAL_BANNER_TOKEN));
+                        + " flag should not be active in token file");
     }
 
     @Test
-    public void validateLicense_commercialProducts_noLocalKeys_buildWithCommercialBannerDisabled_failsWithCommercialBannerSuggestion()
+    void validateLicense_commercialProducts_noLocalKeys_buildWithCommercialBannerDisabled_failsWithCommercialBannerSuggestion()
             throws Exception {
         Mockito.when(adapter.isCommercialBannerEnabled()).thenReturn(false);
 
@@ -589,25 +581,24 @@ public class BuildFrontendUtilTest {
         Mockito.when(frontendDependencies.getModules()).thenReturn(modulesMap);
 
         withMockedLicenseChecker(false, () -> {
-            LicenseException exception = Assert.assertThrows(
-                    LicenseException.class, () -> BuildFrontendUtil
-                            .validateLicenses(adapter, frontendDependencies));
-            commercialProducts.forEach(product -> Assert.assertTrue(
+            LicenseException exception = assertThrows(LicenseException.class,
+                    () -> BuildFrontendUtil.validateLicenses(adapter,
+                            frontendDependencies));
+            commercialProducts.forEach(product -> assertTrue(
+                    exception.getMessage().contains(product),
                     "Exception should list all commercial products but "
-                            + product + " is missing",
-                    exception.getMessage().contains(product)));
-            Assert.assertTrue(
-                    "Expected exception message to suggest usage of commercial banner build",
+                            + product + " is missing"));
+            assertTrue(
                     exception.getMessage()
-                            .contains(InitParameters.COMMERCIAL_WITH_BANNER));
-            Assert.assertFalse(
-                    "Expected output directory to be deleted but was not",
-                    adapter.frontendOutputDirectory().exists());
+                            .contains(InitParameters.COMMERCIAL_WITH_BANNER),
+                    "Expected exception message to suggest usage of commercial banner build");
+            assertFalse(adapter.frontendOutputDirectory().exists(),
+                    "Expected output directory to be deleted but was not");
         });
     }
 
     @Test
-    public void validateLicense_commercialFrontendProducts_noLocalKeys_buildWithCommercialBannerEnabled_propagateMissingKeyException()
+    void validateLicense_commercialFrontendProducts_noLocalKeys_buildWithCommercialBannerEnabled_propagateMissingKeyException()
             throws Exception {
         Mockito.when(adapter.isCommercialBannerEnabled()).thenReturn(true);
         Files.createDirectories(statsJson.toPath().getParent());
@@ -629,12 +620,11 @@ public class BuildFrontendUtilTest {
         Mockito.when(frontendDependencies.getModules()).thenReturn(modulesMap);
 
         withMockedLicenseChecker(false, () -> {
-            Assert.assertThrows(MissingLicenseKeyException.class,
+            assertThrows(MissingLicenseKeyException.class,
                     () -> BuildFrontendUtil.validateLicenses(adapter,
                             frontendDependencies));
-            Assert.assertTrue(
-                    "Expected output directory to be preserved but was not",
-                    adapter.frontendOutputDirectory().exists());
+            assertTrue(adapter.frontendOutputDirectory().exists(),
+                    "Expected output directory to be preserved but was not");
         });
     }
 
@@ -674,13 +664,12 @@ public class BuildFrontendUtilTest {
         BuildFrontendUtil.propagateBuildInfo(adapter);
 
         File tokenFile = new File(resourceOutput, FrontendUtils.TOKEN_FILE);
-        Assert.assertTrue("Token file should have been created",
-                tokenFile.exists());
+        assertTrue(tokenFile.exists(), "Token file should have been created");
         return tokenFile;
     }
 
     @Test
-    public void runNodeUpdater_generateFeatureFlagsJsFile() throws Exception {
+    void runNodeUpdater_generateFeatureFlagsJsFile() throws Exception {
         setupPluginAdapterDefaults();
 
         File targetDir = baseDir.toPath().resolve(adapter.buildFolder())
@@ -720,9 +709,10 @@ public class BuildFrontendUtilTest {
                 .readString(generatedFeatureFlagsFile.toPath())
                 .replace("\r\n", "\n");
 
-        Assert.assertFalse("Example feature should not be set at build time",
+        assertFalse(
                 featureFlagsJs.contains(
-                        "window.Vaadin.featureFlags.exampleFeatureFlag"));
+                        "window.Vaadin.featureFlags.exampleFeatureFlag"),
+                "Example feature should not be set at build time");
     }
 
     private void fillAdapter() throws URISyntaxException {
@@ -730,15 +720,15 @@ public class BuildFrontendUtilTest {
                 .thenReturn(URI.create("http://something/node/"));
         Mockito.when(adapter.nodeVersion()).thenReturn("v0.0.0");
         Mockito.when(adapter.frontendDirectory())
-                .thenReturn(new File(tmpDir.getRoot(), "frontend"));
+                .thenReturn(tmpDir.resolve("frontend").toFile());
         Mockito.when(adapter.javaSourceFolder())
-                .thenReturn(new File(tmpDir.getRoot(), "src/main/java"));
+                .thenReturn(tmpDir.resolve("src/main/java").toFile());
         Mockito.when(adapter.javaResourceFolder())
-                .thenReturn(new File(tmpDir.getRoot(), "src/main/resources"));
-        Mockito.when(adapter.applicationProperties()).thenReturn(new File(
-                tmpDir.getRoot(), "src/main/resources/application.properties"));
-        Mockito.when(adapter.openApiJsonFile()).thenReturn(new File(
-                tmpDir.getRoot(), "target/generated-resources/openapi.json"));
+                .thenReturn(tmpDir.resolve("src/main/resources").toFile());
+        Mockito.when(adapter.applicationProperties()).thenReturn(tmpDir
+                .resolve("src/main/resources/application.properties").toFile());
+        Mockito.when(adapter.openApiJsonFile()).thenReturn(tmpDir
+                .resolve("target/generated-resources/openapi.json").toFile());
         Mockito.when(adapter.buildFolder()).thenReturn("target");
     }
 
@@ -770,10 +760,10 @@ public class BuildFrontendUtilTest {
         Mockito.when(adapter.buildFolder()).thenReturn(Constants.TARGET);
         Mockito.when(adapter.npmFolder()).thenReturn(baseDir);
         File javaSourceFolder = new File(baseDir, "src/main/java");
-        Assert.assertTrue(javaSourceFolder.mkdirs());
+        assertTrue(javaSourceFolder.mkdirs());
         Mockito.when(adapter.javaSourceFolder()).thenReturn(javaSourceFolder);
         File javaResourceFolder = new File(baseDir, "src/main/resources");
-        Assert.assertTrue(javaResourceFolder.mkdirs());
+        assertTrue(javaResourceFolder.mkdirs());
         Mockito.when(adapter.javaResourceFolder())
                 .thenReturn(javaResourceFolder);
         Mockito.when(adapter.openApiJsonFile())

--- a/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/ConvertPolymerCommandTest.java
+++ b/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/ConvertPolymerCommandTest.java
@@ -15,16 +15,15 @@
  */
 package com.vaadin.flow.plugin.base;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.MockedConstruction;
 import org.mockito.Mockito;
@@ -34,9 +33,9 @@ import com.vaadin.flow.internal.FrontendUtils.CommandExecutionException;
 import com.vaadin.flow.polymer2lit.FrontendConverter;
 import com.vaadin.flow.polymer2lit.ServerConverter;
 
-public class ConvertPolymerCommandTest {
-    @Rule
-    public TemporaryFolder tmpDir = new TemporaryFolder();
+class ConvertPolymerCommandTest {
+    @TempDir
+    Path tmpDir;
 
     @Mock
     private MockedConstruction<FrontendConverter> frontendConverterMock;
@@ -52,29 +51,28 @@ public class ConvertPolymerCommandTest {
 
     private AutoCloseable closeable;
 
-    @Before
-    public void init()
-            throws IOException, URISyntaxException, IllegalAccessException {
+    @BeforeEach
+    void init() throws IOException, URISyntaxException, IllegalAccessException {
         closeable = MockitoAnnotations.openMocks(this);
-        TestUtil.stubPluginAdapterBase(adapter, tmpDir.getRoot());
+        TestUtil.stubPluginAdapterBase(adapter, tmpDir.toFile());
 
-        tmpDir.newFile("component.js");
-        tmpDir.newFolder("nested");
-        tmpDir.newFile("nested/component.js");
-        tmpDir.newFolder("node_modules");
-        tmpDir.newFile("node_modules/component.js");
-        tmpDir.newFile("Component.java");
-        tmpDir.newFile("nested/Component.java");
+        Files.createFile(tmpDir.resolve("component.js"));
+        Files.createDirectories(tmpDir.resolve("nested"));
+        Files.createFile(tmpDir.resolve("nested/component.js"));
+        Files.createDirectories(tmpDir.resolve("node_modules"));
+        Files.createFile(tmpDir.resolve("node_modules/component.js"));
+        Files.createFile(tmpDir.resolve("Component.java"));
+        Files.createFile(tmpDir.resolve("nested/Component.java"));
     }
 
-    @After
-    public void teardown() throws Exception {
+    @AfterEach
+    void teardown() throws Exception {
         closeable.close();
     }
 
     @Test
-    public void execute() throws URISyntaxException, IOException,
-            InterruptedException, CommandExecutionException {
+    void execute() throws URISyntaxException, IOException, InterruptedException,
+            CommandExecutionException {
         try (ConvertPolymerCommand command = new ConvertPolymerCommand(adapter,
                 null, false, false)) {
             command.execute();
@@ -106,7 +104,7 @@ public class ConvertPolymerCommandTest {
     }
 
     @Test
-    public void setSpecificFrontendFile_execute() throws URISyntaxException,
+    void setSpecificFrontendFile_execute() throws URISyntaxException,
             IOException, InterruptedException, CommandExecutionException {
         try (ConvertPolymerCommand command = new ConvertPolymerCommand(adapter,
                 "/nested/component.js", false, false)) {
@@ -129,8 +127,8 @@ public class ConvertPolymerCommandTest {
     }
 
     @Test
-    public void setSpecificServerFile_execute() throws URISyntaxException,
-            IOException, InterruptedException, CommandExecutionException {
+    void setSpecificServerFile_execute() throws URISyntaxException, IOException,
+            InterruptedException, CommandExecutionException {
         try (ConvertPolymerCommand command = new ConvertPolymerCommand(adapter,
                 "/nested/Component.java", false, false)) {
             command.execute();
@@ -152,7 +150,7 @@ public class ConvertPolymerCommandTest {
     }
 
     @Test
-    public void useLit1_execute() throws URISyntaxException, IOException,
+    void useLit1_execute() throws URISyntaxException, IOException,
             InterruptedException, CommandExecutionException {
         try (ConvertPolymerCommand command = new ConvertPolymerCommand(adapter,
                 null, true, false)) {
@@ -168,7 +166,7 @@ public class ConvertPolymerCommandTest {
     }
 
     @Test
-    public void disableOptionalChaining_execute() throws URISyntaxException,
+    void disableOptionalChaining_execute() throws URISyntaxException,
             IOException, InterruptedException, CommandExecutionException {
         try (ConvertPolymerCommand command = new ConvertPolymerCommand(adapter,
                 null, false, true)) {
@@ -184,6 +182,6 @@ public class ConvertPolymerCommandTest {
     }
 
     private Path getTmpFilePath(String path) {
-        return new File(tmpDir.getRoot(), path).toPath();
+        return tmpDir.resolve(path);
     }
 }

--- a/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/server/scanner/ReflectionsClassFinderTest.java
+++ b/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/server/scanner/ReflectionsClassFinderTest.java
@@ -30,31 +30,34 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 
-public class ReflectionsClassFinderTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ReflectionsClassFinderTest {
 
     private static final String CLASS_TEMPLATE = "package %s;\n" + "\n"
             + "import com.vaadin.flow.component.dependency.NpmPackage;\n" + "\n"
             + "import com.vaadin.flow.component.Component;\n" + "\n"
             + "@NpmPackage(value = \"@vaadin/something\", version = \"%s\")\n"
             + "public class %s extends Component {\n" + "}\n";
-    @Rule
-    public TemporaryFolder externalModules = new TemporaryFolder();
+    @TempDir
+    Path externalModules;
 
     URL[] urls;
     private ClassFinder.DefaultClassFinder defaultClassFinder;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    void setUp() throws Exception {
         urls = new URL[] {
                 createTestModule("module-1", "com.vaadin.flow.test.last",
                         "ComponentN", "3.0.0"),
@@ -73,7 +76,7 @@ public class ReflectionsClassFinderTest {
     }
 
     @Test
-    public void getSubTypesOf_orderIsDeterministic() {
+    void getSubTypesOf_orderIsDeterministic() {
         List<String> a1 = toList(new ReflectionsClassFinder(urls)
                 .getSubTypesOf(Component.class));
         List<String> a2 = toList(
@@ -83,26 +86,26 @@ public class ReflectionsClassFinderTest {
                 new ReflectionsClassFinder(urls[1], urls[2], urls[0])
                         .getSubTypesOf(Component.class));
 
-        Assert.assertEquals(a1, a2);
-        Assert.assertEquals(a2, a3);
+        assertEquals(a1, a2);
+        assertEquals(a2, a3);
     }
 
     @Test
-    public void getSubTypesOf_rejectNotVaadinKnownPackages() throws Exception {
+    void getSubTypesOf_rejectNotVaadinKnownPackages() throws Exception {
         urls = Arrays.copyOf(urls, urls.length + 1);
         urls[urls.length - 1] = createTestModule("module-4",
                 "org.springframework.feature.ui", "SpringUIComponent", "2.0.0");
         Set<String> result = new ReflectionsClassFinder(urls)
                 .getSubTypesOf(Component.class).stream().map(Class::getName)
                 .collect(Collectors.toSet());
-        Assert.assertFalse(
-                "Classes from know not-UI packages should be rejected by default",
+        assertFalse(
                 result.contains(
-                        "org.springframework.feature.ui.SpringUIComponent"));
+                        "org.springframework.feature.ui.SpringUIComponent"),
+                "Classes from know not-UI packages should be rejected by default");
     }
 
     @Test
-    public void getSubTypesOf_defaultRejectDisabled_scansAllPackages()
+    void getSubTypesOf_defaultRejectDisabled_scansAllPackages()
             throws Exception {
         urls = Arrays.copyOf(urls, urls.length + 1);
         urls[urls.length - 1] = createTestModule("module-4",
@@ -113,10 +116,10 @@ public class ReflectionsClassFinderTest {
             Set<String> result = new ReflectionsClassFinder(urls)
                     .getSubTypesOf(Component.class).stream().map(Class::getName)
                     .collect(Collectors.toSet());
-            Assert.assertTrue(
-                    "Classes from know not-UI packages should be found when default rejection is disabled",
+            assertTrue(
                     result.contains(
-                            "org.springframework.feature.ui.SpringUIComponent"));
+                            "org.springframework.feature.ui.SpringUIComponent"),
+                    "Classes from know not-UI packages should be found when default rejection is disabled");
         } finally {
             System.clearProperty(
                     ReflectionsClassFinder.DISABLE_DEFAULT_PACKAGE_FILTER);
@@ -124,7 +127,7 @@ public class ReflectionsClassFinderTest {
     }
 
     @Test
-    public void getAnnotatedClasses_orderIsDeterministic() {
+    void getAnnotatedClasses_orderIsDeterministic() {
         List<String> a1 = toList(new ReflectionsClassFinder(urls)
                 .getAnnotatedClasses(NpmPackage.class));
         List<String> a2 = toList(
@@ -134,21 +137,20 @@ public class ReflectionsClassFinderTest {
                 new ReflectionsClassFinder(urls[1], urls[2], urls[0])
                         .getAnnotatedClasses(NpmPackage.class));
 
-        Assert.assertEquals(a1, a2);
-        Assert.assertEquals(a2, a3);
+        assertEquals(a1, a2);
+        assertEquals(a2, a3);
     }
 
     @Test
-    public void getSubTypesOf_order_sameAsDefaultClassFinder() {
-        Assert.assertEquals(
-                toList(defaultClassFinder.getSubTypesOf(Component.class)),
+    void getSubTypesOf_order_sameAsDefaultClassFinder() {
+        assertEquals(toList(defaultClassFinder.getSubTypesOf(Component.class)),
                 toList(new ReflectionsClassFinder(urls)
                         .getSubTypesOf(Component.class)));
     }
 
     @Test
-    public void getAnnotatedClasses_order_sameAsDefaultClassFinder() {
-        Assert.assertEquals(
+    void getAnnotatedClasses_order_sameAsDefaultClassFinder() {
+        assertEquals(
                 toList(defaultClassFinder
                         .getAnnotatedClasses(NpmPackage.class)),
                 toList(new ReflectionsClassFinder(urls)
@@ -156,22 +158,20 @@ public class ReflectionsClassFinderTest {
     }
 
     @Test
-    public void notExistingDirectory_noExceptionThrown() throws Exception {
-        Path notExistingDir = Files.createTempDirectory("test")
-                .resolve(Path.of("target", "classes"));
+    void notExistingDirectory_noExceptionThrown() throws Exception {
+        Path notExistingDir = externalModules
+                .resolve(Path.of("not-existing", "target", "classes"));
         // ClassGraph should handle non-existing directories gracefully
         ReflectionsClassFinder finder = new ReflectionsClassFinder(
                 notExistingDir.toUri().toURL());
         // Verify scan completed successfully (returns empty set, not null)
         Set<Class<?>> result = finder.getAnnotatedClasses(NpmPackage.class);
-        Assert.assertNotNull(
-                "Scan should complete even with non-existing directory",
-                result);
+        assertNotNull(result,
+                "Scan should complete even with non-existing directory");
     }
 
     @Test
-    public void getAnnotatedClasses_findsRepeatableAnnotations()
-            throws Exception {
+    void getAnnotatedClasses_findsRepeatableAnnotations() throws Exception {
         // When a @Repeatable annotation is used multiple times, Java wraps
         // them in the container annotation. The finder should detect this and
         // find classes annotated with the container when searching for the
@@ -187,9 +187,8 @@ public class ReflectionsClassFinderTest {
         Class<?> testClass = classLoader.loadClass(
                 "com.vaadin.flow.test.repeatable.ComponentWithMultipleNpmPackages");
 
-        Assert.assertTrue(
-                "Should find class with repeatable NpmPackage annotations through container",
-                result.contains(testClass));
+        assertTrue(result.contains(testClass),
+                "Should find class with repeatable NpmPackage annotations through container");
     }
 
     private URL createRepeatableAnnotationTestModule() throws IOException {
@@ -203,10 +202,18 @@ public class ReflectionsClassFinderTest {
                 + "@NpmPackage(value = \"@vaadin/test-package-3\", version = \"3.0.0\")\n"
                 + "public class %s extends Component {\n}\n", pkg, className);
 
-        File sources = externalModules.newFolder("repeatable-test/src");
-        File sourcePkg = externalModules
-                .newFolder("repeatable-test/src/" + pkg.replace('.', '/'));
-        File buildDir = externalModules.newFolder("repeatable-test/target");
+        File sources = Files
+                .createDirectories(
+                        externalModules.resolve("repeatable-test/src"))
+                .toFile();
+        File sourcePkg = Files
+                .createDirectories(externalModules.resolve(
+                        "repeatable-test/src/" + pkg.replace('.', '/')))
+                .toFile();
+        File buildDir = Files
+                .createDirectories(
+                        externalModules.resolve("repeatable-test/target"))
+                .toFile();
 
         Path sourceFile = sourcePkg.toPath().resolve(className + ".java");
         Files.writeString(sourceFile, classSource, StandardCharsets.UTF_8);
@@ -221,10 +228,17 @@ public class ReflectionsClassFinderTest {
 
     private URL createTestModule(String moduleName, String pkg,
             String className, String npmPackageVersion) throws IOException {
-        File sources = externalModules.newFolder(moduleName + "/src");
-        File sourcePkg = externalModules
-                .newFolder(moduleName + "/src/" + pkg.replace('.', '/'));
-        File buildDir = externalModules.newFolder(moduleName + "/target");
+        File sources = Files
+                .createDirectories(externalModules.resolve(moduleName + "/src"))
+                .toFile();
+        File sourcePkg = Files
+                .createDirectories(externalModules
+                        .resolve(moduleName + "/src/" + pkg.replace('.', '/')))
+                .toFile();
+        File buildDir = Files
+                .createDirectories(
+                        externalModules.resolve(moduleName + "/target"))
+                .toFile();
 
         Path sourceFile = sourcePkg.toPath().resolve(className + ".java");
         Files.writeString(sourceFile, String.format(CLASS_TEMPLATE, pkg,
@@ -237,7 +251,7 @@ public class ReflectionsClassFinderTest {
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         int result = compiler.run(null, null, null, "-d", outputPath.getPath(),
                 "-sourcepath", sourcePath.getPath(), sourceFile.getPath());
-        Assert.assertEquals("Failed to compile " + sourceFile, 0, result);
+        assertEquals(0, result, "Failed to compile " + sourceFile);
     }
 
 }


### PR DESCRIPTION
Migrate all test files in flow-maven-plugin and flow-plugin-base from JUnit 4 to JUnit 6. Replace @Rule TemporaryFolder with @TempDir, @Rule ExpectedException with assertThrows, @Before/@After with @BeforeEach/@AfterEach, @Test(expected) with assertThrows, and JUnit 4 Assert with JUnit 5 Assertions with reordered message parameters.

Apply JUnit 5 migration conventions: replace qualified Assertions.xxx() with static imports, make test classes and methods package-private, and replace Files.createTempDirectory() with @TempDir-managed paths.
