### PR TITLE
chore: collect jetty-start.out in IT test artifacts

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -217,7 +217,7 @@ jobs:
           $cmd verify | tee -a mvn-it-tests-${{matrix.current}}.out
       - name: Package test-report files
         if: ${{ failure() || success() }}
-        run: find . -name surefire-reports -o -name failsafe-reports -o -name error-screenshots -o -name "mvn-*.out" | tar -czf tests-report-it-${{matrix.current}}.tgz -T -
+        run: find . -name surefire-reports -o -name failsafe-reports -o -name error-screenshots -o -name "mvn-*.out" -o -name "jetty-start.out" | tar -czf tests-report-it-${{matrix.current}}.tgz -T -
       - uses: actions/upload-artifact@v4
         if: ${{ failure() || success() }}
         with:


### PR DESCRIPTION
When Jetty runs in FORK mode, the forked process output is redirected to target/jetty-start.out instead of Maven's console. If the forked server fails to start, the reason is currently lost because this file is not collected as a CI artifact.
