### PR TITLE
test: prevent starting jetty when tests are skipped

### DIFF
--- a/flow-tests/test-multi-war/deployment/pom.xml
+++ b/flow-tests/test-multi-war/deployment/pom.xml
@@ -15,28 +15,38 @@
 
   <dependencies/>
 
-  <build>
-    <plugins>
-      <!-- Run jetty before ITs -->
-      <plugin>
-        <groupId>org.eclipse.jetty.ee10</groupId>
-        <artifactId>jetty-ee10-maven-plugin</artifactId>
-        <configuration>
-          <webApp>
-            <contextPath>/</contextPath>
-          </webApp>
-          <jettyXmls>
-            <jettyXml>${project.basedir}/src/main/jetty/jetty.xml</jettyXml>
-          </jettyXmls>
-          <jettyProperties>
-            <webapp1.warPath>${project.parent.basedir}${file.separator}test-war1${file.separator}target${file.separator}flow-test-multi-war1.war</webapp1.warPath>
-            <webapp1.context>/test-war1</webapp1.context>
-            <webapp2.warPath>${project.parent.basedir}${file.separator}test-war2${file.separator}target${file.separator}flow-test-multi-war2.war</webapp2.warPath>
-            <webapp2.context>/test-war2</webapp2.context>
-          </jettyProperties>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
+  <profiles>
+    <profile>
+      <id>run-tests</id>
+      <activation>
+        <property>
+          <name>!skipTests</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <!-- Run jetty before ITs -->
+          <plugin>
+            <groupId>org.eclipse.jetty.ee10</groupId>
+            <artifactId>jetty-ee10-maven-plugin</artifactId>
+            <configuration>
+              <webApp>
+                <contextPath>/</contextPath>
+              </webApp>
+              <jettyXmls>
+                <jettyXml>${project.basedir}/src/main/jetty/jetty.xml</jettyXml>
+              </jettyXmls>
+              <jettyProperties>
+                <webapp1.warPath>${project.parent.basedir}${file.separator}test-war1${file.separator}target${file.separator}flow-test-multi-war1.war</webapp1.warPath>
+                <webapp1.context>/test-war1</webapp1.context>
+                <webapp2.warPath>${project.parent.basedir}${file.separator}test-war2${file.separator}target${file.separator}flow-test-multi-war2.war</webapp2.warPath>
+                <webapp2.context>/test-war2</webapp2.context>
+              </jettyProperties>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>

--- a/flow-tests/test-tailwindcss/pom.xml
+++ b/flow-tests/test-tailwindcss/pom.xml
@@ -54,12 +54,28 @@
           </execution>
         </executions>
       </plugin>
-      <!-- This module is mapped to default web context -->
-      <plugin>
-        <groupId>org.eclipse.jetty.ee10</groupId>
-        <artifactId>jetty-ee10-maven-plugin</artifactId>
-      </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>run-tests</id>
+      <activation>
+        <property>
+          <name>!skipTests</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <!-- Run jetty before ITs -->
+          <!-- This module is mapped to default web context -->
+          <plugin>
+            <groupId>org.eclipse.jetty.ee10</groupId>
+            <artifactId>jetty-ee10-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>


### PR DESCRIPTION
The validation workflow first builds modules skipping tests (-DskipTests) then executes the validation.
However, a couple of modules are configured to start Jetty even if tests are skipped, potentially failing to shutdown it because of fast start/stop execution. This causes the subsequent validation to fail becuse the Jetty port is already in use.
