### PR TITLE
fix: Use String type for Style.bind return value

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/dom/Style.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Style.java
@@ -233,7 +233,7 @@ public interface Style extends Serializable {
      *
      * @since 25.0
      */
-    default SignalBinding<?> bind(String name, Signal<String> signal) {
+    default SignalBinding<String> bind(String name, Signal<String> signal) {
         // experimental API, do not force implementation
         throw new UnsupportedOperationException();
     };

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/BasicElementStyle.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/BasicElementStyle.java
@@ -98,7 +98,7 @@ public class BasicElementStyle implements Style {
     }
 
     @Override
-    public SignalBinding<?> bind(String name, Signal<String> signal) {
+    public SignalBinding<String> bind(String name, Signal<String> signal) {
         ElementUtil.validateStylePropertyName(name);
         String attribute = StyleUtil.stylePropertyToAttribute(name);
         Element owner = Element.get(propertyMap.getNode());

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/ImmutableEmptyStyle.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/ImmutableEmptyStyle.java
@@ -70,7 +70,7 @@ public class ImmutableEmptyStyle implements Style {
      * to a style property,
      */
     @Override
-    public SignalBinding<?> bind(String name, Signal<String> signal) {
+    public SignalBinding<String> bind(String name, Signal<String> signal) {
         throw new UnsupportedOperationException(CANT_MODIFY_MESSAGE);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/AbstractPropertyMap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/AbstractPropertyMap.java
@@ -181,12 +181,14 @@ public abstract class AbstractPropertyMap extends NodeMap {
      * @param writeCallback
      *            the callback to propagate value changes back, or
      *            <code>null</code> for a read-only binding
+     * @param <T>
+     *            the type of the signal value
      * @throws com.vaadin.flow.signals.BindingActiveException
      *             thrown when there is already an existing binding for the
      *             given property
      */
-    public SignalBinding<?> bindSignal(Element owner, String name,
-            Signal<?> signal, SerializableConsumer<?> writeCallback) {
+    public <T> SignalBinding<T> bindSignal(Element owner, String name,
+            Signal<T> signal, SerializableConsumer<?> writeCallback) {
         return super.bindSignal(owner, name, signal,
                 (element, value) -> setPropertyFromSignal(name, value),
                 writeCallback);

--- a/flow-server/src/test/java/com/vaadin/flow/dom/StyleBindTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/StyleBindTest.java
@@ -28,6 +28,7 @@ import com.vaadin.flow.signals.local.ValueSignal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -182,7 +183,7 @@ class StyleBindTest extends SignalsUnitTest {
         UI.getCurrent().getElement().appendChild(element);
 
         ValueSignal<String> signal = new ValueSignal<>("red");
-        List<BindingContext<?>> contexts = new ArrayList<>();
+        List<BindingContext<String>> contexts = new ArrayList<>();
 
         element.getStyle().bind("background-color", signal)
                 .onChange(contexts::add);
@@ -193,11 +194,33 @@ class StyleBindTest extends SignalsUnitTest {
         signal.set("blue");
 
         assertEquals(2, contexts.size());
-        BindingContext<?> ctx = contexts.get(1);
+        BindingContext<String> ctx = contexts.get(1);
         assertFalse(ctx.isInitialRun());
         assertEquals("red", ctx.getOldValue());
         assertEquals("blue", ctx.getNewValue());
         assertEquals(element, ctx.getElement());
+    }
+
+    @Test
+    public void bind_returnsTypedSignalBinding() {
+        Element element = new Element("div");
+        UI.getCurrent().getElement().appendChild(element);
+
+        ValueSignal<String> signal = new ValueSignal<>("red");
+
+        // Verify that bind returns SignalBinding<String>
+        SignalBinding<String> binding = element.getStyle()
+                .bind("background-color", signal);
+
+        // Verify that we can use the typed binding with String context
+        binding.onChange(ctx -> {
+            String oldValue = ctx.getOldValue(); // No cast needed
+            String newValue = ctx.getNewValue(); // No cast needed
+            assertNotNull(oldValue);
+            assertNotNull(newValue);
+            assertEquals(String.class, oldValue.getClass());
+            assertEquals(String.class, newValue.getClass());
+        });
     }
 
 }


### PR DESCRIPTION
Change Style.bind(String, Signal<String>) return type from SignalBinding<?> to SignalBinding<String> since the method always accepts a Signal<String> and we always know the value type is String.

This provides better type safety and eliminates the need for casts when using the binding's onChange callbacks.

Changes:
- Style.bind: return SignalBinding<String> instead of SignalBinding<?>
- BasicElementStyle.bind: update implementation
- ImmutableEmptyStyle.bind: update implementation
- AbstractPropertyMap.bindSignal: make generic with type parameter <T>
- StyleBindTest: update tests to use typed BindingContext<String>
- StyleBindTest: add test to verify typed return value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

