### PR TITLE
refactor: Use Signal<Double> instead of SharedNumberSignal in RangeInput API

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/RangeInput.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/RangeInput.java
@@ -30,7 +30,6 @@ import com.vaadin.flow.data.value.HasValueChangeMode;
 import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.signals.Signal;
-import com.vaadin.flow.signals.shared.SharedNumberSignal;
 
 /**
  * Creates a new input element with type "range".
@@ -174,7 +173,7 @@ public class RangeInput extends AbstractSinglePropertyField<RangeInput, Double>
      *
      * @since 25.1
      */
-    public void bindMin(SharedNumberSignal minSignal) {
+    public void bindMin(Signal<Double> minSignal) {
         Objects.requireNonNull(minSignal, "Signal cannot be null");
         getElement().bindAttribute("min", minSignal.map(Object::toString));
     }
@@ -224,7 +223,7 @@ public class RangeInput extends AbstractSinglePropertyField<RangeInput, Double>
      *
      * @since 25.1
      */
-    public void bindMax(SharedNumberSignal maxSignal) {
+    public void bindMax(Signal<Double> maxSignal) {
         Objects.requireNonNull(maxSignal, "Signal cannot be null");
         getElement().bindAttribute("max", maxSignal.map(Object::toString));
     }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/RangeInputBindTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/RangeInputBindTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.dom.SignalsUnitTest;
 import com.vaadin.flow.signals.BindingActiveException;
-import com.vaadin.flow.signals.shared.SharedNumberSignal;
+import com.vaadin.flow.signals.local.ValueSignal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -32,7 +32,7 @@ public class RangeInputBindTest extends SignalsUnitTest {
         RangeInput rangeInput = new RangeInput();
         UI.getCurrent().add(rangeInput);
 
-        SharedNumberSignal signal = new SharedNumberSignal(0.0);
+        ValueSignal<Double> signal = new ValueSignal<>(0.0);
         rangeInput.bindMin(signal);
 
         signal.set(5.5);
@@ -47,7 +47,7 @@ public class RangeInputBindTest extends SignalsUnitTest {
         RangeInput rangeInput = new RangeInput();
         UI.getCurrent().add(rangeInput);
 
-        SharedNumberSignal signal = new SharedNumberSignal(0.0);
+        ValueSignal<Double> signal = new ValueSignal<>(0.0);
         rangeInput.bindMin(signal);
 
         assertThrows(BindingActiveException.class,
@@ -68,7 +68,7 @@ public class RangeInputBindTest extends SignalsUnitTest {
         RangeInput rangeInput = new RangeInput();
         UI.getCurrent().add(rangeInput);
 
-        SharedNumberSignal signal = new SharedNumberSignal(100.0);
+        ValueSignal<Double> signal = new ValueSignal<>(100.0);
         rangeInput.bindMax(signal);
 
         signal.set(150.5);
@@ -83,7 +83,7 @@ public class RangeInputBindTest extends SignalsUnitTest {
         RangeInput rangeInput = new RangeInput();
         UI.getCurrent().add(rangeInput);
 
-        SharedNumberSignal signal = new SharedNumberSignal(100.0);
+        ValueSignal<Double> signal = new ValueSignal<>(100.0);
         rangeInput.bindMax(signal);
 
         assertThrows(BindingActiveException.class,


### PR DESCRIPTION
bindMin() and bindMax() only read the signal value via .map(), so they don't need the specialized SharedNumberSignal type. Using the generic Signal<Double> interface allows callers to pass any signal implementation.
