### PR TITLE
fix: prevent addon stylesheet links from being removed during CSS live reload

### DIFF
--- a/flow-tests/test-live-reload/src/main/java/com/vaadin/flow/uitest/ui/StylesheetLiveReloadView.java
+++ b/flow-tests/test-live-reload/src/main/java/com/vaadin/flow/uitest/ui/StylesheetLiveReloadView.java
@@ -23,6 +23,7 @@ import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 @Route(value = "com.vaadin.flow.uitest.ui.StylesheetLiveReloadView", layout = ViewTestLayout.class)
 @StyleSheet("context://css/view/view.css")
 @StyleSheet("context://css/view/for-deletion.css")
+@StyleSheet("context://frontend/addon.css")
 public class StylesheetLiveReloadView extends AbstractLiveReloadView {
 
     public StylesheetLiveReloadView() {
@@ -37,6 +38,7 @@ public class StylesheetLiveReloadView extends AbstractLiveReloadView {
                 "css/view/nested/nested-imported.css"));
         add(makeDiv("view-image", "css/images/viking.png"));
         add(makeDivForDelete());
+        add(makeDiv("addon-style", "frontend/addon.css"));
     }
 
     private Div makeDiv(String id, String resourceFilePath) {

--- a/flow-tests/test-live-reload/src/test/java/com/vaadin/flow/uitest/ui/StylesheetLiveReloadIT.java
+++ b/flow-tests/test-live-reload/src/test/java/com/vaadin/flow/uitest/ui/StylesheetLiveReloadIT.java
@@ -50,15 +50,18 @@ public class StylesheetLiveReloadIT extends AbstractLiveReloadIT {
     private static final String VIEW_STYLES_DIV_BG_COLOR = "rgba(75, 0, 130, 1)";
     private static final String VIEW_IMPORTED_DIV_BG_COLOR = "rgba(205, 133, 63, 1)";
     private static final String VIEW_NESTED_IMPORTED_DIV_BG_COLOR = "rgba(255, 127, 80, 1)";
+    private static final String ADDON_STYLE_DIV_BG_COLOR = "rgba(0, 128, 128, 1)";
     private final Map<Path, byte[]> styleSheetRestore = new HashMap<>();
     private static final String DIV_BG_COLOR_BEFORE_DELETE = "rgba(0, 255, 0, 1)";
 
     private Path resourcesPath;
     private Path sourceResourcesPath;
+    private Path jarResourcesPath;
     private Path updatedImagePath;
 
     @Before
-    public void detectStylesheetsLocation() throws URISyntaxException {
+    public void detectStylesheetsLocation()
+            throws URISyntaxException, IOException {
         URL markerUrl = getClass().getResource("/META-INF/resources/.marker");
         Assert.assertNotNull("No marker file found", markerUrl);
         Assert.assertEquals(
@@ -84,13 +87,44 @@ public class StylesheetLiveReloadIT extends AbstractLiveReloadIT {
                 projectDir);
         sourceResourcesPath = projectDir
                 .resolve("src/main/resources/META-INF/resources");
+        jarResourcesPath = projectDir
+                .resolve("src/main/frontend/generated/jar-resources");
+
+        // Create addon CSS in the target directory so Jetty can serve it
+        // on initial page load at /context/frontend/addon.css.
+        // The jar-resources copy is created later during the reload trigger
+        // to avoid a Vite rebuild at startup.
+        String addonCss = ".addon-style { background-color: "
+                + ADDON_STYLE_DIV_BG_COLOR + "; }\n";
+
+        Path targetAddonDir = resourcesPath.resolve("frontend");
+        Files.createDirectories(targetAddonDir);
+        Path targetAddonCss = targetAddonDir.resolve("addon.css");
+        Files.write(targetAddonCss, addonCss.getBytes());
+        styleSheetRestore.put(targetAddonCss, null);
     }
 
     @After
     public void restoreStylesheets() throws IOException {
         for (Map.Entry<Path, byte[]> entry : styleSheetRestore.entrySet()) {
-            System.out.println("Restoring " + entry.getKey());
-            Files.write(entry.getKey(), entry.getValue());
+            Path path = entry.getKey();
+            if (entry.getValue() == null) {
+                // File was created by the test; delete it and clean up
+                // empty parent directories
+                System.out.println("Deleting " + path);
+                Files.deleteIfExists(path);
+                Path parent = path.getParent();
+                if (parent != null && Files.isDirectory(parent)) {
+                    try (var entries = Files.list(parent)) {
+                        if (entries.findFirst().isEmpty()) {
+                            Files.delete(parent);
+                        }
+                    }
+                }
+            } else {
+                System.out.println("Restoring " + path);
+                Files.write(path, entry.getValue());
+            }
         }
     }
 
@@ -119,6 +153,8 @@ public class StylesheetLiveReloadIT extends AbstractLiveReloadIT {
 
         assertImageIsReloaded("appshell-image", "css/images/gobo.png");
         assertImageIsReloaded("view-image", "css/images/viking.png");
+
+        assertJarResourceStyleSheetIsReloaded();
 
         assertStyleSheetIsRemoved();
     }
@@ -161,6 +197,38 @@ public class StylesheetLiveReloadIT extends AbstractLiveReloadIT {
                         "$1");
         waitUntilContentMatches(backgroundImage,
                 Files.readAllBytes(updatedImagePath));
+    }
+
+    private void assertJarResourceStyleSheetIsReloaded() throws IOException {
+        String backgroundColor = $("div").id("addon-style")
+                .getCssValue("backgroundColor");
+        Assert.assertEquals(ADDON_STYLE_DIV_BG_COLOR, backgroundColor);
+
+        // Update the target file so the servlet serves the new content
+        triggerReloadStyleSheet("addon-style");
+
+        // Create the jar-resources file with the updated CSS to trigger
+        // the file watcher. The file sits at jar-resources/addon.css
+        // (without frontend/ prefix, as TaskCopyFrontendFiles strips it)
+        String updatedCss = ".addon-style { background-color: "
+                + UPDATED_DIV_BG_COLOR + "; }\n";
+        Path jarAddonCss = jarResourcesPath.resolve("addon.css");
+        try (var writer = Files.newBufferedWriter(jarAddonCss,
+                StandardOpenOption.CREATE, StandardOpenOption.WRITE,
+                StandardOpenOption.SYNC)) {
+            writer.write(updatedCss);
+            writer.flush();
+        }
+        styleSheetRestore.put(jarAddonCss, null);
+
+        Assert.assertEquals("Page should not be reloaded", getInitialAttachId(),
+                getAttachId());
+
+        waitUntil(d -> {
+            var newBgColor = $("div").id("addon-style")
+                    .getCssValue("backgroundColor");
+            return UPDATED_DIV_BG_COLOR.equals(newBgColor);
+        });
     }
 
     private void assertStyleSheetIsRemoved() throws IOException {
@@ -215,7 +283,10 @@ public class StylesheetLiveReloadIT extends AbstractLiveReloadIT {
         Assert.assertTrue("Resource file not found: " + resourcePath,
                 Files.exists(resourcePath));
 
-        styleSheetRestore.put(resourcePath, Files.readAllBytes(resourcePath));
+        if (!styleSheetRestore.containsKey(resourcePath)) {
+            styleSheetRestore.put(resourcePath,
+                    Files.readAllBytes(resourcePath));
+        }
         updater.accept(resourcePath);
 
         final byte[] content = Files.readAllBytes(resourcePath);
@@ -228,8 +299,21 @@ public class StylesheetLiveReloadIT extends AbstractLiveReloadIT {
         Path sourcePath = sourceResourcesPath
                 .resolve(resourceRelativePath.replace('/', File.separatorChar));
         if (Files.exists(sourcePath)) {
-            styleSheetRestore.put(sourcePath, Files.readAllBytes(sourcePath));
+            if (!styleSheetRestore.containsKey(sourcePath)) {
+                styleSheetRestore.put(sourcePath,
+                        Files.readAllBytes(sourcePath));
+            }
             updater.accept(sourcePath);
+        }
+
+        // Also check jar-resources path for addon stylesheets
+        Path jarPath = jarResourcesPath
+                .resolve(resourceRelativePath.replace('/', File.separatorChar));
+        if (Files.exists(jarPath)) {
+            if (!styleSheetRestore.containsKey(jarPath)) {
+                styleSheetRestore.put(jarPath, Files.readAllBytes(jarPath));
+            }
+            updater.accept(jarPath);
         }
     }
 

--- a/vaadin-dev-server/src/main/frontend/vaadin-dev-tools.ts
+++ b/vaadin-dev-server/src/main/frontend/vaadin-dev-tools.ts
@@ -744,8 +744,12 @@ export class VaadinDevTools extends LitElement {
     const links = Array.from(document.head.querySelectorAll('link[rel="stylesheet"]')) as HTMLLinkElement[];
     links.forEach((link) => {
       let filePath = link.getAttribute('data-file-path') || link.getAttribute('href');
-      if (filePath && filePath.includes(path)) {
-        link.remove();
+      if (filePath) {
+        // Strip query string and fragment for comparison
+        const cleanPath = filePath.split(/[?#]/)[0];
+        if (cleanPath === path || cleanPath.endsWith('/' + path)) {
+          link.remove();
+        }
       }
     });
   }

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerManagerImpl.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerManagerImpl.java
@@ -173,14 +173,18 @@ public class DevModeHandlerManagerImpl implements DevModeHandlerManager {
         try {
             File projectFolder = config.getProjectFolder();
             File resourceFolder = config.getJavaResourceFolder();
-            List<String> locations = Stream.concat(Stream
+            File jarResourcesFolder = FrontendUtils
+                    .getJarResourcesFolder(config.getFrontendFolder());
+            List<String> locations = Stream.of(Stream
                     .of("META-INF/resources", "resources", "static", "public")
                     .map(location -> new File(resourceFolder, location)),
-                    Stream.of(new File(projectFolder, "src/main/webapp")))
+                    Stream.of(new File(projectFolder, "src/main/webapp"),
+                            jarResourcesFolder))
+                    .flatMap(s -> s)
                     .filter(root -> root.exists() && root.isDirectory())
                     .filter(File::exists)
-                    .map(staticResourceFolder -> FrontendUtils
-                            .getUnixPath(staticResourceFolder.toPath()))
+                    .map(staticResourceFolder -> FrontendUtils.getUnixPath(
+                            staticResourceFolder.toPath().normalize()))
                     .toList();
             registerWatcherShutdownCommand(
                     new PublicResourcesLiveUpdater(locations, context));

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/PublicResourcesLiveUpdater.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/PublicResourcesLiveUpdater.java
@@ -29,6 +29,8 @@ import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.di.ResourceProvider;
 import com.vaadin.flow.internal.ActiveStyleSheetTracker;
 import com.vaadin.flow.internal.BrowserLiveReload;
 import com.vaadin.flow.internal.BrowserLiveReloadAccessor;
@@ -60,6 +62,7 @@ public class PublicResourcesLiveUpdater implements Closeable {
     private final List<File> roots = new ArrayList<>();
     private final VaadinContext context;
     private final PublicStyleSheetBundler bundler;
+    private final ResourceProvider resourceProvider;
 
     /**
      * Starts watching the given list of source folders for CSS changes.
@@ -84,6 +87,10 @@ public class PublicResourcesLiveUpdater implements Closeable {
             }
         }
         this.bundler = PublicStyleSheetBundler.forResourceLocations(this.roots);
+        Lookup lookup = context.getAttribute(Lookup.class);
+        this.resourceProvider = lookup != null
+                ? lookup.lookup(ResourceProvider.class)
+                : null;
         if (liveReload.isEmpty()) {
             getLogger().error(
                     "Browser live reload is not available. Unable to watch public resources for changes");
@@ -133,11 +140,16 @@ public class PublicResourcesLiveUpdater implements Closeable {
                     String normalized = PublicStyleSheetBundler
                             .normalizeUrl(url);
                     String contextPath = getContextPath();
-                    String content = bundler.bundle(url, contextPath)
-                            .orElse(null);
+                    Optional<String> content = bundler.bundle(url, contextPath);
+                    if (content.isEmpty() && isClasspathResource(normalized)) {
+                        // Resource exists on classpath (e.g. from an addon
+                        // JAR) but not in local source roots — leave it
+                        // untouched
+                        continue;
+                    }
                     String path = ApplicationConstants.CONTEXT_PROTOCOL_PREFIX
                             + normalized;
-                    liveReload.update(path, content);
+                    liveReload.update(path, content.orElse(null));
                     getLogger().debug("Pushed bundled stylesheet update for {}",
                             path);
 
@@ -190,6 +202,14 @@ public class PublicResourcesLiveUpdater implements Closeable {
         }
         watchers.clear();
         roots.clear();
+    }
+
+    private boolean isClasspathResource(String normalizedPath) {
+        if (resourceProvider == null) {
+            return false;
+        }
+        return resourceProvider.getApplicationResource(
+                "META-INF/resources/" + normalizedPath) != null;
     }
 
     private boolean isTempFile(File file) {

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/PublicStyleSheetBundler.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/PublicStyleSheetBundler.java
@@ -87,7 +87,15 @@ public final class PublicStyleSheetBundler {
         }
         String normalized = normalizeUrl(url);
         for (File root : sourceRoots) {
-            File entry = new File(root, normalized);
+            String relativePath = normalized;
+            if (relativePath.startsWith("frontend/")
+                    && isCopiedJarResourcesRoot(root)) {
+                // Addon resources under META-INF/resources/frontend/ are
+                // copied to jar-resources with the frontend/ prefix stripped
+                // by TaskCopyFrontendFiles, so look up without it
+                relativePath = relativePath.substring("frontend/".length());
+            }
+            File entry = new File(root, relativePath);
             if (entry.exists() && entry.isFile()) {
                 try {
                     String bundled = CssBundler.inlineImportsForPublicResources(
@@ -102,6 +110,11 @@ public final class PublicStyleSheetBundler {
             }
         }
         return Optional.empty();
+    }
+
+    private static boolean isCopiedJarResourcesRoot(File root) {
+        String path = FrontendUtils.getUnixPath(root.toPath());
+        return path.endsWith("generated/jar-resources");
     }
 
     /**

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/PublicResourcesLiveUpdaterTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/PublicResourcesLiveUpdaterTest.java
@@ -32,6 +32,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.di.ResourceProvider;
 import com.vaadin.flow.internal.ActiveStyleSheetTracker;
 import com.vaadin.flow.internal.BrowserLiveReload;
 import com.vaadin.flow.internal.BrowserLiveReloadAccessor;
@@ -296,6 +297,265 @@ class PublicResourcesLiveUpdaterTest {
             Awaitility.await().untilAsserted(() -> {
                 Mockito.verifyNoInteractions(liveReload);
             });
+        }
+    }
+
+    @Test
+    void cssChange_skipsUpdateForClasspathStylesheet() throws Exception {
+        // Arrange a project with one local CSS, and a stylesheet that only
+        // exists on the classpath (e.g. from an addon JAR)
+        File project = new File(temporaryFolder, "project-cp");
+        project.mkdirs();
+        File publicRoot = new File(project, "src/main/resources/public");
+        assertTrue(publicRoot.mkdirs());
+
+        File localCss = new File(publicRoot, "styles.css");
+        Files.writeString(localCss.toPath(), "body{margin:0;}",
+                StandardCharsets.UTF_8);
+
+        ApplicationConfiguration config = Mockito
+                .mock(ApplicationConfiguration.class);
+        Mockito.when(config.getProjectFolder()).thenReturn(project);
+        appConfigStatic = Mockito.mockStatic(ApplicationConfiguration.class);
+
+        VaadinContext context = new MockVaadinContext();
+        appConfigStatic
+                .when(() -> ApplicationConfiguration.get(Mockito.eq(context)))
+                .thenReturn(config);
+
+        // Mock ResourceProvider to report the classpath stylesheet exists
+        ResourceProvider resourceProvider = Mockito
+                .mock(ResourceProvider.class);
+        Mockito.when(resourceProvider.getApplicationResource(
+                "META-INF/resources/frontend/addon.styles.css"))
+                .thenReturn(getClass().getResource("/"));
+        Lookup lookup = context.getAttribute(Lookup.class);
+        Mockito.when(lookup.lookup(ResourceProvider.class))
+                .thenReturn(resourceProvider);
+
+        BrowserLiveReload liveReload = Mockito.mock(BrowserLiveReload.class);
+        liveReloadAccessorStatic = Mockito
+                .mockStatic(BrowserLiveReloadAccessor.class);
+        liveReloadAccessorStatic
+                .when(() -> BrowserLiveReloadAccessor
+                        .getLiveReloadFromContext(Mockito.eq(context)))
+                .thenReturn(Optional.of(liveReload));
+
+        // Register both a local and a classpath-only stylesheet
+        ActiveStyleSheetTracker.get(context).trackForAppShell(Set.of(
+                "context://styles.css", "context://frontend/addon.styles.css"));
+
+        try (PublicResourcesLiveUpdater ignored = new PublicResourcesLiveUpdater(
+                List.of(publicRoot.getAbsolutePath()), context)) {
+            // Modify local CSS to trigger the watcher
+            Files.writeString(localCss.toPath(), "body{margin:8px;}",
+                    StandardCharsets.UTF_8);
+
+            // The local stylesheet should be updated with content
+            Awaitility.await().untilAsserted(() -> Mockito
+                    .verify(liveReload, Mockito.atLeastOnce())
+                    .update(eq("context://styles.css"), argThat(c -> c != null
+                            && c.contains("body{margin:8px;}"))));
+
+            // The classpath stylesheet must NOT be updated with null
+            Mockito.verify(liveReload, Mockito.never()).update(
+                    eq("context://frontend/addon.styles.css"),
+                    Mockito.isNull());
+        }
+    }
+
+    @Test
+    void cssChange_updatesStylesheetFromJarResources() throws Exception {
+        // When the CSS exists in jar-resources (passed as a source root),
+        // the bundler finds it and pushes content for both local and
+        // jar-resources stylesheets.
+        File project = new File(temporaryFolder, "project-jar-res");
+        project.mkdirs();
+        File publicRoot = new File(project, "src/main/resources/public");
+        assertTrue(publicRoot.mkdirs());
+
+        // Simulate the jar-resources folder at its real location inside the
+        // project's frontend generated directory
+        File jarResources = new File(project,
+                "src/main/frontend/generated/jar-resources");
+        assertTrue(jarResources.mkdirs());
+
+        File localCss = new File(publicRoot, "app.css");
+        Files.writeString(localCss.toPath(), ".app{display:block;}",
+                StandardCharsets.UTF_8);
+
+        File addonCss = new File(jarResources, "addon.css");
+        Files.writeString(addonCss.toPath(), ".addon{color:blue;}",
+                StandardCharsets.UTF_8);
+
+        ApplicationConfiguration config = Mockito
+                .mock(ApplicationConfiguration.class);
+        Mockito.when(config.getProjectFolder()).thenReturn(project);
+        appConfigStatic = Mockito.mockStatic(ApplicationConfiguration.class);
+
+        VaadinContext context = new MockVaadinContext();
+        appConfigStatic
+                .when(() -> ApplicationConfiguration.get(Mockito.eq(context)))
+                .thenReturn(config);
+
+        BrowserLiveReload liveReload = Mockito.mock(BrowserLiveReload.class);
+        liveReloadAccessorStatic = Mockito
+                .mockStatic(BrowserLiveReloadAccessor.class);
+        liveReloadAccessorStatic
+                .when(() -> BrowserLiveReloadAccessor
+                        .getLiveReloadFromContext(Mockito.eq(context)))
+                .thenReturn(Optional.of(liveReload));
+
+        // Both local and jar-resources CSS are active
+        ActiveStyleSheetTracker.get(context).trackForAppShell(
+                Set.of("context://app.css", "context://addon.css"));
+
+        // Pass both the publicRoot and jar-resources as source roots
+        try (PublicResourcesLiveUpdater ignored = new PublicResourcesLiveUpdater(
+                List.of(publicRoot.getAbsolutePath(),
+                        jarResources.getAbsolutePath()),
+                context)) {
+            // Trigger watcher by modifying the local CSS
+            Files.writeString(localCss.toPath(), ".app{display:flex;}",
+                    StandardCharsets.UTF_8);
+
+            // Both stylesheets should be updated with content
+            Awaitility.await().untilAsserted(() -> {
+                Mockito.verify(liveReload, Mockito.atLeastOnce())
+                        .update(eq("context://app.css"), argThat(c -> c != null
+                                && c.contains(".app{display:flex;}")));
+                Mockito.verify(liveReload, Mockito.atLeastOnce()).update(
+                        eq("context://addon.css"), argThat(c -> c != null
+                                && c.contains(".addon{color:blue;}")));
+            });
+        }
+    }
+
+    @Test
+    void cssChange_updatesJarResourceStylesheetWithFrontendPrefix()
+            throws Exception {
+        // Addon stylesheets are referenced with frontend/ prefix in
+        // @StyleSheet but TaskCopyFrontendFiles strips it when copying
+        // to jar-resources. The bundler should find the file without the
+        // prefix.
+        File project = new File(temporaryFolder, "project-frontend-prefix");
+        project.mkdirs();
+        File publicRoot = new File(project, "src/main/resources/public");
+        assertTrue(publicRoot.mkdirs());
+
+        File jarResources = new File(project,
+                "src/main/frontend/generated/jar-resources");
+        assertTrue(jarResources.mkdirs());
+
+        File localCss = new File(publicRoot, "local.css");
+        Files.writeString(localCss.toPath(), ".local{display:block;}",
+                StandardCharsets.UTF_8);
+
+        // The addon CSS sits at jar-resources/addon.css (no frontend/ prefix)
+        File addonCss = new File(jarResources, "addon.css");
+        Files.writeString(addonCss.toPath(), ".addon{color:teal;}",
+                StandardCharsets.UTF_8);
+
+        ApplicationConfiguration config = Mockito
+                .mock(ApplicationConfiguration.class);
+        Mockito.when(config.getProjectFolder()).thenReturn(project);
+        appConfigStatic = Mockito.mockStatic(ApplicationConfiguration.class);
+
+        VaadinContext context = new MockVaadinContext();
+        appConfigStatic
+                .when(() -> ApplicationConfiguration.get(Mockito.eq(context)))
+                .thenReturn(config);
+
+        BrowserLiveReload liveReload = Mockito.mock(BrowserLiveReload.class);
+        liveReloadAccessorStatic = Mockito
+                .mockStatic(BrowserLiveReloadAccessor.class);
+        liveReloadAccessorStatic
+                .when(() -> BrowserLiveReloadAccessor
+                        .getLiveReloadFromContext(Mockito.eq(context)))
+                .thenReturn(Optional.of(liveReload));
+
+        // Active URL uses frontend/ prefix, but file is at jar-resources root
+        ActiveStyleSheetTracker.get(context).trackForAppShell(
+                Set.of("context://local.css", "context://frontend/addon.css"));
+
+        try (PublicResourcesLiveUpdater ignored = new PublicResourcesLiveUpdater(
+                List.of(publicRoot.getAbsolutePath(),
+                        jarResources.getAbsolutePath()),
+                context)) {
+            // Trigger watcher by modifying the local CSS
+            Files.writeString(localCss.toPath(), ".local{display:flex;}",
+                    StandardCharsets.UTF_8);
+
+            // Both stylesheets should be updated with content
+            Awaitility.await().untilAsserted(() -> {
+                Mockito.verify(liveReload, Mockito.atLeastOnce()).update(
+                        eq("context://local.css"), argThat(c -> c != null
+                                && c.contains(".local{display:flex;}")));
+                Mockito.verify(liveReload, Mockito.atLeastOnce()).update(
+                        eq("context://frontend/addon.css"),
+                        argThat(c -> c != null
+                                && c.contains(".addon{color:teal;}")));
+            });
+        }
+    }
+
+    @Test
+    void cssChange_removesDeletedStylesheet() throws Exception {
+        // When a CSS file is deleted and does not exist on the classpath,
+        // the updater should push null content (removal).
+        File project = new File(temporaryFolder, "project-deleted");
+        project.mkdirs();
+        File publicRoot = new File(project, "src/main/resources/public");
+        assertTrue(publicRoot.mkdirs());
+
+        File localCss = new File(publicRoot, "keep.css");
+        Files.writeString(localCss.toPath(), ".keep{color:red;}",
+                StandardCharsets.UTF_8);
+
+        // Create a CSS file that will be "deleted" — it exists initially so
+        // that the bundler can find it, but we delete it before triggering
+        File deletedCss = new File(publicRoot, "gone.css");
+        Files.writeString(deletedCss.toPath(), ".gone{color:gray;}",
+                StandardCharsets.UTF_8);
+
+        ApplicationConfiguration config = Mockito
+                .mock(ApplicationConfiguration.class);
+        Mockito.when(config.getProjectFolder()).thenReturn(project);
+        appConfigStatic = Mockito.mockStatic(ApplicationConfiguration.class);
+
+        VaadinContext context = new MockVaadinContext();
+        appConfigStatic
+                .when(() -> ApplicationConfiguration.get(Mockito.eq(context)))
+                .thenReturn(config);
+
+        BrowserLiveReload liveReload = Mockito.mock(BrowserLiveReload.class);
+        liveReloadAccessorStatic = Mockito
+                .mockStatic(BrowserLiveReloadAccessor.class);
+        liveReloadAccessorStatic
+                .when(() -> BrowserLiveReloadAccessor
+                        .getLiveReloadFromContext(Mockito.eq(context)))
+                .thenReturn(Optional.of(liveReload));
+
+        ActiveStyleSheetTracker.get(context).trackForAppShell(
+                Set.of("context://keep.css", "context://gone.css"));
+
+        try (PublicResourcesLiveUpdater ignored = new PublicResourcesLiveUpdater(
+                List.of(publicRoot.getAbsolutePath()), context)) {
+            // Delete the file, then trigger watcher with a change to keep.css
+            assertTrue(deletedCss.delete());
+            Files.writeString(localCss.toPath(), ".keep{color:blue;}",
+                    StandardCharsets.UTF_8);
+
+            // keep.css should be updated with content
+            Awaitility.await().untilAsserted(() -> Mockito
+                    .verify(liveReload, Mockito.atLeastOnce())
+                    .update(eq("context://keep.css"), argThat(c -> c != null
+                            && c.contains(".keep{color:blue;}"))));
+
+            // gone.css should be updated with null (removal) since it's
+            // not on classpath either
+            Mockito.verify(liveReload, Mockito.atLeastOnce())
+                    .update(eq("context://gone.css"), Mockito.isNull());
         }
     }
 


### PR DESCRIPTION
During CSS live reload, `PublicResourcesLiveUpdater` pushed null content for addon stylesheets not found in local source roots, and `removeOldLinks()` in vaadin-dev-tools used substring matching (`.includes()`) which could incorrectly remove unrelated `<link>` tags.

Server-side changes:
- Add jar-resources folder as a watched source root in `DevModeHandlerManagerImpl` so addon CSS changes are detected
- Skip pushing null updates for stylesheets that exist on the classpath (e.g. from addon JARs) in `PublicResourcesLiveUpdater`
- Use `ResourceProvider` to check classpath existence before deciding to remove a stylesheet
- Strip `frontend/` prefix in `PublicStyleSheetBundler` when resolving addon stylesheets against jar-resources roots, since `TaskCopyFrontendFiles` removes that prefix during copy

Client-side change:
- Replace `.includes(path)` with path-suffix matching in `removeOldLinks()` to only remove links whose href ends with `'/' + path` or exactly equals `path`, after stripping query strings and fragments

Fixes #23880