### PR TITLE
chore: prepare for Vite 8 by making bundler output handling robust

### DIFF
--- a/flow-server/src/main/resources/META-INF/frontend/theme-util.js
+++ b/flow-server/src/main/resources/META-INF/frontend/theme-util.js
@@ -31,7 +31,7 @@ const createLinkReferences = (css, target) => {
     const link = document.createElement('link');
     link.rel = 'stylesheet';
     link.href = match[2] || match[4];
-    const media = match[1] || match[5];
+    const media = (match[1] || match[5] || '').trim();
     if (media) {
       link.media = media;
     }

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/sw.ts
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/sw.ts
@@ -2,7 +2,7 @@
 
 self.__WB_DISABLE_DEV_LOGS = true;
 
-importScripts('sw-runtime-resources-precache.js');
+self.importScripts('sw-runtime-resources-precache.js');
 import { clientsClaim, cacheNames, WorkboxPlugin } from 'workbox-core';
 import { matchPrecache, precacheAndRoute, getCacheKeyForURL } from 'workbox-precaching';
 import { NavigationRoute, registerRoute } from 'workbox-routing';

--- a/flow-tests/test-pwa/src/test/java/com/vaadin/flow/pwatest/ui/PwaTestIT.java
+++ b/flow-tests/test-pwa/src/test/java/com/vaadin/flow/pwatest/ui/PwaTestIT.java
@@ -124,11 +124,13 @@ public class PwaTestIT extends ChromeDeviceTest {
         String serviceWorkerJS = readStringFromUrl(serviceWorkerUrl);
 
         // For Vite search for the precache file as it is loaded at runtime
-        // and not compiled into sw.js during build
+        // and not compiled into sw.js during build.
+        // Check quote-agnostic since different bundlers use different quote
+        // styles (double, single, or backtick).
         Assert.assertTrue(
                 "Expected sw-runtime-resources-precache.js to be imported, but was not",
-                serviceWorkerJS.contains(
-                        "importScripts(\"sw-runtime-resources-precache.js\")"));
+                serviceWorkerJS.contains("importScripts(") && serviceWorkerJS
+                        .contains("sw-runtime-resources-precache.js"));
 
         serviceWorkerUrl = getRootURL() + "/sw-runtime-resources-precache.js";
         serviceWorkerJS = readStringFromUrl(serviceWorkerUrl);


### PR DESCRIPTION
Trim media query in theme-util.js to handle leading whitespace from CSS @import parsing — previously trimmed by esbuild's CSS minification but not by Lightning CSS.

Use self.importScripts() in sw.ts instead of bare importScripts() to ensure the call is preserved by all bundlers in IIFE output.

Make PwaTestIT importScripts assertion quote-agnostic since different bundlers use different quote styles (double, single, or backtick).
