### PR TITLE
chore: prepare for Vite 8 by migrating deprecated APIs

### DIFF
--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -23,7 +23,6 @@ import {
   UserConfigFn
 } from 'vite';
 
-import * as rollup from 'rollup';
 import brotli from 'rollup-plugin-brotli';
 import checker from 'vite-plugin-checker';
 import postcssLit from '#buildFolder#/plugins/rollup-plugin-postcss-lit-custom/rollup-plugin-postcss-lit.js';
@@ -325,8 +324,8 @@ function themePlugin(opts: { devMode: boolean }): PluginOption {
       server.watcher.on('add', handleThemeFileCreateDelete);
       server.watcher.on('unlink', handleThemeFileCreateDelete);
     },
-    handleHotUpdate(context) {
-      const contextPath = path.resolve(context.file);
+    hotUpdate({ file }) {
+      const contextPath = path.resolve(file);
       const themePath = path.resolve(themeFolder);
       if (contextPath.startsWith(themePath)) {
         const changed = path.relative(themePath, contextPath);
@@ -397,8 +396,8 @@ const allowedFrontendFolders = [frontendFolder, nodeModulesFolder];
 function showRecompileReason(): PluginOption {
   return {
     name: 'vaadin:why-you-compile',
-    handleHotUpdate(context) {
-      console.log('Recompiling because', context.file, 'changed');
+    hotUpdate({ file }) {
+      console.log('Recompiling because', file, 'changed');
     }
   };
 }
@@ -491,7 +490,7 @@ export const vaadinConfig: UserConfigFn = (env) => {
           //   - https://github.com/vitejs/vite/issues/12209
           manualChunks: (id: string) => id.startsWith('\0commonjsHelpers.js') ? 'commonjsHelpers' : null
         },
-        onwarn: (warning: rollup.RollupLog, defaultHandler: rollup.LoggingFunction) => {
+        onwarn: (warning: any, defaultHandler: (warning: any) => void) => {
           const ignoreEvalWarning = [
             'generated/jar-resources/FlowClient.js',
             'generated/jar-resources/vaadin-spreadsheet/spreadsheet-export.js',


### PR DESCRIPTION
Migrate handleHotUpdate to hotUpdate hook (introduced in Vite 6) and remove the direct rollup import, replacing rollup.RollupLog and rollup.LoggingFunction types with inline types. This decouples from the rollup package ahead of Vite 8's switch to Rolldown.
