### PR TITLE
test: remove unnecessary public modifiers from JUnit 6 tests (#23870) (CP: 25.1)

### DIFF
--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
@@ -877,7 +877,7 @@ abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
     }
 
     @Test
-    public void generatedFlowImports_importsAreOnTopBeforeOtherInstructions() {
+    void generatedFlowImports_importsAreOnTopBeforeOtherInstructions() {
         updater.run();
 
         List<String> lines = updater.getOutput()
@@ -886,7 +886,7 @@ abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
     }
 
     @Test
-    public void generatedFlowWebComponentImports_importsAreOnTopBeforeOtherInstructions()
+    void generatedFlowWebComponentImports_importsAreOnTopBeforeOtherInstructions()
             throws Exception {
         Class<?>[] testClasses = { CssImportExporter.class, FooCssImport.class,
                 UI.class, AllEagerAppConf.class };

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -401,7 +401,7 @@ class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
     }
 
     @Test
-    public void runPnpmInstall_devMode_usesNoFrozenLockfile()
+    void runPnpmInstall_devMode_usesNoFrozenLockfile()
             throws ExecutionFailedException, IOException {
         TaskRunNpmInstall task = createTask();
         getNodeUpdater().modified = true;
@@ -417,7 +417,7 @@ class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
     }
 
     @Test
-    public void runPnpmInstall_ciBuild_usesFrozenLockfile()
+    void runPnpmInstall_ciBuild_usesFrozenLockfile()
             throws ExecutionFailedException, IOException {
         TaskRunNpmInstall ciTask = createCiTask();
         getNodeUpdater().modified = true;

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderSignalTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderSignalTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Tests for Binder and Binding integration with Signals.
  */
-public class BinderSignalTest extends SignalsUnitTest {
+class BinderSignalTest extends SignalsUnitTest {
 
     private TestTextField firstNameField;
     private TestTextField lastNameField;
@@ -49,7 +49,7 @@ public class BinderSignalTest extends SignalsUnitTest {
     private Person item;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         binder = new Binder<>(Person.class);
         item = new Person();
         firstNameField = new TestTextField();
@@ -69,7 +69,7 @@ public class BinderSignalTest extends SignalsUnitTest {
 
     // verifies that Binding.valueSignal() works with property name bindings
     @Test
-    public void bindingValue_withBinderBindPropertyName() {
+    void bindingValue_withBinderBindPropertyName() {
         item.setFirstName("Alice");
 
         var field = new TestTextField();
@@ -86,7 +86,7 @@ public class BinderSignalTest extends SignalsUnitTest {
 
     // verifies that Binding.valueSignal() works with getter/setter bindings
     @Test
-    public void bindingValue_withBinderBindGetterSetter() {
+    void bindingValue_withBinderBindGetterSetter() {
         binder = new Binder<>();
         item.setFirstName("Alice");
 
@@ -106,7 +106,7 @@ public class BinderSignalTest extends SignalsUnitTest {
     // verifies that Binding.valueSignal() with a signal-bound field works
     // correctly
     @Test
-    public void bindingValue_withSignal() {
+    void bindingValue_withSignal() {
         binder = new Binder<>();
         item.setFirstName("Alice");
 
@@ -131,7 +131,7 @@ public class BinderSignalTest extends SignalsUnitTest {
 
     // verifies that bindValue throws NPE for null signal
     @Test
-    public void bindValue_nullSignal_throwsNPE() {
+    void bindValue_nullSignal_throwsNPE() {
         var field = new TestTextField();
         assertThrows(NullPointerException.class,
                 () -> field.bindValue(null, null));
@@ -139,7 +139,7 @@ public class BinderSignalTest extends SignalsUnitTest {
 
     // verifies that cross-field validation works with signal-bound fields
     @Test
-    public void bindingValue_crossFieldValidation_withSignal() {
+    void bindingValue_crossFieldValidation_withSignal() {
         item.setFirstName("Alice");
         item.setLastName("Smith");
 
@@ -172,7 +172,7 @@ public class BinderSignalTest extends SignalsUnitTest {
     // verifies that cross-field validation works also without signal-bound
     // fields
     @Test
-    public void bindingValue_crossFieldValidation_withoutSignal() {
+    void bindingValue_crossFieldValidation_withoutSignal() {
         item.setFirstName("Alice");
         item.setLastName("Smith");
 
@@ -199,7 +199,7 @@ public class BinderSignalTest extends SignalsUnitTest {
     // verifies that cross-field validation works with mix of signal-bound and
     // not-bound fields
     @Test
-    public void bindingValue_crossFieldValidation_withMixedFields() {
+    void bindingValue_crossFieldValidation_withMixedFields() {
         item.setFirstName("Alice");
         item.setLastName("Smith");
         item.setAge(30);
@@ -271,7 +271,7 @@ public class BinderSignalTest extends SignalsUnitTest {
 
     // verifies that cross-field validation works correctly with setBean
     @Test
-    public void crossFieldValidation_setBean_validationTriggeredOnFieldChange() {
+    void crossFieldValidation_setBean_validationTriggeredOnFieldChange() {
         item.setFirstName("Alice");
         item.setLastName("Smith");
 
@@ -308,7 +308,7 @@ public class BinderSignalTest extends SignalsUnitTest {
 
     // verifies that cross-field validation works correctly with readBean
     @Test
-    public void crossFieldValidation_readBean_validationTriggeredOnFieldChange() {
+    void crossFieldValidation_readBean_validationTriggeredOnFieldChange() {
         item.setFirstName("Alice");
         item.setLastName("Smith");
 
@@ -346,7 +346,7 @@ public class BinderSignalTest extends SignalsUnitTest {
     // verifies that cross-field validation works correctly with readBean and
     // signal-bound fields
     @Test
-    public void crossFieldValidation_readBean_withSignals() {
+    void crossFieldValidation_readBean_withSignals() {
         item.setFirstName("Alice");
         item.setLastName("Smith");
 
@@ -384,7 +384,7 @@ public class BinderSignalTest extends SignalsUnitTest {
 
     // verifies that switching from setBean to readBean works correctly
     @Test
-    public void crossFieldValidation_switchFromSetBeanToReadBean() {
+    void crossFieldValidation_switchFromSetBeanToReadBean() {
         var item1 = new Person();
         item1.setFirstName("Alice");
         item1.setLastName("Smith");
@@ -427,7 +427,7 @@ public class BinderSignalTest extends SignalsUnitTest {
 
     // verifies that cross-field validation works with records
     @Test
-    public void crossFieldValidation_record_readRecord() {
+    void crossFieldValidation_record_readRecord() {
         record TestRecord(String firstName, String lastName) {
         }
 
@@ -461,7 +461,7 @@ public class BinderSignalTest extends SignalsUnitTest {
     // verifies that cross-field validation works with records and signal-bound
     // fields
     @Test
-    public void crossFieldValidation_record_readRecord_withSignals() {
+    void crossFieldValidation_record_readRecord_withSignals() {
         record TestRecord(String firstName, String lastName) {
         }
 
@@ -500,7 +500,7 @@ public class BinderSignalTest extends SignalsUnitTest {
     // verifies that multiple bean changes work correctly with cross-field
     // validation
     @Test
-    public void crossFieldValidation_multipleBeanChanges() {
+    void crossFieldValidation_multipleBeanChanges() {
         var item1 = new Person();
         item1.setFirstName("Alice");
         item1.setLastName("Smith");
@@ -547,7 +547,7 @@ public class BinderSignalTest extends SignalsUnitTest {
     // verifies that cross-field validation state is preserved when changing
     // beans
     @Test
-    public void crossFieldValidation_validationStatePreservedOnBeanChange() {
+    void crossFieldValidation_validationStatePreservedOnBeanChange() {
         var item1 = new Person();
         item1.setFirstName("Alice");
         item1.setLastName("Smith");
@@ -585,7 +585,7 @@ public class BinderSignalTest extends SignalsUnitTest {
     // verifies that cross-field validation with signals only works when fields
     // are attached
     @Test
-    public void crossFieldValidation_onlyWorksWithAttachedFields() {
+    void crossFieldValidation_onlyWorksWithAttachedFields() {
         item.setFirstName("Alice");
         item.setLastName("Smith");
 
@@ -647,7 +647,7 @@ public class BinderSignalTest extends SignalsUnitTest {
 
     // verifies that unbind() removes signal registration.
     @Test
-    public void unbind_removesSignalRegistration() {
+    void unbind_removesSignalRegistration() {
         item.setFirstName("Alice");
         item.setLastName("Smith");
 
@@ -690,7 +690,7 @@ public class BinderSignalTest extends SignalsUnitTest {
     }
 
     @Test
-    public void beanLevelValidator_throwWhenSignalIsUsed() {
+    void beanLevelValidator_throwWhenSignalIsUsed() {
         item.setFirstName("Alice");
         var firstNameSignal = new ValueSignal<>("");
         UI.getCurrent().add(firstNameField);
@@ -714,7 +714,7 @@ public class BinderSignalTest extends SignalsUnitTest {
     }
 
     @Test
-    public void getValidationStatus_signalInitialized() {
+    void getValidationStatus_signalInitialized() {
         Signal<BinderValidationStatus<Person>> statusSignal = binder
                 .validationStatusSignal();
         assertNotNull(statusSignal,
@@ -724,7 +724,7 @@ public class BinderSignalTest extends SignalsUnitTest {
     }
 
     @Test
-    public void getValidationStatus_signalIsReadOnly() {
+    void getValidationStatus_signalIsReadOnly() {
         Signal<BinderValidationStatus<Person>> statusSignal = binder
                 .validationStatusSignal();
         assertThrows(ClassCastException.class,
@@ -733,7 +733,7 @@ public class BinderSignalTest extends SignalsUnitTest {
     }
 
     @Test
-    public void getValidationStatus_statusChangeUpdatesSignal() {
+    void getValidationStatus_statusChangeUpdatesSignal() {
         item.setFirstName("Alice");
         item.setLastName("Smith");
         UI.getCurrent().add(firstNameField, lastNameField);
@@ -759,7 +759,7 @@ public class BinderSignalTest extends SignalsUnitTest {
 
     // verifies that field-specific validation statuses are updated correctly
     @Test
-    public void getValidationStatus_fieldChanged_validationStatusSignalUpdated() {
+    void getValidationStatus_fieldChanged_validationStatusSignalUpdated() {
         item.setFirstName("Alice");
         item.setLastName("Smith");
         UI.getCurrent().add(firstNameField, lastNameField);
@@ -800,7 +800,7 @@ public class BinderSignalTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindingValue_converterNotTracking() {
+    void bindingValue_converterNotTracking() {
         item.setLastName("Smith");
         item.setAge(30);
 
@@ -844,12 +844,12 @@ public class BinderSignalTest extends SignalsUnitTest {
     }
 
     @Test
-    public void getValidationStatus_setBean_statusChangeRunEffects() {
+    void getValidationStatus_setBean_statusChangeRunEffects() {
         testStatusChangeRunEffects(() -> binder.setBean(item));
     }
 
     @Test
-    public void getValidationStatus_readBean_statusChangeRunEffects() {
+    void getValidationStatus_readBean_statusChangeRunEffects() {
         testStatusChangeRunEffects(() -> binder.readBean(item));
     }
 
@@ -893,17 +893,17 @@ public class BinderSignalTest extends SignalsUnitTest {
     }
 
     @Test
-    public void getValidationStatus_setBean_initialStatus() {
+    void getValidationStatus_setBean_initialStatus() {
         testInitialStatusChangeRunEffects(item -> binder.setBean(item));
     }
 
     @Test
-    public void getValidationStatus_readBean_initialStatus() {
+    void getValidationStatus_readBean_initialStatus() {
         testInitialStatusChangeRunEffects(item -> binder.readBean(item));
     }
 
     @Test
-    public void bindingValue_multipleValueSignalCalls_revalidateTriggeredForEach() {
+    void bindingValue_multipleValueSignalCalls_revalidateTriggeredForEach() {
         item.setFirstName("Alice");
         item.setLastName("Smith");
 
@@ -959,7 +959,7 @@ public class BinderSignalTest extends SignalsUnitTest {
     }
 
     @Test
-    public void asRequired_setBeanBeforeBind_fieldNotInvalidOnAttach() {
+    void asRequired_setBeanBeforeBind_fieldNotInvalidOnAttach() {
         var field = new TestTextField();
         binder.setBean(item);
         binder.forField(field).asRequired("Required field")

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorBindTextTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorBindTextTest.java
@@ -36,10 +36,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Unit tests for Anchor constructors that accept Signal<String> and related
  * bindText(Signal) semantics as documented in Anchor Javadoc.
  */
-public class AnchorBindTextTest extends SignalsUnitTest {
+class AnchorBindTextTest extends SignalsUnitTest {
 
     @Test
-    public void constructor_href_signal_lifecycleAndUpdates() {
+    void constructor_href_signal_lifecycleAndUpdates() {
         // Detached: binding inactive
         var signal = new ValueSignal<>("one");
         Anchor anchor = new Anchor("/path", signal);
@@ -69,7 +69,7 @@ public class AnchorBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindText_nullSignal_throwsNPE() {
+    void bindText_nullSignal_throwsNPE() {
         Anchor anchor = new Anchor("/a", "text");
         UI.getCurrent().add(anchor);
 
@@ -77,7 +77,7 @@ public class AnchorBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void setText_whileBindingActive_throwsBindingActiveException() {
+    void setText_whileBindingActive_throwsBindingActiveException() {
         var signal = new ValueSignal<>("x");
         Anchor anchor = new Anchor("/x", signal);
         UI.getCurrent().add(anchor);
@@ -86,7 +86,7 @@ public class AnchorBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindText_againWhileActive_throwsBindingActiveException() {
+    void bindText_againWhileActive_throwsBindingActiveException() {
         var signal = new ValueSignal<>("first");
         Anchor anchor = new Anchor("/x", signal);
         UI.getCurrent().add(anchor);
@@ -96,7 +96,7 @@ public class AnchorBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void constructor_downloadHandler_signal_setsDownloadAttributeAccordingToHandlerType() {
+    void constructor_downloadHandler_signal_setsDownloadAttributeAccordingToHandlerType() {
         // AbstractDownloadHandler default: attachment (download attribute true)
         var attachmentHandler = new AttachmentHandler();
         Anchor a1 = new Anchor(attachmentHandler, new ValueSignal<>("d1"));

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/FieldSetBindLegendTextTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/FieldSetBindLegendTextTest.java
@@ -29,10 +29,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * Tests for {@link FieldSet#bindLegendText(com.vaadin.flow.signals.Signal)}
  * using {@link SignalsUnitTest} setup.
  */
-public class FieldSetBindLegendTextTest extends SignalsUnitTest {
+class FieldSetBindLegendTextTest extends SignalsUnitTest {
 
     @Test
-    public void bindLegendText_updatesLegendOnSignalChange() {
+    void bindLegendText_updatesLegendOnSignalChange() {
         FieldSet fieldSet = new FieldSet();
         UI.getCurrent().add(fieldSet);
 
@@ -47,7 +47,7 @@ public class FieldSetBindLegendTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindLegendText_setLegendTextWhileBindingActive_throws() {
+    void bindLegendText_setLegendTextWhileBindingActive_throws() {
         FieldSet fieldSet = new FieldSet();
         UI.getCurrent().add(fieldSet);
 
@@ -59,7 +59,7 @@ public class FieldSetBindLegendTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindLegendText_nullSignal_throwsNPE() {
+    void bindLegendText_nullSignal_throwsNPE() {
         FieldSet fieldSet = new FieldSet();
         UI.getCurrent().add(fieldSet);
 
@@ -68,7 +68,7 @@ public class FieldSetBindLegendTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindLegendText_attachedThenDetached_stopsUpdates() {
+    void bindLegendText_attachedThenDetached_stopsUpdates() {
         FieldSet fieldSet = new FieldSet();
         UI.getCurrent().add(fieldSet);
 

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlObjectBindDataTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlObjectBindDataTest.java
@@ -28,10 +28,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 /**
  * Tests for {@link HtmlObject#bindData(com.vaadin.flow.signals.Signal)}.
  */
-public class HtmlObjectBindDataTest extends SignalsUnitTest {
+class HtmlObjectBindDataTest extends SignalsUnitTest {
 
     @Test
-    public void bindData_updatesAttributeOnSignalChange() {
+    void bindData_updatesAttributeOnSignalChange() {
         HtmlObject htmlObject = new HtmlObject();
         UI.getCurrent().add(htmlObject);
 
@@ -48,7 +48,7 @@ public class HtmlObjectBindDataTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindData_attachedThenDetached_stopsUpdates() {
+    void bindData_attachedThenDetached_stopsUpdates() {
         HtmlObject htmlObject = new HtmlObject();
         UI.getCurrent().add(htmlObject);
 
@@ -65,7 +65,7 @@ public class HtmlObjectBindDataTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindData_nullSignal_throwsNPE() {
+    void bindData_nullSignal_throwsNPE() {
         HtmlObject htmlObject = new HtmlObject();
         UI.getCurrent().add(htmlObject);
 
@@ -74,7 +74,7 @@ public class HtmlObjectBindDataTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindData_setDataWhileBound_throwsException() {
+    void bindData_setDataWhileBound_throwsException() {
         HtmlObject htmlObject = new HtmlObject();
         UI.getCurrent().add(htmlObject);
 
@@ -86,7 +86,7 @@ public class HtmlObjectBindDataTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindData_bindAgainWhileBound_throwsException() {
+    void bindData_bindAgainWhileBound_throwsException() {
         HtmlObject htmlObject = new HtmlObject();
         UI.getCurrent().add(htmlObject);
 

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeDetailsBindOpenTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeDetailsBindOpenTest.java
@@ -27,10 +27,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class NativeDetailsBindOpenTest extends SignalsUnitTest {
+class NativeDetailsBindOpenTest extends SignalsUnitTest {
 
     @Test
-    public void bindOpen_signalBound_propertySync() {
+    void bindOpen_signalBound_propertySync() {
         NativeDetails details = new NativeDetails();
         ValueSignal<Boolean> signal = new ValueSignal<>(false);
         details.bindOpen(signal, signal::set);
@@ -46,7 +46,7 @@ public class NativeDetailsBindOpenTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindOpen_notAttached_noEffect() {
+    void bindOpen_notAttached_noEffect() {
         NativeDetails details = new NativeDetails();
         ValueSignal<Boolean> signal = new ValueSignal<>(false);
         details.bindOpen(signal, signal::set);
@@ -57,7 +57,7 @@ public class NativeDetailsBindOpenTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindOpen_detachAndReattach() {
+    void bindOpen_detachAndReattach() {
         NativeDetails details = new NativeDetails();
         ValueSignal<Boolean> signal = new ValueSignal<>(false);
         details.bindOpen(signal, signal::set);
@@ -75,7 +75,7 @@ public class NativeDetailsBindOpenTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindOpen_setWhileBoundReadOnly_throws() {
+    void bindOpen_setWhileBoundReadOnly_throws() {
         NativeDetails details = new NativeDetails();
         ValueSignal<Boolean> signal = new ValueSignal<>(false);
         details.bindOpen(signal, null);
@@ -85,7 +85,7 @@ public class NativeDetailsBindOpenTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindOpen_setWhileBoundWithWriteCallback_updateSignalValue() {
+    void bindOpen_setWhileBoundWithWriteCallback_updateSignalValue() {
         NativeDetails details = new NativeDetails();
         ValueSignal<Boolean> signal = new ValueSignal<>(false);
         details.bindOpen(signal, signal::set);
@@ -96,7 +96,7 @@ public class NativeDetailsBindOpenTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindOpen_doubleBind_throws() {
+    void bindOpen_doubleBind_throws() {
         NativeDetails details = new NativeDetails();
         ValueSignal<Boolean> signal = new ValueSignal<>(false);
         details.bindOpen(signal, signal::set);
@@ -106,7 +106,7 @@ public class NativeDetailsBindOpenTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindOpen_nullSignal_throwsNPE() {
+    void bindOpen_nullSignal_throwsNPE() {
         NativeDetails details = new NativeDetails();
         assertThrows(NullPointerException.class,
                 () -> details.bindOpen(null, null));

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeDetailsBindTextTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeDetailsBindTextTest.java
@@ -25,10 +25,10 @@ import com.vaadin.flow.signals.local.ValueSignal;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class NativeDetailsBindTextTest extends SignalsUnitTest {
+class NativeDetailsBindTextTest extends SignalsUnitTest {
 
     @Test
-    public void bindSummaryText_updatesTextOnSignalChange() {
+    void bindSummaryText_updatesTextOnSignalChange() {
         NativeDetails details = new NativeDetails();
         UI.getCurrent().add(details);
 
@@ -43,7 +43,7 @@ public class NativeDetailsBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindSummaryText_setSummaryTextWhileBindingActive_throws() {
+    void bindSummaryText_setSummaryTextWhileBindingActive_throws() {
         NativeDetails details = new NativeDetails();
         UI.getCurrent().add(details);
 
@@ -55,7 +55,7 @@ public class NativeDetailsBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindSummaryText_nullSignal_throwsNPE() {
+    void bindSummaryText_nullSignal_throwsNPE() {
         NativeDetails details = new NativeDetails();
         UI.getCurrent().add(details);
 
@@ -64,7 +64,7 @@ public class NativeDetailsBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void constructorWithSignal_bindsSummaryText() {
+    void constructorWithSignal_bindsSummaryText() {
         ValueSignal<String> signal = new ValueSignal<>("initial");
         NativeDetails details = new NativeDetails(signal);
         UI.getCurrent().add(details);
@@ -76,7 +76,7 @@ public class NativeDetailsBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void constructorWithSignalAndContent_bindsSummaryTextAndSetsContent() {
+    void constructorWithSignalAndContent_bindsSummaryTextAndSetsContent() {
         ValueSignal<String> signal = new ValueSignal<>("initial");
         Span content = new Span("content");
         NativeDetails details = new NativeDetails(signal, content);

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeLabelBindTextTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeLabelBindTextTest.java
@@ -25,10 +25,10 @@ import com.vaadin.flow.signals.local.ValueSignal;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class NativeLabelBindTextTest extends SignalsUnitTest {
+class NativeLabelBindTextTest extends SignalsUnitTest {
 
     @Test
-    public void bindText_updatesTextOnSignalChange() {
+    void bindText_updatesTextOnSignalChange() {
         NativeLabel label = new NativeLabel();
         UI.getCurrent().add(label);
 
@@ -43,7 +43,7 @@ public class NativeLabelBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindText_setTextWhileBindingActive_throws() {
+    void bindText_setTextWhileBindingActive_throws() {
         NativeLabel label = new NativeLabel();
         UI.getCurrent().add(label);
 
@@ -55,7 +55,7 @@ public class NativeLabelBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindText_nullSignal_throwsNPE() {
+    void bindText_nullSignal_throwsNPE() {
         NativeLabel label = new NativeLabel();
         UI.getCurrent().add(label);
 
@@ -63,7 +63,7 @@ public class NativeLabelBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void constructorWithSignal_bindsText() {
+    void constructorWithSignal_bindsText() {
         ValueSignal<String> signal = new ValueSignal<>("initial");
         NativeLabel label = new NativeLabel(signal);
         UI.getCurrent().add(label);

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableCellBindTextTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeTableCellBindTextTest.java
@@ -25,10 +25,10 @@ import com.vaadin.flow.signals.local.ValueSignal;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class NativeTableCellBindTextTest extends SignalsUnitTest {
+class NativeTableCellBindTextTest extends SignalsUnitTest {
 
     @Test
-    public void bindText_updatesTextOnSignalChange() {
+    void bindText_updatesTextOnSignalChange() {
         NativeTableCell cell = new NativeTableCell();
         UI.getCurrent().add(cell);
 
@@ -43,7 +43,7 @@ public class NativeTableCellBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindText_setTextWhileBindingActive_throws() {
+    void bindText_setTextWhileBindingActive_throws() {
         NativeTableCell cell = new NativeTableCell();
         UI.getCurrent().add(cell);
 
@@ -55,7 +55,7 @@ public class NativeTableCellBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindText_nullSignal_throwsNPE() {
+    void bindText_nullSignal_throwsNPE() {
         NativeTableCell cell = new NativeTableCell();
         UI.getCurrent().add(cell);
 
@@ -63,7 +63,7 @@ public class NativeTableCellBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void constructorWithSignal_bindsText() {
+    void constructorWithSignal_bindsText() {
         ValueSignal<String> signal = new ValueSignal<>("initial");
         NativeTableCell cell = new NativeTableCell(signal);
         UI.getCurrent().add(cell);

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/ParamBindTextTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/ParamBindTextTest.java
@@ -27,10 +27,10 @@ import com.vaadin.flow.signals.local.ValueSignal;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class ParamBindTextTest extends SignalsUnitTest {
+class ParamBindTextTest extends SignalsUnitTest {
 
     @Test
-    public void bindName_updatesAttributeOnSignalChange() {
+    void bindName_updatesAttributeOnSignalChange() {
         Param param = new Param();
         UI.getCurrent().add(param);
 
@@ -45,7 +45,7 @@ public class ParamBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindName_setNameWhileBindingActive_throws() {
+    void bindName_setNameWhileBindingActive_throws() {
         Param param = new Param();
         UI.getCurrent().add(param);
 
@@ -57,7 +57,7 @@ public class ParamBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindName_nullSignal_throwsNPE() {
+    void bindName_nullSignal_throwsNPE() {
         Param param = new Param();
         UI.getCurrent().add(param);
 
@@ -65,7 +65,7 @@ public class ParamBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_updatesAttributeOnSignalChange() {
+    void bindValue_updatesAttributeOnSignalChange() {
         Param param = new Param();
         UI.getCurrent().add(param);
 
@@ -80,7 +80,7 @@ public class ParamBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_setValueWhileBindingActive_throws() {
+    void bindValue_setValueWhileBindingActive_throws() {
         Param param = new Param();
         UI.getCurrent().add(param);
 
@@ -92,7 +92,7 @@ public class ParamBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_nullSignal_throwsNPE() {
+    void bindValue_nullSignal_throwsNPE() {
         Param param = new Param();
         UI.getCurrent().add(param);
 

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/RangeInputBindTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/RangeInputBindTest.java
@@ -25,10 +25,10 @@ import com.vaadin.flow.signals.local.ValueSignal;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class RangeInputBindTest extends SignalsUnitTest {
+class RangeInputBindTest extends SignalsUnitTest {
 
     @Test
-    public void bindMin_updatesAttributeOnSignalChange() {
+    void bindMin_updatesAttributeOnSignalChange() {
         RangeInput rangeInput = new RangeInput();
         UI.getCurrent().add(rangeInput);
 
@@ -43,7 +43,7 @@ public class RangeInputBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindMin_setMinWhileBindingActive_throws() {
+    void bindMin_setMinWhileBindingActive_throws() {
         RangeInput rangeInput = new RangeInput();
         UI.getCurrent().add(rangeInput);
 
@@ -55,7 +55,7 @@ public class RangeInputBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindMin_nullSignal_throwsNPE() {
+    void bindMin_nullSignal_throwsNPE() {
         RangeInput rangeInput = new RangeInput();
         UI.getCurrent().add(rangeInput);
 
@@ -64,7 +64,7 @@ public class RangeInputBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindMax_updatesAttributeOnSignalChange() {
+    void bindMax_updatesAttributeOnSignalChange() {
         RangeInput rangeInput = new RangeInput();
         UI.getCurrent().add(rangeInput);
 
@@ -79,7 +79,7 @@ public class RangeInputBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindMax_setMaxWhileBindingActive_throws() {
+    void bindMax_setMaxWhileBindingActive_throws() {
         RangeInput rangeInput = new RangeInput();
         UI.getCurrent().add(rangeInput);
 
@@ -91,7 +91,7 @@ public class RangeInputBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindMax_nullSignal_throwsNPE() {
+    void bindMax_nullSignal_throwsNPE() {
         RangeInput rangeInput = new RangeInput();
         UI.getCurrent().add(rangeInput);
 

--- a/flow-server/src/test/java/com/vaadin/AssertionTest.java
+++ b/flow-server/src/test/java/com/vaadin/AssertionTest.java
@@ -21,10 +21,10 @@ import org.junit.jupiter.api.Test;
 /**
  * Test that tests are run with assertions activated
  */
-public class AssertionTest {
+class AssertionTest {
 
     @Test
-    public void testAssertionsAreEnabled() {
+    void testAssertionsAreEnabled() {
         boolean assertOn = false;
         // *assigns* true if assertions are on.
         assert assertOn = true;

--- a/flow-server/src/test/java/com/vaadin/experimental/FeatureFlagsTest.java
+++ b/flow-server/src/test/java/com/vaadin/experimental/FeatureFlagsTest.java
@@ -62,7 +62,7 @@ class FeatureFlagsTest {
     private File featureFlagsFile;
 
     @BeforeEach
-    public void before() throws IOException {
+    void before() throws IOException {
         propertiesDir = Files.createTempDirectory(temporaryFolder, "temp")
                 .toFile();
 
@@ -82,7 +82,7 @@ class FeatureFlagsTest {
     }
 
     @Test
-    public void propertiesLoaded() throws IOException {
+    void propertiesLoaded() throws IOException {
         assertFalse(featureFlags.isEnabled(TestFeatureFlagProvider.EXAMPLE),
                 "Feature should be initially disabled");
 
@@ -98,7 +98,7 @@ class FeatureFlagsTest {
     }
 
     @Test
-    public void setPropertiesLocation() throws Exception {
+    void setPropertiesLocation() throws Exception {
         // Set location and ensure flags are loaded from there
         createFeatureFlagsFile(
                 "com.vaadin.experimental.exampleFeatureFlag=true\n");
@@ -110,8 +110,7 @@ class FeatureFlagsTest {
     }
 
     @Test
-    public void setPropertiesLocationWithNoFileDisablesFeatures()
-            throws Exception {
+    void setPropertiesLocationWithNoFileDisablesFeatures() throws Exception {
         // given an enabled feature
         createFeatureFlagsFile(
                 "com.vaadin.experimental.exampleFeatureFlag=true\n");
@@ -128,7 +127,7 @@ class FeatureFlagsTest {
     }
 
     @Test
-    public void enableDisableFeature() throws IOException {
+    void enableDisableFeature() throws IOException {
         createFeatureFlagsFile(
                 "com.vaadin.experimental.exampleFeatureFlag=false\n");
         featureFlags.loadProperties();
@@ -153,7 +152,7 @@ class FeatureFlagsTest {
     }
 
     @Test
-    public void setEnabledOnlyInDevelopmentMode() throws IOException {
+    void setEnabledOnlyInDevelopmentMode() throws IOException {
         Mockito.when(configuration.isProductionMode()).thenReturn(true);
 
         createFeatureFlagsFile(
@@ -166,8 +165,7 @@ class FeatureFlagsTest {
     }
 
     @Test
-    public void disabledFeatureFlagsNotMarkedInStatsWhenLoading()
-            throws IOException {
+    void disabledFeatureFlagsNotMarkedInStatsWhenLoading() throws IOException {
         UsageStatistics.resetEntries();
         createFeatureFlagsFile("");
         featureFlags.loadProperties();
@@ -175,8 +173,7 @@ class FeatureFlagsTest {
     }
 
     @Test
-    public void enabledFeatureFlagsMarkedInStatsWhenLoading()
-            throws IOException {
+    void enabledFeatureFlagsMarkedInStatsWhenLoading() throws IOException {
         createFeatureFlagsFile(
                 "com.vaadin.experimental.exampleFeatureFlag=true\n");
         featureFlags.loadProperties();
@@ -184,8 +181,7 @@ class FeatureFlagsTest {
     }
 
     @Test
-    public void disabledFeatureFlagsNotMarkedInStatsWhenToggled()
-            throws IOException {
+    void disabledFeatureFlagsNotMarkedInStatsWhenToggled() throws IOException {
         createFeatureFlagsFile(
                 "com.vaadin.experimental.exampleFeatureFlag=true\n");
         UsageStatistics.resetEntries();
@@ -194,8 +190,7 @@ class FeatureFlagsTest {
     }
 
     @Test
-    public void enabledFeatureFlagsMarkedInStatsWhenToggled()
-            throws IOException {
+    void enabledFeatureFlagsMarkedInStatsWhenToggled() throws IOException {
         createFeatureFlagsFile(
                 "com.vaadin.experimental.exampleFeatureFlag=false\n");
         UsageStatistics.resetEntries();
@@ -204,8 +199,7 @@ class FeatureFlagsTest {
     }
 
     @Test
-    public void featureFlagShouldBeOverridableWithSystemProperty()
-            throws IOException {
+    void featureFlagShouldBeOverridableWithSystemProperty() throws IOException {
         var feature = "exampleFeatureFlag";
         var propertyName = FeatureFlags.SYSTEM_PROPERTY_PREFIX_EXPERIMENTAL
                 + feature;
@@ -232,7 +226,7 @@ class FeatureFlagsTest {
     }
 
     @Test
-    public void featureFlagLoadedByResourceProviderShouldBeOverridableWithSystemProperty()
+    void featureFlagLoadedByResourceProviderShouldBeOverridableWithSystemProperty()
             throws IOException {
         var feature = "exampleFeatureFlag";
         var propertyName = FeatureFlags.SYSTEM_PROPERTY_PREFIX_EXPERIMENTAL
@@ -271,7 +265,7 @@ class FeatureFlagsTest {
     }
 
     @Test
-    public void noFeatureFlagFile_systemPropertyProvided_featureEnabled()
+    void noFeatureFlagFile_systemPropertyProvided_featureEnabled()
             throws IOException {
         var feature = "exampleFeatureFlag";
         var propertyName = FeatureFlags.SYSTEM_PROPERTY_PREFIX_EXPERIMENTAL
@@ -295,7 +289,7 @@ class FeatureFlagsTest {
     }
 
     @Test
-    public void noFeatureFlagFile_noSystemPropertyProvided_allFeatureDisabled()
+    void noFeatureFlagFile_noSystemPropertyProvided_allFeatureDisabled()
             throws IOException {
         var feature = "exampleFeatureFlag";
         var propertyName = FeatureFlags.SYSTEM_PROPERTY_PREFIX_EXPERIMENTAL
@@ -318,8 +312,7 @@ class FeatureFlagsTest {
 
     // https://github.com/vaadin/flow/issues/17637
     @Test
-    public void get_concurrentAccess_servletContextLock_noDeadlock()
-            throws Exception {
+    void get_concurrentAccess_servletContextLock_noDeadlock() throws Exception {
         BiConsumer<Void, Throwable> errorLogger = (unused, throwable) -> {
             if (throwable != null) {
                 LoggerFactory.getLogger(FeatureFlagsTest.class)
@@ -368,8 +361,7 @@ class FeatureFlagsTest {
 
     // https://github.com/vaadin/flow/issues/13962
     @Test
-    public void get_concurrentAccess_vaadinContextLock_noDeadlock()
-            throws Exception {
+    void get_concurrentAccess_vaadinContextLock_noDeadlock() throws Exception {
         BiConsumer<Void, Throwable> errorLogger = (unused, throwable) -> {
             if (throwable != null) {
                 LoggerFactory.getLogger(FeatureFlagsTest.class)
@@ -407,8 +399,7 @@ class FeatureFlagsTest {
     }
 
     @Test
-    public void propertiesFileCheckedForUnsupportedFeatureFlags()
-            throws IOException {
+    void propertiesFileCheckedForUnsupportedFeatureFlags() throws IOException {
         Logger mockedLogger = Mockito.mock(Logger.class);
 
         try (MockedStatic<LoggerFactory> context = Mockito
@@ -430,7 +421,7 @@ class FeatureFlagsTest {
     }
 
     @Test
-    public void propertiesFileCheckForUnsupportedFeatureFlagsRanOnlyOnce()
+    void propertiesFileCheckForUnsupportedFeatureFlagsRanOnlyOnce()
             throws IOException {
         Logger mockedLogger = Mockito.mock(Logger.class);
 
@@ -451,7 +442,7 @@ class FeatureFlagsTest {
     }
 
     @Test
-    public void systemPropertiesCheckedForUnsupportedFeatureFlags() {
+    void systemPropertiesCheckedForUnsupportedFeatureFlags() {
         Logger mockedLogger = Mockito.mock(Logger.class);
         String exampleProperty = FeatureFlags.SYSTEM_PROPERTY_PREFIX_EXPERIMENTAL
                 + "exampleFeatureFlag";

--- a/flow-server/src/test/java/com/vaadin/flow/ComponentTrackerLocationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/ComponentTrackerLocationTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class ComponentTrackerLocationTest {
 
     @Test
-    public void findJavaFile_simpleClass() {
+    void findJavaFile_simpleClass() {
         File fakeSrcDir = new File("src");
         AbstractConfiguration configuration = Mockito
                 .mock(AbstractConfiguration.class);
@@ -47,7 +47,7 @@ class ComponentTrackerLocationTest {
     }
 
     @Test
-    public void findJavaFile_simpleClass_dollarInPackage() {
+    void findJavaFile_simpleClass_dollarInPackage() {
         File fakeSrcDir = new File("src");
         AbstractConfiguration configuration = Mockito
                 .mock(AbstractConfiguration.class);
@@ -65,7 +65,7 @@ class ComponentTrackerLocationTest {
     }
 
     @Test
-    public void findJavaFile_simpleClass_dollarInName() {
+    void findJavaFile_simpleClass_dollarInName() {
         File fakeSrcDir = new File("src");
         AbstractConfiguration configuration = Mockito
                 .mock(AbstractConfiguration.class);
@@ -84,7 +84,7 @@ class ComponentTrackerLocationTest {
     }
 
     @Test
-    public void findJavaFile_innerClass() {
+    void findJavaFile_innerClass() {
         File fakeSrcDir = new File("src");
         AbstractConfiguration configuration = Mockito
                 .mock(AbstractConfiguration.class);
@@ -103,7 +103,7 @@ class ComponentTrackerLocationTest {
     }
 
     @Test
-    public void findJavaFile_nestedInnerClass() {
+    void findJavaFile_nestedInnerClass() {
         File fakeSrcDir = new File("src");
         AbstractConfiguration configuration = Mockito
                 .mock(AbstractConfiguration.class);
@@ -122,7 +122,7 @@ class ComponentTrackerLocationTest {
     }
 
     @Test
-    public void findKotlinFile_simpleClass() {
+    void findKotlinFile_simpleClass() {
         File defaultJavaSrcDir = new File("src/main/java");
         File kotlinExpectedSrcDir = new File("src/main/kotlin");
         AbstractConfiguration configuration = Mockito

--- a/flow-server/src/test/java/com/vaadin/flow/ComponentTrackerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/ComponentTrackerTest.java
@@ -57,7 +57,7 @@ class ComponentTrackerTest {
     private Field disabledField;
 
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() throws Exception {
         disabledField = ComponentTracker.class.getDeclaredField("disabled");
         disabledField.setAccessible(true);
         previousDisabled = disabledField.get(null);
@@ -65,12 +65,12 @@ class ComponentTrackerTest {
     }
 
     @AfterEach
-    public void teardown() throws Exception {
+    void teardown() throws Exception {
         disabledField.set(null, previousDisabled);
     }
 
     @Test
-    public void createLocationTracked() {
+    void createLocationTracked() {
         Component1 c1 = new Component1();
         Component c2;
         c2 = new Component1();
@@ -81,7 +81,7 @@ class ComponentTrackerTest {
     }
 
     @Test
-    public void attachLocationTracked() {
+    void attachLocationTracked() {
         Component1 c1 = new Component1();
         Component c2 = new Component1();
         Component c3 = new Component1();
@@ -105,7 +105,7 @@ class ComponentTrackerTest {
     }
 
     @Test
-    public void offsetApplied() {
+    void offsetApplied() {
         Component1 c1 = new Component1();
         Component c2 = new Component1();
         Component c3 = new Component1();
@@ -123,7 +123,7 @@ class ComponentTrackerTest {
     }
 
     @Test
-    public void memoryIsReleased() throws Exception {
+    void memoryIsReleased() throws Exception {
         Field createThrowableField = ComponentTracker.class
                 .getDeclaredField("createThrowable");
         Field attachThrowableField = ComponentTracker.class
@@ -146,7 +146,7 @@ class ComponentTrackerTest {
     }
 
     @Test
-    public void ordinalValueSet() {
+    void ordinalValueSet() {
         Component1 c1 = new Component1();
         Component c2 = new Component1();
         Layout layout = new Layout();
@@ -157,7 +157,7 @@ class ComponentTrackerTest {
     }
 
     @Test
-    public void attachOrderChangesOrdinal() {
+    void attachOrderChangesOrdinal() {
         Component1 c1 = new Component1();
         Component c2 = new Component1();
         Layout layout = new Layout();
@@ -168,7 +168,7 @@ class ComponentTrackerTest {
     }
 
     @Test
-    public void createOrderChangesOrdinal() {
+    void createOrderChangesOrdinal() {
         Component c2 = new Component1();
         Component1 c1 = new Component1();
         Layout layout = new Layout();
@@ -179,7 +179,7 @@ class ComponentTrackerTest {
     }
 
     @Test
-    public void componentsHaveDifferentOrdinalWhenCreatedInSameLine() {
+    void componentsHaveDifferentOrdinalWhenCreatedInSameLine() {
         var components = new Component[] { new Component1(), new Component1() };
         new Layout(components);
         assertCreateLocation(components[0], 183, getClass().getName());

--- a/flow-server/src/test/java/com/vaadin/flow/DisableComponentTrackerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/DisableComponentTrackerTest.java
@@ -40,7 +40,7 @@ class DisableComponentTrackerTest {
     private Field disabledField;
 
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() throws Exception {
         disabledField = ComponentTracker.class.getDeclaredField("disabled");
         disabledField.setAccessible(true);
         previousDisabled = disabledField.get(null);
@@ -48,12 +48,12 @@ class DisableComponentTrackerTest {
     }
 
     @AfterEach
-    public void teardown() throws Exception {
+    void teardown() throws Exception {
         disabledField.set(null, previousDisabled);
     }
 
     @Test
-    public void trackCreate_disabledInProductionMode() {
+    void trackCreate_disabledInProductionMode() {
         withVaadinEnvironment(appCfg -> {
             Mockito.when(appCfg.isProductionMode()).thenReturn(true);
             Mockito.when(appCfg.getBooleanProperty(ArgumentMatchers.eq(
@@ -66,7 +66,7 @@ class DisableComponentTrackerTest {
     }
 
     @Test
-    public void trackAttach_disabledInProductionMode() {
+    void trackAttach_disabledInProductionMode() {
         withVaadinEnvironment(appCfg -> {
             Mockito.when(appCfg.isProductionMode()).thenReturn(true);
             Mockito.when(appCfg.getBooleanProperty(ArgumentMatchers.eq(
@@ -81,7 +81,7 @@ class DisableComponentTrackerTest {
     }
 
     @Test
-    public void trackCreate_disabledByConfiguration() {
+    void trackCreate_disabledByConfiguration() {
         withVaadinEnvironment(appCfg -> {
             Mockito.when(appCfg.isProductionMode()).thenReturn(false);
             Mockito.when(appCfg.getBooleanProperty(ArgumentMatchers.eq(
@@ -94,7 +94,7 @@ class DisableComponentTrackerTest {
     }
 
     @Test
-    public void trackAttach_disabledByConfiguration() {
+    void trackAttach_disabledByConfiguration() {
         withVaadinEnvironment(appCfg -> {
             Mockito.when(appCfg.isProductionMode()).thenReturn(false);
             Mockito.when(appCfg.getBooleanProperty(ArgumentMatchers.eq(

--- a/flow-server/src/test/java/com/vaadin/flow/NotifierTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/NotifierTest.java
@@ -35,7 +35,7 @@ class NotifierTest {
     }
 
     @Test
-    public void addNotifiers() {
+    void addNotifiers() {
         // Just testing that adding notifiers actually compiles and doesn't
         // throw. Test is on purpose outside com.vaadin.flow.component to
         // uncover visibility problems.

--- a/flow-server/src/test/java/com/vaadin/flow/component/AbstractCompositeFieldBindValueTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/AbstractCompositeFieldBindValueTest.java
@@ -69,7 +69,7 @@ class AbstractCompositeFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void multipleFieldsField_bindValue_detached_setValueDoesNotUpdateSignal() {
+    void multipleFieldsField_bindValue_detached_setValueDoesNotUpdateSignal() {
         MultipleFieldsField field = new MultipleFieldsField();
 
         ValueSignal<String> signal = new ValueSignal<>("Hello Cool World");
@@ -85,7 +85,7 @@ class AbstractCompositeFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void multipleFieldsField_bindValue_detached_setModelValueDoesNotUpdateSignal() {
+    void multipleFieldsField_bindValue_detached_setModelValueDoesNotUpdateSignal() {
         MultipleFieldsField field = new MultipleFieldsField();
 
         ValueSignal<String> signal = new ValueSignal<>("Hello Cool World");
@@ -102,7 +102,7 @@ class AbstractCompositeFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void multipleFieldsField_bindValue_attached() {
+    void multipleFieldsField_bindValue_attached() {
         MultipleFieldsField field = new MultipleFieldsField();
         UI.getCurrent().add(field);
 
@@ -129,7 +129,7 @@ class AbstractCompositeFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_nullSignal_throwsNPE() {
+    void bindValue_nullSignal_throwsNPE() {
         MultipleFieldsField field = new MultipleFieldsField();
         UI.getCurrent().add(field);
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/AbstractCompositeFieldTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/AbstractCompositeFieldTest.java
@@ -68,7 +68,7 @@ class AbstractCompositeFieldTest {
     }
 
     @Test
-    public void reverseCaseField() {
+    void reverseCaseField() {
         ReverseCaseField outerField = new ReverseCaseField();
         StringField innerField = outerField.getContent();
 
@@ -80,7 +80,7 @@ class AbstractCompositeFieldTest {
     }
 
     @Test
-    public void emptyValueEquals() {
+    void emptyValueEquals() {
         ReverseCaseField field = new ReverseCaseField();
 
         assertTrue(field.isEmpty());
@@ -134,7 +134,7 @@ class AbstractCompositeFieldTest {
     }
 
     @Test
-    public void multipleFieldsField() {
+    void multipleFieldsField() {
         MultipleFieldsField field = new MultipleFieldsField();
 
         field.setValue("Hello Cool World");
@@ -149,7 +149,7 @@ class AbstractCompositeFieldTest {
     }
 
     @Test
-    public void serializable() {
+    void serializable() {
         ReverseCaseField field = new ReverseCaseField();
         field.addValueChangeListener(ignore -> {
         });

--- a/flow-server/src/test/java/com/vaadin/flow/component/AbstractFieldBindValueTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/AbstractFieldBindValueTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 class AbstractFieldBindValueTest extends SignalsUnitTest {
 
     @Test
-    public void bindValue_elementAttachedBefore_bindingActive() {
+    void bindValue_elementAttachedBefore_bindingActive() {
         TestInput input = new TestInput();
         // attach before bindValue
         UI.getCurrent().add(input);
@@ -48,7 +48,7 @@ class AbstractFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_elementAttachedAfter_bindingActive() {
+    void bindValue_elementAttachedAfter_bindingActive() {
         TestInput input = new TestInput();
         assertEquals("", input.getValue());
         ValueSignal<String> signal = new ValueSignal<>("foo");
@@ -60,7 +60,7 @@ class AbstractFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_elementAttached_bindingActive() {
+    void bindValue_elementAttached_bindingActive() {
         TestInput input = new TestInput();
         UI.getCurrent().add(input);
         ValueSignal<String> signal = new ValueSignal<>("foo");
@@ -79,7 +79,7 @@ class AbstractFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_elementNotAttached_bindingInactive() {
+    void bindValue_elementNotAttached_bindingInactive() {
         TestInput input = new TestInput();
         ValueSignal<String> signal = new ValueSignal<>("foo");
         input.bindValue(signal, signal::set);
@@ -93,7 +93,7 @@ class AbstractFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_elementDetached_bindingInactive() {
+    void bindValue_elementDetached_bindingInactive() {
         TestInput input = new TestInput();
         UI.getCurrent().add(input);
         ValueSignal<String> signal = new ValueSignal<>("foo");
@@ -105,7 +105,7 @@ class AbstractFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_elementReAttached_bindingActivate() {
+    void bindValue_elementReAttached_bindingActivate() {
         TestInput input = new TestInput();
         UI.getCurrent().add(input);
         ValueSignal<String> signal = new ValueSignal<>("foo");
@@ -118,7 +118,7 @@ class AbstractFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_bindValueWhileBindingIsActive_throwException() {
+    void bindValue_bindValueWhileBindingIsActive_throwException() {
         TestInput input = new TestInput();
         UI.getCurrent().add(input);
         ValueSignal<String> signal1 = new ValueSignal<>("foo");
@@ -131,7 +131,7 @@ class AbstractFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_setValueWhileBindingIsActive_signalUpdated() {
+    void bindValue_setValueWhileBindingIsActive_signalUpdated() {
         TestInput input = new TestInput();
         UI.getCurrent().add(input);
         ValueSignal<String> signal = new ValueSignal<>("foo");
@@ -143,7 +143,7 @@ class AbstractFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_nullSignal_throwsNPE() {
+    void bindValue_nullSignal_throwsNPE() {
         TestInput input = new TestInput();
         UI.getCurrent().add(input);
 
@@ -152,7 +152,7 @@ class AbstractFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_lazyInitSignalBindingFeature() {
+    void bindValue_lazyInitSignalBindingFeature() {
         TestInput input = new TestInput();
         UI.getCurrent().add(input);
         input.setValue("foo");
@@ -172,7 +172,7 @@ class AbstractFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_addValueChangeListener_signalValueChangeTriggersEvent() {
+    void bindValue_addValueChangeListener_signalValueChangeTriggersEvent() {
         TestInput input = new TestInput();
         UI.getCurrent().add(input);
 
@@ -189,7 +189,7 @@ class AbstractFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_addValueChangeListener_bindValueTriggersEvent() {
+    void bindValue_addValueChangeListener_bindValueTriggersEvent() {
         TestInput input = new TestInput();
         UI.getCurrent().add(input);
 
@@ -205,7 +205,7 @@ class AbstractFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_setValue_countEffectExecutions() {
+    void bindValue_setValue_countEffectExecutions() {
         TestInput input = new TestInput();
 
         ValueSignal<String> signal = new ValueSignal<>("foo");
@@ -240,7 +240,7 @@ class AbstractFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_forElementProperty_addValueChangeListener_bindingValueChangeTriggersEvent() {
+    void bindValue_forElementProperty_addValueChangeListener_bindingValueChangeTriggersEvent() {
         TestPropertyInput input = new TestPropertyInput();
         UI.getCurrent().add(input);
 
@@ -273,7 +273,7 @@ class AbstractFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_readOnlyBinding_setValueThrows() {
+    void bindValue_readOnlyBinding_setValueThrows() {
         TestInput input = new TestInput();
         UI.getCurrent().add(input);
         ValueSignal<String> signal = new ValueSignal<>("foo");
@@ -287,7 +287,7 @@ class AbstractFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_readOnlyBinding_signalChangesStillWork() {
+    void bindValue_readOnlyBinding_signalChangesStillWork() {
         TestInput input = new TestInput();
         UI.getCurrent().add(input);
         ValueSignal<String> signal = new ValueSignal<>("foo");
@@ -300,7 +300,7 @@ class AbstractFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_readOnlyBinding_detachedSetValueDoesNotThrow() {
+    void bindValue_readOnlyBinding_detachedSetValueDoesNotThrow() {
         TestInput input = new TestInput();
         ValueSignal<String> signal = new ValueSignal<>("foo");
         input.bindValue(signal, null);
@@ -311,7 +311,7 @@ class AbstractFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_noOpCallback_revertsToSignalValue() {
+    void bindValue_noOpCallback_revertsToSignalValue() {
         TestInput input = new TestInput();
         UI.getCurrent().add(input);
         ValueSignal<String> signal = new ValueSignal<>("foo");
@@ -326,7 +326,7 @@ class AbstractFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_transformingCallback_componentShowsTransformed() {
+    void bindValue_transformingCallback_componentShowsTransformed() {
         TestInput input = new TestInput();
         UI.getCurrent().add(input);
         ValueSignal<String> signal = new ValueSignal<>("foo");
@@ -340,7 +340,7 @@ class AbstractFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_normalCallback_setValueUpdatesBoth() {
+    void bindValue_normalCallback_setValueUpdatesBoth() {
         TestInput input = new TestInput();
         UI.getCurrent().add(input);
         ValueSignal<String> signal = new ValueSignal<>("foo");
@@ -352,7 +352,7 @@ class AbstractFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_readOnlySignal_signalToComponentDirection() {
+    void bindValue_readOnlySignal_signalToComponentDirection() {
         TestInput input = new TestInput();
         UI.getCurrent().add(input);
         ValueSignal<String> writable = new ValueSignal<>("foo");
@@ -366,7 +366,7 @@ class AbstractFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_writeCallbackThrows() {
+    void bindValue_writeCallbackThrows() {
         TestInput input = new TestInput();
         UI.getCurrent().add(input);
         ValueSignal<String> signal = new ValueSignal<>("foo");
@@ -383,7 +383,7 @@ class AbstractFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_normalCallback_valueChangeEventTriggered() {
+    void bindValue_normalCallback_valueChangeEventTriggered() {
         TestInput input = new TestInput();
         UI.getCurrent().add(input);
         ValueSignal<String> signal = new ValueSignal<>("foo");
@@ -402,7 +402,7 @@ class AbstractFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_transformingCallback_valueChangeEventTriggered() {
+    void bindValue_transformingCallback_valueChangeEventTriggered() {
         TestInput input = new TestInput();
         UI.getCurrent().add(input);
         ValueSignal<String> signal = new ValueSignal<>("foo");
@@ -421,7 +421,7 @@ class AbstractFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_noOpCallback_valueChangeEventNotTriggered() {
+    void bindValue_noOpCallback_valueChangeEventNotTriggered() {
         TestInput input = new TestInput();
         UI.getCurrent().add(input);
         ValueSignal<String> signal = new ValueSignal<>("foo");
@@ -438,7 +438,7 @@ class AbstractFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_updaterHelper_immutableRecord() {
+    void bindValue_updaterHelper_immutableRecord() {
         TestInput input = new TestInput();
         UI.getCurrent().add(input);
 
@@ -467,7 +467,7 @@ class AbstractFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_modifierHelper_mutableBean() {
+    void bindValue_modifierHelper_mutableBean() {
         TestInput input = new TestInput();
         UI.getCurrent().add(input);
 
@@ -512,7 +512,7 @@ class AbstractFieldBindValueTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindValue_updaterHelper_valueChangeEvents() {
+    void bindValue_updaterHelper_valueChangeEvents() {
         TestInput input = new TestInput();
         UI.getCurrent().add(input);
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/AbstractFieldTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/AbstractFieldTest.java
@@ -117,14 +117,14 @@ class AbstractFieldTest {
     }
 
     @Test
-    public void initialValue_used() {
+    void initialValue_used() {
         TestAbstractField<String> field = new TestAbstractField<>("foo");
 
         assertEquals("foo", field.getValue());
     }
 
     @Test
-    public void emptyValue_sameAsInitial() {
+    void emptyValue_sameAsInitial() {
         TestAbstractField<String> field = new TestAbstractField<>("foo");
 
         assertEquals("foo", field.getEmptyValue());
@@ -136,7 +136,7 @@ class AbstractFieldTest {
     }
 
     @Test
-    public void initialValue_defaultNull() {
+    void initialValue_defaultNull() {
         TestAbstractField<String> field = new TestAbstractField<>();
 
         assertNull(field.getValue());
@@ -144,7 +144,7 @@ class AbstractFieldTest {
     }
 
     @Test
-    public void setValue_differentValue_firesOneEvent() {
+    void setValue_differentValue_firesOneEvent() {
         TestAbstractField<String> field = new TestAbstractField<>();
         ValueChangeMonitor<String> eventMonitor = new ValueChangeMonitor<>(
                 field);
@@ -156,7 +156,7 @@ class AbstractFieldTest {
     }
 
     @Test
-    public void setValue_sameValue_firesNoEvent() {
+    void setValue_sameValue_firesNoEvent() {
         TestAbstractField<String> field = new TestAbstractField<>();
         ValueChangeMonitor<String> eventMonitor = new ValueChangeMonitor<>(
                 field);
@@ -167,7 +167,7 @@ class AbstractFieldTest {
     }
 
     @Test
-    public void clear_firesIfNotEmpty() {
+    void clear_firesIfNotEmpty() {
         TestAbstractField<String> field = new TestAbstractField<>();
         ValueChangeMonitor<String> eventMonitor = new ValueChangeMonitor<>(
                 field);
@@ -188,7 +188,7 @@ class AbstractFieldTest {
     }
 
     @Test
-    public void clear_customEmptyValue_emptyValueUsed() {
+    void clear_customEmptyValue_emptyValueUsed() {
         TestAbstractField<String> field = new TestAbstractField<>();
         field.emptyValue = () -> "";
 
@@ -200,7 +200,7 @@ class AbstractFieldTest {
     }
 
     @Test
-    public void updateFromClient_differentValue_updatesAndFires() {
+    void updateFromClient_differentValue_updatesAndFires() {
         TestAbstractField<String> field = new TestAbstractField<>();
         ValueChangeMonitor<String> eventMonitor = new ValueChangeMonitor<>(
                 field);
@@ -213,7 +213,7 @@ class AbstractFieldTest {
     }
 
     @Test
-    public void customEquals() {
+    void customEquals() {
         TestAbstractField<Integer> field = new TestAbstractField<>();
         field.valueEquals = (value1, value2) -> value1 == value2;
 
@@ -239,7 +239,7 @@ class AbstractFieldTest {
     }
 
     @Test
-    public void customEquals_isEmpty() {
+    void customEquals_isEmpty() {
         Integer value1 = new Integer(0);
         Integer value2 = new Integer(0);
 
@@ -259,7 +259,7 @@ class AbstractFieldTest {
     }
 
     @Test
-    public void getValue_changesAfterUpdatedFromClient() {
+    void getValue_changesAfterUpdatedFromClient() {
         TestAbstractField<String> field = new TestAbstractField<>();
         assertNull(field.getValue());
 
@@ -271,7 +271,7 @@ class AbstractFieldTest {
     }
 
     @Test
-    public void setPresentation_setSameValue_notRunAgain() {
+    void setPresentation_setSameValue_notRunAgain() {
         TestAbstractField<String> field = new TestAbstractField<>();
         AtomicReference<String> lastWriteValue = new AtomicReference<>();
         field.setPresentationValue = value -> {
@@ -289,7 +289,7 @@ class AbstractFieldTest {
     }
 
     @Test
-    public void updatePresentation_doesntCallSetPresentation() {
+    void updatePresentation_doesntCallSetPresentation() {
         TestAbstractField<String> field = new TestAbstractField<>();
         field.setPresentationValue = value -> fail(
                 "setPresentationValue should not run");
@@ -299,7 +299,7 @@ class AbstractFieldTest {
     }
 
     @Test
-    public void setPresentation_throws_sameException_valuePreserved() {
+    void setPresentation_throws_sameException_valuePreserved() {
         TestAbstractField<String> field = new TestAbstractField<>();
         ValueChangeMonitor<String> eventMonitor = new ValueChangeMonitor<>(
                 field);
@@ -320,7 +320,7 @@ class AbstractFieldTest {
     }
 
     @Test
-    public void setPresentation_partialUpdates_onlyOneEvent() {
+    void setPresentation_partialUpdates_onlyOneEvent() {
         TestAbstractField<String> field = new TestAbstractField<>();
         ValueChangeMonitor<String> eventMonitor = new ValueChangeMonitor<>(
                 field);
@@ -340,7 +340,7 @@ class AbstractFieldTest {
     }
 
     @Test
-    public void setPresentation_changesValue_onlyOneEvent() {
+    void setPresentation_changesValue_onlyOneEvent() {
         TestAbstractField<String> field = new TestAbstractField<>();
         ValueChangeMonitor<String> eventMonitor = new ValueChangeMonitor<>(
                 field);
@@ -359,7 +359,7 @@ class AbstractFieldTest {
     }
 
     @Test
-    public void setPresentation_revertsValue_noEvent() {
+    void setPresentation_revertsValue_noEvent() {
         TestAbstractField<String> field = new TestAbstractField<>();
         ValueChangeMonitor<String> eventMonitor = new ValueChangeMonitor<>(
                 field);
@@ -377,7 +377,7 @@ class AbstractFieldTest {
     }
 
     @Test
-    public void setValueInEventHandler() {
+    void setValueInEventHandler() {
         TestAbstractField<String> field = new TestAbstractField<>();
 
         List<ValueChangeEvent<String>> beforeEvents = new ArrayList<>();
@@ -403,7 +403,7 @@ class AbstractFieldTest {
     }
 
     @Test
-    public void requiredIndicator_writtenToElement() {
+    void requiredIndicator_writtenToElement() {
         TestAbstractField<String> field = new TestAbstractField<>();
         Element element = field.getElement();
 
@@ -417,7 +417,7 @@ class AbstractFieldTest {
     }
 
     @Test
-    public void requiredIndicator_readFromElement() {
+    void requiredIndicator_readFromElement() {
         TestAbstractField<String> field = new TestAbstractField<>();
         Element element = field.getElement();
 
@@ -431,7 +431,7 @@ class AbstractFieldTest {
     }
 
     @Test
-    public void readonly_writtenToElement() {
+    void readonly_writtenToElement() {
         TestAbstractField<String> field = new TestAbstractField<>();
         Element element = field.getElement();
 
@@ -445,7 +445,7 @@ class AbstractFieldTest {
     }
 
     @Test
-    public void readonly_readFromElement() {
+    void readonly_readFromElement() {
         TestAbstractField<String> field = new TestAbstractField<>();
         Element element = field.getElement();
 
@@ -459,7 +459,7 @@ class AbstractFieldTest {
     }
 
     @Test
-    public void readonly_setValue_accepted() {
+    void readonly_setValue_accepted() {
         TestAbstractField<String> field = new TestAbstractField<>();
         ValueChangeMonitor<String> eventMonitor = new ValueChangeMonitor<>(
                 field);
@@ -473,7 +473,7 @@ class AbstractFieldTest {
     }
 
     @Test
-    public void readonly_presentationFromClient_reverted() {
+    void readonly_presentationFromClient_reverted() {
         TestAbstractField<String> field = new TestAbstractField<>();
         ValueChangeMonitor<String> eventMonitor = new ValueChangeMonitor<>(
                 field);
@@ -487,7 +487,7 @@ class AbstractFieldTest {
     }
 
     @Test
-    public void readonly_presentationFromServer_accepted() {
+    void readonly_presentationFromServer_accepted() {
         TestAbstractField<String> field = new TestAbstractField<>();
         ValueChangeMonitor<String> eventMonitor = new ValueChangeMonitor<>(
                 field);
@@ -501,7 +501,7 @@ class AbstractFieldTest {
     }
 
     @Test
-    public void noOwnPublicApi() {
+    void noOwnPublicApi() {
         List<Method> newPublicMethods = PublicApiAnalyzer
                 .findNewPublicMethods(AbstractField.class)
                 .collect(Collectors.toList());
@@ -509,7 +509,7 @@ class AbstractFieldTest {
     }
 
     @Test
-    public void serializable() {
+    void serializable() {
         TestAbstractField<String> field = new TestAbstractField<>();
         field.addValueChangeListener(ignore -> {
         });

--- a/flow-server/src/test/java/com/vaadin/flow/component/AbstractSinglePropertyFieldTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/AbstractSinglePropertyFieldTest.java
@@ -68,7 +68,7 @@ class AbstractSinglePropertyFieldTest {
     }
 
     @Test
-    public void stringField_basicCases() {
+    void stringField_basicCases() {
         StringField field = new StringField();
         ValueChangeMonitor<String> monitor = new ValueChangeMonitor<>(field);
 
@@ -92,7 +92,7 @@ class AbstractSinglePropertyFieldTest {
     }
 
     @Test
-    public void stringField_setValueNull_exceptionAndNoEvent() {
+    void stringField_setValueNull_exceptionAndNoEvent() {
         StringField field = new StringField();
         ValueChangeMonitor<String> monitor = new ValueChangeMonitor<>(field);
 
@@ -105,7 +105,7 @@ class AbstractSinglePropertyFieldTest {
     }
 
     @Test
-    public void stringField_initProperty_noEvent() {
+    void stringField_initProperty_noEvent() {
         StringField field = new StringField();
         ValueChangeMonitor<String> monitor = new ValueChangeMonitor<>(field);
 
@@ -115,7 +115,7 @@ class AbstractSinglePropertyFieldTest {
     }
 
     @Test
-    public void synchronizedEvent_default() {
+    void synchronizedEvent_default() {
         StringField stringField = new StringField();
 
         assertEquals("property-changed",
@@ -123,7 +123,7 @@ class AbstractSinglePropertyFieldTest {
     }
 
     @Test
-    public void synchronizedEvent_redefined() {
+    void synchronizedEvent_redefined() {
         StringField stringField = new StringField();
         DomListenerRegistration origReg = stringField
                 .getSynchronizationRegistration();
@@ -140,7 +140,7 @@ class AbstractSinglePropertyFieldTest {
     }
 
     @Test
-    public void synchronizedEvent_null_noSynchronization() {
+    void synchronizedEvent_null_noSynchronization() {
         StringField stringField = new StringField();
         SerializableRunnable unregisterListener = Mockito
                 .mock(SerializableRunnable.class);
@@ -153,7 +153,7 @@ class AbstractSinglePropertyFieldTest {
     }
 
     @Test
-    public void synchronizedEvent_camelCaseProperty_dashCaseEvent() {
+    void synchronizedEvent_camelCaseProperty_dashCaseEvent() {
         StringField stringField = new StringField("immediateValue");
 
         assertEquals("immediate-value-changed",
@@ -169,7 +169,7 @@ class AbstractSinglePropertyFieldTest {
     }
 
     @Test
-    public void stringNullField_basicCases() {
+    void stringNullField_basicCases() {
         StringNullField field = new StringNullField();
         ValueChangeMonitor<String> monitor = new ValueChangeMonitor<>(field);
 
@@ -195,7 +195,7 @@ class AbstractSinglePropertyFieldTest {
     }
 
     @Test
-    public void doubleField_basicCases() {
+    void doubleField_basicCases() {
         DoubleField field = new DoubleField();
         ValueChangeMonitor<Double> monitor = new ValueChangeMonitor<>(field);
 
@@ -227,7 +227,7 @@ class AbstractSinglePropertyFieldTest {
     }
 
     @Test
-    public void integerField_basicCases() {
+    void integerField_basicCases() {
         IntegerField field = new IntegerField();
         ValueChangeMonitor<Integer> monitor = new ValueChangeMonitor<>(field);
 
@@ -259,7 +259,7 @@ class AbstractSinglePropertyFieldTest {
     }
 
     @Test
-    public void booleanField_basicCases() {
+    void booleanField_basicCases() {
         BooleanField field = new BooleanField();
         ValueChangeMonitor<Boolean> monitor = new ValueChangeMonitor<>(field);
 
@@ -297,7 +297,7 @@ class AbstractSinglePropertyFieldTest {
     }
 
     @Test
-    public void simpleDateField_constructor_throws() {
+    void simpleDateField_constructor_throws() {
         assertThrows(IllegalArgumentException.class, () -> {
             new SimpleDateField();
         });
@@ -313,7 +313,7 @@ class AbstractSinglePropertyFieldTest {
     }
 
     @Test
-    public void dateField_basicCases() {
+    void dateField_basicCases() {
         DateField field = new DateField();
         ValueChangeMonitor<LocalDate> monitor = new ValueChangeMonitor<>(field);
 
@@ -352,7 +352,7 @@ class AbstractSinglePropertyFieldTest {
     }
 
     @Test
-    public void integerToString_basicCases() {
+    void integerToString_basicCases() {
         IntegerToStringField field = new IntegerToStringField();
         ValueChangeMonitor<Integer> monitor = new ValueChangeMonitor<>(field);
         assertNull(field.getValue());
@@ -373,7 +373,7 @@ class AbstractSinglePropertyFieldTest {
     }
 
     @Test
-    public void integerToString_nonIntegerInput_ignore() {
+    void integerToString_nonIntegerInput_ignore() {
         IntegerToStringField field = new IntegerToStringField();
         ValueChangeMonitor<Integer> monitor = new ValueChangeMonitor<>(field);
 
@@ -417,7 +417,7 @@ class AbstractSinglePropertyFieldTest {
     }
 
     @Test
-    public void radixField() {
+    void radixField() {
         RadixField field = new RadixField();
         ValueChangeMonitor<Integer> changeMonitor = new ValueChangeMonitor<>(
                 field);
@@ -452,7 +452,7 @@ class AbstractSinglePropertyFieldTest {
     }
 
     @Test
-    public void jsonField() {
+    void jsonField() {
         JsonField field = new JsonField();
         ValueChangeMonitor<JsonNode> monitor = new ValueChangeMonitor<>(field);
 
@@ -476,7 +476,7 @@ class AbstractSinglePropertyFieldTest {
     }
 
     @Test
-    public void jsonArrayField() {
+    void jsonArrayField() {
         JsonArrayField field = new JsonArrayField();
         ValueChangeMonitor<ArrayNode> monitor = new ValueChangeMonitor<>(field);
 
@@ -497,7 +497,7 @@ class AbstractSinglePropertyFieldTest {
     }
 
     @Test
-    public void noOwnPublicApi() {
+    void noOwnPublicApi() {
         List<Method> newPublicMethods = PublicApiAnalyzer
                 .findNewPublicMethods(AbstractSinglePropertyField.class)
                 .collect(Collectors.toList());
@@ -505,7 +505,7 @@ class AbstractSinglePropertyFieldTest {
     }
 
     @Test
-    public void serializable() {
+    void serializable() {
         StringField field = new StringField();
         field.addValueChangeListener(ignore -> {
         });
@@ -516,7 +516,7 @@ class AbstractSinglePropertyFieldTest {
     }
 
     @Test
-    public void getValue_wrapExistingElement_elementHasProperty_valueIsThePropertyValue() {
+    void getValue_wrapExistingElement_elementHasProperty_valueIsThePropertyValue() {
         Element element = new Element("tag");
         element.setProperty("property", "foo");
 
@@ -554,7 +554,7 @@ class AbstractSinglePropertyFieldTest {
     }
 
     @Test
-    public void jacksonField() {
+    void jacksonField() {
         JacksonField field = new JacksonField();
         ValueChangeMonitor<BaseJsonNode> monitor = new ValueChangeMonitor<>(
                 field);
@@ -579,7 +579,7 @@ class AbstractSinglePropertyFieldTest {
     }
 
     @Test
-    public void jacksonArrayField() {
+    void jacksonArrayField() {
         JacksonArrayField field = new JacksonArrayField();
         ValueChangeMonitor<ArrayNode> monitor = new ValueChangeMonitor<>(field);
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentEventBusTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentEventBusTest.java
@@ -114,7 +114,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void mappedDomEvent_fire() {
+    void mappedDomEvent_fire() {
         TestComponent component = new TestComponent();
         EventTracker<MappedToDomEvent> eventTracker = new EventTracker<>();
 
@@ -137,7 +137,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void serverEvent_fire() {
+    void serverEvent_fire() {
         AtomicInteger eventHandlerCalled = new AtomicInteger(0);
         AtomicReference<BigDecimal> dataValueInEvent = new AtomicReference<>(
                 new BigDecimal(0));
@@ -156,7 +156,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void serverNoDataEvent_fire() {
+    void serverNoDataEvent_fire() {
         TestComponent c = new TestComponent();
         EventTracker<ServerNoDataEvent> eventTracker = new EventTracker<>();
         c.addListener(ServerNoDataEvent.class, eventTracker);
@@ -166,19 +166,19 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void serverNoDataEvent_fire_noListeners() {
+    void serverNoDataEvent_fire_noListeners() {
         TestComponent c = new TestComponent();
         c.fireEvent(new ServerNoDataEvent(c, false));
     }
 
     @Test
-    public void mappedDomEvent_fire_noListeners() {
+    void mappedDomEvent_fire_noListeners() {
         TestComponent c = new TestComponent();
         fireDomEvent(c, "dom-event", createMinimalEventData());
     }
 
     @Test
-    public void mappedDomEvent_fire_missingData() {
+    void mappedDomEvent_fire_missingData() {
         TestComponent c = new TestComponent();
         EventTracker<MappedToDomEvent> eventListener = new EventTracker<>();
         c.addListener(MappedToDomEvent.class, eventListener);
@@ -193,7 +193,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void mappedDomEventWithElementEventData_clientReportsElement_mapsElement() {
+    void mappedDomEventWithElementEventData_clientReportsElement_mapsElement() {
         final MockUI ui = new MockUI();
         final TestComponent component = new TestComponent();
         final TestComponent child = new TestComponent();
@@ -210,7 +210,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void mappedDomEventWithComponentEventData_clientReportsTypeComponent_mapsComponent() {
+    void mappedDomEventWithComponentEventData_clientReportsTypeComponent_mapsComponent() {
         final MockUI ui = new MockUI();
         final TestComponent component = new TestComponent();
         final TestComponent child = new TestComponent();
@@ -227,7 +227,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void mappedDomEventWithComponentEventData_clientReportsConcreteComponents_mapsComponents() {
+    void mappedDomEventWithComponentEventData_clientReportsConcreteComponents_mapsComponents() {
         final MockUI ui = new MockUI();
         final TestComponent component = new TestComponent();
         final TestComponent child = new TestComponent();
@@ -249,7 +249,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void mappedDomEventWithComponentEventData_clientReportsMissingComponent_mapsComponentAndNull() {
+    void mappedDomEventWithComponentEventData_clientReportsMissingComponent_mapsComponentAndNull() {
         final MockUI ui = new MockUI();
         final TestComponent component = new TestComponent();
         final TestComponent child = new TestComponent();
@@ -280,7 +280,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void mappedDomEventWithComponentEventData_clientReportsSiblingComponentToEventSource_mapsComponents() {
+    void mappedDomEventWithComponentEventData_clientReportsSiblingComponentToEventSource_mapsComponents() {
         final MockUI ui = new MockUI();
         final TestComponent component = new TestComponent();
         final TestComponent child = new TestComponent();
@@ -300,7 +300,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void mappedDomEventWithComponentEventData_clientReportsElementMissing_returnsNull() {
+    void mappedDomEventWithComponentEventData_clientReportsElementMissing_returnsNull() {
         final MockUI ui = new MockUI();
         final TestComponent component = new TestComponent();
         final TestComponent child = new TestComponent();
@@ -317,7 +317,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void mappedDomEventWithComponentEventData_clientReportsMissingNodeIdReported_returnsNull() {
+    void mappedDomEventWithComponentEventData_clientReportsMissingNodeIdReported_returnsNull() {
         final MockUI ui = new MockUI();
         final TestComponent component = new TestComponent();
         final TestComponent child = new TestComponent();
@@ -334,7 +334,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void mappedDomEventWithElementOrComponentEventData_clientReportsStateNodeForInvisibleComponent_returnsNull() {
+    void mappedDomEventWithElementOrComponentEventData_clientReportsStateNodeForInvisibleComponent_returnsNull() {
         final MockUI ui = new MockUI();
         final TestComponent component = new TestComponent();
         final TestComponent invisible = new TestComponent();
@@ -408,7 +408,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void domEvent_removeListener() {
+    void domEvent_removeListener() {
         TestComponent component = new TestComponent();
         EventTracker<MappedToDomEvent> eventTracker = new EventTracker<>();
         Registration remover = component.addListener(MappedToDomEvent.class,
@@ -427,7 +427,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void domEvent_fireClientEvent() {
+    void domEvent_fireClientEvent() {
         TestComponent component = new TestComponent();
         EventTracker<MappedToDomEvent> eventTracker = new EventTracker<>();
         component.addListener(MappedToDomEvent.class, eventTracker);
@@ -444,7 +444,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void domEvent_fireServerEvent() {
+    void domEvent_fireServerEvent() {
         TestComponent component = new TestComponent();
         EventTracker<MappedToDomEvent> eventTracker = new EventTracker<>();
         component.addListener(MappedToDomEvent.class, eventTracker);
@@ -461,7 +461,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void nonDomEvent_removeListener() {
+    void nonDomEvent_removeListener() {
         TestComponent component = new TestComponent();
         EventTracker<ServerEvent> eventTracker = new EventTracker<>();
         Registration remover = component.addListener(ServerEvent.class,
@@ -475,7 +475,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void nonDomEvent_fireEvent() {
+    void nonDomEvent_fireEvent() {
         TestComponent component = new TestComponent();
         EventTracker<ServerEvent> eventTracker = new EventTracker<>();
         component.addListener(ServerEvent.class, eventTracker);
@@ -486,7 +486,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void domEvent_addListenerWithDomListenerConsumer() {
+    void domEvent_addListenerWithDomListenerConsumer() {
         TestComponent component = new TestComponent();
         EventTracker<MappedToDomEvent> eventTracker = new EventTracker<>();
         component.getEventBus().addListener(MappedToDomEvent.class,
@@ -494,7 +494,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void nonDomEvent_addListenerWithDomListenerConsumer_throws() {
+    void nonDomEvent_addListenerWithDomListenerConsumer_throws() {
         TestComponent component = new TestComponent();
         EventTracker<ServerEvent> eventTracker = new EventTracker<>();
         assertThrows(IllegalArgumentException.class,
@@ -506,7 +506,7 @@ class ComponentEventBusTest {
     private int calls = 0;
 
     @Test
-    public void domEvent_addSameListenerTwice() {
+    void domEvent_addSameListenerTwice() {
         TestComponent component = new TestComponent();
 
         ComponentEventListener<MappedToDomEvent> listener = e -> calls++;
@@ -540,7 +540,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void multipleEventsForSameDomEvent_removeListener() {
+    void multipleEventsForSameDomEvent_removeListener() {
         TestComponent component = new TestComponent();
         EventTracker<MappedToDomEvent> eventTracker = new EventTracker<>();
         EventTracker<MappedToDomNoDataEvent> eventTracker2 = new EventTracker<>();
@@ -562,7 +562,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void multipleEventsForSameDomEvent_fireEvent() {
+    void multipleEventsForSameDomEvent_fireEvent() {
         TestComponent component = new TestComponent();
         EventTracker<MappedToDomEvent> eventTracker = new EventTracker<>();
         EventTracker<MappedToDomNoDataEvent> eventTracker2 = new EventTracker<>();
@@ -582,7 +582,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void multipleListenersForSameEvent_fireEvent() {
+    void multipleListenersForSameEvent_fireEvent() {
         TestComponent component = new TestComponent();
         EventTracker<MappedToDomEvent> eventTracker = new EventTracker<>();
         EventTracker<MappedToDomEvent> eventTracker2 = new EventTracker<>();
@@ -604,7 +604,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void multipleListenersForSameEvent_removeListener() {
+    void multipleListenersForSameEvent_removeListener() {
         TestComponent component = new TestComponent();
         EventTracker<MappedToDomEvent> eventTracker = new EventTracker<>();
         EventTracker<MappedToDomEvent> eventTracker2 = new EventTracker<>();
@@ -628,7 +628,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void invalidEventConstructor_addListener() {
+    void invalidEventConstructor_addListener() {
         TestComponent c = new TestComponent();
         assertThrows(IllegalArgumentException.class,
                 () -> c.addListener(InvalidMappedToDomEvent.class, e -> {
@@ -636,7 +636,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void invalidEventDataInConstructor_addListener() {
+    void invalidEventDataInConstructor_addListener() {
         TestComponent c = new TestComponent();
         assertThrows(IllegalArgumentException.class,
                 () -> c.addListener(MappedToDomInvalidEventData.class, e -> {
@@ -644,7 +644,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void multipleEventDataConstructors_addListener() {
+    void multipleEventDataConstructors_addListener() {
         TestComponent c = new TestComponent();
         assertThrows(IllegalArgumentException.class, () -> c
                 .addListener(MappedToDomEventMultipleConstructors.class, e -> {
@@ -652,21 +652,21 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void hasListeners_nullEventType_throws() {
+    void hasListeners_nullEventType_throws() {
         ComponentEventBus eventBus = new ComponentEventBus(new TestComponent());
         assertThrows(IllegalArgumentException.class,
                 () -> eventBus.hasListener(null));
     }
 
     @Test
-    public void getListeners_nullEventType_throws() {
+    void getListeners_nullEventType_throws() {
         ComponentEventBus eventBus = new ComponentEventBus(new TestComponent());
         assertThrows(IllegalArgumentException.class,
                 () -> eventBus.getListeners(null));
     }
 
     @Test
-    public void getListeners_eventType_listenersCollection() {
+    void getListeners_eventType_listenersCollection() {
         TestComponent component = new TestComponent();
         EventTracker<MappedToDomEvent> eventTracker = new EventTracker<>();
         Registration remover = component.addListener(MappedToDomEvent.class,
@@ -678,7 +678,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void getListeners_subclassOfEventType_listenersCollection() {
+    void getListeners_subclassOfEventType_listenersCollection() {
         TestComponent component = new TestComponent();
         EventTracker<KeyPressEvent> eventTracker = new EventTracker<>();
         EventTracker<KeyUpEvent> eventTracker2 = new EventTracker<>();
@@ -693,7 +693,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void getListeners_notExistingEventType_emptyListenersCollection() {
+    void getListeners_notExistingEventType_emptyListenersCollection() {
         TestComponent component = new TestComponent();
         EventTracker<MappedToDomEvent> eventTracker = new EventTracker<>();
         Registration remover = component.addListener(MappedToDomEvent.class,
@@ -704,7 +704,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void testFireEvent_noListeners_eventBusNotCreated() {
+    void testFireEvent_noListeners_eventBusNotCreated() {
         AtomicInteger eventBusCreated = new AtomicInteger();
         TestComponent c = new TestComponent() {
             @Override
@@ -719,7 +719,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void eventUnregisterListener_insideListener() {
+    void eventUnregisterListener_insideListener() {
         TestComponent c = new TestComponent();
         c.addListener(ServerEvent.class, e -> {
             e.unregisterListener();
@@ -730,7 +730,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void eventUnregisterListener_insideListenerTwiceThrows() {
+    void eventUnregisterListener_insideListenerTwiceThrows() {
         TestComponent c = new TestComponent();
         c.addListener(ServerEvent.class, e -> {
             e.unregisterListener();
@@ -741,7 +741,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void eventUnregisterListener_outsideListenerTwiceThrows() {
+    void eventUnregisterListener_outsideListenerTwiceThrows() {
         TestComponent c = new TestComponent();
         AtomicReference<ServerEvent> storedEvent = new AtomicReference<>();
         c.addListener(ServerEvent.class, e -> {
@@ -753,7 +753,7 @@ class ComponentEventBusTest {
     }
 
     @Test // #7826
-    public void addListener_eventDataExpressionsPresent_constantPoolKeyNotCreatedAfterEachExpression() {
+    void addListener_eventDataExpressionsPresent_constantPoolKeyNotCreatedAfterEachExpression() {
         final TestButton button = new TestButton();
         try (MockedStatic<MessageDigestUtil> util = Mockito
                 .mockStatic(MessageDigestUtil.class)) {
@@ -767,7 +767,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void addListener_nullListener_failFast() {
+    void addListener_nullListener_failFast() {
         final TestButton button = new TestButton();
         IllegalArgumentException ex = assertThrows(
                 IllegalArgumentException.class,
@@ -777,7 +777,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void eventWithBeanParameter_beanDeserialized() {
+    void eventWithBeanParameter_beanDeserialized() {
         // Test that @EventData works with bean types, not just primitives
         TestComponent c = new TestComponent();
         EventTracker<EventWithBeanData> eventTracker = new EventTracker<>();
@@ -809,7 +809,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void inertElement_domEventWithoutAllowInert_listenerNotCalled() {
+    void inertElement_domEventWithoutAllowInert_listenerNotCalled() {
         TestComponent component = new TestComponent();
 
         // Make element inert first
@@ -830,7 +830,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void inertElement_domEventWithAllowInert_listenerCalled() {
+    void inertElement_domEventWithAllowInert_listenerCalled() {
         TestComponent component = new TestComponent();
 
         // Make element inert first
@@ -852,7 +852,7 @@ class ComponentEventBusTest {
     }
 
     @Test
-    public void nonInertElement_domEventWithAllowInert_listenerCalled() {
+    void nonInertElement_domEventWithAllowInert_listenerCalled() {
         TestComponent component = new TestComponent();
         EventTracker<MappedToDomEventWithAllowInert> eventTracker = new EventTracker<>();
         component.addListener(MappedToDomEventWithAllowInert.class,

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentEventBusUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentEventBusUtilTest.java
@@ -49,7 +49,7 @@ class ComponentEventBusUtilTest {
     }
 
     @Test
-    public void domEvent_constructorCached() {
+    void domEvent_constructorCached() {
         ReflectionCache<ComponentEvent<?>, ?> cache = ComponentEventBusUtil.cache;
         TestComponent component = new TestComponent();
         cache.clear();
@@ -60,7 +60,7 @@ class ComponentEventBusUtilTest {
     }
 
     @Test
-    public void domEvent_dataExpressionCached() {
+    void domEvent_dataExpressionCached() {
         TestComponent component = new TestComponent();
         ReflectionCache<ComponentEvent<?>, ?> cache = ComponentEventBusUtil.cache;
         cache.clear();
@@ -71,7 +71,7 @@ class ComponentEventBusUtilTest {
     }
 
     @Test
-    public void domEvent_innerEventClass() {
+    void domEvent_innerEventClass() {
         try {
             ComponentEventBusUtil.getEventConstructor(InnerClass.class);
         } catch (IllegalArgumentException exception) {
@@ -83,14 +83,14 @@ class ComponentEventBusUtilTest {
     }
 
     @Test
-    public void domEvent_nestedEventClass() {
+    void domEvent_nestedEventClass() {
         Constructor<NestedClass> ctor = ComponentEventBusUtil
                 .getEventConstructor(NestedClass.class);
         assertNotNull(ctor);
     }
 
     @Test
-    public void domEvent_localEventClass() {
+    void domEvent_localEventClass() {
         @DomEvent("dom-event")
         class LocalClass extends ComponentEvent<Component> {
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentMetaDataTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentMetaDataTest.java
@@ -101,32 +101,32 @@ class ComponentMetaDataTest {
     }
 
     @Test
-    public void synchronizedProperties_methodInClass() {
+    void synchronizedProperties_methodInClass() {
         assertFooProperty(Sample.class);
     }
 
     @Test
-    public void synchronizedProperties_methodInInterface() {
+    void synchronizedProperties_methodInInterface() {
         assertFooProperty(HasFooImpl.class, DisabledUpdateMode.ALWAYS);
     }
 
     @Test
-    public void synchronizedProperties_protectedMethod() {
+    void synchronizedProperties_protectedMethod() {
         assertFooProperty(HasFooProtected.class);
     }
 
     @Test
-    public void synchronizedProperties_packagePrivateMethod() {
+    void synchronizedProperties_packagePrivateMethod() {
         assertFooProperty(HasFooPackagePrivate.class);
     }
 
     @Test
-    public void synchronizedProperties_privateMethod() {
+    void synchronizedProperties_privateMethod() {
         assertFooProperty(HasFooPrivate.class);
     }
 
     @Test
-    public void synchronizedProperties_hasOverriddenMethod() {
+    void synchronizedProperties_hasOverriddenMethod() {
         ComponentMetaData data = new ComponentMetaData(SubClass.class);
 
         Collection<SynchronizedPropertyInfo> props = data
@@ -148,7 +148,7 @@ class ComponentMetaDataTest {
     }
 
     @Test
-    public void synchronizedProperties_overridesMethodAndProperty() {
+    void synchronizedProperties_overridesMethodAndProperty() {
         ComponentMetaData data = new ComponentMetaData(
                 ChangeSyncProperty.class);
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentUtilTest.java
@@ -33,7 +33,7 @@ class ComponentUtilTest {
     private Component component = new TestDiv();
 
     @Test
-    public void setData_byString() {
+    void setData_byString() {
         assertNull(ComponentUtil.getData(component, "name"),
                 "There should initially not be any value");
 
@@ -53,7 +53,7 @@ class ComponentUtilTest {
     }
 
     @Test
-    public void setData_byClass() {
+    void setData_byClass() {
         Integer instance1 = new Integer(1);
         Integer instance2 = new Integer(2);
 
@@ -79,7 +79,7 @@ class ComponentUtilTest {
     }
 
     @Test
-    public void addListenerToComponent_hasListener_returnsTrue() {
+    void addListenerToComponent_hasListener_returnsTrue() {
         assertFalse(ComponentUtil.hasEventListener(component, PollEvent.class));
 
         Registration listener = ComponentUtil.addListener(component,
@@ -92,7 +92,7 @@ class ComponentUtilTest {
     }
 
     @Test
-    public void addListenerToComponent_getListeners_returnsCollection() {
+    void addListenerToComponent_getListeners_returnsCollection() {
         assertFalse(ComponentUtil.hasEventListener(component, PollEvent.class));
 
         Registration listener = ComponentUtil.addListener(component,
@@ -108,7 +108,7 @@ class ComponentUtilTest {
     }
 
     @Test
-    public void registerComponentClass_and_getComponentsByTag_shouldReturnCorrectComponent() {
+    void registerComponentClass_and_getComponentsByTag_shouldReturnCorrectComponent() {
         Class<? extends Component> testComponentClass = TestDiv.class;
         String testTag = "test-div";
 
@@ -124,7 +124,7 @@ class ComponentUtilTest {
     }
 
     @Test
-    public void getComponentsByTag_withUnregisteredTag_shouldReturnEmptySet() {
+    void getComponentsByTag_withUnregisteredTag_shouldReturnEmptySet() {
         String unregisteredTag = "unregistered-tag";
 
         Set<Class<? extends Component>> retrievedClasses = ComponentUtil

--- a/flow-server/src/test/java/com/vaadin/flow/component/CompositeNestedTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/CompositeNestedTest.java
@@ -76,7 +76,7 @@ class CompositeNestedTest {
     }
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         layout = new TestLayout();
         componentInComposite = new TestComponent(
                 ElementFactory.createDiv("Inside composite"));
@@ -96,62 +96,62 @@ class CompositeNestedTest {
     }
 
     @Test
-    public void compositeOuterElement() {
+    void compositeOuterElement() {
         assertEquals(componentInComposite.getElement(),
                 compositeOuter.getElement());
     }
 
     @Test
-    public void compositeInnerElement() {
+    void compositeInnerElement() {
         assertEquals(componentInComposite.getElement(),
                 compositeInner.getElement());
     }
 
     @Test
-    public void getParentElement_compositeOuter() {
+    void getParentElement_compositeOuter() {
         assertEquals(layout.getElement(),
                 compositeOuter.getElement().getParent());
     }
 
     @Test
-    public void getParentElement_compositeInner() {
+    void getParentElement_compositeInner() {
         assertEquals(layout.getElement(),
                 compositeInner.getElement().getParent());
     }
 
     @Test
-    public void layoutChildElements() {
+    void layoutChildElements() {
         CompositeTest.assertElementChildren(layout.getElement(),
                 componentInComposite.getElement());
     }
 
     @Test
-    public void getParent_compositeOuter() {
+    void getParent_compositeOuter() {
         assertEquals(layout, compositeOuter.getParent().get());
     }
 
     @Test
-    public void getParent_compositeInner() {
+    void getParent_compositeInner() {
         assertEquals(compositeOuter, compositeInner.getParent().get());
     }
 
     @Test
-    public void getParent_componentInComposite() {
+    void getParent_componentInComposite() {
         assertEquals(compositeInner, componentInComposite.getParent().get());
     }
 
     @Test
-    public void getChildren_layout() {
+    void getChildren_layout() {
         ComponentTest.assertChildren(layout, compositeOuter);
     }
 
     @Test
-    public void getChildren_compositeOuter() {
+    void getChildren_compositeOuter() {
         ComponentTest.assertChildren(compositeOuter, compositeInner);
     }
 
     @Test
-    public void getChildren_compositeInner() {
+    void getChildren_compositeInner() {
         ComponentTest.assertChildren(compositeInner, componentInComposite);
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/CompositeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/CompositeTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @NotThreadSafe
-public class CompositeTest {
+class CompositeTest {
 
     // layoutWithSingleComponentComposite (TestLayout)
     // - compositeWithComponent (CompositeWithComponent)
@@ -93,7 +93,7 @@ public class CompositeTest {
     }
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         compositeWithComponent = new CompositeWithComponent() {
             @Override
             public String toString() {
@@ -125,66 +125,66 @@ public class CompositeTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         VaadinService.setCurrent(null);
     }
 
     @Test
-    public void getElement_compositeAndCompositeComponent() {
+    void getElement_compositeAndCompositeComponent() {
         assertEquals(layoutInsideComposite.getElement(),
                 compositeWithComponent.getElement());
     }
 
     @Test
-    public void getParentElement_compositeInLayout() {
+    void getParentElement_compositeInLayout() {
         assertEquals(layoutWithSingleComponentComposite.getElement(),
                 compositeWithComponent.getElement().getParent());
     }
 
     @Test
-    public void getElementChildren_layoutWithComponentInComposite() {
+    void getElementChildren_layoutWithComponentInComposite() {
         assertElementChildren(layoutWithSingleComponentComposite.getElement(),
                 layoutInsideComposite.getElement());
     }
 
     @Test
-    public void getParent_compositeInLayout() {
+    void getParent_compositeInLayout() {
         assertEquals(layoutWithSingleComponentComposite,
                 compositeWithComponent.getParent().get());
     }
 
     @Test
-    public void getParent_componentInComposite() {
+    void getParent_componentInComposite() {
         assertEquals(compositeWithComponent,
                 layoutInsideComposite.getParent().get());
     }
 
     @Test
-    public void getParent_componentInLayoutInComposite() {
+    void getParent_componentInLayoutInComposite() {
         assertEquals(layoutInsideComposite,
                 componentInsideLayoutInsideComposite.getParent().get());
     }
 
     @Test
-    public void getChildren_layoutWithComposite() {
+    void getChildren_layoutWithComposite() {
         ComponentTest.assertChildren(layoutWithSingleComponentComposite,
                 compositeWithComponent);
     }
 
     @Test
-    public void getChildren_compositeWithComponent() {
+    void getChildren_compositeWithComponent() {
         ComponentTest.assertChildren(compositeWithComponent,
                 layoutInsideComposite);
     }
 
     @Test
-    public void getChildren_layoutInComposite() {
+    void getChildren_layoutInComposite() {
         ComponentTest.assertChildren(layoutInsideComposite,
                 componentInsideLayoutInsideComposite);
     }
 
     @Test
-    public void automaticCompositeContentType() {
+    void automaticCompositeContentType() {
         class CompositeWithGenericType extends Composite<TestComponent> {
         }
 
@@ -194,7 +194,7 @@ public class CompositeTest {
     }
 
     @Test
-    public void compositeContentTypeWithVariableTypeParameter() {
+    void compositeContentTypeWithVariableTypeParameter() {
         class CompositeWithVariableType<C extends Component>
                 extends Composite<C> {
         }
@@ -207,7 +207,7 @@ public class CompositeTest {
     }
 
     @Test
-    public void compositeContentTypeWithSpecifiedType() {
+    void compositeContentTypeWithSpecifiedType() {
         class CompositeWithCustomComponent
                 extends Composite<CustomComponent<List<String>>> {
         }
@@ -222,7 +222,7 @@ public class CompositeTest {
     }
 
     @Test
-    public void compositeContentTypeWithTypeVariable() {
+    void compositeContentTypeWithTypeVariable() {
         class CompositeWithComposite
                 extends Composite<CompositeWithVariableType<TestComponent>> {
         }
@@ -232,7 +232,7 @@ public class CompositeTest {
     }
 
     @Test
-    public void rawContentType() {
+    void rawContentType() {
         @SuppressWarnings("rawtypes")
         class CompositeWithRawType extends Composite {
         }
@@ -242,7 +242,7 @@ public class CompositeTest {
     }
 
     @Test
-    public void noDefaultConstructor() {
+    void noDefaultConstructor() {
         class NoDefaultConstructor extends Composite<Text> {
         }
 
@@ -252,7 +252,7 @@ public class CompositeTest {
     }
 
     @Test
-    public void compositeHierarchy() {
+    void compositeHierarchy() {
         class Class1<T extends Component> extends Composite<T> {
         }
         class Class2<T, V extends Component> extends Class1<V> {
@@ -274,7 +274,7 @@ public class CompositeTest {
     // --- layoutInsideComposite (TestLayout) content for compositeWithComponent
     // ---- componentInsideLayoutInsideComposite (TestComponent)
     @Test
-    public void attachDetachEvents_compositeHierarchy_correctOrder() {
+    void attachDetachEvents_compositeHierarchy_correctOrder() {
         UI ui = new UI();
 
         List<Component> attached = new ArrayList<>();
@@ -335,7 +335,7 @@ public class CompositeTest {
     }
 
     @Test
-    public void testOnAttachOnDetachAndEventsOrder() {
+    void testOnAttachOnDetachAndEventsOrder() {
         List<Integer> triggered = new ArrayList<>();
 
         Component component = new Component(new Element("div")) {

--- a/flow-server/src/test/java/com/vaadin/flow/component/DefaultWebComponentExporterFactoryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/DefaultWebComponentExporterFactoryTest.java
@@ -53,14 +53,14 @@ class DefaultWebComponentExporterFactoryTest {
     }
 
     @Test
-    public void ctor_nullArg_throws() {
+    void ctor_nullArg_throws() {
         assertThrows(NullPointerException.class, () -> {
             new DefaultWebComponentExporterFactory<Component>(null);
         });
     }
 
     @Test
-    public void createInnerClass_throws() {
+    void createInnerClass_throws() {
         DefaultWebComponentExporterFactory<Component> factory = new DefaultWebComponentExporterFactory<>(
                 InnerClass.class);
 
@@ -72,7 +72,7 @@ class DefaultWebComponentExporterFactoryTest {
     }
 
     @Test
-    public void create_exporterHasNoTag_throws() {
+    void create_exporterHasNoTag_throws() {
         DefaultWebComponentExporterFactory<Component> factory = new DefaultWebComponentExporterFactory<>(
                 NoSpecifiedTagClass.class);
         IllegalArgumentException ex = assertThrows(

--- a/flow-server/src/test/java/com/vaadin/flow/component/DomEventTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/DomEventTest.java
@@ -45,7 +45,7 @@ class DomEventTest {
     }
 
     @Test
-    public void bareAnnotation() {
+    void bareAnnotation() {
         assertSettings(BareAnnotation.class, null, 0);
     }
 
@@ -57,7 +57,7 @@ class DomEventTest {
     }
 
     @Test
-    public void filter() {
+    void filter() {
         assertSettings(FilterEvent.class, "a == b", 0);
     }
 
@@ -72,7 +72,7 @@ class DomEventTest {
     }
 
     @Test
-    public void debouncePhases() {
+    void debouncePhases() {
         assertSettings(DebounceTimeoutPhasesEvent.class,
                 ElementListenerMap.ALWAYS_TRUE_FILTER, 200,
                 DebouncePhase.INTERMEDIATE, DebouncePhase.TRAILING);
@@ -87,7 +87,7 @@ class DomEventTest {
     }
 
     @Test
-    public void emptyPhases() {
+    void emptyPhases() {
         assertThrows(IllegalStateException.class, () -> {
             getEventSettings(DebounceEmptyPhasesEvent.class);
         });
@@ -101,7 +101,7 @@ class DomEventTest {
     }
 
     @Test
-    public void debounceFilter() {
+    void debounceFilter() {
         assertSettings(DebounceFilterEvent.class, "filter(event)", 300,
                 DebouncePhase.TRAILING);
     }

--- a/flow-server/src/test/java/com/vaadin/flow/component/FocusableTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/FocusableTest.java
@@ -39,7 +39,7 @@ class FocusableTest {
     private final FocusableTestComponent component = new FocusableTestComponent();
 
     @Test
-    public void focusUnattached_nothingScheduled() {
+    void focusUnattached_nothingScheduled() {
         component.focus();
 
         assertPendingInvocationCount(
@@ -48,7 +48,7 @@ class FocusableTest {
     }
 
     @Test
-    public void focusBeforeAttach_executionScheduled() {
+    void focusBeforeAttach_executionScheduled() {
         component.focus();
         ui.add(component);
 
@@ -58,7 +58,7 @@ class FocusableTest {
     }
 
     @Test
-    public void focusAfterAttach_executionScheduled() {
+    void focusAfterAttach_executionScheduled() {
         ui.add(component);
         component.focus();
 
@@ -68,7 +68,7 @@ class FocusableTest {
     }
 
     @Test
-    public void detachAfterFocus_nothingScheduled() {
+    void detachAfterFocus_nothingScheduled() {
         ui.add(component);
         component.focus();
         ui.remove(component);
@@ -85,7 +85,7 @@ class FocusableTest {
     }
 
     @Test
-    public void focus_withFocusVisible_generatesCorrectJS() {
+    void focus_withFocusVisible_generatesCorrectJS() {
         ui.add(component);
         component.focus(FocusVisible.VISIBLE);
 
@@ -112,7 +112,7 @@ class FocusableTest {
     }
 
     @Test
-    public void focus_withFocusNotVisible_generatesCorrectJS() {
+    void focus_withFocusNotVisible_generatesCorrectJS() {
         ui.add(component);
         component.focus(FocusVisible.NOT_VISIBLE);
 
@@ -137,7 +137,7 @@ class FocusableTest {
     }
 
     @Test
-    public void focus_withPreventScrollEnabled_generatesCorrectJS() {
+    void focus_withPreventScrollEnabled_generatesCorrectJS() {
         ui.add(component);
         component.focus(PreventScroll.ENABLED);
 
@@ -164,7 +164,7 @@ class FocusableTest {
     }
 
     @Test
-    public void focus_withPreventScrollDisabled_generatesCorrectJS() {
+    void focus_withPreventScrollDisabled_generatesCorrectJS() {
         ui.add(component);
         component.focus(PreventScroll.DISABLED);
 
@@ -189,7 +189,7 @@ class FocusableTest {
     }
 
     @Test
-    public void focus_withBothOptions_generatesCorrectJS() {
+    void focus_withBothOptions_generatesCorrectJS() {
         ui.add(component);
         component.focus(FocusVisible.VISIBLE, PreventScroll.ENABLED);
 
@@ -216,7 +216,7 @@ class FocusableTest {
     }
 
     @Test
-    public void focus_withBothOptionsFalse_generatesCorrectJS() {
+    void focus_withBothOptionsFalse_generatesCorrectJS() {
         ui.add(component);
         component.focus(FocusVisible.NOT_VISIBLE, PreventScroll.DISABLED);
 
@@ -243,7 +243,7 @@ class FocusableTest {
     }
 
     @Test
-    public void focus_withoutOptions_generatesCorrectJS() {
+    void focus_withoutOptions_generatesCorrectJS() {
         ui.add(component);
         component.focus();
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/HTMLTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HTMLTest.java
@@ -29,56 +29,56 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class HTMLTest {
 
     @Test
-    public void attachedToElement() {
+    void attachedToElement() {
         // This will throw an assertion error if the element is not attached to
         // the component
         new Html("<b>Hello</b>").getParent();
     }
 
     @Test
-    public void nullHtml() {
+    void nullHtml() {
         assertThrows(IllegalArgumentException.class, () -> {
             new Html((String) null);
         });
     }
 
     @Test
-    public void nullStream() {
+    void nullStream() {
         assertThrows(IllegalArgumentException.class, () -> {
             new Html((InputStream) null);
         });
     }
 
     @Test
-    public void emptyHtml() {
+    void emptyHtml() {
         assertThrows(IllegalArgumentException.class, () -> {
             new Html("");
         });
     }
 
     @Test
-    public void twoRoots() {
+    void twoRoots() {
         assertThrows(IllegalArgumentException.class, () -> {
             new Html("<b></b><div></div>");
         });
     }
 
     @Test
-    public void text() {
+    void text() {
         assertThrows(IllegalArgumentException.class, () -> {
             new Html("hello");
         });
     }
 
     @Test
-    public void simpleHtml() {
+    void simpleHtml() {
         Html html = new Html("<span>hello</span>");
         assertEquals(Tag.SPAN, html.getElement().getTag());
         assertEquals("hello", html.getInnerHtml());
     }
 
     @Test
-    public void setHtmlContent() {
+    void setHtmlContent() {
         Html html = new Html("<span>hello</span>");
         assertEquals(Tag.SPAN, html.getElement().getTag());
         assertEquals("hello", html.getInnerHtml());
@@ -87,7 +87,7 @@ class HTMLTest {
     }
 
     @Test
-    public void setHtmlContent_tagMismatch() {
+    void setHtmlContent_tagMismatch() {
         Html html = new Html("<span>hello</span>");
         assertEquals(Tag.SPAN, html.getElement().getTag());
         assertEquals("hello", html.getInnerHtml());
@@ -96,7 +96,7 @@ class HTMLTest {
     }
 
     @Test
-    public void rootAttributes() {
+    void rootAttributes() {
         Html html = new Html("<span foo='bar'>hello</span>");
         assertEquals(Tag.SPAN, html.getElement().getTag());
         assertEquals(1, html.getElement().getAttributeNames().count());
@@ -105,7 +105,7 @@ class HTMLTest {
     }
 
     @Test
-    public void rootSpecialAttributes() {
+    void rootSpecialAttributes() {
         Html html = new Html(
                 "<span class='foo' style='color: red'>hello</span>");
         Element element = html.getElement();
@@ -118,20 +118,20 @@ class HTMLTest {
     }
 
     @Test
-    public void fromStream() {
+    void fromStream() {
         new Html(new ByteArrayInputStream(
                 "<div><span>contents</span></div>".getBytes()));
     }
 
     @Test
-    public void brokenHtml() {
+    void brokenHtml() {
         Html html = new Html("<b></div>");
         assertEquals("b", html.getElement().getTag());
         assertEquals("", html.getInnerHtml());
     }
 
     @Test
-    public void extraWhitespace() {
+    void extraWhitespace() {
         String input = "   <span>    " //
                 + "    <div>" //
                 + "       <b>Hello!</b>" //
@@ -147,7 +147,7 @@ class HTMLTest {
     }
 
     @Test
-    public void emptyAttribute_elementIsCreatedAndHasAttribute() {
+    void emptyAttribute_elementIsCreatedAndHasAttribute() {
         Html html = new Html("<audio controls></audio>");
 
         assertEquals("", html.getElement().getAttribute("controls"));
@@ -157,14 +157,14 @@ class HTMLTest {
     }
 
     @Test
-    public void styleElementAsString_elementIsUsed() {
+    void styleElementAsString_elementIsUsed() {
         Html html = new Html("<style></style>");
         assertEquals("style", html.getElement().getTag());
     }
 
     @Test
 
-    public void styleElementAsStream_elementIsUsed() {
+    void styleElementAsStream_elementIsUsed() {
         Html html = new Html(new ByteArrayInputStream(
                 "<style></style>".getBytes(StandardCharsets.UTF_8)));
         assertEquals("style", html.getElement().getTag());

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasAriaLabelTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasAriaLabelTest.java
@@ -29,28 +29,28 @@ class HasAriaLabelTest {
     }
 
     @Test
-    public void withoutAriaLabelComponent_getAriaLabelReturnsEmptyOptional() {
+    void withoutAriaLabelComponent_getAriaLabelReturnsEmptyOptional() {
         TestComponent component = new TestComponent();
 
         assertFalse(component.getAriaLabel().isPresent());
     }
 
     @Test
-    public void withNullAriaLabel_getAriaLabelReturnsEmptyOptional() {
+    void withNullAriaLabel_getAriaLabelReturnsEmptyOptional() {
         TestComponent component = new TestComponent();
         component.setAriaLabel(null);
         assertFalse(component.getAriaLabel().isPresent());
     }
 
     @Test
-    public void withEmptyAriaLabel_getAriaLabelReturnsEmptyString() {
+    void withEmptyAriaLabel_getAriaLabelReturnsEmptyString() {
         TestComponent component = new TestComponent();
         component.setAriaLabel("");
         assertEquals("", component.getAriaLabel().get());
     }
 
     @Test
-    public void withAriaLabel_setAriaLabelToNullClearsAriaLabel() {
+    void withAriaLabel_setAriaLabelToNullClearsAriaLabel() {
         TestComponent component = new TestComponent();
         component.setAriaLabel("test AriaLabel");
 
@@ -59,7 +59,7 @@ class HasAriaLabelTest {
     }
 
     @Test
-    public void setAriaLabel() {
+    void setAriaLabel() {
         TestComponent component = new TestComponent();
         component.setAriaLabel("test AriaLabel");
 
@@ -67,28 +67,28 @@ class HasAriaLabelTest {
     }
 
     @Test
-    public void withoutAriaLabelledByComponent_getAriaLabelledByReturnsEmptyOptional() {
+    void withoutAriaLabelledByComponent_getAriaLabelledByReturnsEmptyOptional() {
         TestComponent component = new TestComponent();
 
         assertFalse(component.getAriaLabelledBy().isPresent());
     }
 
     @Test
-    public void withNullAriaLabelledBy_getAriaLabelledByReturnsEmptyOptional() {
+    void withNullAriaLabelledBy_getAriaLabelledByReturnsEmptyOptional() {
         TestComponent component = new TestComponent();
         component.setAriaLabelledBy(null);
         assertFalse(component.getAriaLabelledBy().isPresent());
     }
 
     @Test
-    public void withEmptyAriaLabelledBy_getAriaLabelledByReturnsEmptyString() {
+    void withEmptyAriaLabelledBy_getAriaLabelledByReturnsEmptyString() {
         TestComponent component = new TestComponent();
         component.setAriaLabelledBy("");
         assertEquals("", component.getAriaLabelledBy().get());
     }
 
     @Test
-    public void withAriaLabelledBy_setAriaLabelledByToNullClearsAriaLabelledBy() {
+    void withAriaLabelledBy_setAriaLabelledByToNullClearsAriaLabelledBy() {
         TestComponent component = new TestComponent();
         component.setAriaLabelledBy("test AriaLabelledBy");
 
@@ -97,7 +97,7 @@ class HasAriaLabelTest {
     }
 
     @Test
-    public void setAriaLabelledBy() {
+    void setAriaLabelledBy() {
         TestComponent component = new TestComponent();
         component.setAriaLabelledBy("test AriaLabelledBy");
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasComponentsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasComponentsTest.java
@@ -50,18 +50,18 @@ class HasComponentsTest {
     }
 
     @BeforeAll
-    public static void init() {
+    static void init() {
         service = new MockVaadinServletService();
     }
 
     @AfterAll
-    public static void clean() {
+    static void clean() {
         CurrentInstance.clearAll();
         service.destroy();
     }
 
     @Test
-    public void addStringToComponent() {
+    void addStringToComponent() {
         String text = "Add text";
         TestComponent component = new TestComponent();
         component.add(text);
@@ -70,7 +70,7 @@ class HasComponentsTest {
     }
 
     @Test
-    public void insertComponentAtFirst() {
+    void insertComponentAtFirst() {
         TestComponent component = createTestStructure();
         TestComponent innerComponent = new TestComponent();
         innerComponent.setId("insert-component-first");
@@ -81,7 +81,7 @@ class HasComponentsTest {
     }
 
     @Test
-    public void insertComponentAtIndex() {
+    void insertComponentAtIndex() {
         TestComponent component = createTestStructure();
         TestComponent innerComponent = new TestComponent();
         innerComponent.setId("insert-component-index");
@@ -92,7 +92,7 @@ class HasComponentsTest {
     }
 
     @Test
-    public void insertComponentIndexLessThanZero() {
+    void insertComponentIndexLessThanZero() {
         TestComponent component = createTestStructure();
         TestComponent innerComponent = new TestComponent();
         innerComponent.setId("insert-component-index-less");
@@ -101,7 +101,7 @@ class HasComponentsTest {
     }
 
     @Test
-    public void insertComponentIndexGreaterThanChildrenNumber() {
+    void insertComponentIndexGreaterThanChildrenNumber() {
         TestComponent component = createTestStructure();
         TestComponent innerComponent = new TestComponent();
         innerComponent.setId("insert-component-index-greater");
@@ -110,7 +110,7 @@ class HasComponentsTest {
     }
 
     @Test
-    public void remove_removeComponentWithNoParent() {
+    void remove_removeComponentWithNoParent() {
         TestComponent component = createTestStructure();
         TestComponent innerComponent = new TestComponent();
 
@@ -119,7 +119,7 @@ class HasComponentsTest {
     }
 
     @Test
-    public void remove_removeSeveralComponents_oneHasParent_nothingRemovedAndThrows() {
+    void remove_removeSeveralComponents_oneHasParent_nothingRemovedAndThrows() {
         TestComponent component = createTestStructure();
 
         TestComponent child = new TestComponent();
@@ -138,7 +138,7 @@ class HasComponentsTest {
     }
 
     @Test
-    public void remove_removeSeveralComponents_oneHasNoParent_childIsRemoved() {
+    void remove_removeSeveralComponents_oneHasNoParent_childIsRemoved() {
         TestComponent component = createTestStructure();
 
         TestComponent child = new TestComponent();
@@ -153,7 +153,7 @@ class HasComponentsTest {
     }
 
     @Test
-    public void remove_removeComponentWithCorrectParent() {
+    void remove_removeComponentWithCorrectParent() {
         TestComponent component = createTestStructure();
         TestComponent innerComponent = new TestComponent();
 
@@ -167,7 +167,7 @@ class HasComponentsTest {
     }
 
     @Test
-    public void remove_removeComponentWithDifferentParent() {
+    void remove_removeComponentWithDifferentParent() {
         TestComponent component = createTestStructure();
 
         TestComponent another = createTestStructure();
@@ -193,7 +193,7 @@ class HasComponentsTest {
     }
 
     @Test
-    public void bindChildren_addsChildrenFromListSignal() {
+    void bindChildren_addsChildrenFromListSignal() {
         CurrentInstance.clearAll();
         TestComponent container = new TestComponent();
         new MockUI().add(container);
@@ -215,7 +215,7 @@ class HasComponentsTest {
     }
 
     @Test
-    public void bindChildren_updatesChildrenOnListChange() {
+    void bindChildren_updatesChildrenOnListChange() {
         CurrentInstance.clearAll();
         TestComponent container = new TestComponent();
         new MockUI().add(container);
@@ -239,7 +239,7 @@ class HasComponentsTest {
     }
 
     @Test
-    public void bindChildren_throwsIfContainerNotEmpty() {
+    void bindChildren_throwsIfContainerNotEmpty() {
         CurrentInstance.clearAll();
         TestComponent container = new TestComponent();
         new MockUI().add(container);
@@ -252,7 +252,7 @@ class HasComponentsTest {
     }
 
     @Test
-    public void bindChildren_throwsIfBindingAlreadyExists() {
+    void bindChildren_throwsIfBindingAlreadyExists() {
         CurrentInstance.clearAll();
         TestComponent container = new TestComponent();
         new MockUI().add(container);
@@ -268,7 +268,7 @@ class HasComponentsTest {
     }
 
     @Test
-    public void bindChildren_addSlottedComponentWhileBindingActive_succeeds() {
+    void bindChildren_addSlottedComponentWhileBindingActive_succeeds() {
         CurrentInstance.clearAll();
         TestComponent container = new TestComponent();
         new MockUI().add(container);
@@ -287,7 +287,7 @@ class HasComponentsTest {
     }
 
     @Test
-    public void bindChildren_removeSlottedComponentWhileBindingActive_succeeds() {
+    void bindChildren_removeSlottedComponentWhileBindingActive_succeeds() {
         CurrentInstance.clearAll();
         TestComponent container = new TestComponent();
         new MockUI().add(container);
@@ -310,7 +310,7 @@ class HasComponentsTest {
     }
 
     @Test
-    public void bindChildren_parentHasOnlySlottedChildren_succeeds() {
+    void bindChildren_parentHasOnlySlottedChildren_succeeds() {
         CurrentInstance.clearAll();
         TestComponent container = new TestComponent();
         new MockUI().add(container);
@@ -326,7 +326,7 @@ class HasComponentsTest {
     }
 
     @Test
-    public void bindChildren_removeAllThrowsWhileBindingActive() {
+    void bindChildren_removeAllThrowsWhileBindingActive() {
         CurrentInstance.clearAll();
         TestComponent container = new TestComponent();
         new MockUI().add(container);
@@ -341,7 +341,7 @@ class HasComponentsTest {
     }
 
     @Test
-    public void bindChildren_addThrowsWhileBindingActive() {
+    void bindChildren_addThrowsWhileBindingActive() {
         CurrentInstance.clearAll();
         TestComponent container = new TestComponent();
         new MockUI().add(container);
@@ -357,7 +357,7 @@ class HasComponentsTest {
     }
 
     @Test
-    public void bindChildren_removeThrowsWhileBindingActive() {
+    void bindChildren_removeThrowsWhileBindingActive() {
         CurrentInstance.clearAll();
         TestComponent container = new TestComponent();
         new MockUI().add(container);
@@ -375,7 +375,7 @@ class HasComponentsTest {
     }
 
     @Test
-    public void textBindingActive_addThrows() {
+    void textBindingActive_addThrows() {
         TestComponent container = createContainerWithTextBinding();
 
         assertThrows(BindingActiveException.class,
@@ -384,7 +384,7 @@ class HasComponentsTest {
     }
 
     @Test
-    public void textBindingActive_removeThrows() {
+    void textBindingActive_removeThrows() {
         TestComponent container = new TestComponent();
         TestComponent child = new TestComponent();
         container.add(child);
@@ -399,7 +399,7 @@ class HasComponentsTest {
     }
 
     @Test
-    public void textBindingActive_removeAllThrows() {
+    void textBindingActive_removeAllThrows() {
         TestComponent container = createContainerWithTextBinding();
 
         assertThrows(BindingActiveException.class, container::removeAll,
@@ -407,7 +407,7 @@ class HasComponentsTest {
     }
 
     @Test
-    public void textBindingActive_addComponentAtIndexThrows() {
+    void textBindingActive_addComponentAtIndexThrows() {
         TestComponent container = createContainerWithTextBinding();
 
         assertThrows(BindingActiveException.class,
@@ -416,7 +416,7 @@ class HasComponentsTest {
     }
 
     @Test
-    public void textBindingActive_bindChildrenThrows() {
+    void textBindingActive_bindChildrenThrows() {
         CurrentInstance.clearAll();
         TestComponent container = new TestComponent();
         new MockUI().add(container);

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasEnabledTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasEnabledTest.java
@@ -29,14 +29,14 @@ class HasEnabledTest {
     }
 
     @Test
-    public void enabledComponent_isEnabledReturnsTrue() {
+    void enabledComponent_isEnabledReturnsTrue() {
         TestComponent component = new TestComponent();
 
         assertTrue(component.isEnabled());
     }
 
     @Test
-    public void explicitlyDisabledComponent_isEnabledReturnsFalse() {
+    void explicitlyDisabledComponent_isEnabledReturnsFalse() {
         TestComponent component = new TestComponent();
         component.setEnabled(false);
 
@@ -44,7 +44,7 @@ class HasEnabledTest {
     }
 
     @Test
-    public void implicitlyDisabledComponent_isEnabledReturnsFalse() {
+    void implicitlyDisabledComponent_isEnabledReturnsFalse() {
         TestComponent component = new TestComponent();
 
         TestComponent parent = new TestComponent();
@@ -56,7 +56,7 @@ class HasEnabledTest {
     }
 
     @Test
-    public void implicitlyDisabledComponent_detach_componentBecomesEnabled() {
+    void implicitlyDisabledComponent_detach_componentBecomesEnabled() {
         TestComponent component = new TestComponent();
 
         TestComponent parent = new TestComponent();
@@ -70,7 +70,7 @@ class HasEnabledTest {
     }
 
     @Test
-    public void explicitlyDisabledComponent_enableParent_componentRemainsDisabled() {
+    void explicitlyDisabledComponent_enableParent_componentRemainsDisabled() {
         TestComponent component = new TestComponent();
         component.setEnabled(false);
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasHelperBindHelperTextTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasHelperBindHelperTextTest.java
@@ -32,7 +32,7 @@ class HasHelperBindHelperTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindHelperText_updatesPropertyOnSignalChange() {
+    void bindHelperText_updatesPropertyOnSignalChange() {
         HasHelperComponent c = new HasHelperComponent();
         UI.getCurrent().add(c);
 
@@ -47,7 +47,7 @@ class HasHelperBindHelperTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindHelperText_setHelperTextWhileBindingActive_throws() {
+    void bindHelperText_setHelperTextWhileBindingActive_throws() {
         HasHelperComponent c = new HasHelperComponent();
         UI.getCurrent().add(c);
 
@@ -59,7 +59,7 @@ class HasHelperBindHelperTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindHelperText_nullSignal_throwsNPE() {
+    void bindHelperText_nullSignal_throwsNPE() {
         HasHelperComponent c = new HasHelperComponent();
         UI.getCurrent().add(c);
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasHelperTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasHelperTest.java
@@ -28,26 +28,26 @@ class HasHelperTest {
     }
 
     @Test
-    public void getHelperText() {
+    void getHelperText() {
         final HasHelperComponent c = new HasHelperComponent();
         assertNull(c.getHelperText());
     }
 
     @Test
-    public void getHelperComponent() {
+    void getHelperComponent() {
         final HasHelperComponent c = new HasHelperComponent();
         assertNull(c.getHelperComponent());
     }
 
     @Test
-    public void setHelperText() {
+    void setHelperText() {
         final HasHelperComponent c = new HasHelperComponent();
         c.setHelperText("helper");
         assertEquals("helper", c.getHelperText());
     }
 
     @Test
-    public void setHelperComponent() {
+    void setHelperComponent() {
         final HasHelperComponent c = new HasHelperComponent();
         final HasHelperComponent slotted = new HasHelperComponent();
         c.setHelperComponent(slotted);
@@ -55,7 +55,7 @@ class HasHelperTest {
     }
 
     @Test
-    public void removeHelperText() {
+    void removeHelperText() {
         final HasHelperComponent c = new HasHelperComponent();
         c.setHelperText("helper");
         assertEquals("helper", c.getHelperText());
@@ -65,7 +65,7 @@ class HasHelperTest {
     }
 
     @Test
-    public void removeHelperComponent() {
+    void removeHelperComponent() {
         final HasHelperComponent c = new HasHelperComponent();
         final HasHelperComponent slotted = new HasHelperComponent();
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasLabelTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasLabelTest.java
@@ -28,28 +28,28 @@ class HasLabelTest {
     }
 
     @Test
-    public void withoutLabelComponent_getLabelReturnsNull() {
+    void withoutLabelComponent_getLabelReturnsNull() {
         TestComponent component = new TestComponent();
 
         assertNull(component.getLabel());
     }
 
     @Test
-    public void withNullLabel_getLabelReturnsNull() {
+    void withNullLabel_getLabelReturnsNull() {
         TestComponent component = new TestComponent();
         component.setLabel(null);
         assertNull(component.getLabel());
     }
 
     @Test
-    public void withEmptyLabel_getLabelReturnsEmptyString() {
+    void withEmptyLabel_getLabelReturnsEmptyString() {
         TestComponent component = new TestComponent();
         component.setLabel("");
         assertEquals("", component.getLabel());
     }
 
     @Test
-    public void setLabel() {
+    void setLabel() {
         TestComponent component = new TestComponent();
         component.setLabel("test label");
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasOrderedComponentsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasOrderedComponentsTest.java
@@ -60,7 +60,7 @@ class HasOrderedComponentsTest {
     private TestComponentContianer contianer = new TestComponentContianer();
 
     @Test
-    public void indexOf_componentIsChild_returnsIndexOfChild() {
+    void indexOf_componentIsChild_returnsIndexOfChild() {
         Component comp = Mockito.mock(Component.class);
         Mockito.when(components.getChildren())
                 .thenReturn(Arrays.asList(Mockito.mock(Component.class), comp,
@@ -75,7 +75,7 @@ class HasOrderedComponentsTest {
     }
 
     @Test
-    public void indexOf_componentIsNotChild_returnsNegative() {
+    void indexOf_componentIsNotChild_returnsNegative() {
         Component comp = Mockito.mock(Component.class);
         Mockito.when(components.getChildren())
                 .thenReturn(Arrays.asList(Mockito.mock(Component.class),
@@ -85,7 +85,7 @@ class HasOrderedComponentsTest {
     }
 
     @Test
-    public void indexOf_componentIsNull_throws() {
+    void indexOf_componentIsNull_throws() {
         Mockito.when(components.getChildren()).thenReturn(Stream.empty());
 
         assertThrows(IllegalArgumentException.class,
@@ -93,7 +93,7 @@ class HasOrderedComponentsTest {
     }
 
     @Test
-    public void getComponentCount_returnsChildrenSize() {
+    void getComponentCount_returnsChildrenSize() {
         Mockito.when(components.getChildren())
                 .thenReturn(Arrays.asList(Mockito.mock(Component.class),
                         Mockito.mock(Component.class)).stream());
@@ -105,7 +105,7 @@ class HasOrderedComponentsTest {
     }
 
     @Test
-    public void getComponentAt_returnsComponentAtIndex() {
+    void getComponentAt_returnsComponentAtIndex() {
         Component comp = Mockito.mock(Component.class);
         Mockito.when(components.getChildren())
                 .thenReturn(Arrays.asList(Mockito.mock(Component.class), comp,
@@ -120,7 +120,7 @@ class HasOrderedComponentsTest {
     }
 
     @Test
-    public void getComponentAt_negativeIndex_throws() {
+    void getComponentAt_negativeIndex_throws() {
         Mockito.when(components.getChildren())
                 .thenReturn(Arrays.asList(Mockito.mock(Component.class),
                         Mockito.mock(Component.class)).stream());
@@ -130,7 +130,7 @@ class HasOrderedComponentsTest {
     }
 
     @Test
-    public void getComponentAt_indexIsGreaterThanSize_throws() {
+    void getComponentAt_indexIsGreaterThanSize_throws() {
         Mockito.when(components.getChildren())
                 .thenReturn(Stream.of(Mockito.mock(Component.class)));
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasPlaceholderBindTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasPlaceholderBindTest.java
@@ -36,7 +36,7 @@ class HasPlaceholderBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindPlaceholder_elementAttached_updatesWithSignal() {
+    void bindPlaceholder_elementAttached_updatesWithSignal() {
         TestComponent component = new TestComponent();
         // Attach component so that Element.bindProperty becomes active
         UI.getCurrent().add(component);
@@ -56,7 +56,7 @@ class HasPlaceholderBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindPlaceholder_elementNotAttached_bindingInactive() {
+    void bindPlaceholder_elementNotAttached_bindingInactive() {
         TestComponent component = new TestComponent();
         // Not attached yet
         ValueSignal<String> signal = new ValueSignal<>("foo");
@@ -69,7 +69,7 @@ class HasPlaceholderBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindPlaceholder_attachAfterBinding_activatesAndAppliesLatest() {
+    void bindPlaceholder_attachAfterBinding_activatesAndAppliesLatest() {
         TestComponent component = new TestComponent();
         ValueSignal<String> signal = new ValueSignal<>("foo");
         component.bindPlaceholder(signal);
@@ -84,7 +84,7 @@ class HasPlaceholderBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindPlaceholder_elementDetached_bindingInactive_andReactivatesOnAttach() {
+    void bindPlaceholder_elementDetached_bindingInactive_andReactivatesOnAttach() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
         ValueSignal<String> signal = new ValueSignal<>("foo");
@@ -101,7 +101,7 @@ class HasPlaceholderBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindPlaceholder_nullSignal_throwsNPE() {
+    void bindPlaceholder_nullSignal_throwsNPE() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -110,7 +110,7 @@ class HasPlaceholderBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void setPlaceholder_whileBindingActive_throwsBindingActiveException() {
+    void setPlaceholder_whileBindingActive_throwsBindingActiveException() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
         ValueSignal<String> signal = new ValueSignal<>("foo");
@@ -122,7 +122,7 @@ class HasPlaceholderBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindPlaceholder_againWhileActive_throwsBindingActiveException() {
+    void bindPlaceholder_againWhileActive_throwsBindingActiveException() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
         ValueSignal<String> signal = new ValueSignal<>("foo");

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasPlaceholderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasPlaceholderTest.java
@@ -29,28 +29,28 @@ class HasPlaceholderTest {
     }
 
     @Test
-    public void withoutPlaceholderComponent_getPlaceholderReturnsNull() {
+    void withoutPlaceholderComponent_getPlaceholderReturnsNull() {
         TestComponent component = new TestComponent();
 
         assertNull(component.getPlaceholder());
     }
 
     @Test
-    public void withNullPlaceholder_getPlaceholderReturnsEmptyString() {
+    void withNullPlaceholder_getPlaceholderReturnsEmptyString() {
         TestComponent component = new TestComponent();
         component.setPlaceholder(null);
         assertEquals("", component.getPlaceholder());
     }
 
     @Test
-    public void withEmptyPlaceholder_getPlaceholderReturnsEmptyString() {
+    void withEmptyPlaceholder_getPlaceholderReturnsEmptyString() {
         TestComponent component = new TestComponent();
         component.setPlaceholder("");
         assertEquals("", component.getPlaceholder());
     }
 
     @Test
-    public void setPlaceholder() {
+    void setPlaceholder() {
         TestComponent component = new TestComponent();
         component.setPlaceholder("test Placeholder");
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasSizeBindWidthHeightTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasSizeBindWidthHeightTest.java
@@ -38,7 +38,7 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindWidth_elementAttachedBefore_bindingActive() {
+    void bindWidth_elementAttachedBefore_bindingActive() {
         HasSizeComponent component = new HasSizeComponent();
         UI.getCurrent().add(component);
         assertNull(component.getWidth());
@@ -50,7 +50,7 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindWidth_elementAttachedAfter_bindingActive() {
+    void bindWidth_elementAttachedAfter_bindingActive() {
         HasSizeComponent component = new HasSizeComponent();
         assertNull(component.getWidth());
 
@@ -62,7 +62,7 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindWidth_elementAttached_bindingActive() {
+    void bindWidth_elementAttached_bindingActive() {
         HasSizeComponent component = new HasSizeComponent();
         UI.getCurrent().add(component);
         ValueSignal<String> signal = new ValueSignal<>("200px");
@@ -80,7 +80,7 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindWidth_elementNotAttached_bindingInactive() {
+    void bindWidth_elementNotAttached_bindingInactive() {
         HasSizeComponent component = new HasSizeComponent();
         ValueSignal<String> signal = new ValueSignal<>("200px");
         component.bindWidth(signal);
@@ -94,7 +94,7 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindWidth_elementDetached_bindingInactive() {
+    void bindWidth_elementDetached_bindingInactive() {
         HasSizeComponent component = new HasSizeComponent();
         UI.getCurrent().add(component);
         ValueSignal<String> signal = new ValueSignal<>("200px");
@@ -106,7 +106,7 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindWidth_elementReAttached_bindingActivate() {
+    void bindWidth_elementReAttached_bindingActivate() {
         HasSizeComponent component = new HasSizeComponent();
         UI.getCurrent().add(component);
         ValueSignal<String> signal = new ValueSignal<>("200px");
@@ -119,7 +119,7 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindWidth_setWidthWhileBindingIsActive_throwException() {
+    void bindWidth_setWidthWhileBindingIsActive_throwException() {
         HasSizeComponent component = new HasSizeComponent();
         UI.getCurrent().add(component);
         component.bindWidth(new ValueSignal<>("200px"));
@@ -138,7 +138,7 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindWidth_bindWidthWhileBindingIsActive_throwException() {
+    void bindWidth_bindWidthWhileBindingIsActive_throwException() {
         HasSizeComponent component = new HasSizeComponent();
         UI.getCurrent().add(component);
         component.bindWidth(new ValueSignal<>("200px"));
@@ -151,7 +151,7 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindWidth_nullSignal_throwsNPE() {
+    void bindWidth_nullSignal_throwsNPE() {
         HasSizeComponent component = new HasSizeComponent();
         UI.getCurrent().add(component);
 
@@ -160,7 +160,7 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindWidth_fullWidth_widthFullAttributeSet() {
+    void bindWidth_fullWidth_widthFullAttributeSet() {
         HasSizeComponent component = new HasSizeComponent();
         UI.getCurrent().add(component);
         ValueSignal<String> signal = new ValueSignal<>("100%");
@@ -172,7 +172,7 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindWidth_notFullWidth_widthFullAttributeNotSet() {
+    void bindWidth_notFullWidth_widthFullAttributeNotSet() {
         HasSizeComponent component = new HasSizeComponent();
         UI.getCurrent().add(component);
         ValueSignal<String> signal = new ValueSignal<>("200px");
@@ -184,7 +184,7 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindWidth_changeFromFullWidthToOther_widthFullAttributeRemoved() {
+    void bindWidth_changeFromFullWidthToOther_widthFullAttributeRemoved() {
         HasSizeComponent component = new HasSizeComponent();
         UI.getCurrent().add(component);
         ValueSignal<String> signal = new ValueSignal<>("100%");
@@ -200,7 +200,7 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindWidth_changeFromOtherToFullWidth_widthFullAttributeSet() {
+    void bindWidth_changeFromOtherToFullWidth_widthFullAttributeSet() {
         HasSizeComponent component = new HasSizeComponent();
         UI.getCurrent().add(component);
         ValueSignal<String> signal = new ValueSignal<>("200px");
@@ -216,7 +216,7 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindHeight_elementAttachedBefore_bindingActive() {
+    void bindHeight_elementAttachedBefore_bindingActive() {
         HasSizeComponent component = new HasSizeComponent();
         UI.getCurrent().add(component);
         assertNull(component.getHeight());
@@ -228,7 +228,7 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindHeight_elementAttachedAfter_bindingActive() {
+    void bindHeight_elementAttachedAfter_bindingActive() {
         HasSizeComponent component = new HasSizeComponent();
         assertNull(component.getHeight());
 
@@ -240,7 +240,7 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindHeight_elementAttached_bindingActive() {
+    void bindHeight_elementAttached_bindingActive() {
         HasSizeComponent component = new HasSizeComponent();
         UI.getCurrent().add(component);
         ValueSignal<String> signal = new ValueSignal<>("200px");
@@ -258,7 +258,7 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindHeight_elementNotAttached_bindingInactive() {
+    void bindHeight_elementNotAttached_bindingInactive() {
         HasSizeComponent component = new HasSizeComponent();
         ValueSignal<String> signal = new ValueSignal<>("200px");
         component.bindHeight(signal);
@@ -272,7 +272,7 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindHeight_elementDetached_bindingInactive() {
+    void bindHeight_elementDetached_bindingInactive() {
         HasSizeComponent component = new HasSizeComponent();
         UI.getCurrent().add(component);
         ValueSignal<String> signal = new ValueSignal<>("200px");
@@ -284,7 +284,7 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindHeight_elementReAttached_bindingActivate() {
+    void bindHeight_elementReAttached_bindingActivate() {
         HasSizeComponent component = new HasSizeComponent();
         UI.getCurrent().add(component);
         ValueSignal<String> signal = new ValueSignal<>("200px");
@@ -297,7 +297,7 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindHeight_setHeightWhileBindingIsActive_throwException() {
+    void bindHeight_setHeightWhileBindingIsActive_throwException() {
         HasSizeComponent component = new HasSizeComponent();
         UI.getCurrent().add(component);
         component.bindHeight(new ValueSignal<>("200px"));
@@ -316,7 +316,7 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindHeight_bindHeightWhileBindingIsActive_throwException() {
+    void bindHeight_bindHeightWhileBindingIsActive_throwException() {
         HasSizeComponent component = new HasSizeComponent();
         UI.getCurrent().add(component);
         component.bindHeight(new ValueSignal<>("200px"));
@@ -327,7 +327,7 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindHeight_nullSignal_throwsNPE() {
+    void bindHeight_nullSignal_throwsNPE() {
         HasSizeComponent component = new HasSizeComponent();
         UI.getCurrent().add(component);
 
@@ -336,7 +336,7 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindHeight_fullHeight_heightFullAttributeSet() {
+    void bindHeight_fullHeight_heightFullAttributeSet() {
         HasSizeComponent component = new HasSizeComponent();
         UI.getCurrent().add(component);
         ValueSignal<String> signal = new ValueSignal<>("100%");
@@ -348,7 +348,7 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindHeight_notFullHeight_heightFullAttributeNotSet() {
+    void bindHeight_notFullHeight_heightFullAttributeNotSet() {
         HasSizeComponent component = new HasSizeComponent();
         UI.getCurrent().add(component);
         ValueSignal<String> signal = new ValueSignal<>("200px");
@@ -360,7 +360,7 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindHeight_changeFromFullHeightToOther_heightFullAttributeRemoved() {
+    void bindHeight_changeFromFullHeightToOther_heightFullAttributeRemoved() {
         HasSizeComponent component = new HasSizeComponent();
         UI.getCurrent().add(component);
         ValueSignal<String> signal = new ValueSignal<>("100%");
@@ -376,7 +376,7 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindHeight_changeFromOtherToFullHeight_heightFullAttributeSet() {
+    void bindHeight_changeFromOtherToFullHeight_heightFullAttributeSet() {
         HasSizeComponent component = new HasSizeComponent();
         UI.getCurrent().add(component);
         ValueSignal<String> signal = new ValueSignal<>("200px");
@@ -392,7 +392,7 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindWidth_onChange_receivesBindingContext() {
+    void bindWidth_onChange_receivesBindingContext() {
         HasSizeComponent component = new HasSizeComponent();
         UI.getCurrent().add(component);
 
@@ -415,7 +415,7 @@ class HasSizeBindWidthHeightTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindHeight_onChange_receivesBindingContext() {
+    void bindHeight_onChange_receivesBindingContext() {
         HasSizeComponent component = new HasSizeComponent();
         UI.getCurrent().add(component);
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasSizeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasSizeTest.java
@@ -32,28 +32,28 @@ class HasSizeTest {
     }
 
     @Test
-    public void setWidth() {
+    void setWidth() {
         HasSizeComponent c = new HasSizeComponent();
         c.setWidth("100px");
         assertEquals("100px", c.getWidth());
     }
 
     @Test
-    public void setMinWidth() {
+    void setMinWidth() {
         HasSizeComponent c = new HasSizeComponent();
         c.setMinWidth("100px");
         assertEquals("100px", c.getMinWidth());
     }
 
     @Test
-    public void setMaxWidth() {
+    void setMaxWidth() {
         HasSizeComponent c = new HasSizeComponent();
         c.setMaxWidth("100px");
         assertEquals("100px", c.getMaxWidth());
     }
 
     @Test
-    public void removeWidth() {
+    void removeWidth() {
         HasSizeComponent c = new HasSizeComponent();
         c.setWidth("100px");
         assertEquals("100px", c.getWidth());
@@ -63,7 +63,7 @@ class HasSizeTest {
     }
 
     @Test
-    public void removeMinWidth() {
+    void removeMinWidth() {
         HasSizeComponent c = new HasSizeComponent();
         c.setMinWidth("100px");
         assertEquals("100px", c.getMinWidth());
@@ -73,7 +73,7 @@ class HasSizeTest {
     }
 
     @Test
-    public void removeMaxWidth() {
+    void removeMaxWidth() {
         HasSizeComponent c = new HasSizeComponent();
         c.setMaxWidth("100px");
         assertEquals("100px", c.getMaxWidth());
@@ -83,28 +83,28 @@ class HasSizeTest {
     }
 
     @Test
-    public void setHeight() {
+    void setHeight() {
         HasSizeComponent c = new HasSizeComponent();
         c.setHeight("100px");
         assertEquals("100px", c.getHeight());
     }
 
     @Test
-    public void setMinHeight() {
+    void setMinHeight() {
         HasSizeComponent c = new HasSizeComponent();
         c.setMinHeight("100px");
         assertEquals("100px", c.getMinHeight());
     }
 
     @Test
-    public void setMaxHeight() {
+    void setMaxHeight() {
         HasSizeComponent c = new HasSizeComponent();
         c.setMaxHeight("100px");
         assertEquals("100px", c.getMaxHeight());
     }
 
     @Test
-    public void removeHeight() {
+    void removeHeight() {
         HasSizeComponent c = new HasSizeComponent();
         c.setHeight("100px");
         assertEquals("100px", c.getHeight());
@@ -114,7 +114,7 @@ class HasSizeTest {
     }
 
     @Test
-    public void removeMinHeight() {
+    void removeMinHeight() {
         HasSizeComponent c = new HasSizeComponent();
         c.setMinHeight("100px");
         assertEquals("100px", c.getMinHeight());
@@ -124,7 +124,7 @@ class HasSizeTest {
     }
 
     @Test
-    public void removeMaxHeight() {
+    void removeMaxHeight() {
         HasSizeComponent c = new HasSizeComponent();
         c.setMaxHeight("100px");
         assertEquals("100px", c.getMaxHeight());
@@ -134,7 +134,7 @@ class HasSizeTest {
     }
 
     @Test
-    public void setSizeFull() {
+    void setSizeFull() {
         HasSizeComponent component = new HasSizeComponent();
         component.setSizeFull();
 
@@ -143,7 +143,7 @@ class HasSizeTest {
     }
 
     @Test
-    public void setSizeFull_addsDataAttribute() {
+    void setSizeFull_addsDataAttribute() {
         HasSizeComponent component = new HasSizeComponent();
         component.setSizeFull();
 
@@ -154,7 +154,7 @@ class HasSizeTest {
     }
 
     @Test
-    public void setSizeFull_setSize_removesDataAttribute() {
+    void setSizeFull_setSize_removesDataAttribute() {
         HasSizeComponent component = new HasSizeComponent();
         component.setSizeFull();
 
@@ -172,7 +172,7 @@ class HasSizeTest {
     }
 
     @Test
-    public void setSizeFull_setSizeUndefined_removesDataAttribute() {
+    void setSizeFull_setSizeUndefined_removesDataAttribute() {
         HasSizeComponent component = new HasSizeComponent();
         component.setSizeFull();
         component.setSizeUndefined();
@@ -184,7 +184,7 @@ class HasSizeTest {
     }
 
     @Test
-    public void setWidthFull() {
+    void setWidthFull() {
         HasSizeComponent component = new HasSizeComponent();
         component.setWidthFull();
 
@@ -192,7 +192,7 @@ class HasSizeTest {
     }
 
     @Test
-    public void setWidthFull_addsDataAttribute() {
+    void setWidthFull_addsDataAttribute() {
         HasSizeComponent component = new HasSizeComponent();
         component.setWidthFull();
 
@@ -203,7 +203,7 @@ class HasSizeTest {
     }
 
     @Test
-    public void setWidthFull_setWidth_removesDataAttribute() {
+    void setWidthFull_setWidth_removesDataAttribute() {
         HasSizeComponent component = new HasSizeComponent();
         component.setWidthFull();
         component.setWidth("10px");
@@ -215,7 +215,7 @@ class HasSizeTest {
     }
 
     @Test
-    public void setHeightFull() {
+    void setHeightFull() {
         HasSizeComponent component = new HasSizeComponent();
         component.setHeightFull();
 
@@ -223,7 +223,7 @@ class HasSizeTest {
     }
 
     @Test
-    public void setHeightFull_addsDataAttribute() {
+    void setHeightFull_addsDataAttribute() {
         HasSizeComponent component = new HasSizeComponent();
         component.setHeightFull();
 
@@ -234,7 +234,7 @@ class HasSizeTest {
     }
 
     @Test
-    public void setHeightFull_setHeight_removesDataAttribute() {
+    void setHeightFull_setHeight_removesDataAttribute() {
         HasSizeComponent component = new HasSizeComponent();
         component.setHeightFull();
         component.setHeight("10px");
@@ -246,7 +246,7 @@ class HasSizeTest {
     }
 
     @Test
-    public void setSizeUndefined() {
+    void setSizeUndefined() {
         HasSizeComponent component = new HasSizeComponent();
         component.setWidth("10px");
         component.setHeight("5em");
@@ -258,7 +258,7 @@ class HasSizeTest {
     }
 
     @Test
-    public void getWidthUnit() {
+    void getWidthUnit() {
         HasSizeComponent component = new HasSizeComponent();
         assertFalse(component.getWidthUnit().isPresent());
 
@@ -271,7 +271,7 @@ class HasSizeTest {
     }
 
     @Test
-    public void getHeightUnit() {
+    void getHeightUnit() {
         HasSizeComponent component = new HasSizeComponent();
         assertFalse(component.getHeightUnit().isPresent());
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasSizeUnitTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasSizeUnitTest.java
@@ -31,7 +31,7 @@ class HasSizeUnitTest {
     }
 
     @Test
-    public void setWidthFloat() {
+    void setWidthFloat() {
         HasSizeComponent c = new HasSizeComponent();
         for (Unit unit : Unit.values()) {
             c.setWidth(100, unit);
@@ -40,7 +40,7 @@ class HasSizeUnitTest {
     }
 
     @Test
-    public void setMinWidthFloat() {
+    void setMinWidthFloat() {
         HasSizeComponent c = new HasSizeComponent();
         for (Unit unit : Unit.values()) {
             c.setMinWidth(100, unit);
@@ -49,7 +49,7 @@ class HasSizeUnitTest {
     }
 
     @Test
-    public void setMaxWidthFloat() {
+    void setMaxWidthFloat() {
         HasSizeComponent c = new HasSizeComponent();
         for (Unit unit : Unit.values()) {
             c.setMaxWidth(100, unit);
@@ -58,7 +58,7 @@ class HasSizeUnitTest {
     }
 
     @Test
-    public void setHeightFloat() {
+    void setHeightFloat() {
         HasSizeComponent c = new HasSizeComponent();
         for (Unit unit : Unit.values()) {
             c.setHeight(100, unit);
@@ -67,7 +67,7 @@ class HasSizeUnitTest {
     }
 
     @Test
-    public void setMinHeightFloat() {
+    void setMinHeightFloat() {
         HasSizeComponent c = new HasSizeComponent();
         for (Unit unit : Unit.values()) {
             c.setMinHeight(100, unit);
@@ -76,7 +76,7 @@ class HasSizeUnitTest {
     }
 
     @Test
-    public void setMaxHeightFloat() {
+    void setMaxHeightFloat() {
         HasSizeComponent c = new HasSizeComponent();
         for (Unit unit : Unit.values()) {
             c.setMaxHeight(100, unit);
@@ -85,7 +85,7 @@ class HasSizeUnitTest {
     }
 
     @Test
-    public void getUnit() {
+    void getUnit() {
         for (Unit unit : Unit.values()) {
             String cssSize = 100f + unit.toString();
             Optional<Unit> theUnit = Unit.getUnit(cssSize);
@@ -95,7 +95,7 @@ class HasSizeUnitTest {
     }
 
     @Test
-    public void getSize() {
+    void getSize() {
         for (Unit unit : Unit.values()) {
             String cssSize = 100f + unit.toString();
             float size = Unit.getSize(cssSize);
@@ -109,7 +109,7 @@ class HasSizeUnitTest {
     }
 
     @Test
-    public void getSizeException() {
+    void getSizeException() {
         assertThrows(NumberFormatException.class, () -> {
             String cssSize = "10a0px";
             float size = Unit.getSize(cssSize);
@@ -117,7 +117,7 @@ class HasSizeUnitTest {
     }
 
     @Test
-    public void getSizeNoUnit() {
+    void getSizeNoUnit() {
         assertThrows(IllegalArgumentException.class, () -> {
             String cssSize = "100";
             float size = Unit.getSize(cssSize);
@@ -125,7 +125,7 @@ class HasSizeUnitTest {
     }
 
     @Test
-    public void getSizeNoValidUnit() {
+    void getSizeNoValidUnit() {
         assertThrows(IllegalArgumentException.class, () -> {
             String cssSize = "100p";
             float size = Unit.getSize(cssSize);

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasStyleSignalTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasStyleSignalTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests for
  * {@link HasStyle#bindClassName(String, com.vaadin.flow.signals.Signal)}.
  */
-public class HasStyleSignalTest extends SignalsUnitTest {
+class HasStyleSignalTest extends SignalsUnitTest {
 
     @Tag("div")
     public static class HasStyleComponent extends Component
@@ -37,7 +37,7 @@ public class HasStyleSignalTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindClassName_signalBound_classNameToggledWhenAttached() {
+    void bindClassName_signalBound_classNameToggledWhenAttached() {
         HasStyleComponent component = new HasStyleComponent();
         UI.getCurrent().add(component);
 
@@ -54,7 +54,7 @@ public class HasStyleSignalTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindClassName_signalTrue_classNameAdded() {
+    void bindClassName_signalTrue_classNameAdded() {
         HasStyleComponent component = new HasStyleComponent();
         UI.getCurrent().add(component);
 
@@ -65,7 +65,7 @@ public class HasStyleSignalTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindClassName_attachedThenDetached_stopsUpdates() {
+    void bindClassName_attachedThenDetached_stopsUpdates() {
         HasStyleComponent component = new HasStyleComponent();
         UI.getCurrent().add(component);
 
@@ -82,7 +82,7 @@ public class HasStyleSignalTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindClassName_multipleClassNames_independentBindings() {
+    void bindClassName_multipleClassNames_independentBindings() {
         HasStyleComponent component = new HasStyleComponent();
         UI.getCurrent().add(component);
 
@@ -104,7 +104,7 @@ public class HasStyleSignalTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindClassName_addClassNameWhileBound_throwsException() {
+    void bindClassName_addClassNameWhileBound_throwsException() {
         HasStyleComponent component = new HasStyleComponent();
         UI.getCurrent().add(component);
 
@@ -116,7 +116,7 @@ public class HasStyleSignalTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindClassName_bindAgainWhileBound_throwsException() {
+    void bindClassName_bindAgainWhileBound_throwsException() {
         HasStyleComponent component = new HasStyleComponent();
         UI.getCurrent().add(component);
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasStyleTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasStyleTest.java
@@ -38,7 +38,7 @@ class HasStyleTest {
     }
 
     @Test
-    public void addClassName() {
+    void addClassName() {
         HasStyleComponent component = new HasStyleComponent();
         component.addClassName("foo");
         assertClasses(component, "foo");
@@ -52,7 +52,7 @@ class HasStyleTest {
     }
 
     @Test
-    public void setClassName_useClassList() {
+    void setClassName_useClassList() {
         HasStyleComponent component = new HasStyleComponent();
         component.setClassName("foo bar");
 
@@ -61,7 +61,7 @@ class HasStyleTest {
     }
 
     @Test
-    public void removeClassName() {
+    void removeClassName() {
         HasStyleComponent component = new HasStyleComponent();
         component.setClassName("foo Bar baz");
         component.removeClassName("foo");
@@ -81,7 +81,7 @@ class HasStyleTest {
     }
 
     @Test
-    public void setClassName() {
+    void setClassName() {
         HasStyleComponent component = new HasStyleComponent();
         component.setClassName("foo");
         assertClasses(component, "foo");
@@ -101,7 +101,7 @@ class HasStyleTest {
     }
 
     @Test
-    public void getClassName() {
+    void getClassName() {
         HasStyleComponent component = new HasStyleComponent();
         component.setClassName("foo");
         assertEquals("foo", component.getClassName());
@@ -110,7 +110,7 @@ class HasStyleTest {
     }
 
     @Test
-    public void setClassNameToggle() {
+    void setClassNameToggle() {
         HasStyleComponent component = new HasStyleComponent();
         component.setClassName("foo", false);
         assertClasses(component);
@@ -128,7 +128,7 @@ class HasStyleTest {
     }
 
     @Test
-    public void hasClassName() {
+    void hasClassName() {
         HasStyleComponent component = new HasStyleComponent();
         assertFalse(component.hasClassName("foo"));
         component.setClassName("foo");
@@ -141,7 +141,7 @@ class HasStyleTest {
     }
 
     @Test
-    public void getClassList_elementClassList() {
+    void getClassList_elementClassList() {
         HasStyleComponent component = new HasStyleComponent();
 
         assertEquals(component.getElement().getClassList(),
@@ -149,7 +149,7 @@ class HasStyleTest {
     }
 
     @Test
-    public void testAddClassNames() {
+    void testAddClassNames() {
         HasStyleComponent component = new HasStyleComponent();
         component.addClassNames();
         assertClasses(component);
@@ -167,7 +167,7 @@ class HasStyleTest {
     }
 
     @Test
-    public void testRemoveClassNames() {
+    void testRemoveClassNames() {
         HasStyleComponent component = new HasStyleComponent();
         component.setClassName("foo bar baz1 baz2 foo2 bar1");
 
@@ -182,7 +182,7 @@ class HasStyleTest {
     }
 
     @Test
-    public void addClassNames_extraSpacesBetweenAndAroundClassNames_validationPasses() {
+    void addClassNames_extraSpacesBetweenAndAroundClassNames_validationPasses() {
         HasStyleComponent component = new HasStyleComponent();
         component.addClassNames("   foo  bar    baz");
 
@@ -195,7 +195,7 @@ class HasStyleTest {
     }
 
     @Test
-    public void removeClassNames_extraSpacesBetweenAndAroundClassNames_validationPasses() {
+    void removeClassNames_extraSpacesBetweenAndAroundClassNames_validationPasses() {
         HasStyleComponent component = new HasStyleComponent();
         component.addClassNames("foo", "bar", "baz");
         component.removeClassNames("   foo  bar    baz");
@@ -205,35 +205,35 @@ class HasStyleTest {
     }
 
     @Test
-    public void addClassNames_addEmptyClassName_throws() {
+    void addClassNames_addEmptyClassName_throws() {
         HasStyleComponent component = new HasStyleComponent();
         assertThrows(IllegalArgumentException.class,
                 () -> component.addClassNames(" "));
     }
 
     @Test
-    public void addClassNames_addNullClassName_throws() {
+    void addClassNames_addNullClassName_throws() {
         HasStyleComponent component = new HasStyleComponent();
         assertThrows(IllegalArgumentException.class,
                 () -> component.addClassNames(null, null));
     }
 
     @Test
-    public void removeClassNames_removeEmptyClassName_throws() {
+    void removeClassNames_removeEmptyClassName_throws() {
         HasStyleComponent component = new HasStyleComponent();
         assertThrows(IllegalArgumentException.class,
                 () -> component.removeClassNames(" "));
     }
 
     @Test
-    public void removeClassNames_removeNullClassName_throws() {
+    void removeClassNames_removeNullClassName_throws() {
         HasStyleComponent component = new HasStyleComponent();
         assertThrows(IllegalArgumentException.class,
                 () -> component.removeClassNames(null, null));
     }
 
     @Test
-    public void setColorScheme_setsInlineStyleProperty() {
+    void setColorScheme_setsInlineStyleProperty() {
         HasStyleComponent component = new HasStyleComponent();
 
         component.getStyle().setColorScheme(ColorScheme.Value.DARK);
@@ -250,7 +250,7 @@ class HasStyleTest {
     }
 
     @Test
-    public void getColorScheme_retrievesSetValue() {
+    void getColorScheme_retrievesSetValue() {
         HasStyleComponent component = new HasStyleComponent();
 
         component.getStyle().setColorScheme(ColorScheme.Value.DARK);
@@ -263,7 +263,7 @@ class HasStyleTest {
     }
 
     @Test
-    public void setColorScheme_nullClearsProperty() {
+    void setColorScheme_nullClearsProperty() {
         HasStyleComponent component = new HasStyleComponent();
 
         component.getStyle().setColorScheme(ColorScheme.Value.DARK);
@@ -277,7 +277,7 @@ class HasStyleTest {
     }
 
     @Test
-    public void setColorScheme_normalClearsProperty() {
+    void setColorScheme_normalClearsProperty() {
         HasStyleComponent component = new HasStyleComponent();
 
         component.getStyle().setColorScheme(ColorScheme.Value.DARK);
@@ -291,7 +291,7 @@ class HasStyleTest {
     }
 
     @Test
-    public void colorScheme_roundtripWorks() {
+    void colorScheme_roundtripWorks() {
         HasStyleComponent component = new HasStyleComponent();
 
         for (ColorScheme.Value value : ColorScheme.Value.values()) {
@@ -306,7 +306,7 @@ class HasStyleTest {
     }
 
     @Test
-    public void getColorScheme_notSet_returnsNormal() {
+    void getColorScheme_notSet_returnsNormal() {
         HasStyleComponent component = new HasStyleComponent();
         assertEquals(ColorScheme.Value.NORMAL,
                 component.getStyle().getColorScheme());

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasTextTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasTextTest.java
@@ -35,7 +35,7 @@ class HasTextTest {
     private HasText hasText = Mockito.mock(HasText.class);
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         Element element = ElementFactory.createDiv();
         Mockito.when(hasText.getElement()).thenReturn(element);
 
@@ -46,7 +46,7 @@ class HasTextTest {
     }
 
     @Test
-    public void setWhiteSpace_styleIsSet() {
+    void setWhiteSpace_styleIsSet() {
         hasText.setWhiteSpace(WhiteSpace.NOWRAP);
 
         assertEquals("nowrap",
@@ -54,25 +54,25 @@ class HasTextTest {
     }
 
     @Test
-    public void getWhiteSpace_getStyleValue() {
+    void getWhiteSpace_getStyleValue() {
         hasText.getElement().getStyle().setWhiteSpace(Style.WhiteSpace.INHERIT);
         assertEquals(WhiteSpace.INHERIT, hasText.getWhiteSpace());
     }
 
     @Test
-    public void getWhiteSpace_noStyleIsSet_normalIsReturned() {
+    void getWhiteSpace_noStyleIsSet_normalIsReturned() {
         assertEquals(WhiteSpace.NORMAL, hasText.getWhiteSpace());
     }
 
     @Test
-    public void getWhiteSpace_notStandardValue_nullIsReturned() {
+    void getWhiteSpace_notStandardValue_nullIsReturned() {
         hasText.getElement().getStyle().set("white-space", "foo");
 
         assertEquals(null, hasText.getWhiteSpace());
     }
 
     @Test
-    public void setText_throwsWhenChildrenBindingActive() {
+    void setText_throwsWhenChildrenBindingActive() {
         SignalBindingFeature feature = hasText.getElement().getNode()
                 .getFeature(SignalBindingFeature.class);
         feature.setBinding(SignalBindingFeature.CHILDREN,
@@ -83,7 +83,7 @@ class HasTextTest {
     }
 
     @Test
-    public void bindText_throwsWhenChildrenBindingActive() {
+    void bindText_throwsWhenChildrenBindingActive() {
         SignalBindingFeature feature = hasText.getElement().getNode()
                 .getFeature(SignalBindingFeature.class);
         feature.setBinding(SignalBindingFeature.CHILDREN,

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasThemeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasThemeTest.java
@@ -35,7 +35,7 @@ class HasThemeTest {
     }
 
     @Test
-    public void addThemeName() {
+    void addThemeName() {
         HasThemeTest.HasThemeComponent component = new HasThemeTest.HasThemeComponent();
         component.addThemeName("foo");
         assertThemes(component, "foo");
@@ -49,7 +49,7 @@ class HasThemeTest {
     }
 
     @Test
-    public void setThemeName_useThemeList() {
+    void setThemeName_useThemeList() {
         HasThemeTest.HasThemeComponent component = new HasThemeTest.HasThemeComponent();
         component.setThemeName("foo bar");
 
@@ -58,7 +58,7 @@ class HasThemeTest {
     }
 
     @Test
-    public void removeThemeName() {
+    void removeThemeName() {
         HasThemeTest.HasThemeComponent component = new HasThemeTest.HasThemeComponent();
         component.setThemeName("foo Bar baz");
         component.removeThemeName("foo");
@@ -78,7 +78,7 @@ class HasThemeTest {
     }
 
     @Test
-    public void setThemeName() {
+    void setThemeName() {
         HasThemeTest.HasThemeComponent component = new HasThemeTest.HasThemeComponent();
         assertNull(component.getThemeName());
         component.setThemeName("foo");
@@ -94,7 +94,7 @@ class HasThemeTest {
     }
 
     @Test
-    public void getThemeName() {
+    void getThemeName() {
         HasThemeTest.HasThemeComponent component = new HasThemeTest.HasThemeComponent();
         assertNull(component.getThemeName());
         component.setThemeName("foo");
@@ -104,7 +104,7 @@ class HasThemeTest {
     }
 
     @Test
-    public void setThemeNameToggle() {
+    void setThemeNameToggle() {
         HasThemeTest.HasThemeComponent component = new HasThemeTest.HasThemeComponent();
         component.setThemeName("foo", false);
         assertThemes(component);
@@ -122,7 +122,7 @@ class HasThemeTest {
     }
 
     @Test
-    public void hasThemeName() {
+    void hasThemeName() {
         HasThemeTest.HasThemeComponent component = new HasThemeTest.HasThemeComponent();
         assertFalse(component.hasThemeName("foo"));
         component.setThemeName("foo");
@@ -135,7 +135,7 @@ class HasThemeTest {
     }
 
     @Test
-    public void getThemeList_elementThemeList() {
+    void getThemeList_elementThemeList() {
         HasThemeTest.HasThemeComponent component = new HasThemeTest.HasThemeComponent();
 
         assertEquals(component.getElement().getThemeList().isEmpty(),
@@ -143,7 +143,7 @@ class HasThemeTest {
     }
 
     @Test
-    public void testAddThemeNames() {
+    void testAddThemeNames() {
         HasThemeTest.HasThemeComponent component = new HasThemeTest.HasThemeComponent();
         component.addThemeNames();
         assertThemes(component);
@@ -154,7 +154,7 @@ class HasThemeTest {
     }
 
     @Test
-    public void testRemoveThemeNames() {
+    void testRemoveThemeNames() {
         HasThemeTest.HasThemeComponent component = new HasThemeTest.HasThemeComponent();
         component.setThemeName("foo bar baz1 baz2 foo2 bar1");
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasValueBindReadOnlyTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasValueBindReadOnlyTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class HasValueBindReadOnlyTest extends SignalsUnitTest {
 
     @Test
-    public void bindReadOnly_elementAttachedBefore_bindingActive() {
+    void bindReadOnly_elementAttachedBefore_bindingActive() {
         TestComponent component = new TestComponent();
         // attach before bindReadOnly
         UI.getCurrent().add(component);
@@ -45,7 +45,7 @@ class HasValueBindReadOnlyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindReadOnly_elementAttachedAfter_bindingActive() {
+    void bindReadOnly_elementAttachedAfter_bindingActive() {
         TestComponent component = new TestComponent();
         assertFalse(component.isReadOnly());
 
@@ -58,7 +58,7 @@ class HasValueBindReadOnlyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindReadOnly_elementAttached_bindingActive() {
+    void bindReadOnly_elementAttached_bindingActive() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
         ValueSignal<Boolean> signal = new ValueSignal<>(true);
@@ -77,7 +77,7 @@ class HasValueBindReadOnlyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindReadOnly_elementNotAttached_bindingInactive() {
+    void bindReadOnly_elementNotAttached_bindingInactive() {
         TestComponent component = new TestComponent();
         ValueSignal<Boolean> signal = new ValueSignal<>(true);
         component.bindReadOnly(signal);
@@ -91,7 +91,7 @@ class HasValueBindReadOnlyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindReadOnly_elementDetached_bindingInactive() {
+    void bindReadOnly_elementDetached_bindingInactive() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
         ValueSignal<Boolean> signal = new ValueSignal<>(true);
@@ -103,7 +103,7 @@ class HasValueBindReadOnlyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindReadOnly_elementReAttached_bindingActivate() {
+    void bindReadOnly_elementReAttached_bindingActivate() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
         ValueSignal<Boolean> signal = new ValueSignal<>(true);
@@ -116,7 +116,7 @@ class HasValueBindReadOnlyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindReadOnly_bindOrSetReadOnlyWhileBindingIsActive_throwException() {
+    void bindReadOnly_bindOrSetReadOnlyWhileBindingIsActive_throwException() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
         component.bindReadOnly(new ValueSignal<>(true));
@@ -129,7 +129,7 @@ class HasValueBindReadOnlyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindReadOnly_nullSignal_throwsNPE() {
+    void bindReadOnly_nullSignal_throwsNPE() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -138,7 +138,7 @@ class HasValueBindReadOnlyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindReadOnly_nullSignalValue_setsReadOnlyToFalse() {
+    void bindReadOnly_nullSignalValue_setsReadOnlyToFalse() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
         ValueSignal<Boolean> signal = new ValueSignal<>(true);
@@ -151,7 +151,7 @@ class HasValueBindReadOnlyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindReadOnly_toggleSignalValue_readOnlyUpdates() {
+    void bindReadOnly_toggleSignalValue_readOnlyUpdates() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
         ValueSignal<Boolean> signal = new ValueSignal<>(false);

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasValueBindRequiredIndicatorVisibleTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasValueBindRequiredIndicatorVisibleTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class HasValueBindRequiredIndicatorVisibleTest extends SignalsUnitTest {
 
     @Test
-    public void bindRequired_elementAttachedBefore_bindingActive() {
+    void bindRequired_elementAttachedBefore_bindingActive() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
         assertFalse(component.isRequiredIndicatorVisible());
@@ -44,7 +44,7 @@ class HasValueBindRequiredIndicatorVisibleTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindRequired_elementAttachedAfter_bindingActive() {
+    void bindRequired_elementAttachedAfter_bindingActive() {
         TestComponent component = new TestComponent();
         assertFalse(component.isRequiredIndicatorVisible());
 
@@ -56,7 +56,7 @@ class HasValueBindRequiredIndicatorVisibleTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindRequired_elementAttached_bindingActive() {
+    void bindRequired_elementAttached_bindingActive() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
         ValueSignal<Boolean> signal = new ValueSignal<>(true);
@@ -75,7 +75,7 @@ class HasValueBindRequiredIndicatorVisibleTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindRequired_elementNotAttached_bindingInactive() {
+    void bindRequired_elementNotAttached_bindingInactive() {
         TestComponent component = new TestComponent();
         ValueSignal<Boolean> signal = new ValueSignal<>(true);
         component.bindRequiredIndicatorVisible(signal);
@@ -89,7 +89,7 @@ class HasValueBindRequiredIndicatorVisibleTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindRequired_elementDetached_bindingInactive() {
+    void bindRequired_elementDetached_bindingInactive() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
         ValueSignal<Boolean> signal = new ValueSignal<>(true);
@@ -101,7 +101,7 @@ class HasValueBindRequiredIndicatorVisibleTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindRequired_elementReAttached_bindingActivate() {
+    void bindRequired_elementReAttached_bindingActivate() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
         ValueSignal<Boolean> signal = new ValueSignal<>(true);
@@ -114,7 +114,7 @@ class HasValueBindRequiredIndicatorVisibleTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindRequired_bindOrSetRequiredWhileBindingIsActive_throwException() {
+    void bindRequired_bindOrSetRequiredWhileBindingIsActive_throwException() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
         component.bindRequiredIndicatorVisible(new ValueSignal<>(true));
@@ -127,7 +127,7 @@ class HasValueBindRequiredIndicatorVisibleTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindRequired_nullSignal_throwsNPE() {
+    void bindRequired_nullSignal_throwsNPE() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -136,7 +136,7 @@ class HasValueBindRequiredIndicatorVisibleTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindRequired_nullSignalValue_setsRequiredToFalse() {
+    void bindRequired_nullSignalValue_setsRequiredToFalse() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
         ValueSignal<Boolean> signal = new ValueSignal<>(true);
@@ -149,7 +149,7 @@ class HasValueBindRequiredIndicatorVisibleTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindRequired_toggleSignalValue_requiredUpdates() {
+    void bindRequired_toggleSignalValue_requiredUpdates() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
         ValueSignal<Boolean> signal = new ValueSignal<>(false);

--- a/flow-server/src/test/java/com/vaadin/flow/component/HtmlBindHtmlContentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HtmlBindHtmlContentTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class HtmlBindHtmlContentTest extends SignalsUnitTest {
 
     @Test
-    public void bindHtmlContent_componentAttachedBefore_bindingActive() {
+    void bindHtmlContent_componentAttachedBefore_bindingActive() {
         Html html = new Html("<div id='a'>init</div>");
         // attach before bind
         UI.getCurrent().add(html);
@@ -44,7 +44,7 @@ class HtmlBindHtmlContentTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindHtmlContent_componentAttachedAfter_bindingActive() {
+    void bindHtmlContent_componentAttachedAfter_bindingActive() {
         Html html = new Html("<div id='a'>init</div>");
         ValueSignal<String> signal = new ValueSignal<>(
                 "<div id='b'>after</div>");
@@ -58,7 +58,7 @@ class HtmlBindHtmlContentTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindHtmlContent_componentAttached_bindingActive_updatesOnChange() {
+    void bindHtmlContent_componentAttached_bindingActive_updatesOnChange() {
         Html html = new Html("<div id='a'>init</div>");
         UI.getCurrent().add(html);
 
@@ -75,7 +75,7 @@ class HtmlBindHtmlContentTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindHtmlContent_componentNotAttached_bindingInactive() {
+    void bindHtmlContent_componentNotAttached_bindingInactive() {
         Html html = new Html("<div id='a'>init</div>");
         ValueSignal<String> signal = new ValueSignal<>(
                 "<div id='b'>after</div>");
@@ -92,7 +92,7 @@ class HtmlBindHtmlContentTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindHtmlContent_componentDetached_bindingInactive() {
+    void bindHtmlContent_componentDetached_bindingInactive() {
         Html html = new Html("<div id='a'>init</div>");
         UI.getCurrent().add(html);
         ValueSignal<String> signal = new ValueSignal<>(
@@ -109,7 +109,7 @@ class HtmlBindHtmlContentTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindHtmlContent_componentReAttached_bindingActivate() {
+    void bindHtmlContent_componentReAttached_bindingActivate() {
         Html html = new Html("<div id='a'>init</div>");
         UI.getCurrent().add(html);
         ValueSignal<String> signal = new ValueSignal<>(
@@ -128,7 +128,7 @@ class HtmlBindHtmlContentTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindHtmlContent_withNullValue_recordsErrorAndDoesNotChange() {
+    void bindHtmlContent_withNullValue_recordsErrorAndDoesNotChange() {
         Html html = new Html("<div id='a'>init</div>");
         UI.getCurrent().add(html);
         ValueSignal<String> signal = new ValueSignal<>(
@@ -151,7 +151,7 @@ class HtmlBindHtmlContentTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindHtmlContent_nullSignal_throwsNPE() {
+    void bindHtmlContent_nullSignal_throwsNPE() {
         Html html = new Html("<div id='a'>init</div>");
         UI.getCurrent().add(html);
 
@@ -160,7 +160,7 @@ class HtmlBindHtmlContentTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindHtmlContent_setterAndRebindWhileActive_throwException() {
+    void bindHtmlContent_setterAndRebindWhileActive_throwException() {
         Html html = new Html("<div id='a'>init</div>");
         UI.getCurrent().add(html);
         ValueSignal<String> signal = new ValueSignal<>(

--- a/flow-server/src/test/java/com/vaadin/flow/component/InvalidUrlTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/InvalidUrlTest.java
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 class InvalidUrlTest {
 
     @Test
-    public void invalidUrlAtInitialization_uiInitialiazesWith404ReturnCode()
+    void invalidUrlAtInitialization_uiInitialiazesWith404ReturnCode()
             throws InvalidRouteConfigurationException, ServiceException {
         UI ui = new UI();
 
@@ -58,7 +58,7 @@ class InvalidUrlTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         CurrentInstance.clearAll();
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/JavaScriptInvocationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/JavaScriptInvocationTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 class JavaScriptInvocationTest {
     @Test
-    public void testSerializable() {
+    void testSerializable() {
         JavaScriptInvocation invocation = new UIInternals.JavaScriptInvocation(
                 "expression", "string", JacksonUtils.writeValue("jsonString"));
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/KeyTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/KeyTest.java
@@ -35,7 +35,7 @@ class KeyTest {
     }
 
     @Test
-    public void listenerWithMultipleKeyValues() {
+    void listenerWithMultipleKeyValues() {
         InputComponent input = new InputComponent();
         AtomicBoolean fired = new AtomicBoolean(false);
         input.addKeyPressListener(Key.of("foo", "bar"),
@@ -54,7 +54,7 @@ class KeyTest {
     }
 
     @Test
-    public void of_toString_returnsKeys() {
+    void of_toString_returnsKeys() {
         Key key = Key.of("foo");
 
         assertEquals("foo", key.toString());
@@ -65,7 +65,7 @@ class KeyTest {
     }
 
     @Test
-    public void of_equals_stringRepresentationsEqual_toKeysAreEqual() {
+    void of_equals_stringRepresentationsEqual_toKeysAreEqual() {
         Key key1 = Key.of("foo");
         Key key2 = Key.of("foo");
 
@@ -73,7 +73,7 @@ class KeyTest {
     }
 
     @Test
-    public void of_equals_stringRepresentationsNotEqual_toKeysAreNotEqual() {
+    void of_equals_stringRepresentationsNotEqual_toKeysAreNotEqual() {
         Key key1 = Key.of("foo");
         Key key2 = Key.of("bar");
 
@@ -81,7 +81,7 @@ class KeyTest {
     }
 
     @Test
-    public void of_equals_secondKeyHasAdditionalKeys_toKeysAreNotEqual() {
+    void of_equals_secondKeyHasAdditionalKeys_toKeysAreNotEqual() {
         Key key1 = Key.of("foo");
         Key key2 = Key.of("foo", "bar");
 
@@ -89,7 +89,7 @@ class KeyTest {
     }
 
     @Test
-    public void of_equals_differentClasses_toKeysAreNotEqual() {
+    void of_equals_differentClasses_toKeysAreNotEqual() {
         Key key1 = Key.of("foo");
         Key key2 = new Key() {
 
@@ -103,7 +103,7 @@ class KeyTest {
     }
 
     @Test
-    public void of_equalKeys_hasSameHashCode() {
+    void of_equalKeys_hasSameHashCode() {
         Key key1 = Key.of("foo", "bar");
         Key key2 = Key.of("foo", "bar");
         assertEquals(key1.hashCode(), key2.hashCode());

--- a/flow-server/src/test/java/com/vaadin/flow/component/LocationObserverTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/LocationObserverTest.java
@@ -60,14 +60,14 @@ class LocationObserverTest {
     }
 
     @BeforeEach
-    public void init() throws NoSuchFieldException, SecurityException,
+    void init() throws NoSuchFieldException, SecurityException,
             IllegalArgumentException, IllegalAccessException {
         ui = new MockUI();
         eventCollector.clear();
     }
 
     @Test
-    public void navigation_and_locale_change_should_fire_locale_change_observer()
+    void navigation_and_locale_change_should_fire_locale_change_observer()
             throws InvalidRouteConfigurationException {
         router = new Router(new TestRouteRegistry());
         ui = new MockUI(router);
@@ -95,7 +95,7 @@ class LocationObserverTest {
     }
 
     @Test
-    public void location_change_should_only_fire_if_location_actually_changed() {
+    void location_change_should_only_fire_if_location_actually_changed() {
         ui.add(new Translations());
 
         assertEquals(1, eventCollector.size(),
@@ -121,7 +121,7 @@ class LocationObserverTest {
     }
 
     @Test
-    public void location_change_should_be_fired_also_on_component_attach() {
+    void location_change_should_be_fired_also_on_component_attach() {
         RootComponent root = new RootComponent();
 
         ui.add(root);
@@ -140,7 +140,7 @@ class LocationObserverTest {
     }
 
     @Test
-    public void location_change_should_be_fired_also_on_consequent_component_attach() {
+    void location_change_should_be_fired_also_on_consequent_component_attach() {
         RootComponent root = new RootComponent();
 
         ui.add(root);

--- a/flow-server/src/test/java/com/vaadin/flow/component/NpmPackageTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/NpmPackageTest.java
@@ -37,7 +37,7 @@ class NpmPackageTest {
     }
 
     @Test
-    public void testDummy() {
+    void testDummy() {
         Annotation[] annotations = TestComponent.class.getAnnotations();
 
         boolean found = Arrays.stream(annotations)

--- a/flow-server/src/test/java/com/vaadin/flow/component/PropertyDescriptorsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/PropertyDescriptorsTest.java
@@ -68,19 +68,19 @@ class PropertyDescriptorsTest {
             .propertyWithDefault(TEST_PROPERTY, true);
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         component = new TestComponent();
     }
 
     @Test
-    public void stringPropertyDefaultEmptyString_initial() {
+    void stringPropertyDefaultEmptyString_initial() {
         assertEquals(EMPTY_STRING, stringPropertyDefaultEmpty.get(component));
         assertFalse(component.getElement().hasProperty(TEST_PROPERTY));
         assertFalse(component.getElement().hasAttribute(TEST_PROPERTY));
     }
 
     @Test
-    public void stringPropertyDefaultEmptyString_setNonDefault() {
+    void stringPropertyDefaultEmptyString_setNonDefault() {
         stringPropertyDefaultEmpty.set(component, SOME_STRING_VALUE);
         assertEquals(SOME_STRING_VALUE,
                 stringPropertyDefaultEmpty.get(component));
@@ -90,7 +90,7 @@ class PropertyDescriptorsTest {
     }
 
     @Test
-    public void stringPropertyDefaultEmptyString_resetToDefault() {
+    void stringPropertyDefaultEmptyString_resetToDefault() {
         stringPropertyDefaultEmpty.set(component, SOME_STRING_VALUE);
         stringPropertyDefaultEmpty.set(component, EMPTY_STRING);
         assertEquals(EMPTY_STRING, stringPropertyDefaultEmpty.get(component));
@@ -99,21 +99,21 @@ class PropertyDescriptorsTest {
     }
 
     @Test
-    public void stringPropertyDefaultEmptyString_setToNull() {
+    void stringPropertyDefaultEmptyString_setToNull() {
         assertThrows(IllegalArgumentException.class, () -> {
             stringPropertyDefaultEmpty.set(component, null);
         });
     }
 
     @Test
-    public void stringPropertyDefaultFoo_initial() {
+    void stringPropertyDefaultFoo_initial() {
         assertEquals(FOO, stringPropertyDefaultFoo.get(component));
         assertFalse(component.getElement().hasProperty(TEST_PROPERTY));
         assertFalse(component.getElement().hasAttribute(TEST_PROPERTY));
     }
 
     @Test
-    public void stringPropertyDefaultFoo_setNonDefault() {
+    void stringPropertyDefaultFoo_setNonDefault() {
         stringPropertyDefaultFoo.set(component, SOME_STRING_VALUE);
         assertEquals(SOME_STRING_VALUE,
                 stringPropertyDefaultFoo.get(component));
@@ -123,7 +123,7 @@ class PropertyDescriptorsTest {
     }
 
     @Test
-    public void stringPropertyDefaultFoo_resetToDefault() {
+    void stringPropertyDefaultFoo_resetToDefault() {
         stringPropertyDefaultFoo.set(component, SOME_STRING_VALUE);
         stringPropertyDefaultFoo.set(component, FOO);
         assertEquals(FOO, stringPropertyDefaultFoo.get(component));
@@ -132,21 +132,21 @@ class PropertyDescriptorsTest {
     }
 
     @Test
-    public void stringPropertyDefaultFoo_setToNull() {
+    void stringPropertyDefaultFoo_setToNull() {
         assertThrows(IllegalArgumentException.class, () -> {
             stringPropertyDefaultFoo.set(component, null);
         });
     }
 
     @Test
-    public void integerPropertyDefaultZero_initial() {
+    void integerPropertyDefaultZero_initial() {
         assertEquals(ZERO, integerPropertyDefaultZero.get(component));
         assertFalse(component.getElement().hasProperty(TEST_PROPERTY));
         assertFalse(component.getElement().hasAttribute(TEST_PROPERTY));
     }
 
     @Test
-    public void integerPropertyDefaultZero_setNonDefault() {
+    void integerPropertyDefaultZero_setNonDefault() {
         integerPropertyDefaultZero.set(component, SOME_INTEGER_VALUE);
         assertEquals(SOME_INTEGER_VALUE,
                 integerPropertyDefaultZero.get(component));
@@ -156,7 +156,7 @@ class PropertyDescriptorsTest {
     }
 
     @Test
-    public void integerPropertyDefaultZero_resetToDefault() {
+    void integerPropertyDefaultZero_resetToDefault() {
         integerPropertyDefaultZero.set(component, SOME_INTEGER_VALUE);
         integerPropertyDefaultZero.set(component, ZERO);
         assertEquals(ZERO, integerPropertyDefaultZero.get(component));
@@ -165,21 +165,21 @@ class PropertyDescriptorsTest {
     }
 
     @Test
-    public void integerPropertyDefaultZero_setToNull() {
+    void integerPropertyDefaultZero_setToNull() {
         assertThrows(IllegalArgumentException.class, () -> {
             integerPropertyDefaultZero.set(component, null);
         });
     }
 
     @Test
-    public void integerPropertyDefaultOne_initial() {
+    void integerPropertyDefaultOne_initial() {
         assertEquals(ONE, integerPropertyDefaultOne.get(component));
         assertFalse(component.getElement().hasProperty(TEST_PROPERTY));
         assertFalse(component.getElement().hasAttribute(TEST_PROPERTY));
     }
 
     @Test
-    public void integerPropertyDefaultOne_setNonDefault() {
+    void integerPropertyDefaultOne_setNonDefault() {
         integerPropertyDefaultOne.set(component, SOME_INTEGER_VALUE);
         assertEquals(SOME_INTEGER_VALUE,
                 integerPropertyDefaultOne.get(component));
@@ -189,7 +189,7 @@ class PropertyDescriptorsTest {
     }
 
     @Test
-    public void integerPropertyDefaultOne_resetToDefault() {
+    void integerPropertyDefaultOne_resetToDefault() {
         integerPropertyDefaultOne.set(component, SOME_INTEGER_VALUE);
         integerPropertyDefaultOne.set(component, ONE);
         assertEquals(ONE, integerPropertyDefaultOne.get(component));
@@ -198,21 +198,21 @@ class PropertyDescriptorsTest {
     }
 
     @Test
-    public void integerPropertyDefaultOne_setToNull() {
+    void integerPropertyDefaultOne_setToNull() {
         assertThrows(IllegalArgumentException.class, () -> {
             integerPropertyDefaultOne.set(component, null);
         });
     }
 
     @Test
-    public void doublePropertyDefaultZero_initial() {
+    void doublePropertyDefaultZero_initial() {
         assertEquals(ZERO_DOUBLE, doublePropertyDefaultZero.get(component));
         assertFalse(component.getElement().hasProperty(TEST_PROPERTY));
         assertFalse(component.getElement().hasAttribute(TEST_PROPERTY));
     }
 
     @Test
-    public void doublePropertyDefaultZero_setNonDefault() {
+    void doublePropertyDefaultZero_setNonDefault() {
         doublePropertyDefaultZero.set(component, SOME_DOUBLE_VALUE);
         assertEquals(SOME_DOUBLE_VALUE,
                 doublePropertyDefaultZero.get(component));
@@ -222,7 +222,7 @@ class PropertyDescriptorsTest {
     }
 
     @Test
-    public void doublePropertyDefaultZero_resetToDefault() {
+    void doublePropertyDefaultZero_resetToDefault() {
         doublePropertyDefaultZero.set(component, SOME_DOUBLE_VALUE);
         doublePropertyDefaultZero.set(component, ZERO_DOUBLE);
         assertEquals(ZERO_DOUBLE, doublePropertyDefaultZero.get(component));
@@ -231,21 +231,21 @@ class PropertyDescriptorsTest {
     }
 
     @Test
-    public void doublePropertyDefaultZero_setToNull() {
+    void doublePropertyDefaultZero_setToNull() {
         assertThrows(IllegalArgumentException.class, () -> {
             doublePropertyDefaultZero.set(component, null);
         });
     }
 
     @Test
-    public void doublePropertyDefaultOne_initial() {
+    void doublePropertyDefaultOne_initial() {
         assertEquals(ONE_DOUBLE, doublePropertyDefaultOne.get(component));
         assertFalse(component.getElement().hasProperty(TEST_PROPERTY));
         assertFalse(component.getElement().hasAttribute(TEST_PROPERTY));
     }
 
     @Test
-    public void doublePropertyDefaultOne_setNonDefault() {
+    void doublePropertyDefaultOne_setNonDefault() {
         doublePropertyDefaultOne.set(component, SOME_DOUBLE_VALUE);
         assertEquals(SOME_DOUBLE_VALUE,
                 doublePropertyDefaultOne.get(component));
@@ -255,7 +255,7 @@ class PropertyDescriptorsTest {
     }
 
     @Test
-    public void doublePropertyDefaultOne_resetToDefault() {
+    void doublePropertyDefaultOne_resetToDefault() {
         doublePropertyDefaultOne.set(component, SOME_DOUBLE_VALUE);
         doublePropertyDefaultOne.set(component, ONE_DOUBLE);
         assertEquals(ONE_DOUBLE, doublePropertyDefaultOne.get(component));
@@ -264,21 +264,21 @@ class PropertyDescriptorsTest {
     }
 
     @Test
-    public void doublePropertyDefaultOne_setToNull() {
+    void doublePropertyDefaultOne_setToNull() {
         assertThrows(IllegalArgumentException.class, () -> {
             doublePropertyDefaultOne.set(component, null);
         });
     }
 
     @Test
-    public void booleanPropertyDefaultFalse_initial() {
+    void booleanPropertyDefaultFalse_initial() {
         assertEquals(false, booleanPropertyDefaultFalse.get(component));
         assertFalse(component.getElement().hasProperty(TEST_PROPERTY));
         assertFalse(component.getElement().hasAttribute(TEST_PROPERTY));
     }
 
     @Test
-    public void booleanPropertyDefaultFalse_setNonDefault() {
+    void booleanPropertyDefaultFalse_setNonDefault() {
         booleanPropertyDefaultFalse.set(component, true);
         assertEquals(true, booleanPropertyDefaultFalse.get(component));
         assertEquals(true, Boolean.valueOf(component.getElement()
@@ -287,7 +287,7 @@ class PropertyDescriptorsTest {
     }
 
     @Test
-    public void booleanPropertyDefaultFalse_resetToDefault() {
+    void booleanPropertyDefaultFalse_resetToDefault() {
         booleanPropertyDefaultFalse.set(component, true);
         booleanPropertyDefaultFalse.set(component, false);
         assertEquals(false, booleanPropertyDefaultFalse.get(component));
@@ -296,21 +296,21 @@ class PropertyDescriptorsTest {
     }
 
     @Test
-    public void booleanPropertyDefaultFalse_setToNull() {
+    void booleanPropertyDefaultFalse_setToNull() {
         assertThrows(IllegalArgumentException.class, () -> {
             booleanPropertyDefaultFalse.set(component, null);
         });
     }
 
     @Test
-    public void booleanPropertyDefaultTrue_initial() {
+    void booleanPropertyDefaultTrue_initial() {
         assertEquals(true, booleanPropertyDefaultTrue.get(component));
         assertFalse(component.getElement().hasProperty(TEST_PROPERTY));
         assertFalse(component.getElement().hasAttribute(TEST_PROPERTY));
     }
 
     @Test
-    public void booleanPropertyDefaultTrue_setNonDefault() {
+    void booleanPropertyDefaultTrue_setNonDefault() {
         booleanPropertyDefaultTrue.set(component, false);
         assertEquals(false, booleanPropertyDefaultTrue.get(component));
         assertEquals(false, Boolean.valueOf(component.getElement()
@@ -319,7 +319,7 @@ class PropertyDescriptorsTest {
     }
 
     @Test
-    public void booleanPropertyDefaultTrue_resetToDefault() {
+    void booleanPropertyDefaultTrue_resetToDefault() {
         booleanPropertyDefaultTrue.set(component, false);
         booleanPropertyDefaultTrue.set(component, true);
         assertEquals(true, booleanPropertyDefaultTrue.get(component));
@@ -328,21 +328,21 @@ class PropertyDescriptorsTest {
     }
 
     @Test
-    public void booleanPropertyDefaultTrue_setToNull() {
+    void booleanPropertyDefaultTrue_setToNull() {
         assertThrows(IllegalArgumentException.class, () -> {
             booleanPropertyDefaultTrue.set(component, null);
         });
     }
 
     @Test
-    public void stringAttributeDefaultEmpty_initial() {
+    void stringAttributeDefaultEmpty_initial() {
         assertEquals(EMPTY_STRING, stringAttributeDefaultEmpty.get(component));
         assertFalse(component.getElement().hasAttribute(TEST_PROPERTY));
         assertFalse(component.getElement().hasProperty(TEST_PROPERTY));
     }
 
     @Test
-    public void stringAttributeDefaultEmpty_setNonDefault() {
+    void stringAttributeDefaultEmpty_setNonDefault() {
         stringAttributeDefaultEmpty.set(component, SOME_STRING_VALUE);
         assertEquals(SOME_STRING_VALUE,
                 stringAttributeDefaultEmpty.get(component));
@@ -352,7 +352,7 @@ class PropertyDescriptorsTest {
     }
 
     @Test
-    public void stringAttributeDefaultEmpty_resetToDefault() {
+    void stringAttributeDefaultEmpty_resetToDefault() {
         stringAttributeDefaultEmpty.set(component, SOME_STRING_VALUE);
         stringAttributeDefaultEmpty.set(component, EMPTY_STRING);
         assertEquals(EMPTY_STRING, stringAttributeDefaultEmpty.get(component));
@@ -362,21 +362,21 @@ class PropertyDescriptorsTest {
     }
 
     @Test
-    public void stringAttributeDefaultEmpty_setToNull() {
+    void stringAttributeDefaultEmpty_setToNull() {
         assertThrows(IllegalArgumentException.class, () -> {
             stringAttributeDefaultEmpty.set(component, null);
         });
     }
 
     @Test
-    public void stringAttributeDefaultFoo_initial() {
+    void stringAttributeDefaultFoo_initial() {
         assertEquals(FOO, stringAttributeDefaultFoo.get(component));
         assertFalse(component.getElement().hasAttribute(TEST_PROPERTY));
         assertFalse(component.getElement().hasProperty(TEST_PROPERTY));
     }
 
     @Test
-    public void stringAttributeDefaultFoo_setNonDefault() {
+    void stringAttributeDefaultFoo_setNonDefault() {
         stringAttributeDefaultFoo.set(component, SOME_STRING_VALUE);
         assertEquals(SOME_STRING_VALUE,
                 stringAttributeDefaultFoo.get(component));
@@ -386,7 +386,7 @@ class PropertyDescriptorsTest {
     }
 
     @Test
-    public void stringAttributeDefaultFoo_resetToDefault() {
+    void stringAttributeDefaultFoo_resetToDefault() {
         stringAttributeDefaultFoo.set(component, SOME_STRING_VALUE);
         stringAttributeDefaultFoo.set(component, FOO);
         assertEquals(FOO, stringAttributeDefaultFoo.get(component));
@@ -396,14 +396,14 @@ class PropertyDescriptorsTest {
     }
 
     @Test
-    public void stringAttributeDefaultFoo_setToNull() {
+    void stringAttributeDefaultFoo_setToNull() {
         assertThrows(IllegalArgumentException.class, () -> {
             stringAttributeDefaultFoo.set(component, null);
         });
     }
 
     @Test
-    public void stringAttributeOptionalDefaultEmpty_initial() {
+    void stringAttributeOptionalDefaultEmpty_initial() {
         assertEquals(Optional.empty(),
                 stringAttributeOptionalDefaultEmpty.get(component));
         assertFalse(component.getElement().hasAttribute(TEST_PROPERTY));
@@ -411,7 +411,7 @@ class PropertyDescriptorsTest {
     }
 
     @Test
-    public void stringAttributeOptionalDefaultEmpty_setNonOptionalDefault() {
+    void stringAttributeOptionalDefaultEmpty_setNonOptionalDefault() {
         stringAttributeOptionalDefaultEmpty.set(component, SOME_STRING_VALUE);
         assertEquals(Optional.of(SOME_STRING_VALUE),
                 stringAttributeOptionalDefaultEmpty.get(component));
@@ -421,7 +421,7 @@ class PropertyDescriptorsTest {
     }
 
     @Test
-    public void stringAttributeOptionalDefaultEmpty_resetToOptionalDefault() {
+    void stringAttributeOptionalDefaultEmpty_resetToOptionalDefault() {
         stringAttributeOptionalDefaultEmpty.set(component, SOME_STRING_VALUE);
         stringAttributeOptionalDefaultEmpty.set(component, EMPTY_STRING);
         assertEquals(Optional.empty(),
@@ -432,14 +432,14 @@ class PropertyDescriptorsTest {
     }
 
     @Test
-    public void stringAttributeOptionalDefaultEmpty_setToNull() {
+    void stringAttributeOptionalDefaultEmpty_setToNull() {
         assertThrows(IllegalArgumentException.class, () -> {
             stringAttributeOptionalDefaultEmpty.set(component, null);
         });
     }
 
     @Test
-    public void stringAttributeOptionalDefaultFoo_initial() {
+    void stringAttributeOptionalDefaultFoo_initial() {
         assertEquals(Optional.empty(),
                 stringAttributeOptionalDefaultFoo.get(component));
         assertFalse(component.getElement().hasAttribute(TEST_PROPERTY));
@@ -447,7 +447,7 @@ class PropertyDescriptorsTest {
     }
 
     @Test
-    public void stringAttributeOptionalDefaultFoo_setNonOptionalDefault() {
+    void stringAttributeOptionalDefaultFoo_setNonOptionalDefault() {
         stringAttributeOptionalDefaultFoo.set(component, SOME_STRING_VALUE);
         assertEquals(Optional.of(SOME_STRING_VALUE),
                 stringAttributeOptionalDefaultFoo.get(component));
@@ -457,7 +457,7 @@ class PropertyDescriptorsTest {
     }
 
     @Test
-    public void stringAttributeOptionalDefaultFoo_resetToOptionalDefault() {
+    void stringAttributeOptionalDefaultFoo_resetToOptionalDefault() {
         stringAttributeOptionalDefaultFoo.set(component, SOME_STRING_VALUE);
         stringAttributeOptionalDefaultFoo.set(component, FOO);
         assertEquals(Optional.empty(),
@@ -468,14 +468,14 @@ class PropertyDescriptorsTest {
     }
 
     @Test
-    public void stringAttributeOptionalDefaultFoo_setToNull() {
+    void stringAttributeOptionalDefaultFoo_setToNull() {
         assertThrows(IllegalArgumentException.class, () -> {
             stringAttributeOptionalDefaultFoo.set(component, null);
         });
     }
 
     @Test
-    public void propertyName() {
+    void propertyName() {
         assertEquals(TEST_PROPERTY,
                 stringAttributeDefaultEmpty.getPropertyName());
     }

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortCutRegistrationFilterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortCutRegistrationFilterTest.java
@@ -93,7 +93,7 @@ class ShortCutRegistrationFilterTest {
     }
 
     @Test
-    public void testGenerateEventModifierFilterWithModifierKeyAlt()
+    void testGenerateEventModifierFilterWithModifierKeyAlt()
             throws InvocationTargetException, NoSuchMethodException,
             IllegalAccessException, ClassNotFoundException,
             InstantiationException {
@@ -107,7 +107,7 @@ class ShortCutRegistrationFilterTest {
     }
 
     @Test
-    public void testGenerateEventModifierFilterWithModifierKeyAltGr()
+    void testGenerateEventModifierFilterWithModifierKeyAltGr()
             throws InvocationTargetException, NoSuchMethodException,
             IllegalAccessException, ClassNotFoundException,
             InstantiationException {
@@ -120,7 +120,7 @@ class ShortCutRegistrationFilterTest {
     }
 
     @Test
-    public void testGenerateEventModifierFilterWithModifierKeyAltAndAltGr()
+    void testGenerateEventModifierFilterWithModifierKeyAltAndAltGr()
             throws InvocationTargetException, NoSuchMethodException,
             IllegalAccessException, ClassNotFoundException,
             InstantiationException {
@@ -134,7 +134,7 @@ class ShortCutRegistrationFilterTest {
     }
 
     @Test
-    public void testGenerateEventModifierFilterWithModifierKeyAltGrAndCtrl()
+    void testGenerateEventModifierFilterWithModifierKeyAltGrAndCtrl()
             throws InvocationTargetException, NoSuchMethodException,
             IllegalAccessException, ClassNotFoundException,
             InstantiationException {
@@ -148,7 +148,7 @@ class ShortCutRegistrationFilterTest {
     }
 
     @Test
-    public void testGenerateEventModifierFilterWithModifierKeyAltAndCtrl()
+    void testGenerateEventModifierFilterWithModifierKeyAltAndCtrl()
             throws InvocationTargetException, NoSuchMethodException,
             IllegalAccessException, ClassNotFoundException,
             InstantiationException {

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutEventTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutEventTest.java
@@ -35,7 +35,7 @@ class ShortcutEventTest {
             KeyModifier.ALT, KeyModifier.ALT_GRAPH);
 
     @Test
-    public void matches() {
+    void matches() {
         assertFalse(eventNoModifiers.matches(null),
                 "Null key should return false");
         assertFalse(eventNoModifiers.matches(Key.KEY_F, KeyModifier.ALT),

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
@@ -62,7 +62,7 @@ class ShortcutRegistrationTest {
     private Component[] listenOn = new Component[3];
 
     @BeforeEach
-    public void initTests() {
+    void initTests() {
         ui = mock(UI.class);
         lifecycleOwner = mock(Component.class);
         Arrays.setAll(listenOn, i -> mock(Component.class));
@@ -79,7 +79,7 @@ class ShortcutRegistrationTest {
     }
 
     @Test
-    public void registrationWillBeCompletedBeforeClientResponse() {
+    void registrationWillBeCompletedBeforeClientResponse() {
         ShortcutRegistration registration = new ShortcutRegistration(
                 lifecycleOwner, () -> listenOn, event -> {
                 }, Key.KEY_A);
@@ -96,7 +96,7 @@ class ShortcutRegistrationTest {
     }
 
     @Test
-    public void constructedRegistrationIsDirty() {
+    void constructedRegistrationIsDirty() {
         ShortcutRegistration registration = new ShortcutRegistration(
                 lifecycleOwner, () -> listenOn, event -> {
                 }, Key.KEY_A);
@@ -105,7 +105,7 @@ class ShortcutRegistrationTest {
     }
 
     @Test
-    public void lateUpdateOfModifiersDirtiesRegistration() {
+    void lateUpdateOfModifiersDirtiesRegistration() {
         ShortcutRegistration registration = new ShortcutRegistration(
                 lifecycleOwner, () -> listenOn, event -> {
                 }, Key.KEY_A);
@@ -121,7 +121,7 @@ class ShortcutRegistrationTest {
     }
 
     @Test
-    public void fluentModifiersAreAddedCorrectly() {
+    void fluentModifiersAreAddedCorrectly() {
         ShortcutRegistration registration = new ShortcutRegistration(
                 lifecycleOwner, () -> listenOn, event -> {
                 }, Key.KEY_A);
@@ -132,7 +132,7 @@ class ShortcutRegistrationTest {
     }
 
     @Test
-    public void preventDefaultAndStopPropagationValuesDefaultToTrue() {
+    void preventDefaultAndStopPropagationValuesDefaultToTrue() {
         ShortcutRegistration registration = new ShortcutRegistration(
                 lifecycleOwner, () -> listenOn, event -> {
                 }, Key.KEY_A);
@@ -147,7 +147,7 @@ class ShortcutRegistrationTest {
     }
 
     @Test
-    public void resetFocusOnActiveElementValuesDefaultToTrue() {
+    void resetFocusOnActiveElementValuesDefaultToTrue() {
         ShortcutRegistration registration = new ShortcutRegistration(
                 lifecycleOwner, () -> listenOn, event -> {
                 }, Key.KEY_A);
@@ -158,7 +158,7 @@ class ShortcutRegistrationTest {
     }
 
     @Test
-    public void bindLifecycleToChangesLifecycleOwner() {
+    void bindLifecycleToChangesLifecycleOwner() {
         Component newOwner = mock(Component.class);
 
         ShortcutRegistration registration = new ShortcutRegistration(
@@ -174,7 +174,7 @@ class ShortcutRegistrationTest {
     }
 
     @Test
-    public void settersAndGettersChangeValuesCorrectly() {
+    void settersAndGettersChangeValuesCorrectly() {
 
         // Component listenOn = mock(Component.class);
         ShortcutRegistration registration = new ShortcutRegistration(
@@ -209,7 +209,7 @@ class ShortcutRegistrationTest {
     }
 
     @Test
-    public void listenOnChangesTheComponentThatOwnsTheListener() {
+    void listenOnChangesTheComponentThatOwnsTheListener() {
         ShortcutRegistration registration = new ShortcutRegistration(
                 lifecycleOwner, () -> listenOn, event -> {
                 }, Key.KEY_A);
@@ -238,7 +238,7 @@ class ShortcutRegistrationTest {
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
-    public void listenOnComponentIsChanged_eventIsPopulatedForANewListenOnComponent() {
+    void listenOnComponentIsChanged_eventIsPopulatedForANewListenOnComponent() {
         UI ui = Mockito.spy(UI.class);
         Component owner = new FakeComponent();
         Component initialComponentToListenOn = new FakeComponent();
@@ -283,7 +283,7 @@ class ShortcutRegistrationTest {
     }
 
     @Test
-    public void listenOnUIIsClosing_eventIsPopulatedForANewUI() {
+    void listenOnUIIsClosing_eventIsPopulatedForANewUI() {
         UI ui = Mockito.spy(UI.class);
         Component owner = new FakeComponent();
 
@@ -316,7 +316,7 @@ class ShortcutRegistrationTest {
     }
 
     @Test
-    public void shortcutRegistrationReturnedByClickNotifierHasCorrectDefault() {
+    void shortcutRegistrationReturnedByClickNotifierHasCorrectDefault() {
         FakeComponent fakeComponent = new FakeComponent();
 
         ShortcutRegistration registration = fakeComponent
@@ -333,7 +333,7 @@ class ShortcutRegistrationTest {
     }
 
     @Test
-    public void shortcutRegistrationReturnedByFocusableHasCorrectDefaults() {
+    void shortcutRegistrationReturnedByFocusableHasCorrectDefaults() {
         FakeComponent fakeComponent = new FakeComponent();
 
         ShortcutRegistration registration = fakeComponent
@@ -350,7 +350,7 @@ class ShortcutRegistrationTest {
     }
 
     @Test
-    public void listenOnWithDuplicateShouldThrowException() {
+    void listenOnWithDuplicateShouldThrowException() {
         ShortcutRegistration registration = new ShortcutRegistration(
                 lifecycleOwner, () -> listenOn, event -> {
                 }, Key.KEY_A);
@@ -363,7 +363,7 @@ class ShortcutRegistrationTest {
     }
 
     @Test
-    public void listenOnWithNullEntriesShouldThrowException() {
+    void listenOnWithNullEntriesShouldThrowException() {
         ShortcutRegistration registration = new ShortcutRegistration(
                 lifecycleOwner, () -> listenOn, event -> {
                 }, Key.KEY_A);
@@ -376,7 +376,7 @@ class ShortcutRegistrationTest {
     }
 
     @Test
-    public void listenOnItemsAreChangedAfterCallingListenOnShouldNotHaveAnyEffect() {
+    void listenOnItemsAreChangedAfterCallingListenOnShouldNotHaveAnyEffect() {
         ShortcutRegistration registration = new ShortcutRegistration(
                 lifecycleOwner, () -> listenOn, event -> {
                 }, Key.KEY_A);
@@ -392,7 +392,7 @@ class ShortcutRegistrationTest {
     }
 
     @Test
-    public void listenOnComponentHasElementLocatorJs_jsExecutionScheduled() {
+    void listenOnComponentHasElementLocatorJs_jsExecutionScheduled() {
         final ElementLocatorTestFixture fixture = new ElementLocatorTestFixture();
         final Key key = Key.KEY_A;
         fixture.createNewShortcut(key);
@@ -429,7 +429,7 @@ class ShortcutRegistrationTest {
     }
 
     @Test
-    public void listenOnComponentHasElementLocatorJs_allowBrowserDefault_JsExecutionDoesNotPreventDefault() {
+    void listenOnComponentHasElementLocatorJs_allowBrowserDefault_JsExecutionDoesNotPreventDefault() {
         final ElementLocatorTestFixture fixture = new ElementLocatorTestFixture();
         final Key key = Key.KEY_A;
         fixture.createNewShortcut(key).allowBrowserDefault();
@@ -446,7 +446,7 @@ class ShortcutRegistrationTest {
     }
 
     @Test
-    public void listenOnComponentHasElementLocatorJs_resetFocusOnActiveElement_JsExecutionResetFocusOnActiveElement() {
+    void listenOnComponentHasElementLocatorJs_resetFocusOnActiveElement_JsExecutionResetFocusOnActiveElement() {
         final ElementLocatorTestFixture fixture = new ElementLocatorTestFixture();
         final Key key = Key.KEY_A;
         fixture.createNewShortcut(key).resetFocusOnActiveElement();
@@ -463,7 +463,7 @@ class ShortcutRegistrationTest {
     }
 
     @Test
-    public void constructedRegistration_lifecycleIsVisibleAndEnabled_shorcutEventIsFired() {
+    void constructedRegistration_lifecycleIsVisibleAndEnabled_shorcutEventIsFired() {
         AtomicReference<ShortcutEvent> event = new AtomicReference<>();
 
         new ShortcutRegistration(lifecycleOwner, () -> listenOn, event::set,
@@ -480,7 +480,7 @@ class ShortcutRegistrationTest {
     }
 
     @Test
-    public void constructedRegistration_lifecycleOnwerIsDisabled_shorcutEventIsNotFired() {
+    void constructedRegistration_lifecycleOnwerIsDisabled_shorcutEventIsNotFired() {
         AtomicReference<ShortcutEvent> event = new AtomicReference<>();
 
         new ShortcutRegistration(lifecycleOwner, () -> listenOn, event::set,
@@ -498,7 +498,7 @@ class ShortcutRegistrationTest {
     }
 
     @Test
-    public void constructedRegistration_lifecycleOwnerIsDisabledWithDisabledUpdateModeAlways_shortcutEventIsFired() {
+    void constructedRegistration_lifecycleOwnerIsDisabledWithDisabledUpdateModeAlways_shortcutEventIsFired() {
         AtomicReference<ShortcutEvent> event = new AtomicReference<>();
 
         new ShortcutRegistration(lifecycleOwner, () -> listenOn, event::set,
@@ -516,7 +516,7 @@ class ShortcutRegistrationTest {
     }
 
     @Test
-    public void constructedRegistration_lifecycleOnwerIsInvisible_shorcutEventIsNotFired() {
+    void constructedRegistration_lifecycleOnwerIsInvisible_shorcutEventIsNotFired() {
         AtomicReference<ShortcutEvent> event = new AtomicReference<>();
 
         new ShortcutRegistration(lifecycleOwner, () -> listenOn, event::set,
@@ -533,7 +533,7 @@ class ShortcutRegistrationTest {
     }
 
     @Test
-    public void constructedRegistration_lifecycleOnwerAncestorsAreVisible_shorcutEventIsFired() {
+    void constructedRegistration_lifecycleOnwerAncestorsAreVisible_shorcutEventIsFired() {
         AtomicReference<ShortcutEvent> event = new AtomicReference<>();
 
         new ShortcutRegistration(lifecycleOwner, () -> listenOn, event::set,
@@ -552,7 +552,7 @@ class ShortcutRegistrationTest {
     }
 
     @Test
-    public void uiRegistration_uiHasModalComponent_eventIsSentFromModalComponentInsteadOfUi() {
+    void uiRegistration_uiHasModalComponent_eventIsSentFromModalComponentInsteadOfUi() {
         AtomicReference<ShortcutEvent> eventRef = new AtomicReference<>();
 
         Component modal = Mockito.mock(Component.class);
@@ -586,7 +586,7 @@ class ShortcutRegistrationTest {
     }
 
     @Test
-    public void constructedRegistration_lifecycleOnwerHasInvisibleParent_shorcutEventIsNotFired() {
+    void constructedRegistration_lifecycleOnwerHasInvisibleParent_shorcutEventIsNotFired() {
         AtomicReference<ShortcutEvent> event = new AtomicReference<>();
 
         new ShortcutRegistration(lifecycleOwner, () -> listenOn, event::set,
@@ -608,7 +608,7 @@ class ShortcutRegistrationTest {
     }
 
     @Test
-    public void constructedRegistration_lifecycleOwnerNulledBeforeKeyEvent_noNPE()
+    void constructedRegistration_lifecycleOwnerNulledBeforeKeyEvent_noNPE()
             throws Exception {
         AtomicReference<ShortcutEvent> event = new AtomicReference<>();
 
@@ -634,7 +634,7 @@ class ShortcutRegistrationTest {
     }
 
     @Test
-    public void constructedRegistration_lifeCycleOwnerIsDetached_detachListenerIsDeregisteredFromListenOnComponents() {
+    void constructedRegistration_lifeCycleOwnerIsDetached_detachListenerIsDeregisteredFromListenOnComponents() {
         AtomicReference<ComponentEventListener> detachListener = new AtomicReference<>();
         Mockito.doAnswer(invocaation -> {
             detachListener.set(
@@ -659,7 +659,7 @@ class ShortcutRegistrationTest {
     }
 
     @Test
-    public void reattachComponent_detachListenerIsAddedOnEveryAttach_listenOnUIIsClosing_eventIsPopulatedForANewUI() {
+    void reattachComponent_detachListenerIsAddedOnEveryAttach_listenOnUIIsClosing_eventIsPopulatedForANewUI() {
         UI ui = Mockito.spy(UI.class);
         Component owner = new FakeComponent();
 
@@ -714,7 +714,7 @@ class ShortcutRegistrationTest {
     }
 
     @Test
-    public void attachAndDetachComponent_sameRoundTrip_beforeClientResponseListenerRemoved() {
+    void attachAndDetachComponent_sameRoundTrip_beforeClientResponseListenerRemoved() {
         UI ui = Mockito.spy(UI.class);
         Component owner = new FakeComponent();
 
@@ -747,7 +747,7 @@ class ShortcutRegistrationTest {
     }
 
     @Test
-    public void toString_listenOnComponentsNotInitialized_doesNotFail() {
+    void toString_listenOnComponentsNotInitialized_doesNotFail() {
         ShortcutRegistration registration = new ShortcutRegistration(
                 lifecycleOwner, () -> listenOn, event -> {
                 }, Key.KEY_A);

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutSerializationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutSerializationTest.java
@@ -28,8 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 class ShortcutSerializationTest {
 
     @Test
-    public void addShortcutForLifecycleOwner_serializationWorks()
-            throws Exception {
+    void addShortcutForLifecycleOwner_serializationWorks() throws Exception {
         Component owner = new FakeComponent();
         UI ui = new UI();
         Component[] components = new Component[] { ui };
@@ -42,7 +41,7 @@ class ShortcutSerializationTest {
     }
 
     @Test
-    public void addAndRemoverShortcutForLifecycleOwner_serializationWorks()
+    void addAndRemoverShortcutForLifecycleOwner_serializationWorks()
             throws Exception {
         Component owner = new FakeComponent();
         UI ui = new UI();

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutsTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 class ShortcutsTest {
 
     @Test
-    public void hasOnlyStaticMethods() {
+    void hasOnlyStaticMethods() {
         Method[] methods = Shortcuts.class.getDeclaredMethods();
 
         for (Method method : methods) {
@@ -47,7 +47,7 @@ class ShortcutsTest {
     }
 
     @Test
-    public void setShortcutListenOnElementLocatorJs_storesLocatorOnComponentData() {
+    void setShortcutListenOnElementLocatorJs_storesLocatorOnComponentData() {
         final RouterLink routerLink = new RouterLink();
         final String locator = "foobar";
         final Registration registration = Shortcuts
@@ -63,7 +63,7 @@ class ShortcutsTest {
     }
 
     @Test
-    public void setShortcutListenOnElementLocatorJs_registrationDoesNotRemoveModifiedData_nullClearsAlways() {
+    void setShortcutListenOnElementLocatorJs_registrationDoesNotRemoveModifiedData_nullClearsAlways() {
         final RouterLink routerLink = new RouterLink();
         final String locator = "foobar";
         final Registration registration = Shortcuts

--- a/flow-server/src/test/java/com/vaadin/flow/component/SignalPropertySupportTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/SignalPropertySupportTest.java
@@ -54,25 +54,25 @@ class SignalPropertySupportTest {
     private AtomicReference<Object> lastValue;
 
     @BeforeAll
-    public static void init() {
+    static void init() {
         service = new MockVaadinServletService();
     }
 
     @AfterAll
-    public static void clean() {
+    static void clean() {
         CurrentInstance.clearAll();
         service.destroy();
     }
 
     @BeforeEach
-    public void before() {
+    void before() {
         events = mockLockedSessionWithErrorHandler();
         callCount = new AtomicInteger(0);
         lastValue = new AtomicReference<>();
     }
 
     @AfterEach
-    public void after() {
+    void after() {
         assertTrue(events.isEmpty());
         CurrentInstance.clearAll();
         events = null;
@@ -92,7 +92,7 @@ class SignalPropertySupportTest {
     }
 
     @Test
-    public void create_nullArguments_throwException() {
+    void create_nullArguments_throwException() {
         assertThrows(NullPointerException.class,
                 () -> SignalPropertySupport.create(null, value -> {
                 }));
@@ -101,7 +101,7 @@ class SignalPropertySupportTest {
     }
 
     @Test
-    public void get_notBound_nullValue() {
+    void get_notBound_nullValue() {
         var component = new TestComponent();
         SignalPropertySupport<String> signalPropertySupport = SignalPropertySupport
                 .create(component, value -> {
@@ -110,7 +110,7 @@ class SignalPropertySupportTest {
     }
 
     @Test
-    public void get_boundButNotAttached_valueSetInitially() {
+    void get_boundButNotAttached_valueSetInitially() {
         var component = new TestComponent();
 
         ValueSignal<String> signal = new ValueSignal<>("foo");
@@ -126,7 +126,7 @@ class SignalPropertySupportTest {
     }
 
     @Test
-    public void get_boundAndAttached_valueSet() {
+    void get_boundAndAttached_valueSet() {
         var component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -150,7 +150,7 @@ class SignalPropertySupportTest {
     }
 
     @Test
-    public void set_notBound_valueSet() {
+    void set_notBound_valueSet() {
         var component = new TestComponent();
 
         SignalPropertySupport<String> signalPropertySupport = SignalPropertySupport
@@ -171,7 +171,7 @@ class SignalPropertySupportTest {
     }
 
     @Test
-    public void set_alreadyBound_throwException() {
+    void set_alreadyBound_throwException() {
         var component = new TestComponent();
         ValueSignal<String> signal = new ValueSignal<>("foo");
         SignalPropertySupport<String> signalPropertySupport = SignalPropertySupport
@@ -187,7 +187,7 @@ class SignalPropertySupportTest {
     }
 
     @Test
-    public void set_computedSignal_valueSet() {
+    void set_computedSignal_valueSet() {
         var component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -201,7 +201,7 @@ class SignalPropertySupportTest {
     }
 
     @Test
-    public void set_mappedSignal_valueSet() {
+    void set_mappedSignal_valueSet() {
         var component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -214,7 +214,7 @@ class SignalPropertySupportTest {
     }
 
     @Test
-    public void bind_nullSignal_throwsNPE() {
+    void bind_nullSignal_throwsNPE() {
         var component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -227,7 +227,7 @@ class SignalPropertySupportTest {
     }
 
     @Test
-    public void bind_alreadyBound_throw() {
+    void bind_alreadyBound_throw() {
         var component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -241,7 +241,7 @@ class SignalPropertySupportTest {
     }
 
     @Test
-    public void bind_boundDetachedAttached_bindingRemovedAndAddedBack() {
+    void bind_boundDetachedAttached_bindingRemovedAndAddedBack() {
         var component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -259,7 +259,7 @@ class SignalPropertySupportTest {
     }
 
     @Test
-    public void bind_onChange_receivesBindingContext() {
+    void bind_onChange_receivesBindingContext() {
         var component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -285,7 +285,7 @@ class SignalPropertySupportTest {
     }
 
     @Test
-    public void bind_onChange_bindThenAttach() {
+    void bind_onChange_bindThenAttach() {
         var component = new TestComponent();
 
         ValueSignal<String> signal = new ValueSignal<>("initial");
@@ -305,7 +305,7 @@ class SignalPropertySupportTest {
     }
 
     @Test
-    public void bind_onChange_bindThenChangeAndAttach() {
+    void bind_onChange_bindThenChangeAndAttach() {
         var component = new TestComponent();
 
         ValueSignal<String> signal = new ValueSignal<>("initial");

--- a/flow-server/src/test/java/com/vaadin/flow/component/SvgTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/SvgTest.java
@@ -27,21 +27,21 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class SvgTest {
 
     @Test
-    public void attachedToElement() {
+    void attachedToElement() {
         // This will throw an assertion error if the element is not attached to
         // the component
         new Svg("<svg></svg>").getParent();
     }
 
     @Test
-    public void nullStream() {
+    void nullStream() {
         assertThrows(IllegalArgumentException.class, () -> {
             new Svg((InputStream) null);
         });
     }
 
     @Test
-    public void text() {
+    void text() {
         assertThrows(IllegalArgumentException.class, () -> {
             new Svg("hello");
         });
@@ -72,19 +72,19 @@ class SvgTest {
             </svg>""";
 
     @Test
-    public void simpleSvg() {
+    void simpleSvg() {
         Svg svg = new Svg(TRIVIAL_SVG);
         assertEquals(TRIVIAL_SVG, getSvgDocumentBody(svg));
     }
 
     @Test
-    public void withDocType() {
+    void withDocType() {
         Svg svg = new Svg(SVG_WITH_DOCTYPE_ET_AL);
         assertTrue(getSvgDocumentBody(svg).startsWith("<svg"));
     }
 
     @Test
-    public void resetSvg() {
+    void resetSvg() {
         Svg svg = new Svg(TRIVIAL_SVG);
         assertEquals(TRIVIAL_SVG, getSvgDocumentBody(svg));
         svg.setSvg(TRIVIAL_SVG2);
@@ -92,7 +92,7 @@ class SvgTest {
     }
 
     @Test
-    public void fromStream() {
+    void fromStream() {
         Svg svg = new Svg(new ByteArrayInputStream(TRIVIAL_SVG.getBytes()));
         assertEquals(TRIVIAL_SVG, getSvgDocumentBody(svg));
     }

--- a/flow-server/src/test/java/com/vaadin/flow/component/TextTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/TextTest.java
@@ -171,7 +171,7 @@ class TextTest {
     }
 
     @Test
-    public void lazyInitSignalBindingFeature() {
+    void lazyInitSignalBindingFeature() {
         Text text = new Text("text");
         text.getElement().getNode()
                 .getFeatureIfInitialized(SignalBindingFeature.class)

--- a/flow-server/src/test/java/com/vaadin/flow/component/UILocaleSignalTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/UILocaleSignalTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 class UILocaleSignalTest extends SignalsUnitTest {
 
     @Test
-    public void localeSignal_initialValue_matchesGetLocale() {
+    void localeSignal_initialValue_matchesGetLocale() {
         UI ui = UI.getCurrent();
         Signal<Locale> signal = ui.localeSignal();
 
@@ -42,7 +42,7 @@ class UILocaleSignalTest extends SignalsUnitTest {
     }
 
     @Test
-    public void localeSignal_setLocale_signalUpdated() {
+    void localeSignal_setLocale_signalUpdated() {
         UI ui = UI.getCurrent();
         Signal<Locale> signal = ui.localeSignal();
 
@@ -63,7 +63,7 @@ class UILocaleSignalTest extends SignalsUnitTest {
     }
 
     @Test
-    public void localeSignal_multipleLocaleChanges_signalFollows() {
+    void localeSignal_multipleLocaleChanges_signalFollows() {
         UI ui = UI.getCurrent();
         Signal<Locale> signal = ui.localeSignal();
 
@@ -78,7 +78,7 @@ class UILocaleSignalTest extends SignalsUnitTest {
     }
 
     @Test
-    public void localeSignal_bindValue_updatesLocale() {
+    void localeSignal_bindValue_updatesLocale() {
         UI ui = UI.getCurrent();
         LocaleField field = new LocaleField();
         ui.add(field);
@@ -97,7 +97,7 @@ class UILocaleSignalTest extends SignalsUnitTest {
     }
 
     @Test
-    public void setLocale_uiLocaleIndependentFromSession() {
+    void setLocale_uiLocaleIndependentFromSession() {
         UI ui = UI.getCurrent();
 
         // Set UI to a locale different from the session

--- a/flow-server/src/test/java/com/vaadin/flow/component/UnitTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/UnitTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 class UnitTest {
 
     @Test
-    public void getUnit() {
+    void getUnit() {
         assertFalse(Unit.getUnit(null).isPresent());
         assertFalse(Unit.getUnit("").isPresent());
         assertFalse(Unit.getUnit("10unknown").isPresent());

--- a/flow-server/src/test/java/com/vaadin/flow/component/WebComponentConfigurationFactoryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/WebComponentConfigurationFactoryTest.java
@@ -32,7 +32,7 @@ class WebComponentConfigurationFactoryTest {
     private WebComponentExporter.WebComponentConfigurationFactory factory = new WebComponentExporter.WebComponentConfigurationFactory();
 
     @Test
-    public void create_constructsValidConfiguration() {
+    void create_constructsValidConfiguration() {
         WebComponentConfiguration<? extends Component> config1 = factory.create(
                 new DefaultWebComponentExporterFactory<WebComponentExporterTest.MyComponent>(
                         MyComponentExporter.class).create());
@@ -47,7 +47,7 @@ class WebComponentConfigurationFactoryTest {
     }
 
     @Test
-    public void create_instance_throwsOnNullArgument() {
+    void create_instance_throwsOnNullArgument() {
         NullPointerException ex = assertThrows(NullPointerException.class,
                 () -> factory.create(null));
         assertTrue(ex.getMessage().contains("'exporter'"));
@@ -55,7 +55,7 @@ class WebComponentConfigurationFactoryTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void create_configuration_hashCode() {
+    void create_configuration_hashCode() {
         WebComponentConfiguration<WebComponentExporterTest.MyComponent> myComponentConfig = factory
                 .create(new DefaultWebComponentExporterFactory<WebComponentExporterTest.MyComponent>(
                         MyComponentExporter.class).create());
@@ -84,7 +84,7 @@ class WebComponentConfigurationFactoryTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void create_configuration_equals() {
+    void create_configuration_equals() {
         WebComponentConfiguration<WebComponentExporterTest.MyComponent> myComponentConfig = factory
                 .create(new DefaultWebComponentExporterFactory<>(
                         MyComponentExporter.class).create());

--- a/flow-server/src/test/java/com/vaadin/flow/component/WebComponentExporterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/WebComponentExporterTest.java
@@ -46,14 +46,14 @@ class WebComponentExporterTest {
 
     @BeforeEach
     @SuppressWarnings("unchecked")
-    public void setUp() {
+    void setUp() {
         exporter = new MyComponentExporter();
         config = (WebComponentConfiguration<MyComponent>) new WebComponentExporter.WebComponentConfigurationFactory()
                 .create(exporter);
     }
 
     @Test
-    public void addProperty_differentTypes() {
+    void addProperty_differentTypes() {
         exporter.addProperty("int", 1);
         exporter.addProperty("string", "string");
         exporter.addProperty("boolean", true);
@@ -75,7 +75,7 @@ class WebComponentExporterTest {
     }
 
     @Test
-    public void addProperty_propertyWithTheSameNameGetsOverwritten() {
+    void addProperty_propertyWithTheSameNameGetsOverwritten() {
         exporter.addProperty("int", 1);
 
         assertTrue(config.hasProperty("int"));
@@ -89,12 +89,12 @@ class WebComponentExporterTest {
     }
 
     @Test
-    public void configuration_getTag() {
+    void configuration_getTag() {
         assertEquals(TAG, config.getTag());
     }
 
     @Test
-    public void configuration_getPropertyType_differentTypes() {
+    void configuration_getPropertyType_differentTypes() {
         exporter.addProperty("int", 1);
         exporter.addProperty("string", "string");
         exporter.addProperty("boolean", true);
@@ -107,7 +107,7 @@ class WebComponentExporterTest {
     }
 
     @Test
-    public void configuration_deliverPropertyUpdate() {
+    void configuration_deliverPropertyUpdate() {
         exporter.addProperty("int", 0).onChange(MyComponent::update);
 
         WebComponentBinding<MyComponent> binding = config
@@ -123,7 +123,7 @@ class WebComponentExporterTest {
     }
 
     @Test
-    public void configuration_getPropertyDataSet() {
+    void configuration_getPropertyDataSet() {
         exporter.addProperty("int", 1);
         exporter.addProperty("string", "string");
         exporter.addProperty("boolean", true);
@@ -135,14 +135,14 @@ class WebComponentExporterTest {
     }
 
     @Test
-    public void configuration_getComponentClass() {
+    void configuration_getComponentClass() {
         assertEquals(MyComponent.class, config.getComponentClass(),
                 "Component class should be MyComponent.class");
     }
 
     @Test
     @SuppressWarnings("unchecked")
-    public void configuration_createWebComponentBinding() {
+    void configuration_createWebComponentBinding() {
         exporter = new MyComponentExporter() {
             @Override
             public void configureInstance(
@@ -171,7 +171,7 @@ class WebComponentExporterTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void configuration_createWebComponentBinding_overridesDefaultValues() {
+    void configuration_createWebComponentBinding_overridesDefaultValues() {
         exporter.addProperty("value", 1).onChange(MyComponent::update);
 
         config = (WebComponentConfiguration<MyComponent>) new WebComponentExporter.WebComponentConfigurationFactory()
@@ -188,7 +188,7 @@ class WebComponentExporterTest {
     }
 
     @Test
-    public void configuration_bindProxy_withoutInstanceConfigurator() {
+    void configuration_bindProxy_withoutInstanceConfigurator() {
         WebComponentBinding<MyComponent> binding = config
                 .createWebComponentBinding(new MockInstantiator(),
                         mock(Element.class), JacksonUtils.createObjectNode());
@@ -202,7 +202,7 @@ class WebComponentExporterTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void configuration_bindProxy_throwsIfExporterSharesTagWithComponent() {
+    void configuration_bindProxy_throwsIfExporterSharesTagWithComponent() {
         SharedTagExporter sharedTagExporter = new SharedTagExporter();
         WebComponentConfiguration<SharedTagComponent> sharedConfig = (WebComponentConfiguration<SharedTagComponent>) new WebComponentExporter.WebComponentConfigurationFactory()
                 .create(sharedTagExporter);
@@ -214,7 +214,7 @@ class WebComponentExporterTest {
     }
 
     @Test
-    public void configuration_hasProperty() {
+    void configuration_hasProperty() {
         exporter.addProperty("int", 1);
         exporter.addProperty("string", "string");
         exporter.addProperty("boolean", true);
@@ -229,7 +229,7 @@ class WebComponentExporterTest {
     }
 
     @Test
-    public void configuration_callAddProperty_throws() {
+    void configuration_callAddProperty_throws() {
         AddPropertyInsideConfigureInstance exporter = new AddPropertyInsideConfigureInstance();
         WebComponentConfiguration<?> config = new WebComponentExporter.WebComponentConfigurationFactory()
                 .create(exporter);
@@ -241,7 +241,7 @@ class WebComponentExporterTest {
     }
 
     @Test
-    public void exporterConstructorThrowsIfNoComponentDefined() {
+    void exporterConstructorThrowsIfNoComponentDefined() {
         assertThrows(IllegalStateException.class, () -> {
             NoComponentExporter exporter = new NoComponentExporter();
         });

--- a/flow-server/src/test/java/com/vaadin/flow/component/WhiteSpaceTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/WhiteSpaceTest.java
@@ -24,13 +24,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class WhiteSpaceTest {
 
     @Test
-    public void toString_styleValueIsReturned() {
+    void toString_styleValueIsReturned() {
         assertEquals("nowrap", WhiteSpace.NOWRAP.toString());
         assertEquals("pre-line", WhiteSpace.PRE_LINE.toString());
     }
 
     @Test
-    public void forString_enumIsReturned() {
+    void forString_enumIsReturned() {
         assertEquals(WhiteSpace.NORMAL, WhiteSpace.forString("normal"));
         assertEquals(WhiteSpace.PRE_WRAP, WhiteSpace.forString("pre-wrap"));
     }

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/DependencyTreeCacheTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/DependencyTreeCacheTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 class DependencyTreeCacheTest {
     @Test
-    public void multipleLevels_allIncluded_noneParsedAgain() {
+    void multipleLevels_allIncluded_noneParsedAgain() {
         MockParser parser = new MockParser().addResult("/a", "/b")
                 .addResult("/b", "/c").addResult("/c");
 
@@ -53,7 +53,7 @@ class DependencyTreeCacheTest {
     }
 
     @Test
-    public void sharedDependency_onlyParsedOnce() {
+    void sharedDependency_onlyParsedOnce() {
         MockParser parser = new MockParser().addResult("/a", "/b", "/c")
                 .addResult("/b", "/d").addResult("/c", "/d").addResult("/d");
 
@@ -66,7 +66,7 @@ class DependencyTreeCacheTest {
     }
 
     @Test
-    public void concurrentParse_onlyParsedOnce() throws InterruptedException {
+    void concurrentParse_onlyParsedOnce() throws InterruptedException {
         MockParser parser = new MockParser();
         parser.addResult("/a", "/b");
         parser.addResult("/b", 100);
@@ -98,7 +98,7 @@ class DependencyTreeCacheTest {
     }
 
     @Test
-    public void parallelParsing_potentialSpeedup() throws InterruptedException {
+    void parallelParsing_potentialSpeedup() throws InterruptedException {
         // Eventually, we should see both a case when the randomization makes
         // parsing progress in parallel and a case when it happens sequentially
         int maxDuration = Integer.MIN_VALUE;

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
@@ -184,7 +184,7 @@ class JavaScriptBootstrapUITest {
     }
 
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() throws Exception {
         mocks = new MockServletServiceSessionSetup();
         mocks.getService().getRouter().getRegistry().setRoute("clean",
                 Clean.class, Collections.emptyList());
@@ -230,12 +230,12 @@ class JavaScriptBootstrapUITest {
     }
 
     @AfterEach
-    public void cleanup() {
+    void cleanup() {
         mocks.cleanup();
     }
 
     @Test
-    public void should_allow_navigation() {
+    void should_allow_navigation() {
         ui.browserNavigate(
                 new BrowserNavigateEvent(ui, true, "/clean", "", "", null, ""));
         assertEquals(Tag.HEADER,
@@ -253,7 +253,7 @@ class JavaScriptBootstrapUITest {
     }
 
     @Test
-    public void should_navigate_when_endingSlash() {
+    void should_navigate_when_endingSlash() {
         ui.browserNavigate(new BrowserNavigateEvent(ui, true, "/clean/", "", "",
                 null, ""));
         assertEquals(Tag.HEADER,
@@ -263,14 +263,14 @@ class JavaScriptBootstrapUITest {
     }
 
     @Test
-    public void getChildren_should_notReturnAnEmptyList() {
+    void getChildren_should_notReturnAnEmptyList() {
         ui.browserNavigate(
                 new BrowserNavigateEvent(ui, true, "/clean", "", "", null, ""));
         assertEquals(1, ui.getChildren().count());
     }
 
     @Test
-    public void addRemoveComponent_clientSideRouting_addsToBody() {
+    void addRemoveComponent_clientSideRouting_addsToBody() {
         final Element uiElement = ui.getElement();
 
         ui.browserNavigate(
@@ -302,7 +302,7 @@ class JavaScriptBootstrapUITest {
     }
 
     @Test
-    public void addComponent_clientSideRouterAndNavigation_componentsRemain() {
+    void addComponent_clientSideRouterAndNavigation_componentsRemain() {
         final Element uiElement = ui.getElement();
         // trigger route via client
         ui.browserNavigate(
@@ -322,7 +322,7 @@ class JavaScriptBootstrapUITest {
     }
 
     @Test
-    public void should_prevent_navigation_on_dirty() {
+    void should_prevent_navigation_on_dirty() {
         ui.browserNavigate(
                 new BrowserNavigateEvent(ui, true, "/dirty", "", "", null, ""));
         assertEquals(Tag.SPAN,
@@ -344,7 +344,7 @@ class JavaScriptBootstrapUITest {
     }
 
     @Test
-    public void should_remove_content_on_leaveNavigation() {
+    void should_remove_content_on_leaveNavigation() {
         ui.browserNavigate(
                 new BrowserNavigateEvent(ui, true, "/clean", "", "", null, ""));
         assertEquals(Tag.HEADER,
@@ -359,7 +359,7 @@ class JavaScriptBootstrapUITest {
     }
 
     @Test
-    public void should_keep_content_on_leaveNavigation_postpone() {
+    void should_keep_content_on_leaveNavigation_postpone() {
         ui.browserNavigate(
                 new BrowserNavigateEvent(ui, true, "/dirty", "", "", null, ""));
         assertEquals(Tag.SPAN,
@@ -376,7 +376,7 @@ class JavaScriptBootstrapUITest {
     }
 
     @Test
-    public void should_handle_forward_to_client_side_view_on_beforeEnter() {
+    void should_handle_forward_to_client_side_view_on_beforeEnter() {
         ui.browserNavigate(new BrowserNavigateEvent(ui, true,
                 "/forwardToClientSideViewOnBeforeEnter", "", "", null, ""));
 
@@ -384,7 +384,7 @@ class JavaScriptBootstrapUITest {
     }
 
     @Test
-    public void should_not_handle_forward_to_client_side_view_on_beforeLeave() {
+    void should_not_handle_forward_to_client_side_view_on_beforeLeave() {
         ui.browserNavigate(new BrowserNavigateEvent(ui, true,
                 "/forwardToClientSideViewOnBeforeLeave", "", "", null, ""));
 
@@ -392,7 +392,7 @@ class JavaScriptBootstrapUITest {
     }
 
     @Test
-    public void should_not_handle_forward_to_client_side_view_on_reroute() {
+    void should_not_handle_forward_to_client_side_view_on_reroute() {
         ui.browserNavigate(new BrowserNavigateEvent(ui, true,
                 "/forwardToClientSideViewOnReroute", "", "", null, ""));
 
@@ -400,7 +400,7 @@ class JavaScriptBootstrapUITest {
     }
 
     @Test
-    public void should_handle_forward_to_server_side_view_on_beforeEnter_and_update_url() {
+    void should_handle_forward_to_server_side_view_on_beforeEnter_and_update_url() {
         ui.browserNavigate(new BrowserNavigateEvent(ui, true,
                 "/forwardToServerSideViewOnBeforeEnter", "", "", null, ""));
 
@@ -422,7 +422,7 @@ class JavaScriptBootstrapUITest {
     }
 
     @Test
-    public void should_show_error_page() {
+    void should_show_error_page() {
         ui.browserNavigate(
                 new BrowserNavigateEvent(ui, true, "/err", "", "", null, ""));
         assertEquals(Tag.DIV,
@@ -432,7 +432,7 @@ class JavaScriptBootstrapUITest {
     }
 
     @Test
-    public void should_invoke_clientRoute_when_navigationHasNotBeenStarted() {
+    void should_invoke_clientRoute_when_navigationHasNotBeenStarted() {
         ui = Mockito.spy(ui);
         Page page = mockPage();
 
@@ -447,7 +447,7 @@ class JavaScriptBootstrapUITest {
     }
 
     @Test
-    public void should_update_pushState_when_navigationHasBeenAlreadyStarted() {
+    void should_update_pushState_when_navigationHasBeenAlreadyStarted() {
         ui = Mockito.spy(ui);
         Page page = mockPage();
 
@@ -505,7 +505,7 @@ class JavaScriptBootstrapUITest {
     }
 
     @Test
-    public void should_not_notify_clientRoute_when_navigatingToTheSame() {
+    void should_not_notify_clientRoute_when_navigatingToTheSame() {
         ui = Mockito.spy(ui);
         Page page = mockPage();
 
@@ -522,7 +522,7 @@ class JavaScriptBootstrapUITest {
     }
 
     @Test
-    public void server_should_not_doClientRoute_when_navigatingToServer() {
+    void server_should_not_doClientRoute_when_navigatingToServer() {
         ui.browserNavigate(
                 new BrowserNavigateEvent(ui, true, "/clean", "", "", null, ""));
         assertEquals(Tag.HEADER,
@@ -559,7 +559,7 @@ class JavaScriptBootstrapUITest {
     }
 
     @Test
-    public void should_updatePageTitle_when_serverNavigation() {
+    void should_updatePageTitle_when_serverNavigation() {
         ui.navigate("empty");
         assertNull(ui.getInternals().getTitle());
         ui.navigate("product");
@@ -567,7 +567,7 @@ class JavaScriptBootstrapUITest {
     }
 
     @Test
-    public void should_updatePageTitle_when_serverNavigationToProxyViewClass() {
+    void should_updatePageTitle_when_serverNavigationToProxyViewClass() {
         ui.navigate("empty");
         assertNull(ui.getInternals().getTitle());
         ui.navigate("proxy-product");
@@ -575,7 +575,7 @@ class JavaScriptBootstrapUITest {
     }
 
     @Test
-    public void should_removeTitle_when_noAppShellTitle() {
+    void should_removeTitle_when_noAppShellTitle() {
         ui.navigate("empty");
         assertNull(ui.getInternals().getTitle());
         ui.navigate("dirty");
@@ -583,7 +583,7 @@ class JavaScriptBootstrapUITest {
     }
 
     @Test
-    public void should_restoreIndexHtmlTitle() {
+    void should_restoreIndexHtmlTitle() {
         ui.browserNavigate(new BrowserNavigateEvent(ui, true, "empty", "",
                 "app-shell-title", null, ""));
         assertEquals("", ui.getInternals().getTitle());
@@ -593,7 +593,7 @@ class JavaScriptBootstrapUITest {
     }
 
     @Test
-    public void should_not_share_dynamic_app_title_for_different_UIs() {
+    void should_not_share_dynamic_app_title_for_different_UIs() {
         String dynamicTitle = UUID.randomUUID().toString();
         ui.browserNavigate(new BrowserNavigateEvent(ui, true, "clean", "",
                 dynamicTitle, null, ""));
@@ -612,7 +612,7 @@ class JavaScriptBootstrapUITest {
     }
 
     @Test
-    public void navigate_firsClientSideRoutingThrows_navigationInProgressIsReset_secondClientSideRoutingWorks() {
+    void navigate_firsClientSideRoutingThrows_navigationInProgressIsReset_secondClientSideRoutingWorks() {
         VaadinSession session = Mockito.mock(VaadinSession.class);
 
         VaadinService service = Mockito.mock(VaadinService.class);

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/PageTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/PageTest.java
@@ -38,26 +38,26 @@ class PageTest {
     private Page page = ui.getPage();
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         UI.setCurrent(null);
     }
 
     @Test
-    public void testAddNullStyleSheet() {
+    void testAddNullStyleSheet() {
         assertThrows(IllegalArgumentException.class, () -> {
             page.addStyleSheet(null);
         });
     }
 
     @Test
-    public void testAddNullJavaScript() {
+    void testAddNullJavaScript() {
         assertThrows(IllegalArgumentException.class, () -> {
             page.addJavaScript(null);
         });
     }
 
     @Test
-    public void testJavasScriptExecutionCancel() {
+    void testJavasScriptExecutionCancel() {
         assertEquals(0, countPendingInvocations());
 
         PendingJavaScriptResult executeJavaScript = page
@@ -71,7 +71,7 @@ class PageTest {
     }
 
     @Test
-    public void testJavaScriptExecutionTooLateCancel() {
+    void testJavaScriptExecutionTooLateCancel() {
         assertEquals(0, countPendingInvocations());
 
         PendingJavaScriptResult executeJavaScript = page
@@ -88,7 +88,7 @@ class PageTest {
     }
 
     @Test
-    public void addDynamicImport_dynamicDependencyIsAvaialbleViaGetPendingSendToClient() {
+    void addDynamicImport_dynamicDependencyIsAvaialbleViaGetPendingSendToClient() {
         page.addDynamicImport("foo");
 
         DependencyList list = ui.getInternals().getDependencyList();

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/PendingJavaScriptInvocationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/PendingJavaScriptInvocationTest.java
@@ -61,7 +61,7 @@ class PendingJavaScriptInvocationTest {
     private BiConsumer<String, Throwable> stringFutureHandler;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         invocation = new PendingJavaScriptInvocation(
                 new Element("dummy").getNode(), new JavaScriptInvocation(""));
 
@@ -87,7 +87,7 @@ class PendingJavaScriptInvocationTest {
     }
 
     @Test
-    public void untypedIgnoreErrors_success() {
+    void untypedIgnoreErrors_success() {
         invocation.then(jsonSuccessConsumer);
 
         invocation.complete(fooJsonString);
@@ -96,7 +96,7 @@ class PendingJavaScriptInvocationTest {
     }
 
     @Test
-    public void untypedIgnoreErrors_fail() {
+    void untypedIgnoreErrors_fail() {
         invocation.then(jsonSuccessConsumer);
 
         invocation.completeExceptionally(fooJsonString);
@@ -105,7 +105,7 @@ class PendingJavaScriptInvocationTest {
     }
 
     @Test
-    public void untypedCaptureErrors_success() {
+    void untypedCaptureErrors_success() {
         invocation.then(jsonSuccessConsumer, errorConsumer);
 
         invocation.complete(fooJsonString);
@@ -114,7 +114,7 @@ class PendingJavaScriptInvocationTest {
     }
 
     @Test
-    public void untypedCaptureErrors_fail() {
+    void untypedCaptureErrors_fail() {
         invocation.then(jsonSuccessConsumer, errorConsumer);
 
         invocation.completeExceptionally(fooJsonString);
@@ -123,7 +123,7 @@ class PendingJavaScriptInvocationTest {
     }
 
     @Test
-    public void untypedFuture_success() {
+    void untypedFuture_success() {
         invocation.toCompletableFuture().whenComplete(jsonFutureHandler);
 
         invocation.complete(fooJsonString);
@@ -132,7 +132,7 @@ class PendingJavaScriptInvocationTest {
     }
 
     @Test
-    public void untypedFuture_fail() {
+    void untypedFuture_fail() {
         invocation.toCompletableFuture().whenComplete(jsonFutureHandler);
 
         invocation.completeExceptionally(fooJsonString);
@@ -141,7 +141,7 @@ class PendingJavaScriptInvocationTest {
     }
 
     @Test
-    public void typedIgnoreErrors_success() {
+    void typedIgnoreErrors_success() {
         invocation.then(String.class, stringSuccessConsumer);
 
         invocation.complete(fooJsonString);
@@ -150,7 +150,7 @@ class PendingJavaScriptInvocationTest {
     }
 
     @Test
-    public void typedCaptureErrors_fail() {
+    void typedCaptureErrors_fail() {
         invocation.then(String.class, stringSuccessConsumer);
 
         invocation.completeExceptionally(fooJsonString);
@@ -159,7 +159,7 @@ class PendingJavaScriptInvocationTest {
     }
 
     @Test
-    public void typedCaptureErrors_success() {
+    void typedCaptureErrors_success() {
         invocation.then(String.class, stringSuccessConsumer, errorConsumer);
 
         invocation.complete(fooJsonString);
@@ -168,7 +168,7 @@ class PendingJavaScriptInvocationTest {
     }
 
     @Test
-    public void typedIgnoreErrors_fail() {
+    void typedIgnoreErrors_fail() {
         invocation.then(String.class, stringSuccessConsumer, errorConsumer);
 
         invocation.completeExceptionally(fooJsonString);
@@ -177,7 +177,7 @@ class PendingJavaScriptInvocationTest {
     }
 
     @Test
-    public void typedFuture_success() {
+    void typedFuture_success() {
         invocation.toCompletableFuture(String.class)
                 .whenComplete(stringFutureHandler);
 
@@ -187,7 +187,7 @@ class PendingJavaScriptInvocationTest {
     }
 
     @Test
-    public void typedFuture_fail() {
+    void typedFuture_fail() {
         invocation.toCompletableFuture(String.class)
                 .whenComplete(stringFutureHandler);
 
@@ -197,7 +197,7 @@ class PendingJavaScriptInvocationTest {
     }
 
     @Test
-    public void multipleSuccessHandlers() {
+    void multipleSuccessHandlers() {
         invocation.then(jsonSuccessConsumer, errorConsumer);
         invocation.then(String.class, stringSuccessConsumer);
 
@@ -209,7 +209,7 @@ class PendingJavaScriptInvocationTest {
     }
 
     @Test
-    public void multipleErrorHandlers() {
+    void multipleErrorHandlers() {
         SingleCaptureConsumer<String> extraErrorHandler = new SingleCaptureConsumer<>();
 
         invocation.then(jsonSuccessConsumer, errorConsumer);
@@ -225,7 +225,7 @@ class PendingJavaScriptInvocationTest {
     }
 
     @Test
-    public void thenAfterSend_throws() {
+    void thenAfterSend_throws() {
         invocation.setSentToBrowser();
 
         assertThrows(IllegalStateException.class,
@@ -233,7 +233,7 @@ class PendingJavaScriptInvocationTest {
     }
 
     @Test
-    public void subscribeAfterCancel_callFailHandler() {
+    void subscribeAfterCancel_callFailHandler() {
         invocation.cancelExecution();
 
         invocation.then(jsonSuccessConsumer, errorConsumer);
@@ -242,7 +242,7 @@ class PendingJavaScriptInvocationTest {
     }
 
     @Test
-    public void susbscribeBeforeCancel_callFailHandler() {
+    void susbscribeBeforeCancel_callFailHandler() {
         invocation.then(jsonSuccessConsumer, errorConsumer);
 
         invocation.cancelExecution();
@@ -251,7 +251,7 @@ class PendingJavaScriptInvocationTest {
     }
 
     @Test
-    public void blockFromInvokingThread_throws() throws Exception {
+    void blockFromInvokingThread_throws() throws Exception {
         MockVaadinSession session = new MockVaadinSession();
         session.runWithLock(() -> {
             CompletableFuture<JsonNode> completableFuture = invocation
@@ -272,8 +272,7 @@ class PendingJavaScriptInvocationTest {
     }
 
     @Test
-    public void blockFromSessionThreadAfterCompleting_doesNotThrow()
-            throws Exception {
+    void blockFromSessionThreadAfterCompleting_doesNotThrow() throws Exception {
         MockVaadinSession session = new MockVaadinSession();
         session.runWithLock(() -> {
             CompletableFuture<JsonNode> completableFuture = invocation
@@ -293,8 +292,7 @@ class PendingJavaScriptInvocationTest {
     }
 
     @Test
-    public void blockFromSessionThreadAfterFailing_doesNotThrow()
-            throws Exception {
+    void blockFromSessionThreadAfterFailing_doesNotThrow() throws Exception {
         MockVaadinSession session = new MockVaadinSession();
         session.runWithLock(() -> {
             CompletableFuture<JsonNode> completableFuture = invocation
@@ -320,7 +318,7 @@ class PendingJavaScriptInvocationTest {
     }
 
     @Test
-    public void blockFromOtherThread_doesNotThrow() throws Exception {
+    void blockFromOtherThread_doesNotThrow() throws Exception {
         MockVaadinSession session = new MockVaadinSession();
         VaadinSession.setCurrent(session);
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/UIInternalsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/UIInternalsTest.java
@@ -130,7 +130,7 @@ class UIInternalsTest {
     }
 
     @BeforeEach
-    public void init() {
+    void init() {
         MockitoAnnotations.initMocks(this);
 
         Mockito.when(ui.getUI()).thenReturn(Optional.of(ui));
@@ -147,7 +147,7 @@ class UIInternalsTest {
     }
 
     @Test
-    public void heartbeatTimestampSet_heartbeatListenersAreCalled() {
+    void heartbeatTimestampSet_heartbeatListenersAreCalled() {
         List<Long> heartbeats = new ArrayList<>();
         Registration registration = internals.addHeartbeatListener(
                 event -> heartbeats.add(event.getHeartbeatTime()));
@@ -166,7 +166,7 @@ class UIInternalsTest {
     }
 
     @Test
-    public void heartbeatListenerRemovedFromHeartbeatEvent_noExplosion() {
+    void heartbeatListenerRemovedFromHeartbeatEvent_noExplosion() {
         AtomicReference<Registration> reference = new AtomicReference<>();
         AtomicInteger runCount = new AtomicInteger();
 
@@ -185,7 +185,7 @@ class UIInternalsTest {
     }
 
     @Test
-    public void showRouteTarget_clientSideBootstrap() {
+    void showRouteTarget_clientSideBootstrap() {
         PushConfiguration pushConfig = setUpInitialPush();
 
         internals.showRouteTarget(Mockito.mock(Location.class),
@@ -195,7 +195,7 @@ class UIInternalsTest {
     }
 
     @Test
-    public void showRouteTarget_navigateToAnotherViewWithinSameLayoutHierarchy_detachedRouterLayoutChildrenRemoved() {
+    void showRouteTarget_navigateToAnotherViewWithinSameLayoutHierarchy_detachedRouterLayoutChildrenRemoved() {
         MainLayout mainLayout = new MainLayout();
         SubLayout subLayout = new SubLayout();
         FirstView firstView = new FirstView();
@@ -254,7 +254,7 @@ class UIInternalsTest {
     }
 
     @Test
-    public void showRouteTarget_navigateToAnotherLayoutHierarchy_detachedLayoutHierarchyChildrenRemoved() {
+    void showRouteTarget_navigateToAnotherLayoutHierarchy_detachedLayoutHierarchyChildrenRemoved() {
         MainLayout mainLayout = new MainLayout();
         SubLayout subLayout = new SubLayout();
         FirstView firstView = new FirstView();
@@ -287,7 +287,7 @@ class UIInternalsTest {
     }
 
     @Test
-    public void dumpPendingJavaScriptInvocations_detachListenerRegisteredOnce() {
+    void dumpPendingJavaScriptInvocations_detachListenerRegisteredOnce() {
         StateNode node = Mockito.spy(new StateNode(ElementData.class));
         node.getFeature(ElementData.class).setVisible(false);
         internals.getStateTree().getRootNode()
@@ -304,7 +304,7 @@ class UIInternalsTest {
     }
 
     @Test
-    public void dumpPendingJavaScriptInvocations_multipleInvocationPerNode_onlyOneDetachListenerRegistered() {
+    void dumpPendingJavaScriptInvocations_multipleInvocationPerNode_onlyOneDetachListenerRegistered() {
         StateNode node = Mockito.spy(new StateNode(ElementData.class));
         node.getFeature(ElementData.class).setVisible(false);
         internals.getStateTree().getRootNode()
@@ -323,7 +323,7 @@ class UIInternalsTest {
     }
 
     @Test
-    public void dumpPendingJavaScriptInvocations_registerOneDetachListenerPerNode() {
+    void dumpPendingJavaScriptInvocations_registerOneDetachListenerPerNode() {
         StateNode node1 = Mockito.spy(new StateNode(ElementData.class));
         node1.getFeature(ElementData.class).setVisible(false);
         internals.getStateTree().getRootNode()
@@ -347,7 +347,7 @@ class UIInternalsTest {
     }
 
     @Test
-    public void dumpPendingJavaScriptInvocations_invocationCompletes_pendingListPurged() {
+    void dumpPendingJavaScriptInvocations_invocationCompletes_pendingListPurged() {
         StateNode node = Mockito.spy(new StateNode(ElementData.class));
         node.getFeature(ElementData.class).setVisible(false);
         internals.getStateTree().getRootNode()
@@ -367,7 +367,7 @@ class UIInternalsTest {
     }
 
     @Test
-    public void dumpPendingJavaScriptInvocations_invocationFails_pendingListPurged() {
+    void dumpPendingJavaScriptInvocations_invocationFails_pendingListPurged() {
         StateNode node = Mockito.spy(new StateNode(ElementData.class));
         node.getFeature(ElementData.class).setVisible(false);
         internals.getStateTree().getRootNode()
@@ -388,7 +388,7 @@ class UIInternalsTest {
     }
 
     @Test
-    public void dumpPendingJavaScriptInvocations_invocationCanceled_pendingListPurged() {
+    void dumpPendingJavaScriptInvocations_invocationCanceled_pendingListPurged() {
         StateNode node = Mockito.spy(new StateNode(ElementData.class));
         node.getFeature(ElementData.class).setVisible(false);
         internals.getStateTree().getRootNode()
@@ -408,7 +408,7 @@ class UIInternalsTest {
     }
 
     @Test
-    public void dumpPendingJavaScriptInvocations_nodeDetached_pendingListPurged() {
+    void dumpPendingJavaScriptInvocations_nodeDetached_pendingListPurged() {
         StateNode node = Mockito.spy(new StateNode(ElementData.class));
         node.getFeature(ElementData.class).setVisible(false);
         internals.getStateTree().getRootNode()
@@ -428,7 +428,7 @@ class UIInternalsTest {
     }
 
     @Test
-    public void dumpPendingJavaScriptInvocations_multipleInvocation_detachListenerRegisteredOnce() {
+    void dumpPendingJavaScriptInvocations_multipleInvocation_detachListenerRegisteredOnce() {
         StateNode node = Mockito.spy(new StateNode(ElementData.class));
         node.getFeature(ElementData.class).setVisible(false);
         internals.getStateTree().getRootNode()
@@ -454,7 +454,7 @@ class UIInternalsTest {
     }
 
     @Test
-    public void isDirty_noPendingJsInvocation_returnsFalse() {
+    void isDirty_noPendingJsInvocation_returnsFalse() {
         StateNode node1 = Mockito.spy(new StateNode(ElementData.class));
         StateNode node2 = Mockito.spy(new StateNode(ElementData.class));
         node2.getFeature(ElementData.class).setVisible(false);
@@ -473,7 +473,7 @@ class UIInternalsTest {
     }
 
     @Test
-    public void isDirty_pendingJsInvocationReadyToSend_returnsTrue() {
+    void isDirty_pendingJsInvocationReadyToSend_returnsTrue() {
         StateNode node1 = Mockito.spy(new StateNode(ElementData.class));
         StateNode node2 = Mockito.spy(new StateNode(ElementData.class));
         node2.getFeature(ElementData.class).setVisible(false);
@@ -496,7 +496,7 @@ class UIInternalsTest {
     }
 
     @Test
-    public void isDirty_pendingJsInvocationNotReadyToSend_returnsFalse() {
+    void isDirty_pendingJsInvocationNotReadyToSend_returnsFalse() {
         StateNode node1 = Mockito.spy(new StateNode(ElementData.class));
         StateNode node2 = Mockito.spy(new StateNode(ElementData.class));
         node2.getFeature(ElementData.class).setVisible(false);
@@ -521,7 +521,7 @@ class UIInternalsTest {
     }
 
     @Test
-    public void setTitle_titleAndPendingJsInvocationSetsCorrectTitle() {
+    void setTitle_titleAndPendingJsInvocationSetsCorrectTitle() {
         internals.setTitle("new title");
         assertEquals("new title", internals.getTitle());
 
@@ -560,7 +560,7 @@ class UIInternalsTest {
     }
 
     @Test
-    public void getDeploymentConfiguration() {
+    void getDeploymentConfiguration() {
         AlwaysLockedVaadinSession session = Mockito
                 .mock(AlwaysLockedVaadinSession.class);
         MockVaadinServletService mockVaadinServletService = Mockito

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/ColorSchemeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/ColorSchemeTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class ColorSchemeTest {
 
     @Test
-    public void getValue_returnsCorrectValue() {
+    void getValue_returnsCorrectValue() {
         assertEquals("light", ColorScheme.Value.LIGHT.getValue());
         assertEquals("dark", ColorScheme.Value.DARK.getValue());
         assertEquals("light dark", ColorScheme.Value.LIGHT_DARK.getValue());
@@ -32,14 +32,14 @@ class ColorSchemeTest {
     }
 
     @Test
-    public void getThemeValue_singleValue_returnsUnchanged() {
+    void getThemeValue_singleValue_returnsUnchanged() {
         assertEquals("light", ColorScheme.Value.LIGHT.getThemeValue());
         assertEquals("dark", ColorScheme.Value.DARK.getThemeValue());
         assertEquals("normal", ColorScheme.Value.NORMAL.getThemeValue());
     }
 
     @Test
-    public void getThemeValue_multiValue_replacesSpaceWithHyphen() {
+    void getThemeValue_multiValue_replacesSpaceWithHyphen() {
         assertEquals("light-dark",
                 ColorScheme.Value.LIGHT_DARK.getThemeValue());
         assertEquals("dark-light",
@@ -48,7 +48,7 @@ class ColorSchemeTest {
     }
 
     @Test
-    public void fromString_validValues_returnsCorrectEnum() {
+    void fromString_validValues_returnsCorrectEnum() {
         assertEquals(ColorScheme.Value.LIGHT,
                 ColorScheme.Value.fromString("light"));
         assertEquals(ColorScheme.Value.DARK,
@@ -62,7 +62,7 @@ class ColorSchemeTest {
     }
 
     @Test
-    public void fromString_nullOrEmpty_returnsNormal() {
+    void fromString_nullOrEmpty_returnsNormal() {
         assertEquals(ColorScheme.Value.NORMAL,
                 ColorScheme.Value.fromString(null));
         assertEquals(ColorScheme.Value.NORMAL,
@@ -70,7 +70,7 @@ class ColorSchemeTest {
     }
 
     @Test
-    public void fromString_unrecognizedValue_returnsNormal() {
+    void fromString_unrecognizedValue_returnsNormal() {
         assertEquals(ColorScheme.Value.NORMAL,
                 ColorScheme.Value.fromString("invalid"));
         assertEquals(ColorScheme.Value.NORMAL,
@@ -78,7 +78,7 @@ class ColorSchemeTest {
     }
 
     @Test
-    public void fromString_lightDark_returnsLightDarkNotSystem() {
+    void fromString_lightDark_returnsLightDarkNotSystem() {
         // Ensure backward compatibility: parsing "light dark" returns
         // LIGHT_DARK
         assertEquals(ColorScheme.Value.LIGHT_DARK,

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/ExtendedClientDetailsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/ExtendedClientDetailsTest.java
@@ -30,12 +30,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ExtendedClientDetailsTest {
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         CurrentInstance.clearAll();
     }
 
     @Test
-    public void initializeWithClientValues_gettersReturnExpectedValues() {
+    void initializeWithClientValues_gettersReturnExpectedValues() {
         final ExtendedClientDetails details = new ExtendBuilder()
                 .buildDetails();
 
@@ -62,7 +62,7 @@ class ExtendedClientDetailsTest {
     }
 
     @Test
-    public void differentNavigatorPlatformDetails_isIPadReturnsExpectedValue() {
+    void differentNavigatorPlatformDetails_isIPadReturnsExpectedValue() {
         ExtendBuilder detailsBuilder = new ExtendBuilder();
 
         ExtendedClientDetails details = detailsBuilder.buildDetails();
@@ -86,7 +86,7 @@ class ExtendedClientDetailsTest {
     }
 
     @Test
-    public void differentNavigatorPlatformDetails_Ipod_isIOSReturnsExpectedValue() {
+    void differentNavigatorPlatformDetails_Ipod_isIOSReturnsExpectedValue() {
         ExtendedClientDetails details = new ExtendBuilder()
                 .setNavigatorPlatform("iPod ..").buildDetails();
 
@@ -102,7 +102,7 @@ class ExtendedClientDetailsTest {
     }
 
     @Test
-    public void isIOS_isIPad_returnsTrue() {
+    void isIOS_isIPad_returnsTrue() {
         ExtendedClientDetails details = Mockito
                 .mock(ExtendedClientDetails.class);
         Mockito.doCallRealMethod().when(details).isIOS();
@@ -112,7 +112,7 @@ class ExtendedClientDetailsTest {
     }
 
     @Test
-    public void isIOS_notIPadIsIPhone_returnsTrue() {
+    void isIOS_notIPadIsIPhone_returnsTrue() {
         ExtendedClientDetails details = Mockito
                 .mock(ExtendedClientDetails.class);
         Mockito.doCallRealMethod().when(details).isIOS();
@@ -129,7 +129,7 @@ class ExtendedClientDetailsTest {
     }
 
     @Test
-    public void isIOS_notIPad_notIsIPhone_returnsFalse() {
+    void isIOS_notIPad_notIsIPhone_returnsFalse() {
         ExtendedClientDetails details = Mockito
                 .mock(ExtendedClientDetails.class);
         Mockito.doCallRealMethod().when(details).isIOS();

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/HistoryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/HistoryTest.java
@@ -76,7 +76,7 @@ class HistoryTest {
     private static final String REPLACE_STATE_REACT = "window.dispatchEvent(new CustomEvent('vaadin-navigate', { detail: { state: $0, url: $1, replace: true, callback: $2 } }));";
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         history = new History(ui);
         configuration = Mockito.mock(DeploymentConfiguration.class);
 
@@ -88,7 +88,7 @@ class HistoryTest {
     }
 
     @Test
-    public void pushState_locationWithQueryParameters_queryParametersRetained() {
+    void pushState_locationWithQueryParameters_queryParametersRetained() {
         history.pushState(JacksonUtils.readTree("{'foo':'bar'}"),
                 "context/view?param=4");
 
@@ -113,7 +113,7 @@ class HistoryTest {
     }
 
     @Test
-    public void pushState_locationWithFragment_fragmentRetained() {
+    void pushState_locationWithFragment_fragmentRetained() {
         history.pushState(null, "context/view#foobar");
 
         assertEquals(PUSH_STATE_JS, page.expression,
@@ -132,7 +132,7 @@ class HistoryTest {
     }
 
     @Test // #11628
-    public void pushState_locationWithQueryParametersAndFragment_QueryParametersAndFragmentRetained() {
+    void pushState_locationWithQueryParametersAndFragment_QueryParametersAndFragmentRetained() {
         history.pushState(null, "context/view?foo=bar#foobar");
 
         assertEquals(PUSH_STATE_JS, page.expression,
@@ -151,7 +151,7 @@ class HistoryTest {
     }
 
     @Test // #11628
-    public void replaceState_locationWithQueryParametersAndFragment_QueryParametersAndFragmentRetained() {
+    void replaceState_locationWithQueryParametersAndFragment_QueryParametersAndFragmentRetained() {
         history.replaceState(null, "context/view?foo=bar#foobar");
 
         assertEquals(REPLACE_STATE_JS, page.expression,
@@ -170,7 +170,7 @@ class HistoryTest {
     }
 
     @Test // #11628
-    public void replaceState_locationEmpty_pushesPeriod() {
+    void replaceState_locationEmpty_pushesPeriod() {
         history.replaceState(null, "");
         assertEquals(REPLACE_STATE_JS, page.expression,
                 "replace state JS not included");
@@ -179,7 +179,7 @@ class HistoryTest {
     }
 
     @Test
-    public void pushState_locationWithQueryParameters_queryParametersRetained_react() {
+    void pushState_locationWithQueryParameters_queryParametersRetained_react() {
         Mockito.when(configuration.isReactEnabled()).thenReturn(true);
         history.pushState(JacksonUtils.readTree("{'foo':'bar'}"),
                 "context/view?param=4");
@@ -205,7 +205,7 @@ class HistoryTest {
     }
 
     @Test
-    public void pushState_locationWithFragment_fragmentRetained_react() {
+    void pushState_locationWithFragment_fragmentRetained_react() {
         Mockito.when(configuration.isReactEnabled()).thenReturn(true);
         history.pushState(null, "context/view#foobar");
 
@@ -225,7 +225,7 @@ class HistoryTest {
     }
 
     @Test // #11628
-    public void pushState_locationWithQueryParametersAndFragment_QueryParametersAndFragmentRetained_react() {
+    void pushState_locationWithQueryParametersAndFragment_QueryParametersAndFragmentRetained_react() {
         Mockito.when(configuration.isReactEnabled()).thenReturn(true);
         history.pushState(null, "context/view?foo=bar#foobar");
 
@@ -245,7 +245,7 @@ class HistoryTest {
     }
 
     @Test // #11628
-    public void replaceState_locationWithQueryParametersAndFragment_QueryParametersAndFragmentRetained_react() {
+    void replaceState_locationWithQueryParametersAndFragment_QueryParametersAndFragmentRetained_react() {
         Mockito.when(configuration.isReactEnabled()).thenReturn(true);
         history.replaceState(null, "context/view?foo=bar#foobar");
 
@@ -265,7 +265,7 @@ class HistoryTest {
     }
 
     @Test // #11628
-    public void replaceState_locationEmpty_pushesPeriod_react() {
+    void replaceState_locationEmpty_pushesPeriod_react() {
         Mockito.when(configuration.isReactEnabled()).thenReturn(true);
         history.replaceState(null, "");
         assertEquals(REPLACE_STATE_REACT, page.expression,

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
@@ -84,14 +84,14 @@ class PageTest {
 
     @Test
 
-    public void addNullAsAListener_trows() {
+    void addNullAsAListener_trows() {
         assertThrows(NullPointerException.class, () -> {
             page.addBrowserWindowResizeListener(null);
         });
     }
 
     @Test
-    public void retrieveExtendedClientDetails_twice_jsOnceAndCallbackTwice() {
+    void retrieveExtendedClientDetails_twice_jsOnceAndCallbackTwice() {
         // given
         final MockUI mockUI = new MockUI();
         final Page page = new Page(mockUI) {
@@ -151,7 +151,7 @@ class PageTest {
     }
 
     @Test
-    public void fetchCurrentUrl_consumerReceivesCorrectURL() {
+    void fetchCurrentUrl_consumerReceivesCorrectURL() {
         // given
         final UI mockUI = new MockUI();
         final Page page = new Page(mockUI) {
@@ -198,7 +198,7 @@ class PageTest {
     }
 
     @Test
-    public void fetchCurrentUrl_passNullCallback_throwsNullPointerException() {
+    void fetchCurrentUrl_passNullCallback_throwsNullPointerException() {
         final UI mockUI = new MockUI();
         Page page = new Page(mockUI);
         assertThrows(NullPointerException.class,
@@ -206,7 +206,7 @@ class PageTest {
     }
 
     @Test
-    public void addJsModule_accepts_onlyExternalAndStartingSlash() {
+    void addJsModule_accepts_onlyExternalAndStartingSlash() {
         List<String> urls = new LinkedList<>();
         urls.add("http://sample.com/mod.js");
         urls.add("https://sample.com/mod.js");
@@ -240,7 +240,7 @@ class PageTest {
     }
 
     @Test
-    public void addJsModule_rejects_files() {
+    void addJsModule_rejects_files() {
         try {
             page.addJsModule("mod.js");
 
@@ -250,7 +250,7 @@ class PageTest {
     }
 
     @Test
-    public void executeJavaScript_delegatesToExecJs() {
+    void executeJavaScript_delegatesToExecJs() {
         AtomicReference<String> invokedExpression = new AtomicReference<>();
         AtomicReference<Object[]> invokedParams = new AtomicReference<>();
 
@@ -279,7 +279,7 @@ class PageTest {
     }
 
     @Test
-    public void open_openInSameWindow_closeTheClientApplication() {
+    void open_openInSameWindow_closeTheClientApplication() {
         AtomicReference<String> capture = new AtomicReference<>();
         List<Object> params = new ArrayList<>();
         Page page = new Page(new MockUI()) {
@@ -302,7 +302,7 @@ class PageTest {
     }
 
     @Test
-    public void setLocation_dispatchesRedirectPendingEvent() {
+    void setLocation_dispatchesRedirectPendingEvent() {
         AtomicReference<String> capture = new AtomicReference<>();
         List<Object> params = new ArrayList<>();
         Page page = new Page(new MockUI()) {
@@ -327,7 +327,7 @@ class PageTest {
     }
 
     @Test
-    public void open_dispatchesRedirectPendingEventBeforeRedirect() {
+    void open_dispatchesRedirectPendingEventBeforeRedirect() {
         AtomicReference<String> capture = new AtomicReference<>();
         Page page = new Page(new MockUI()) {
             @Override
@@ -351,7 +351,7 @@ class PageTest {
     }
 
     @Test
-    public void setColorScheme_setsStyleProperty() {
+    void setColorScheme_setsStyleProperty() {
         AtomicReference<String> capturedExpression = new AtomicReference<>();
         AtomicReference<Object[]> capturedParams = new AtomicReference<>();
         MockUI mockUI = new MockUI();
@@ -379,7 +379,7 @@ class PageTest {
     }
 
     @Test
-    public void setColorScheme_lightDark_setsCorrectValues() {
+    void setColorScheme_lightDark_setsCorrectValues() {
         AtomicReference<String> capturedExpression = new AtomicReference<>();
         AtomicReference<Object[]> capturedParams = new AtomicReference<>();
         MockUI mockUI = new MockUI();
@@ -408,7 +408,7 @@ class PageTest {
     }
 
     @Test
-    public void setColorScheme_null_clearsProperty() {
+    void setColorScheme_null_clearsProperty() {
         MockUI mockUI = new MockUI();
 
         AtomicReference<String> capturedExpression = new AtomicReference<>();
@@ -432,7 +432,7 @@ class PageTest {
     }
 
     @Test
-    public void setColorScheme_normal_clearsProperty() {
+    void setColorScheme_normal_clearsProperty() {
         MockUI mockUI = new MockUI();
 
         AtomicReference<String> capturedExpression = new AtomicReference<>();
@@ -453,13 +453,13 @@ class PageTest {
     }
 
     @Test
-    public void getColorScheme_returnsNormal_whenNotSet() {
+    void getColorScheme_returnsNormal_whenNotSet() {
         Page page = new Page(new MockUI());
         assertEquals(ColorScheme.Value.NORMAL, page.getColorScheme());
     }
 
     @Test
-    public void getColorScheme_returnsCachedValue() {
+    void getColorScheme_returnsCachedValue() {
         MockUI mockUI = new MockUI();
         // Set up ExtendedClientDetails with color scheme
         ExtendedClientDetails details = new ExtendedClientDetails(mockUI, null,
@@ -472,7 +472,7 @@ class PageTest {
     }
 
     @Test
-    public void setColorScheme_updatesGetColorScheme() {
+    void setColorScheme_updatesGetColorScheme() {
         MockUI mockUI = new MockUI();
         // Set up ExtendedClientDetails
         ExtendedClientDetails details = new ExtendedClientDetails(mockUI, null,

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/StylesheetRemovalTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/StylesheetRemovalTest.java
@@ -49,7 +49,7 @@ class StylesheetRemovalTest {
     private DependencyList dependencyList;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         ui = new MockUI();
         page = ui.getPage();
         internals = ui.getInternals();
@@ -57,7 +57,7 @@ class StylesheetRemovalTest {
     }
 
     @Test
-    public void addStyleSheet_returnsNonNullRegistration() {
+    void addStyleSheet_returnsNonNullRegistration() {
         Registration reg1 = page.addStyleSheet("styles.css");
         Registration reg2 = page.addStyleSheet("styles.css", LoadMode.LAZY);
 
@@ -67,7 +67,7 @@ class StylesheetRemovalTest {
     }
 
     @Test
-    public void addStyleSheet_returnsRegistration_thatRemovesStylesheet() {
+    void addStyleSheet_returnsRegistration_thatRemovesStylesheet() {
         String url = "http://example.com/style.css";
 
         // Add stylesheet
@@ -93,7 +93,7 @@ class StylesheetRemovalTest {
     }
 
     @Test
-    public void stylesheetCanBeReAddedAfterRemoval() {
+    void stylesheetCanBeReAddedAfterRemoval() {
         String url = "http://example.com/reusable.css";
 
         Registration reg1 = page.addStyleSheet(url);
@@ -118,7 +118,7 @@ class StylesheetRemovalTest {
     }
 
     @Test
-    public void stylesheetWithLoadMode_canBeReAddedWithDifferentMode() {
+    void stylesheetWithLoadMode_canBeReAddedWithDifferentMode() {
         String url = "http://example.com/lazy.css";
 
         // Add with LAZY mode
@@ -143,7 +143,7 @@ class StylesheetRemovalTest {
     }
 
     @Test
-    public void multipleStylesheets_removeOne_othersRemainIntact() {
+    void multipleStylesheets_removeOne_othersRemainIntact() {
         String url1 = "http://example.com/style1.css";
         String url2 = "http://example.com/style2.css";
         String url3 = "http://example.com/style3.css";
@@ -179,7 +179,7 @@ class StylesheetRemovalTest {
     }
 
     @Test
-    public void uidlWriter_includesStylesheetRemovals() {
+    void uidlWriter_includesStylesheetRemovals() {
         String url = "http://example.com/to-remove.css";
 
         // Add and get the dependency ID
@@ -212,7 +212,7 @@ class StylesheetRemovalTest {
     }
 
     @Test
-    public void duplicateStylesheet_notAddedUntilRemovedFromCache() {
+    void duplicateStylesheet_notAddedUntilRemovedFromCache() {
         String url = "http://example.com/cached-style.css";
 
         // Add stylesheet
@@ -230,7 +230,7 @@ class StylesheetRemovalTest {
     }
 
     @Test
-    public void duplicateStylesheet_firstRegistrationCanRemove() {
+    void duplicateStylesheet_firstRegistrationCanRemove() {
         String url = "http://example.com/duplicate.css";
 
         // Add stylesheet twice - both should use same ID
@@ -252,7 +252,7 @@ class StylesheetRemovalTest {
     }
 
     @Test
-    public void duplicateStylesheet_secondRegistrationCanRemove() {
+    void duplicateStylesheet_secondRegistrationCanRemove() {
         String url = "http://example.com/duplicate2.css";
 
         // Add stylesheet twice - both should use same ID

--- a/flow-server/src/test/java/com/vaadin/flow/component/webcomponent/WebComponentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/webcomponent/WebComponentTest.java
@@ -40,7 +40,7 @@ class WebComponentTest {
     private WebComponent<Component> webComponent;
 
     @BeforeEach
-    public void init() {
+    void init() {
         WebComponentBinding<Component> componentBinding = new WebComponentBinding<>(
                 mock(Component.class));
         webComponent = new WebComponent<>(componentBinding, new Element("tag"));
@@ -54,7 +54,7 @@ class WebComponentTest {
     }
 
     @Test
-    public void fireEvent_doesNotThrowOnNullObjectData() {
+    void fireEvent_doesNotThrowOnNullObjectData() {
         webComponent.fireEvent("name", (JsonNode) null);
     }
 
@@ -114,7 +114,7 @@ class WebComponentTest {
     }
 
     @Test
-    public void setProperty_attemptsToWriteSupportedTypes() {
+    void setProperty_attemptsToWriteSupportedTypes() {
         Element element = spy(new Element("tag"));
 
         // configurations

--- a/flow-server/src/test/java/com/vaadin/flow/component/webcomponent/WebComponentWrapperTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/webcomponent/WebComponentWrapperTest.java
@@ -55,7 +55,7 @@ class WebComponentWrapperTest {
     private WebComponentWrapper wrapper;
 
     @BeforeEach
-    public void init() {
+    void init() {
         element = new Element("tag");
         exporter = new MyComponentExporter();
 
@@ -69,7 +69,7 @@ class WebComponentWrapperTest {
     }
 
     @Test
-    public void wrappedMyComponent_syncSetsCorrectValuesToFields() {
+    void wrappedMyComponent_syncSetsCorrectValuesToFields() {
         wrapper.sync(MSG_PROPERTY, JacksonUtils.writeValue("MyMessage"));
 
         assertEquals("MyMessage", component.message,
@@ -82,7 +82,7 @@ class WebComponentWrapperTest {
     }
 
     @Test
-    public void wrappedComponentPropertyListener_listenerFiredWithCorrectValuesOnSync() {
+    void wrappedComponentPropertyListener_listenerFiredWithCorrectValuesOnSync() {
         wrapper.sync(MSG_PROPERTY, JacksonUtils.writeValue("one"));
         wrapper.sync(INT_PROPERTY, JacksonUtils.writeValue(2));
         wrapper.sync(MSG_PROPERTY, JacksonUtils.writeValue("three"));
@@ -105,7 +105,7 @@ class WebComponentWrapperTest {
     }
 
     @Test
-    public void exportingExtendedComponent_inheritedFieldsAreAvailableAndOverridden() {
+    void exportingExtendedComponent_inheritedFieldsAreAvailableAndOverridden() {
         WebComponentBinding<MyExtension> binding = constructWrapperAndGetBinding(
                 new MyExtensionExporter(), null, null);
 
@@ -134,7 +134,7 @@ class WebComponentWrapperTest {
     }
 
     @Test
-    public void extendedExporter_propertiesAreOverwrittenAndAvailable() {
+    void extendedExporter_propertiesAreOverwrittenAndAvailable() {
         WebComponentBinding<MyComponent> binding = constructWrapperAndGetBinding(
                 new ExtendedExporter(), null, null);
 
@@ -166,7 +166,7 @@ class WebComponentWrapperTest {
     }
 
     @Test
-    public void disconnectReconnect_componentIsNotCleaned() {
+    void disconnectReconnect_componentIsNotCleaned() {
         Element element = new Element("tag");
         WebComponentUI ui = constructWebComponentUI(element);
         constructWrapperAndGetBinding(new MyComponentExporter(), element, ui);
@@ -188,7 +188,7 @@ class WebComponentWrapperTest {
     }
 
     @Test
-    public void disconnectOnClient_componentIsCleaned() {
+    void disconnectOnClient_componentIsCleaned() {
         Element element = new Element("tag");
         WebComponentUI ui = constructWebComponentUI(element);
         constructWrapperAndGetBinding(new MyComponentExporter(), element, ui);

--- a/flow-server/src/test/java/com/vaadin/flow/di/AppShellPredicateImplTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/di/AppShellPredicateImplTest.java
@@ -36,12 +36,12 @@ class AppShellPredicateImplTest {
     }
 
     @Test
-    public void isShell_isAppShellConfigurator_returnsTrue() {
+    void isShell_isAppShellConfigurator_returnsTrue() {
         assertTrue(predicate.isShell(TestAppShellPredicateConfig.class));
     }
 
     @Test
-    public void isShell_isNotAppShellConfigurator_returnsFalse() {
+    void isShell_isNotAppShellConfigurator_returnsFalse() {
         assertFalse(predicate.isShell(List.class));
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/di/DefaultInstantiatorTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/di/DefaultInstantiatorTest.java
@@ -43,7 +43,7 @@ class DefaultInstantiatorTest {
     }
 
     @Test
-    public void createComponent_dontDependOnGetOrCreate() {
+    void createComponent_dontDependOnGetOrCreate() {
         DefaultInstantiator instantiator = Mockito
                 .mock(DefaultInstantiator.class);
 
@@ -60,7 +60,7 @@ class DefaultInstantiatorTest {
     }
 
     @Test
-    public void getOrCreate_lookupHasObject_returnObjectFromLookup() {
+    void getOrCreate_lookupHasObject_returnObjectFromLookup() {
         VaadinService service = Mockito.mock(VaadinService.class);
         Lookup lookup = mockLookup(service);
 
@@ -73,7 +73,7 @@ class DefaultInstantiatorTest {
     }
 
     @Test
-    public void getOrCreate_lookupHasNoObject_createNewObject() {
+    void getOrCreate_lookupHasNoObject_createNewObject() {
         VaadinService service = Mockito.mock(VaadinService.class);
         mockLookup(service);
 
@@ -84,7 +84,7 @@ class DefaultInstantiatorTest {
     }
 
     @Test
-    public void getApplicationClass_regularClass_getsSameClass() {
+    void getApplicationClass_regularClass_getsSameClass() {
         VaadinService service = Mockito.mock(VaadinService.class);
         mockLookup(service);
 
@@ -98,7 +98,7 @@ class DefaultInstantiatorTest {
     }
 
     @Test
-    public void getApplicationClass_syntheticClass_getsApplicationClass()
+    void getApplicationClass_syntheticClass_getsApplicationClass()
             throws Exception {
         VaadinService service = Mockito.mock(VaadinService.class);
         mockLookup(service);

--- a/flow-server/src/test/java/com/vaadin/flow/di/LookupInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/di/LookupInitializerTest.java
@@ -73,7 +73,7 @@ class LookupInitializerTest {
     private LookupInitializer initializer = new LookupInitializer();
 
     @Test
-    public void createLookup_instantiatorsAreProvidedAsAService_lookupThrows()
+    void createLookup_instantiatorsAreProvidedAsAService_lookupThrows()
             throws ServletException {
         assertThrows(IllegalStateException.class, () -> {
             // Java standard SPI is used to register several instantiators via
@@ -85,7 +85,7 @@ class LookupInitializerTest {
     }
 
     @Test
-    public void createLookup_instantiatorsAreProvidedAsScannedClasses_multipleInstantiatorInstances_lookupThrows()
+    void createLookup_instantiatorsAreProvidedAsScannedClasses_multipleInstantiatorInstances_lookupThrows()
             throws ServletException {
         assertThrows(IllegalStateException.class, () -> {
             Lookup lookup = initializer.createLookup(null,
@@ -98,7 +98,7 @@ class LookupInitializerTest {
     }
 
     @Test
-    public void initialize_noResourcePorvider_defaultResourceProviderIsCreated()
+    void initialize_noResourcePorvider_defaultResourceProviderIsCreated()
             throws ServletException, IOException {
         AtomicReference<Lookup> capture = new AtomicReference<>();
         initializer.initialize(null, new HashMap<>(), capture::set);
@@ -108,7 +108,7 @@ class LookupInitializerTest {
     }
 
     @Test
-    public void initialize_noStaticFileHandlerFactory_defaultStaticFileHandlerFactoryCreated()
+    void initialize_noStaticFileHandlerFactory_defaultStaticFileHandlerFactoryCreated()
             throws ServletException {
         AtomicReference<Lookup> capture = new AtomicReference<>();
         initializer.initialize(null, new HashMap<>(), capture::set);
@@ -131,7 +131,7 @@ class LookupInitializerTest {
     }
 
     @Test
-    public void initialize_StaticFileHandlerFactoryIdDelegatedToEnsureService()
+    void initialize_StaticFileHandlerFactoryIdDelegatedToEnsureService()
             throws ServletException {
         Map mock = Mockito.mock(Map.class);
         AtomicBoolean factoryIsPassed = new AtomicBoolean();
@@ -156,7 +156,7 @@ class LookupInitializerTest {
     }
 
     @Test
-    public void initialize_hasOneTimeInitializerPredicate_predicateReturnsTrue()
+    void initialize_hasOneTimeInitializerPredicate_predicateReturnsTrue()
             throws ServletException, IOException {
         AtomicReference<Lookup> capture = new AtomicReference<>();
         initializer.initialize(null, new HashMap<>(), capture::set);
@@ -169,7 +169,7 @@ class LookupInitializerTest {
     }
 
     @Test
-    public void ensureResourceProvider_defaultImplClassIsStoredAsAService() {
+    void ensureResourceProvider_defaultImplClassIsStoredAsAService() {
         HashMap<Class<?>, Collection<Class<?>>> map = new HashMap<>();
         initializer.ensureService(map, ResourceProvider.class,
                 ResourceProviderImpl.class);
@@ -181,7 +181,7 @@ class LookupInitializerTest {
     }
 
     @Test
-    public void ensureResourceProvider_defaultImplClassIsProvided_defaultImplIsStoredAsAService() {
+    void ensureResourceProvider_defaultImplClassIsProvided_defaultImplIsStoredAsAService() {
         HashMap<Class<?>, Collection<Class<?>>> map = new HashMap<>();
         map.put(ResourceProvider.class,
                 Collections.singletonList(ResourceProviderImpl.class));
@@ -195,7 +195,7 @@ class LookupInitializerTest {
     }
 
     @Test
-    public void ensureRoutePathResolver_defaultImplClassIsStoredAsAService() {
+    void ensureRoutePathResolver_defaultImplClassIsStoredAsAService() {
         HashMap<Class<?>, Collection<Class<?>>> map = new HashMap<>();
         initializer.ensureService(map, RoutePathProvider.class,
                 DefaultRoutePathProvider.class);
@@ -207,7 +207,7 @@ class LookupInitializerTest {
     }
 
     @Test
-    public void ensureRoutePathResolver_defaultImplClassIsProvided_defaultImplIsStoredAsAService() {
+    void ensureRoutePathResolver_defaultImplClassIsProvided_defaultImplIsStoredAsAService() {
         HashMap<Class<?>, Collection<Class<?>>> map = new HashMap<>();
         map.put(RoutePathProvider.class,
                 Collections.singletonList(DefaultRoutePathProvider.class));
@@ -221,7 +221,7 @@ class LookupInitializerTest {
     }
 
     @Test
-    public void ensureApplicationConfigurationFactories_defaultFactoryOnly_defaultFactoryIsReturned()
+    void ensureApplicationConfigurationFactories_defaultFactoryOnly_defaultFactoryIsReturned()
             throws ServletException {
         HashMap<Class<?>, Collection<Class<?>>> map = new HashMap<>();
         map.put(ApplicationConfigurationFactory.class, Collections
@@ -237,7 +237,7 @@ class LookupInitializerTest {
     }
 
     @Test
-    public void ensureApplicationConfigurationFactories_noAvailableFactory_defaultFactoryIsReturned()
+    void ensureApplicationConfigurationFactories_noAvailableFactory_defaultFactoryIsReturned()
             throws ServletException {
         HashMap<Class<?>, Collection<Class<?>>> map = new HashMap<>();
         map.put(ApplicationConfigurationFactory.class, Collections.emptyList());
@@ -253,7 +253,7 @@ class LookupInitializerTest {
 
     @SuppressWarnings("rawtypes")
     @Test
-    public void createLookup_createLookupIsInvoked_lookupcontainsProvidedServices()
+    void createLookup_createLookupIsInvoked_lookupcontainsProvidedServices()
             throws ServletException {
         HashMap<Class<?>, Collection<Class<?>>> map = new HashMap<>();
         map.put(List.class, Arrays.asList(ArrayList.class, LinkedList.class));
@@ -278,7 +278,7 @@ class LookupInitializerTest {
     }
 
     @Test
-    public void createLookup_instantiatorsAreProvidedAsScannedClassAndAsAService_lookupReturnsTheProviderInstance_lookupAllReturnsAllInstances()
+    void createLookup_instantiatorsAreProvidedAsScannedClassAndAsAService_lookupReturnsTheProviderInstance_lookupAllReturnsAllInstances()
             throws ServletException {
         HashMap<Class<?>, Collection<Class<?>>> map = new HashMap<>();
         map.put(InstantiatorFactory.class,
@@ -309,15 +309,13 @@ class LookupInitializerTest {
     }
 
     @Test
-    public void resourceProviderImpl_returnsClassPathResources()
-            throws IOException {
+    void resourceProviderImpl_returnsClassPathResources() throws IOException {
         assertResourceProvider(new ResourceProviderImpl());
     }
 
     @SuppressWarnings("unchecked")
     @Test
-    public void initialize_callEnsureMethodsAndBootstrap()
-            throws ServletException {
+    void initialize_callEnsureMethodsAndBootstrap() throws ServletException {
         LookupInitializer initializer = Mockito.spy(LookupInitializer.class);
         Map<Class<?>, Collection<Class<?>>> services = Mockito
                 .mock(HashMap.class);
@@ -336,7 +334,7 @@ class LookupInitializerTest {
     }
 
     @Test
-    public void ensureService_noServiceProvided_defaultIsUsed() {
+    void ensureService_noServiceProvided_defaultIsUsed() {
         Map<Class<?>, Collection<Class<?>>> services = new HashMap<>();
         initializer.ensureService(services, List.class, ArrayList.class);
 
@@ -347,7 +345,7 @@ class LookupInitializerTest {
     }
 
     @Test
-    public void ensureService_defaultServiceProvided_defaultIsUsed() {
+    void ensureService_defaultServiceProvided_defaultIsUsed() {
         Map<Class<?>, Collection<Class<?>>> services = new HashMap<>();
         services.put(List.class, Collections.singleton(ArrayList.class));
         initializer.ensureService(services, List.class, ArrayList.class);
@@ -359,7 +357,7 @@ class LookupInitializerTest {
     }
 
     @Test
-    public void ensureService_severalServicesProvided_throws() {
+    void ensureService_severalServicesProvided_throws() {
         assertThrows(IllegalStateException.class, () -> {
             Map<Class<?>, Collection<Class<?>>> services = new HashMap<>();
             services.put(List.class,

--- a/flow-server/src/test/java/com/vaadin/flow/di/LookupTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/di/LookupTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class LookupTest {
 
     @Test
-    public void of_nullServiceObject_throws() {
+    void of_nullServiceObject_throws() {
         assertThrows(NullPointerException.class, () -> {
             Lookup.of(null);
         });
@@ -39,7 +39,7 @@ class LookupTest {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Test
-    public void of_serviceNotExtendingType_throws() {
+    void of_serviceNotExtendingType_throws() {
         assertThrows(IllegalArgumentException.class, () -> {
             String service = "";
             Class type = List.class;
@@ -48,7 +48,7 @@ class LookupTest {
     }
 
     @Test
-    public void of_serviceIsFoundByProvidedTypes_serviceIsNotFoundByNotProvidedTypes() {
+    void of_serviceIsFoundByProvidedTypes_serviceIsNotFoundByNotProvidedTypes() {
         ArrayList<String> service = new ArrayList<String>();
         Lookup lookup = Lookup.of(service, Collection.class);
         assertEquals(service, lookup.lookup(Collection.class));
@@ -60,7 +60,7 @@ class LookupTest {
     }
 
     @Test
-    public void compose_bothLookupsHasService_resultingLookupReturnsServiceFromFirstLookup() {
+    void compose_bothLookupsHasService_resultingLookupReturnsServiceFromFirstLookup() {
         ArrayList<String> service = new ArrayList<String>();
         Lookup lookup1 = Lookup.of(service, Collection.class);
         Lookup lookup2 = Lookup.of(new LinkedList<String>(), Collection.class);
@@ -70,7 +70,7 @@ class LookupTest {
     }
 
     @Test
-    public void compose_firstLookupHasNoService_resultingLookupReturnsServiceFromSecondLookup() {
+    void compose_firstLookupHasNoService_resultingLookupReturnsServiceFromSecondLookup() {
         Lookup lookup1 = Lookup.of(new LinkedList<String>(), List.class);
         ArrayList<String> service = new ArrayList<String>();
         Lookup lookup2 = Lookup.of(service, Collection.class);
@@ -80,7 +80,7 @@ class LookupTest {
     }
 
     @Test
-    public void compose_differentServicesForSameType_resultingLookupAllReturnsAllServices() {
+    void compose_differentServicesForSameType_resultingLookupAllReturnsAllServices() {
         LinkedList<String> service1 = new LinkedList<String>();
         Lookup lookup1 = Lookup.of(service1, List.class);
         ArrayList<String> service2 = new ArrayList<String>();

--- a/flow-server/src/test/java/com/vaadin/flow/dom/AbstractNodeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/AbstractNodeTest.java
@@ -35,24 +35,24 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public abstract class AbstractNodeTest {
+abstract class AbstractNodeTest {
 
     @Test
-    public void insertWithNullParameter() {
+    void insertWithNullParameter() {
         Node<?> parent = createParentNode();
         assertThrows(IllegalArgumentException.class,
                 () -> parent.insertChild(0, (Element[]) null));
     }
 
     @Test
-    public void insertNullChild() {
+    void insertNullChild() {
         Node<?> parent = createParentNode();
         assertThrows(IllegalArgumentException.class,
                 () -> parent.insertChild(0, new Element[] { null }));
     }
 
     @Test
-    public void appendChildren() {
+    void appendChildren() {
         Node<?> parent = createParentNode();
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
@@ -73,7 +73,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void insertChildFirst() {
+    void insertChildFirst() {
         Node<?> parent = createParentNode();
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
@@ -84,7 +84,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void insertChildMiddle() {
+    void insertChildMiddle() {
         Node<?> parent = createParentNode();
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
@@ -96,7 +96,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void insertChildAsLast() {
+    void insertChildAsLast() {
         Node<?> parent = createParentNode();
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
@@ -108,7 +108,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void insertChildAfterLast() {
+    void insertChildAfterLast() {
         Node<?> parent = createParentNode();
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
@@ -119,7 +119,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void removeChildFirst() {
+    void removeChildFirst() {
         Node<?> parent = createParentNode();
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
@@ -131,7 +131,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void removeChildFirstIndex() {
+    void removeChildFirstIndex() {
         Node<?> parent = createParentNode();
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
@@ -143,7 +143,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void removeChildrenFirst() {
+    void removeChildrenFirst() {
         Node<?> parent = createParentNode();
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
@@ -155,7 +155,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void removeChildMiddle() {
+    void removeChildMiddle() {
         Node<?> parent = createParentNode();
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
@@ -167,7 +167,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void removeChildMiddleIndex() {
+    void removeChildMiddleIndex() {
         Node<?> parent = createParentNode();
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
@@ -179,7 +179,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void removeChildrenMiddle() {
+    void removeChildrenMiddle() {
         Node<?> parent = createParentNode();
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
@@ -192,7 +192,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void removeChildLast() {
+    void removeChildLast() {
         Node<?> parent = createParentNode();
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
@@ -204,7 +204,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void removeChildLastIndex() {
+    void removeChildLastIndex() {
         Node<?> parent = createParentNode();
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
@@ -216,7 +216,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void removeChildrenLast() {
+    void removeChildrenLast() {
         Node<?> parent = createParentNode();
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
@@ -229,7 +229,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void removeAllChildren() {
+    void removeAllChildren() {
         Node<?> parent = createParentNode();
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
@@ -242,7 +242,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void removeAllChildrenEmpty() {
+    void removeAllChildrenEmpty() {
         Node<?> parent = createParentNode();
         parent.removeAllChildren();
 
@@ -250,7 +250,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void testGetChildren() {
+    void testGetChildren() {
         Node<?> parent = createParentNode();
 
         Element child1 = ElementFactory.createDiv();
@@ -265,14 +265,14 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void testGetChildren_empty() {
+    void testGetChildren_empty() {
         Node<?> parent = createParentNode();
 
         assertEquals(0, parent.getChildren().count());
     }
 
     @Test
-    public void removeNonChild() {
+    void removeNonChild() {
         Node<?> parent = createParentNode();
         Element otherElement = new Element("other");
         assertThrows(IllegalArgumentException.class,
@@ -280,7 +280,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void getChild() {
+    void getChild() {
         Node<?> parent = createParentNode();
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
@@ -294,7 +294,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void getNegativeChild() {
+    void getNegativeChild() {
         Node<?> parent = createParentNode();
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
@@ -303,7 +303,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void getAfterLastChild() {
+    void getAfterLastChild() {
         Node<?> parent = createParentNode();
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
@@ -312,7 +312,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void appendChild() {
+    void appendChild() {
         Node<?> parent = createParentNode();
         Element child = new Element("child");
         parent.appendChild(child);
@@ -321,14 +321,14 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void appendNullChild() {
+    void appendNullChild() {
         Node<?> parent = createParentNode();
         assertThrows(IllegalArgumentException.class,
                 () -> parent.appendChild((Element[]) null));
     }
 
     @Test
-    public void replaceNullChild() {
+    void replaceNullChild() {
         Node<?> parent = createParentNode();
         Element child1 = new Element("child1");
         parent.appendChild(child1);
@@ -337,14 +337,14 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void removeNullChild() {
+    void removeNullChild() {
         Node<?> parent = createParentNode();
         assertThrows(IllegalArgumentException.class,
                 () -> parent.removeChild((Element[]) null));
     }
 
     @Test
-    public void replaceBeforeFirstChild() {
+    void replaceBeforeFirstChild() {
         Node<?> parent = createParentNode();
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
@@ -354,7 +354,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void setForEmptyParent() {
+    void setForEmptyParent() {
         Node<?> parent = createParentNode();
         Element child1 = new Element("child1");
         parent.setChild(0, child1);
@@ -362,7 +362,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void replaceAfterLastChild() {
+    void replaceAfterLastChild() {
         Node<?> parent = createParentNode();
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
@@ -372,7 +372,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void replaceAfterAfterLastChild() {
+    void replaceAfterAfterLastChild() {
         Node<?> parent = createParentNode();
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
@@ -382,7 +382,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void replaceChildWithItself() {
+    void replaceChildWithItself() {
         Node<?> parent = createParentNode();
         Element child1 = new Element("child1");
         parent.appendChild(child1);
@@ -400,7 +400,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void removeChildBeforeFirst() {
+    void removeChildBeforeFirst() {
         Node<?> parent = createParentNode();
         Element child1 = new Element("child1");
         parent.appendChild(child1);
@@ -409,7 +409,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void removeChildAfterLast() {
+    void removeChildAfterLast() {
         Node<?> parent = createParentNode();
         Element child1 = new Element("child1");
         parent.appendChild(child1);
@@ -418,7 +418,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void appendAttachedChild() {
+    void appendAttachedChild() {
         Node<?> parent = createParentNode();
         Element child = ElementFactory.createDiv();
         parent.appendChild(child);
@@ -433,7 +433,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void indexOfChild_firstChild() {
+    void indexOfChild_firstChild() {
         Node<?> parent = createParentNode();
         Element child = ElementFactory.createDiv();
         parent.appendChild(child);
@@ -442,7 +442,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void indexOfChild_childInTheMiddle() {
+    void indexOfChild_childInTheMiddle() {
         Node<?> parent = createParentNode();
         Element child1 = ElementFactory.createDiv();
         Element child2 = ElementFactory.createAnchor();
@@ -453,7 +453,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void indexOfChild_notAChild() {
+    void indexOfChild_notAChild() {
         Node<?> parent = createParentNode();
         Element child = ElementFactory.createDiv();
 
@@ -461,7 +461,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void appendFirstChildToOwnParent() {
+    void appendFirstChildToOwnParent() {
         Node<?> parent = createParentNode();
         Element child1 = ElementFactory.createDiv();
         Element child2 = ElementFactory.createDiv();
@@ -472,7 +472,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void appendLastChildToOwnParent() {
+    void appendLastChildToOwnParent() {
         Node<?> parent = createParentNode();
         Element child1 = ElementFactory.createDiv();
         Element child2 = ElementFactory.createDiv();
@@ -483,7 +483,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void appendManyChildrenToOwnParent() {
+    void appendManyChildrenToOwnParent() {
         Node<?> parent = createParentNode();
         Element child1 = ElementFactory.createDiv();
         Element child2 = ElementFactory.createDiv();
@@ -495,7 +495,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void appendExistingAndNewChildren() {
+    void appendExistingAndNewChildren() {
         Node<?> parent = createParentNode();
         Element child1 = ElementFactory.createDiv();
         Element child2 = ElementFactory.createDiv();
@@ -507,7 +507,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void insertAttachedChild() {
+    void insertAttachedChild() {
         Node<?> parent = createParentNode();
         Element child = ElementFactory.createDiv();
         parent.appendChild(child);
@@ -523,7 +523,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void setAttachedChild() {
+    void setAttachedChild() {
         Node<?> parent = createParentNode();
         Element child = ElementFactory.createDiv();
         parent.appendChild(child);
@@ -539,7 +539,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void removeFromParent() {
+    void removeFromParent() {
         Node<?> parent = createParentNode();
         Element otherElement = new Element("other");
         parent.appendChild(otherElement);
@@ -549,7 +549,7 @@ public abstract class AbstractNodeTest {
     }
 
     @Test
-    public void replaceFirstChild() {
+    void replaceFirstChild() {
         Node<?> parent = createParentNode();
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");

--- a/flow-server/src/test/java/com/vaadin/flow/dom/BasicElementStateProviderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/BasicElementStateProviderTest.java
@@ -40,20 +40,20 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class BasicElementStateProviderTest {
 
     @Test
-    public void supportsSelfCreatedNode() {
+    void supportsSelfCreatedNode() {
         BasicElementStateProvider provider = BasicElementStateProvider.get();
         StateNode node = BasicElementStateProvider.createStateNode("foo");
         assertTrue(provider.supports(node));
     }
 
     @Test
-    public void doesNotSupportEmptyNode() {
+    void doesNotSupportEmptyNode() {
         BasicElementStateProvider provider = BasicElementStateProvider.get();
         assertFalse(provider.supports(new StateNode()));
     }
 
     @Test
-    public void supportsUIRootNode() {
+    void supportsUIRootNode() {
         BasicElementStateProvider provider = BasicElementStateProvider.get();
         UI ui = new UI() {
 
@@ -68,13 +68,13 @@ class BasicElementStateProviderTest {
     }
 
     @Test
-    public void getParent_parentNodeIsNull_parentIsNull() {
+    void getParent_parentNodeIsNull_parentIsNull() {
         Element div = ElementFactory.createDiv();
         assertNull(BasicElementStateProvider.get().getParent(div.getNode()));
     }
 
     @Test
-    public void getParent_parentNodeIsNotNull_parentIsNotNull() {
+    void getParent_parentNodeIsNotNull_parentIsNotNull() {
         Element parent = ElementFactory.createDiv();
         Element child = ElementFactory.createDiv();
         parent.appendChild(child);
@@ -83,7 +83,7 @@ class BasicElementStateProviderTest {
     }
 
     @Test
-    public void getParent_parentNodeIsShadowRootNode_parentIsShadowRoot() {
+    void getParent_parentNodeIsShadowRootNode_parentIsShadowRoot() {
         ShadowRoot parent = ElementFactory.createDiv().attachShadow();
         Element child = ElementFactory.createDiv();
         parent.appendChild(child);
@@ -92,13 +92,13 @@ class BasicElementStateProviderTest {
     }
 
     @Test
-    public void createStateNode_stateNodeHasRequiredElementDataFeature() {
+    void createStateNode_stateNodeHasRequiredElementDataFeature() {
         StateNode stateNode = BasicElementStateProvider.createStateNode("div");
         assertTrue(stateNode.isReportedFeature(ElementData.class));
     }
 
     @Test
-    public void visitOnlyNode_hasDescendants_nodeVisitedAndNoDescendantsVisited() {
+    void visitOnlyNode_hasDescendants_nodeVisitedAndNoDescendantsVisited() {
         TestNodeVisitor visitor = new TestNodeVisitor(false);
 
         Map<Node<?>, ElementType> map = new HashMap<>();
@@ -114,7 +114,7 @@ class BasicElementStateProviderTest {
     }
 
     @Test
-    public void visitOnlyNode_hasDescendants_nodeAndDescendatnsAreVisited() {
+    void visitOnlyNode_hasDescendants_nodeAndDescendatnsAreVisited() {
         TestNodeVisitor visitor = new TestNodeVisitor(true);
 
         Map<Node<?>, ElementType> map = new HashMap<>();
@@ -130,7 +130,7 @@ class BasicElementStateProviderTest {
     }
 
     @Test
-    public void visitNode_noChildren_featuresNotInitialized() {
+    void visitNode_noChildren_featuresNotInitialized() {
         Element element = ElementFactory.createDiv();
 
         assertNoChildFeatures(element);
@@ -150,7 +150,7 @@ class BasicElementStateProviderTest {
     }
 
     @Test
-    public void setVisible() {
+    void setVisible() {
         Element element = ElementFactory.createDiv();
 
         assertTrue(element.getNode().getFeature(ElementData.class).isVisible());

--- a/flow-server/src/test/java/com/vaadin/flow/dom/BasicTextElementStateProviderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/BasicTextElementStateProviderTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class BasicTextElementStateProviderTest {
 
     @Test
-    public void createStateNode_stateNodeHasRequiredElementDataFeature() {
+    void createStateNode_stateNodeHasRequiredElementDataFeature() {
         StateNode stateNode = BasicTextElementStateProvider
                 .createStateNode("foo");
         assertTrue(stateNode.isReportedFeature(TextNodeMap.class));

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ClassListBindTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ClassListBindTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 class ClassListBindTest extends SignalsUnitTest {
 
     @Test
-    public void bindingMirrorsSignalWhileAttached_toggleAddsRemovesClass() {
+    void bindingMirrorsSignalWhileAttached_toggleAddsRemovesClass() {
         Element element = new Element("span");
         UI.getCurrent().getElement().appendChild(element);
 
@@ -52,7 +52,7 @@ class ClassListBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindingInactiveWhenDetached_reactivatedOnAttach_appliesCurrentValue() {
+    void bindingInactiveWhenDetached_reactivatedOnAttach_appliesCurrentValue() {
         Element element = new Element("span");
         UI.getCurrent().getElement().appendChild(element);
         ValueSignal<Boolean> signal = new ValueSignal<>(false);
@@ -71,7 +71,7 @@ class ClassListBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void manualAddRemoveForBoundName_throwsBindingActiveException() {
+    void manualAddRemoveForBoundName_throwsBindingActiveException() {
         Element element = new Element("div");
         UI.getCurrent().getElement().appendChild(element);
         ValueSignal<Boolean> signal = new ValueSignal<>(true);
@@ -88,7 +88,7 @@ class ClassListBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void clear_throwsWhenBindingsActive() {
+    void clear_throwsWhenBindingsActive() {
         Element element = new Element("div");
         UI.getCurrent().getElement().appendChild(element);
         ValueSignal<Boolean> signal = new ValueSignal<>(true);
@@ -99,7 +99,7 @@ class ClassListBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void setAttributeClass_throwsWhenBindingsActive() {
+    void setAttributeClass_throwsWhenBindingsActive() {
         Element element = new Element("div");
         UI.getCurrent().getElement().appendChild(element);
         ValueSignal<Boolean> bound = new ValueSignal<>(true);
@@ -111,7 +111,7 @@ class ClassListBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bind_nullSignal_throwsNPE() {
+    void bind_nullSignal_throwsNPE() {
         Element element = new Element("div");
         UI.getCurrent().getElement().appendChild(element);
 
@@ -120,7 +120,7 @@ class ClassListBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void rebinding_alreadyBound_throws() {
+    void rebinding_alreadyBound_throws() {
         Element element = new Element("div");
         UI.getCurrent().getElement().appendChild(element);
         ValueSignal<Boolean> s1 = new ValueSignal<>(true);
@@ -135,7 +135,7 @@ class ClassListBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void internalUpdatesDoNotThrowOrRecurse() {
+    void internalUpdatesDoNotThrowOrRecurse() {
         Element element = new Element("div");
         UI.getCurrent().getElement().appendChild(element);
         ValueSignal<Boolean> signal = new ValueSignal<>(false);
@@ -155,7 +155,7 @@ class ClassListBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void lazyInitSignalBindingFeature() {
+    void lazyInitSignalBindingFeature() {
         Element element = new Element("div");
         UI.getCurrent().getElement().appendChild(element);
         element.getClassList().add("spin");

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ClassListGroupBindTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ClassListGroupBindTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ClassListGroupBindTest extends SignalsUnitTest {
 
     @Test
-    public void basicGroupBinding_addsAndRemovesClasses() {
+    void basicGroupBinding_addsAndRemovesClasses() {
         Element element = new Element("div");
         UI.getCurrent().getElement().appendChild(element);
 
@@ -60,7 +60,7 @@ class ClassListGroupBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void nullList_treatedAsEmpty() {
+    void nullList_treatedAsEmpty() {
         Element element = new Element("div");
         UI.getCurrent().getElement().appendChild(element);
 
@@ -71,7 +71,7 @@ class ClassListGroupBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void nullAndEmptyEntriesInList_silentlyIgnored() {
+    void nullAndEmptyEntriesInList_silentlyIgnored() {
         Element element = new Element("div");
         UI.getCurrent().getElement().appendChild(element);
 
@@ -85,7 +85,7 @@ class ClassListGroupBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void secondGroupBind_throwsBindingActiveException() {
+    void secondGroupBind_throwsBindingActiveException() {
         Element element = new Element("div");
         UI.getCurrent().getElement().appendChild(element);
 
@@ -98,7 +98,7 @@ class ClassListGroupBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void coexistenceWithStaticAdd_bothPresent() {
+    void coexistenceWithStaticAdd_bothPresent() {
         Element element = new Element("div");
         UI.getCurrent().getElement().appendChild(element);
 
@@ -113,7 +113,7 @@ class ClassListGroupBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void coexistenceWithStaticAdd_groupRemovalRemovesFromFlatList() {
+    void coexistenceWithStaticAdd_groupRemovalRemovesFromFlatList() {
         Element element = new Element("div");
         UI.getCurrent().getElement().appendChild(element);
 
@@ -135,7 +135,7 @@ class ClassListGroupBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void coexistenceWithToggleBind_bothWorkIndependently() {
+    void coexistenceWithToggleBind_bothWorkIndependently() {
         Element element = new Element("div");
         UI.getCurrent().getElement().appendChild(element);
 
@@ -158,7 +158,7 @@ class ClassListGroupBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void clear_throwsWhenGroupBindingActive() {
+    void clear_throwsWhenGroupBindingActive() {
         Element element = new Element("div");
         UI.getCurrent().getElement().appendChild(element);
 
@@ -172,7 +172,7 @@ class ClassListGroupBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void detachAndReattach_reappliesCurrentValue() {
+    void detachAndReattach_reappliesCurrentValue() {
         Element element = new Element("div");
         UI.getCurrent().getElement().appendChild(element);
 
@@ -195,7 +195,7 @@ class ClassListGroupBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void incrementalUpdates_diffAppliedCorrectly() {
+    void incrementalUpdates_diffAppliedCorrectly() {
         Element element = new Element("div");
         UI.getCurrent().getElement().appendChild(element);
 
@@ -213,7 +213,7 @@ class ClassListGroupBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindClassNames_shorthandOnHasStyle() {
+    void bindClassNames_shorthandOnHasStyle() {
         HasStyleComponent component = new HasStyleComponent();
         UI.getCurrent().add(component);
 
@@ -229,7 +229,7 @@ class ClassListGroupBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bind_onChange_receivesBindingContext() {
+    void bind_onChange_receivesBindingContext() {
         Element element = new Element("div");
         UI.getCurrent().getElement().appendChild(element);
 

--- a/flow-server/src/test/java/com/vaadin/flow/dom/DisabledUpdateModeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/DisabledUpdateModeTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class DisabledUpdateModeTest {
 
     @Test
-    public void permissiveOrdering() {
+    void permissiveOrdering() {
         assertMostPermissive(ALWAYS, ALWAYS, ALWAYS);
         assertMostPermissive(ALWAYS, ALWAYS, ONLY_WHEN_ENABLED);
         assertMostPermissive(ALWAYS, ALWAYS, null);

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementBindAttributeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementBindAttributeTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ElementBindAttributeTest extends SignalsUnitTest {
 
     @Test
-    public void bindAttribute_nullAttribute_throwException() {
+    void bindAttribute_nullAttribute_throwException() {
         Element element = new Element("foo");
         ValueSignal<String> signal = new ValueSignal<>("bar");
         assertThrows(IllegalArgumentException.class,
@@ -41,7 +41,7 @@ class ElementBindAttributeTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindAttribute_illegalAttribute_throwException() {
+    void bindAttribute_illegalAttribute_throwException() {
         Element element = new Element("foo");
         ValueSignal<String> signal = new ValueSignal<>("bar");
         assertThrows(IllegalArgumentException.class,
@@ -49,7 +49,7 @@ class ElementBindAttributeTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindAttribute_notComponent_doNotThrowException() {
+    void bindAttribute_notComponent_doNotThrowException() {
         Element element = new Element("foo");
         UI.getCurrent().getElement().appendChild(element);
 
@@ -60,7 +60,7 @@ class ElementBindAttributeTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindAttribute_componentNotAttached_bindingIgnored() {
+    void bindAttribute_componentNotAttached_bindingIgnored() {
         TestComponent component = new TestComponent();
 
         ValueSignal<String> signal = new ValueSignal<>("bar");
@@ -76,7 +76,7 @@ class ElementBindAttributeTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindAttribute_componentDetached_bindingIgnored() {
+    void bindAttribute_componentDetached_bindingIgnored() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -93,7 +93,7 @@ class ElementBindAttributeTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindAttribute_componentAttached_bindingActive() {
+    void bindAttribute_componentAttached_bindingActive() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -106,7 +106,7 @@ class ElementBindAttributeTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindAttribute_componentReAttached_bindingSynced() {
+    void bindAttribute_componentReAttached_bindingSynced() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -128,7 +128,7 @@ class ElementBindAttributeTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindAttribute_setAttributeWhileBindingIsActive_throwException() {
+    void bindAttribute_setAttributeWhileBindingIsActive_throwException() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -142,7 +142,7 @@ class ElementBindAttributeTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindAttribute_removeAttributeWhileBindingIsActive_throwException() {
+    void bindAttribute_removeAttributeWhileBindingIsActive_throwException() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -156,7 +156,7 @@ class ElementBindAttributeTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindAttribute_updateSignal_attributeChanged() {
+    void bindAttribute_updateSignal_attributeChanged() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -170,7 +170,7 @@ class ElementBindAttributeTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindAttribute_nullSignal_throwsNPE() {
+    void bindAttribute_nullSignal_throwsNPE() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -179,7 +179,7 @@ class ElementBindAttributeTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindAttribute_withTwoAttributesWithSameSignal_attributesChanged() {
+    void bindAttribute_withTwoAttributesWithSameSignal_attributesChanged() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -199,7 +199,7 @@ class ElementBindAttributeTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindAttribute_withTwoAttributesAndSignals_attributesChanged() {
+    void bindAttribute_withTwoAttributesAndSignals_attributesChanged() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -221,7 +221,7 @@ class ElementBindAttributeTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindAttribute_simpleComputedSignal_bindingActive() {
+    void bindAttribute_simpleComputedSignal_bindingActive() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -235,7 +235,7 @@ class ElementBindAttributeTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindAttribute_computedSignal_bindingActive() {
+    void bindAttribute_computedSignal_bindingActive() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -255,7 +255,7 @@ class ElementBindAttributeTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindAttribute_nullAttributeValue_attributeRemoved() {
+    void bindAttribute_nullAttributeValue_attributeRemoved() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementBindEnabledTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementBindEnabledTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 class ElementBindEnabledTest extends SignalsUnitTest {
 
     @Test
-    public void bindEnabled_elementAttachedBefore_bindingActive() {
+    void bindEnabled_elementAttachedBefore_bindingActive() {
         Element element = new Element("foo");
         // attach before bindEnabled
         UI.getCurrent().getElement().appendChild(element);
@@ -45,7 +45,7 @@ class ElementBindEnabledTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindEnabled_elementAttachedAfter_bindingActive() {
+    void bindEnabled_elementAttachedAfter_bindingActive() {
         Element element = new Element("foo");
         assertTrue(element.isEnabled());
         ValueSignal<Boolean> signal = new ValueSignal<>(false);
@@ -57,7 +57,7 @@ class ElementBindEnabledTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindEnabled_elementAttached_bindingActive() {
+    void bindEnabled_elementAttached_bindingActive() {
         Element element = new Element("foo");
         UI.getCurrent().getElement().appendChild(element);
         ValueSignal<Boolean> signal = new ValueSignal<>(false);
@@ -76,7 +76,7 @@ class ElementBindEnabledTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindEnabled_elementNotAttached_bindingInactive() {
+    void bindEnabled_elementNotAttached_bindingInactive() {
         Element element = new Element("foo");
         ValueSignal<Boolean> signal = new ValueSignal<>(true);
         element.bindEnabled(signal);
@@ -86,7 +86,7 @@ class ElementBindEnabledTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindEnabled_elementDetached_bindingInactive() {
+    void bindEnabled_elementDetached_bindingInactive() {
         Element element = new Element("foo");
         UI.getCurrent().getElement().appendChild(element);
         ValueSignal<Boolean> signal = new ValueSignal<>(true);
@@ -98,7 +98,7 @@ class ElementBindEnabledTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindEnabled_elementReAttached_bindingActivate() {
+    void bindEnabled_elementReAttached_bindingActivate() {
         Element element = new Element("foo");
         UI.getCurrent().getElement().appendChild(element);
         ValueSignal<Boolean> signal = new ValueSignal<>(true);
@@ -111,7 +111,7 @@ class ElementBindEnabledTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindEnabled_setEnabledAndBindEnabledWhileBindingIsActive_throwException() {
+    void bindEnabled_setEnabledAndBindEnabledWhileBindingIsActive_throwException() {
         Element element = new Element("foo");
         UI.getCurrent().getElement().appendChild(element);
         element.bindEnabled(new ValueSignal<>(true));
@@ -124,7 +124,7 @@ class ElementBindEnabledTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindEnabled_nullSignal_throwsNPE() {
+    void bindEnabled_nullSignal_throwsNPE() {
         Element element = new Element("foo");
         UI.getCurrent().getElement().appendChild(element);
 
@@ -133,7 +133,7 @@ class ElementBindEnabledTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindEnabled_lazyInitSignalBindingFeature() {
+    void bindEnabled_lazyInitSignalBindingFeature() {
         Element element = new Element("foo");
         UI.getCurrent().getElement().appendChild(element);
         element.setEnabled(false);
@@ -151,7 +151,7 @@ class ElementBindEnabledTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindEnabled_implicitlyDisabledComponent_isEnabledReturnsFalse() {
+    void bindEnabled_implicitlyDisabledComponent_isEnabledReturnsFalse() {
         TestComponent component = new TestComponent();
         component.bindEnabled(new ValueSignal<>(true));
 
@@ -165,7 +165,7 @@ class ElementBindEnabledTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindEnabled_implicitlyDisabledComponent_detach_componentBecomesEnabled() {
+    void bindEnabled_implicitlyDisabledComponent_detach_componentBecomesEnabled() {
         TestComponent component = new TestComponent();
         component.bindEnabled(new ValueSignal<>(true));
 
@@ -181,7 +181,7 @@ class ElementBindEnabledTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindEnabled_explicitlyDisabledComponent_enableParent_componentRemainsDisabled() {
+    void bindEnabled_explicitlyDisabledComponent_enableParent_componentRemainsDisabled() {
         TestComponent component = new TestComponent();
         component.bindEnabled(new ValueSignal<>(false));
 

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementBindPropertyTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementBindPropertyTest.java
@@ -54,7 +54,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     // common property signal binding tests
 
     @Test
-    public void bindProperty_nullProperty_throwException() {
+    void bindProperty_nullProperty_throwException() {
         Element element = new Element("foo");
         ValueSignal<String> signal = new ValueSignal<>("bar");
         assertThrows(IllegalArgumentException.class,
@@ -62,7 +62,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindProperty_illegalProperty_throwException() {
+    void bindProperty_illegalProperty_throwException() {
         Element element = new Element("foo");
         ValueSignal<String> signal = new ValueSignal<>("bar");
         assertThrows(IllegalArgumentException.class,
@@ -76,7 +76,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindProperty_notComponent_doNotThrowException() {
+    void bindProperty_notComponent_doNotThrowException() {
         Element element = new Element("foo");
         UI.getCurrent().getElement().appendChild(element);
 
@@ -87,7 +87,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindProperty_setPropertyWhileReadOnlyBindingIsActive_throwException() {
+    void bindProperty_setPropertyWhileReadOnlyBindingIsActive_throwException() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -102,7 +102,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindProperty_setPropertyWhileWritableBindingIsActive_updatesSignal() {
+    void bindProperty_setPropertyWhileWritableBindingIsActive_updatesSignal() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -119,7 +119,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindProperty_setPropertySignalReverts_propertyRevertedToSignalValue() {
+    void bindProperty_setPropertySignalReverts_propertyRevertedToSignalValue() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -137,7 +137,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindProperty_setPropertyWithNoopWritableBinding_propertyRevertedToSignalValue() {
+    void bindProperty_setPropertyWithNoopWritableBinding_propertyRevertedToSignalValue() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -155,7 +155,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindProperty_setPropertyWriteCallbackThrows_exceptionPropagated() {
+    void bindProperty_setPropertyWriteCallbackThrows_exceptionPropagated() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -172,7 +172,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindBooleanProperty_setPropertyWhileWritableBindingIsActive_updatesSignal() {
+    void bindBooleanProperty_setPropertyWhileWritableBindingIsActive_updatesSignal() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -186,7 +186,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindDoubleProperty_setPropertyWhileWritableBindingIsActive_updatesSignal() {
+    void bindDoubleProperty_setPropertyWhileWritableBindingIsActive_updatesSignal() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -201,7 +201,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindProperty_setPropertyWhileWritableBindingIsActive_propertyChangeEventFired() {
+    void bindProperty_setPropertyWhileWritableBindingIsActive_propertyChangeEventFired() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -224,7 +224,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindProperty_nullSignal_throwsNPE() {
+    void bindProperty_nullSignal_throwsNPE() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -233,7 +233,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindProperty_removePropertyWhileBindingIsActive_throwException() {
+    void bindProperty_removePropertyWhileBindingIsActive_throwException() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -247,7 +247,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindPropertyComputedSignal_getPropertyValue_returnsCorrectValue() {
+    void bindPropertyComputedSignal_getPropertyValue_returnsCorrectValue() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -261,7 +261,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindPropertyMappedSignal_getPropertyValue_returnsCorrectValue() {
+    void bindPropertyMappedSignal_getPropertyValue_returnsCorrectValue() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -274,7 +274,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindPropertyJacksonNull_getPropertyValue_returnsCorrectValue() {
+    void bindPropertyJacksonNull_getPropertyValue_returnsCorrectValue() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -290,7 +290,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindPropertyJacksonObjectNode_getPropertyValue_returnsCorrectValue() {
+    void bindPropertyJacksonObjectNode_getPropertyValue_returnsCorrectValue() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -306,7 +306,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindProperty_addPropertyChangeListenerAttached_listenerReceivesValueChange() {
+    void bindProperty_addPropertyChangeListenerAttached_listenerReceivesValueChange() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -337,7 +337,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindProperty_addPropertyChangeListenerDetached_listenerReceivesValueChange() {
+    void bindProperty_addPropertyChangeListenerDetached_listenerReceivesValueChange() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -362,7 +362,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     // boolean property signal binding tests
 
     @Test
-    public void bindBooleanProperty_componentNotAttached_bindingIgnored() {
+    void bindBooleanProperty_componentNotAttached_bindingIgnored() {
         TestComponent component = new TestComponent();
 
         ValueSignal<Boolean> signal = new ValueSignal<>(true);
@@ -378,7 +378,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindBooleanProperty_componentDetached_bindingIgnored() {
+    void bindBooleanProperty_componentDetached_bindingIgnored() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -395,7 +395,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindBooleanProperty_componentAttached_bindingActive() {
+    void bindBooleanProperty_componentAttached_bindingActive() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -408,7 +408,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindBooleanProperty_componentReAttached_bindingSynced() {
+    void bindBooleanProperty_componentReAttached_bindingSynced() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -432,7 +432,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     // double property signal binding tests
 
     @Test
-    public void bindDoubleProperty_componentNotAttached_bindingIgnored() {
+    void bindDoubleProperty_componentNotAttached_bindingIgnored() {
         TestComponent component = new TestComponent();
 
         ValueSignal<Double> signal = new ValueSignal<>(1.0d);
@@ -450,7 +450,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindDoubleProperty_componentDetached_bindingIgnored() {
+    void bindDoubleProperty_componentDetached_bindingIgnored() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -468,7 +468,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindDoubleProperty_componentAttached_bindingActive() {
+    void bindDoubleProperty_componentAttached_bindingActive() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -482,7 +482,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindDoubleProperty_componentReAttached_bindingSynced() {
+    void bindDoubleProperty_componentReAttached_bindingSynced() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -509,7 +509,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     // integer property signal binding tests
 
     @Test
-    public void bindIntegerProperty_componentNotAttached_bindingIgnored() {
+    void bindIntegerProperty_componentNotAttached_bindingIgnored() {
         TestComponent component = new TestComponent();
 
         ValueSignal<Integer> signal = new ValueSignal<>(1);
@@ -525,7 +525,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindIntegerProperty_componentDetached_bindingIgnored() {
+    void bindIntegerProperty_componentDetached_bindingIgnored() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -542,7 +542,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindIntegerProperty_componentAttached_bindingActive() {
+    void bindIntegerProperty_componentAttached_bindingActive() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -555,7 +555,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindIntegerProperty_componentReAttached_bindingSynced() {
+    void bindIntegerProperty_componentReAttached_bindingSynced() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -579,7 +579,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     // string property signal binding tests
 
     @Test
-    public void bindStringProperty_componentNotAttached_bindingIgnored() {
+    void bindStringProperty_componentNotAttached_bindingIgnored() {
         TestComponent component = new TestComponent();
 
         ValueSignal<String> signal = new ValueSignal<>("bar");
@@ -595,7 +595,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindStringProperty_componentDetached_bindingIgnored() {
+    void bindStringProperty_componentDetached_bindingIgnored() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -613,7 +613,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindStringProperty_componentAttached_bindingActive() {
+    void bindStringProperty_componentAttached_bindingActive() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -627,7 +627,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindStringProperty_componentReAttached_bindingSynced() {
+    void bindStringProperty_componentReAttached_bindingSynced() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -654,7 +654,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     // bean property signal binding tests
 
     @Test
-    public void bindBeanProperty_componentNotAttached_bindingIgnored() {
+    void bindBeanProperty_componentNotAttached_bindingIgnored() {
         TestComponent component = new TestComponent();
 
         JacksonUtilsTest.Person john = createJohn();
@@ -672,7 +672,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindBeanProperty_componentDetached_bindingIgnored() {
+    void bindBeanProperty_componentDetached_bindingIgnored() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -691,7 +691,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindBeanProperty_componentAttached_bindingActive() {
+    void bindBeanProperty_componentAttached_bindingActive() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -705,7 +705,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindBeanProperty_componentReAttached_bindingSynced() {
+    void bindBeanProperty_componentReAttached_bindingSynced() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -734,7 +734,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     // list property signal binding tests
 
     @Test
-    public void bindListProperty_componentNotAttached_bindingIgnored() {
+    void bindListProperty_componentNotAttached_bindingIgnored() {
         TestComponent component = new TestComponent();
 
         ValueSignal<List<JacksonUtilsTest.Person>> signal = new ValueSignal<>(
@@ -754,7 +754,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindListProperty_componentDetached_bindingIgnored() {
+    void bindListProperty_componentDetached_bindingIgnored() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -778,7 +778,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindListProperty_componentAttached_bindingActive() {
+    void bindListProperty_componentAttached_bindingActive() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -794,7 +794,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindListProperty_componentReAttached_bindingSynced() {
+    void bindListProperty_componentReAttached_bindingSynced() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -833,7 +833,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     // map property signal binding tests
 
     @Test
-    public void bindMapProperty_componentNotAttached_bindingIgnored() {
+    void bindMapProperty_componentNotAttached_bindingIgnored() {
         TestComponent component = new TestComponent();
 
         ValueSignal<Map<String, JacksonUtilsTest.Person>> signal = new ValueSignal<>(
@@ -853,7 +853,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindMapProperty_componentDetached_bindingIgnored() {
+    void bindMapProperty_componentDetached_bindingIgnored() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -877,7 +877,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindMapProperty_componentAttached_bindingActive() {
+    void bindMapProperty_componentAttached_bindingActive() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -893,7 +893,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindMapProperty_componentReAttached_bindingSynced() {
+    void bindMapProperty_componentReAttached_bindingSynced() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -930,7 +930,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindProperty_writeCallbackThrows() {
+    void bindProperty_writeCallbackThrows() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
         ValueSignal<String> signal = new ValueSignal<>("foo");
@@ -950,7 +950,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindProperty_normalCallback_valueChangeEventTriggered() {
+    void bindProperty_normalCallback_valueChangeEventTriggered() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
         ValueSignal<String> signal = new ValueSignal<>("foo");
@@ -970,7 +970,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindProperty_transformingCallback_valueChangeEventTriggered() {
+    void bindProperty_transformingCallback_valueChangeEventTriggered() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
         ValueSignal<String> signal = new ValueSignal<>("foo");
@@ -991,7 +991,7 @@ class ElementBindPropertyTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindProperty_noOpCallback_valueChangeEventNotTriggered() {
+    void bindProperty_noOpCallback_valueChangeEventNotTriggered() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
         ValueSignal<String> signal = new ValueSignal<>("foo");

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementBindTextTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementBindTextTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 class ElementBindTextTest extends SignalsUnitTest {
 
     @Test
-    public void bindTextComputedSignal_getText_returnsCorrectValue() {
+    void bindTextComputedSignal_getText_returnsCorrectValue() {
         Element element = new Element("span");
         UI.getCurrent().getElement().appendChild(element);
 
@@ -48,7 +48,7 @@ class ElementBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindTextMappedSignal_getText_returnsCorrectValue() {
+    void bindTextMappedSignal_getText_returnsCorrectValue() {
         Element element = new Element("span");
         UI.getCurrent().getElement().appendChild(element);
 
@@ -59,7 +59,7 @@ class ElementBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindText_detachAttach_returnsCorrectValue() {
+    void bindText_detachAttach_returnsCorrectValue() {
         Element element = new Element("span");
         UI.getCurrent().getElement().appendChild(element);
 
@@ -75,7 +75,7 @@ class ElementBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindText_setTextWithExistingActiveBinding_throws() {
+    void bindText_setTextWithExistingActiveBinding_throws() {
         Element element = new Element("span");
         UI.getCurrent().getElement().appendChild(element);
         ValueSignal<String> signal = new ValueSignal<>("text");
@@ -86,7 +86,7 @@ class ElementBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindText_setTextWithExistingInactiveBinding_throws() {
+    void bindText_setTextWithExistingInactiveBinding_throws() {
         Element element = new Element("span");
         UI.getCurrent().getElement().appendChild(element);
         ValueSignal<String> signal = new ValueSignal<>("text");
@@ -98,7 +98,7 @@ class ElementBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindText_initialEmptySignalValue_treatAsBlank() {
+    void bindText_initialEmptySignalValue_treatAsBlank() {
         Element element = new Element("span");
         UI.getCurrent().getElement().appendChild(element);
         ValueSignal<@Nullable String> signal = new ValueSignal<>(null);
@@ -108,7 +108,7 @@ class ElementBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindText_setNullSignalValue_treatAsBlank() {
+    void bindText_setNullSignalValue_treatAsBlank() {
         Element element = new Element("span");
         UI.getCurrent().getElement().appendChild(element);
         ValueSignal<String> signal = new ValueSignal<>("text");
@@ -119,7 +119,7 @@ class ElementBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindText_bindTextWithExistingActiveBinding_throws() {
+    void bindText_bindTextWithExistingActiveBinding_throws() {
         Element element = new Element("span");
         UI.getCurrent().getElement().appendChild(element);
         ValueSignal<String> signal = new ValueSignal<>("text");
@@ -131,7 +131,7 @@ class ElementBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindText_bindTextWithExistingInactiveBinding_returnsCorrectValue() {
+    void bindText_bindTextWithExistingInactiveBinding_returnsCorrectValue() {
         Element element = new Element("span");
         UI.getCurrent().getElement().appendChild(element);
         ValueSignal<String> signal = new ValueSignal<>("text");
@@ -143,7 +143,7 @@ class ElementBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindText_nullSignal_throwsNPE() {
+    void bindText_nullSignal_throwsNPE() {
         Element element = new Element("span");
         UI.getCurrent().getElement().appendChild(element);
 
@@ -151,7 +151,7 @@ class ElementBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindText_componentNotAttached_bindingIgnored() {
+    void bindText_componentNotAttached_bindingIgnored() {
         Element element = new Element("span");
         ValueSignal<String> signal = new ValueSignal<>("text");
         element.bindText(signal);
@@ -165,7 +165,7 @@ class ElementBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindText_componentAttached_returnsCorrectValue() {
+    void bindText_componentAttached_returnsCorrectValue() {
         Element element = new Element("span");
         UI.getCurrent().getElement().appendChild(element);
         ValueSignal<String> signal = new ValueSignal<>("text");
@@ -178,7 +178,7 @@ class ElementBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void lazyInitSignalBindingFeature() {
+    void lazyInitSignalBindingFeature() {
         Element element = new Element("span");
         UI.getCurrent().getElement().appendChild(element);
         element.setText("text2");
@@ -201,7 +201,7 @@ class ElementBindTextTest extends SignalsUnitTest {
      * bindText. This test verifies that with a custom Span component.
      */
     @Test
-    public void bindText_componentWithHasText() {
+    void bindText_componentWithHasText() {
         @Tag(Tag.SPAN)
         class SpanWithHasText extends Component implements HasText {
         }
@@ -233,7 +233,7 @@ class ElementBindTextTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindText_hasText_nullSignal_throwsNPE() {
+    void bindText_hasText_nullSignal_throwsNPE() {
         @Tag(Tag.SPAN)
         class SpanWithHasText extends Component implements HasText {
         }

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementBindVisibleTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementBindVisibleTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ElementBindVisibleTest extends SignalsUnitTest {
 
     @Test
-    public void bindVisible_elementAttachedBefore_bindingActive() {
+    void bindVisible_elementAttachedBefore_bindingActive() {
         Element element = new Element("foo");
         // attach before bindVisible
         UI.getCurrent().getElement().appendChild(element);
@@ -41,7 +41,7 @@ class ElementBindVisibleTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindVisible_elementAttachedAfter_bindingActive() {
+    void bindVisible_elementAttachedAfter_bindingActive() {
         Element element = new Element("foo");
         assertTrue(element.isVisible());
         ValueSignal<Boolean> signal = new ValueSignal<>(false);
@@ -54,7 +54,7 @@ class ElementBindVisibleTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindVisible_elementAttached_bindingActive() {
+    void bindVisible_elementAttached_bindingActive() {
         Element element = new Element("foo");
         UI.getCurrent().getElement().appendChild(element);
         ValueSignal<Boolean> signal = new ValueSignal<>(false);
@@ -74,7 +74,7 @@ class ElementBindVisibleTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindVisible_elementNotAttached_bindingInactive() {
+    void bindVisible_elementNotAttached_bindingInactive() {
         Element element = new Element("foo");
         ValueSignal<Boolean> signal = new ValueSignal<>(true);
         element.bindVisible(signal);
@@ -84,7 +84,7 @@ class ElementBindVisibleTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindVisible_elementDetached_bindingInactive() {
+    void bindVisible_elementDetached_bindingInactive() {
         Element element = new Element("foo");
         UI.getCurrent().getElement().appendChild(element);
         ValueSignal<Boolean> signal = new ValueSignal<>(true);
@@ -97,7 +97,7 @@ class ElementBindVisibleTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindVisible_elementReAttached_bindingActivate() {
+    void bindVisible_elementReAttached_bindingActivate() {
         Element element = new Element("foo");
         UI.getCurrent().getElement().appendChild(element);
         ValueSignal<Boolean> signal = new ValueSignal<>(true);
@@ -111,7 +111,7 @@ class ElementBindVisibleTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindVisible_setVisibleAndBindVisibleWhileBindingIsActive_throwException() {
+    void bindVisible_setVisibleAndBindVisibleWhileBindingIsActive_throwException() {
         Element element = new Element("foo");
         UI.getCurrent().getElement().appendChild(element);
         element.bindVisible(new ValueSignal<>(true));
@@ -125,7 +125,7 @@ class ElementBindVisibleTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindVisible_nullSignal_throwsNPE() {
+    void bindVisible_nullSignal_throwsNPE() {
         Element element = new Element("foo");
         UI.getCurrent().getElement().appendChild(element);
 

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementEffectTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementEffectTest.java
@@ -124,18 +124,18 @@ class ElementEffectTest {
     }
 
     @BeforeAll
-    public static void init() {
+    static void init() {
         service = new TestService();
     }
 
     @AfterAll
-    public static void clean() {
+    static void clean() {
         CurrentInstance.clearAll();
         service.destroy();
     }
 
     @Test
-    public void effect_triggeredWithOwnerUILocked_effectRunSynchronously() {
+    void effect_triggeredWithOwnerUILocked_effectRunSynchronously() {
         CurrentInstance.clearAll();
         MockUI ui = new MockUI();
 
@@ -154,7 +154,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void contextAwareEffect_receivesEffectContext() {
+    void contextAwareEffect_receivesEffectContext() {
         CurrentInstance.clearAll();
         MockUI ui = new MockUI();
 
@@ -177,7 +177,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void contextAwareEffect_detectsBackgroundChange() {
+    void contextAwareEffect_detectsBackgroundChange() {
         CurrentInstance.clearAll();
         MockUI ui = new MockUI();
 
@@ -211,7 +211,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void bindText_returnsSignalBinding() {
+    void bindText_returnsSignalBinding() {
         CurrentInstance.clearAll();
         MockUI ui = new MockUI();
         Element span = new Element("span");
@@ -224,7 +224,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void signalBinding_onChange_receivesBindingContext() {
+    void signalBinding_onChange_receivesBindingContext() {
         CurrentInstance.clearAll();
         MockUI ui = new MockUI();
         Element span = new Element("span");
@@ -260,7 +260,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void signalBinding_onChange_bindThenAttach() {
+    void signalBinding_onChange_bindThenAttach() {
         CurrentInstance.clearAll();
         MockUI ui = new MockUI();
         Element span = new Element("span");
@@ -294,7 +294,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void signalBinding_onChange_bindThenChangeAndAttach() {
+    void signalBinding_onChange_bindThenChangeAndAttach() {
         CurrentInstance.clearAll();
         MockUI ui = new MockUI();
         Element span = new Element("span");
@@ -323,7 +323,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void signalBinding_onChange_calledImmediatelyInitially() {
+    void signalBinding_onChange_calledImmediatelyInitially() {
         CurrentInstance.clearAll();
         MockUI ui = new MockUI();
         Element span = new Element("span");
@@ -371,7 +371,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void bindingContext_getComponent_returnsNearestComponent() {
+    void bindingContext_getComponent_returnsNearestComponent() {
         CurrentInstance.clearAll();
         MockUI ui = new MockUI();
 
@@ -390,7 +390,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void effect_triggeredWithNoUILocked_effectRunAsynchronously() {
+    void effect_triggeredWithNoUILocked_effectRunAsynchronously() {
         CurrentInstance.clearAll();
         VaadinService.setCurrent(service);
 
@@ -418,7 +418,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void effect_triggeredWithOtherUILocked_effectRunAsynchronously() {
+    void effect_triggeredWithOtherUILocked_effectRunAsynchronously() {
         CurrentInstance.clearAll();
         VaadinService.setCurrent(service);
 
@@ -455,7 +455,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void effect_throwExceptionWhenRunningDirectly_delegatedToErrorHandler() {
+    void effect_throwExceptionWhenRunningDirectly_delegatedToErrorHandler() {
         CurrentInstance.clearAll();
         VaadinService.setCurrent(service);
 
@@ -479,7 +479,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void effect_throwExceptionWhenRunningAsynchronously_delegatedToErrorHandler() {
+    void effect_throwExceptionWhenRunningAsynchronously_delegatedToErrorHandler() {
         CurrentInstance.clearAll();
         VaadinService.setCurrent(service);
 
@@ -510,7 +510,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void effect_notAttached_effectRunsImmediatelyAsProbe() {
+    void effect_notAttached_effectRunsImmediatelyAsProbe() {
         CurrentInstance.clearAll();
         TestComponent component = new TestComponent();
         ValueSignal<String> signal = new ValueSignal<>("initial");
@@ -526,7 +526,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void effect_notAttached_noSignalRead_throwsEagerly() {
+    void effect_notAttached_noSignalRead_throwsEagerly() {
         CurrentInstance.clearAll();
         TestComponent component = new TestComponent();
 
@@ -538,7 +538,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void effect_componentAttachedAndDetached_effectEnabledAndDisabled() {
+    void effect_componentAttachedAndDetached_effectEnabledAndDisabled() {
         CurrentInstance.clearAll();
         TestComponent component = new TestComponent();
         ValueSignal<String> signal = new ValueSignal<>("initial");
@@ -580,7 +580,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void effect_reattachWithoutChanges_effectNotReRun() {
+    void effect_reattachWithoutChanges_effectNotReRun() {
         CurrentInstance.clearAll();
         TestComponent component = new TestComponent();
         ValueSignal<String> signal = new ValueSignal<>("initial");
@@ -609,7 +609,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void effect_reattachWithChanges_effectReRunWithInitialRun() {
+    void effect_reattachWithChanges_effectReRunWithInitialRun() {
         CurrentInstance.clearAll();
         TestComponent component = new TestComponent();
         ValueSignal<String> signal = new ValueSignal<>("initial");
@@ -634,7 +634,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void effect_reattachWithoutChanges_nextChangeNotInitialRun() {
+    void effect_reattachWithoutChanges_nextChangeNotInitialRun() {
         CurrentInstance.clearAll();
         TestComponent component = new TestComponent();
         ValueSignal<String> signal = new ValueSignal<>("initial");
@@ -659,7 +659,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void elementEffect_signalValueChanges_componentUpdated() {
+    void elementEffect_signalValueChanges_componentUpdated() {
         CurrentInstance.clearAll();
         TestComponent component = new TestComponent();
         ValueSignal<String> signal = new ValueSignal<>("initial");
@@ -695,7 +695,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void bindChildren_nullArguments_throws() {
+    void bindChildren_nullArguments_throws() {
         CurrentInstance.clearAll();
         ListSignal<String> taskList = new ListSignal<>();
         TestLayout parentComponent = new TestLayout();
@@ -708,7 +708,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void bindChildren_emptySharedListSignal_emptyParent() {
+    void bindChildren_emptySharedListSignal_emptyParent() {
         CurrentInstance.clearAll();
         ListSignal<String> taskList = new ListSignal<>();
         TestLayout parentComponent = new TestLayout();
@@ -719,7 +719,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void bindChildren_emptySharedListSignalWithNotInitiallyEmptyParent_throw() {
+    void bindChildren_emptySharedListSignalWithNotInitiallyEmptyParent_throw() {
         CurrentInstance.clearAll();
         ListSignal<String> taskList = new ListSignal<>();
         TestLayout parentComponent = new TestLayout();
@@ -738,7 +738,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void bindChildren_listSignalWithItem_parentUpdated() {
+    void bindChildren_listSignalWithItem_parentUpdated() {
         CurrentInstance.clearAll();
         ListSignal<String> taskList = new ListSignal<>();
         taskList.insertFirst("first");
@@ -761,7 +761,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void bindChildren_addItem_parentUpdated() {
+    void bindChildren_addItem_parentUpdated() {
         CurrentInstance.clearAll();
         ListSignal<String> taskList = new ListSignal<>();
         taskList.insertFirst("first");
@@ -793,7 +793,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void bindChildren_removeItem_parentUpdated() {
+    void bindChildren_removeItem_parentUpdated() {
         CurrentInstance.clearAll();
         ListSignal<String> taskList = new ListSignal<>();
         taskList.insertFirst("first");
@@ -831,7 +831,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void bindChildren_moveItem_parentUpdated() {
+    void bindChildren_moveItem_parentUpdated() {
         CurrentInstance.clearAll();
         ListSignal<String> taskList = new ListSignal<>();
         taskList.insertFirst("first");
@@ -869,7 +869,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void bindChildren_moveLastToFirst_verifyElementAttachDetachCount() {
+    void bindChildren_moveLastToFirst_verifyElementAttachDetachCount() {
         CurrentInstance.clearAll();
         ListSignal<String> taskList = new ListSignal<>();
         taskList.insertFirst("first");
@@ -893,7 +893,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void bindChildren_moveFirstToLast_verifyElementAttachDetachCount() {
+    void bindChildren_moveFirstToLast_verifyElementAttachDetachCount() {
         CurrentInstance.clearAll();
         ListSignal<String> taskList = new ListSignal<>();
         taskList.insertFirst("first");
@@ -917,7 +917,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void bindChildren_moveLastBetweenFirstAndSecond_verifyElementAttachDetachCount() {
+    void bindChildren_moveLastBetweenFirstAndSecond_verifyElementAttachDetachCount() {
         CurrentInstance.clearAll();
         ListSignal<String> taskList = new ListSignal<>();
         taskList.insertFirst("first");
@@ -941,7 +941,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void bindChildren_addToParentComponentAndAddItem_throw() {
+    void bindChildren_addToParentComponentAndAddItem_throw() {
         // When adding children directly to parent, exception will be thrown
         // from the effect on next related Signal change.
         CurrentInstance.clearAll();
@@ -982,7 +982,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void bindChildren_directParentComponentChanges_sameChildrenSizeBeforeAfter_throw() {
+    void bindChildren_directParentComponentChanges_sameChildrenSizeBeforeAfter_throw() {
         // When adding children directly to parent, exception will be thrown
         // from the effect on next related Signal change.
         CurrentInstance.clearAll();
@@ -1033,7 +1033,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void bindChildren_directParentComponentChangeByFactory_throw() {
+    void bindChildren_directParentComponentChangeByFactory_throw() {
         // When adding children directly to parent, exception will be thrown
         // from the effect on next related Signal change.
         CurrentInstance.clearAll();
@@ -1080,7 +1080,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void bindChildren_directParentComponentChangeByCustomAttach_throw() {
+    void bindChildren_directParentComponentChangeByCustomAttach_throw() {
         // When adding children directly to parent, exception will be thrown
         // from the effect on next related Signal change.
         CurrentInstance.clearAll();
@@ -1127,7 +1127,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void bindChildren_directParentComponentChildOrderChanges_throw() {
+    void bindChildren_directParentComponentChildOrderChanges_throw() {
         // When adding children directly to parent, exception will be thrown
         // from the effect on next related Signal change.
         // Exception is thrown only in final validation in the end when change
@@ -1175,7 +1175,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void bindChildren_runInTransaction_effectRunOnce() {
+    void bindChildren_runInTransaction_effectRunOnce() {
         CurrentInstance.clearAll();
         var expectedMockedElements = new ArrayList<Element>();
 
@@ -1226,7 +1226,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void bindChildren_withNullFromChildFactory_throws() {
+    void bindChildren_withNullFromChildFactory_throws() {
         CurrentInstance.clearAll();
         LinkedList<ErrorEvent> events = mockLockedSessionWithErrorHandler();
         UI ui = UI.getCurrent();
@@ -1250,7 +1250,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void bindChildren_signalGetInsideCallback_throws() {
+    void bindChildren_signalGetInsideCallback_throws() {
         CurrentInstance.clearAll();
         mockLockedSessionWithErrorHandler();
         UI ui = UI.getCurrent();
@@ -1268,7 +1268,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void bindChildren_registrationRemove_effectRemoved() {
+    void bindChildren_registrationRemove_effectRemoved() {
         CurrentInstance.clearAll();
         ListSignal<String> taskList = new ListSignal<>();
         taskList.insertFirst("first");
@@ -1309,7 +1309,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void bindChildren_withLocalValueSignalList_parentUpdated() {
+    void bindChildren_withLocalValueSignalList_parentUpdated() {
         CurrentInstance.clearAll();
         ValueSignal<String> first = new ValueSignal<>("first");
         ValueSignal<String> second = new ValueSignal<>("second");
@@ -1354,7 +1354,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void bindChildren_parentWithSlottedChild_succeeds() {
+    void bindChildren_parentWithSlottedChild_succeeds() {
         CurrentInstance.clearAll();
         ListSignal<String> taskList = new ListSignal<>();
         TestLayout parentComponent = new TestLayout();
@@ -1372,7 +1372,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void bindChildren_parentWithDefaultSlotChild_throws() {
+    void bindChildren_parentWithDefaultSlotChild_throws() {
         CurrentInstance.clearAll();
         ListSignal<String> taskList = new ListSignal<>();
         TestLayout parentComponent = new TestLayout();
@@ -1388,7 +1388,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void bindChildren_addSlottedChildAfterBinding_signalUpdatePreservesIt() {
+    void bindChildren_addSlottedChildAfterBinding_signalUpdatePreservesIt() {
         CurrentInstance.clearAll();
         ListSignal<String> taskList = new ListSignal<>();
         taskList.insertFirst("first");
@@ -1424,7 +1424,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void bindChildren_factoryReturnsSlottedElement_throws() {
+    void bindChildren_factoryReturnsSlottedElement_throws() {
         CurrentInstance.clearAll();
         LinkedList<ErrorEvent> events = mockLockedSessionWithErrorHandler();
         UI ui = UI.getCurrent();
@@ -1451,7 +1451,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void bindChildren_moveItemsWithSlottedChildPresent_correctOrder() {
+    void bindChildren_moveItemsWithSlottedChildPresent_correctOrder() {
         CurrentInstance.clearAll();
         ListSignal<String> taskList = new ListSignal<>();
         taskList.insertFirst("first");
@@ -1486,7 +1486,7 @@ class ElementEffectTest {
     }
 
     @Test
-    public void bindChildren_removeItemsWithSlottedChildPresent_slottedUnaffected() {
+    void bindChildren_removeItemsWithSlottedChildPresent_slottedUnaffected() {
         CurrentInstance.clearAll();
         ListSignal<String> taskList = new ListSignal<>();
         taskList.insertFirst("first");

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementFactoryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementFactoryTest.java
@@ -45,14 +45,14 @@ class ElementFactoryTest {
     }
 
     @Test
-    public void automatedTest() throws Exception {
+    void automatedTest() throws Exception {
         for (Method method : ElementFactory.class.getMethods()) {
             testMethod(method);
         }
     }
 
     @Test
-    public void createAnchor() {
+    void createAnchor() {
         String href = "hrefhref";
         String textContent = "textContent";
 
@@ -65,7 +65,7 @@ class ElementFactoryTest {
     }
 
     @Test
-    public void createTextInput() {
+    void createTextInput() {
         String type = "typetype";
 
         assertElement("<input type='" + type + "'></input>",

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementJacksonTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementJacksonTest.java
@@ -92,7 +92,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 class ElementJacksonTest extends AbstractNodeTest {
 
     @Test
-    public void createElementWithTag() {
+    void createElementWithTag() {
         Element e = ElementFactory.createDiv();
         assertEquals(Tag.DIV, e.getTag());
         assertFalse(e.hasAttribute("is"));
@@ -100,28 +100,28 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void createElementWithInvalidTag() {
+    void createElementWithInvalidTag() {
         assertThrows(IllegalArgumentException.class, () -> {
             new Element("<div>");
         });
     }
 
     @Test
-    public void createElementWithEmptyTag() {
+    void createElementWithEmptyTag() {
         assertThrows(IllegalArgumentException.class, () -> {
             new Element("");
         });
     }
 
     @Test
-    public void createElementWithNullTag() {
+    void createElementWithNullTag() {
         assertThrows(IllegalArgumentException.class, () -> {
             new Element(null);
         });
     }
 
     @Test
-    public void elementsUpdateSameData() {
+    void elementsUpdateSameData() {
         Element te = new Element("testelem");
         Element e = Element.get(te.getNode());
 
@@ -136,7 +136,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void getElementFromInvalidNode() {
+    void getElementFromInvalidNode() {
         assertThrows(IllegalArgumentException.class, () -> {
             StateNode node = new StateNode(ElementPropertyMap.class);
             Element.get(node);
@@ -144,7 +144,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void publicElementMethodsShouldReturnElement() {
+    void publicElementMethodsShouldReturnElement() {
         Set<String> ignore = new HashSet<>();
         ignore.add("toString");
         ignore.add("hashCode");
@@ -185,7 +185,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void publicElementStyleMethodsShouldReturnElement() {
+    void publicElementStyleMethodsShouldReturnElement() {
         Set<String> ignore = new HashSet<>();
         ignore.add("toString");
         ignore.add("hashCode");
@@ -214,21 +214,21 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void stringAttribute() {
+    void stringAttribute() {
         Element e = ElementFactory.createDiv();
         e.setAttribute("foo", "bar");
         assertEquals("bar", e.getAttribute("foo"));
     }
 
     @Test
-    public void setEmptyAttribute() {
+    void setEmptyAttribute() {
         Element e = ElementFactory.createDiv();
         e.setAttribute("foo", "");
         assertEquals("", e.getAttribute("foo"));
     }
 
     @Test
-    public void setBooleanAttribute() {
+    void setBooleanAttribute() {
         Element e = ElementFactory.createDiv();
 
         e.setAttribute("foo", true);
@@ -241,7 +241,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setNullAttribute() {
+    void setNullAttribute() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element e = ElementFactory.createDiv();
             e.setAttribute("foo", (String) null);
@@ -249,7 +249,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void getNullAttribute() {
+    void getNullAttribute() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element e = ElementFactory.createDiv();
             e.getAttribute(null);
@@ -257,7 +257,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void hasNullAttribute() {
+    void hasNullAttribute() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element e = ElementFactory.createDiv();
             e.hasAttribute(null);
@@ -265,7 +265,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void removeNullAttribute() {
+    void removeNullAttribute() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element e = ElementFactory.createDiv();
             e.removeAttribute(null);
@@ -273,7 +273,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setInvalidAttribute() {
+    void setInvalidAttribute() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element e = ElementFactory.createDiv();
             e.setAttribute("\"foo\"", "bar");
@@ -281,20 +281,20 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void hasDefinedAttribute() {
+    void hasDefinedAttribute() {
         Element e = ElementFactory.createDiv();
         e.setAttribute("foo", "bar");
         assertTrue(e.hasAttribute("foo"));
     }
 
     @Test
-    public void doesNotHaveUndefinedAttribute() {
+    void doesNotHaveUndefinedAttribute() {
         Element e = ElementFactory.createDiv();
         assertFalse(e.hasAttribute("foo"));
     }
 
     @Test
-    public void doesNotHaveRemovedAttribute() {
+    void doesNotHaveRemovedAttribute() {
         Element e = ElementFactory.createDiv();
         e.setAttribute("foo", "bar");
         e.removeAttribute("foo");
@@ -302,7 +302,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void removeNonExistingAttributeIsNoOp() {
+    void removeNonExistingAttributeIsNoOp() {
         Element e = ElementFactory.createDiv();
         assertFalse(e.hasAttribute("foo"));
         e.removeAttribute("foo");
@@ -310,13 +310,13 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void attributesWhenNoneDefined() {
+    void attributesWhenNoneDefined() {
         Element e = ElementFactory.createDiv();
         assertEquals(0, e.getAttributeNames().count());
     }
 
     @Test
-    public void attributesNames() {
+    void attributesNames() {
         Element e = ElementFactory.createDiv();
         e.setAttribute("foo", "bar");
         assertArrayEquals(new String[] { "foo" },
@@ -324,7 +324,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void attributesNamesAfterRemoved() {
+    void attributesNamesAfterRemoved() {
         Element e = ElementFactory.createDiv();
         e.setAttribute("foo", "bar");
         e.setAttribute("bar", "baz");
@@ -334,7 +334,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setGetAttributeValueCaseSensitive() {
+    void setGetAttributeValueCaseSensitive() {
         Element e = new Element(Tag.SPAN);
         e.setAttribute("foo", "bAr");
         assertEquals("bAr", e.getAttribute("foo"));
@@ -343,7 +343,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setGetAttributeNameCaseInsensitive() {
+    void setGetAttributeNameCaseInsensitive() {
         Element e = new Element(Tag.SPAN);
         e.setAttribute("foo", "bar");
         e.setAttribute("FOO", "baz");
@@ -353,14 +353,14 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void hasAttributeNamesCaseInsensitive() {
+    void hasAttributeNamesCaseInsensitive() {
         Element e = new Element(Tag.SPAN);
         e.setAttribute("fooo", "bar");
         assertTrue(e.hasAttribute("fOoO"));
     }
 
     @Test
-    public void getAttributeNamesLowerCase() {
+    void getAttributeNamesLowerCase() {
         Element e = new Element(Tag.SPAN);
         e.setAttribute("FOO", "bar");
         e.setAttribute("Baz", "bar");
@@ -374,7 +374,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void removeDetachedFromParent() {
+    void removeDetachedFromParent() {
         Element otherElement = new Element("other");
         assertNull(otherElement.getParent());
         otherElement.removeFromParent(); // No op
@@ -382,14 +382,14 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void getDetachedParent() {
+    void getDetachedParent() {
         Element otherElement = new Element("other");
         assertNull(otherElement.getParent());
         assertNull(otherElement.getParentNode());
     }
 
     @Test
-    public void addNullEventListener() {
+    void addNullEventListener() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element e = ElementFactory.createDiv();
             e.addEventListener("foo", null);
@@ -397,7 +397,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void addEventListenerForNullType() {
+    void addEventListenerForNullType() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element e = ElementFactory.createDiv();
             e.addEventListener(null, ignore -> {
@@ -406,19 +406,19 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void equalsSelf() {
+    void equalsSelf() {
         Element e = ElementFactory.createDiv();
         assertTrue(e.equals(e));
     }
 
     @Test
-    public void notEqualsNull() {
+    void notEqualsNull() {
         Element e = ElementFactory.createDiv();
         assertFalse(e.equals(null));
     }
 
     @Test
-    public void notEqualsString() {
+    void notEqualsString() {
         Element e = ElementFactory.createDiv();
         assertFalse(e.equals(Tag.DIV));
     }
@@ -464,7 +464,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     // }
 
     @Test
-    public void getPropertyDefaults() {
+    void getPropertyDefaults() {
         Element element = ElementFactory.createDiv();
 
         element.setProperty("null", null);
@@ -491,7 +491,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void getPropertyStringConversions() {
+    void getPropertyStringConversions() {
         assertPropertyString(null, null);
         assertPropertyString("foo", "foo");
         assertPropertyString("", "");
@@ -513,7 +513,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testPropertyBooleanConversions() {
+    void testPropertyBooleanConversions() {
         assertPropertyBoolean(true, Boolean.TRUE);
         assertPropertyBoolean(false, Boolean.FALSE);
 
@@ -546,7 +546,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testPropertyDoubleConversions() {
+    void testPropertyDoubleConversions() {
         assertPropertyDouble(1, Double.valueOf(1));
         assertPropertyDouble(.1, Double.valueOf(.1));
         assertPropertyDouble(Double.NaN, Double.valueOf(Double.NaN));
@@ -583,7 +583,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testPropertyIntConversions() {
+    void testPropertyIntConversions() {
         assertPropertyInt(1, Double.valueOf(1));
         assertPropertyInt(1, Double.valueOf(1.9));
         assertPropertyInt(0, Double.valueOf(Double.NaN));
@@ -661,7 +661,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void propertyRawValues() {
+    void propertyRawValues() {
         Element element = ElementFactory.createDiv();
 
         element.setProperty("p", "v");
@@ -709,7 +709,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void addAndRemoveProperty() {
+    void addAndRemoveProperty() {
         Element element = ElementFactory.createDiv();
 
         assertFalse(element.hasProperty("foo"));
@@ -726,7 +726,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void propertyNames() {
+    void propertyNames() {
         Element element = ElementFactory.createDiv();
 
         assertEquals(0, element.getPropertyNames().count());
@@ -740,7 +740,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setProperty_javaTimeObject() {
+    void setProperty_javaTimeObject() {
         BeanWithTemporalFields bean = new BeanWithTemporalFields();
         Element element = ElementFactory.createDiv();
 
@@ -801,7 +801,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testGetTextContent() {
+    void testGetTextContent() {
         Element child = new Element("child");
         child.appendChild(Element.createText("bar"));
 
@@ -814,7 +814,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testSetTextContent() {
+    void testSetTextContent() {
         Element element = ElementFactory.createDiv();
         element.setText("foo");
 
@@ -824,7 +824,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testSetTextContentRemovesOldContent() {
+    void testSetTextContentRemovesOldContent() {
         Element child = new Element("child");
         Element element = ElementFactory.createDiv();
         element.appendChild(child);
@@ -836,7 +836,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testSetTextReplacesOldTextNode() {
+    void testSetTextReplacesOldTextNode() {
         Element element = ElementFactory.createDiv();
         Element text = Element.createText("foo");
         element.appendChild(text);
@@ -848,7 +848,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testSetTextContentPropertyThrows() {
+    void testSetTextContentPropertyThrows() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element element = new Element("element");
             element.setProperty("textContent", "foo");
@@ -856,7 +856,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setOuterHtmlProperty_throws() {
+    void setOuterHtmlProperty_throws() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element element = new Element("element");
             element.setProperty("outerHTML", "<br>");
@@ -864,7 +864,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setInnerHtmlProeprty_setValueAndRemoveAllChildren() {
+    void setInnerHtmlProeprty_setValueAndRemoveAllChildren() {
         Element element = new Element("element");
         element.appendChild(ElementFactory.createAnchor(),
                 ElementFactory.createDiv());
@@ -875,7 +875,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testGetTextContentProperty() {
+    void testGetTextContentProperty() {
         Element element = ElementFactory.createDiv();
         element.setText("foo");
 
@@ -885,7 +885,7 @@ class ElementJacksonTest extends AbstractNodeTest {
 
     @Test
     // Because that's how it works in browsers
-    public void clearTextContentRemovesChild() {
+    void clearTextContentRemovesChild() {
         Element element = ElementFactory.createDiv();
         element.setText("foo");
 
@@ -897,7 +897,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void newElementClasses() {
+    void newElementClasses() {
         Element element = ElementFactory.createDiv();
 
         assertFalse(element.hasAttribute("class"));
@@ -905,7 +905,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void addElementClasses() {
+    void addElementClasses() {
         Element element = ElementFactory.createDiv();
 
         element.getClassList().add("foo");
@@ -924,7 +924,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testSetClassAttribute() {
+    void testSetClassAttribute() {
         Element element = ElementFactory.createDiv();
 
         // Get instance right away to see that changes are live
@@ -943,7 +943,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testSetEmptyClassAttribute() {
+    void testSetEmptyClassAttribute() {
         Element element = new Element(Tag.DIV);
 
         // Get instance right away to see that changes are live
@@ -955,7 +955,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testAddEmptyClassname() {
+    void testAddEmptyClassname() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element element = new Element(Tag.DIV);
 
@@ -967,7 +967,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testRemoveClassName() {
+    void testRemoveClassName() {
         Element element = ElementFactory.createDiv();
 
         element.setAttribute("class", "foo bar");
@@ -985,7 +985,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testRemoveClassAttribute() {
+    void testRemoveClassAttribute() {
         Element element = ElementFactory.createDiv();
 
         Set<String> classList = element.getClassList();
@@ -998,7 +998,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void addExistingClass_noop() {
+    void addExistingClass_noop() {
         Element element = ElementFactory.createDiv();
 
         element.setAttribute("class", "foo");
@@ -1009,14 +1009,14 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testAddClassWithSpaces_throws() {
+    void testAddClassWithSpaces_throws() {
         assertThrows(IllegalArgumentException.class, () -> {
             ElementFactory.createDiv().getClassList().add("foo bar");
         });
     }
 
     @Test
-    public void testRemoveClassWithSpaces() {
+    void testRemoveClassWithSpaces() {
         ClassList cl = ElementFactory.createDiv().getClassList();
         cl.add("foo");
         cl.add("bar");
@@ -1025,7 +1025,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testContainsClassWithSpaces() {
+    void testContainsClassWithSpaces() {
         ClassList cl = ElementFactory.createDiv().getClassList();
         cl.add("foo");
         cl.add("bar");
@@ -1034,7 +1034,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void classListSetAdd() {
+    void classListSetAdd() {
         Element e = new Element(Tag.DIV);
         assertTrue(e.getClassList().set("foo", true));
         assertEquals("foo", e.getAttribute("class"));
@@ -1043,7 +1043,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void classListSetRemove() {
+    void classListSetRemove() {
         Element e = new Element(Tag.DIV);
         e.setAttribute("class", "foo bar");
         assertTrue(e.getClassList().set("foo", false));
@@ -1053,21 +1053,21 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testClassListProperty_throws() {
+    void testClassListProperty_throws() {
         assertThrows(IllegalArgumentException.class, () -> {
             ElementFactory.createDiv().setProperty("classList", "foo");
         });
     }
 
     @Test
-    public void testClassNameProperty_throws() {
+    void testClassNameProperty_throws() {
         assertThrows(IllegalArgumentException.class, () -> {
             ElementFactory.createDiv().setProperty("className", "foo");
         });
     }
 
     @Test
-    public void setStyle() {
+    void setStyle() {
         Element e = ElementFactory.createDiv();
         Style s = e.getStyle();
         s.set("foo", "bar");
@@ -1077,14 +1077,14 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void getUnsetStyle() {
+    void getUnsetStyle() {
         Element e = ElementFactory.createDiv();
         Style s = e.getStyle();
         assertNull(s.get("foo"));
     }
 
     @Test
-    public void getNullStyle() {
+    void getNullStyle() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element e = ElementFactory.createDiv();
             Style s = e.getStyle();
@@ -1093,7 +1093,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void replaceStyle() {
+    void replaceStyle() {
         Element e = ElementFactory.createDiv();
         Style s = e.getStyle();
         s.set("foo", "bar");
@@ -1102,7 +1102,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void removeSingleStyle() {
+    void removeSingleStyle() {
         Element e = ElementFactory.createDiv();
         Style s = e.getStyle();
         s.set("foo", "bar");
@@ -1111,14 +1111,14 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void emptyStyleAsAttribute() {
+    void emptyStyleAsAttribute() {
         Element e = ElementFactory.createDiv();
         assertFalse(e.hasAttribute("style"));
         assertNull(e.getAttribute("style"));
     }
 
     @Test
-    public void semicolonInStyle() {
+    void semicolonInStyle() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element e = ElementFactory.createDiv();
             Style s = e.getStyle();
@@ -1127,7 +1127,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void getSingleStyleAsAttribute() {
+    void getSingleStyleAsAttribute() {
         Element e = ElementFactory.createDiv();
         Style s = e.getStyle();
         s.setBorder("1px solid black");
@@ -1136,7 +1136,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void getMultipleStylesAsAttribute() {
+    void getMultipleStylesAsAttribute() {
         Element e = ElementFactory.createDiv();
         Style s = e.getStyle();
         s.set("border", "1px solid black");
@@ -1149,7 +1149,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setSingleStyleAsAttribute() {
+    void setSingleStyleAsAttribute() {
         Element e = ElementFactory.createDiv();
         String style = "width:12em";
         e.setAttribute("style", style);
@@ -1158,7 +1158,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setStyleAttributeMultipleTimes() {
+    void setStyleAttributeMultipleTimes() {
         Element e = ElementFactory.createDiv();
         e.setAttribute("style", "width:12em");
         e.setAttribute("style", "height:12em");
@@ -1167,7 +1167,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setMultipleStylesAsAttribute() {
+    void setMultipleStylesAsAttribute() {
         Element e = ElementFactory.createDiv();
         String style = "width:12em;height:2em";
         e.setAttribute("style", style);
@@ -1176,7 +1176,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setComplexStylesAsAttribute() {
+    void setComplexStylesAsAttribute() {
         testStyleAttribute(
                 "background:rgb(0,255,0) url(http://foo.bar/smiley.gif) no-repeat fixed center");
         testStyleAttribute("content:\"content: bar\"");
@@ -1212,7 +1212,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setInvalidStyleAsAttribute() {
+    void setInvalidStyleAsAttribute() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element e = ElementFactory.createDiv();
             e.setAttribute("style", "width:");
@@ -1220,7 +1220,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setInvalidStyleAsAttribute2() {
+    void setInvalidStyleAsAttribute2() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element e = ElementFactory.createDiv();
             e.setAttribute("style", "width");
@@ -1228,7 +1228,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setVendorSpecificStylesProperty() {
+    void setVendorSpecificStylesProperty() {
         Element e = ElementFactory.createDiv();
         String style = "-moz-user-input:inherit";
         e.setAttribute("style", style);
@@ -1237,7 +1237,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setVendorSpecificStylesValue() {
+    void setVendorSpecificStylesValue() {
         Element e = ElementFactory.createDiv();
         String style = "display:-moz-box";
         e.setAttribute("style", style);
@@ -1247,7 +1247,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setStyleAttributeTrailingSemicolon() {
+    void setStyleAttributeTrailingSemicolon() {
         Element e = ElementFactory.createDiv();
         String style = "width:12em";
         e.setAttribute("style", style + ";");
@@ -1267,7 +1267,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setEmptyStyleName() {
+    void setEmptyStyleName() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element e = ElementFactory.createDiv();
             e.getStyle().set("", "foo");
@@ -1275,7 +1275,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setStyleNameExtraWhitespace() {
+    void setStyleNameExtraWhitespace() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element e = ElementFactory.createDiv();
             e.getStyle().set("   color", "red");
@@ -1283,7 +1283,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setStyleNameColon() {
+    void setStyleNameColon() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element e = ElementFactory.createDiv();
             e.getStyle().set("color:", "red");
@@ -1291,7 +1291,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setStyleValueExtraWhitespace() {
+    void setStyleValueExtraWhitespace() {
         Element e = ElementFactory.createDiv();
         e.getStyle().setColor("red   ");
         assertEquals("color:red", e.getAttribute("style"));
@@ -1299,7 +1299,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void removeStyles() {
+    void removeStyles() {
         Element element = ElementFactory.createDiv();
 
         element.getStyle().setZIndex(12);
@@ -1318,7 +1318,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void removeStyleAttribute() {
+    void removeStyleAttribute() {
         Element element = ElementFactory.createDiv();
 
         Style style = element.getStyle();
@@ -1331,7 +1331,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void validStyleWithSemicolon() {
+    void validStyleWithSemicolon() {
         Element element = ElementFactory.createDiv();
         String validStyle = "background: url('foo;bar')";
         Style style = element.getStyle();
@@ -1340,7 +1340,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void dashSeparatedSetStyle() {
+    void dashSeparatedSetStyle() {
         Element element = ElementFactory.createDiv();
 
         Style style = element.getStyle();
@@ -1349,7 +1349,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void dashSeparatedGetStyle() {
+    void dashSeparatedGetStyle() {
         Element element = ElementFactory.createDiv();
 
         Style style = element.getStyle();
@@ -1360,7 +1360,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void dashSeparatedHasStyle() {
+    void dashSeparatedHasStyle() {
         Element element = ElementFactory.createDiv();
 
         Style style = element.getStyle();
@@ -1371,7 +1371,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void dashSeparatedRemoveStyle() {
+    void dashSeparatedRemoveStyle() {
         Element element = ElementFactory.createDiv();
 
         Style style = element.getStyle();
@@ -1385,7 +1385,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void styleGetNamesDashAndCamelCase() {
+    void styleGetNamesDashAndCamelCase() {
         Element element = ElementFactory.createDiv();
 
         Style style = element.getStyle();
@@ -1399,7 +1399,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void nullStyleValue() {
+    void nullStyleValue() {
         Element element = ElementFactory.createDiv();
 
         Style style = element.getStyle();
@@ -1410,7 +1410,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void sendPropertyInCorrectFormatToClient() {
+    void sendPropertyInCorrectFormatToClient() {
         assertClientStyleKey("--some-variable", "--some-variable");
         assertClientStyleKey("-webkit-border", "-webkit-border");
         assertClientStyleKey("background-color", "background-color");
@@ -1436,7 +1436,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void customPropertyStyle() {
+    void customPropertyStyle() {
         Element element = ElementFactory.createDiv();
         Style style = element.getStyle();
         style.set("--some-variable", "foo");
@@ -1444,7 +1444,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void useCustomPropertyStyle() {
+    void useCustomPropertyStyle() {
         Element element = ElementFactory.createDiv();
 
         Style style = element.getStyle();
@@ -1493,7 +1493,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     // }
 
     @Test
-    public void addAsOwnChild() {
+    void addAsOwnChild() {
         assertThrows(IllegalStateException.class, () -> {
             Element element = ElementFactory.createDiv();
             element.appendChild(element);
@@ -1501,7 +1501,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void addAsChildOfChild() {
+    void addAsChildOfChild() {
         assertThrows(IllegalStateException.class, () -> {
             Element parent = ElementFactory.createDiv();
             Element child = ElementFactory.createDiv();
@@ -1519,7 +1519,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testGetOwnTextContent() {
+    void testGetOwnTextContent() {
         Element element = ElementFactory.createDiv();
         element.setText("foo");
         element.appendChild(ElementFactory.createDiv()
@@ -1533,7 +1533,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_elementIsNotAttached_elementHasAttribute() {
+    void setResourceAttribute_elementIsNotAttached_elementHasAttribute() {
         UI.setCurrent(createUI());
         Element element = ElementFactory.createDiv();
         String resName = "resource";
@@ -1546,7 +1546,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_elementIsNotAttachedAndHasAttribute_elementHasAttribute() {
+    void setResourceAttribute_elementIsNotAttachedAndHasAttribute_elementHasAttribute() {
         UI.setCurrent(createUI());
         Element element = ElementFactory.createDiv();
         element.setAttribute("foo", "bar");
@@ -1561,7 +1561,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttributeSeveralTimes_elementIsNotAttached_elementHasAttribute() {
+    void setResourceAttributeSeveralTimes_elementIsNotAttached_elementHasAttribute() {
         UI.setCurrent(createUI());
         Element element = ElementFactory.createDiv();
         String resName = "resource";
@@ -1580,7 +1580,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_nullValue() {
+    void setResourceAttribute_nullValue() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element element = ElementFactory.createDiv();
             element.setAttribute("foo", (StreamResource) null);
@@ -1588,7 +1588,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_classAttribute() {
+    void setResourceAttribute_classAttribute() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element element = ElementFactory.createDiv();
             element.setAttribute("class", Mockito.mock(StreamResource.class));
@@ -1596,7 +1596,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_nullAttribute() {
+    void setResourceAttribute_nullAttribute() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element element = ElementFactory.createDiv();
             element.setAttribute(null, Mockito.mock(StreamResource.class));
@@ -1604,7 +1604,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_elementIsAttached_elementHasAttribute() {
+    void setResourceAttribute_elementIsAttached_elementHasAttribute() {
         UI ui = createUI();
         UI.setCurrent(ui);
         String resName = "resource";
@@ -1616,7 +1616,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_elementIsAttached_setAnotherResource()
+    void setResourceAttribute_elementIsAttached_setAnotherResource()
             throws URISyntaxException {
         UI ui = createUI();
         UI.setCurrent(ui);
@@ -1639,7 +1639,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_elementIsAttached_setRawAttribute()
+    void setResourceAttribute_elementIsAttached_setRawAttribute()
             throws URISyntaxException, InterruptedException {
         UI ui = createUI();
         UI.setCurrent(ui);
@@ -1667,7 +1667,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_elementIsAttached_removeAttribute()
+    void setResourceAttribute_elementIsAttached_removeAttribute()
             throws URISyntaxException, InterruptedException {
         UI ui = createUI();
         UI.setCurrent(ui);
@@ -1694,7 +1694,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_attachElement_resourceIsRegistered()
+    void setResourceAttribute_attachElement_resourceIsRegistered()
             throws URISyntaxException {
         UI ui = createUI();
         UI.setCurrent(ui);
@@ -1714,7 +1714,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_attachElement_setAnotherResource()
+    void setResourceAttribute_attachElement_setAnotherResource()
             throws URISyntaxException, InterruptedException {
         UI ui = createUI();
         UI.setCurrent(ui);
@@ -1746,7 +1746,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_attachElement_setRawAttribute()
+    void setResourceAttribute_attachElement_setRawAttribute()
             throws URISyntaxException, InterruptedException {
         UI ui = createUI();
         UI.setCurrent(ui);
@@ -1769,7 +1769,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_attachElement_removeAttribute()
+    void setResourceAttribute_attachElement_removeAttribute()
             throws URISyntaxException, InterruptedException {
         UI ui = createUI();
         UI.setCurrent(ui);
@@ -1793,7 +1793,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_attachElement_setAnotherResourceAfterAttaching()
+    void setResourceAttribute_attachElement_setAnotherResourceAfterAttaching()
             throws URISyntaxException, InterruptedException {
         UI ui = createUI();
         UI.setCurrent(ui);
@@ -1824,7 +1824,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_attachElement_setRawAttributeAfterAttaching()
+    void setResourceAttribute_attachElement_setRawAttributeAfterAttaching()
             throws URISyntaxException, InterruptedException {
         UI ui = createUI();
         UI.setCurrent(ui);
@@ -1850,7 +1850,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_attachElement_removeAttributeAfterAttaching()
+    void setResourceAttribute_attachElement_removeAttributeAfterAttaching()
             throws URISyntaxException, InterruptedException {
         UI ui = createUI();
         UI.setCurrent(ui);
@@ -1876,7 +1876,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_detachElement_resourceIsUnregistered()
+    void setResourceAttribute_detachElement_resourceIsUnregistered()
             throws URISyntaxException, InterruptedException {
         UI ui = createUI();
         UI.setCurrent(ui);
@@ -1914,7 +1914,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_detachAndReattachElement_resourceReregistered()
+    void setResourceAttribute_detachAndReattachElement_resourceReregistered()
             throws URISyntaxException {
         UI ui = createUI();
         UI.setCurrent(ui);
@@ -1945,7 +1945,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_attachAndDetachAndReattachElement_resourceReregistered()
+    void setResourceAttribute_attachAndDetachAndReattachElement_resourceReregistered()
             throws URISyntaxException {
         UI ui = createUI();
         UI.setCurrent(ui);
@@ -1977,7 +1977,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_elementIsText_operationIsNotSupported() {
+    void setResourceAttribute_elementIsText_operationIsNotSupported() {
         assertThrows(UnsupportedOperationException.class, () -> {
             Element.createText("").setAttribute("foo",
                     Mockito.mock(StreamResource.class));
@@ -1985,7 +1985,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testAttachListener_parentAttach_childListenersTriggered() {
+    void testAttachListener_parentAttach_childListenersTriggered() {
         Element body = new UI().getElement();
         Element parent = ElementFactory.createDiv();
         Element child = ElementFactory.createDiv();
@@ -2037,7 +2037,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testDetachListener_parentDetach_childListenersTriggered() {
+    void testDetachListener_parentDetach_childListenersTriggered() {
         Element body = new UI().getElement();
         Element parent = ElementFactory.createDiv();
         Element child = ElementFactory.createDiv();
@@ -2078,7 +2078,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testAttachListener_eventOrder_childFirst() {
+    void testAttachListener_eventOrder_childFirst() {
         Element body = new UI().getElement();
         Element parent = ElementFactory.createDiv();
         Element child = ElementFactory.createDiv();
@@ -2103,7 +2103,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testDetachListener_eventOrder_childFirst() {
+    void testDetachListener_eventOrder_childFirst() {
         Element body = new UI().getElement();
         Element parent = ElementFactory.createDiv();
         Element child = ElementFactory.createDiv();
@@ -2129,7 +2129,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testAttachDetach_elementMoved_bothEventsTriggered() {
+    void testAttachDetach_elementMoved_bothEventsTriggered() {
         Element body = new UI().getElement();
         Element parent = ElementFactory.createDiv();
         Element child = ElementFactory.createDiv();
@@ -2156,7 +2156,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testAttachEvent_stateTreeCanFound() {
+    void testAttachEvent_stateTreeCanFound() {
         Element body = new UI().getElement();
         Element child = ElementFactory.createDiv();
 
@@ -2174,7 +2174,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testDetachEvent_stateTreeCanFound() {
+    void testDetachEvent_stateTreeCanFound() {
         Element body = new UI().getElement();
         Element child = ElementFactory.createDiv();
         body.appendChild(child);
@@ -2194,7 +2194,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testMoveFromUiToUi_doesNotThrow() {
+    void testMoveFromUiToUi_doesNotThrow() {
         Element body = new UI().getElement();
         Element child = ElementFactory.createDiv();
         body.appendChild(child);
@@ -2207,7 +2207,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testRemoveFromTree_inDetachListener_removedFromParent() {
+    void testRemoveFromTree_inDetachListener_removedFromParent() {
         Element body = new UI().getElement();
         Element child = ElementFactory.createDiv();
         body.appendChild(child);
@@ -2220,7 +2220,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testRemoveFromTree_isVirtualChild_removedFromParent() {
+    void testRemoveFromTree_isVirtualChild_removedFromParent() {
         Element body = new UI().getElement();
         Element child = ElementFactory.createDiv();
 
@@ -2255,7 +2255,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void insertAtCurrentPositionNoOp() {
+    void insertAtCurrentPositionNoOp() {
         // Must have an UI to get attach events
         UI ui = new UI();
         Element parent = ui.getElement();
@@ -2268,25 +2268,25 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void textNodeTransformsNullToEmptyAndDoesNotThrowException() {
+    void textNodeTransformsNullToEmptyAndDoesNotThrowException() {
         Element e = Element.createText(null);
         assertEquals("", e.getText());
     }
 
     @Test
-    public void textNodeOuterHtml() {
+    void textNodeOuterHtml() {
         Element e = Element.createText("foobar");
         assertEquals("foobar", e.getOuterHTML());
     }
 
     @Test
-    public void singleElementOuterHtml() {
+    void singleElementOuterHtml() {
         Element e = ElementFactory.createAnchor();
         assertEquals("<a></a>", e.getOuterHTML());
     }
 
     @Test
-    public void elementTreeOuterHtml() {
+    void elementTreeOuterHtml() {
         Element div = ElementFactory.createDiv();
         Element span = ElementFactory.createSpan();
         Element button = ElementFactory.createButton("hello");
@@ -2299,7 +2299,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void elementAttributesOuterHtml() {
+    void elementAttributesOuterHtml() {
         Element div = ElementFactory.createDiv();
         div.setAttribute("foo", "bar");
         div.getStyle().setWidth("20px");
@@ -2312,7 +2312,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void elementAttributeSpecialCharactersOuterHtml() {
+    void elementAttributeSpecialCharactersOuterHtml() {
         Element div = ElementFactory.createDiv();
         div.setAttribute("foo", "bar\"'&quot;");
 
@@ -2321,7 +2321,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void htmlComponentOuterHtml() {
+    void htmlComponentOuterHtml() {
         Html html = new Html(
                 "<div style='background:green'><span><button>hello</button></span></div>");
         assertEquals("<div style=\"background:green\">\n"
@@ -2330,7 +2330,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void callFunctionBeforeAttach() {
+    void callFunctionBeforeAttach() {
         UI ui = new MockUI();
         Element element = ElementFactory.createDiv();
         element.callJsFunction("noArgsMethod");
@@ -2341,7 +2341,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void callFunctionAfterAttach() {
+    void callFunctionAfterAttach() {
         UI ui = new MockUI();
         Element element = ElementFactory.createDiv();
         ui.getElement().appendChild(element);
@@ -2352,7 +2352,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void callFunctionBeforeDetach() {
+    void callFunctionBeforeDetach() {
         UI ui = new MockUI();
         Element element = ElementFactory.createDiv();
         ui.getElement().appendChild(element);
@@ -2366,7 +2366,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void callFunctionBeforeReAttach() {
+    void callFunctionBeforeReAttach() {
         UI ui = new MockUI();
         Element element = ElementFactory.createDiv();
         ui.getElement().appendChild(element);
@@ -2382,7 +2382,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void callFunctionOneParam() {
+    void callFunctionOneParam() {
         UI ui = new MockUI();
         Element element = ElementFactory.createDiv();
         element.callJsFunction("method", "foo");
@@ -2394,7 +2394,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void callFunctionTwoParams() {
+    void callFunctionTwoParams() {
         UI ui = new MockUI();
         Element element = ElementFactory.createDiv();
         element.callJsFunction("method", "foo", 123);
@@ -2405,7 +2405,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void callFunctionWithBean() {
+    void callFunctionWithBean() {
         UI ui = new MockUI();
         Element element = ElementFactory.createDiv();
         SimpleBean bean = new SimpleBean();
@@ -2417,7 +2417,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void callFunctionOnProperty() {
+    void callFunctionOnProperty() {
         UI ui = new MockUI();
         Element element = ElementFactory.createDiv();
         element.callJsFunction("property.method");
@@ -2428,7 +2428,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void callFunctionOnSubProperty() {
+    void callFunctionOnSubProperty() {
         UI ui = new MockUI();
         Element element = ElementFactory.createDiv();
         element.callJsFunction("property.other.method");
@@ -2439,7 +2439,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void attachShadowRoot_shadowRootCreatedAndChildrenArePreserved() {
+    void attachShadowRoot_shadowRootCreatedAndChildrenArePreserved() {
         Element element = ElementFactory.createDiv();
         Element button = ElementFactory.createButton();
         Element emphasis = ElementFactory.createEmphasis();
@@ -2456,13 +2456,13 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void getShadowRoot_shadowRootIsEmpty() {
+    void getShadowRoot_shadowRootIsEmpty() {
         Element element = ElementFactory.createDiv();
         assertFalse(element.getShadowRoot().isPresent());
     }
 
     @Test
-    public void getParentNode_parentNodeIsTheSameAsParent() {
+    void getParentNode_parentNodeIsTheSameAsParent() {
         Element element = ElementFactory.createDiv();
         Element child = ElementFactory.createDiv();
 
@@ -2472,7 +2472,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void getParentNode_elementInShadowRoot_parentIsNull() {
+    void getParentNode_elementInShadowRoot_parentIsNull() {
         ShadowRoot element = ElementFactory.createDiv().attachShadow();
         Element child = ElementFactory.createDiv();
 
@@ -2483,7 +2483,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void parentIsDisabled_childIsDisabled() {
+    void parentIsDisabled_childIsDisabled() {
         Element parent = ElementFactory.createDiv();
         Element child = ElementFactory.createDiv();
 
@@ -2503,7 +2503,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void emptyElement_setDisabled_noChildFeatures() {
+    void emptyElement_setDisabled_noChildFeatures() {
         Element element = ElementFactory.createDiv();
 
         element.setEnabled(false);
@@ -2512,7 +2512,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void emptyElement_isVirtualChild_noChildFeatures() {
+    void emptyElement_isVirtualChild_noChildFeatures() {
         Element element = ElementFactory.createDiv();
 
         element.isVirtualChild();
@@ -2521,7 +2521,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void elementWithoutComponent_getComponentFeature() {
+    void elementWithoutComponent_getComponentFeature() {
         Element element = ElementFactory.createDiv();
         element.appendChild(ElementFactory.createDiv());
 
@@ -2533,7 +2533,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void readMissingProperty_noFeatureInitialized() {
+    void readMissingProperty_noFeatureInitialized() {
         Element element = ElementFactory.createDiv();
 
         element.getProperty("foo");
@@ -2547,7 +2547,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void readMissingAttribute_noFeatureInitialized() {
+    void readMissingAttribute_noFeatureInitialized() {
         Element element = ElementFactory.createDiv();
 
         element.getAttribute("foo");
@@ -2561,7 +2561,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void virtualChildren_areIdentifiedAsSuch() {
+    void virtualChildren_areIdentifiedAsSuch() {
         Element parent = ElementFactory.createDiv();
         Element child = ElementFactory.createDiv();
         Element virtualChild = ElementFactory.createDiv();
@@ -2578,7 +2578,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void domPropertyListener_registersListenerAndDomTrigger() {
+    void domPropertyListener_registersListenerAndDomTrigger() {
         Element element = ElementFactory.createDiv();
 
         AtomicReference<Serializable> listenerValue = new AtomicReference<>();
@@ -2609,7 +2609,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void domPropertyListener_unregisterCleansEverything() {
+    void domPropertyListener_unregisterCleansEverything() {
         Element element = ElementFactory.createDiv();
 
         DomListenerRegistration registration = element
@@ -2635,7 +2635,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void removingVirtualChildrenIsPossible() {
+    void removingVirtualChildrenIsPossible() {
         Element parent = new Element("root");
         Element child1 = new Element("main");
         Element child2 = new Element("menu");
@@ -2652,7 +2652,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void removeVirtualChildren_notVirtualChild_fails() {
+    void removeVirtualChildren_notVirtualChild_fails() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element parent = new Element("root");
             Element child1 = new Element("main");
@@ -2664,7 +2664,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void removeFromParent_virtualChild_fails() {
+    void removeFromParent_virtualChild_fails() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element parent = new Element("root");
             Element child1 = new Element("main");
@@ -2676,7 +2676,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void executeJavaScript_delegatesToExecJs() {
+    void executeJavaScript_delegatesToExecJs() {
         AtomicReference<String> invokedExpression = new AtomicReference<>();
         AtomicReference<Object[]> invokedParams = new AtomicReference<>();
 
@@ -2702,7 +2702,7 @@ class ElementJacksonTest extends AbstractNodeTest {
     }
 
     @Test
-    public void callFunction_delegatesToCallJsFunction() {
+    void callFunction_delegatesToCallJsFunction() {
         AtomicReference<String> invokedFuction = new AtomicReference<>();
         AtomicReference<Object[]> invokedParams = new AtomicReference<>();
 

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
@@ -94,7 +94,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 class ElementTest extends AbstractNodeTest {
 
     @Test
-    public void createElementWithTag() {
+    void createElementWithTag() {
         Element e = ElementFactory.createDiv();
         assertEquals(Tag.DIV, e.getTag());
         assertFalse(e.hasAttribute("is"));
@@ -102,28 +102,28 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void createElementWithInvalidTag() {
+    void createElementWithInvalidTag() {
         assertThrows(IllegalArgumentException.class, () -> {
             new Element("<div>");
         });
     }
 
     @Test
-    public void createElementWithEmptyTag() {
+    void createElementWithEmptyTag() {
         assertThrows(IllegalArgumentException.class, () -> {
             new Element("");
         });
     }
 
     @Test
-    public void createElementWithNullTag() {
+    void createElementWithNullTag() {
         assertThrows(IllegalArgumentException.class, () -> {
             new Element(null);
         });
     }
 
     @Test
-    public void elementsUpdateSameData() {
+    void elementsUpdateSameData() {
         Element te = new Element("testelem");
         Element e = Element.get(te.getNode());
 
@@ -138,7 +138,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void getElementFromInvalidNode() {
+    void getElementFromInvalidNode() {
         assertThrows(IllegalArgumentException.class, () -> {
             StateNode node = new StateNode(ElementPropertyMap.class);
             Element.get(node);
@@ -146,7 +146,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void publicElementMethodsShouldReturnElement() {
+    void publicElementMethodsShouldReturnElement() {
         Set<String> ignore = new HashSet<>();
         ignore.add("toString");
         ignore.add("hashCode");
@@ -187,7 +187,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void publicElementStyleMethodsShouldReturnElement() {
+    void publicElementStyleMethodsShouldReturnElement() {
         Set<String> ignore = new HashSet<>();
         ignore.add("toString");
         ignore.add("hashCode");
@@ -216,21 +216,21 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void stringAttribute() {
+    void stringAttribute() {
         Element e = ElementFactory.createDiv();
         e.setAttribute("foo", "bar");
         assertEquals("bar", e.getAttribute("foo"));
     }
 
     @Test
-    public void setEmptyAttribute() {
+    void setEmptyAttribute() {
         Element e = ElementFactory.createDiv();
         e.setAttribute("foo", "");
         assertEquals("", e.getAttribute("foo"));
     }
 
     @Test
-    public void setBooleanAttribute() {
+    void setBooleanAttribute() {
         Element e = ElementFactory.createDiv();
 
         e.setAttribute("foo", true);
@@ -243,7 +243,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setNullAttribute() {
+    void setNullAttribute() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element e = ElementFactory.createDiv();
             e.setAttribute("foo", (String) null);
@@ -251,7 +251,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void getNullAttribute() {
+    void getNullAttribute() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element e = ElementFactory.createDiv();
             e.getAttribute(null);
@@ -259,7 +259,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void hasNullAttribute() {
+    void hasNullAttribute() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element e = ElementFactory.createDiv();
             e.hasAttribute(null);
@@ -267,7 +267,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void removeNullAttribute() {
+    void removeNullAttribute() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element e = ElementFactory.createDiv();
             e.removeAttribute(null);
@@ -275,7 +275,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setInvalidAttribute() {
+    void setInvalidAttribute() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element e = ElementFactory.createDiv();
             e.setAttribute("\"foo\"", "bar");
@@ -283,20 +283,20 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void hasDefinedAttribute() {
+    void hasDefinedAttribute() {
         Element e = ElementFactory.createDiv();
         e.setAttribute("foo", "bar");
         assertTrue(e.hasAttribute("foo"));
     }
 
     @Test
-    public void doesNotHaveUndefinedAttribute() {
+    void doesNotHaveUndefinedAttribute() {
         Element e = ElementFactory.createDiv();
         assertFalse(e.hasAttribute("foo"));
     }
 
     @Test
-    public void doesNotHaveRemovedAttribute() {
+    void doesNotHaveRemovedAttribute() {
         Element e = ElementFactory.createDiv();
         e.setAttribute("foo", "bar");
         e.removeAttribute("foo");
@@ -304,7 +304,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void removeNonExistingAttributeIsNoOp() {
+    void removeNonExistingAttributeIsNoOp() {
         Element e = ElementFactory.createDiv();
         assertFalse(e.hasAttribute("foo"));
         e.removeAttribute("foo");
@@ -312,13 +312,13 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void attributesWhenNoneDefined() {
+    void attributesWhenNoneDefined() {
         Element e = ElementFactory.createDiv();
         assertEquals(0, e.getAttributeNames().count());
     }
 
     @Test
-    public void attributesNames() {
+    void attributesNames() {
         Element e = ElementFactory.createDiv();
         e.setAttribute("foo", "bar");
         assertArrayEquals(new String[] { "foo" },
@@ -326,7 +326,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void attributesNamesAfterRemoved() {
+    void attributesNamesAfterRemoved() {
         Element e = ElementFactory.createDiv();
         e.setAttribute("foo", "bar");
         e.setAttribute("bar", "baz");
@@ -336,7 +336,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setGetAttributeValueCaseSensitive() {
+    void setGetAttributeValueCaseSensitive() {
         Element e = new Element(Tag.SPAN);
         e.setAttribute("foo", "bAr");
         assertEquals("bAr", e.getAttribute("foo"));
@@ -345,7 +345,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setGetAttributeNameCaseInsensitive() {
+    void setGetAttributeNameCaseInsensitive() {
         Element e = new Element(Tag.SPAN);
         e.setAttribute("foo", "bar");
         e.setAttribute("FOO", "baz");
@@ -355,14 +355,14 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void hasAttributeNamesCaseInsensitive() {
+    void hasAttributeNamesCaseInsensitive() {
         Element e = new Element(Tag.SPAN);
         e.setAttribute("fooo", "bar");
         assertTrue(e.hasAttribute("fOoO"));
     }
 
     @Test
-    public void getAttributeNamesLowerCase() {
+    void getAttributeNamesLowerCase() {
         Element e = new Element(Tag.SPAN);
         e.setAttribute("FOO", "bar");
         e.setAttribute("Baz", "bar");
@@ -376,7 +376,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void removeDetachedFromParent() {
+    void removeDetachedFromParent() {
         Element otherElement = new Element("other");
         assertNull(otherElement.getParent());
         otherElement.removeFromParent(); // No op
@@ -384,14 +384,14 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void getDetachedParent() {
+    void getDetachedParent() {
         Element otherElement = new Element("other");
         assertNull(otherElement.getParent());
         assertNull(otherElement.getParentNode());
     }
 
     @Test
-    public void addNullEventListener() {
+    void addNullEventListener() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element e = ElementFactory.createDiv();
             e.addEventListener("foo", null);
@@ -399,7 +399,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void addEventListenerForNullType() {
+    void addEventListenerForNullType() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element e = ElementFactory.createDiv();
             e.addEventListener(null, ignore -> {
@@ -408,25 +408,25 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void equalsSelf() {
+    void equalsSelf() {
         Element e = ElementFactory.createDiv();
         assertTrue(e.equals(e));
     }
 
     @Test
-    public void notEqualsNull() {
+    void notEqualsNull() {
         Element e = ElementFactory.createDiv();
         assertFalse(e.equals(null));
     }
 
     @Test
-    public void notEqualsString() {
+    void notEqualsString() {
         Element e = ElementFactory.createDiv();
         assertFalse(e.equals(Tag.DIV));
     }
 
     @Test
-    public void listenerReceivesEvents() {
+    void listenerReceivesEvents() {
         Element e = ElementFactory.createDiv();
         AtomicInteger listenerCalls = new AtomicInteger(0);
         DomEventListener myListener = event -> listenerCalls.incrementAndGet();
@@ -439,7 +439,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void listenerReceivesEventsWithAllowInert() {
+    void listenerReceivesEventsWithAllowInert() {
         Element e = ElementFactory.createDiv();
         // Inert the node, verify events no more passed through
         InertData inertData = e.getNode().getFeature(InertData.class);
@@ -466,7 +466,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void getPropertyDefaults() {
+    void getPropertyDefaults() {
         Element element = ElementFactory.createDiv();
 
         element.setProperty("null", null);
@@ -493,7 +493,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void getPropertyStringConversions() {
+    void getPropertyStringConversions() {
         assertPropertyString(null, null);
         assertPropertyString("foo", "foo");
         assertPropertyString("", "");
@@ -515,7 +515,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testPropertyBooleanConversions() {
+    void testPropertyBooleanConversions() {
         assertPropertyBoolean(true, Boolean.TRUE);
         assertPropertyBoolean(false, Boolean.FALSE);
 
@@ -548,7 +548,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testPropertyDoubleConversions() {
+    void testPropertyDoubleConversions() {
         assertPropertyDouble(1, Double.valueOf(1));
         assertPropertyDouble(.1, Double.valueOf(.1));
         assertPropertyDouble(Double.NaN, Double.valueOf(Double.NaN));
@@ -585,7 +585,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testPropertyIntConversions() {
+    void testPropertyIntConversions() {
         assertPropertyInt(1, Double.valueOf(1));
         assertPropertyInt(1, Double.valueOf(1.9));
         assertPropertyInt(0, Double.valueOf(Double.NaN));
@@ -663,7 +663,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void propertyRawValues() {
+    void propertyRawValues() {
         Element element = ElementFactory.createDiv();
 
         element.setProperty("p", "v");
@@ -707,7 +707,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void addAndRemoveProperty() {
+    void addAndRemoveProperty() {
         Element element = ElementFactory.createDiv();
 
         assertFalse(element.hasProperty("foo"));
@@ -724,7 +724,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void propertyNames() {
+    void propertyNames() {
         Element element = ElementFactory.createDiv();
 
         assertEquals(0, element.getPropertyNames().count());
@@ -738,7 +738,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setProperty_javaTimeObject() {
+    void setProperty_javaTimeObject() {
         BeanWithTemporalFields bean = new BeanWithTemporalFields();
         Element element = ElementFactory.createDiv();
 
@@ -798,7 +798,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testGetTextContent() {
+    void testGetTextContent() {
         Element child = new Element("child");
         child.appendChild(Element.createText("bar"));
 
@@ -811,7 +811,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testSetTextContent() {
+    void testSetTextContent() {
         Element element = ElementFactory.createDiv();
         element.setText("foo");
 
@@ -821,7 +821,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testSetTextContentRemovesOldContent() {
+    void testSetTextContentRemovesOldContent() {
         Element child = new Element("child");
         Element element = ElementFactory.createDiv();
         element.appendChild(child);
@@ -833,7 +833,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testSetTextReplacesOldTextNode() {
+    void testSetTextReplacesOldTextNode() {
         Element element = ElementFactory.createDiv();
         Element text = Element.createText("foo");
         element.appendChild(text);
@@ -845,7 +845,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testSetTextContentPropertyThrows() {
+    void testSetTextContentPropertyThrows() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element element = new Element("element");
             element.setProperty("textContent", "foo");
@@ -853,7 +853,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setOuterHtmlProperty_throws() {
+    void setOuterHtmlProperty_throws() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element element = new Element("element");
             element.setProperty("outerHTML", "<br>");
@@ -861,7 +861,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setInnerHtmlProeprty_setValueAndRemoveAllChildren() {
+    void setInnerHtmlProeprty_setValueAndRemoveAllChildren() {
         Element element = new Element("element");
         element.appendChild(ElementFactory.createAnchor(),
                 ElementFactory.createDiv());
@@ -872,7 +872,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testGetTextContentProperty() {
+    void testGetTextContentProperty() {
         Element element = ElementFactory.createDiv();
         element.setText("foo");
 
@@ -882,7 +882,7 @@ class ElementTest extends AbstractNodeTest {
 
     @Test
     // Because that's how it works in browsers
-    public void clearTextContentRemovesChild() {
+    void clearTextContentRemovesChild() {
         Element element = ElementFactory.createDiv();
         element.setText("foo");
 
@@ -894,7 +894,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void newElementClasses() {
+    void newElementClasses() {
         Element element = ElementFactory.createDiv();
 
         assertFalse(element.hasAttribute("class"));
@@ -902,7 +902,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void addElementClasses() {
+    void addElementClasses() {
         Element element = ElementFactory.createDiv();
 
         element.getClassList().add("foo");
@@ -921,7 +921,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testSetClassAttribute() {
+    void testSetClassAttribute() {
         Element element = ElementFactory.createDiv();
 
         // Get instance right away to see that changes are live
@@ -940,7 +940,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testSetEmptyClassAttribute() {
+    void testSetEmptyClassAttribute() {
         Element element = new Element(Tag.DIV);
 
         // Get instance right away to see that changes are live
@@ -952,7 +952,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testAddEmptyClassname() {
+    void testAddEmptyClassname() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element element = new Element(Tag.DIV);
 
@@ -964,7 +964,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testRemoveClassName() {
+    void testRemoveClassName() {
         Element element = ElementFactory.createDiv();
 
         element.setAttribute("class", "foo bar");
@@ -982,7 +982,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testRemoveClassAttribute() {
+    void testRemoveClassAttribute() {
         Element element = ElementFactory.createDiv();
 
         Set<String> classList = element.getClassList();
@@ -995,7 +995,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void addExistingClass_noop() {
+    void addExistingClass_noop() {
         Element element = ElementFactory.createDiv();
 
         element.setAttribute("class", "foo");
@@ -1006,14 +1006,14 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testAddClassWithSpaces_throws() {
+    void testAddClassWithSpaces_throws() {
         assertThrows(IllegalArgumentException.class, () -> {
             ElementFactory.createDiv().getClassList().add("foo bar");
         });
     }
 
     @Test
-    public void testRemoveClassWithSpaces() {
+    void testRemoveClassWithSpaces() {
         ClassList cl = ElementFactory.createDiv().getClassList();
         cl.add("foo");
         cl.add("bar");
@@ -1022,7 +1022,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testContainsClassWithSpaces() {
+    void testContainsClassWithSpaces() {
         ClassList cl = ElementFactory.createDiv().getClassList();
         cl.add("foo");
         cl.add("bar");
@@ -1031,7 +1031,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void classListSetAdd() {
+    void classListSetAdd() {
         Element e = new Element(Tag.DIV);
         assertTrue(e.getClassList().set("foo", true));
         assertEquals("foo", e.getAttribute("class"));
@@ -1040,7 +1040,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void classListSetRemove() {
+    void classListSetRemove() {
         Element e = new Element(Tag.DIV);
         e.setAttribute("class", "foo bar");
         assertTrue(e.getClassList().set("foo", false));
@@ -1050,14 +1050,14 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testClassListProperty_throws() {
+    void testClassListProperty_throws() {
         assertThrows(IllegalArgumentException.class, () -> {
             ElementFactory.createDiv().setProperty("classList", "foo");
         });
     }
 
     @Test
-    public void testClassNameProperty_throws() {
+    void testClassNameProperty_throws() {
         assertThrows(IllegalArgumentException.class, () -> {
             ElementFactory.createDiv().setProperty("className", "foo");
         });
@@ -1071,14 +1071,14 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void getUnsetStyle() {
+    void getUnsetStyle() {
         Element e = ElementFactory.createDiv();
         Style s = e.getStyle();
         assertNull(s.get("foo"));
     }
 
     @Test
-    public void getNullStyle() {
+    void getNullStyle() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element e = ElementFactory.createDiv();
             Style s = e.getStyle();
@@ -1087,7 +1087,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void replaceStyle() {
+    void replaceStyle() {
         Element e = ElementFactory.createDiv();
         Style s = e.getStyle();
         s.set("foo", "bar");
@@ -1096,7 +1096,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void removeSingleStyle() {
+    void removeSingleStyle() {
         Element e = ElementFactory.createDiv();
         Style s = e.getStyle();
         s.set("foo", "bar");
@@ -1105,14 +1105,14 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void emptyStyleAsAttribute() {
+    void emptyStyleAsAttribute() {
         Element e = ElementFactory.createDiv();
         assertFalse(e.hasAttribute("style"));
         assertNull(e.getAttribute("style"));
     }
 
     @Test
-    public void semicolonInStyle() {
+    void semicolonInStyle() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element e = ElementFactory.createDiv();
             Style s = e.getStyle();
@@ -1121,7 +1121,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void getSingleStyleAsAttribute() {
+    void getSingleStyleAsAttribute() {
         Element e = ElementFactory.createDiv();
         Style s = e.getStyle();
         s.setBorder("1px solid black");
@@ -1130,7 +1130,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void getMultipleStylesAsAttribute() {
+    void getMultipleStylesAsAttribute() {
         Element e = ElementFactory.createDiv();
         Style s = e.getStyle();
         s.set("border", "1px solid black");
@@ -1143,7 +1143,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setSingleStyleAsAttribute() {
+    void setSingleStyleAsAttribute() {
         Element e = ElementFactory.createDiv();
         String style = "width:12em";
         e.setAttribute("style", style);
@@ -1152,7 +1152,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setStyleAttributeMultipleTimes() {
+    void setStyleAttributeMultipleTimes() {
         Element e = ElementFactory.createDiv();
         e.setAttribute("style", "width:12em");
         e.setAttribute("style", "height:12em");
@@ -1161,7 +1161,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setMultipleStylesAsAttribute() {
+    void setMultipleStylesAsAttribute() {
         Element e = ElementFactory.createDiv();
         String style = "width:12em;height:2em";
         e.setAttribute("style", style);
@@ -1170,7 +1170,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setComplexStylesAsAttribute() {
+    void setComplexStylesAsAttribute() {
         testStyleAttribute(
                 "background:rgb(0,255,0) url(http://foo.bar/smiley.gif) no-repeat fixed center");
         testStyleAttribute("content:\"content: bar\"");
@@ -1189,7 +1189,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setInvalidStyleAsAttribute() {
+    void setInvalidStyleAsAttribute() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element e = ElementFactory.createDiv();
             e.setAttribute("style", "width:");
@@ -1197,7 +1197,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setInvalidStyleAsAttribute2() {
+    void setInvalidStyleAsAttribute2() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element e = ElementFactory.createDiv();
             e.setAttribute("style", "width");
@@ -1205,7 +1205,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setVendorSpecificStylesProperty() {
+    void setVendorSpecificStylesProperty() {
         Element e = ElementFactory.createDiv();
         String style = "-moz-user-input:inherit";
         e.setAttribute("style", style);
@@ -1214,7 +1214,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setVendorSpecificStylesValue() {
+    void setVendorSpecificStylesValue() {
         Element e = ElementFactory.createDiv();
         String style = "display:-moz-box";
         e.setAttribute("style", style);
@@ -1224,7 +1224,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setStyleAttributeTrailingSemicolon() {
+    void setStyleAttributeTrailingSemicolon() {
         Element e = ElementFactory.createDiv();
         String style = "width:12em";
         e.setAttribute("style", style + ";");
@@ -1244,7 +1244,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setEmptyStyleName() {
+    void setEmptyStyleName() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element e = ElementFactory.createDiv();
             e.getStyle().set("", "foo");
@@ -1252,7 +1252,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setStyleNameExtraWhitespace() {
+    void setStyleNameExtraWhitespace() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element e = ElementFactory.createDiv();
             e.getStyle().set("   color", "red");
@@ -1260,7 +1260,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setStyleNameColon() {
+    void setStyleNameColon() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element e = ElementFactory.createDiv();
             e.getStyle().set("color:", "red");
@@ -1268,7 +1268,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setStyleValueExtraWhitespace() {
+    void setStyleValueExtraWhitespace() {
         Element e = ElementFactory.createDiv();
         e.getStyle().setColor("red   ");
         assertEquals("color:red", e.getAttribute("style"));
@@ -1276,7 +1276,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void removeStyles() {
+    void removeStyles() {
         Element element = ElementFactory.createDiv();
 
         element.getStyle().setZIndex(12);
@@ -1295,7 +1295,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void removeStyleAttribute() {
+    void removeStyleAttribute() {
         Element element = ElementFactory.createDiv();
 
         Style style = element.getStyle();
@@ -1308,7 +1308,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void validStyleWithSemicolon() {
+    void validStyleWithSemicolon() {
         Element element = ElementFactory.createDiv();
         String validStyle = "background: url('foo;bar')";
         Style style = element.getStyle();
@@ -1317,7 +1317,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void dashSeparatedSetStyle() {
+    void dashSeparatedSetStyle() {
         Element element = ElementFactory.createDiv();
 
         Style style = element.getStyle();
@@ -1326,7 +1326,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void dashSeparatedGetStyle() {
+    void dashSeparatedGetStyle() {
         Element element = ElementFactory.createDiv();
 
         Style style = element.getStyle();
@@ -1337,7 +1337,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void dashSeparatedHasStyle() {
+    void dashSeparatedHasStyle() {
         Element element = ElementFactory.createDiv();
 
         Style style = element.getStyle();
@@ -1348,7 +1348,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void dashSeparatedRemoveStyle() {
+    void dashSeparatedRemoveStyle() {
         Element element = ElementFactory.createDiv();
 
         Style style = element.getStyle();
@@ -1362,7 +1362,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void styleGetNamesDashAndCamelCase() {
+    void styleGetNamesDashAndCamelCase() {
         Element element = ElementFactory.createDiv();
 
         Style style = element.getStyle();
@@ -1376,7 +1376,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void nullStyleValue() {
+    void nullStyleValue() {
         Element element = ElementFactory.createDiv();
 
         Style style = element.getStyle();
@@ -1387,7 +1387,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void sendPropertyInCorrectFormatToClient() {
+    void sendPropertyInCorrectFormatToClient() {
         assertClientStyleKey("--some-variable", "--some-variable");
         assertClientStyleKey("-webkit-border", "-webkit-border");
         assertClientStyleKey("background-color", "background-color");
@@ -1413,7 +1413,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void customPropertyStyle() {
+    void customPropertyStyle() {
         Element element = ElementFactory.createDiv();
         Style style = element.getStyle();
         style.set("--some-variable", "foo");
@@ -1421,7 +1421,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void useCustomPropertyStyle() {
+    void useCustomPropertyStyle() {
         Element element = ElementFactory.createDiv();
 
         Style style = element.getStyle();
@@ -1430,7 +1430,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void listenersFiredInRegisteredOrder() {
+    void listenersFiredInRegisteredOrder() {
         Element element = ElementFactory.createDiv();
         List<Integer> eventOrder = new ArrayList<>();
 
@@ -1453,7 +1453,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void eventsWhenListenerIsRegisteredManyTimes() {
+    void eventsWhenListenerIsRegisteredManyTimes() {
         AtomicInteger invocations = new AtomicInteger(0);
 
         DomEventListener listener = e -> {
@@ -1469,7 +1469,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void addAsOwnChild() {
+    void addAsOwnChild() {
         assertThrows(IllegalStateException.class, () -> {
             Element element = ElementFactory.createDiv();
             element.appendChild(element);
@@ -1477,7 +1477,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void addAsChildOfChild() {
+    void addAsChildOfChild() {
         assertThrows(IllegalStateException.class, () -> {
             Element parent = ElementFactory.createDiv();
             Element child = ElementFactory.createDiv();
@@ -1495,7 +1495,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testGetOwnTextContent() {
+    void testGetOwnTextContent() {
         Element element = ElementFactory.createDiv();
         element.setText("foo");
         element.appendChild(ElementFactory.createDiv()
@@ -1509,7 +1509,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_elementIsNotAttached_elementHasAttribute() {
+    void setResourceAttribute_elementIsNotAttached_elementHasAttribute() {
         UI.setCurrent(createUI());
         Element element = ElementFactory.createDiv();
         String resName = "resource";
@@ -1522,7 +1522,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_elementIsNotAttachedAndHasAttribute_elementHasAttribute() {
+    void setResourceAttribute_elementIsNotAttachedAndHasAttribute_elementHasAttribute() {
         UI.setCurrent(createUI());
         Element element = ElementFactory.createDiv();
         element.setAttribute("foo", "bar");
@@ -1537,7 +1537,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttributeSeveralTimes_elementIsNotAttached_elementHasAttribute() {
+    void setResourceAttributeSeveralTimes_elementIsNotAttached_elementHasAttribute() {
         UI.setCurrent(createUI());
         Element element = ElementFactory.createDiv();
         String resName = "resource";
@@ -1556,7 +1556,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_nullValue() {
+    void setResourceAttribute_nullValue() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element element = ElementFactory.createDiv();
             element.setAttribute("foo", (StreamResource) null);
@@ -1564,7 +1564,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_classAttribute() {
+    void setResourceAttribute_classAttribute() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element element = ElementFactory.createDiv();
             element.setAttribute("class", Mockito.mock(StreamResource.class));
@@ -1572,7 +1572,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_nullAttribute() {
+    void setResourceAttribute_nullAttribute() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element element = ElementFactory.createDiv();
             element.setAttribute(null, Mockito.mock(StreamResource.class));
@@ -1580,7 +1580,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_elementIsAttached_elementHasAttribute() {
+    void setResourceAttribute_elementIsAttached_elementHasAttribute() {
         UI ui = createUI();
         UI.setCurrent(ui);
         String resName = "resource";
@@ -1592,7 +1592,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_elementIsAttached_setAnotherResource()
+    void setResourceAttribute_elementIsAttached_setAnotherResource()
             throws URISyntaxException {
         UI ui = createUI();
         UI.setCurrent(ui);
@@ -1615,7 +1615,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_elementIsAttached_setRawAttribute()
+    void setResourceAttribute_elementIsAttached_setRawAttribute()
             throws URISyntaxException, InterruptedException {
         UI ui = createUI();
         UI.setCurrent(ui);
@@ -1643,7 +1643,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_elementIsAttached_removeAttribute()
+    void setResourceAttribute_elementIsAttached_removeAttribute()
             throws URISyntaxException, InterruptedException {
         UI ui = createUI();
         UI.setCurrent(ui);
@@ -1670,7 +1670,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_attachElement_resourceIsRegistered()
+    void setResourceAttribute_attachElement_resourceIsRegistered()
             throws URISyntaxException {
         UI ui = createUI();
         UI.setCurrent(ui);
@@ -1690,7 +1690,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_attachElement_setAnotherResource()
+    void setResourceAttribute_attachElement_setAnotherResource()
             throws URISyntaxException, InterruptedException {
         UI ui = createUI();
         UI.setCurrent(ui);
@@ -1722,7 +1722,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_attachElement_setRawAttribute()
+    void setResourceAttribute_attachElement_setRawAttribute()
             throws URISyntaxException, InterruptedException {
         UI ui = createUI();
         UI.setCurrent(ui);
@@ -1745,7 +1745,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_attachElement_removeAttribute()
+    void setResourceAttribute_attachElement_removeAttribute()
             throws URISyntaxException, InterruptedException {
         UI ui = createUI();
         UI.setCurrent(ui);
@@ -1769,7 +1769,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_attachElement_setAnotherResourceAfterAttaching()
+    void setResourceAttribute_attachElement_setAnotherResourceAfterAttaching()
             throws URISyntaxException, InterruptedException {
         UI ui = createUI();
         UI.setCurrent(ui);
@@ -1800,7 +1800,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_attachElement_setRawAttributeAfterAttaching()
+    void setResourceAttribute_attachElement_setRawAttributeAfterAttaching()
             throws URISyntaxException, InterruptedException {
         UI ui = createUI();
         UI.setCurrent(ui);
@@ -1826,7 +1826,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_attachElement_removeAttributeAfterAttaching()
+    void setResourceAttribute_attachElement_removeAttributeAfterAttaching()
             throws URISyntaxException, InterruptedException {
         UI ui = createUI();
         UI.setCurrent(ui);
@@ -1852,7 +1852,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_detachElement_resourceIsUnregistered()
+    void setResourceAttribute_detachElement_resourceIsUnregistered()
             throws URISyntaxException, InterruptedException {
         UI ui = createUI();
         UI.setCurrent(ui);
@@ -1890,7 +1890,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_detachAndReattachElement_resourceReregistered()
+    void setResourceAttribute_detachAndReattachElement_resourceReregistered()
             throws URISyntaxException {
         UI ui = createUI();
         UI.setCurrent(ui);
@@ -1921,7 +1921,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_attachAndDetachAndReattachElement_resourceReregistered()
+    void setResourceAttribute_attachAndDetachAndReattachElement_resourceReregistered()
             throws URISyntaxException {
         UI ui = createUI();
         UI.setCurrent(ui);
@@ -1953,7 +1953,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void setResourceAttribute_elementIsText_operationIsNotSupported() {
+    void setResourceAttribute_elementIsText_operationIsNotSupported() {
         assertThrows(UnsupportedOperationException.class, () -> {
             Element.createText("").setAttribute("foo",
                     Mockito.mock(StreamResource.class));
@@ -1961,7 +1961,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testAttachListener_parentAttach_childListenersTriggered() {
+    void testAttachListener_parentAttach_childListenersTriggered() {
         Element body = new UI().getElement();
         Element parent = ElementFactory.createDiv();
         Element child = ElementFactory.createDiv();
@@ -2013,7 +2013,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testDetachListener_parentDetach_childListenersTriggered() {
+    void testDetachListener_parentDetach_childListenersTriggered() {
         Element body = new UI().getElement();
         Element parent = ElementFactory.createDiv();
         Element child = ElementFactory.createDiv();
@@ -2054,7 +2054,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testAttachListener_eventOrder_childFirst() {
+    void testAttachListener_eventOrder_childFirst() {
         Element body = new UI().getElement();
         Element parent = ElementFactory.createDiv();
         Element child = ElementFactory.createDiv();
@@ -2079,7 +2079,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testDetachListener_eventOrder_childFirst() {
+    void testDetachListener_eventOrder_childFirst() {
         Element body = new UI().getElement();
         Element parent = ElementFactory.createDiv();
         Element child = ElementFactory.createDiv();
@@ -2105,7 +2105,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testAttachDetach_elementMoved_bothEventsTriggered() {
+    void testAttachDetach_elementMoved_bothEventsTriggered() {
         Element body = new UI().getElement();
         Element parent = ElementFactory.createDiv();
         Element child = ElementFactory.createDiv();
@@ -2132,7 +2132,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testAttachEvent_stateTreeCanFound() {
+    void testAttachEvent_stateTreeCanFound() {
         Element body = new UI().getElement();
         Element child = ElementFactory.createDiv();
 
@@ -2150,7 +2150,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testDetachEvent_stateTreeCanFound() {
+    void testDetachEvent_stateTreeCanFound() {
         Element body = new UI().getElement();
         Element child = ElementFactory.createDiv();
         body.appendChild(child);
@@ -2170,7 +2170,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testMoveFromUiToUi_doesNotThrow() {
+    void testMoveFromUiToUi_doesNotThrow() {
         Element body = new UI().getElement();
         Element child = ElementFactory.createDiv();
         body.appendChild(child);
@@ -2183,7 +2183,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testRemoveFromTree_inDetachListener_removedFromParent() {
+    void testRemoveFromTree_inDetachListener_removedFromParent() {
         Element body = new UI().getElement();
         Element child = ElementFactory.createDiv();
         body.appendChild(child);
@@ -2196,7 +2196,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void testRemoveFromTree_isVirtualChild_removedFromParent() {
+    void testRemoveFromTree_isVirtualChild_removedFromParent() {
         Element body = new UI().getElement();
         Element child = ElementFactory.createDiv();
 
@@ -2231,7 +2231,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void insertAtCurrentPositionNoOp() {
+    void insertAtCurrentPositionNoOp() {
         // Must have an UI to get attach events
         UI ui = new UI();
         Element parent = ui.getElement();
@@ -2244,25 +2244,25 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void textNodeTransformsNullToEmptyAndDoesNotThrowException() {
+    void textNodeTransformsNullToEmptyAndDoesNotThrowException() {
         Element e = Element.createText(null);
         assertEquals("", e.getText());
     }
 
     @Test
-    public void textNodeOuterHtml() {
+    void textNodeOuterHtml() {
         Element e = Element.createText("foobar");
         assertEquals("foobar", e.getOuterHTML());
     }
 
     @Test
-    public void singleElementOuterHtml() {
+    void singleElementOuterHtml() {
         Element e = ElementFactory.createAnchor();
         assertEquals("<a></a>", e.getOuterHTML());
     }
 
     @Test
-    public void elementTreeOuterHtml() {
+    void elementTreeOuterHtml() {
         Element div = ElementFactory.createDiv();
         Element span = ElementFactory.createSpan();
         Element button = ElementFactory.createButton("hello");
@@ -2275,7 +2275,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void elementAttributesOuterHtml() {
+    void elementAttributesOuterHtml() {
         Element div = ElementFactory.createDiv();
         div.setAttribute("foo", "bar");
         div.getStyle().setWidth("20px");
@@ -2288,7 +2288,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void elementAttributeSpecialCharactersOuterHtml() {
+    void elementAttributeSpecialCharactersOuterHtml() {
         Element div = ElementFactory.createDiv();
         div.setAttribute("foo", "bar\"'&quot;");
 
@@ -2297,7 +2297,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void htmlComponentOuterHtml() {
+    void htmlComponentOuterHtml() {
         Html html = new Html(
                 "<div style='background:green'><span><button>hello</button></span></div>");
         assertEquals("<div style=\"background:green\">\n"
@@ -2306,7 +2306,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void callFunctionBeforeAttach() {
+    void callFunctionBeforeAttach() {
         UI ui = new MockUI();
         Element element = ElementFactory.createDiv();
         element.callJsFunction("noArgsMethod");
@@ -2317,7 +2317,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void callFunctionAfterAttach() {
+    void callFunctionAfterAttach() {
         UI ui = new MockUI();
         Element element = ElementFactory.createDiv();
         ui.getElement().appendChild(element);
@@ -2328,7 +2328,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void callFunctionBeforeDetach() {
+    void callFunctionBeforeDetach() {
         UI ui = new MockUI();
         Element element = ElementFactory.createDiv();
         ui.getElement().appendChild(element);
@@ -2342,7 +2342,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void callFunctionBeforeReAttach() {
+    void callFunctionBeforeReAttach() {
         UI ui = new MockUI();
         Element element = ElementFactory.createDiv();
         ui.getElement().appendChild(element);
@@ -2358,7 +2358,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void callFunctionOneParam() {
+    void callFunctionOneParam() {
         UI ui = new MockUI();
         Element element = ElementFactory.createDiv();
         element.callJsFunction("method", "foo");
@@ -2370,7 +2370,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void callFunctionTwoParams() {
+    void callFunctionTwoParams() {
         UI ui = new MockUI();
         Element element = ElementFactory.createDiv();
         element.callJsFunction("method", "foo", 123);
@@ -2381,7 +2381,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void callFunctionOnProperty() {
+    void callFunctionOnProperty() {
         UI ui = new MockUI();
         Element element = ElementFactory.createDiv();
         element.callJsFunction("property.method");
@@ -2392,7 +2392,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void callFunctionOnSubProperty() {
+    void callFunctionOnSubProperty() {
         UI ui = new MockUI();
         Element element = ElementFactory.createDiv();
         element.callJsFunction("property.other.method");
@@ -2403,7 +2403,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void attachShadowRoot_shadowRootCreatedAndChildrenArePreserved() {
+    void attachShadowRoot_shadowRootCreatedAndChildrenArePreserved() {
         Element element = ElementFactory.createDiv();
         Element button = ElementFactory.createButton();
         Element emphasis = ElementFactory.createEmphasis();
@@ -2420,13 +2420,13 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void getShadowRoot_shadowRootIsEmpty() {
+    void getShadowRoot_shadowRootIsEmpty() {
         Element element = ElementFactory.createDiv();
         assertFalse(element.getShadowRoot().isPresent());
     }
 
     @Test
-    public void getParentNode_parentNodeIsTheSameAsParent() {
+    void getParentNode_parentNodeIsTheSameAsParent() {
         Element element = ElementFactory.createDiv();
         Element child = ElementFactory.createDiv();
 
@@ -2436,7 +2436,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void getParentNode_elementInShadowRoot_parentIsNull() {
+    void getParentNode_elementInShadowRoot_parentIsNull() {
         ShadowRoot element = ElementFactory.createDiv().attachShadow();
         Element child = ElementFactory.createDiv();
 
@@ -2447,7 +2447,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void parentIsDisabled_childIsDisabled() {
+    void parentIsDisabled_childIsDisabled() {
         Element parent = ElementFactory.createDiv();
         Element child = ElementFactory.createDiv();
 
@@ -2467,7 +2467,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void emptyElement_setDisabled_noChildFeatures() {
+    void emptyElement_setDisabled_noChildFeatures() {
         Element element = ElementFactory.createDiv();
 
         element.setEnabled(false);
@@ -2476,7 +2476,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void emptyElement_isVirtualChild_noChildFeatures() {
+    void emptyElement_isVirtualChild_noChildFeatures() {
         Element element = ElementFactory.createDiv();
 
         element.isVirtualChild();
@@ -2485,7 +2485,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void elementWithoutComponent_getComponentFeature() {
+    void elementWithoutComponent_getComponentFeature() {
         Element element = ElementFactory.createDiv();
         element.appendChild(ElementFactory.createDiv());
 
@@ -2497,7 +2497,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void readMissingProperty_noFeatureInitialized() {
+    void readMissingProperty_noFeatureInitialized() {
         Element element = ElementFactory.createDiv();
 
         element.getProperty("foo");
@@ -2511,7 +2511,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void readMissingAttribute_noFeatureInitialized() {
+    void readMissingAttribute_noFeatureInitialized() {
         Element element = ElementFactory.createDiv();
 
         element.getAttribute("foo");
@@ -2525,7 +2525,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void virtualChildren_areIdentifiedAsSuch() {
+    void virtualChildren_areIdentifiedAsSuch() {
         Element parent = ElementFactory.createDiv();
         Element child = ElementFactory.createDiv();
         Element virtualChild = ElementFactory.createDiv();
@@ -2542,7 +2542,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void domPropertyListener_registersListenerAndDomTrigger() {
+    void domPropertyListener_registersListenerAndDomTrigger() {
         Element element = ElementFactory.createDiv();
 
         AtomicReference<Serializable> listenerValue = new AtomicReference<>();
@@ -2573,7 +2573,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void domPropertyListener_unregisterCleansEverything() {
+    void domPropertyListener_unregisterCleansEverything() {
         Element element = ElementFactory.createDiv();
 
         DomListenerRegistration registration = element
@@ -2599,7 +2599,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void removingVirtualChildrenIsPossible() {
+    void removingVirtualChildrenIsPossible() {
         Element parent = new Element("root");
         Element child1 = new Element("main");
         Element child2 = new Element("menu");
@@ -2616,7 +2616,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void removeVirtualChildren_notVirtualChild_fails() {
+    void removeVirtualChildren_notVirtualChild_fails() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element parent = new Element("root");
             Element child1 = new Element("main");
@@ -2628,7 +2628,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void removeFromParent_virtualChild_fails() {
+    void removeFromParent_virtualChild_fails() {
         assertThrows(IllegalArgumentException.class, () -> {
             Element parent = new Element("root");
             Element child1 = new Element("main");
@@ -2640,7 +2640,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void executeJavaScript_delegatesToExecJs() {
+    void executeJavaScript_delegatesToExecJs() {
         AtomicReference<String> invokedExpression = new AtomicReference<>();
         AtomicReference<Object[]> invokedParams = new AtomicReference<>();
 
@@ -2666,7 +2666,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void givenTypeDefinedArray_ArrayStoreExceptionNotThrown() {
+    void givenTypeDefinedArray_ArrayStoreExceptionNotThrown() {
         Element element = new Element("div") {
             @Override
             public PendingJavaScriptResult executeJs(String expression,
@@ -2687,7 +2687,7 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
-    public void callFunction_delegatesToCallJsFunction() {
+    void callFunction_delegatesToCallJsFunction() {
         AtomicReference<String> invokedFuction = new AtomicReference<>();
         AtomicReference<Object[]> invokedParams = new AtomicReference<>();
 

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementUtilTest.java
@@ -43,17 +43,17 @@ class ElementUtilTest {
     private StateTree stateTree;
 
     @Test
-    public void isNullValidAttribute() {
+    void isNullValidAttribute() {
         assertFalse(ElementUtil.isValidAttributeName(null));
     }
 
     @Test
-    public void isEmptyValidAttribute() {
+    void isEmptyValidAttribute() {
         assertFalse(ElementUtil.isValidAttributeName(""));
     }
 
     @Test
-    public void isUpperCaseValidAttribute() {
+    void isUpperCaseValidAttribute() {
         assertThrows(AssertionError.class, () -> {
             // isValidAttributeName is designed to only be called with lowercase
             // attribute names
@@ -62,13 +62,13 @@ class ElementUtilTest {
     }
 
     @Test
-    public void componentNotInitiallyAttached() {
+    void componentNotInitiallyAttached() {
         Element e = ElementFactory.createDiv();
         assertFalse(e.getComponent().isPresent());
     }
 
     @Test
-    public void attachToComponent() {
+    void attachToComponent() {
         Element e = ElementFactory.createDiv();
         Component c = Mockito.mock(Component.class);
         ElementUtil.setComponent(e, c);
@@ -76,7 +76,7 @@ class ElementUtilTest {
     }
 
     @Test
-    public void attachComponentToTextElement() {
+    void attachComponentToTextElement() {
         Element e = Element.createText("Text text");
         Component c = Mockito.mock(Component.class);
         ElementUtil.setComponent(e, c);
@@ -84,7 +84,7 @@ class ElementUtilTest {
     }
 
     @Test
-    public void attachTwiceToComponent() {
+    void attachTwiceToComponent() {
         Element e = ElementFactory.createDiv();
         Component c = Mockito.mock(Component.class);
         ElementUtil.setComponent(e, c);
@@ -93,14 +93,14 @@ class ElementUtilTest {
     }
 
     @Test
-    public void attachToNull() {
+    void attachToNull() {
         Element e = ElementFactory.createDiv();
         assertThrows(IllegalArgumentException.class,
                 () -> ElementUtil.setComponent(e, null));
     }
 
     @Test
-    public void attachTwoComponents() {
+    void attachTwoComponents() {
         Element e = ElementFactory.createDiv();
         Component c = Mockito.mock(Component.class);
         Component c2 = Mockito.mock(Component.class);
@@ -110,7 +110,7 @@ class ElementUtilTest {
     }
 
     @Test
-    public void toAndFromJsoup() {
+    void toAndFromJsoup() {
         final String EXPECTED_TEXT_1 = "Some text";
         final String EXPECTED_TEXT_2 = "Other text";
 
@@ -147,7 +147,7 @@ class ElementUtilTest {
     }
 
     @Test
-    public void isValidTagName_validTagNames() {
+    void isValidTagName_validTagNames() {
         assertTrue(ElementUtil.isValidTagName("foo"));
         assertTrue(ElementUtil.isValidTagName("foo-bar"));
         assertTrue(ElementUtil.isValidTagName("foo_bar"));
@@ -158,7 +158,7 @@ class ElementUtilTest {
     }
 
     @Test
-    public void isValidTagName_invalidTagNames() {
+    void isValidTagName_invalidTagNames() {
         assertFalse(ElementUtil.isValidTagName("1foo"));
         assertFalse(ElementUtil.isValidTagName("-foo"));
         assertFalse(ElementUtil.isValidTagName("_foo"));
@@ -168,7 +168,7 @@ class ElementUtilTest {
     }
 
     @Test
-    public void parentIsInert_childIgnoresParentInert_allThePermutations() {
+    void parentIsInert_childIgnoresParentInert_allThePermutations() {
         setupElementHierarchy();
 
         assertFalse(isIgnoreParentInert(child),
@@ -215,7 +215,7 @@ class ElementUtilTest {
     }
 
     @Test
-    public void parentInert_grandChildIgnoresInert_notInert() {
+    void parentInert_grandChildIgnoresInert_notInert() {
         setupElementHierarchy();
 
         ElementUtil.setInert(parent, true);
@@ -241,7 +241,7 @@ class ElementUtilTest {
     }
 
     @Test
-    public void parentInertGrandChildIgnores_statesChangedAtSameTime_changesApplied() {
+    void parentInertGrandChildIgnores_statesChangedAtSameTime_changesApplied() {
         setupElementHierarchy();
 
         ElementUtil.setInert(parent, true);
@@ -254,12 +254,12 @@ class ElementUtilTest {
     }
 
     @Test
-    public void parentInert_siblingIgnoresInheritingInert_siblingInert() {
+    void parentInert_siblingIgnoresInheritingInert_siblingInert() {
         final Element sibling = ElementFactory.createDiv();
     }
 
     @Test
-    public void elementsUpdateSameData() {
+    void elementsUpdateSameData() {
         Element te = new Element("testelem");
         Element e = ElementUtil.from(te.getNode()).orElse(null);
 
@@ -268,7 +268,7 @@ class ElementUtilTest {
     }
 
     @Test
-    public void getElementFromInvalidNode() {
+    void getElementFromInvalidNode() {
         StateNode node = new StateNode(ElementPropertyMap.class);
         assertFalse(ElementUtil.from(node).isPresent());
     }

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ShadowRootStateProviderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ShadowRootStateProviderTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ShadowRootStateProviderTest {
 
     @Test
-    public void supportsSelfCreatedNode() {
+    void supportsSelfCreatedNode() {
         ShadowRootStateProvider provider = ShadowRootStateProvider.get();
         StateNode node = new StateNode(ShadowRootData.class);
         StateNode shadowRoot = provider.createShadowRootNode(node);
@@ -36,13 +36,13 @@ class ShadowRootStateProviderTest {
     }
 
     @Test
-    public void doesNotSupportEmptyNode() {
+    void doesNotSupportEmptyNode() {
         ShadowRootStateProvider provider = ShadowRootStateProvider.get();
         assertFalse(provider.supports(new StateNode()));
     }
 
     @Test
-    public void createShadowRootNode_originalNodeIsInitialized() {
+    void createShadowRootNode_originalNodeIsInitialized() {
         ShadowRootStateProvider provider = ShadowRootStateProvider.get();
         StateNode node = new StateNode(ShadowRootData.class);
         StateNode shadowRoot = provider.createShadowRootNode(node);
@@ -51,7 +51,7 @@ class ShadowRootStateProviderTest {
     }
 
     @Test
-    public void getParent_parentIsHostElement() {
+    void getParent_parentIsHostElement() {
         ShadowRootStateProvider provider = ShadowRootStateProvider.get();
         StateNode node = new StateNode(ShadowRootData.class);
         StateNode shadowRoot = provider.createShadowRootNode(node);

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ShadowRootTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ShadowRootTest.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 class ShadowRootTest extends AbstractNodeTest {
 
     @Test
-    public void publicElementMethodsShouldReturnElement() {
+    void publicElementMethodsShouldReturnElement() {
         Set<String> ignore = new HashSet<>();
         ignore.add("toString");
         ignore.add("hashCode");
@@ -55,7 +55,7 @@ class ShadowRootTest extends AbstractNodeTest {
     }
 
     @Test
-    public void insertAtCurrentPositionNoOp() {
+    void insertAtCurrentPositionNoOp() {
         // Must have an UI to get attach events
         UI ui = new UI();
         ShadowRoot parent = ui.getElement().attachShadow();
@@ -68,19 +68,19 @@ class ShadowRootTest extends AbstractNodeTest {
     }
 
     @Test
-    public void equalsSelf() {
+    void equalsSelf() {
         ShadowRoot root = createParentNode();
         assertTrue(root.equals(root));
     }
 
     @Test
-    public void notEqualsNull() {
+    void notEqualsNull() {
         ShadowRoot root = createParentNode();
         assertFalse(root.equals(null));
     }
 
     @Test
-    public void attachListener_parentAttach_childListenersTriggered() {
+    void attachListener_parentAttach_childListenersTriggered() {
         Element body = new UI().getElement();
         Element parent = ElementFactory.createDiv();
         Element child = ElementFactory.createDiv();
@@ -132,7 +132,7 @@ class ShadowRootTest extends AbstractNodeTest {
     }
 
     @Test
-    public void detachListener_parentDetach_childListenersTriggered() {
+    void detachListener_parentDetach_childListenersTriggered() {
         Element body = new UI().getElement();
         Element parent = ElementFactory.createDiv();
         Element child = ElementFactory.createDiv();
@@ -173,7 +173,7 @@ class ShadowRootTest extends AbstractNodeTest {
     }
 
     @Test
-    public void attachListener_eventOrder_childFirst() {
+    void attachListener_eventOrder_childFirst() {
         Element body = new UI().getElement();
         Element parent = ElementFactory.createDiv();
         Element child = ElementFactory.createDiv();
@@ -198,7 +198,7 @@ class ShadowRootTest extends AbstractNodeTest {
     }
 
     @Test
-    public void detachListener_eventOrder_childFirst() {
+    void detachListener_eventOrder_childFirst() {
         Element body = new UI().getElement();
         Element parent = ElementFactory.createDiv();
         Element child = ElementFactory.createDiv();
@@ -224,7 +224,7 @@ class ShadowRootTest extends AbstractNodeTest {
     }
 
     @Test
-    public void attachDetach_elementMoved_bothEventsTriggered() {
+    void attachDetach_elementMoved_bothEventsTriggered() {
         ShadowRoot bodyShadow = new UI().getElement().attachShadow();
         Element parent = ElementFactory.createDiv();
         Element child = ElementFactory.createDiv();
@@ -251,7 +251,7 @@ class ShadowRootTest extends AbstractNodeTest {
     }
 
     @Test
-    public void attachEvent_stateTreeCanFound() {
+    void attachEvent_stateTreeCanFound() {
         ShadowRoot bodyShadow = new UI().getElement().attachShadow();
         Element child = ElementFactory.createDiv();
 
@@ -269,7 +269,7 @@ class ShadowRootTest extends AbstractNodeTest {
     }
 
     @Test
-    public void detachEvent_stateTreeCanFound() {
+    void detachEvent_stateTreeCanFound() {
         ShadowRoot bodyShadow = new UI().getElement().attachShadow();
         Element child = ElementFactory.createDiv();
         bodyShadow.appendChild(child);
@@ -289,13 +289,13 @@ class ShadowRootTest extends AbstractNodeTest {
     }
 
     @Test
-    public void getParentNode_parentNodeIsNull() {
+    void getParentNode_parentNodeIsNull() {
         ShadowRoot root = createParentNode();
         assertNull(root.getParentNode());
     }
 
     @Test
-    public void visitOnlyNode_hasDescendants_nodeVisitedAndNoDescendantsVisited() {
+    void visitOnlyNode_hasDescendants_nodeVisitedAndNoDescendantsVisited() {
         TestNodeVisitor visitor = new TestNodeVisitor(false);
 
         Map<Node<?>, ElementType> map = new HashMap<>();
@@ -310,7 +310,7 @@ class ShadowRootTest extends AbstractNodeTest {
     }
 
     @Test
-    public void visitOnlyNode_hasDescendants_nodeAndDescendatnsAreVisited() {
+    void visitOnlyNode_hasDescendants_nodeAndDescendatnsAreVisited() {
         TestNodeVisitor visitor = new TestNodeVisitor(true);
 
         Map<Node<?>, ElementType> map = new HashMap<>();

--- a/flow-server/src/test/java/com/vaadin/flow/dom/StyleBindTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/StyleBindTest.java
@@ -40,7 +40,7 @@ class StyleBindTest extends SignalsUnitTest {
 
     // Lifecycle: applies on attachment and signal changes when attached
     @Test
-    public void bindingMirrorsSignalWhileAttached_updatesStyleValue() {
+    void bindingMirrorsSignalWhileAttached_updatesStyleValue() {
         Element element = new Element("div");
         UI.getCurrent().getElement().appendChild(element);
 
@@ -60,7 +60,7 @@ class StyleBindTest extends SignalsUnitTest {
     // Lifecycle: no updates while detached; lastApplied preserved across
     // detach/attachment
     @Test
-    public void detached_noUpdates_lastAppliedPreservedOnReattach() {
+    void detached_noUpdates_lastAppliedPreservedOnReattach() {
         Element element = new Element("div");
         UI.getCurrent().getElement().appendChild(element);
 
@@ -82,7 +82,7 @@ class StyleBindTest extends SignalsUnitTest {
 
     // Conflict prevention: set/remove throw while binding is active
     @Test
-    public void conflict_setRemoveThrowWhileBoundAndActive() {
+    void conflict_setRemoveThrowWhileBoundAndActive() {
         Element element = new Element("div");
         UI.getCurrent().getElement().appendChild(element);
 
@@ -96,7 +96,7 @@ class StyleBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void clear_throwsWhenBindingsActive() {
+    void clear_throwsWhenBindingsActive() {
         Element element = new Element("div");
         UI.getCurrent().getElement().appendChild(element);
 
@@ -108,7 +108,7 @@ class StyleBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bind_nullSignal_throwsNPE() {
+    void bind_nullSignal_throwsNPE() {
         Element element = new Element("div");
         UI.getCurrent().getElement().appendChild(element);
 
@@ -118,7 +118,7 @@ class StyleBindTest extends SignalsUnitTest {
 
     // Getters semantics
     @Test
-    public void getters_returnLastAppliedAndNamesWithValues() {
+    void getters_returnLastAppliedAndNamesWithValues() {
         Element element = new Element("div");
         UI.getCurrent().getElement().appendChild(element);
 
@@ -154,7 +154,7 @@ class StyleBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void nullSignalValue_removesStyleAndHasReturnsFalse() {
+    void nullSignalValue_removesStyleAndHasReturnsFalse() {
         Element element = new Element("div");
         UI.getCurrent().getElement().appendChild(element);
 
@@ -178,7 +178,7 @@ class StyleBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bind_onChange_receivesBindingContext() {
+    void bind_onChange_receivesBindingContext() {
         Element element = new Element("div");
         UI.getCurrent().getElement().appendChild(element);
 
@@ -202,7 +202,7 @@ class StyleBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bind_returnsTypedSignalBinding() {
+    void bind_returnsTypedSignalBinding() {
         Element element = new Element("div");
         UI.getCurrent().getElement().appendChild(element);
 

--- a/flow-server/src/test/java/com/vaadin/flow/dom/StyleUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/StyleUtilTest.java
@@ -34,7 +34,7 @@ class StyleUtilTest {
     }
 
     @Test
-    public void attributeToProperty() {
+    void attributeToProperty() {
         stylepPropertyToAttribute.entrySet().forEach((entry) -> {
             String property = entry.getKey();
             String attribute = entry.getValue();
@@ -45,7 +45,7 @@ class StyleUtilTest {
     }
 
     @Test
-    public void propertyToAttribute() {
+    void propertyToAttribute() {
         stylepPropertyToAttribute.entrySet().forEach((entry) -> {
             String property = entry.getKey();
             String attribute = entry.getValue();

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ThemeListBindTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ThemeListBindTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ThemeListBindTest extends SignalsUnitTest {
 
     @Test
-    public void bindingMirrorsSignalWhileAttached_toggleAddsRemovesTheme() {
+    void bindingMirrorsSignalWhileAttached_toggleAddsRemovesTheme() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -56,7 +56,7 @@ class ThemeListBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindingInactiveWhenDetached_reactivatedOnAttach_appliesCurrentValue() {
+    void bindingInactiveWhenDetached_reactivatedOnAttach_appliesCurrentValue() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
         ValueSignal<Boolean> signal = new ValueSignal<>(false);
@@ -75,7 +75,7 @@ class ThemeListBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void manualAddRemoveForBoundName_throwsBindingActiveException() {
+    void manualAddRemoveForBoundName_throwsBindingActiveException() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
         ValueSignal<Boolean> signal = new ValueSignal<>(true);
@@ -101,7 +101,7 @@ class ThemeListBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void clear_throwsWhenBindingsActive() {
+    void clear_throwsWhenBindingsActive() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
         ValueSignal<Boolean> signal = new ValueSignal<>(true);
@@ -112,7 +112,7 @@ class ThemeListBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void setThemeName_throwsWhenBindingsActive() {
+    void setThemeName_throwsWhenBindingsActive() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
         ValueSignal<Boolean> bound = new ValueSignal<>(true);
@@ -124,7 +124,7 @@ class ThemeListBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bind_nullSignal_throwsNPE() {
+    void bind_nullSignal_throwsNPE() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -133,7 +133,7 @@ class ThemeListBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void rebinding_alreadyBound_throws() {
+    void rebinding_alreadyBound_throws() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
         ValueSignal<Boolean> s1 = new ValueSignal<>(true);
@@ -148,7 +148,7 @@ class ThemeListBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void internalUpdatesDoNotThrowOrRecurse() {
+    void internalUpdatesDoNotThrowOrRecurse() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
         ValueSignal<Boolean> signal = new ValueSignal<>(false);
@@ -168,7 +168,7 @@ class ThemeListBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bindMultipleSignals() {
+    void bindMultipleSignals() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ThemeListGroupBindTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ThemeListGroupBindTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ThemeListGroupBindTest extends SignalsUnitTest {
 
     @Test
-    public void basicGroupBinding_addsAndRemovesThemes() {
+    void basicGroupBinding_addsAndRemovesThemes() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -61,7 +61,7 @@ class ThemeListGroupBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void nullList_treatedAsEmpty() {
+    void nullList_treatedAsEmpty() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -72,7 +72,7 @@ class ThemeListGroupBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void nullAndEmptyEntriesInList_silentlyIgnored() {
+    void nullAndEmptyEntriesInList_silentlyIgnored() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -86,7 +86,7 @@ class ThemeListGroupBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void secondGroupBind_throwsBindingActiveException() {
+    void secondGroupBind_throwsBindingActiveException() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -99,7 +99,7 @@ class ThemeListGroupBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void duplicateInAttribute_staticAndGroupAreDeduplicated() {
+    void duplicateInAttribute_staticAndGroupAreDeduplicated() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -116,7 +116,7 @@ class ThemeListGroupBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void staticRemovalWhileGroupHasSameName_nameIsRemoved() {
+    void staticRemovalWhileGroupHasSameName_nameIsRemoved() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -134,7 +134,7 @@ class ThemeListGroupBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void groupRemovalWhileStaticHasSameName_nameIsRemoved() {
+    void groupRemovalWhileStaticHasSameName_nameIsRemoved() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -150,7 +150,7 @@ class ThemeListGroupBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void clear_throwsWhenGroupBindingActive() {
+    void clear_throwsWhenGroupBindingActive() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -164,7 +164,7 @@ class ThemeListGroupBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void detachAndReattach_reappliesCurrentValue() {
+    void detachAndReattach_reappliesCurrentValue() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -187,7 +187,7 @@ class ThemeListGroupBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void coexistenceWithToggleBind_bothWorkIndependently() {
+    void coexistenceWithToggleBind_bothWorkIndependently() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 
@@ -210,7 +210,7 @@ class ThemeListGroupBindTest extends SignalsUnitTest {
     }
 
     @Test
-    public void bind_onChange_receivesBindingContext() {
+    void bind_onChange_receivesBindingContext() {
         TestComponent component = new TestComponent();
         UI.getCurrent().add(component);
 

--- a/flow-server/src/test/java/com/vaadin/flow/dom/impl/ElementStateProviderDeserializationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/impl/ElementStateProviderDeserializationTest.java
@@ -38,8 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class ElementStateProviderDeserializationTest {
 
     @Test
-    public void shouldRemoveChildComponentFromDeserializedParent()
-            throws Exception {
+    void shouldRemoveChildComponentFromDeserializedParent() throws Exception {
 
         TestParentComponent parent = (TestParentComponent) deserialize(
                 serialize(new TestParentComponent(new TestChildComponent())));

--- a/flow-server/src/test/java/com/vaadin/flow/dom/impl/ThemeListImplTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/impl/ThemeListImplTest.java
@@ -70,7 +70,7 @@ class ThemeListImplTest {
     }
 
     @Test
-    public void themeListCreatedWithNoThemes() {
+    void themeListCreatedWithNoThemes() {
         ThemeListImpl emptyList = new ThemeListImpl(new MockElement());
 
         assertTrue(emptyList.isEmpty(),
@@ -80,7 +80,7 @@ class ThemeListImplTest {
     }
 
     @Test
-    public void themeListCreatedWithOneThemes() {
+    void themeListCreatedWithOneThemes() {
         String themeName = "theme1";
 
         ThemeListImpl elementWithOneTheme = new ThemeListImpl(
@@ -93,7 +93,7 @@ class ThemeListImplTest {
     }
 
     @Test
-    public void themeListCreatedWithMultipleThemes() {
+    void themeListCreatedWithMultipleThemes() {
         String[] themeNames = { "theme1", "theme2" };
         ThemeListImpl elementWithMultipleThemes = new ThemeListImpl(
                 new MockElement(themeNames));
@@ -109,7 +109,7 @@ class ThemeListImplTest {
     }
 
     @Test
-    public void themeListCreatedWithDuplicateThemes() {
+    void themeListCreatedWithDuplicateThemes() {
         String[] themeNames = { "theme1", "theme1", "theme1" };
         ThemeListImpl elementWithMultipleThemes = new ThemeListImpl(
                 new MockElement(themeNames));
@@ -121,7 +121,7 @@ class ThemeListImplTest {
     }
 
     @Test
-    public void clear() {
+    void clear() {
         MockElement element = new MockElement("theme1", "theme2");
         ThemeListImpl themeList = new ThemeListImpl(element);
 
@@ -134,7 +134,7 @@ class ThemeListImplTest {
     }
 
     @Test
-    public void remove() {
+    void remove() {
         String themeToRemove = "theme2";
         String themeToLeave = "theme1";
         MockElement element = new MockElement(themeToLeave, themeToRemove);
@@ -152,7 +152,7 @@ class ThemeListImplTest {
     }
 
     @Test
-    public void removeAll() {
+    void removeAll() {
         String themeToRemove1 = "theme3";
         String themeToRemove2 = "theme2";
         String themeToLeave = "theme1";
@@ -172,7 +172,7 @@ class ThemeListImplTest {
     }
 
     @Test
-    public void removeAllThemes() {
+    void removeAllThemes() {
         String[] themeNames = { "theme1", "theme2" };
         MockElement element = new MockElement(themeNames);
         ThemeListImpl themeList = new ThemeListImpl(element);
@@ -186,7 +186,7 @@ class ThemeListImplTest {
     }
 
     @Test
-    public void retainAll() {
+    void retainAll() {
         List<String> elementsToRetain = Arrays.asList("retained",
                 "notRetained");
         String[] themeNames = { elementsToRetain.get(0), "theme2", "theme3" };
@@ -203,7 +203,7 @@ class ThemeListImplTest {
     }
 
     @Test
-    public void add() {
+    void add() {
         String themeToAdd = "theme";
         MockElement element = new MockElement();
         ThemeListImpl themeList = new ThemeListImpl(element);
@@ -220,7 +220,7 @@ class ThemeListImplTest {
     }
 
     @Test
-    public void addAll() {
+    void addAll() {
         List<String> themesToAdd = Arrays.asList("theme1", "theme2", "theme3");
         MockElement element = new MockElement();
         ThemeListImpl themeList = new ThemeListImpl(element);
@@ -240,7 +240,7 @@ class ThemeListImplTest {
     }
 
     @Test
-    public void addDuplicates() {
+    void addDuplicates() {
         List<String> themesToAdd = Arrays.asList("theme1", "theme1", "theme1");
         MockElement element = new MockElement();
         ThemeListImpl themeList = new ThemeListImpl(element);
@@ -257,7 +257,7 @@ class ThemeListImplTest {
     }
 
     @Test
-    public void iteratorRemoval() {
+    void iteratorRemoval() {
         String[] themeNames = { "theme1", "theme2", "theme3" };
         List<String> originalThemes = Arrays.asList(themeNames);
         MockElement element = new MockElement(themeNames);

--- a/flow-server/src/test/java/com/vaadin/flow/i18n/DefaultInstantiatorI18NTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/i18n/DefaultInstantiatorI18NTest.java
@@ -52,7 +52,7 @@ class DefaultInstantiatorI18NTest {
     private ClassLoader urlClassLoader;
 
     @BeforeEach
-    public void init()
+    void init()
             throws IOException, NoSuchFieldException, IllegalAccessException {
         File resources = Files.createTempDirectory(temporaryFolder, "temp")
                 .toFile();
@@ -66,14 +66,14 @@ class DefaultInstantiatorI18NTest {
     }
 
     @AfterEach
-    public void cleanup() throws NoSuchFieldException, IllegalAccessException {
+    void cleanup() throws NoSuchFieldException, IllegalAccessException {
         ResourceBundle.clearCache(urlClassLoader);
         I18NProviderTest.clearI18NProviderField();
         VaadinService.setCurrent(null);
     }
 
     @Test
-    public void translationFileOnClasspath_instantiateDefaultI18N()
+    void translationFileOnClasspath_instantiateDefaultI18N()
             throws IOException {
 
         createTranslationFiles(translations);
@@ -126,8 +126,7 @@ class DefaultInstantiatorI18NTest {
     }
 
     @Test
-    public void onlyDefaultTranslation_instantiateDefaultI18N()
-            throws IOException {
+    void onlyDefaultTranslation_instantiateDefaultI18N() throws IOException {
         File file = new File(translations,
                 DefaultI18NProvider.BUNDLE_FILENAME + ".properties");
         Files.writeString(file.toPath(), "title=Default lang",
@@ -174,8 +173,7 @@ class DefaultInstantiatorI18NTest {
     }
 
     @Test
-    public void onlyLangTransalation_nonExistingLangReturnsKey()
-            throws IOException {
+    void onlyLangTransalation_nonExistingLangReturnsKey() throws IOException {
         File file = new File(translations,
                 DefaultI18NProvider.BUNDLE_FILENAME + "_ja.properties");
         Files.writeString(file.toPath(), "title=No Default",
@@ -209,7 +207,7 @@ class DefaultInstantiatorI18NTest {
     }
 
     @Test
-    public void translate_withoutProvider_returnsKey() {
+    void translate_withoutProvider_returnsKey() {
         VaadinService service = Mockito.mock(VaadinService.class);
         VaadinService.setCurrent(service);
 
@@ -222,7 +220,7 @@ class DefaultInstantiatorI18NTest {
     }
 
     @Test
-    public void translationFilesOnClassPath_getI18NProvider_usesThreadContextClassLoader()
+    void translationFilesOnClassPath_getI18NProvider_usesThreadContextClassLoader()
             throws IOException {
         createTranslationFiles(translations);
 

--- a/flow-server/src/test/java/com/vaadin/flow/i18n/I18NUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/i18n/I18NUtilTest.java
@@ -54,14 +54,13 @@ class I18NUtilTest {
     private ClassLoader mockLoader;
 
     @BeforeEach
-    public void init() throws IOException {
+    void init() throws IOException {
         MockitoAnnotations.openMocks(this);
         resources = Files.createTempDirectory(temporaryFolder, "temp").toFile();
     }
 
     @Test
-    public void foundResourceFolder_returnsExpectedLocales()
-            throws IOException {
+    void foundResourceFolder_returnsExpectedLocales() throws IOException {
         Mockito.when(mockLoader.getResource(DefaultI18NProvider.BUNDLE_FOLDER))
                 .thenReturn(resources.toURI().toURL());
 
@@ -98,7 +97,7 @@ class I18NUtilTest {
     }
 
     @Test
-    public void noTranslationFiles_returnsEmptyList() throws IOException {
+    void noTranslationFiles_returnsEmptyList() throws IOException {
         Mockito.when(mockLoader.getResource(DefaultI18NProvider.BUNDLE_FOLDER))
                 .thenReturn(resources.toURI().toURL());
 
@@ -109,8 +108,7 @@ class I18NUtilTest {
     }
 
     @Test
-    public void onlyDefaultTranslationFile_returnsEmptyList()
-            throws IOException {
+    void onlyDefaultTranslationFile_returnsEmptyList() throws IOException {
         Mockito.when(mockLoader.getResource(DefaultI18NProvider.BUNDLE_FOLDER))
                 .thenReturn(resources.toURI().toURL());
 
@@ -126,8 +124,7 @@ class I18NUtilTest {
     }
 
     @Test
-    public void onlyDefaultTranslationFile_returnsTrueForDefault()
-            throws IOException {
+    void onlyDefaultTranslationFile_returnsTrueForDefault() throws IOException {
         File translations = new File(resources,
                 DefaultI18NProvider.BUNDLE_FOLDER);
         translations.mkdirs();
@@ -145,7 +142,7 @@ class I18NUtilTest {
     }
 
     @Test
-    public void noTranslationFilesInExistingFolder_returnsFalseForDefault()
+    void noTranslationFilesInExistingFolder_returnsFalseForDefault()
             throws IOException {
         File translations = new File(resources,
                 DefaultI18NProvider.BUNDLE_FOLDER);
@@ -159,7 +156,7 @@ class I18NUtilTest {
     }
 
     @Test
-    public void translationFilesInJar_returnsTrueForDefault_findsLanguages()
+    void translationFilesInJar_returnsTrueForDefault_findsLanguages()
             throws IOException {
         Path path = generateZipArchive(temporaryFolder);
 
@@ -182,7 +179,7 @@ class I18NUtilTest {
     // Open Liberty may use 'wsjar' as protocol of JAR resources
     // https://openliberty.io/docs/latest/reference/config/classloading.html
     @Test
-    public void openliberty_translationFilesInJar_returnsTrueForDefault_findsLanguages()
+    void openliberty_translationFilesInJar_returnsTrueForDefault_findsLanguages()
             throws IOException {
         Path path = generateZipArchive(temporaryFolder);
 
@@ -256,7 +253,7 @@ class I18NUtilTest {
 
     // vfs:/content/my.war/WEB-INF/classes/vaadin-i18n/
     @Test
-    public void jbossVfs_translationFilesInJar_returnsTrueForDefault_findsLanguages()
+    void jbossVfs_translationFilesInJar_returnsTrueForDefault_findsLanguages()
             throws IOException {
         Path path = generateZipArchive(temporaryFolder);
         JarFile jarFile = new JarFile(path.toFile());

--- a/flow-server/src/test/java/com/vaadin/flow/i18n/TranslationFileRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/i18n/TranslationFileRequestHandlerTest.java
@@ -83,24 +83,24 @@ class TranslationFileRequestHandlerTest {
     private I18NProvider i18NProvider;
 
     @BeforeEach
-    public void configure() throws IOException {
+    void configure() throws IOException {
         initTranslationsFolder();
     }
 
     @AfterEach
-    public void cleanup() {
+    void cleanup() {
         ResourceBundle.clearCache(urlClassLoader);
     }
 
     @Test
-    public void pathDoesNotMatch_requestNotHandled() throws IOException {
+    void pathDoesNotMatch_requestNotHandled() throws IOException {
         configure(true);
         setRequestParams(null, "other", null, null);
         assertFalse(handler.handleRequest(session, request, response));
     }
 
     @Test
-    public void withRootBundle_languageTagIsNull_responseIsRootBundle()
+    void withRootBundle_languageTagIsNull_responseIsRootBundle()
             throws IOException {
         configure(true);
         testResponseContent(null, "{\"title\":\"Root bundle lang\"}", "und");
@@ -108,7 +108,7 @@ class TranslationFileRequestHandlerTest {
     }
 
     @Test
-    public void withoutRootBundle_languageTagIsNull_responseIsEmpty()
+    void withoutRootBundle_languageTagIsNull_responseIsEmpty()
             throws IOException {
         configure(false);
         testResponseContent(null, "", null);
@@ -116,7 +116,7 @@ class TranslationFileRequestHandlerTest {
     }
 
     @Test
-    public void withRootBundle_languageTagIsEmpty_responseIsRootBundle()
+    void withRootBundle_languageTagIsEmpty_responseIsRootBundle()
             throws IOException {
         configure(true);
         testResponseContent("", "{\"title\":\"Root bundle lang\"}", "und");
@@ -124,7 +124,7 @@ class TranslationFileRequestHandlerTest {
     }
 
     @Test
-    public void withoutRootBundle_languageTagIsEmpty_responseIsEmpty()
+    void withoutRootBundle_languageTagIsEmpty_responseIsEmpty()
             throws IOException {
         configure(false);
         testResponseContent("", "", null);
@@ -132,7 +132,7 @@ class TranslationFileRequestHandlerTest {
     }
 
     @Test
-    public void languageTagWithoutCountryAvailable_responseIsCorrect()
+    void languageTagWithoutCountryAvailable_responseIsCorrect()
             throws IOException {
         configure(true);
         testResponseContent("fi", "{\"title\":\"Suomi\"}", "fi");
@@ -140,7 +140,7 @@ class TranslationFileRequestHandlerTest {
     }
 
     @Test
-    public void tagContainsOnlyLanguage_languageOnlyAvailableWithCountry_responseIsEmpty()
+    void tagContainsOnlyLanguage_languageOnlyAvailableWithCountry_responseIsEmpty()
             throws IOException {
         configure(false);
         testResponseContent("es", "", null);
@@ -148,7 +148,7 @@ class TranslationFileRequestHandlerTest {
     }
 
     @Test
-    public void languageTagWithCountryAvailable_responseIsCorrect()
+    void languageTagWithCountryAvailable_responseIsCorrect()
             throws IOException {
         configure(false);
         testResponseContent("es-ES", "{\"title\":\"Espanol (Spain)\"}",
@@ -157,7 +157,7 @@ class TranslationFileRequestHandlerTest {
     }
 
     @Test
-    public void withRootBundle_requestedLocaleBundleNotAvailable_responseIsRootBundle()
+    void withRootBundle_requestedLocaleBundleNotAvailable_responseIsRootBundle()
             throws IOException {
         configure(true);
         testResponseContent("en-US", "{\"title\":\"Root bundle lang\"}",
@@ -166,7 +166,7 @@ class TranslationFileRequestHandlerTest {
     }
 
     @Test
-    public void withoutRootBundle_requestedLocaleBundleNotAvailable_responseIsEmpty()
+    void withoutRootBundle_requestedLocaleBundleNotAvailable_responseIsEmpty()
             throws IOException {
         configure(false);
         testResponseContent("en-US", "", null);
@@ -174,7 +174,7 @@ class TranslationFileRequestHandlerTest {
     }
 
     @Test
-    public void languageTagWithUnderscoresAvailable_responseIsCorrect()
+    void languageTagWithUnderscoresAvailable_responseIsCorrect()
             throws IOException {
         configure(false);
         testResponseContent("es_ES", "{\"title\":\"Espanol (Spain)\"}",
@@ -183,7 +183,7 @@ class TranslationFileRequestHandlerTest {
     }
 
     @Test
-    public void withRootBundle_languageTagWithUnderscoresNotAvailable_responseIsRootBundle()
+    void withRootBundle_languageTagWithUnderscoresNotAvailable_responseIsRootBundle()
             throws IOException {
         configure(true);
         testResponseContent("it_IT", "{\"title\":\"Root bundle lang\"}",
@@ -192,7 +192,7 @@ class TranslationFileRequestHandlerTest {
     }
 
     @Test
-    public void withoutRootBundle_languageTagWithUnderscoresNotAvailable_responseIsEmpty()
+    void withoutRootBundle_languageTagWithUnderscoresNotAvailable_responseIsEmpty()
             throws IOException {
         configure(false);
         testResponseContent("it_IT", "", null);
@@ -200,7 +200,7 @@ class TranslationFileRequestHandlerTest {
     }
 
     @Test
-    public void withCustomizedDefaultI18nProvider_requestedLocaleBundleAvailable_responseIsRootBundle()
+    void withCustomizedDefaultI18nProvider_requestedLocaleBundleAvailable_responseIsRootBundle()
             throws IOException {
         configure(true, CustomI18NProvider.class, false);
         testResponseContent("fi", "{\"title\":\"title-fi\"}", "fi");
@@ -208,7 +208,7 @@ class TranslationFileRequestHandlerTest {
     }
 
     @Test
-    public void productionMode_withCustomizedDefaultI18nProvider_requestedLocaleBundleAvailable_responseIsRootBundle()
+    void productionMode_withCustomizedDefaultI18nProvider_requestedLocaleBundleAvailable_responseIsRootBundle()
             throws IOException {
         configure(true, CustomI18NProvider.class, true);
         testResponseContent("fi", "{\"title\":\"title-fi\"}", "fi");
@@ -259,14 +259,14 @@ class TranslationFileRequestHandlerTest {
     }
 
     @Test
-    public void productionMode_withChunks_filtersKeys() throws IOException {
+    void productionMode_withChunks_filtersKeys() throws IOException {
         setUpChunkedTest();
         testResponseContent("", new String[] { "indexhtml" }, null,
                 "{\"title\":\"Root bundle lang\"}", "und");
     }
 
     @Test
-    public void productionMode_withKeys_onlyReturnsThose() throws IOException {
+    void productionMode_withKeys_onlyReturnsThose() throws IOException {
         setUpChunkedTest();
         testResponseContent("", null, new String[] { "title" },
                 "{\"title\":\"Root bundle lang\"}", "und");
@@ -412,7 +412,7 @@ class TranslationFileRequestHandlerTest {
     }
 
     @Test
-    public void handleSessionExpired_translationRequest_returnsTranslations()
+    void handleSessionExpired_translationRequest_returnsTranslations()
             throws IOException {
         configure(true);
         setRequestParams("fi",
@@ -428,7 +428,7 @@ class TranslationFileRequestHandlerTest {
     }
 
     @Test
-    public void handleSessionExpired_nonTranslationRequest_returnsFalse()
+    void handleSessionExpired_nonTranslationRequest_returnsFalse()
             throws IOException {
         configure(true);
         setRequestParams(null, "other", null, null);
@@ -438,8 +438,7 @@ class TranslationFileRequestHandlerTest {
     }
 
     @Test
-    public void handleSessionExpired_noI18nProvider_returnsError()
-            throws IOException {
+    void handleSessionExpired_noI18nProvider_returnsError() throws IOException {
         // Create handler without I18NProvider
         createTranslationFiles(true);
         mockResponse();
@@ -460,7 +459,7 @@ class TranslationFileRequestHandlerTest {
     }
 
     @Test
-    public void handleSessionExpired_noI18nProvider_productionMode_returnsNotFound()
+    void handleSessionExpired_noI18nProvider_productionMode_returnsNotFound()
             throws IOException {
         // Create handler without I18NProvider
         createTranslationFiles(true);

--- a/flow-server/src/test/java/com/vaadin/flow/internal/ActiveStyleSheetTrackerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/ActiveStyleSheetTrackerTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ActiveStyleSheetTrackerTest {
 
     @Test
-    public void singletonPerContext() {
+    void singletonPerContext() {
         VaadinService service = new MockVaadinServletService();
         ActiveStyleSheetTracker t1 = ActiveStyleSheetTracker.get(service);
         ActiveStyleSheetTracker t2 = ActiveStyleSheetTracker.get(service);
@@ -38,7 +38,7 @@ class ActiveStyleSheetTrackerTest {
     }
 
     @Test
-    public void addRemoveAndAppShellMerge() {
+    void addRemoveAndAppShellMerge() {
         VaadinService service = new MockVaadinServletService();
 
         ActiveStyleSheetTracker tracker = ActiveStyleSheetTracker.get(service);

--- a/flow-server/src/test/java/com/vaadin/flow/internal/BeanUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/BeanUtilTest.java
@@ -130,7 +130,7 @@ class BeanUtilTest {
 
     // Test for getBeanPropertyDescriptors with regular class
     @Test
-    public void getBeanPropertyDescriptors_regularClass()
+    void getBeanPropertyDescriptors_regularClass()
             throws IntrospectionException {
         List<PropertyDescriptor> descriptors = BeanUtil
                 .getBeanPropertyDescriptors(TestBean.class);
@@ -168,8 +168,7 @@ class BeanUtilTest {
 
     // Test for getBeanPropertyDescriptors with record
     @Test
-    public void getBeanPropertyDescriptors_record()
-            throws IntrospectionException {
+    void getBeanPropertyDescriptors_record() throws IntrospectionException {
         List<PropertyDescriptor> descriptors = BeanUtil
                 .getBeanPropertyDescriptors(TestRecord.class);
 
@@ -199,8 +198,7 @@ class BeanUtilTest {
 
     // Test for getBeanPropertyDescriptors with interface
     @Test
-    public void getBeanPropertyDescriptors_interface()
-            throws IntrospectionException {
+    void getBeanPropertyDescriptors_interface() throws IntrospectionException {
         List<PropertyDescriptor> descriptors = BeanUtil
                 .getBeanPropertyDescriptors(TestInterface.class);
 
@@ -215,7 +213,7 @@ class BeanUtilTest {
 
     // Test for getPropertyType with simple property
     @Test
-    public void getPropertyType_simpleProperty() throws IntrospectionException {
+    void getPropertyType_simpleProperty() throws IntrospectionException {
         Class<?> nameType = BeanUtil.getPropertyType(TestBean.class, "name");
         assertEquals(String.class, nameType);
 
@@ -225,7 +223,7 @@ class BeanUtilTest {
 
     // Test for getPropertyType with nested property
     @Test
-    public void getPropertyType_nestedProperty() throws IntrospectionException {
+    void getPropertyType_nestedProperty() throws IntrospectionException {
         Class<?> nestedValueType = BeanUtil.getPropertyType(TestBean.class,
                 "nested.value");
         assertEquals(String.class, nestedValueType);
@@ -233,8 +231,7 @@ class BeanUtilTest {
 
     // Test for getPropertyType with non-existent property
     @Test
-    public void getPropertyType_nonExistentProperty()
-            throws IntrospectionException {
+    void getPropertyType_nonExistentProperty() throws IntrospectionException {
         Class<?> nonExistentType = BeanUtil.getPropertyType(TestBean.class,
                 "nonExistent");
         assertNull(nonExistentType);
@@ -242,8 +239,7 @@ class BeanUtilTest {
 
     // Test for getPropertyDescriptor with simple property
     @Test
-    public void getPropertyDescriptor_simpleProperty()
-            throws IntrospectionException {
+    void getPropertyDescriptor_simpleProperty() throws IntrospectionException {
         PropertyDescriptor nameDescriptor = BeanUtil
                 .getPropertyDescriptor(TestBean.class, "name");
         assertNotNull(nameDescriptor);
@@ -255,8 +251,7 @@ class BeanUtilTest {
 
     // Test for getPropertyDescriptor with nested property
     @Test
-    public void getPropertyDescriptor_nestedProperty()
-            throws IntrospectionException {
+    void getPropertyDescriptor_nestedProperty() throws IntrospectionException {
         PropertyDescriptor nestedValueDescriptor = BeanUtil
                 .getPropertyDescriptor(TestBean.class, "nested.value");
         assertNotNull(nestedValueDescriptor);
@@ -268,7 +263,7 @@ class BeanUtilTest {
 
     // Test for getPropertyDescriptor with non-existent property
     @Test
-    public void getPropertyDescriptor_nonExistentProperty()
+    void getPropertyDescriptor_nonExistentProperty()
             throws IntrospectionException {
         PropertyDescriptor nonExistentDescriptor = BeanUtil
                 .getPropertyDescriptor(TestBean.class, "nonExistent");
@@ -277,8 +272,7 @@ class BeanUtilTest {
 
     // Test for getBeanPropertyDescriptors with null input
     @Test
-    public void getBeanPropertyDescriptors_nullInput()
-            throws IntrospectionException {
+    void getBeanPropertyDescriptors_nullInput() throws IntrospectionException {
         List<PropertyDescriptor> result = BeanUtil
                 .getBeanPropertyDescriptors(null);
         assertNotNull(result);
@@ -287,15 +281,14 @@ class BeanUtilTest {
 
     // Test empty property name
     @Test
-    public void getPropertyType_emptyPropertyName()
-            throws IntrospectionException {
+    void getPropertyType_emptyPropertyName() throws IntrospectionException {
         Class<?> result = BeanUtil.getPropertyType(TestBean.class, "");
         assertNull(result);
     }
 
     // Test empty property name for descriptor
     @Test
-    public void getPropertyDescriptor_emptyPropertyName()
+    void getPropertyDescriptor_emptyPropertyName()
             throws IntrospectionException {
         PropertyDescriptor result = BeanUtil
                 .getPropertyDescriptor(TestBean.class, "");
@@ -304,8 +297,7 @@ class BeanUtilTest {
 
     // Test property with deep nesting
     @Test
-    public void getPropertyType_deepNestedProperty()
-            throws IntrospectionException {
+    void getPropertyType_deepNestedProperty() throws IntrospectionException {
         // This would fail because our test bean doesn't have deep nesting,
         // but tests the recursive behavior
         Class<?> result = BeanUtil.getPropertyType(TestBean.class,
@@ -315,7 +307,7 @@ class BeanUtilTest {
 
     // Test getPropertyType with record
     @Test
-    public void getPropertyType_recordProperty() throws IntrospectionException {
+    void getPropertyType_recordProperty() throws IntrospectionException {
         Class<?> recordPropertyType = BeanUtil.getPropertyType(TestRecord.class,
                 "recordProperty");
         assertEquals(String.class, recordPropertyType);
@@ -327,8 +319,7 @@ class BeanUtilTest {
 
     // Test interface properties
     @Test
-    public void getPropertyType_interfaceProperty()
-            throws IntrospectionException {
+    void getPropertyType_interfaceProperty() throws IntrospectionException {
         Class<?> interfacePropertyType = BeanUtil
                 .getPropertyType(TestInterface.class, "interfaceProperty");
         assertEquals(String.class, interfacePropertyType);
@@ -336,7 +327,7 @@ class BeanUtilTest {
 
     // Test that Object methods are filtered out
     @Test
-    public void getPropertyDescriptor_objectMethodsFiltered()
+    void getPropertyDescriptor_objectMethodsFiltered()
             throws IntrospectionException {
         // The "class" property should be filtered out by BeanUtil
         PropertyDescriptor classProperty = BeanUtil
@@ -346,7 +337,7 @@ class BeanUtilTest {
 
     // Test that getBeanPropertyDescriptors includes all valid properties
     @Test
-    public void getBeanPropertyDescriptors_includesAllValidProperties()
+    void getBeanPropertyDescriptors_includesAllValidProperties()
             throws IntrospectionException {
         List<PropertyDescriptor> descriptors = BeanUtil
                 .getBeanPropertyDescriptors(TestBean.class);
@@ -363,7 +354,7 @@ class BeanUtilTest {
 
     // Test from main branch: duplicate property descriptors are removed
     @Test
-    public void duplicatesAreRemoved() throws Exception {
+    void duplicatesAreRemoved() throws Exception {
         List<PropertyDescriptor> descriptors = BeanUtil
                 .getBeanPropertyDescriptors(TestSomething.class);
         List<PropertyDescriptor> existsInAllPlacesProperties = descriptors

--- a/flow-server/src/test/java/com/vaadin/flow/internal/BundleUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/BundleUtilsTest.java
@@ -40,7 +40,7 @@ class BundleUtilsTest {
     Path temporaryFolder;
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         for (AutoCloseable closeable : closeOnTearDown) {
             try {
                 closeable.close();
@@ -51,7 +51,7 @@ class BundleUtilsTest {
     }
 
     @Test
-    public void frontendImportVariantsIncluded() {
+    void frontendImportVariantsIncluded() {
         mockStatsJson("Frontend/foo.js");
         Set<String> bundleImports = BundleUtils.loadBundleImports();
 
@@ -61,7 +61,7 @@ class BundleUtilsTest {
     }
 
     @Test
-    public void jarImportVariantsIncluded() {
+    void jarImportVariantsIncluded() {
         mockStatsJson("Frontend/generated/jar-resources/my/addon.js");
         Set<String> bundleImports = BundleUtils.loadBundleImports();
 
@@ -72,7 +72,7 @@ class BundleUtilsTest {
     }
 
     @Test
-    public void frontendInTheMiddleNotTouched() {
+    void frontendInTheMiddleNotTouched() {
         mockStatsJson("my/Frontend/foo.js");
         Set<String> bundleImports = BundleUtils.loadBundleImports();
 
@@ -80,7 +80,7 @@ class BundleUtilsTest {
     }
 
     @Test
-    public void themeVariantsHandled() {
+    void themeVariantsHandled() {
         mockStatsJson("@foo/bar/theme/lumo/file.js");
         Set<String> bundleImports = BundleUtils.loadBundleImports();
 
@@ -89,7 +89,7 @@ class BundleUtilsTest {
     }
 
     @Test
-    public void themeVariantsFromJarHandled() {
+    void themeVariantsFromJarHandled() {
         mockStatsJson("Frontend/generated/jar-resources/theme/lumo/file.js",
                 "Frontend/generated/jar-resources/theme/material/file.js");
         Set<String> bundleImports = BundleUtils.loadBundleImports();
@@ -122,7 +122,7 @@ class BundleUtilsTest {
     }
 
     @Test
-    public void loadStatsJson_cachesResult_returnsSameInstance() {
+    void loadStatsJson_cachesResult_returnsSameInstance() {
         // First call loads and caches
         ObjectNode first = BundleUtils.loadStatsJson();
         // Second call returns cached instance
@@ -132,7 +132,7 @@ class BundleUtilsTest {
     }
 
     @Test
-    public void loadStatsJson_cachedResultIsConsistent() {
+    void loadStatsJson_cachedResultIsConsistent() {
         ObjectNode first = BundleUtils.loadStatsJson();
         ObjectNode second = BundleUtils.loadStatsJson();
 
@@ -142,7 +142,7 @@ class BundleUtilsTest {
     }
 
     @Test
-    public void isPreCompiledProductionBundle_usesCachedStats() {
+    void isPreCompiledProductionBundle_usesCachedStats() {
         // Call multiple times
         boolean first = BundleUtils.isPreCompiledProductionBundle();
         boolean second = BundleUtils.isPreCompiledProductionBundle();

--- a/flow-server/src/test/java/com/vaadin/flow/internal/CaseUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/CaseUtilTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 class CaseUtilTest {
 
     @Test
-    public void upperCaseUnderscoreToHumanFriendly() {
+    void upperCaseUnderscoreToHumanFriendly() {
         assertNull(CaseUtil.upperCaseUnderscoreToHumanFriendly(null));
         assertEquals("", CaseUtil.upperCaseUnderscoreToHumanFriendly(""));
         assertEquals("My Bean Container", CaseUtil
@@ -38,7 +38,7 @@ class CaseUtilTest {
     }
 
     @Test
-    public void capitalize() {
+    void capitalize() {
         assertNull(CaseUtil.capitalize(null));
         assertEquals("", CaseUtil.capitalize(""));
         assertEquals("Great", CaseUtil.capitalize("great"));

--- a/flow-server/src/test/java/com/vaadin/flow/internal/ConstantPoolTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/ConstantPoolTest.java
@@ -27,14 +27,14 @@ class ConstantPoolTest {
     private ConstantPool constantPool = new ConstantPool();
 
     @Test
-    public void newConstantPool_noNewItems() {
+    void newConstantPool_noNewItems() {
         assertFalse(constantPool.hasNewConstants());
         assertEquals(0,
                 JacksonUtils.getKeys(constantPool.dumpConstants()).size());
     }
 
     @Test
-    public void valueIsRegistered() {
+    void valueIsRegistered() {
         ConstantPoolKey reference = new ConstantPoolKey(
                 JacksonUtils.createObjectNode());
 
@@ -49,7 +49,7 @@ class ConstantPoolTest {
     }
 
     @Test
-    public void sameValue_sameId() {
+    void sameValue_sameId() {
         ConstantPoolKey reference = new ConstantPoolKey(
                 JacksonUtils.createObjectNode());
 
@@ -64,7 +64,7 @@ class ConstantPoolTest {
     }
 
     @Test
-    public void differentValue_differentId() {
+    void differentValue_differentId() {
         ConstantPoolKey reference = new ConstantPoolKey(
                 JacksonUtils.createObjectNode());
 
@@ -79,7 +79,7 @@ class ConstantPoolTest {
     }
 
     @Test
-    public void constantPoolKey_exportedDirectly_idCreated() {
+    void constantPoolKey_exportedDirectly_idCreated() {
         final ConstantPoolKey constantPoolKey = new ConstantPoolKey(
                 JacksonUtils.createObjectNode());
         final ObjectNode message = JacksonUtils.createObjectNode();

--- a/flow-server/src/test/java/com/vaadin/flow/internal/CssBundlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/CssBundlerTest.java
@@ -37,13 +37,13 @@ class CssBundlerTest {
     private File themeFolder;
 
     @BeforeEach
-    public void setup() throws IOException {
+    void setup() throws IOException {
         themesFolder = Files.createTempDirectory("cssbundlertest").toFile();
         themeFolder = new File(themesFolder, "my-theme");
     }
 
     @Test
-    public void differentImportSyntaxesSupported() throws Exception {
+    void differentImportSyntaxesSupported() throws Exception {
         String[] validImports = new String[] { //
                 // The typical you actually use
                 "@import url(foo.css);", //
@@ -67,7 +67,7 @@ class CssBundlerTest {
     }
 
     @Test
-    public void layerImportsNotHandled() throws IOException {
+    void layerImportsNotHandled() throws IOException {
         assertImportNotHandled("@import url('foo.css') layer(foo);");
         assertImportNotHandled("@import url('foo.css') layer(foo) ;");
         assertImportNotHandled("@import 'theme.css' layer(utilities);");
@@ -77,7 +77,7 @@ class CssBundlerTest {
     }
 
     @Test
-    public void conditionalImportsNotHandled() throws IOException {
+    void conditionalImportsNotHandled() throws IOException {
         assertImportNotHandled("@import url('foo.css') print;");
         assertImportNotHandled("@import url('bluish.css') print, screen;");
         assertImportNotHandled("@import \"common.css\" screen;");
@@ -86,7 +86,7 @@ class CssBundlerTest {
     }
 
     @Test
-    public void relativeUrlsRewritten() throws IOException {
+    void relativeUrlsRewritten() throws IOException {
         writeCss("background-image: url('foo/bar.png');", "styles.css");
         createThemeFile("foo/bar.png");
 
@@ -111,7 +111,7 @@ class CssBundlerTest {
     }
 
     @Test
-    public void relativeUrlsWithExtraInfoRewritten() throws IOException {
+    void relativeUrlsWithExtraInfoRewritten() throws IOException {
         writeCss(
                 """
                         @font-face {
@@ -136,7 +136,7 @@ class CssBundlerTest {
     }
 
     @Test
-    public void relativeUrlsInSubFolderRewritten() throws IOException {
+    void relativeUrlsInSubFolderRewritten() throws IOException {
         writeCss("@import url('sub/sub.css');", "styles.css");
         writeCss("background-image: url('./file.png');", "sub/sub.css");
         createThemeFile("sub/file.png");
@@ -148,7 +148,7 @@ class CssBundlerTest {
     }
 
     @Test
-    public void dollarAndBackslashWorks() throws IOException {
+    void dollarAndBackslashWorks() throws IOException {
         String css = "body { content: '$\\'}";
         writeCss("@import 'other.css';", "styles.css");
         writeCss(css, "other.css");
@@ -159,7 +159,7 @@ class CssBundlerTest {
     }
 
     @Test
-    public void unhandledImportsAreMovedToTop() throws IOException {
+    void unhandledImportsAreMovedToTop() throws IOException {
         writeCss("body {background: blue};", "other.css");
         writeCss(
                 """
@@ -194,7 +194,7 @@ class CssBundlerTest {
     }
 
     @Test
-    public void themeAssetsRelativeUrlsRewritten() throws IOException {
+    void themeAssetsRelativeUrlsRewritten() throws IOException {
         createThemeJson("""
                 {
                   "assets": {
@@ -221,8 +221,7 @@ class CssBundlerTest {
     }
 
     @Test
-    public void themeAssetsRelativeUrlsInSubFolderRewritten()
-            throws IOException {
+    void themeAssetsRelativeUrlsInSubFolderRewritten() throws IOException {
         createThemeJson("""
                 {
                   "assets": {
@@ -258,7 +257,7 @@ class CssBundlerTest {
     }
 
     @Test
-    public void relativeUrl_notThemeResourceNotAssets_notRewritten()
+    void relativeUrl_notThemeResourceNotAssets_notRewritten()
             throws IOException {
         createThemeJson("""
                 {
@@ -295,7 +294,7 @@ class CssBundlerTest {
     }
 
     @Test
-    public void ignoreCommentedRules() throws Exception {
+    void ignoreCommentedRules() throws Exception {
         File cssFile = writeCss("""
                 /*
                 @import url('a.css');
@@ -366,14 +365,14 @@ class CssBundlerTest {
     }
 
     @Test
-    public void minifyCss_removesComments() {
+    void minifyCss_removesComments() {
         String css = "/* comment */ .class { color: red; }";
         String result = CssBundler.minifyCss(css);
         assertEquals(".class{color: red}", result);
     }
 
     @Test
-    public void minifyCss_doesNotRemoveContentComment() {
+    void minifyCss_doesNotRemoveContentComment() {
         String css = """
                 .selector {
                   content: "/* not a comment, should not remove */";
@@ -386,7 +385,7 @@ class CssBundlerTest {
     }
 
     @Test
-    public void minifyCss_removesMultilineComments() {
+    void minifyCss_removesMultilineComments() {
         String css = """
                 /* This is a
                    multiline comment */
@@ -397,21 +396,21 @@ class CssBundlerTest {
     }
 
     @Test
-    public void minifyCss_collapsesWhitespace() {
+    void minifyCss_collapsesWhitespace() {
         String css = ".class   {   color:   red;   }";
         String result = CssBundler.minifyCss(css);
         assertEquals(".class{color: red}", result);
     }
 
     @Test
-    public void minifyCss_removesTrailingSemicolons() {
+    void minifyCss_removesTrailingSemicolons() {
         String css = ".class { color: red; }";
         String result = CssBundler.minifyCss(css);
         assertEquals(".class{color: red}", result);
     }
 
     @Test
-    public void minifyCss_handlesMultipleRules() {
+    void minifyCss_handlesMultipleRules() {
         String css = """
                 .class1 { color: red; }
                 .class2 { background: blue; }
@@ -421,7 +420,7 @@ class CssBundlerTest {
     }
 
     @Test
-    public void minifyCss_handlesCalc_noRemovalOfWhitespace() {
+    void minifyCss_handlesCalc_noRemovalOfWhitespace() {
         String css = """
                 span.test::before {
                     content: "";
@@ -441,14 +440,14 @@ class CssBundlerTest {
     }
 
     @Test
-    public void minifyCss_preservesSelectorsWithCombinators() {
+    void minifyCss_preservesSelectorsWithCombinators() {
         String css = ".parent > .child { color: red; }";
         String result = CssBundler.minifyCss(css);
         assertEquals(".parent>.child{color: red}", result);
     }
 
     @Test
-    public void minifyCss_keyframes() {
+    void minifyCss_keyframes() {
         String content = """
                 @-webkit-keyframes configuratorFlyLeft {
                 	0% {left: 0;}
@@ -466,7 +465,7 @@ class CssBundlerTest {
     }
 
     @Test
-    public void minifyCss_CSSMediaQueriesHandled() {
+    void minifyCss_CSSMediaQueriesHandled() {
         String content = """
                 @media (max-width: 1200px) {
                     legend {
@@ -480,14 +479,14 @@ class CssBundlerTest {
     }
 
     @Test
-    public void minifyCss_handlesEmptyInput() {
+    void minifyCss_handlesEmptyInput() {
         assertEquals("", CssBundler.minifyCss(""));
         assertEquals("", CssBundler.minifyCss("   "));
         assertEquals("", CssBundler.minifyCss("/* only comment */"));
     }
 
     @Test
-    public void inlineImports_resolvesNodeModulesImport() throws IOException {
+    void inlineImports_resolvesNodeModulesImport() throws IOException {
         // Create a node_modules structure
         File nodeModules = new File(themesFolder, "node_modules");
         File packageDir = new File(nodeModules, "some-package");
@@ -512,8 +511,7 @@ class CssBundlerTest {
     }
 
     @Test
-    public void inlineImports_prefersRelativeOverNodeModules()
-            throws IOException {
+    void inlineImports_prefersRelativeOverNodeModules() throws IOException {
         // Create a node_modules structure
         File nodeModules = new File(themesFolder, "node_modules");
         File packageDir = new File(nodeModules, "local");
@@ -546,8 +544,7 @@ class CssBundlerTest {
     }
 
     @Test
-    public void inlineImports_handlesNullNodeModulesFolder()
-            throws IOException {
+    void inlineImports_handlesNullNodeModulesFolder() throws IOException {
         writeCss("@import 'nonexistent/styles.css';\n.main { color: red; }",
                 "styles.css");
 
@@ -563,7 +560,7 @@ class CssBundlerTest {
     }
 
     @Test
-    public void cyclicImportsDoNotCauseStackOverflow() throws IOException {
+    void cyclicImportsDoNotCauseStackOverflow() throws IOException {
         // a.css imports b.css, b.css imports a.css
         writeCss("@import 'b.css';\n.from-a { color: red; }", "a.css");
         writeCss("@import 'a.css';\n.from-b { color: blue; }", "b.css");
@@ -582,8 +579,7 @@ class CssBundlerTest {
     }
 
     @Test
-    public void transitiveCyclicImportsDoNotCauseStackOverflow()
-            throws IOException {
+    void transitiveCyclicImportsDoNotCauseStackOverflow() throws IOException {
         // a.css -> b.css -> c.css -> a.css
         writeCss("@import 'b.css';\n.from-a { color: red; }", "a.css");
         writeCss("@import 'c.css';\n.from-b { color: blue; }", "b.css");
@@ -602,7 +598,7 @@ class CssBundlerTest {
     }
 
     @Test
-    public void selfImportDoesNotCauseStackOverflow() throws IOException {
+    void selfImportDoesNotCauseStackOverflow() throws IOException {
         // a.css imports itself
         writeCss("@import 'a.css';\n.from-a { color: red; }", "a.css");
         writeCss("@import 'a.css';", "styles.css");
@@ -617,7 +613,7 @@ class CssBundlerTest {
     }
 
     @Test
-    public void cyclicImportsInNestedFoldersDoNotCauseStackOverflow()
+    void cyclicImportsInNestedFoldersDoNotCauseStackOverflow()
             throws IOException {
         // styles.css imports sub/a.css
         // sub/a.css imports ../b.css (back to root)

--- a/flow-server/src/test/java/com/vaadin/flow/internal/CurrentInstanceTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/CurrentInstanceTest.java
@@ -44,18 +44,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class CurrentInstanceTest {
 
     @BeforeEach
-    public void clearExistingThreadLocals() {
+    void clearExistingThreadLocals() {
         // Ensure no previous test left some thread locals hanging
         CurrentInstance.clearAll();
     }
 
     @Test
-    public void testInitiallyCleared() throws Exception {
+    void testInitiallyCleared() throws Exception {
         assertCleared();
     }
 
     @Test
-    public void testClearedAfterRemove() throws Exception {
+    void testClearedAfterRemove() throws Exception {
         CurrentInstance.set(CurrentInstanceTest.class, this);
         assertEquals(this, CurrentInstance.get(CurrentInstanceTest.class));
         CurrentInstance.set(CurrentInstanceTest.class, null);
@@ -64,7 +64,7 @@ class CurrentInstanceTest {
     }
 
     @Test
-    public void testClearedWithClearAll() throws Exception {
+    void testClearedWithClearAll() throws Exception {
         CurrentInstance.set(CurrentInstanceTest.class, this);
         assertEquals(this, CurrentInstance.get(CurrentInstanceTest.class));
         CurrentInstance.clearAll();
@@ -103,7 +103,7 @@ class CurrentInstanceTest {
     }
 
     @Test
-    public void testRestoringNullUIWorks() throws Exception {
+    void testRestoringNullUIWorks() throws Exception {
         // First make sure current instance is empty
         CurrentInstance.clearAll();
 
@@ -117,7 +117,7 @@ class CurrentInstanceTest {
     }
 
     @Test
-    public void testRestoringNullSessionWorks() throws Exception {
+    void testRestoringNullSessionWorks() throws Exception {
         // First make sure current instance is empty
         CurrentInstance.clearAll();
 
@@ -133,8 +133,7 @@ class CurrentInstanceTest {
     }
 
     @Test
-    public void testRestoreWithGarbageCollectedValue()
-            throws InterruptedException {
+    void testRestoreWithGarbageCollectedValue() throws InterruptedException {
         VaadinSession session1 = new VaadinSession(
                 new MockVaadinServletService()) {
             @Override
@@ -166,7 +165,7 @@ class CurrentInstanceTest {
     }
 
     @Test
-    public void nonInheritableThreadLocals()
+    void nonInheritableThreadLocals()
             throws InterruptedException, ExecutionException {
         CurrentInstance.clearAll();
         CurrentInstance.set(CurrentInstanceTest.class, this);

--- a/flow-server/src/test/java/com/vaadin/flow/internal/CustomElementNameValidatorTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/CustomElementNameValidatorTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class CustomElementNameValidatorTest {
 
     @Test
-    public void testInvalidElementNames() {
+    void testInvalidElementNames() {
         Stream.of("", "foo", "annotation-xml", "0-foo", "-foo", "foo-$",
                 "foo-/", "FOO-BAR", "foo/", "øl-unicorn", "foo-💩",
                 "5th-element")
@@ -40,7 +40,7 @@ class CustomElementNameValidatorTest {
     }
 
     @Test
-    public void testValidNamesWithoutErrorOrWarning() {
+    void testValidNamesWithoutErrorOrWarning() {
         Stream.of("foo-bar", "custom-element", "date-field", "dos-box",
                 "home-4-good")
                 .forEach(name -> assertTrue(
@@ -51,7 +51,7 @@ class CustomElementNameValidatorTest {
     }
 
     @Test
-    public void testValidButWithWarning() {
+    void testValidButWithWarning() {
         Stream.of("polymer-", "x-", "ng-", "unicorn-", "unicorn-ø", "uni--corn",
                 "uni-----corn", "uni-co___rn", "uni-co.rn", "uni-corné",
                 "xml-unicorn", "não-tém", "foo-bår")

--- a/flow-server/src/test/java/com/vaadin/flow/internal/DevBundleUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/DevBundleUtilsTest.java
@@ -34,7 +34,7 @@ class DevBundleUtilsTest {
     Path temporaryFolder;
 
     @Test
-    public void compileDevBundle_uncompileDevBundle_filesHasSameHash()
+    void compileDevBundle_uncompileDevBundle_filesHasSameHash()
             throws IOException {
         File projectBase = temporaryFolder.toFile();
         File devFolder = new File(projectBase, "target/dev-bundle");

--- a/flow-server/src/test/java/com/vaadin/flow/internal/EncodeUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/EncodeUtilTest.java
@@ -25,21 +25,21 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class EncodeUtilTest {
 
     @Test
-    public void rfc5987Encode_withNull_nullPointerException() {
+    void rfc5987Encode_withNull_nullPointerException() {
         assertThrows(NullPointerException.class, () -> {
             EncodeUtil.rfc5987Encode(null);
         });
     }
 
     @Test
-    public void rfc2047Encode_withNull_nullPointerException() {
+    void rfc2047Encode_withNull_nullPointerException() {
         assertThrows(NullPointerException.class, () -> {
             EncodeUtil.rfc2047Encode(null);
         });
     }
 
     @Test
-    public void rfc5987Encode_asciiCharacters() {
+    void rfc5987Encode_asciiCharacters() {
         String input = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$&'*+-.^_`|~";
         assertEquals(
                 "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$&%27%2A+-.^_`|~",
@@ -48,7 +48,7 @@ class EncodeUtilTest {
 
     // UTF-8 Basic Latin & Controls
     @Test
-    public void rfc5987Encode_unicodeCharacters0to126() throws Exception {
+    void rfc5987Encode_unicodeCharacters0to126() throws Exception {
         StringBuilder text = new StringBuilder();
         for (int codePoint = 0; codePoint <= 126; codePoint++) {
             text.append(new String(new int[] { codePoint }, 0, 1));
@@ -60,19 +60,18 @@ class EncodeUtilTest {
 
     // UTF-8 Latin-1 Supplement
     @Test
-    public void rfc5987Encode_unicodeLatin1SupplementCharacters()
-            throws Exception {
+    void rfc5987Encode_unicodeLatin1SupplementCharacters() throws Exception {
         assertEquals("%E2%82%AC%20%C3%BF", EncodeUtil.rfc5987Encode("€ ÿ"));
     }
 
     // UTF-8 Latin Extended A
     @Test
-    public void rfc5987Encode_unicodeLatinExtendACharacters() throws Exception {
+    void rfc5987Encode_unicodeLatinExtendACharacters() throws Exception {
         assertEquals("%C4%80%C4%81", EncodeUtil.rfc5987Encode("Āā"));
     }
 
     @Test
-    public void rfc2047Encode_asciiCharacters() {
+    void rfc2047Encode_asciiCharacters() {
         String input = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$&'*+-.^_`|~ ?=\"";
         assertEquals(
                 "=?UTF-8?Q?abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$&'*+-.^=5F`|~_=3F=3D=22?=",
@@ -80,7 +79,7 @@ class EncodeUtilTest {
     }
 
     @Test
-    public void rfc2047Encode_nonAsciiCharacters() {
+    void rfc2047Encode_nonAsciiCharacters() {
         String input = "Řřüñîçødë 1中文 € ÿĀā";
         assertEquals(
                 "=?UTF-8?Q?=C5=98=C5=99=C3=BC=C3=B1=C3=AE=C3=A7=C3=B8d=C3=AB_1=E4=B8=AD=E6=96=87_=E2=82=AC_=C3=BF=C4=80=C4=81?=",
@@ -88,13 +87,13 @@ class EncodeUtilTest {
     }
 
     @Test
-    public void isPureUSASCII_withAsciiOnly_returnTrue() {
+    void isPureUSASCII_withAsciiOnly_returnTrue() {
         String input = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$&'*+-.^_`|~ ?=\"";
         assertTrue(EncodeUtil.isPureUSASCII(input));
     }
 
     @Test
-    public void isPureUSASCII_withNonAscii_returnFalse() {
+    void isPureUSASCII_withNonAscii_returnFalse() {
         String input = "Řřüñîçøë中文€ÿĀā";
         input.chars().forEach(c -> {
             assertFalse(EncodeUtil.isPureUSASCII(Character.toString((char) c)),

--- a/flow-server/src/test/java/com/vaadin/flow/internal/FileIOUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/FileIOUtilsTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 class FileIOUtilsTest {
 
     @Test
-    public void projectFolderOnWindows() throws Exception {
+    void projectFolderOnWindows() throws Exception {
         assumeTrue(OSUtils.isWindows());
 
         URL url = new URL(
@@ -42,7 +42,7 @@ class FileIOUtilsTest {
     }
 
     @Test
-    public void projectFolderOnMacOrLinux() throws Exception {
+    void projectFolderOnMacOrLinux() throws Exception {
         assumeFalse(OSUtils.isWindows());
 
         URL url = new URL(
@@ -52,7 +52,7 @@ class FileIOUtilsTest {
     }
 
     @Test
-    public void tempFilesAreTempFiles() {
+    void tempFilesAreTempFiles() {
         assertTrue(FileIOUtils.isProbablyTemporaryFile(new File("foo.txt~")));
         assertFalse(FileIOUtils.isProbablyTemporaryFile(new File("foo.txt")));
     }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
@@ -52,7 +52,7 @@ class JacksonCodecTest {
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
-    public void encodeWithoutTypeInfo_supportedTypes() {
+    void encodeWithoutTypeInfo_supportedTypes() {
         assertJsonEquals(objectMapper.valueToTree(true),
                 JacksonCodec.encodeWithoutTypeInfo(Boolean.TRUE));
         assertJsonEquals(objectMapper.valueToTree("string"),
@@ -84,7 +84,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void encodeWithoutTypeInfo_unsupportedTypes() {
+    void encodeWithoutTypeInfo_unsupportedTypes() {
         List<Object> unsupported = new ArrayList<>(complexTypeValues);
         unsupported.add(ElementFactory.createDiv());
 
@@ -103,7 +103,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void encodeWithTypeInfo_basicTypes() {
+    void encodeWithTypeInfo_basicTypes() {
         assertJsonEquals(objectMapper.valueToTree(true),
                 JacksonCodec.encodeWithTypeInfo(Boolean.TRUE));
         assertJsonEquals(objectMapper.nullNode(),
@@ -122,7 +122,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void encodeWithTypeInfo_attachedElement() {
+    void encodeWithTypeInfo_attachedElement() {
         Element element = ElementFactory.createDiv();
 
         StateTree tree = new StateTree(new UI().getInternals(),
@@ -140,7 +140,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void encodeWithTypeInfo_detachedElement() {
+    void encodeWithTypeInfo_detachedElement() {
         Element element = ElementFactory.createDiv();
 
         JsonNode json = JacksonCodec.encodeWithTypeInfo(element);
@@ -154,14 +154,14 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void decodeAs_booleanJson() {
+    void decodeAs_booleanJson() {
         JsonNode json = objectMapper.valueToTree(true);
         assertTrue(JacksonCodec.decodeAs(json, Boolean.class));
         assertEquals(json, JacksonCodec.decodeAs(json, JsonNode.class));
     }
 
     @Test
-    public void decodeAs_stringJson() {
+    void decodeAs_stringJson() {
         JsonNode json = objectMapper.valueToTree("Test123 String\n !%");
         assertEquals("Test123 String\n !%",
                 JacksonCodec.decodeAs(json, String.class));
@@ -169,7 +169,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void decodeAs_numberJson() {
+    void decodeAs_numberJson() {
         // Test integer
         JsonNode intJson = objectMapper.valueToTree(15);
         assertEquals(Integer.valueOf(15),
@@ -186,7 +186,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void decodeAs_nullJson() {
+    void decodeAs_nullJson() {
         JsonNode json = objectMapper.nullNode();
         assertNull(JacksonCodec.decodeAs(json, Boolean.class));
         assertNull(JacksonCodec.decodeAs(json, String.class));
@@ -196,14 +196,14 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void decodeAs_jsonValue() {
+    void decodeAs_jsonValue() {
         ObjectNode json = objectMapper.createObjectNode();
         json.put("foo", "bar");
         assertEquals(json, JacksonCodec.decodeAs(json, JsonNode.class));
     }
 
     @Test
-    public void decodeAs_jsonValueWrongType_classCastException() {
+    void decodeAs_jsonValueWrongType_classCastException() {
         ObjectNode json = objectMapper.createObjectNode();
         json.put("foo", "bar");
         assertThrows(ClassCastException.class,
@@ -211,7 +211,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void decodeAs_unsupportedType() {
+    void decodeAs_unsupportedType() {
         assertThrows(IllegalArgumentException.class, () -> {
             assertNull(JacksonCodec.decodeAs(objectMapper.valueToTree("foo"),
                     float.class));
@@ -219,7 +219,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void testSimpleBeanSerialization() {
+    void testSimpleBeanSerialization() {
         SimpleBean bean = new SimpleBean("Test", 42);
 
         JsonNode encoded = JacksonCodec.encodeWithTypeInfo(bean);
@@ -231,7 +231,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void testNestedBeanSerialization() {
+    void testNestedBeanSerialization() {
         NestedBean nested = new NestedBean("inner", 123);
         OuterBean outer = new OuterBean("outer", nested);
 
@@ -247,7 +247,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void testComplexTypeSerialization() {
+    void testComplexTypeSerialization() {
         // Test Object - should serialize as empty object
         Object obj = new Object();
         JsonNode objEncoded = JacksonCodec.encodeWithTypeInfo(obj);
@@ -379,7 +379,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void testDecodeAsSimpleBean() {
+    void testDecodeAsSimpleBean() {
         ObjectNode json = objectMapper.createObjectNode();
         json.put("text", "TestBean");
         json.put("value", 42);
@@ -391,7 +391,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void testDecodeAsNestedBean() {
+    void testDecodeAsNestedBean() {
         ObjectNode nestedJson = objectMapper.createObjectNode();
         nestedJson.put("text", "NestedTest");
         nestedJson.put("number", 456);
@@ -408,7 +408,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void testDecodeAsNullValue() {
+    void testDecodeAsNullValue() {
         JsonNode nullNode = objectMapper.nullNode();
 
         SimpleBean decoded = JacksonCodec.decodeAs(nullNode, SimpleBean.class);
@@ -416,7 +416,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void testDecodeAsInvalidJson() {
+    void testDecodeAsInvalidJson() {
         JsonNode invalidJson = objectMapper.valueToTree("not an object");
 
         try {
@@ -429,7 +429,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void testDecodeAsForPrimitiveTypes() {
+    void testDecodeAsForPrimitiveTypes() {
         assertEquals("test", JacksonCodec
                 .decodeAs(objectMapper.valueToTree("test"), String.class));
         assertEquals(Integer.valueOf(42), JacksonCodec
@@ -441,7 +441,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void testListOfBeansSerialization() {
+    void testListOfBeansSerialization() {
         List<SimpleBean> beanList = Arrays.asList(new SimpleBean("First", 1),
                 new SimpleBean("Second", 2), new SimpleBean("Third", 3));
 
@@ -460,7 +460,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void testListOfBeansDeserialization() {
+    void testListOfBeansDeserialization() {
         // Create JSON array manually
         ObjectNode bean1 = objectMapper.createObjectNode();
         bean1.put("text", "FirstBean");
@@ -486,7 +486,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void testSetOfBeansSerialization() {
+    void testSetOfBeansSerialization() {
         Set<SimpleBean> beanSet = new HashSet<>(Arrays.asList(
                 new SimpleBean("Alpha", 10), new SimpleBean("Beta", 20)));
 
@@ -511,7 +511,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void testSetOfBeansDeserialization() {
+    void testSetOfBeansDeserialization() {
         // Create JSON array manually
         ObjectNode bean1 = objectMapper.createObjectNode();
         bean1.put("text", "Gamma");
@@ -544,7 +544,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void testListOfIntegersSerialization() {
+    void testListOfIntegersSerialization() {
         List<Integer> integerList = List.of(1, 2, 3);
 
         JsonNode encoded = JacksonCodec.encodeWithTypeInfo(integerList);
@@ -558,7 +558,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void testMapOfBeansSerialization() {
+    void testMapOfBeansSerialization() {
         Map<String, SimpleBean> beanMap = new HashMap<>();
         beanMap.put("first", new SimpleBean("FirstBean", 100));
         beanMap.put("second", new SimpleBean("SecondBean", 200));
@@ -580,7 +580,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void testMapOfBeansDeserialization() {
+    void testMapOfBeansDeserialization() {
         // Create JSON object manually
         ObjectNode bean1 = objectMapper.createObjectNode();
         bean1.put("text", "Alpha");
@@ -610,7 +610,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void testNestedMapSerialization() {
+    void testNestedMapSerialization() {
         Map<String, Object> nestedMap = new HashMap<>();
         nestedMap.put("bean", new SimpleBean("NestedBean", 999));
         nestedMap.put("number", 42);
@@ -637,7 +637,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void testListOfComponentElementsSerialization() {
+    void testListOfComponentElementsSerialization() {
         // Create elements directly instead of through components to avoid
         // attachment issues
         Element element1 = ElementFactory.createDiv();
@@ -673,7 +673,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void testBeanWithComponentSerialization() {
+    void testBeanWithComponentSerialization() {
         TestComponent component = new TestComponent();
         BeanWithComponent bean = new BeanWithComponent("TestComponent",
                 component, 42);
@@ -697,7 +697,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void testArrayWithComponentsSerialization() {
+    void testArrayWithComponentsSerialization() {
         TestComponent component1 = new TestComponent();
         TestComponent component2 = new TestComponent();
 
@@ -718,7 +718,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void testListOfBeansWithComponentsSerialization() {
+    void testListOfBeansWithComponentsSerialization() {
         TestComponent component1 = new TestComponent();
         TestComponent component2 = new TestComponent();
 
@@ -775,7 +775,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void testTypeReferenceListDeserialization() {
+    void testTypeReferenceListDeserialization() {
         // Create JSON array with bean objects
         ObjectNode bean1 = objectMapper.createObjectNode();
         bean1.put("text", "FirstBean");
@@ -802,7 +802,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void testTypeReferenceMapDeserialization() {
+    void testTypeReferenceMapDeserialization() {
         // Create JSON object with bean values
         ObjectNode bean1 = objectMapper.createObjectNode();
         bean1.put("text", "Alpha");
@@ -831,7 +831,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void testTypeReferenceNestedList() {
+    void testTypeReferenceNestedList() {
         // Create nested structure: List<Map<String, SimpleBean>>
         ObjectNode innerBean = objectMapper.createObjectNode();
         innerBean.put("text", "Nested");
@@ -857,7 +857,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void testTypeReferenceNullHandling() {
+    void testTypeReferenceNullHandling() {
         JsonNode nullJson = objectMapper.nullNode();
 
         TypeReference<List<SimpleBean>> typeRef = new TypeReference<List<SimpleBean>>() {
@@ -868,7 +868,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void testTypeReferenceListOfPrimitives() {
+    void testTypeReferenceListOfPrimitives() {
         JsonNode arrayJson = objectMapper.createArrayNode().add(10).add(20)
                 .add(30);
 
@@ -884,7 +884,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void testNestedRecordDeserialization() {
+    void testNestedRecordDeserialization() {
         // Test that nested records work for event data pattern
         record EventDetails(int button, int clientX, int clientY) {
         }
@@ -914,7 +914,7 @@ class JacksonCodecTest {
     }
 
     @Test
-    public void testNestedRecordWithTypeReference() {
+    void testNestedRecordWithTypeReference() {
         // Test List<Record> deserialization
         record Point(int x, int y) {
         }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/JacksonSerializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/JacksonSerializerTest.java
@@ -307,7 +307,7 @@ class JacksonSerializerTest {
     }
 
     @Test
-    public void serializeBasicTypes_returnJsonBasicTypes() {
+    void serializeBasicTypes_returnJsonBasicTypes() {
         JsonNode json = JacksonSerializer.toJson("someString");
         assertTrue(json instanceof StringNode,
                 "The JsonNode should be instanceof JsonString");
@@ -355,14 +355,14 @@ class JacksonSerializerTest {
     }
 
     @Test
-    public void serializeNull_returnNull() {
+    void serializeNull_returnNull() {
         JsonNode json = JacksonSerializer.toJson((Object) null);
         assertTrue(json instanceof NullNode,
                 "The JsonNode should be instanceof JsonNull");
     }
 
     @Test
-    public void serializeEmptyObjectWithBasicTypes_returnJsonObjectWithEmptyProperties() {
+    void serializeEmptyObjectWithBasicTypes_returnJsonObjectWithEmptyProperties() {
         ObjectWithSimpleTypes bean = new ObjectWithSimpleTypes();
         JsonNode json = JacksonSerializer.toJson(bean);
         assertTrue(json instanceof ObjectNode,
@@ -410,7 +410,7 @@ class JacksonSerializerTest {
     }
 
     @Test
-    public void serializePopulatedObjectWithBasicTypes_returnJsonObjectWithDefinedProperties() {
+    void serializePopulatedObjectWithBasicTypes_returnJsonObjectWithDefinedProperties() {
         ObjectWithSimpleTypes bean = getPopulatedObjectWithSimpleTypes();
 
         JsonNode json = JacksonSerializer.toJson(bean);
@@ -463,7 +463,7 @@ class JacksonSerializerTest {
     }
 
     @Test
-    public void serializeEmptyObjectWithObjects_returnJsonObjectWithNullProperties() {
+    void serializeEmptyObjectWithObjects_returnJsonObjectWithNullProperties() {
         ObjectWithOtherObjects bean = new ObjectWithOtherObjects();
 
         JsonNode json = JacksonSerializer.toJson(bean);
@@ -488,7 +488,7 @@ class JacksonSerializerTest {
     }
 
     @Test
-    public void serializeObjectWithObjects_returnJsonObjectWithPopulatedProperties() {
+    void serializeObjectWithObjects_returnJsonObjectWithPopulatedProperties() {
         ObjectWithOtherObjects bean = new ObjectWithOtherObjects();
         ObjectWithSimpleTypes innerBean = getPopulatedObjectWithSimpleTypes();
         bean.setObject1(innerBean);
@@ -582,7 +582,7 @@ class JacksonSerializerTest {
     }
 
     @Test
-    public void serializeEmptyRecursiveObject_returnJsonObjectWithNullProperties() {
+    void serializeEmptyRecursiveObject_returnJsonObjectWithNullProperties() {
         RecursiveObject bean = new RecursiveObject();
 
         JsonNode json = JacksonSerializer.toJson(bean);
@@ -603,7 +603,7 @@ class JacksonSerializerTest {
     }
 
     @Test
-    public void serializePopulatedRecursiveObject_returnJsonObjectWithPopulatedProperties() {
+    void serializePopulatedRecursiveObject_returnJsonObjectWithPopulatedProperties() {
         final int recursions = 10;
         RecursiveObject bean = createRecusiveObject(recursions, 0);
 
@@ -630,7 +630,7 @@ class JacksonSerializerTest {
     }
 
     @Test
-    public void serializeEmptyObjectWithBasicCollections_returnJsonObjectWithNullProperties() {
+    void serializeEmptyObjectWithBasicCollections_returnJsonObjectWithNullProperties() {
         ObjectWithBasicCollections bean = new ObjectWithBasicCollections();
 
         /*
@@ -668,7 +668,7 @@ class JacksonSerializerTest {
     }
 
     @Test
-    public void serializeObjectWithCollections_returnJsonObjectWithPopulatedProperties() {
+    void serializeObjectWithCollections_returnJsonObjectWithPopulatedProperties() {
         ObjectWithBasicCollections bean = new ObjectWithBasicCollections();
 
         bean.setListOfStrings(Arrays.asList("string1", "string2"));
@@ -719,7 +719,7 @@ class JacksonSerializerTest {
     }
 
     @Test
-    public void serializeRecordWithRecordAndObject_returnJsonObjectWithPopulatedProperties() {
+    void serializeRecordWithRecordAndObject_returnJsonObjectWithPopulatedProperties() {
         SomeRecord record = new SomeRecord("someone", 42);
         ObjectWithSimpleTypes bean = getPopulatedObjectWithSimpleTypes();
         RecordWithRecordAndObject mainRecord = new RecordWithRecordAndObject(

--- a/flow-server/src/test/java/com/vaadin/flow/internal/LocaleUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/LocaleUtilTest.java
@@ -43,7 +43,7 @@ class LocaleUtilTest {
     VaadinRequest request;
 
     @BeforeEach
-    public void init() {
+    void init() {
         MockitoAnnotations.initMocks(this);
 
         // request locales are returned as Enumeration
@@ -53,7 +53,7 @@ class LocaleUtilTest {
     }
 
     @Test
-    public void exact_match_provided_matches() {
+    void exact_match_provided_matches() {
         Optional<Locale> exactLocaleMatch = LocaleUtil.getExactLocaleMatch(
                 request, Arrays.asList(Locale.ENGLISH, LOCALE_EN));
 
@@ -62,7 +62,7 @@ class LocaleUtilTest {
     }
 
     @Test
-    public void no_exact_match_returns_null() {
+    void no_exact_match_returns_null() {
         Optional<Locale> exactLocaleMatch = LocaleUtil
                 .getExactLocaleMatch(request, Arrays.asList(Locale.ENGLISH));
 
@@ -71,7 +71,7 @@ class LocaleUtilTest {
     }
 
     @Test
-    public void language_match_gets_correct_target_by_request_priority() {
+    void language_match_gets_correct_target_by_request_priority() {
         Optional<Locale> exactLocaleMatch = LocaleUtil.getLocaleMatchByLanguage(
                 request, Arrays.asList(Locale.US, LOCALE_FI));
 
@@ -80,7 +80,7 @@ class LocaleUtilTest {
     }
 
     @Test
-    public void language_match_returns_null_when_no_match() {
+    void language_match_returns_null_when_no_match() {
         Optional<Locale> exactLocaleMatch = LocaleUtil.getLocaleMatchByLanguage(
                 request, Arrays.asList(Locale.FRENCH, Locale.KOREA));
 

--- a/flow-server/src/test/java/com/vaadin/flow/internal/RangeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/RangeTest.java
@@ -25,21 +25,21 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class RangeTest {
 
     @Test
-    public void startAfterEndTest() {
+    void startAfterEndTest() {
         assertThrows(IllegalArgumentException.class, () -> {
             Range.between(10, 9);
         });
     }
 
     @Test
-    public void negativeLengthTest() {
+    void negativeLengthTest() {
         assertThrows(IllegalArgumentException.class, () -> {
             Range.withLength(10, -1);
         });
     }
 
     @Test
-    public void constructorEquivalenceTest() {
+    void constructorEquivalenceTest() {
         assertEquals(Range.withOnly(10), Range.between(10, 11),
                 "10 == [10,11[");
         assertEquals(Range.between(10, 20), Range.withLength(10, 10),
@@ -49,7 +49,7 @@ class RangeTest {
     }
 
     @Test
-    public void boundsTest() {
+    void boundsTest() {
         {
             final Range range = Range.between(0, 10);
             assertEquals(0, range.getStart(), "between(0, 10) start");
@@ -71,7 +71,7 @@ class RangeTest {
 
     @Test
     @SuppressWarnings("boxing")
-    public void equalsTest() {
+    void equalsTest() {
         final Range range1 = Range.between(0, 10);
         final Range range2 = Range.withLength(0, 11);
 
@@ -81,7 +81,7 @@ class RangeTest {
     }
 
     @Test
-    public void containsTest() {
+    void containsTest() {
         final int start = 0;
         final int end = 10;
         final Range range = Range.between(start, end);
@@ -98,7 +98,7 @@ class RangeTest {
     }
 
     @Test
-    public void emptyTest() {
+    void emptyTest() {
         assertTrue(Range.between(0, 0).isEmpty(), "[0..0[ should be empty");
         assertTrue(Range.withLength(0, 0).isEmpty(),
                 "Range of length 0 should be empty");
@@ -110,7 +110,7 @@ class RangeTest {
     }
 
     @Test
-    public void splitTest() {
+    void splitTest() {
         final Range startRange = Range.between(0, 10);
         final Range[] splitRanges = startRange.splitAt(5);
         assertEquals(Range.between(0, 5), splitRanges[0],
@@ -120,7 +120,7 @@ class RangeTest {
     }
 
     @Test
-    public void split_valueBefore() {
+    void split_valueBefore() {
         Range range = Range.between(10, 20);
         Range[] splitRanges = range.splitAt(5);
 
@@ -129,7 +129,7 @@ class RangeTest {
     }
 
     @Test
-    public void split_valueAfter() {
+    void split_valueAfter() {
         Range range = Range.between(10, 20);
         Range[] splitRanges = range.splitAt(25);
 
@@ -138,7 +138,7 @@ class RangeTest {
     }
 
     @Test
-    public void emptySplitTest() {
+    void emptySplitTest() {
         final Range range = Range.between(5, 10);
         final Range[] split1 = range.splitAt(0);
         assertTrue(split1[0].isEmpty(), "split1, [0]");
@@ -150,14 +150,14 @@ class RangeTest {
     }
 
     @Test
-    public void lengthTest() {
+    void lengthTest() {
         assertEquals(5, Range.withLength(10, 5).length(), "withLength length");
         assertEquals(5, Range.between(10, 15).length(), "between length");
         assertEquals(1, Range.withOnly(10).length(), "withOnly 10 length");
     }
 
     @Test
-    public void intersectsTest() {
+    void intersectsTest() {
         assertTrue(Range.between(0, 10).intersects(Range.between(5, 15)),
                 "[0..10[ intersects [5..15[");
         assertTrue(!Range.between(0, 10).intersects(Range.between(10, 20)),
@@ -165,7 +165,7 @@ class RangeTest {
     }
 
     @Test
-    public void intersects_emptyInside() {
+    void intersects_emptyInside() {
         assertTrue(Range.between(5, 5).intersects(Range.between(0, 10)),
                 "[5..5[ does intersect with [0..10[");
         assertTrue(Range.between(0, 10).intersects(Range.between(5, 5)),
@@ -173,7 +173,7 @@ class RangeTest {
     }
 
     @Test
-    public void intersects_emptyOutside() {
+    void intersects_emptyOutside() {
         assertTrue(!Range.between(15, 15).intersects(Range.between(0, 10)),
                 "[15..15[ does not intersect with [0..10[");
         assertTrue(!Range.between(0, 10).intersects(Range.between(15, 15)),
@@ -181,7 +181,7 @@ class RangeTest {
     }
 
     @Test
-    public void subsetTest() {
+    void subsetTest() {
         assertTrue(Range.between(5, 10).isSubsetOf(Range.between(0, 20)),
                 "[5..10[ is subset of [0..20[");
 
@@ -193,12 +193,12 @@ class RangeTest {
     }
 
     @Test
-    public void offsetTest() {
+    void offsetTest() {
         assertEquals(Range.between(5, 15), Range.between(0, 10).offsetBy(5));
     }
 
     @Test
-    public void rangeStartsBeforeTest() {
+    void rangeStartsBeforeTest() {
         final Range former = Range.between(0, 5);
         final Range latter = Range.between(1, 5);
         assertTrue(former.startsBefore(latter),
@@ -211,7 +211,7 @@ class RangeTest {
     }
 
     @Test
-    public void rangeStartsAfterTest() {
+    void rangeStartsAfterTest() {
         final Range former = Range.between(0, 5);
         final Range latter = Range.between(5, 10);
         assertTrue(latter.startsAfter(former),
@@ -224,7 +224,7 @@ class RangeTest {
     }
 
     @Test
-    public void rangeEndsBeforeTest() {
+    void rangeEndsBeforeTest() {
         final Range former = Range.between(0, 5);
         final Range latter = Range.between(5, 10);
         assertTrue(former.endsBefore(latter),
@@ -237,7 +237,7 @@ class RangeTest {
     }
 
     @Test
-    public void rangeEndsAfterTest() {
+    void rangeEndsAfterTest() {
         final Range former = Range.between(1, 5);
         final Range latter = Range.between(1, 6);
         assertTrue(latter.endsAfter(former), "latter should end after former");
@@ -249,35 +249,35 @@ class RangeTest {
     }
 
     @Test
-    public void combine_notOverlappingFirstSmaller() {
+    void combine_notOverlappingFirstSmaller() {
         Range r1 = Range.between(0, 10);
         Range r2 = Range.between(11, 20);
         assertThrows(IllegalArgumentException.class, () -> r1.combineWith(r2));
     }
 
     @Test
-    public void combine_notOverlappingSecondLarger() {
+    void combine_notOverlappingSecondLarger() {
         Range r1 = Range.between(11, 20);
         Range r2 = Range.between(0, 10);
         assertThrows(IllegalArgumentException.class, () -> r1.combineWith(r2));
     }
 
     @Test
-    public void combine_firstEmptyNotOverlapping() {
+    void combine_firstEmptyNotOverlapping() {
         Range r1 = Range.between(15, 15);
         Range r2 = Range.between(0, 10);
         assertThrows(IllegalArgumentException.class, () -> r1.combineWith(r2));
     }
 
     @Test
-    public void combine_secondEmptyNotOverlapping() {
+    void combine_secondEmptyNotOverlapping() {
         Range r1 = Range.between(0, 10);
         Range r2 = Range.between(15, 15);
         assertThrows(IllegalArgumentException.class, () -> r1.combineWith(r2));
     }
 
     @Test
-    public void combine_barelyOverlapping() {
+    void combine_barelyOverlapping() {
         Range r1 = Range.between(0, 10);
         Range r2 = Range.between(10, 20);
 
@@ -291,7 +291,7 @@ class RangeTest {
     }
 
     @Test
-    public void combine_subRange() {
+    void combine_subRange() {
         Range r1 = Range.between(0, 10);
         Range r2 = Range.between(2, 8);
 
@@ -304,7 +304,7 @@ class RangeTest {
     }
 
     @Test
-    public void combine_intersecting() {
+    void combine_intersecting() {
         Range r1 = Range.between(0, 10);
         Range r2 = Range.between(5, 15);
 
@@ -319,7 +319,7 @@ class RangeTest {
     }
 
     @Test
-    public void combine_emptyInside() {
+    void combine_emptyInside() {
         Range r1 = Range.between(0, 10);
         Range r2 = Range.between(5, 5);
 
@@ -332,7 +332,7 @@ class RangeTest {
     }
 
     @Test
-    public void expand_basic() {
+    void expand_basic() {
         Range r1 = Range.between(5, 10);
         Range r2 = r1.expand(2, 3);
 
@@ -340,7 +340,7 @@ class RangeTest {
     }
 
     @Test
-    public void expand_negativeLegal() {
+    void expand_negativeLegal() {
         Range r1 = Range.between(5, 10);
 
         Range r2 = r1.expand(-2, -2);
@@ -354,21 +354,21 @@ class RangeTest {
     }
 
     @Test
-    public void expand_negativeIllegal1() {
+    void expand_negativeIllegal1() {
         Range r1 = Range.between(5, 10);
         // Should throw because the start would contract beyond the end
         assertThrows(IllegalArgumentException.class, () -> r1.expand(-3, -3));
     }
 
     @Test
-    public void expand_negativeIllegal2() {
+    void expand_negativeIllegal2() {
         Range r1 = Range.between(5, 10);
         // Should throw because the end would contract beyond the start
         assertThrows(IllegalArgumentException.class, () -> r1.expand(3, -9));
     }
 
     @Test
-    public void restrictTo_fullyInside() {
+    void restrictTo_fullyInside() {
         Range r1 = Range.between(5, 10);
         Range r2 = Range.between(4, 11);
 
@@ -377,7 +377,7 @@ class RangeTest {
     }
 
     @Test
-    public void restrictTo_fullyOutside() {
+    void restrictTo_fullyOutside() {
         Range r1 = Range.between(4, 11);
         Range r2 = Range.between(5, 10);
 
@@ -386,7 +386,7 @@ class RangeTest {
     }
 
     @Test
-    public void restrictTo_notInterstecting() {
+    void restrictTo_notInterstecting() {
         Range r1 = Range.between(5, 10);
         Range r2 = Range.between(15, 20);
 
@@ -400,7 +400,7 @@ class RangeTest {
     }
 
     @Test
-    public void restrictTo_startOutside() {
+    void restrictTo_startOutside() {
         Range r1 = Range.between(5, 10);
         Range r2 = Range.between(7, 15);
 
@@ -412,7 +412,7 @@ class RangeTest {
     }
 
     @Test
-    public void restrictTo_endOutside() {
+    void restrictTo_endOutside() {
         Range r1 = Range.between(5, 10);
         Range r2 = Range.between(4, 7);
 
@@ -424,7 +424,7 @@ class RangeTest {
     }
 
     @Test
-    public void restrictTo_empty() {
+    void restrictTo_empty() {
         Range r1 = Range.between(5, 10);
         Range r2 = Range.between(0, 0);
 

--- a/flow-server/src/test/java/com/vaadin/flow/internal/ReflectToolsGetFieldValueByTypeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/ReflectToolsGetFieldValueByTypeTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 class ReflectToolsGetFieldValueByTypeTest {
     @Test
-    public void getFieldValue() {
+    void getFieldValue() {
         class MyClass {
             @SuppressWarnings("unused")
             public Integer getField() {
@@ -57,7 +57,7 @@ class ReflectToolsGetFieldValueByTypeTest {
     }
 
     @Test
-    public void getFieldValueViaGetter() {
+    void getFieldValueViaGetter() {
         class MyClass {
             @SuppressWarnings("unused")
             public Integer field = 1;

--- a/flow-server/src/test/java/com/vaadin/flow/internal/ReflectToolsGetPrimitiveFieldValueTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/ReflectToolsGetPrimitiveFieldValueTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class ReflectToolsGetPrimitiveFieldValueTest {
     @Test
-    public void getFieldValueViaGetter() {
+    void getFieldValueViaGetter() {
         class MyClass {
             @SuppressWarnings("unused")
             public int field = 1;

--- a/flow-server/src/test/java/com/vaadin/flow/internal/ReflectToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/ReflectToolsTest.java
@@ -129,7 +129,7 @@ class ReflectToolsTest {
     }
 
     @Test
-    public void testCreateInstance() {
+    void testCreateInstance() {
         OkToCreate instance = ReflectTools.createInstance(OkToCreate.class);
 
         assertNotNull(instance);
@@ -138,7 +138,7 @@ class ReflectToolsTest {
     }
 
     @Test
-    public void testCreateInstance_varArgsCtor() {
+    void testCreateInstance_varArgsCtor() {
         VarArgsCtor instance = ReflectTools.createInstance(VarArgsCtor.class);
 
         assertNotNull(instance);
@@ -147,42 +147,42 @@ class ReflectToolsTest {
     }
 
     @Test
-    public void createNonStaticInnerClass() {
+    void createNonStaticInnerClass() {
         assertError(
                 ReflectTools.CREATE_INSTANCE_FAILED_FOR_NON_STATIC_MEMBER_CLASS,
                 NonStaticInnerClass.class);
     }
 
     @Test
-    public void createPrivateInnerClass() {
+    void createPrivateInnerClass() {
         assertError(
                 ReflectTools.CREATE_INSTANCE_FAILED_FOR_NON_STATIC_MEMBER_CLASS,
                 PrivateInnerClass.class);
     }
 
     @Test
-    public void createStaticInnerPrivateConstructorClass() {
+    void createStaticInnerPrivateConstructorClass() {
         assertError(
                 ReflectTools.CREATE_INSTANCE_FAILED_NO_PUBLIC_NOARG_CONSTRUCTOR,
                 StaticInnerPrivateConstructorClass.class);
     }
 
     @Test
-    public void createStaticInnerConstructorNeedsParamsClass() {
+    void createStaticInnerConstructorNeedsParamsClass() {
         assertError(
                 ReflectTools.CREATE_INSTANCE_FAILED_NO_PUBLIC_NOARG_CONSTRUCTOR,
                 StaticInnerConstructorNeedsParamsClass.class);
     }
 
     @Test
-    public void createConstructorThrowsExceptionClass() {
+    void createConstructorThrowsExceptionClass() {
         assertError(
                 ReflectTools.CREATE_INSTANCE_FAILED_CONSTRUCTOR_THREW_EXCEPTION,
                 ConstructorThrowsExceptionClass.class);
     }
 
     @Test
-    public void localClass() {
+    void localClass() {
         class LocalClass {
         }
         assertError(ReflectTools.CREATE_INSTANCE_FAILED_LOCAL_CLASS,
@@ -190,7 +190,7 @@ class ReflectToolsTest {
     }
 
     @Test
-    public void createProxyForNonStaticInnerClass() {
+    void createProxyForNonStaticInnerClass() {
         Class<NonStaticInnerClass> originalClass = NonStaticInnerClass.class;
         Class<?> proxyClass = createProxyClass(originalClass);
 
@@ -277,7 +277,7 @@ class ReflectToolsTest {
     }
 
     @Test
-    public void getGenericInterfaceClass() {
+    void getGenericInterfaceClass() {
         Class<?> genericInterfaceType = ReflectTools.getGenericInterfaceType(
                 HasInterface.class, TestInterface.class);
 
@@ -290,7 +290,7 @@ class ReflectToolsTest {
     }
 
     @Test
-    public void getGenericInterfaceClasses() {
+    void getGenericInterfaceClasses() {
 
         List<Class<?>> genericInterfaceTypes = ReflectTools
                 .getGenericInterfaceTypes(HasInterface.class,
@@ -323,37 +323,37 @@ class ReflectToolsTest {
     }
 
     @Test
-    public void findCommonBaseType_sameType() {
+    void findCommonBaseType_sameType() {
         assertSame(Number.class,
                 ReflectTools.findCommonBaseType(Number.class, Number.class));
     }
 
     @Test
-    public void findCommonBaseType_aExtendsB() {
+    void findCommonBaseType_aExtendsB() {
         assertSame(Number.class,
                 ReflectTools.findCommonBaseType(Integer.class, Number.class));
     }
 
     @Test
-    public void findCommonBaseType_bExtendsA() {
+    void findCommonBaseType_bExtendsA() {
         assertSame(Number.class,
                 ReflectTools.findCommonBaseType(Number.class, Integer.class));
     }
 
     @Test
-    public void findCommonBaseType_commonBase() {
+    void findCommonBaseType_commonBase() {
         assertSame(Number.class,
                 ReflectTools.findCommonBaseType(Double.class, Integer.class));
     }
 
     @Test
-    public void findCommonBaseType_noCommonBase() {
+    void findCommonBaseType_noCommonBase() {
         assertSame(Object.class,
                 ReflectTools.findCommonBaseType(String.class, Number.class));
     }
 
     @Test
-    public void findCommonBaseType_interfaceNotSupported() {
+    void findCommonBaseType_interfaceNotSupported() {
         var exception = assertThrows(IllegalArgumentException.class,
                 () -> ReflectTools.findCommonBaseType(Comparable.class,
                         Object.class));
@@ -362,7 +362,7 @@ class ReflectToolsTest {
     }
 
     @Test
-    public void findCommonBaseType_primitiveNotSupported() {
+    void findCommonBaseType_primitiveNotSupported() {
         var exception = assertThrows(IllegalArgumentException.class,
                 () -> ReflectTools.findCommonBaseType(int.class, Object.class));
 
@@ -371,7 +371,7 @@ class ReflectToolsTest {
     }
 
     @Test
-    public void getSetters_classIsGeneric_syntheticMethodsAreFilteredOut() {
+    void getSetters_classIsGeneric_syntheticMethodsAreFilteredOut() {
         List<Method> setters = ReflectTools.getSetterMethods(Category.class)
                 .collect(Collectors.toList());
         assertEquals(1, setters.size());
@@ -381,7 +381,7 @@ class ReflectToolsTest {
     }
 
     @Test
-    public void findClosestCommonClassLoaderAncestor_findAncestor_whenBothArgumentsAreTheSame() {
+    void findClosestCommonClassLoaderAncestor_findAncestor_whenBothArgumentsAreTheSame() {
         CustomClassLoader loader = new CustomClassLoader();
         ClassLoader ret = ReflectTools
                 .findClosestCommonClassLoaderAncestor(loader, loader).get();
@@ -400,7 +400,7 @@ class ReflectToolsTest {
     }
 
     @Test
-    public void findClosestCommonClassLoaderAncestor_findsAncestor_whenOneIsParentOfTheOther() {
+    void findClosestCommonClassLoaderAncestor_findsAncestor_whenOneIsParentOfTheOther() {
         CustomClassLoader parent = new CustomClassLoader();
         CustomClassLoader child = new CustomClassLoader(parent);
         ClassLoader ret = ReflectTools
@@ -410,7 +410,7 @@ class ReflectToolsTest {
     }
 
     @Test
-    public void findClosestCommonClassLoaderAncestor_findsAncestor_whenLoadersShareParent() {
+    void findClosestCommonClassLoaderAncestor_findsAncestor_whenLoadersShareParent() {
         CustomClassLoader parent = new CustomClassLoader();
         CustomClassLoader childA = new CustomClassLoader(parent);
         CustomClassLoader childB = new CustomClassLoader(parent);
@@ -421,7 +421,7 @@ class ReflectToolsTest {
     }
 
     @Test
-    public void findClosestCommonClassLoaderAncestor_findsAncestor_whenAncestorsAreOnDifferentLevels() {
+    void findClosestCommonClassLoaderAncestor_findsAncestor_whenAncestorsAreOnDifferentLevels() {
         CustomClassLoader grandParent = new CustomClassLoader();
         CustomClassLoader parent = new CustomClassLoader(grandParent);
         CustomClassLoader childA = new CustomClassLoader(parent);
@@ -434,7 +434,7 @@ class ReflectToolsTest {
     }
 
     @Test
-    public void findClosestCommonClassLoaderAncestor_empty_whenEitherOrBothNull() {
+    void findClosestCommonClassLoaderAncestor_empty_whenEitherOrBothNull() {
         CustomClassLoader loader = new CustomClassLoader();
 
         Optional<ClassLoader> ret;
@@ -450,40 +450,40 @@ class ReflectToolsTest {
     }
 
     @Test
-    public void hasAnnotation_annotationPresents_returnsTrue() {
+    void hasAnnotation_annotationPresents_returnsTrue() {
         assertTrue(ReflectTools.hasAnnotation(ClassWithAnnotation.class,
                 TestAnnotation.class.getName()));
     }
 
     @Test
-    public void hasAnnotation_annotationIsAbsent_returnsFalse() {
+    void hasAnnotation_annotationIsAbsent_returnsFalse() {
         assertFalse(ReflectTools.hasAnnotation(ClassWithoutAnnotation.class,
                 TestAnnotation.class.getName()));
     }
 
     @Test
-    public void hasAnnotationWithSimpleName_annotationPresents_returnsTrue() {
+    void hasAnnotationWithSimpleName_annotationPresents_returnsTrue() {
         assertTrue(ReflectTools.hasAnnotationWithSimpleName(
                 ClassWithAnnotation.class,
                 TestAnnotation.class.getSimpleName()));
     }
 
     @Test
-    public void hasAnnotationWithSimpleName_annotationIsAbsent_returnsFalse() {
+    void hasAnnotationWithSimpleName_annotationIsAbsent_returnsFalse() {
         assertFalse(ReflectTools.hasAnnotationWithSimpleName(
                 ClassWithoutAnnotation.class,
                 TestAnnotation.class.getSimpleName()));
     }
 
     @Test
-    public void getAnnotationMethodValue_annotaitonHasMethod_theValueIsReturned() {
+    void getAnnotationMethodValue_annotaitonHasMethod_theValueIsReturned() {
         assertEquals("foo", ReflectTools.getAnnotationMethodValue(
                 ClassWithAnnotation.class.getAnnotation(TestAnnotation.class),
                 "value"));
     }
 
     @Test
-    public void getAnnotationMethodValue_annotationHasNoMethod_throws() {
+    void getAnnotationMethodValue_annotationHasNoMethod_throws() {
         assertThrows(IllegalArgumentException.class, () -> {
             ReflectTools.getAnnotationMethodValue(ClassWithAnnotation.class
                     .getAnnotation(TestAnnotation.class), "foo");
@@ -491,7 +491,7 @@ class ReflectToolsTest {
     }
 
     @Test
-    public void getAnnotation_annotationPresents_returnsAnnotation() {
+    void getAnnotation_annotationPresents_returnsAnnotation() {
         Optional<Annotation> annotation = ReflectTools.getAnnotation(
                 ClassWithAnnotation.class, TestAnnotation.class.getName());
         assertTrue(annotation.isPresent());
@@ -501,25 +501,25 @@ class ReflectToolsTest {
     }
 
     @Test
-    public void getAnnotation_annotationIsAbsent_returnsEmpty() {
+    void getAnnotation_annotationIsAbsent_returnsEmpty() {
         Optional<Annotation> annotation = ReflectTools.getAnnotation(
                 ClassWithoutAnnotation.class, TestAnnotation.class.getName());
         assertFalse(annotation.isPresent());
     }
 
     @Test
-    public void intefaceShouldNotBeInstantiableService() {
+    void intefaceShouldNotBeInstantiableService() {
         assertFalse(ReflectTools.isInstantiableService(TestInterface.class));
     }
 
     @Test
-    public void abstractClassShouldNotBeInstantiableService() {
+    void abstractClassShouldNotBeInstantiableService() {
         assertFalse(
                 ReflectTools.isInstantiableService(TestAbstractClass.class));
     }
 
     @Test
-    public void nonPublicClassShouldNotBeInstantiableService() {
+    void nonPublicClassShouldNotBeInstantiableService() {
         assertFalse(
                 ReflectTools.isInstantiableService(TestProtectedClass.class));
         assertFalse(ReflectTools
@@ -528,25 +528,25 @@ class ReflectToolsTest {
     }
 
     @Test
-    public void ClassWithoutNonArgConstructorShouldNotBeInstantiableService() {
+    void ClassWithoutNonArgConstructorShouldNotBeInstantiableService() {
         assertFalse(ReflectTools
                 .isInstantiableService(TestNoNonArgConstructorClass.class));
     }
 
     @Test
-    public void nonStaticInnerClassShouldNotBeInstantiableService() {
+    void nonStaticInnerClassShouldNotBeInstantiableService() {
         assertFalse(
                 ReflectTools.isInstantiableService(NonStaticInnerClass.class));
     }
 
     @Test
-    public void privateInnerClassShouldNotBeInstantiableService() {
+    void privateInnerClassShouldNotBeInstantiableService() {
         assertFalse(
                 ReflectTools.isInstantiableService(PrivateInnerClass.class));
     }
 
     @Test
-    public void normalSericieShouldBeInstantiableService() {
+    void normalSericieShouldBeInstantiableService() {
         assertTrue(ReflectTools.isInstantiableService(NormalService.class));
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/internal/ReflectionCacheTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/ReflectionCacheTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ReflectionCacheTest {
 
     @Test
-    public void generateCachedValues() {
+    void generateCachedValues() {
         AtomicInteger count = new AtomicInteger();
 
         ReflectionCache<Object, Integer> cache = new ReflectionCache<>(
@@ -46,7 +46,7 @@ class ReflectionCacheTest {
     }
 
     @Test
-    public void cacheContains() {
+    void cacheContains() {
         ReflectionCache<Object, Object> cache = new ReflectionCache<>(
                 type -> type);
 
@@ -58,7 +58,7 @@ class ReflectionCacheTest {
     }
 
     @Test
-    public void cacheClear() {
+    void cacheClear() {
         ReflectionCache<Object, Object> cache = new ReflectionCache<>(
                 type -> type);
 
@@ -70,7 +70,7 @@ class ReflectionCacheTest {
     }
 
     @Test
-    public void cacheClearEntry() {
+    void cacheClearEntry() {
         ReflectionCache<Number, Object> cache = new ReflectionCache<>(
                 type -> type);
 
@@ -99,7 +99,7 @@ class ReflectionCacheTest {
     }
 
     @Test
-    public void clearAll() {
+    void clearAll() {
         ReflectionCache<Object, Object> cache1 = new ReflectionCache<>(
                 type -> type);
         ReflectionCache<Object, Object> cache2 = new ReflectionCache<>(
@@ -115,7 +115,7 @@ class ReflectionCacheTest {
     }
 
     @Test
-    public void clearAllForGivenType() {
+    void clearAllForGivenType() {
         ReflectionCache<Number, Object> cache1 = new ReflectionCache<>(
                 type -> type);
 
@@ -141,7 +141,7 @@ class ReflectionCacheTest {
     }
 
     @Test
-    public void cacheIsGarbageCollected() throws InterruptedException {
+    void cacheIsGarbageCollected() throws InterruptedException {
         ReflectionCache<Object, Object> cache1 = new ReflectionCache<>(
                 type -> type);
         WeakReference<ReflectionCache<Object, Object>> ref = new WeakReference<>(
@@ -152,7 +152,7 @@ class ReflectionCacheTest {
     }
 
     @Test
-    public void cacheIsClearedAfterGc() throws InterruptedException {
+    void cacheIsClearedAfterGc() throws InterruptedException {
         ReflectionCache<Object, Object> cache = new ReflectionCache<>(
                 type -> type);
         cache.get(Object.class);
@@ -166,7 +166,7 @@ class ReflectionCacheTest {
     }
 
     @Test
-    public void currentInstancesNotAvailable() {
+    void currentInstancesNotAvailable() {
         String currentString = "My string";
         CurrentInstance.set(String.class, currentString);
 

--- a/flow-server/src/test/java/com/vaadin/flow/internal/ResourceContentHashTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/ResourceContentHashTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class ResourceContentHashTest {
+class ResourceContentHashTest {
 
     @TempDir
     Path tempDir;
@@ -50,8 +50,7 @@ public class ResourceContentHashTest {
     }
 
     @Test
-    public void getContentHash_knownContent_returnsExpectedHash()
-            throws Exception {
+    void getContentHash_knownContent_returnsExpectedHash() throws Exception {
         byte[] content = "body { color: red; }"
                 .getBytes(StandardCharsets.UTF_8);
         URL url = createTempResource("body { color: red; }");
@@ -70,35 +69,35 @@ public class ResourceContentHashTest {
     }
 
     @Test
-    public void getContentHash_externalHttpUrl_returnsNull() {
+    void getContentHash_externalHttpUrl_returnsNull() {
         assertNull(ResourceContentHash.getContentHash(service,
                 "http://cdn.example.com/styles.css"));
     }
 
     @Test
-    public void getContentHash_externalHttpsUrl_returnsNull() {
+    void getContentHash_externalHttpsUrl_returnsNull() {
         assertNull(ResourceContentHash.getContentHash(service,
                 "https://cdn.example.com/styles.css"));
     }
 
     @Test
-    public void getContentHash_externalUrlMixedCase_returnsNull() {
+    void getContentHash_externalUrlMixedCase_returnsNull() {
         assertNull(ResourceContentHash.getContentHash(service,
                 "HTTPS://cdn.example.com/styles.css"));
     }
 
     @Test
-    public void getContentHash_nullUrl_returnsNull() {
+    void getContentHash_nullUrl_returnsNull() {
         assertNull(ResourceContentHash.getContentHash(service, null));
     }
 
     @Test
-    public void getContentHash_blankUrl_returnsNull() {
+    void getContentHash_blankUrl_returnsNull() {
         assertNull(ResourceContentHash.getContentHash(service, "  "));
     }
 
     @Test
-    public void getContentHash_missingResource_returnsNull() {
+    void getContentHash_missingResource_returnsNull() {
         Mockito.when(service.resolveResource("missing.css"))
                 .thenReturn("missing.css");
         Mockito.when(service.getStaticResource("missing.css")).thenReturn(null);
@@ -109,8 +108,7 @@ public class ResourceContentHashTest {
     }
 
     @Test
-    public void getContentHash_barePath_fallsBackToSlashPrefixed()
-            throws Exception {
+    void getContentHash_barePath_fallsBackToSlashPrefixed() throws Exception {
         URL url = createTempResource("body { color: blue; }");
         Mockito.when(service.resolveResource("bare.css"))
                 .thenReturn("bare.css");
@@ -123,7 +121,7 @@ public class ResourceContentHashTest {
     }
 
     @Test
-    public void getContentHash_cachedAfterFirstCall() throws Exception {
+    void getContentHash_cachedAfterFirstCall() throws Exception {
         URL url = createTempResource("body {}");
         Mockito.when(service.resolveResource("cached.css"))
                 .thenReturn("cached.css");

--- a/flow-server/src/test/java/com/vaadin/flow/internal/StateTreeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/StateTreeTest.java
@@ -106,7 +106,7 @@ class StateTreeTest {
     }
 
     @Test
-    public void rootNodeState() {
+    void rootNodeState() {
         StateNode rootNode = tree.getRootNode();
 
         assertNull(rootNode.getParent(), "Root node should have no parent");
@@ -121,14 +121,14 @@ class StateTreeTest {
     }
 
     @Test
-    public void rootNode_setStateNodeAsParent_throws() {
+    void rootNode_setStateNodeAsParent_throws() {
         assertThrows(IllegalStateException.class, () -> {
             tree.getRootNode().setParent(new StateNode());
         });
     }
 
     @Test
-    public void rootNode_setNullAsParent_nodeIsDetached() {
+    void rootNode_setNullAsParent_nodeIsDetached() {
         AtomicInteger detachCount = new AtomicInteger();
         assertTrue(tree.hasNode(tree.getRootNode()));
         tree.getRootNode()
@@ -141,7 +141,7 @@ class StateTreeTest {
     }
 
     @Test
-    public void attachedNodeIsAttached() {
+    void attachedNodeIsAttached() {
         StateNode node = StateNodeTest.createEmptyNode();
 
         assertFalse(node.isAttached(), "New node should not be attached");
@@ -158,7 +158,7 @@ class StateTreeTest {
     }
 
     @Test
-    public void moveNodeToOtherRoot_throws() {
+    void moveNodeToOtherRoot_throws() {
         StateNode node = StateNodeTest.createEmptyNode();
         StateNodeTest.setParent(node, tree.getRootNode());
         StateNodeTest.setParent(node, null);
@@ -169,7 +169,7 @@ class StateTreeTest {
     }
 
     @Test
-    public void moveNodeToOtherRoot_removeFromTree_doesNotThrow() {
+    void moveNodeToOtherRoot_removeFromTree_doesNotThrow() {
         StateNode node = StateNodeTest.createEmptyNode();
 
         StateNodeTest.setParent(node, tree.getRootNode());
@@ -183,7 +183,7 @@ class StateTreeTest {
     }
 
     @Test
-    public void testNoRootAttachChange() {
+    void testNoRootAttachChange() {
         List<NodeChange> changes = collectChangesExceptChildrenAddRemove();
 
         for (NodeChange change : changes) {
@@ -200,7 +200,7 @@ class StateTreeTest {
     }
 
     @Test
-    public void testTreeChangeCollection() {
+    void testTreeChangeCollection() {
         StateNode node2 = StateNodeTest.createEmptyNode();
         StateNodeTest.setParent(node2, tree.getRootNode());
 
@@ -231,7 +231,7 @@ class StateTreeTest {
     }
 
     @Test
-    public void testDirtyNodeCollection() {
+    void testDirtyNodeCollection() {
         StateNode node1 = tree.getRootNode();
         StateNode node2 = StateNodeTest.createEmptyNode("node2");
 
@@ -261,7 +261,7 @@ class StateTreeTest {
     }
 
     @Test
-    public void testDirtyNodeCollectionOrder() {
+    void testDirtyNodeCollectionOrder() {
         StateNode rootNode = tree.getRootNode();
         List<StateNode> nodes = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
@@ -290,7 +290,7 @@ class StateTreeTest {
     }
 
     @Test
-    public void testDetachInChanges() {
+    void testDetachInChanges() {
         StateNode node1 = tree.getRootNode();
         StateNode node2 = StateNodeTest.createEmptyNode();
         StateNodeTest.setParent(node2, node1);
@@ -308,7 +308,7 @@ class StateTreeTest {
     }
 
     @Test
-    public void allValuesAfterReattach() {
+    void allValuesAfterReattach() {
         StateNode node1 = tree.getRootNode();
         StateNode node2 = new StateNode(ElementData.class);
 
@@ -355,7 +355,7 @@ class StateTreeTest {
     }
 
     @Test
-    public void testSerializable() {
+    void testSerializable() {
         @SuppressWarnings("unchecked")
         Class<? extends NodeFeature>[] features = new Class[] {
                 ElementChildrenList.class, ElementData.class,
@@ -375,7 +375,7 @@ class StateTreeTest {
     }
 
     @Test
-    public void reattachedNodeRetainsId() throws InterruptedException {
+    void reattachedNodeRetainsId() throws InterruptedException {
         StateNode child = new StateNode(ElementChildrenList.class);
         StateNode grandChild = new StateNode(ElementChildrenList.class);
 
@@ -415,7 +415,7 @@ class StateTreeTest {
     }
 
     @Test
-    public void detachedNodeGarbageCollected() throws InterruptedException {
+    void detachedNodeGarbageCollected() throws InterruptedException {
         StateNode child = new StateNode(ElementChildrenList.class);
         StateNode grandChild = new StateNode(ElementChildrenList.class);
 
@@ -443,7 +443,7 @@ class StateTreeTest {
     }
 
     @Test
-    public void beforeClientResponse_regularOrder() {
+    void beforeClientResponse_regularOrder() {
         StateNode rootNode = new AttachableNode(true);
 
         List<Integer> results = new ArrayList<>();
@@ -463,7 +463,7 @@ class StateTreeTest {
     }
 
     @Test
-    public void beforeClientResponse_initiallyAttachedToOneUI_executedWithAnother_executionDoesNotHappen() {
+    void beforeClientResponse_initiallyAttachedToOneUI_executedWithAnother_executionDoesNotHappen() {
         StateTree initialTree = new UI().getInternals().getStateTree();
 
         StateNode child = new StateNode(ElementChildrenList.class);
@@ -482,7 +482,7 @@ class StateTreeTest {
     }
 
     @Test
-    public void beforeClientResponse_initiallyNotAttached_executedWithUI_executionRun() {
+    void beforeClientResponse_initiallyNotAttached_executedWithUI_executionRun() {
         StateTree someTree = new UI().getInternals().getStateTree();
 
         StateNode child = new StateNode(ElementChildrenList.class);
@@ -497,7 +497,7 @@ class StateTreeTest {
     }
 
     @Test
-    public void beforeClientResponse_withInnerRunnables() {
+    void beforeClientResponse_withInnerRunnables() {
         StateNode rootNode = new AttachableNode(true);
 
         List<Integer> results = new ArrayList<>();
@@ -521,7 +521,7 @@ class StateTreeTest {
     }
 
     @Test
-    public void beforeClientResponse_withUnattachedNodes() {
+    void beforeClientResponse_withUnattachedNodes() {
         StateNode rootNode = new AttachableNode(true);
         StateNode emptyNode = new AttachableNode();
 
@@ -543,7 +543,7 @@ class StateTreeTest {
     }
 
     @Test
-    public void beforeClientResponse_withAttachedNodesDuringExecution() {
+    void beforeClientResponse_withAttachedNodesDuringExecution() {
         StateNode rootNode = tree.getRootNode();
         StateNode emptyNode1 = StateNodeTest.createEmptyNode("node1");
         StateNode emptyNode2 = StateNodeTest.createEmptyNode("node2");
@@ -576,7 +576,7 @@ class StateTreeTest {
     }
 
     @Test
-    public void beforeClientResponse_failingExecutionWithNullErrorHandler_NoNPE() {
+    void beforeClientResponse_failingExecutionWithNullErrorHandler_NoNPE() {
         StateNode rootNode = tree.getRootNode();
         tree.beforeClientResponse(rootNode, context -> {
             throw new IllegalStateException("Throw before client response");
@@ -597,7 +597,7 @@ class StateTreeTest {
     }
 
     @Test
-    public void beforeClientResponse_failingExecutionWithNullSession_NoNPE() {
+    void beforeClientResponse_failingExecutionWithNullSession_NoNPE() {
         StateNode rootNode = tree.getRootNode();
         tree.beforeClientResponse(rootNode, context -> {
             throw new IllegalStateException("Throw before client response");
@@ -611,7 +611,7 @@ class StateTreeTest {
     }
 
     @Test
-    public void beforeClientResponse_nodeGarbageCollectedDespiteClosure()
+    void beforeClientResponse_nodeGarbageCollectedDespiteClosure()
             throws InterruptedException {
         StateNode node1 = tree.getRootNode();
         StateNode node2 = StateNodeTest.createEmptyNode("node2");
@@ -648,7 +648,7 @@ class StateTreeTest {
     }
 
     @Test
-    public void collectChanges_updateActiveState() {
+    void collectChanges_updateActiveState() {
         StateNode node1 = Mockito.mock(StateNode.class);
         StateNode node2 = Mockito.mock(StateNode.class);
 
@@ -666,7 +666,7 @@ class StateTreeTest {
     }
 
     @Test
-    public void collectChanges_parentIsInactive_childrenAreCollected() {
+    void collectChanges_parentIsInactive_childrenAreCollected() {
         StateNode node1 = new CollectableNode();
         StateNode node2 = new CollectableNode();
         StateNode node3 = new CollectableNode();
@@ -695,7 +695,7 @@ class StateTreeTest {
     }
 
     @Test
-    public void prepareForResync_nodeHasAttachAndDetachListeners_treeIsDirtyAndListenersAreCalled() {
+    void prepareForResync_nodeHasAttachAndDetachListeners_treeIsDirtyAndListenersAreCalled() {
         StateNode node1 = tree.getRootNode();
         StateNode node2 = StateNodeTest.createEmptyNode("node2");
         StateNodeTest.setParent(node2, node1);
@@ -742,7 +742,7 @@ class StateTreeTest {
     }
 
     @Test
-    public void pendingJavascriptExecutionForInitiallyInvisibleNode() {
+    void pendingJavascriptExecutionForInitiallyInvisibleNode() {
         UI ui = new UI();
         VaadinSession mockSession = Mockito.mock(VaadinSession.class);
         ui.getInternals().setSession(mockSession);
@@ -767,7 +767,7 @@ class StateTreeTest {
     }
 
     @Test
-    public void pendingJavascriptExecutionForVisibleAndInvisibleNode() {
+    void pendingJavascriptExecutionForVisibleAndInvisibleNode() {
         UI ui = new UI();
         VaadinSession mockSession = Mockito.mock(VaadinSession.class);
         ui.getInternals().setSession(mockSession);
@@ -798,7 +798,7 @@ class StateTreeTest {
     }
 
     @Test
-    public void pendingJavascriptExecutionForVisibleAndInvisibleParentNode() {
+    void pendingJavascriptExecutionForVisibleAndInvisibleParentNode() {
         UI ui = new UI();
         VaadinSession mockSession = Mockito.mock(VaadinSession.class);
         ui.getInternals().setSession(mockSession);

--- a/flow-server/src/test/java/com/vaadin/flow/internal/StringUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/StringUtilTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class StringUtilTest {
 
     @Test
-    public void commentRemoval_handlesCommentsCorrectly() {
+    void commentRemoval_handlesCommentsCorrectly() {
         String singleLineBlock = StringUtil
                 .removeComments("return html'/* single line block comment*/';");
 
@@ -51,7 +51,7 @@ class StringUtilTest {
     }
 
     @Test
-    public void commentRemoval_emojiInString_removalDoesnotThrowResultIsTheSame() {
+    void commentRemoval_emojiInString_removalDoesnotThrowResultIsTheSame() {
         String initialTemplate = "import { html } from '@polymer/polymer/lib/utils/html-tag.js';\n"
                 + "class EmployeeForm extends PolymerElement {\n"
                 + "  static get template() {\n" + "    return html`\n"
@@ -65,13 +65,13 @@ class StringUtilTest {
     }
 
     @Test
-    public void removeComments_commentsWithAsterisksInside_commentIsRemoved() {
+    void removeComments_commentsWithAsterisksInside_commentIsRemoved() {
         String result = StringUtil.removeComments("/* comment **/ ;");
         assertEquals(" ;", result);
     }
 
     @Test
-    public void removeJsComments_handlesApostropheAsInString() {
+    void removeJsComments_handlesApostropheAsInString() {
         String httpImport = "import 'http://localhost:56445/files/transformed/@vaadin/vaadin-text-field/vaadin-text-field.js';";
 
         assertEquals(httpImport, StringUtil.removeComments(httpImport, true),
@@ -109,7 +109,7 @@ class StringUtilTest {
     }
 
     @Test
-    public void stripSuffix() {
+    void stripSuffix() {
         assertEquals("foo", StringUtil.stripSuffix("foo", "bar"));
         assertEquals("foo", StringUtil.stripSuffix("foobar", "bar"));
         assertEquals("foobar", StringUtil.stripSuffix("foobarbar", "bar"));

--- a/flow-server/src/test/java/com/vaadin/flow/internal/UrlUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/UrlUtilTest.java
@@ -35,12 +35,12 @@ class UrlUtilTest {
     private String encodeURIComponentShouldNotBeEscaped = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.!~*'()";
 
     @Test
-    public void isExternal_URLStartsWithTwoSlashes_returnsTrue() {
+    void isExternal_URLStartsWithTwoSlashes_returnsTrue() {
         assertTrue(UrlUtil.isExternal("//foo"));
     }
 
     @Test
-    public void isExternal_URLContainsAnySchemaAsPrefix_returnsTrue() {
+    void isExternal_URLContainsAnySchemaAsPrefix_returnsTrue() {
         assertTrue(UrlUtil.isExternal("http://foo"));
         assertTrue(UrlUtil.isExternal("https://foo"));
         assertTrue(UrlUtil.isExternal("context://foo"));
@@ -48,25 +48,25 @@ class UrlUtilTest {
     }
 
     @Test
-    public void isExternal_URLDoesnotContainSchema_returnsFalse() {
+    void isExternal_URLDoesnotContainSchema_returnsFalse() {
         assertFalse(UrlUtil.isExternal("foo"));
     }
 
     @Test
-    public void plusAndSpaceHandledCorrectly() {
+    void plusAndSpaceHandledCorrectly() {
         assertEquals("Plus+Spa%20+%20ce", UrlUtil.encodeURI("Plus+Spa + ce"));
         assertEquals("Plus%2BSpa%20%2B%20ce",
                 UrlUtil.encodeURIComponent("Plus+Spa + ce"));
     }
 
     @Test
-    public void encodeURI_shouldNotBeEscaped() {
+    void encodeURI_shouldNotBeEscaped() {
         assertEquals(encodeURIShouldNotBeEscaped,
                 UrlUtil.encodeURI(encodeURIShouldNotBeEscaped));
     }
 
     @Test
-    public void encodeURI_mustBeEscaped() {
+    void encodeURI_mustBeEscaped() {
         for (char c = 0; c < 255; c++) {
             String s = String.valueOf(c);
             if (encodeURIShouldNotBeEscaped.contains(s)) {
@@ -77,13 +77,13 @@ class UrlUtilTest {
     }
 
     @Test
-    public void encodeURIComponent_shouldNotBeEscaped() {
+    void encodeURIComponent_shouldNotBeEscaped() {
         assertEquals(encodeURIComponentShouldNotBeEscaped, UrlUtil
                 .encodeURIComponent(encodeURIComponentShouldNotBeEscaped));
     }
 
     @Test
-    public void encodeURIComponent_mustBeEscaped() {
+    void encodeURIComponent_mustBeEscaped() {
         for (char c = 0; c < 255; c++) {
             String s = String.valueOf(c);
             if (encodeURIComponentShouldNotBeEscaped.contains(s)) {
@@ -94,7 +94,7 @@ class UrlUtilTest {
     }
 
     @Test
-    public void getServletPathRelative() {
+    void getServletPathRelative() {
         assertEquals(".", UrlUtil.getServletPathRelative("/foo/bar/",
                 createRequest("/foo", "/bar")));
         assertEquals(".", UrlUtil.getServletPathRelative("/foo/bar",
@@ -134,13 +134,13 @@ class UrlUtilTest {
     }
 
     @Test
-    public void decodeURIComponent_percentEncodedSpace_decoded() {
+    void decodeURIComponent_percentEncodedSpace_decoded() {
         String result = UrlUtil.decodeURIComponent("test%20file.txt");
         assertEquals("test file.txt", result);
     }
 
     @Test
-    public void decodeURIComponent_plusSign_notDecodedAsSpace() {
+    void decodeURIComponent_plusSign_notDecodedAsSpace() {
         // Plus signs should remain as plus signs (RFC 3986, not HTML form
         // encoding)
         String result = UrlUtil.decodeURIComponent("test+file.txt");
@@ -148,58 +148,58 @@ class UrlUtilTest {
     }
 
     @Test
-    public void decodeURIComponent_encodedPlusSign_decoded() {
+    void decodeURIComponent_encodedPlusSign_decoded() {
         String result = UrlUtil.decodeURIComponent("test%2Bfile.txt");
         assertEquals("test+file.txt", result);
     }
 
     @Test
-    public void decodeURIComponent_unicodeCharacters_decoded() {
+    void decodeURIComponent_unicodeCharacters_decoded() {
         // åäö.txt encoded as UTF-8 percent-encoded
         String result = UrlUtil.decodeURIComponent("%C3%A5%C3%A4%C3%B6.txt");
         assertEquals("åäö.txt", result);
     }
 
     @Test
-    public void decodeURIComponent_specialCharacters_decoded() {
+    void decodeURIComponent_specialCharacters_decoded() {
         String result = UrlUtil.decodeURIComponent("special%26%3Dchars.txt");
         assertEquals("special&=chars.txt", result);
     }
 
     @Test
-    public void decodeURIComponent_nullValue_returnsNull() {
+    void decodeURIComponent_nullValue_returnsNull() {
         String result = UrlUtil.decodeURIComponent(null);
         assertNull(result);
     }
 
     @Test
-    public void decodeURIComponent_emptyValue_returnsEmpty() {
+    void decodeURIComponent_emptyValue_returnsEmpty() {
         String result = UrlUtil.decodeURIComponent("");
         assertEquals("", result);
     }
 
     @Test
-    public void decodeURIComponent_noEncodedChars_returnsSame() {
+    void decodeURIComponent_noEncodedChars_returnsSame() {
         String result = UrlUtil.decodeURIComponent("simple.txt");
         assertEquals("simple.txt", result);
     }
 
     @Test
-    public void appendQueryParameter_noExistingParams_usesQuestionMark() {
+    void appendQueryParameter_noExistingParams_usesQuestionMark() {
         String result = UrlUtil.appendQueryParameter("/styles.css", "v-c",
                 "abcd1234");
         assertEquals("/styles.css?v-c=abcd1234", result);
     }
 
     @Test
-    public void appendQueryParameter_existingParams_usesAmpersand() {
+    void appendQueryParameter_existingParams_usesAmpersand() {
         String result = UrlUtil.appendQueryParameter("/styles.css?theme=dark",
                 "v-c", "abcd1234");
         assertEquals("/styles.css?theme=dark&v-c=abcd1234", result);
     }
 
     @Test
-    public void appendQueryParameter_nullValue_returnsOriginalUrl() {
+    void appendQueryParameter_nullValue_returnsOriginalUrl() {
         String result = UrlUtil.appendQueryParameter("/styles.css", "v-c",
                 null);
         assertEquals("/styles.css", result);

--- a/flow-server/src/test/java/com/vaadin/flow/internal/UsageStatisticsExporterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/UsageStatisticsExporterTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class UsageStatisticsExporterTest {
 
     @Test
-    public void should_append_script_element_to_the_body() {
+    void should_append_script_element_to_the_body() {
         Document document = new Document("");
         Element html = document.appendElement("html");
         html.appendElement("body");

--- a/flow-server/src/test/java/com/vaadin/flow/router/DefaultRouteResolverTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/DefaultRouteResolverTest.java
@@ -57,7 +57,7 @@ class DefaultRouteResolverTest extends RoutingTestBase {
     }
 
     @Test
-    public void basic_route_navigation_target_resolved_correctly()
+    void basic_route_navigation_target_resolved_correctly()
             throws InvalidRouteConfigurationException {
 
         setRoutes(router.getRegistry(),
@@ -83,7 +83,7 @@ class DefaultRouteResolverTest extends RoutingTestBase {
     }
 
     @Test
-    public void no_route_found_resolves_to_null() {
+    void no_route_found_resolves_to_null() {
         assertNull(
                 resolver.resolve(new ResolveRequest(router,
                         new Location("Not a configured location"))),
@@ -91,7 +91,7 @@ class DefaultRouteResolverTest extends RoutingTestBase {
     }
 
     @Test
-    public void string_url_parameter_correctly_set_to_state()
+    void string_url_parameter_correctly_set_to_state()
             throws InvalidRouteConfigurationException {
         setRoutes(router.getRegistry(),
                 Collections.singleton(GreetingNavigationTarget.class));
@@ -102,7 +102,7 @@ class DefaultRouteResolverTest extends RoutingTestBase {
     }
 
     @Test
-    public void route_precedence_with_parameters()
+    void route_precedence_with_parameters()
             throws InvalidRouteConfigurationException {
         setRoutes(router.getRegistry(),
                 Stream.of(GreetingNavigationTarget.class,
@@ -116,7 +116,7 @@ class DefaultRouteResolverTest extends RoutingTestBase {
     }
 
     @Test
-    public void wrong_number_of_parameters_does_not_match()
+    void wrong_number_of_parameters_does_not_match()
             throws InvalidRouteConfigurationException {
         setRoutes(router.getRegistry(),
                 Collections.singleton(GreetingNavigationTarget.class));
@@ -126,7 +126,7 @@ class DefaultRouteResolverTest extends RoutingTestBase {
     }
 
     @Test
-    public void clientRouteRequest_getDefinedLayout() {
+    void clientRouteRequest_getDefinedLayout() {
         String path = "route";
 
         router.getRegistry().setLayout(DefaultLayout.class);
@@ -146,7 +146,7 @@ class DefaultRouteResolverTest extends RoutingTestBase {
     }
 
     @Test
-    public void clientRouteRequest_getDefinedLayoutAndParentLayouts() {
+    void clientRouteRequest_getDefinedLayoutAndParentLayouts() {
         String path = "route";
 
         router.getRegistry().setLayout(DefaultWithParentLayout.class);
@@ -172,7 +172,7 @@ class DefaultRouteResolverTest extends RoutingTestBase {
     }
 
     @Test
-    public void clientRouteRequest_withRouteParameters_getDefinedLayout() {
+    void clientRouteRequest_withRouteParameters_getDefinedLayout() {
         router.getRegistry().setLayout(DefaultLayout.class);
 
         try (MockedStatic<MenuRegistry> menuRegistry = Mockito
@@ -217,7 +217,7 @@ class DefaultRouteResolverTest extends RoutingTestBase {
     }
 
     @Test
-    public void clientRouteRequest_withRouteParameters_noLayout() {
+    void clientRouteRequest_withRouteParameters_noLayout() {
         router.getRegistry().setLayout(DefaultLayout.class);
 
         try (MockedStatic<MenuRegistry> menuRegistry = Mockito
@@ -258,7 +258,7 @@ class DefaultRouteResolverTest extends RoutingTestBase {
      * AmbiguousRouteConfigurationException.
      */
     @Test
-    public void clientRouteRequest_withRouteParameters_ambiguousRoutesFirstAddedWins() {
+    void clientRouteRequest_withRouteParameters_ambiguousRoutesFirstAddedWins() {
         router.getRegistry().setLayout(DefaultLayout.class);
 
         try (MockedStatic<MenuRegistry> menuRegistry = Mockito
@@ -310,7 +310,7 @@ class DefaultRouteResolverTest extends RoutingTestBase {
     }
 
     @Test
-    public void clientRouteRequest_noLayoutForPath_Throws() {
+    void clientRouteRequest_noLayoutForPath_Throws() {
         String path = "route";
 
         try (MockedStatic<MenuRegistry> menuRegistry = Mockito

--- a/flow-server/src/test/java/com/vaadin/flow/router/ErrorParameterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/ErrorParameterTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 
 class ErrorParameterTest {
     @Test
-    public void matchingExceptionType() {
+    void matchingExceptionType() {
         NullPointerException exception = new NullPointerException();
 
         ErrorParameter<NullPointerException> errorParameter = new ErrorParameter<>(
@@ -32,7 +32,7 @@ class ErrorParameterTest {
     }
 
     @Test
-    public void superExceptionType() {
+    void superExceptionType() {
         NullPointerException exception = new NullPointerException();
 
         ErrorParameter<RuntimeException> errorParameter = new ErrorParameter<>(
@@ -43,7 +43,7 @@ class ErrorParameterTest {
     }
 
     @Test
-    public void matchingCauseType() {
+    void matchingCauseType() {
         NullPointerException cause = new NullPointerException();
         IllegalStateException exception = new IllegalStateException(cause);
 
@@ -55,7 +55,7 @@ class ErrorParameterTest {
     }
 
     @Test
-    public void superMatchingCauseType() {
+    void superMatchingCauseType() {
         NullPointerException cause = new NullPointerException() {
 
         };

--- a/flow-server/src/test/java/com/vaadin/flow/router/EventUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/EventUtilTest.java
@@ -96,7 +96,7 @@ class EventUtilTest {
     }
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         VaadinSession session = Mockito.mock(VaadinSession.class);
         ui = new UI() {
             @Override
@@ -112,12 +112,12 @@ class EventUtilTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         UI.setCurrent(null);
     }
 
     @Test
-    public void collectBeforeNavigationObserversFromUI() throws Exception {
+    void collectBeforeNavigationObserversFromUI() throws Exception {
         UI ui = UI.getCurrent();
         Element node = ui.getElement();
         node.appendChild(new Element("main"), new Element("menu"));
@@ -136,7 +136,7 @@ class EventUtilTest {
     }
 
     @Test
-    public void collectBeforeNavigationObserversFromUI_elementHasVirtualChildren()
+    void collectBeforeNavigationObserversFromUI_elementHasVirtualChildren()
             throws Exception {
         UI ui = UI.getCurrent();
         Element node = ui.getElement();
@@ -161,7 +161,7 @@ class EventUtilTest {
     }
 
     @Test
-    public void collectBeforeNavigationObserversFromChains() throws Exception {
+    void collectBeforeNavigationObserversFromChains() throws Exception {
         Foo foo = new Foo();
         EnterObserver toBeDetached = new EnterObserver();
         foo.getElement().appendChild(new EnterObserver().getElement(),
@@ -188,7 +188,7 @@ class EventUtilTest {
     }
 
     @Test
-    public void collectAfterNavigationObservers() {
+    void collectAfterNavigationObservers() {
         UI ui = UI.getCurrent();
 
         Element menu = new Element("menu");
@@ -211,7 +211,7 @@ class EventUtilTest {
     }
 
     @Test
-    public void inspectChildrenHierarchy() throws Exception {
+    void inspectChildrenHierarchy() throws Exception {
         Element node = new Element("root");
         node.appendChild(new Element("main"), new Element("menu"));
         Element nested = new Element("nested");
@@ -228,7 +228,7 @@ class EventUtilTest {
     }
 
     @Test
-    public void inspectChildrenHierarchy_selective() throws Exception {
+    void inspectChildrenHierarchy_selective() throws Exception {
         Element node = new Element("root");
         node.appendChild(new Element("main"), new Element("menu"));
         Element nested = new Element("nested");
@@ -246,7 +246,7 @@ class EventUtilTest {
     }
 
     @Test
-    public void inspectMixedChildrenHierarchy() throws Exception {
+    void inspectMixedChildrenHierarchy() throws Exception {
         Element node = new Element("root");
         node.appendVirtualChild(new Element("main"), new Element("menu"));
         Element nested = new Element("nested");
@@ -272,7 +272,7 @@ class EventUtilTest {
     }
 
     @Test
-    public void getImplementingComponents() throws Exception {
+    void getImplementingComponents() throws Exception {
         Element node = new Element("root");
         node.appendChild(new Element("main"), new Element("menu"));
         Element nested = new Element("nested");
@@ -296,7 +296,7 @@ class EventUtilTest {
     }
 
     @Test
-    public void getImplementingComponents_elementHasVirtualChildren()
+    void getImplementingComponents_elementHasVirtualChildren()
             throws Exception {
         Element node = new Element("root");
         node.appendChild(new Element("main"), new Element("menu"));
@@ -322,7 +322,7 @@ class EventUtilTest {
     }
 
     @Test
-    public void collectLocaleChangeObserverFromElement() throws Exception {
+    void collectLocaleChangeObserverFromElement() throws Exception {
         Element node = new Element("root");
         node.appendChild(new Element("main"), new Element("menu"));
         Element nested = new Element("nested-locale");
@@ -340,7 +340,7 @@ class EventUtilTest {
     }
 
     @Test
-    public void collectLocaleChangeObserverFromElement_elementHasVirtualChildren()
+    void collectLocaleChangeObserverFromElement_elementHasVirtualChildren()
             throws Exception {
         Element node = new Element("root");
         node.appendChild(new Element("main"), new Element("menu"));
@@ -361,7 +361,26 @@ class EventUtilTest {
     }
 
     @Test
-    public void collectLocaleChangeObserverFromComponentList()
+    void collectLocaleChangeObserverFromComponentList() throws Exception {
+        Foo foo = new Foo();
+        foo.getElement().appendChild(new Locale().getElement());
+        Bar bar = new Bar();
+
+        Element nested = new Element("nested-locale");
+        nested.appendChild(new Element("nested-child"),
+                new Locale().getElement());
+
+        bar.getElement().appendChild(new Foo().getElement(), nested);
+
+        List<LocaleChangeObserver> beforeNavigationObservers = EventUtil
+                .collectLocaleChangeObservers(Arrays.asList(foo, bar));
+
+        assertEquals(2, beforeNavigationObservers.size(),
+                "Wrong amount of listener instances found");
+    }
+
+    @Test
+    void collectLocaleChangeObserverFromComponentList_elementHasVirtualChildren()
             throws Exception {
         Foo foo = new Foo();
         foo.getElement().appendChild(new Locale().getElement());
@@ -381,27 +400,7 @@ class EventUtilTest {
     }
 
     @Test
-    public void collectLocaleChangeObserverFromComponentList_elementHasVirtualChildren()
-            throws Exception {
-        Foo foo = new Foo();
-        foo.getElement().appendChild(new Locale().getElement());
-        Bar bar = new Bar();
-
-        Element nested = new Element("nested-locale");
-        nested.appendChild(new Element("nested-child"),
-                new Locale().getElement());
-
-        bar.getElement().appendChild(new Foo().getElement(), nested);
-
-        List<LocaleChangeObserver> beforeNavigationObservers = EventUtil
-                .collectLocaleChangeObservers(Arrays.asList(foo, bar));
-
-        assertEquals(2, beforeNavigationObservers.size(),
-                "Wrong amount of listener instances found");
-    }
-
-    @Test
-    public void getImplementingComponents_hasComposite_originalComponentIsReturned() {
+    void getImplementingComponents_hasComposite_originalComponentIsReturned() {
         CompositeWrapper wrapper = new CompositeWrapper();
         List<BeforeEnterObserver> components = EventUtil
                 .getImplementingComponents(Stream.of(wrapper.getElement()),

--- a/flow-server/src/test/java/com/vaadin/flow/router/HighlightConditionsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/HighlightConditionsTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class HighlightConditionsTest {
 
     @Test
-    public void locationPrefix_defaultRoute_emptyLocationMatches() {
+    void locationPrefix_defaultRoute_emptyLocationMatches() {
         HighlightCondition<RouterLink> condition = HighlightConditions
                 .locationPrefix();
         RouterLink link = Mockito.mock(RouterLink.class);
@@ -37,7 +37,7 @@ class HighlightConditionsTest {
     }
 
     @Test
-    public void locationPrefix_defaultRoute_nonEmptyLocationDoesNotMatch() {
+    void locationPrefix_defaultRoute_nonEmptyLocationDoesNotMatch() {
         HighlightCondition<RouterLink> condition = HighlightConditions
                 .locationPrefix();
         RouterLink link = Mockito.mock(RouterLink.class);
@@ -50,7 +50,7 @@ class HighlightConditionsTest {
     }
 
     @Test
-    public void locationPrefix_notDefaultRoute_prefixMatches() {
+    void locationPrefix_notDefaultRoute_prefixMatches() {
         HighlightCondition<RouterLink> condition = HighlightConditions
                 .locationPrefix();
         RouterLink link = Mockito.mock(RouterLink.class);
@@ -63,7 +63,7 @@ class HighlightConditionsTest {
     }
 
     @Test
-    public void locationPrefix_notDefaultRoute_nonPrefixDoesNotMatch() {
+    void locationPrefix_notDefaultRoute_nonPrefixDoesNotMatch() {
         HighlightCondition<RouterLink> condition = HighlightConditions
                 .locationPrefix();
         RouterLink link = Mockito.mock(RouterLink.class);

--- a/flow-server/src/test/java/com/vaadin/flow/router/InternalServerErrorTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/InternalServerErrorTest.java
@@ -39,7 +39,7 @@ class InternalServerErrorTest {
             .mock(DeploymentConfiguration.class);
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         VaadinService.setCurrent(service);
 
         Mockito.when(service.getDeploymentConfiguration())
@@ -50,12 +50,12 @@ class InternalServerErrorTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         VaadinService.setCurrent(null);
     }
 
     @Test
-    public void productionMode_noWarningAndStacktrace() {
+    void productionMode_noWarningAndStacktrace() {
         Mockito.when(configuration.isProductionMode()).thenReturn(true);
 
         InternalServerError testInstance = new InternalServerError();
@@ -68,7 +68,7 @@ class InternalServerErrorTest {
     }
 
     @Test
-    public void nonProductionMode_noLogBinding_showWaringAndStacktrace() {
+    void nonProductionMode_noLogBinding_showWaringAndStacktrace() {
         Mockito.when(configuration.isProductionMode()).thenReturn(false);
 
         InternalServerError testInstance = new InternalServerError() {
@@ -97,7 +97,7 @@ class InternalServerErrorTest {
     }
 
     @Test
-    public void nonProductionMode_hasLogBinding_showStacktraceAndNoWarning() {
+    void nonProductionMode_hasLogBinding_showStacktraceAndNoWarning() {
         Mockito.when(configuration.isProductionMode()).thenReturn(false);
 
         InternalServerError testInstance = new InternalServerError() {

--- a/flow-server/src/test/java/com/vaadin/flow/router/LocationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/LocationTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class LocationTest {
     @Test
-    public void parseLocation() {
+    void parseLocation() {
         Location location = new Location("foo/bar/baz");
 
         assertEquals(Arrays.asList("foo", "bar", "baz"),
@@ -40,33 +40,33 @@ class LocationTest {
     }
 
     @Test
-    public void parseLocationWithEndingSlash() {
+    void parseLocationWithEndingSlash() {
         Location location = new Location("foo/bar/");
 
         assertEquals(Arrays.asList("foo", "bar", ""), location.getSegments());
     }
 
     @Test
-    public void parseLocationStartingWithSlash() {
+    void parseLocationStartingWithSlash() {
         Location location = new Location("/foo/bar/");
         assertEquals(Arrays.asList("foo", "bar", ""), location.getSegments());
     }
 
     @Test
-    public void parseNullLocation() {
+    void parseNullLocation() {
         Location location = new Location((String) null);
         assertEquals(Arrays.asList(""), location.getSegments());
     }
 
     @Test
-    public void parseNullLocationWithParameters() {
+    void parseNullLocationWithParameters() {
         Location location = new Location((String) null,
                 QueryParameters.fromString("foo"));
         assertEquals(Arrays.asList(""), location.getSegments());
     }
 
     @Test
-    public void parseLocationWithQueryStringOnly() {
+    void parseLocationWithQueryStringOnly() {
         Location location = new Location("?hey=hola&zz=");
         assertEquals("", location.getPath());
         Map<String, List<String>> queryMap = new HashMap<>();
@@ -80,7 +80,7 @@ class LocationTest {
     }
 
     @Test
-    public void parseLocationWithQueryString_noValue() {
+    void parseLocationWithQueryString_noValue() {
         Location location = new Location("path?query");
 
         assertEquals("path", location.getPath());
@@ -92,7 +92,7 @@ class LocationTest {
     }
 
     @Test
-    public void parseLocationWithQueryString_emptyValue() {
+    void parseLocationWithQueryString_emptyValue() {
         Location location = new Location("path?query=");
 
         assertEquals("path", location.getPath());
@@ -104,14 +104,14 @@ class LocationTest {
     }
 
     @Test
-    public void locationFromSegments() {
+    void locationFromSegments() {
         Location location = new Location(Arrays.asList("one", "two"));
         assertEquals(Arrays.asList("one", "two"), location.getSegments());
         assertEquals("one/two", location.getPath());
     }
 
     @Test
-    public void queryValue_decodedCorrectly() {
+    void queryValue_decodedCorrectly() {
         QueryParameters queryParameters = new Location("home?value+part")
                 .getQueryParameters();
         assertEquals("value part",
@@ -146,7 +146,7 @@ class LocationTest {
     }
 
     @Test
-    public void subLocation() {
+    void subLocation() {
         Location location = new Location(Arrays.asList("one", "two", "three"));
 
         assertEquals("one", location.getFirstSegment());
@@ -159,14 +159,14 @@ class LocationTest {
     }
 
     @Test
-    public void emptyLocation() {
+    void emptyLocation() {
         assertThrows(IllegalArgumentException.class, () -> {
             new Location(Collections.emptyList());
         });
     }
 
     @Test
-    public void noSubLocation_emptyOptional() {
+    void noSubLocation_emptyOptional() {
         Location location = new Location("foo");
         Optional<Location> maybeSubLocation = location.getSubLocation();
 
@@ -174,13 +174,13 @@ class LocationTest {
     }
 
     @Test
-    public void spaceInLocation() {
+    void spaceInLocation() {
         Location location = new Location("foo bar");
         assertEquals("foo bar", location.getFirstSegment());
     }
 
     @Test
-    public void umlautInLocation() {
+    void umlautInLocation() {
         Location location = new Location("foo/åäö/bar");
 
         assertEquals("foo", location.getSegments().get(0));
@@ -189,7 +189,7 @@ class LocationTest {
     }
 
     @Test
-    public void toggleTrailingSlash() {
+    void toggleTrailingSlash() {
         assertEquals("foo",
                 new Location("foo/").toggleTrailingSlash().getPath());
         assertEquals("foo/",
@@ -197,7 +197,7 @@ class LocationTest {
     }
 
     @Test
-    public void toggleTrailingSlash_emtpyLocation() {
+    void toggleTrailingSlash_emtpyLocation() {
         assertThrows(IllegalArgumentException.class, () -> {
             // Does not make sense to change the location to "/"
             new Location("").toggleTrailingSlash();
@@ -205,7 +205,7 @@ class LocationTest {
     }
 
     @Test
-    public void locationWithParametersPath_emptyParams() {
+    void locationWithParametersPath_emptyParams() {
         String initialPath = "foo/bar/";
         Location location = new Location(initialPath);
 
@@ -216,7 +216,7 @@ class LocationTest {
     }
 
     @Test
-    public void locationWithParametersPath_withTrailingSlash() {
+    void locationWithParametersPath_withTrailingSlash() {
         String initialPath = "foo/bar/";
         QueryParameters queryParams = getQueryParameters();
         Location location = new Location(initialPath, queryParams);
@@ -228,7 +228,7 @@ class LocationTest {
     }
 
     @Test
-    public void locationWithParametersPath_withoutTrailingSlash() {
+    void locationWithParametersPath_withoutTrailingSlash() {
         String initialPath = "foo/bar";
         QueryParameters queryParams = getQueryParameters();
         Location location = new Location(initialPath, queryParams);
@@ -249,7 +249,7 @@ class LocationTest {
     }
 
     @Test
-    public void locationWithParamsInUrl() {
+    void locationWithParamsInUrl() {
         String initialPath = "foo/bar/";
         QueryParameters queryParams = getQueryParameters();
         Location location = new Location(initialPath, queryParams);
@@ -260,7 +260,7 @@ class LocationTest {
     }
 
     @Test
-    public void locationWithParamsInUrlAndParameters() {
+    void locationWithParamsInUrlAndParameters() {
         Location location = new Location("foo/bar/?one&two=222",
                 getQueryParameters());
         assertEquals(Arrays.asList("foo", "bar", "?one&two=222"),
@@ -271,7 +271,7 @@ class LocationTest {
     }
 
     @Test
-    public void locationWithParamWithAndWithoutValue() {
+    void locationWithParamWithAndWithoutValue() {
         Location location = new Location("foo?param&param=bar");
         assertEquals("param&param=bar",
                 location.getQueryParameters().getQueryString());
@@ -282,7 +282,7 @@ class LocationTest {
     }
 
     @Test
-    public void locationWithParamAndEmptyValue() {
+    void locationWithParamAndEmptyValue() {
         Location location = new Location("foo?param=&param=bar");
 
         assertEquals("param&param=bar",
@@ -290,7 +290,7 @@ class LocationTest {
     }
 
     @Test
-    public void locationNameShouldBeAbleToHaveDotDot() {
+    void locationNameShouldBeAbleToHaveDotDot() {
         Location location = new Location("..element");
         assertEquals("..element", location.getFirstSegment());
 
@@ -299,7 +299,7 @@ class LocationTest {
     }
 
     @Test
-    public void locationShouldBeRelative() {
+    void locationShouldBeRelative() {
         InvalidLocationException ex = assertThrows(
                 InvalidLocationException.class, () -> {
 
@@ -310,7 +310,7 @@ class LocationTest {
     }
 
     @Test
-    public void locationShouldNotEndWithDotDotSegment() {
+    void locationShouldNotEndWithDotDotSegment() {
         InvalidLocationException ex = assertThrows(
                 InvalidLocationException.class, () -> {
 
@@ -321,7 +321,7 @@ class LocationTest {
     }
 
     @Test
-    public void dotDotLocationShouldNotWork() {
+    void dotDotLocationShouldNotWork() {
         InvalidLocationException ex = assertThrows(
                 InvalidLocationException.class, () -> {
 
@@ -332,12 +332,12 @@ class LocationTest {
     }
 
     @Test
-    public void pathShouldBeEmpty() {
+    void pathShouldBeEmpty() {
         assertEquals("", new Location("").getPathWithQueryParameters());
     }
 
     @Test
-    public void locationWithUrlEncodedCharacters() {
+    void locationWithUrlEncodedCharacters() {
         Location location = new Location(
                 "foo?bar=a%20b%20%C3%B1%20%26%20%3F&baz=xyz");
         assertEquals(Arrays.asList("a b ñ & ?"),
@@ -349,14 +349,14 @@ class LocationTest {
     }
 
     @Test
-    public void colonInLocationPath_locationIsParsed() {
+    void colonInLocationPath_locationIsParsed() {
         Location location = new Location("abc:foo/bar?baz");
         assertEquals("abc:foo/bar", location.getPath());
         assertEquals("baz", location.getQueryParameters().getQueryString());
     }
 
     @Test
-    public void locationWithFragment_fragmentRetainedForPathWithQueryParameters() {
+    void locationWithFragment_fragmentRetainedForPathWithQueryParameters() {
         String locationString = "foo#fragment";
         Location location = new Location(locationString);
         assertEquals(locationString, location.getPathWithQueryParameters());

--- a/flow-server/src/test/java/com/vaadin/flow/router/ParameterDeserializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/ParameterDeserializerTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ParameterDeserializerTest {
 
     @Test
-    public void testSimple() {
+    void testSimple() {
         assertFalse(ParameterDeserializer.isAnnotatedParameter(Simple.class,
                 OptionalParameter.class));
         assertTrue(ParameterDeserializer.isAnnotatedParameter(
@@ -32,7 +32,7 @@ class ParameterDeserializerTest {
     }
 
     @Test
-    public void testInterface() {
+    void testInterface() {
         assertFalse(ParameterDeserializer.isAnnotatedParameter(Normal.class,
                 OptionalParameter.class));
         assertTrue(ParameterDeserializer.isAnnotatedParameter(
@@ -40,7 +40,7 @@ class ParameterDeserializerTest {
     }
 
     @Test
-    public void parameterizedViaClass() {
+    void parameterizedViaClass() {
         assertFalse(ParameterDeserializer.isAnnotatedParameter(
                 ParameterizedViaSuperClass.class, OptionalParameter.class));
         assertTrue(ParameterDeserializer.isAnnotatedParameter(
@@ -49,7 +49,7 @@ class ParameterDeserializerTest {
     }
 
     @Test
-    public void parameterizedViaInterface() {
+    void parameterizedViaInterface() {
         assertFalse(ParameterDeserializer.isAnnotatedParameter(
                 ParameterizedClass.class, OptionalParameter.class));
         assertTrue(ParameterDeserializer.isAnnotatedParameter(
@@ -57,7 +57,7 @@ class ParameterDeserializerTest {
     }
 
     @Test
-    public void testGenericInterface() {
+    void testGenericInterface() {
         assertFalse(ParameterDeserializer.isAnnotatedParameter(Generic.class,
                 OptionalParameter.class));
         assertTrue(ParameterDeserializer.isAnnotatedParameter(
@@ -65,7 +65,7 @@ class ParameterDeserializerTest {
     }
 
     @Test
-    public void getClassType_concreteClass_parameterFromInterface() {
+    void getClassType_concreteClass_parameterFromInterface() {
         Class<?> type = ParameterDeserializer.getClassType(Simple.class);
         assertEquals(String.class, type);
         type = ParameterDeserializer.getClassType(SimpleAnnotated.class);
@@ -73,7 +73,7 @@ class ParameterDeserializerTest {
     }
 
     @Test
-    public void getClassType_concreteClass_parameterFromExtendedInterface() {
+    void getClassType_concreteClass_parameterFromExtendedInterface() {
         Class<?> type = ParameterDeserializer.getClassType(Normal.class);
         assertEquals(String.class, type);
         type = ParameterDeserializer.getClassType(NormalAnnotated.class);
@@ -81,7 +81,7 @@ class ParameterDeserializerTest {
     }
 
     @Test
-    public void getClassType_concreteClass_parameterFromSuperclass() {
+    void getClassType_concreteClass_parameterFromSuperclass() {
         Class<?> type = ParameterDeserializer
                 .getClassType(ParameterizedViaSuperClass.class);
         assertEquals(String.class, type);
@@ -91,7 +91,7 @@ class ParameterDeserializerTest {
     }
 
     @Test
-    public void getClassType_parameterizedClass_parameterFromInterface() {
+    void getClassType_parameterizedClass_parameterFromInterface() {
         Class<?> type = ParameterDeserializer
                 .getClassType(ParameterizedClass.class);
         assertEquals(String.class, type);
@@ -101,7 +101,7 @@ class ParameterDeserializerTest {
     }
 
     @Test
-    public void getClassType_parameterizedClass_parameterFromParameterizedInterface() {
+    void getClassType_parameterizedClass_parameterFromParameterizedInterface() {
         Class<?> type = ParameterDeserializer.getClassType(Generic.class);
         assertEquals(String.class, type);
         type = ParameterDeserializer.getClassType(GenericAnnotated.class);

--- a/flow-server/src/test/java/com/vaadin/flow/router/QueryParametersTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/QueryParametersTest.java
@@ -65,21 +65,21 @@ class QueryParametersTest {
     }
 
     @Test
-    public void emptyParameters() {
+    void emptyParameters() {
         QueryParameters emptyParams = QueryParameters.empty();
 
         assertEquals(Collections.emptyMap(), emptyParams.getParameters());
     }
 
     @Test
-    public void emptyParametersToQueryString() {
+    void emptyParametersToQueryString() {
         QueryParameters emptyParams = QueryParameters.empty();
 
         assertEquals("", emptyParams.getQueryString());
     }
 
     @Test
-    public void underlyingMapUnmodifiable_empty() {
+    void underlyingMapUnmodifiable_empty() {
         Map<String, List<String>> parameters = QueryParameters.empty()
                 .getParameters();
         assertThrows(UnsupportedOperationException.class,
@@ -87,7 +87,7 @@ class QueryParametersTest {
     }
 
     @Test
-    public void simpleParameters() {
+    void simpleParameters() {
         QueryParameters simpleParams = QueryParameters
                 .simple(getSimpleInputParameters());
 
@@ -99,7 +99,7 @@ class QueryParametersTest {
     }
 
     @Test
-    public void simpleParametersFromQueryString() {
+    void simpleParametersFromQueryString() {
         QueryParameters simpleParams = QueryParameters
                 .fromString(simpleInputQueryString);
 
@@ -115,7 +115,7 @@ class QueryParametersTest {
     }
 
     @Test
-    public void simpleParametersToQueryString() {
+    void simpleParametersToQueryString() {
         QueryParameters simpleParams = QueryParameters
                 .simple(getSimpleInputParameters());
 
@@ -128,7 +128,7 @@ class QueryParametersTest {
     }
 
     @Test
-    public void underlyingMapUnmodifiable_simple() {
+    void underlyingMapUnmodifiable_simple() {
         Map<String, List<String>> parameters = QueryParameters
                 .simple(getSimpleInputParameters()).getParameters();
         assertThrows(UnsupportedOperationException.class,
@@ -136,13 +136,13 @@ class QueryParametersTest {
     }
 
     @Test
-    public void underlyingListsUnmodifiable_simple() {
+    void underlyingListsUnmodifiable_simple() {
         checkListsForImmutability(QueryParameters
                 .simple(getSimpleInputParameters()).getParameters().values());
     }
 
     @Test
-    public void complexParameters() {
+    void complexParameters() {
         QueryParameters fullParams = QueryParameters
                 .full(getFullInputParameters());
 
@@ -154,7 +154,7 @@ class QueryParametersTest {
     }
 
     @Test
-    public void complexParametersFromQueryString() {
+    void complexParametersFromQueryString() {
         QueryParameters fullParams = QueryParameters
                 .fromString(complexInputQueryString);
 
@@ -170,7 +170,7 @@ class QueryParametersTest {
     }
 
     @Test
-    public void complexParametersToQueryString() {
+    void complexParametersToQueryString() {
         QueryParameters fullParams = QueryParameters
                 .full(getFullInputParameters());
 
@@ -192,7 +192,7 @@ class QueryParametersTest {
     }
 
     @Test
-    public void underlyingMapUnmodifiable_full() {
+    void underlyingMapUnmodifiable_full() {
         Map<String, List<String>> parameters = QueryParameters
                 .full(getFullInputParameters()).getParameters();
         assertThrows(UnsupportedOperationException.class,
@@ -200,13 +200,13 @@ class QueryParametersTest {
     }
 
     @Test
-    public void underlyingListsUnmodifiable_full() {
+    void underlyingListsUnmodifiable_full() {
         checkListsForImmutability(QueryParameters.full(getFullInputParameters())
                 .getParameters().values());
     }
 
     @Test
-    public void parameterWithoutValue() {
+    void parameterWithoutValue() {
         QueryParameters params = new QueryParameters(
                 Collections.singletonMap("foo", Collections.singletonList("")));
         assertEquals("foo", params.getQueryString());
@@ -221,14 +221,14 @@ class QueryParametersTest {
     }
 
     @Test
-    public void parameterWithEmptyValue() {
+    void parameterWithEmptyValue() {
         QueryParameters fullParams = new QueryParameters(
                 Collections.singletonMap("foo", Collections.singletonList("")));
         assertEquals("foo", fullParams.getQueryString());
     }
 
     @Test
-    public void shortHands() {
+    void shortHands() {
         QueryParameters qp1 = QueryParameters.of("foo", "bar");
         Optional<String> singleParameter = qp1.getSingleParameter("foo");
         assertEquals("bar", singleParameter.get());
@@ -241,7 +241,7 @@ class QueryParametersTest {
     }
 
     @Test
-    public void excluding() {
+    void excluding() {
         Map<String, List<String>> paramMap = new HashMap<>();
         paramMap.put("one", Collections.singletonList("1"));
         paramMap.put("two", Collections.singletonList("2"));
@@ -259,7 +259,7 @@ class QueryParametersTest {
     }
 
     @Test
-    public void excludingNone() {
+    void excludingNone() {
         Map<String, List<String>> paramMap = new HashMap<>();
         paramMap.put("one", Collections.singletonList("1"));
         paramMap.put("two", Collections.singletonList("2"));
@@ -272,7 +272,7 @@ class QueryParametersTest {
     }
 
     @Test
-    public void including() {
+    void including() {
         Map<String, List<String>> paramMap = new HashMap<>();
         paramMap.put("one", Collections.singletonList("1"));
         paramMap.put("two", Collections.singletonList("2"));
@@ -289,7 +289,7 @@ class QueryParametersTest {
     }
 
     @Test
-    public void includingNone() {
+    void includingNone() {
         Map<String, List<String>> paramMap = new HashMap<>();
         paramMap.put("one", Collections.singletonList("1"));
         paramMap.put("two", Collections.singletonList("2"));
@@ -302,7 +302,7 @@ class QueryParametersTest {
     }
 
     @Test
-    public void includingNonExisting() {
+    void includingNonExisting() {
         Map<String, List<String>> paramMap = new HashMap<>();
         paramMap.put("one", Collections.singletonList("1"));
         paramMap.put("two", Collections.singletonList("2"));
@@ -315,7 +315,7 @@ class QueryParametersTest {
     }
 
     @Test
-    public void merging() {
+    void merging() {
         Map<String, List<String>> paramMap = new HashMap<>();
         paramMap.put("one", Collections.singletonList("1"));
         paramMap.put("two", Collections.singletonList("2"));
@@ -334,7 +334,7 @@ class QueryParametersTest {
     }
 
     @Test
-    public void mergingMultiValue() {
+    void mergingMultiValue() {
         Map<String, List<String>> paramMap = new HashMap<>();
         paramMap.put("one", Collections.singletonList("1"));
         paramMap.put("two", Collections.singletonList("2"));
@@ -351,7 +351,7 @@ class QueryParametersTest {
     }
 
     @Test
-    public void mergingAll() {
+    void mergingAll() {
         Map<String, List<String>> paramMap = new HashMap<>();
         paramMap.put("one", Collections.singletonList("1"));
         paramMap.put("two", Collections.singletonList("2"));
@@ -371,13 +371,13 @@ class QueryParametersTest {
     }
 
     @Test
-    public void toStringValidation() {
+    void toStringValidation() {
         String toString = QueryParameters.of("foo", "bar").toString();
         assertEquals("QueryParameters(foo=bar)", toString);
     }
 
     @Test
-    public void equalsAndHashCode() {
+    void equalsAndHashCode() {
         QueryParameters qp1 = QueryParameters.of("foo", "bar");
         QueryParameters qp2 = QueryParameters.fromString("foo=bar");
         QueryParameters qp3 = QueryParameters.fromString("bar=foo");
@@ -387,19 +387,19 @@ class QueryParametersTest {
     }
 
     @Test
-    public void fromString_emptyString_getsEmptyParameters() {
+    void fromString_emptyString_getsEmptyParameters() {
         QueryParameters params = QueryParameters.fromString("");
         assertEquals(Collections.emptyMap(), params.getParameters());
     }
 
     @Test
-    public void fromString_blankString_getsEmptyParameters() {
+    void fromString_blankString_getsEmptyParameters() {
         QueryParameters params = QueryParameters.fromString("    ");
         assertEquals(Collections.emptyMap(), params.getParameters());
     }
 
     @Test
-    public void fromString_nullString_getsEmptyParameters() {
+    void fromString_nullString_getsEmptyParameters() {
         QueryParameters params = QueryParameters.fromString(null);
         assertEquals(Collections.emptyMap(), params.getParameters());
     }

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouteConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouteConfigurationTest.java
@@ -64,7 +64,7 @@ class RouteConfigurationTest {
     private VaadinServletContext vaadinContext;
 
     @BeforeEach
-    public void init() {
+    void init() {
         servletContext = new MockServletContext();
         vaadinContext = new MockVaadinContext(servletContext);
         registry = ApplicationRouteRegistry.getInstance(vaadinContext);
@@ -108,7 +108,7 @@ class RouteConfigurationTest {
     }
 
     @Test
-    public void routeConfigurationUpdateLock_configurationIsUpdatedOnlyAfterUnlock() {
+    void routeConfigurationUpdateLock_configurationIsUpdatedOnlyAfterUnlock() {
         CountDownLatch waitReaderThread = new CountDownLatch(1);
         CountDownLatch waitUpdaterThread = new CountDownLatch(2);
 
@@ -156,7 +156,7 @@ class RouteConfigurationTest {
     }
 
     @Test
-    public void isRouteRegistered_returnsCorrectly() {
+    void isRouteRegistered_returnsCorrectly() {
         RouteConfiguration routeConfiguration = RouteConfiguration
                 .forRegistry(getRegistry(session));
 
@@ -176,7 +176,7 @@ class RouteConfigurationTest {
     }
 
     @Test
-    public void routeConfiguration_getMethodsReturnCorrectly() {
+    void routeConfiguration_getMethodsReturnCorrectly() {
         RouteConfiguration routeConfiguration = RouteConfiguration
                 .forRegistry(getRegistry(session));
 
@@ -262,7 +262,7 @@ class RouteConfigurationTest {
     }
 
     @Test
-    public void routeConfiguration_routeTemplatesWorkCorrectly() {
+    void routeConfiguration_routeTemplatesWorkCorrectly() {
         RouteConfiguration routeConfiguration = RouteConfiguration
                 .forRegistry(getRegistry(session));
 
@@ -319,7 +319,7 @@ class RouteConfigurationTest {
     }
 
     @Test
-    public void addListenerToApplicationScoped_noEventForSessionChange() {
+    void addListenerToApplicationScoped_noEventForSessionChange() {
         VaadinServlet servlet = Mockito.mock(VaadinServlet.class);
         Mockito.when(servlet.getServletContext()).thenReturn(servletContext);
         Mockito.when(vaadinService.getServlet()).thenReturn(servlet);
@@ -362,7 +362,7 @@ class RouteConfigurationTest {
     }
 
     @Test
-    public void addListenerToSessionScoped_alsoEventsForApplicationScope() {
+    void addListenerToSessionScoped_alsoEventsForApplicationScope() {
         VaadinServlet servlet = Mockito.mock(VaadinServlet.class);
         Mockito.when(servlet.getServletContext()).thenReturn(servletContext);
         Mockito.when(vaadinService.getServlet()).thenReturn(servlet);
@@ -406,7 +406,7 @@ class RouteConfigurationTest {
     }
 
     @Test
-    public void configurationForSessionRegistry_buildsWithCorrectRegistry() {
+    void configurationForSessionRegistry_buildsWithCorrectRegistry() {
         SessionRouteRegistry registry = getRegistry(session);
         registry.update(() -> {
             registry.setRoute("", MyRoute.class, Collections.emptyList());
@@ -428,7 +428,7 @@ class RouteConfigurationTest {
     }
 
     @Test
-    public void configurationForApplicationScope_buildsWithCorrectRegistry() {
+    void configurationForApplicationScope_buildsWithCorrectRegistry() {
         registry.update(() -> {
             registry.setRoute("", MyRoute.class, Collections.emptyList());
             registry.setRoute("path", Secondary.class, Collections.emptyList());
@@ -453,7 +453,7 @@ class RouteConfigurationTest {
     }
 
     @Test
-    public void setRoutes_allExpectedRoutesAreSet() {
+    void setRoutes_allExpectedRoutesAreSet() {
         RouteRegistry registry = mockRegistry();
         RouteConfiguration routeConfiguration = RouteConfiguration
                 .forRegistry(registry);
@@ -487,7 +487,7 @@ class RouteConfigurationTest {
     }
 
     @Test
-    public void registeredRouteWithAlias_allPathsAreRegistered() {
+    void registeredRouteWithAlias_allPathsAreRegistered() {
         RouteRegistry registry = mockRegistry();
         RouteConfiguration routeConfiguration = RouteConfiguration
                 .forRegistry(registry);
@@ -504,7 +504,7 @@ class RouteConfigurationTest {
     }
 
     @Test
-    public void routeWithParent_parentsAreCollectedCorrectly() {
+    void routeWithParent_parentsAreCollectedCorrectly() {
         RouteRegistry registry = mockRegistry();
         RouteConfiguration routeConfiguration = RouteConfiguration
                 .forRegistry(registry);
@@ -521,7 +521,7 @@ class RouteConfigurationTest {
     }
 
     @Test
-    public void parentLayoutAnnotatedClass_parentsCorrecltCollected() {
+    void parentLayoutAnnotatedClass_parentsCorrecltCollected() {
         RouteRegistry registry = Mockito.mock(RouteRegistry.class);
         RouteConfiguration routeConfiguration = RouteConfiguration
                 .forRegistry(registry);

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouteNotFoundErrorTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouteNotFoundErrorTest.java
@@ -42,7 +42,7 @@ class RouteNotFoundErrorTest {
     }
 
     @Test
-    public void setErrorParameter_productionMode_pathContainRoutesTemplate_renderedElementHasNoRoutes() {
+    void setErrorParameter_productionMode_pathContainRoutesTemplate_renderedElementHasNoRoutes() {
 
         RouteNotFoundError page = new RouteNotFoundError();
         BeforeEnterEvent event = createEvent(true);
@@ -83,7 +83,7 @@ class RouteNotFoundErrorTest {
     }
 
     @Test
-    public void setErrorParameter_devMode_noRoutes() {
+    void setErrorParameter_devMode_noRoutes() {
         RouteNotFoundError page = new RouteNotFoundError();
         BeforeEnterEvent event = createEvent(false);
 

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouteParametersTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouteParametersTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 class RouteParametersTest {
 
     @Test
-    public void getters_provide_correct_values() {
+    void getters_provide_correct_values() {
         RouteParameters parameters = getParameters();
 
         // String getter
@@ -61,7 +61,7 @@ class RouteParametersTest {
     }
 
     @Test
-    public void getters_provide_empty_values() {
+    void getters_provide_empty_values() {
         RouteParameters parameters = getParameters();
 
         assertFalse(parameters.get("foo").isPresent(),
@@ -76,7 +76,7 @@ class RouteParametersTest {
     }
 
     @Test
-    public void integer_getter_stringParameter_throws() {
+    void integer_getter_stringParameter_throws() {
         RouteParameters parameters = getParameters();
 
         IllegalArgumentException ex = assertThrows(
@@ -89,7 +89,7 @@ class RouteParametersTest {
     }
 
     @Test
-    public void integer_getter_longParameter_throws() {
+    void integer_getter_longParameter_throws() {
         RouteParameters parameters = getParameters();
 
         IllegalArgumentException ex = assertThrows(
@@ -102,7 +102,7 @@ class RouteParametersTest {
     }
 
     @Test
-    public void integer_getter_varaargsParameter_throws() {
+    void integer_getter_varaargsParameter_throws() {
         RouteParameters parameters = getParameters();
 
         IllegalArgumentException ex = assertThrows(
@@ -115,7 +115,7 @@ class RouteParametersTest {
     }
 
     @Test
-    public void long_getter_varaargsParameter_throws() {
+    void long_getter_varaargsParameter_throws() {
         RouteParameters parameters = getParameters();
 
         IllegalArgumentException ex = assertThrows(
@@ -128,7 +128,7 @@ class RouteParametersTest {
     }
 
     @Test
-    public void long_getter_stringParameter_throws() {
+    void long_getter_stringParameter_throws() {
         RouteParameters parameters = getParameters();
 
         IllegalArgumentException ex = assertThrows(
@@ -141,7 +141,7 @@ class RouteParametersTest {
     }
 
     @Test
-    public void varargs_initializer_throws_exception() {
+    void varargs_initializer_throws_exception() {
         try {
             new RouteParameters(new RouteParam("int", "123"),
                     new RouteParam("int", "123"));

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterConfigurationUrlResolvingTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterConfigurationUrlResolvingTest.java
@@ -50,7 +50,7 @@ class RouterConfigurationUrlResolvingTest extends RoutingTestBase {
             .mock(DeploymentConfiguration.class);
 
     @BeforeEach
-    public void init() throws NoSuchFieldException, IllegalAccessException {
+    void init() throws NoSuchFieldException, IllegalAccessException {
         super.init();
         ui = new RouterTestMockUI(router);
         ui.getSession().lock();
@@ -67,7 +67,7 @@ class RouterConfigurationUrlResolvingTest extends RoutingTestBase {
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         CurrentInstance.clearAll();
     }
 
@@ -82,8 +82,7 @@ class RouterConfigurationUrlResolvingTest extends RoutingTestBase {
     }
 
     @Test
-    public void basic_url_resolving()
-            throws InvalidRouteConfigurationException {
+    void basic_url_resolving() throws InvalidRouteConfigurationException {
         setNavigationTargets(RootNavigationTarget.class,
                 FooNavigationTarget.class, FooBarNavigationTarget.class);
 
@@ -95,7 +94,7 @@ class RouterConfigurationUrlResolvingTest extends RoutingTestBase {
     }
 
     @Test
-    public void nested_layouts_url_resolving()
+    void nested_layouts_url_resolving()
             throws InvalidRouteConfigurationException {
         setNavigationTargets(RouteChild.class, LoneRoute.class);
 
@@ -105,7 +104,7 @@ class RouterConfigurationUrlResolvingTest extends RoutingTestBase {
     }
 
     @Test
-    public void layout_with_url_parameter_url_resolving()
+    void layout_with_url_parameter_url_resolving()
             throws InvalidRouteConfigurationException {
         setNavigationTargets(GreetingNavigationTarget.class,
                 OtherGreetingNavigationTarget.class);
@@ -120,7 +119,7 @@ class RouterConfigurationUrlResolvingTest extends RoutingTestBase {
     }
 
     @Test
-    public void url_resolves_correctly_for_optional_and_wild_parameters()
+    void url_resolves_correctly_for_optional_and_wild_parameters()
             throws InvalidRouteConfigurationException, NotFoundException {
         setNavigationTargets(OptionalParameter.class, WildParameter.class);
 
@@ -142,7 +141,7 @@ class RouterConfigurationUrlResolvingTest extends RoutingTestBase {
     }
 
     @Test
-    public void getUrl_with_wildcard_parameter_requires_pre_encoded_special_chars()
+    void getUrl_with_wildcard_parameter_requires_pre_encoded_special_chars()
             throws InvalidRouteConfigurationException, NotFoundException {
         setNavigationTargets(WildParameter.class);
 
@@ -166,7 +165,7 @@ class RouterConfigurationUrlResolvingTest extends RoutingTestBase {
     }
 
     @Test
-    public void wildcardPathWithEmptyParameter_emptyParameterIsAvailable() {
+    void wildcardPathWithEmptyParameter_emptyParameterIsAvailable() {
         WildParameter.events.clear();
         WildParameter.param = null;
         setNavigationTargets(WildParameter.class);
@@ -188,7 +187,7 @@ class RouterConfigurationUrlResolvingTest extends RoutingTestBase {
     }
 
     @Test
-    public void root_navigation_target_with_wildcard_parameter()
+    void root_navigation_target_with_wildcard_parameter()
             throws InvalidRouteConfigurationException {
         WildRootParameter.events.clear();
         WildRootParameter.param = null;
@@ -218,7 +217,7 @@ class RouterConfigurationUrlResolvingTest extends RoutingTestBase {
     }
 
     @Test
-    public void root_navigation_target_with_optional_parameter()
+    void root_navigation_target_with_optional_parameter()
             throws InvalidRouteConfigurationException {
         OptionalRootParameter.events.clear();
         OptionalRootParameter.param = null;
@@ -249,7 +248,7 @@ class RouterConfigurationUrlResolvingTest extends RoutingTestBase {
     }
 
     @Test
-    public void getUrl_for_has_url_with_supported_parameters()
+    void getUrl_for_has_url_with_supported_parameters()
             throws InvalidRouteConfigurationException {
         setNavigationTargets(IntegerParameter.class, LongParameter.class,
                 BooleanParameter.class);
@@ -265,14 +264,14 @@ class RouterConfigurationUrlResolvingTest extends RoutingTestBase {
     }
 
     @Test // 3519
-    public void getUrl_throws_for_required_parameter() {
+    void getUrl_throws_for_required_parameter() {
         setNavigationTargets(RouteWithParameter.class);
         assertThrows(IllegalArgumentException.class,
                 () -> routeConfiguration.getUrl(RouteWithParameter.class));
     }
 
     @Test // 3519
-    public void getUrl_returns_url_if_parameter_is_wildcard_or_optional()
+    void getUrl_returns_url_if_parameter_is_wildcard_or_optional()
             throws InvalidRouteConfigurationException {
         setNavigationTargets(RouteWithMultipleParameters.class,
                 OptionalParameter.class);
@@ -291,7 +290,7 @@ class RouterConfigurationUrlResolvingTest extends RoutingTestBase {
     }
 
     @Test // 3519
-    public void getUrlBase_returns_url_without_parameter_even_for_required_parameters()
+    void getUrlBase_returns_url_without_parameter_even_for_required_parameters()
             throws InvalidRouteConfigurationException {
         setNavigationTargets(RouteWithParameter.class,
                 RouteWithMultipleParameters.class, OptionalParameter.class,
@@ -320,7 +319,7 @@ class RouterConfigurationUrlResolvingTest extends RoutingTestBase {
     }
 
     @Test // #2740
-    public void getTemplate_returns_url_template()
+    void getTemplate_returns_url_template()
             throws InvalidRouteConfigurationException {
         setNavigationTargets(RouteWithParameter.class,
                 RouteWithMultipleParameters.class, OptionalParameter.class,
@@ -346,7 +345,7 @@ class RouterConfigurationUrlResolvingTest extends RoutingTestBase {
     }
 
     @Test
-    public void routerLinkInParent_updatesWhenNavigating()
+    void routerLinkInParent_updatesWhenNavigating()
             throws InvalidRouteConfigurationException {
         setNavigationTargets(LoneRoute.class, RouteChild.class);
 
@@ -368,7 +367,7 @@ class RouterConfigurationUrlResolvingTest extends RoutingTestBase {
     }
 
     @Test // #2740
-    public void navigation_targets_remove_route_with_same_path()
+    void navigation_targets_remove_route_with_same_path()
             throws InvalidRouteConfigurationException {
         setNavigationTargets(MyPage.class, MyPageWithParam.class);
 
@@ -386,7 +385,7 @@ class RouterConfigurationUrlResolvingTest extends RoutingTestBase {
     }
 
     @Test // #2740
-    public void navigation_targets_remove_route_with_same_path_and_parameter()
+    void navigation_targets_remove_route_with_same_path_and_parameter()
             throws InvalidRouteConfigurationException {
         setNavigationTargets(MyPage.class, MyPageWithParam.class);
 
@@ -399,7 +398,7 @@ class RouterConfigurationUrlResolvingTest extends RoutingTestBase {
     }
 
     @Test // #2740
-    public void navigation_targets_remove_route_target_with_same_path_and_parameter()
+    void navigation_targets_remove_route_target_with_same_path_and_parameter()
             throws InvalidRouteConfigurationException {
         setNavigationTargets(MyPage.class, MyPageWithParam.class);
 
@@ -433,7 +432,7 @@ class RouterConfigurationUrlResolvingTest extends RoutingTestBase {
     }
 
     @Test // #2740
-    public void navigation_targets_with_same_route_and_one_with_parameter()
+    void navigation_targets_with_same_route_and_one_with_parameter()
             throws InvalidRouteConfigurationException {
         setNavigationTargets(MyPage.class, MyPageWithParam.class);
 
@@ -441,7 +440,7 @@ class RouterConfigurationUrlResolvingTest extends RoutingTestBase {
     }
 
     @Test // #2740
-    public void navigation_targets_with_same_route_and_two_with_parameter()
+    void navigation_targets_with_same_route_and_two_with_parameter()
             throws InvalidRouteConfigurationException {
         setNavigationTargets(MyPage.class, MyPageWithParam.class,
                 MyPageWithWildcardParam.class);

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterLayoutTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterLayoutTest.java
@@ -30,12 +30,12 @@ class RouterLayoutTest {
     private TestRouterLayout testRouterLayout;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         testRouterLayout = new TestRouterLayout();
     }
 
     @Test
-    public void show_nonNull_childrenUpdated() {
+    void show_nonNull_childrenUpdated() {
         assertEquals(0, testRouterLayout.getElement().getChildCount());
 
         ComponentTest.TestDiv content = new ComponentTest.TestDiv();
@@ -54,13 +54,13 @@ class RouterLayoutTest {
     }
 
     @Test
-    public void show_null_noChildren() {
+    void show_null_noChildren() {
         testRouterLayout.showRouterLayoutContent(null);
         assertEquals(0, testRouterLayout.getElement().getChildCount());
     }
 
     @Test
-    public void remove_removesContent() {
+    void remove_removesContent() {
         ComponentTest.TestDiv content = new ComponentTest.TestDiv();
         testRouterLayout.element.appendChild(content.getElement());
 

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterLinkTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterLinkTest.java
@@ -64,7 +64,7 @@ class RouterLinkTest extends HasCurrentService {
     }
 
     @BeforeEach
-    public void setUp() throws NoSuchFieldException, IllegalAccessException,
+    void setUp() throws NoSuchFieldException, IllegalAccessException,
             InvalidRouteConfigurationException {
         VaadinService service = VaadinService.getCurrent();
         DeploymentConfiguration config = Mockito
@@ -91,7 +91,7 @@ class RouterLinkTest extends HasCurrentService {
     }
 
     @Test
-    public void createRouterLink_implicitCurrentVaadinServiceRouter() {
+    void createRouterLink_implicitCurrentVaadinServiceRouter() {
         // This method sets mock VaadinService instance which returns
         // Router from the UI.
         RouterLink link = new RouterLink("Show something", TestView.class,
@@ -106,7 +106,7 @@ class RouterLinkTest extends HasCurrentService {
     }
 
     @Test
-    public void setRoute_attachedLink() {
+    void setRoute_attachedLink() {
         UI ui = new UI();
 
         RouterLink link = new RouterLink();
@@ -120,7 +120,7 @@ class RouterLinkTest extends HasCurrentService {
     }
 
     @Test
-    public void setRoute_withoutRouter() {
+    void setRoute_withoutRouter() {
         RouterLink link = new RouterLink();
 
         ui.add(link);
@@ -132,7 +132,7 @@ class RouterLinkTest extends HasCurrentService {
     }
 
     @Test
-    public void setRoute_withoutRouterWithParameter() {
+    void setRoute_withoutRouterWithParameter() {
         RouterLink link = new RouterLink();
 
         ui.add(link);
@@ -144,7 +144,7 @@ class RouterLinkTest extends HasCurrentService {
     }
 
     @Test
-    public void createRouterLink_explicitRouter() {
+    void createRouterLink_explicitRouter() {
         RouterLink link = new RouterLink(router, "Show something",
                 TestView.class, "something");
         assertEquals("Show something", link.getText());
@@ -157,7 +157,7 @@ class RouterLinkTest extends HasCurrentService {
     }
 
     @Test
-    public void createRouterLink_withTargetViewNoText() {
+    void createRouterLink_withTargetViewNoText() {
         RouterLink link = new RouterLink(FooNavigationTarget.class);
         assertEquals("", link.getText());
         assertTrue(link.getElement()
@@ -169,7 +169,7 @@ class RouterLinkTest extends HasCurrentService {
     }
 
     @Test
-    public void createRouterLink_withTargetViewWithParameterNoText() {
+    void createRouterLink_withTargetViewWithParameterNoText() {
         RouterLink link = new RouterLink(TestView.class, "something");
         assertEquals("", link.getText());
         assertTrue(link.getElement()
@@ -181,7 +181,7 @@ class RouterLinkTest extends HasCurrentService {
     }
 
     @Test
-    public void createRouterLink_withTargetViewWithRouteParametersNoText() {
+    void createRouterLink_withTargetViewWithRouteParametersNoText() {
         RouteParameters routeParameters = HasUrlParameterFormat
                 .getParameters("something");
         RouterLink link = new RouterLink(TestView.class, routeParameters);
@@ -195,7 +195,7 @@ class RouterLinkTest extends HasCurrentService {
     }
 
     @Test
-    public void createRouterLink_explicitRouterWithTargetViewNoText() {
+    void createRouterLink_explicitRouterWithTargetViewNoText() {
         RouterLink link = new RouterLink(router, FooNavigationTarget.class);
         assertEquals("", link.getText());
         assertTrue(link.getElement()
@@ -207,7 +207,7 @@ class RouterLinkTest extends HasCurrentService {
     }
 
     @Test
-    public void createRouterLink_explicitRouterWithTargetViewWithParameterNoText() {
+    void createRouterLink_explicitRouterWithTargetViewWithParameterNoText() {
         RouterLink link = new RouterLink(router, TestView.class, "something");
         assertEquals("", link.getText());
         assertTrue(link.getElement()
@@ -219,7 +219,7 @@ class RouterLinkTest extends HasCurrentService {
     }
 
     @Test
-    public void createRouterLink_explicitRouterWithTargetViewWithRouteParametersNoText() {
+    void createRouterLink_explicitRouterWithTargetViewWithRouteParametersNoText() {
         RouteParameters routeParameters = HasUrlParameterFormat
                 .getParameters("something");
         RouterLink link = new RouterLink(router, TestView.class,
@@ -234,7 +234,7 @@ class RouterLinkTest extends HasCurrentService {
     }
 
     @Test
-    public void createReconfigureRouterLink_implicitCurrentVaadinServiceRouter() {
+    void createReconfigureRouterLink_implicitCurrentVaadinServiceRouter() {
         RouterLink link = new RouterLink("Show something", TestView.class,
                 "something");
 
@@ -248,7 +248,7 @@ class RouterLinkTest extends HasCurrentService {
     }
 
     @Test
-    public void createReconfigureRouterLink_explicitRouter() {
+    void createReconfigureRouterLink_explicitRouter() {
         RouterLink link = new RouterLink(router, "Show something",
                 TestView.class, "something");
 
@@ -262,7 +262,7 @@ class RouterLinkTest extends HasCurrentService {
     }
 
     @Test
-    public void reconfigureRouterLink_attachedLink() {
+    void reconfigureRouterLink_attachedLink() {
         RouterLink link = new RouterLink();
         ui.add(link);
 
@@ -276,7 +276,7 @@ class RouterLinkTest extends HasCurrentService {
     }
 
     @Test
-    public void noImplicitRouter() {
+    void noImplicitRouter() {
         VaadinService service = VaadinService.getCurrent();
         Mockito.when(service.getRouter()).thenReturn(null);
         assertThrows(IllegalStateException.class,
@@ -284,12 +284,12 @@ class RouterLinkTest extends HasCurrentService {
     }
 
     @Test
-    public void routerLink_withoutRouter_WithRouteParameters() {
+    void routerLink_withoutRouter_WithRouteParameters() {
         assertRouterLinkRouteParameters(false);
     }
 
     @Test
-    public void routerLink_WithRouteParameters() {
+    void routerLink_WithRouteParameters() {
         assertRouterLinkRouteParameters(true);
     }
 
@@ -340,7 +340,7 @@ class RouterLinkTest extends HasCurrentService {
     }
 
     @Test
-    public void routerLinkCreationForNormalRouteTarget()
+    void routerLinkCreationForNormalRouteTarget()
             throws InvalidRouteConfigurationException {
         RouterLink link = new RouterLink(router, "Foo",
                 FooNavigationTarget.class);
@@ -348,7 +348,7 @@ class RouterLinkTest extends HasCurrentService {
     }
 
     @Test
-    public void routerLinkCreationForUrlParameterRouteTarget()
+    void routerLinkCreationForUrlParameterRouteTarget()
             throws InvalidRouteConfigurationException {
         RouterLink link = new RouterLink(router, "Greeting",
                 GreetingNavigationTarget.class, "hello");
@@ -356,7 +356,7 @@ class RouterLinkTest extends HasCurrentService {
     }
 
     @Test
-    public void routerLinkDefaultHighlightCondition()
+    void routerLinkDefaultHighlightCondition()
             throws InvalidRouteConfigurationException {
         RouterLink link = new RouterLink(router, "Foo",
                 FooNavigationTarget.class);
@@ -369,7 +369,7 @@ class RouterLinkTest extends HasCurrentService {
     }
 
     @Test
-    public void routerLinkSameLocationHighlightCondition()
+    void routerLinkSameLocationHighlightCondition()
             throws InvalidRouteConfigurationException {
         RouterLink link = new RouterLink(router, "Foo",
                 FooNavigationTarget.class);
@@ -383,7 +383,7 @@ class RouterLinkTest extends HasCurrentService {
     }
 
     @Test
-    public void routerLinkLocationPrefixHighlightCondition()
+    void routerLinkLocationPrefixHighlightCondition()
             throws InvalidRouteConfigurationException {
         RouterLink link = new RouterLink(router, "Foo",
                 FooNavigationTarget.class);
@@ -401,7 +401,7 @@ class RouterLinkTest extends HasCurrentService {
     }
 
     @Test
-    public void routerLinkClearOldHighlightAction()
+    void routerLinkClearOldHighlightAction()
             throws InvalidRouteConfigurationException {
         RouterLink link = new RouterLink(router, "Foo",
                 FooNavigationTarget.class);
@@ -414,7 +414,7 @@ class RouterLinkTest extends HasCurrentService {
     }
 
     @Test
-    public void routerLinkClassNameHightlightAction()
+    void routerLinkClassNameHightlightAction()
             throws InvalidRouteConfigurationException {
         RouterLink link = new RouterLink(router, "Foo",
                 FooNavigationTarget.class);
@@ -428,7 +428,7 @@ class RouterLinkTest extends HasCurrentService {
     }
 
     @Test
-    public void routerLinkThemeHightlightAction()
+    void routerLinkThemeHightlightAction()
             throws InvalidRouteConfigurationException {
         RouterLink link = new RouterLink(router, "Foo",
                 FooNavigationTarget.class);
@@ -442,8 +442,7 @@ class RouterLinkTest extends HasCurrentService {
     }
 
     @Test
-    public void routerLinkQueryParameters()
-            throws InvalidRouteConfigurationException {
+    void routerLinkQueryParameters() throws InvalidRouteConfigurationException {
         RouterLink link = new RouterLink(router, "Foo",
                 FooNavigationTarget.class);
 
@@ -465,7 +464,7 @@ class RouterLinkTest extends HasCurrentService {
     }
 
     @Test
-    public void routerLinkToNotRouterTarget_throwsIAE() {
+    void routerLinkToNotRouterTarget_throwsIAE() {
         IllegalArgumentException ex = assertThrows(
                 IllegalArgumentException.class, () -> {
                     new RouterLink("", Foo.class);

--- a/flow-server/src/test/java/com/vaadin/flow/router/RoutingTestBase.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RoutingTestBase.java
@@ -27,7 +27,7 @@ import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.tests.util.AlwaysLockedVaadinSession;
 import com.vaadin.tests.util.MockUI;
 
-public class RoutingTestBase {
+class RoutingTestBase {
 
     @Route("")
     @Tag(Tag.DIV)
@@ -108,7 +108,7 @@ public class RoutingTestBase {
     protected Router router;
 
     @BeforeEach
-    public void init() throws NoSuchFieldException, SecurityException,
+    void init() throws NoSuchFieldException, SecurityException,
             IllegalArgumentException, IllegalAccessException {
         router = new Router(new TestRouteRegistry());
     }

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/AbstractRouteRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/AbstractRouteRegistryTest.java
@@ -52,12 +52,12 @@ class AbstractRouteRegistryTest {
     private AbstractRouteRegistry registry;
 
     @BeforeEach
-    public void init() {
+    void init() {
         registry = new TestAbstractRouteRegistry();
     }
 
     @Test
-    public void lockingConfiguration_configurationIsUpdatedOnlyAfterUnlock() {
+    void lockingConfiguration_configurationIsUpdatedOnlyAfterUnlock() {
         CountDownLatch waitReaderThread = new CountDownLatch(1);
         CountDownLatch waitUpdaterThread = new CountDownLatch(2);
 
@@ -90,7 +90,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void routeChangeListener_correctChangesAreReturned() {
+    void routeChangeListener_correctChangesAreReturned() {
         List<RouteBaseData> added = new ArrayList<>();
         List<RouteBaseData> removed = new ArrayList<>();
 
@@ -130,7 +130,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void routeChangeListener_blockChangesAreGivenCorrectlyInEvent() {
+    void routeChangeListener_blockChangesAreGivenCorrectlyInEvent() {
         registry.setRoute("", MyRoute.class, Collections.emptyList());
 
         List<RouteBaseData> added = new ArrayList<>();
@@ -172,7 +172,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void routeWithAliases_eventShowsCorrectlyAsRemoved() {
+    void routeWithAliases_eventShowsCorrectlyAsRemoved() {
         List<RouteBaseData> added = new ArrayList<>();
         List<RouteBaseData> removed = new ArrayList<>();
 
@@ -203,7 +203,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void changeListenerAddedDuringUpdate_eventIsFiredForListener() {
+    void changeListenerAddedDuringUpdate_eventIsFiredForListener() {
         List<RouteBaseData> added = new ArrayList<>();
         List<RouteBaseData> removed = new ArrayList<>();
 
@@ -237,7 +237,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void removeChangeListener_noEventsAreFired() {
+    void removeChangeListener_noEventsAreFired() {
         List<RoutesChangedEvent> events = new ArrayList<>();
 
         Registration registration = registry
@@ -256,7 +256,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void routeChangedEvent_testRouteAddedAndRemoved() {
+    void routeChangedEvent_testRouteAddedAndRemoved() {
         registry.setRoute("MyRoute1", MyRoute.class, Collections.emptyList());
 
         registry.addRoutesChangeListener(event -> {
@@ -292,7 +292,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void routeChangedEvent_testPathAddedAndRemoved() {
+    void routeChangedEvent_testPathAddedAndRemoved() {
         registry.setRoute("MyRoute1", MyRoute.class, Collections.emptyList());
 
         registry.addRoutesChangeListener(event -> {
@@ -325,7 +325,7 @@ class AbstractRouteRegistryTest {
     /* Parameters tests */
 
     @Test
-    public void only_normal_target_works_as_expected() {
+    void only_normal_target_works_as_expected() {
         addTarget(NormalRoute.class);
 
         assertEquals(NormalRoute.class, getTarget(),
@@ -333,7 +333,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void only_has_url_target_works_as_expected() {
+    void only_has_url_target_works_as_expected() {
         addTarget(HasUrlRoute.class);
 
         assertNull(getTarget(new ArrayList<>()),
@@ -344,7 +344,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void only_optional_target_works_as_expected() {
+    void only_optional_target_works_as_expected() {
         addTarget(OptionalRoute.class);
 
         assertEquals(OptionalRoute.class, getTarget(new ArrayList<>()),
@@ -355,7 +355,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void only_wildcard_target_works_as_expected() {
+    void only_wildcard_target_works_as_expected() {
         addTarget(WildcardRoute.class);
 
         assertEquals(WildcardRoute.class, getTarget(new ArrayList<>()),
@@ -370,7 +370,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void normal_and_has_url_work_together() {
+    void normal_and_has_url_work_together() {
         addTarget(NormalRoute.class);
         addTarget(HasUrlRoute.class);
 
@@ -382,7 +382,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void has_url_and_normal_work_together() {
+    void has_url_and_normal_work_together() {
         addTarget(HasUrlRoute.class);
         addTarget(NormalRoute.class);
 
@@ -394,7 +394,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void normal_and_wildcard_work_together() {
+    void normal_and_wildcard_work_together() {
         addTarget(NormalRoute.class);
         addTarget(WildcardRoute.class);
 
@@ -410,7 +410,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void wildcard_and_normal_work_together() {
+    void wildcard_and_normal_work_together() {
         addTarget(WildcardRoute.class);
         addTarget(NormalRoute.class);
 
@@ -426,7 +426,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void normal_and_has_url_and_wildcard_work_together()
+    void normal_and_has_url_and_wildcard_work_together()
             throws InvalidRouteConfigurationException {
         addTarget(NormalRoute.class);
         addTarget(HasUrlRoute.class);
@@ -436,7 +436,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void normal_and_wildcard_and_has_url_work_together()
+    void normal_and_wildcard_and_has_url_work_together()
             throws InvalidRouteConfigurationException {
         addTarget(NormalRoute.class);
         addTarget(WildcardRoute.class);
@@ -446,7 +446,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void wildcard_and_normal_and_has_url_work_together()
+    void wildcard_and_normal_and_has_url_work_together()
             throws InvalidRouteConfigurationException {
         addTarget(WildcardRoute.class);
         addTarget(HasUrlRoute.class);
@@ -456,7 +456,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void has_url_and_wildcard_and_normal_work_together()
+    void has_url_and_wildcard_and_normal_work_together()
             throws InvalidRouteConfigurationException {
         addTarget(HasUrlRoute.class);
         addTarget(WildcardRoute.class);
@@ -466,7 +466,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void has_url_and_normal_and_wildcard_work_together()
+    void has_url_and_normal_and_wildcard_work_together()
             throws InvalidRouteConfigurationException {
         addTarget(HasUrlRoute.class);
         addTarget(NormalRoute.class);
@@ -488,7 +488,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void has_url_and_optional_parameter_work_together()
+    void has_url_and_optional_parameter_work_together()
             throws InvalidRouteConfigurationException {
         addTarget(HasUrlRoute.class);
         addTarget(OptionalRoute.class);
@@ -501,7 +501,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void has_url_and_wildcard_and_optional_parameter_work_together()
+    void has_url_and_wildcard_and_optional_parameter_work_together()
             throws InvalidRouteConfigurationException {
         addTarget(HasUrlRoute.class);
         addTarget(WildcardRoute.class);
@@ -511,7 +511,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void optional_parameter_and_has_url_and_wildcard_work_together()
+    void optional_parameter_and_has_url_and_wildcard_work_together()
             throws InvalidRouteConfigurationException {
         addTarget(OptionalRoute.class);
         addTarget(HasUrlRoute.class);
@@ -521,7 +521,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void optional_parameter_and_wildcard_and_has_url_work_together()
+    void optional_parameter_and_wildcard_and_has_url_work_together()
             throws InvalidRouteConfigurationException {
         addTarget(OptionalRoute.class);
         addTarget(WildcardRoute.class);
@@ -531,7 +531,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void wildcard_and_has_url_and_optional_parameter_work_together()
+    void wildcard_and_has_url_and_optional_parameter_work_together()
             throws InvalidRouteConfigurationException {
         addTarget(WildcardRoute.class);
         addTarget(HasUrlRoute.class);
@@ -541,7 +541,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void wildcard_and_optional_parameter_and_has_url_work_together()
+    void wildcard_and_optional_parameter_and_has_url_work_together()
             throws InvalidRouteConfigurationException {
         addTarget(WildcardRoute.class);
         addTarget(OptionalRoute.class);
@@ -551,7 +551,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void has_url_and_optional_parameter_and_wildcard_work_together()
+    void has_url_and_optional_parameter_and_wildcard_work_together()
             throws InvalidRouteConfigurationException {
         addTarget(HasUrlRoute.class);
         addTarget(OptionalRoute.class);
@@ -573,7 +573,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void has_url_and_wildcard_work_together()
+    void has_url_and_wildcard_work_together()
             throws InvalidRouteConfigurationException {
         addTarget(HasUrlRoute.class);
         addTarget(WildcardRoute.class);
@@ -582,7 +582,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void wildcard_and_has_url_work_together()
+    void wildcard_and_has_url_work_together()
             throws InvalidRouteConfigurationException {
         addTarget(WildcardRoute.class);
         addTarget(HasUrlRoute.class);
@@ -606,7 +606,7 @@ class AbstractRouteRegistryTest {
 
     /* "normal" target registered first */
     @Test
-    public void multiple_normal_routes_throw_exception()
+    void multiple_normal_routes_throw_exception()
             throws InvalidRouteConfigurationException {
         addTarget(NormalRoute.class);
         InvalidRouteConfigurationException ex = assertThrows(
@@ -619,7 +619,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void normal_and_optional_throws_exception()
+    void normal_and_optional_throws_exception()
             throws InvalidRouteConfigurationException {
         addTarget(NormalRoute.class);
         InvalidRouteConfigurationException ex = assertThrows(
@@ -634,7 +634,7 @@ class AbstractRouteRegistryTest {
     /* Optional target registered first */
 
     @Test
-    public void two_optionals_throw_exception()
+    void two_optionals_throw_exception()
             throws InvalidRouteConfigurationException {
         addTarget(OptionalRoute.class);
         InvalidRouteConfigurationException ex = assertThrows(
@@ -643,7 +643,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void optional_and_normal_throws_exception()
+    void optional_and_normal_throws_exception()
             throws InvalidRouteConfigurationException {
         addTarget(OptionalRoute.class);
         InvalidRouteConfigurationException ex = assertThrows(
@@ -657,7 +657,7 @@ class AbstractRouteRegistryTest {
 
     /* HasUrl parameter */
     @Test
-    public void two_has_route_parameters_throw_exception()
+    void two_has_route_parameters_throw_exception()
             throws InvalidRouteConfigurationException {
         addTarget(HasUrlRoute.class);
         InvalidRouteConfigurationException ex = assertThrows(
@@ -667,7 +667,7 @@ class AbstractRouteRegistryTest {
 
     /* Wildcard parameters */
     @Test
-    public void two_wildcard_parameters_throw_exception()
+    void two_wildcard_parameters_throw_exception()
             throws InvalidRouteConfigurationException {
         addTarget(WildcardRoute.class);
         InvalidRouteConfigurationException ex = assertThrows(
@@ -676,7 +676,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void removing_target_leaves_others() {
+    void removing_target_leaves_others() {
         addTarget(NormalRoute.class);
         addTarget(HasUrlRoute.class);
         addTarget(WildcardRoute.class);
@@ -696,7 +696,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void removing_all_targets_is_possible_and_returns_empty() {
+    void removing_all_targets_is_possible_and_returns_empty() {
         addTarget(NormalRoute.class);
         addTarget(HasUrlRoute.class);
         addTarget(WildcardRoute.class);
@@ -713,7 +713,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void check_has_parameters_returns_correctly() {
+    void check_has_parameters_returns_correctly() {
         registry.setRoute("", NormalRoute.class, null);
         registry.setRoute("url", HasUrlRoute.class, null);
         registry.setRoute("optional", OptionalRoute.class, null);
@@ -743,7 +743,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void multipleLayouts_stricterLayoutMatches_correctLayoutsReturned() {
+    void multipleLayouts_stricterLayoutMatches_correctLayoutsReturned() {
         registry.setLayout(DefaultLayout.class);
         registry.setLayout(ViewLayout.class);
 
@@ -757,7 +757,7 @@ class AbstractRouteRegistryTest {
     }
 
     @Test
-    public void singleLayout_nonMatchingPathsReturnFalseOnHasLayout() {
+    void singleLayout_nonMatchingPathsReturnFalseOnHasLayout() {
         registry.setLayout(ViewLayout.class);
 
         assertTrue(registry.hasLayout("/view"),

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/ConfigureRoutesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/ConfigureRoutesTest.java
@@ -58,7 +58,7 @@ class ConfigureRoutesTest {
     }
 
     @Test
-    public void mutableConfiguration_canSetRouteTarget() {
+    void mutableConfiguration_canSetRouteTarget() {
         ConfigureRoutes mutable = new ConfigureRoutes();
 
         mutable.setRoute("", BaseTarget.class);
@@ -70,7 +70,7 @@ class ConfigureRoutesTest {
     }
 
     @Test
-    public void mutableConfiguration_canSetTargetRoute() {
+    void mutableConfiguration_canSetTargetRoute() {
         ConfigureRoutes mutable = new ConfigureRoutes();
 
         mutable.setRoute("", BaseTarget.class);
@@ -82,7 +82,7 @@ class ConfigureRoutesTest {
     }
 
     @Test
-    public void mutableConfigurationClear_removesRegisteredRoutes() {
+    void mutableConfigurationClear_removesRegisteredRoutes() {
         ConfigureRoutes mutable = new ConfigureRoutes();
 
         assertSetRoutes(mutable);
@@ -99,7 +99,7 @@ class ConfigureRoutesTest {
     }
 
     @Test
-    public void mutableConfigurationClear_preservesErrorRoute() {
+    void mutableConfigurationClear_preservesErrorRoute() {
         ConfigureRoutes mutable = new ConfigureRoutes();
 
         mutable.setErrorRoute(IndexOutOfBoundsException.class, BaseError.class);
@@ -113,7 +113,7 @@ class ConfigureRoutesTest {
     }
 
     @Test
-    public void duplicateRootPathRegistration_throwsException() {
+    void duplicateRootPathRegistration_throwsException() {
         ConfigureRoutes mutable = new ConfigureRoutes();
 
         mutable.setRoute("", BaseTarget.class);
@@ -132,7 +132,7 @@ class ConfigureRoutesTest {
     }
 
     @Test
-    public void duplicateParameterPathRegistration_throwsException() {
+    void duplicateParameterPathRegistration_throwsException() {
         ConfigureRoutes mutable = new ConfigureRoutes();
 
         mutable.setRoute(":param", ParamTarget.class);
@@ -151,7 +151,7 @@ class ConfigureRoutesTest {
     }
 
     @Test
-    public void mutableConfiguration_makingImmutableHasCorrectData() {
+    void mutableConfiguration_makingImmutableHasCorrectData() {
         ConfigureRoutes mutable = new ConfigureRoutes();
 
         mutable.setRoute("", BaseTarget.class);
@@ -169,7 +169,7 @@ class ConfigureRoutesTest {
     }
 
     @Test
-    public void mutableConfiguration_canSetErrorTargets() {
+    void mutableConfiguration_canSetErrorTargets() {
         ConfigureRoutes mutable = new ConfigureRoutes();
 
         mutable.setErrorRoute(IndexOutOfBoundsException.class, BaseError.class);
@@ -183,7 +183,7 @@ class ConfigureRoutesTest {
     }
 
     @Test
-    public void populatedMutableConfiguration_clearRemovesAllContent() {
+    void populatedMutableConfiguration_clearRemovesAllContent() {
         ConfigureRoutes mutable = new ConfigureRoutes();
 
         mutable.setRoute("", BaseTarget.class);

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/ConfiguredRoutesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/ConfiguredRoutesTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ConfiguredRoutesTest {
 
     @Test
-    public void emptyConfiguration_allGetMethodsWork() {
+    void emptyConfiguration_allGetMethodsWork() {
         ConfiguredRoutes configuration = new ConfiguredRoutes();
 
         assertFalse(configuration.hasTemplate(""),
@@ -61,7 +61,7 @@ class ConfiguredRoutesTest {
     }
 
     @Test
-    public void mutableConfiguration_makingImmutableHasCorrectData() {
+    void mutableConfiguration_makingImmutableHasCorrectData() {
         ConfigureRoutes mutable = new ConfigureRoutes();
 
         mutable.setRoute("", BaseTarget.class,
@@ -87,7 +87,7 @@ class ConfiguredRoutesTest {
     }
 
     @Test
-    public void configuration_provides_target_url() {
+    void configuration_provides_target_url() {
         ConfigureRoutes edit = new ConfigureRoutes();
         edit.setRoute("foo/:foo", FooTarget.class);
         edit.setRoute("foo/:foo(qwe)", FooTarget.class);
@@ -127,7 +127,7 @@ class ConfiguredRoutesTest {
     }
 
     @Test
-    public void configuration_provides_formatted_url_template() {
+    void configuration_provides_formatted_url_template() {
         ConfigureRoutes config = new ConfigureRoutes();
 
         final String template = "/path/to" + "/:intType("
@@ -193,7 +193,7 @@ class ConfiguredRoutesTest {
     }
 
     @Test
-    public void configuration_provides_formatted_url_for_route_not_routeAlias() {
+    void configuration_provides_formatted_url_for_route_not_routeAlias() {
         ConfigureRoutes config = new ConfigureRoutes();
 
         config.setRoute(RouteTarget.class.getAnnotation(Route.class).value(),

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/ErrorStateRendererTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/ErrorStateRendererTest.java
@@ -128,7 +128,7 @@ class ErrorStateRendererTest {
     }
 
     @Test
-    public void handle_openNPEErrorTarget_infiniteReroute_noStackOverflow_throws() {
+    void handle_openNPEErrorTarget_infiniteReroute_noStackOverflow_throws() {
         UI ui = configureMocks();
 
         NavigationState state = new NavigationStateBuilder(
@@ -152,7 +152,7 @@ class ErrorStateRendererTest {
     }
 
     @Test
-    public void handle_openNPEView_infiniteReroute_noStackOverflow_throws() {
+    void handle_openNPEView_infiniteReroute_noStackOverflow_throws() {
         UI ui = configureMocks();
 
         NavigationState state = new NavigationStateBuilder(
@@ -191,7 +191,7 @@ class ErrorStateRendererTest {
     }
 
     @Test
-    public void handle_errorViewLayoutForwardsToAView_viewIsNavigated() {
+    void handle_errorViewLayoutForwardsToAView_viewIsNavigated() {
         UI ui = configureMocks();
 
         NavigationState state = new NavigationStateBuilder(

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
@@ -167,7 +167,7 @@ class NavigationStateRendererTest {
     private Router router;
 
     @BeforeEach
-    public void init() {
+    void init() {
         RouteRegistry registry = ApplicationRouteRegistry
                 .getInstance(new MockVaadinContext());
         router = new Router(registry);
@@ -178,7 +178,7 @@ class NavigationStateRendererTest {
     }
 
     @Test
-    public void getRouterLayoutForSingle() {
+    void getRouterLayoutForSingle() {
         NavigationStateRenderer childRenderer = new NavigationStateRenderer(
                 navigationStateFromTarget(RouteParentLayout.class));
 
@@ -190,7 +190,7 @@ class NavigationStateRendererTest {
     }
 
     @Test
-    public void getRouterLayoutForSingleParent() {
+    void getRouterLayoutForSingleParent() {
         NavigationStateRenderer childRenderer = new NavigationStateRenderer(
                 navigationStateFromTarget(SingleView.class));
         RouteConfiguration.forRegistry(router.getRegistry())
@@ -206,7 +206,7 @@ class NavigationStateRendererTest {
     }
 
     @Test
-    public void getRouterLayoutForMulipleLayers() {
+    void getRouterLayoutForMulipleLayers() {
         NavigationStateRenderer childRenderer = new NavigationStateRenderer(
                 navigationStateFromTarget(ChildConfiguration.class));
         RouteConfiguration.forRegistry(router.getRegistry())
@@ -224,7 +224,7 @@ class NavigationStateRendererTest {
     }
 
     @Test
-    public void instantiatorUse() {
+    void instantiatorUse() {
 
         MockVaadinServletService service = new MockVaadinServletService();
         service.init(new MockInstantiator() {
@@ -252,7 +252,7 @@ class NavigationStateRendererTest {
     }
 
     @Test
-    public void getRouteTarget_supportsProxyClasses() {
+    void getRouteTarget_supportsProxyClasses() {
         try {
             Class<? extends ProxyableView> routeProxyClass = new ByteBuddy()
                     .subclass(ProxyableView.class)
@@ -391,7 +391,7 @@ class NavigationStateRendererTest {
     }
 
     @Test
-    public void handle_preserveOnRefreshAndWindowNameNotKnown_clientSideCallTriggered() {
+    void handle_preserveOnRefreshAndWindowNameNotKnown_clientSideCallTriggered() {
         // given a service with instantiator
         MockVaadinServletService service = createMockServiceWithInstantiator();
 
@@ -435,7 +435,7 @@ class NavigationStateRendererTest {
     }
 
     @Test
-    public void handle_preserveOnRefreshAndWindowNameKnown_componentIsCachedRetrievedAndFlushed() {
+    void handle_preserveOnRefreshAndWindowNameKnown_componentIsCachedRetrievedAndFlushed() {
         // given a service with instantiator
         MockVaadinServletService service = createMockServiceWithInstantiator();
 
@@ -506,7 +506,7 @@ class NavigationStateRendererTest {
     }
 
     @Test
-    public void handle_preserveOnRefresh_refreshIsFlaggedInEvent() {
+    void handle_preserveOnRefresh_refreshIsFlaggedInEvent() {
         // given a service with instantiator
         MockVaadinServletService service = createMockServiceWithInstantiator();
 
@@ -558,7 +558,7 @@ class NavigationStateRendererTest {
     }
 
     @Test
-    public void handle_preserveOnRefresh_otherUIChildrenAreMoved() {
+    void handle_preserveOnRefresh_otherUIChildrenAreMoved() {
         // given a service with instantiator
         MockVaadinServletService service = createMockServiceWithInstantiator();
 
@@ -603,7 +603,7 @@ class NavigationStateRendererTest {
     }
 
     @Test
-    public void handle_preserveOnRefreshView_routerLayoutIsPreserved_oldUiIsClosed() {
+    void handle_preserveOnRefreshView_routerLayoutIsPreserved_oldUiIsClosed() {
         // given a service with instantiator
         MockVaadinServletService service = createMockServiceWithInstantiator();
 
@@ -654,7 +654,7 @@ class NavigationStateRendererTest {
     }
 
     @Test
-    public void handle_preserveOnRefresh_sameUI_uiIsNotClosed_childrenAreNotRemoved() {
+    void handle_preserveOnRefresh_sameUI_uiIsNotClosed_childrenAreNotRemoved() {
         // given a service with instantiator
         MockVaadinServletService service = createMockServiceWithInstantiator();
 
@@ -709,7 +709,7 @@ class NavigationStateRendererTest {
     private static String viewUUID;
 
     @Test
-    public void handle_preserveOnRefreshView_refreshCurrentRouteRecreatesComponents() {
+    void handle_preserveOnRefreshView_refreshCurrentRouteRecreatesComponents() {
         layoutAttachCount = new AtomicInteger();
         viewAttachCount = new AtomicInteger();
 
@@ -766,7 +766,7 @@ class NavigationStateRendererTest {
     }
 
     @Test
-    public void handle_normalView_refreshCurrentRouteRecreatesComponents() {
+    void handle_normalView_refreshCurrentRouteRecreatesComponents() {
         layoutAttachCount = new AtomicInteger();
         viewAttachCount = new AtomicInteger();
 
@@ -887,7 +887,7 @@ class NavigationStateRendererTest {
     }
 
     @Test
-    public void handle_clientNavigation_withMatchingFlowRoute() {
+    void handle_clientNavigation_withMatchingFlowRoute() {
         viewAttachCount = new AtomicInteger();
         beforeEnterCount = new AtomicInteger();
 
@@ -935,7 +935,7 @@ class NavigationStateRendererTest {
     }
 
     @Test
-    public void handle_refreshRoute_modalComponentsDetached() {
+    void handle_refreshRoute_modalComponentsDetached() {
         beforeEnterCount = new AtomicInteger();
         viewAttachCount = new AtomicInteger();
 
@@ -1012,7 +1012,7 @@ class NavigationStateRendererTest {
     // - the navigation location is the same as the current location (repeated
     // navigation)
     // - navigation trigger is PAGE_LOAD, HISTORY, or PROGRAMMATIC
-    public void handle_variousInputs_checkPushStateShouldBeCalledOrNot() {
+    void handle_variousInputs_checkPushStateShouldBeCalledOrNot() {
         // given a service with instantiator
         MockVaadinServletService service = createMockServiceWithInstantiator();
         ((MockDeploymentConfiguration) service.getDeploymentConfiguration())
@@ -1095,7 +1095,7 @@ class NavigationStateRendererTest {
     }
 
     @Test
-    public void purgeInactiveUIPreservedChainCache_activeUI_throws() {
+    void purgeInactiveUIPreservedChainCache_activeUI_throws() {
         MockVaadinServletService service = createMockServiceWithInstantiator();
         MockVaadinSession session = new AlwaysLockedVaadinSession(service);
 
@@ -1110,7 +1110,7 @@ class NavigationStateRendererTest {
     }
 
     @Test
-    public void purgeInactiveUIPreservedChainCache_inactiveUI_clearsCache() {
+    void purgeInactiveUIPreservedChainCache_inactiveUI_clearsCache() {
         MockVaadinServletService service = createMockServiceWithInstantiator();
         WrappedSession wrappedSession = Mockito.mock(WrappedSession.class);
         Mockito.when(wrappedSession.getId()).thenReturn("A-SESSION-ID");
@@ -1155,7 +1155,7 @@ class NavigationStateRendererTest {
     }
 
     @Test
-    public void getRouteTarget_usageStatistics() {
+    void getRouteTarget_usageStatistics() {
         DeploymentConfiguration configuration = Mockito
                 .mock(DeploymentConfiguration.class);
         MockVaadinServletService service = new MockVaadinServletService();
@@ -1195,12 +1195,12 @@ class NavigationStateRendererTest {
     }
 
     @Test
-    public void handle_clientNavigationToFlowLayout_setTitleFromClientRoute() {
+    void handle_clientNavigationToFlowLayout_setTitleFromClientRoute() {
         testClientNavigationTitle("Client", true);
     }
 
     @Test
-    public void handle_clientNavigation_doNotSetTitleFromClientRoute() {
+    void handle_clientNavigation_doNotSetTitleFromClientRoute() {
         testClientNavigationTitle(null, false);
     }
 
@@ -1323,7 +1323,7 @@ class NavigationStateRendererTest {
     }
 
     @Test
-    public void forwardToSameViewWithDifferentParams_reusesInstance() {
+    void forwardToSameViewWithDifferentParams_reusesInstance() {
         // Issue #23232: Forward to same view with different route parameters
         // should reuse the view instance instead of creating a new one
         redirectToSameViewWithDifferentParams_reusesInstance(
@@ -1331,7 +1331,7 @@ class NavigationStateRendererTest {
     }
 
     @Test
-    public void rerouteToSameViewWithDifferentParams_reusesInstance() {
+    void rerouteToSameViewWithDifferentParams_reusesInstance() {
         // Reroute to same view with different route parameters
         // should reuse the view instance instead of creating a new one
         redirectToSameViewWithDifferentParams_reusesInstance(

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/PathUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/PathUtilTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class PathUtilTest {
 
     @Test
-    public void methods_output_expected_values() {
+    void methods_output_expected_values() {
         final List<String> segments = Arrays.asList("path", "to", "foo");
         final String path = "path/to/foo";
 
@@ -66,7 +66,7 @@ class PathUtilTest {
     }
 
     @Test
-    public void getSegmentsListWithDecoding_decodesEncodedSlashes() {
+    void getSegmentsListWithDecoding_decodesEncodedSlashes() {
         // Test that %2F in a segment is decoded to / but doesn't split the
         // segment
         List<String> segments = PathUtil
@@ -77,7 +77,7 @@ class PathUtilTest {
     }
 
     @Test
-    public void getSegmentsListWithDecoding_decodesSpaces() {
+    void getSegmentsListWithDecoding_decodesSpaces() {
         List<String> segments = PathUtil
                 .getSegmentsListWithDecoding("hello%20world");
         assertEquals(1, segments.size(), "Should have one segment");
@@ -86,7 +86,7 @@ class PathUtilTest {
     }
 
     @Test
-    public void getSegmentsListWithDecoding_decodesSpecialCharacters() {
+    void getSegmentsListWithDecoding_decodesSpecialCharacters() {
         // Test various special characters
         List<String> segments = PathUtil
                 .getSegmentsListWithDecoding("test%3Fquestion/value%26data");
@@ -97,7 +97,7 @@ class PathUtilTest {
     }
 
     @Test
-    public void getSegmentsListWithDecoding_decodesPlus() {
+    void getSegmentsListWithDecoding_decodesPlus() {
         List<String> segments = PathUtil
                 .getSegmentsListWithDecoding("a%2Bb/c%2Bd");
         assertEquals(2, segments.size(), "Should have two segments");
@@ -106,7 +106,7 @@ class PathUtilTest {
     }
 
     @Test
-    public void getSegmentsListWithDecoding_decodesHash() {
+    void getSegmentsListWithDecoding_decodesHash() {
         List<String> segments = PathUtil
                 .getSegmentsListWithDecoding("item%23123");
         assertEquals(1, segments.size(), "Should have one segment");
@@ -114,7 +114,7 @@ class PathUtilTest {
     }
 
     @Test
-    public void getSegmentsListWithDecoding_decodesPercent() {
+    void getSegmentsListWithDecoding_decodesPercent() {
         List<String> segments = PathUtil
                 .getSegmentsListWithDecoding("50%25off");
         assertEquals(1, segments.size(), "Should have one segment");
@@ -122,7 +122,7 @@ class PathUtilTest {
     }
 
     @Test
-    public void getSegmentsListWithDecoding_handlesMultipleEncodedSegments() {
+    void getSegmentsListWithDecoding_handlesMultipleEncodedSegments() {
         List<String> segments = PathUtil.getSegmentsListWithDecoding(
                 "path%2Fwith%2Fslashes/normal/another%2Fencoded");
         assertEquals(3, segments.size(), "Should have three segments");
@@ -135,19 +135,19 @@ class PathUtilTest {
     }
 
     @Test
-    public void getSegmentsListWithDecoding_handlesEmptyPath() {
+    void getSegmentsListWithDecoding_handlesEmptyPath() {
         List<String> segments = PathUtil.getSegmentsListWithDecoding("");
         assertTrue(segments.isEmpty(), "Empty path should return empty list");
     }
 
     @Test
-    public void getSegmentsListWithDecoding_handlesNullPath() {
+    void getSegmentsListWithDecoding_handlesNullPath() {
         List<String> segments = PathUtil.getSegmentsListWithDecoding(null);
         assertTrue(segments.isEmpty(), "Null path should return empty list");
     }
 
     @Test
-    public void getSegmentsListWithDecoding_handlesLeadingSlash() {
+    void getSegmentsListWithDecoding_handlesLeadingSlash() {
         List<String> segments = PathUtil
                 .getSegmentsListWithDecoding("/path%2Fencoded/normal");
         // Leading slash creates empty first segment
@@ -160,7 +160,7 @@ class PathUtilTest {
     }
 
     @Test
-    public void getSegmentsListWithDecoding_handlesTrailingSlash() {
+    void getSegmentsListWithDecoding_handlesTrailingSlash() {
         List<String> segments = PathUtil
                 .getSegmentsListWithDecoding("path%2Fencoded/");
         assertEquals(1, segments.size(), "Should have one segment");
@@ -169,7 +169,7 @@ class PathUtilTest {
     }
 
     @Test
-    public void getSegmentsListWithDecoding_handlesUtf8Characters() {
+    void getSegmentsListWithDecoding_handlesUtf8Characters() {
         List<String> segments = PathUtil
                 .getSegmentsListWithDecoding("hello%C3%A4%C3%B6%C3%BC");
         assertEquals(1, segments.size(), "Should have one segment");
@@ -178,7 +178,7 @@ class PathUtilTest {
     }
 
     @Test
-    public void getSegmentsList_doesNotDecode() {
+    void getSegmentsList_doesNotDecode() {
         // Verify existing behavior: getSegmentsList does NOT decode
         List<String> segments = PathUtil
                 .getSegmentsList("path%2Fwith%2Fslashes");

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/RouteUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/RouteUtilTest.java
@@ -160,7 +160,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void route_path_should_contain_parent_prefix() {
+    void route_path_should_contain_parent_prefix() {
         String routePath = RouteUtil.getRoutePath(new MockVaadinContext(),
                 BaseRouteWithParentPrefixAndRouteAlias.class);
         assertEquals("parent", routePath,
@@ -168,7 +168,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void absolute_route_should_not_contain_parent_prefix() {
+    void absolute_route_should_not_contain_parent_prefix() {
         String routePath = RouteUtil.getRoutePath(new MockVaadinContext(),
                 AbsoluteRoute.class);
         assertEquals("single", routePath,
@@ -176,7 +176,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void absolute_middle_parent_route_should_not_contain_parent_prefix() {
+    void absolute_middle_parent_route_should_not_contain_parent_prefix() {
         String routePath = RouteUtil.getRoutePath(new MockVaadinContext(),
                 AbsoluteCenterRoute.class);
         assertEquals("absolute/child", routePath,
@@ -184,7 +184,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void absolute_route_alias_should_not_contain_parent_prefix() {
+    void absolute_route_alias_should_not_contain_parent_prefix() {
         String routePath = RouteUtil.getRouteAliasPath(AbsoluteRoute.class,
                 AbsoluteRoute.class.getAnnotation(RouteAlias.class));
         assertEquals("alias", routePath,
@@ -192,7 +192,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void absolute_middle_parent_for_route_alias_should_not_contain_parent_prefix() {
+    void absolute_middle_parent_for_route_alias_should_not_contain_parent_prefix() {
         String routePath = RouteUtil.getRouteAliasPath(AbsoluteRoute.class,
                 AbsoluteCenterRoute.class.getAnnotation(RouteAlias.class));
         assertEquals("absolute/alias", routePath,
@@ -200,7 +200,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void route_path_should_contain_route_and_parent_prefix() {
+    void route_path_should_contain_route_and_parent_prefix() {
         String routePath = RouteUtil.getRoutePath(new MockVaadinContext(),
                 RouteWithParentPrefixAndRouteAlias.class);
         assertEquals("parent/flow", routePath,
@@ -208,7 +208,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void route_alias_path_should_not_contain_parent_prefix() {
+    void route_alias_path_should_not_contain_parent_prefix() {
         String routePath = RouteUtil.getRouteAliasPath(
                 BaseRouteWithParentPrefixAndRouteAlias.class,
                 BaseRouteWithParentPrefixAndRouteAlias.class
@@ -224,7 +224,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void route_alias_should_contain_parent_prefix() {
+    void route_alias_should_contain_parent_prefix() {
         String routePath = RouteUtil.getRouteAliasPath(
                 RouteAliasWithParentPrefix.class,
                 RouteAliasWithParentPrefix.class
@@ -234,7 +234,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void top_parent_layout_should_be_found_for_base_route() {
+    void top_parent_layout_should_be_found_for_base_route() {
         Class<? extends RouterLayout> parent = RouteUtil.getTopParentLayout(
                 new MockVaadinContext(),
                 BaseRouteWithParentPrefixAndRouteAlias.class, "parent");
@@ -245,7 +245,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void top_parent_layout_should_be_found_for_non_base_route() {
+    void top_parent_layout_should_be_found_for_non_base_route() {
         Class<? extends RouterLayout> parent = RouteUtil.getTopParentLayout(
                 new MockVaadinContext(),
                 RouteWithParentPrefixAndRouteAlias.class, "parent/flow");
@@ -256,7 +256,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void no_top_parent_layout_for_route_alias() {
+    void no_top_parent_layout_for_route_alias() {
         Class<? extends RouterLayout> parent = RouteUtil.getTopParentLayout(
                 new MockVaadinContext(),
                 BaseRouteWithParentPrefixAndRouteAlias.class, "alias");
@@ -265,7 +265,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void top_parent_layout_for_route_alias() {
+    void top_parent_layout_for_route_alias() {
         Class<? extends RouterLayout> parent = RouteUtil.getTopParentLayout(
                 new MockVaadinContext(), RouteAliasWithParentPrefix.class,
                 "aliasparent/alias");
@@ -276,7 +276,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void top_parent_layout_for_absolute_route() {
+    void top_parent_layout_for_absolute_route() {
         Class<? extends RouterLayout> parent = RouteUtil.getTopParentLayout(
                 new MockVaadinContext(), AbsoluteRoute.class, "single");
 
@@ -286,7 +286,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void top_parent_layout_for_absolute_route_parent() {
+    void top_parent_layout_for_absolute_route_parent() {
         Class<? extends RouterLayout> parent = RouteUtil.getTopParentLayout(
                 new MockVaadinContext(), AbsoluteCenterRoute.class,
                 "absolute/child");
@@ -297,7 +297,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void top_parent_layout_for_absolute_route_alias() {
+    void top_parent_layout_for_absolute_route_alias() {
         Class<? extends RouterLayout> parent = RouteUtil.getTopParentLayout(
                 new MockVaadinContext(), AbsoluteRoute.class, "alias");
 
@@ -307,7 +307,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void top_parent_layout_for_absolute_route_alias_parent() {
+    void top_parent_layout_for_absolute_route_alias_parent() {
         Class<? extends RouterLayout> parent = RouteUtil.getTopParentLayout(
                 new MockVaadinContext(), AbsoluteCenterRoute.class,
                 "absolute/alias");
@@ -318,7 +318,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void automaticLayoutShouldBeAvailableForDefaultRoute() {
+    void automaticLayoutShouldBeAvailableForDefaultRoute() {
 
         MockVaadinServletService service = new MockVaadinServletService() {
             @Override
@@ -339,7 +339,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void routeAliasForAutoLayoutRoute_correctAliasIsSelectedForRoute() {
+    void routeAliasForAutoLayoutRoute_correctAliasIsSelectedForRoute() {
 
         MockVaadinServletService service = new MockVaadinServletService() {
             @Override
@@ -362,7 +362,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void expected_parent_layouts_are_found_for_route() {
+    void expected_parent_layouts_are_found_for_route() {
         List<Class<? extends RouterLayout>> parentLayouts = RouteUtil
                 .getParentLayouts(new MockVaadinContext(),
                         BaseRouteWithParentPrefixAndRouteAlias.class, "parent");
@@ -382,7 +382,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void expected_to_get_parent_layout() {
+    void expected_to_get_parent_layout() {
         List<Class<? extends RouterLayout>> parentLayouts = RouteUtil
                 .getParentLayoutsForNonRouteTarget(
                         NonRouteTargetWithParents.class);
@@ -396,7 +396,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void expected_parent_layouts_are_found_for_route_alias() {
+    void expected_parent_layouts_are_found_for_route_alias() {
         List<Class<? extends RouterLayout>> parentLayouts = RouteUtil
                 .getParentLayouts(new MockVaadinContext(),
                         RouteAliasWithParentPrefix.class, "aliasparent/alias");
@@ -408,7 +408,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void absolute_route_gets_expected_parent_layouts() {
+    void absolute_route_gets_expected_parent_layouts() {
         List<Class<? extends RouterLayout>> parentLayouts = RouteUtil
                 .getParentLayouts(new MockVaadinContext(), AbsoluteRoute.class,
                         "single");
@@ -429,7 +429,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void abolute_route_alias_gets_expected_parent_layouts() {
+    void abolute_route_alias_gets_expected_parent_layouts() {
         List<Class<? extends RouterLayout>> parentLayouts = RouteUtil
                 .getParentLayouts(new MockVaadinContext(), AbsoluteRoute.class,
                         "alias");
@@ -451,7 +451,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void also_non_routes_can_be_used_to_get_top_parent_layout() {
+    void also_non_routes_can_be_used_to_get_top_parent_layout() {
         Class<? extends RouterLayout> topParentLayout = RouteUtil
                 .getTopParentLayout(new MockVaadinContext(), MiddleParent.class,
                         null);
@@ -460,7 +460,7 @@ class RouteUtilTest {
     }
 
     @Test // 3424
-    public void top_layout_resolves_correctly_for_route_parent() {
+    void top_layout_resolves_correctly_for_route_parent() {
         Class<? extends RouterLayout> topParentLayout = RouteUtil
                 .getTopParentLayout(new MockVaadinContext(), MultiTarget.class,
                         "");
@@ -480,7 +480,7 @@ class RouteUtilTest {
     }
 
     @Test // 3424
-    public void parent_layouts_resolve_correctly_for_route_parent() {
+    void parent_layouts_resolve_correctly_for_route_parent() {
         List<Class<? extends RouterLayout>> parentLayouts = RouteUtil
                 .getParentLayouts(new MockVaadinContext(), MultiTarget.class,
                         "");
@@ -509,7 +509,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void newRouteAnnotatedClass_updateRouteRegistry_routeIsAddedToRegistry() {
+    void newRouteAnnotatedClass_updateRouteRegistry_routeIsAddedToRegistry() {
         // given
         @Route("a")
         class A extends Component {
@@ -532,7 +532,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void newRouteAnnotatedClass_sessionRegistry_updateRouteRegistry_routeIsNotAddedToRegistry() {
+    void newRouteAnnotatedClass_sessionRegistry_updateRouteRegistry_routeIsNotAddedToRegistry() {
         // given
         @Route("a")
         class A extends Component {
@@ -555,7 +555,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void newComponentClass_sessionRegistry_updateRouteRegistry_routeIsNotAddedToRegistry() {
+    void newComponentClass_sessionRegistry_updateRouteRegistry_routeIsNotAddedToRegistry() {
         // given
         class A extends Component {
         }
@@ -577,7 +577,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void newLazyRouteAnnotatedClass_updateRouteRegistry_routeIsNotAddedToRegistry() {
+    void newLazyRouteAnnotatedClass_updateRouteRegistry_routeIsNotAddedToRegistry() {
         // given
         @Route(value = "a", registerAtStartup = false)
         class A extends Component {
@@ -600,7 +600,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void newLazyRouteAnnotatedClass_sessionRegistry_updateRouteRegistry_routeIsNotAddedToRegistry() {
+    void newLazyRouteAnnotatedClass_sessionRegistry_updateRouteRegistry_routeIsNotAddedToRegistry() {
         // given
         @Route(value = "a", registerAtStartup = false)
         class A extends Component {
@@ -623,7 +623,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void newRouteComponentWithoutRouteAnnotation_updateRouteRegistry_routeIsNotAddedToRegistry() {
+    void newRouteComponentWithoutRouteAnnotation_updateRouteRegistry_routeIsNotAddedToRegistry() {
         // given
         class A extends Component {
         }
@@ -645,7 +645,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void deletedRouteAnnotatedClass_updateRouteRegistry_routeIsRemovedFromRegistry() {
+    void deletedRouteAnnotatedClass_updateRouteRegistry_routeIsRemovedFromRegistry() {
         // given
         @Route("a")
         class A extends Component {
@@ -667,7 +667,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void deletedNotAnnotatedRouteClass_updateRouteRegistry_routeIsRemovedFromRegistry() {
+    void deletedNotAnnotatedRouteClass_updateRouteRegistry_routeIsRemovedFromRegistry() {
         // given
         class A extends Component {
         }
@@ -688,7 +688,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void deletedRouteAnnotatedClass_sessionRegistry_updateRouteRegistry_routeIsRemovedFromRegistry() {
+    void deletedRouteAnnotatedClass_sessionRegistry_updateRouteRegistry_routeIsRemovedFromRegistry() {
         // given
         @Route("a")
         class A extends Component {
@@ -709,7 +709,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void deletedNotAnnotatedRouteClass_sessionRegistry_updateRouteRegistry_routeIsRemovedFromRegistry() {
+    void deletedNotAnnotatedRouteClass_sessionRegistry_updateRouteRegistry_routeIsRemovedFromRegistry() {
         // given
         class A extends Component {
         }
@@ -729,7 +729,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void renamedRouteAnnotatedClass_updateRouteRegistry_routeIsUpdatedInRegistry() {
+    void renamedRouteAnnotatedClass_updateRouteRegistry_routeIsUpdatedInRegistry() {
         // given
         @Route("aa")
         class A extends Component {
@@ -755,7 +755,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void changedAliasesRouteAnnotatedClass_updateRouteRegistry_routeIsUpdatedInRegistry() {
+    void changedAliasesRouteAnnotatedClass_updateRouteRegistry_routeIsUpdatedInRegistry() {
         // given
         @Route("a")
         @RouteAlias("alias-new")
@@ -785,7 +785,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void changedToLazyRouteAnnotatedClass_updateRouteRegistry_routeIsRemovedInRegistry() {
+    void changedToLazyRouteAnnotatedClass_updateRouteRegistry_routeIsRemovedInRegistry() {
         // given
         @Route(value = "a", registerAtStartup = false)
         class A extends Component {
@@ -814,7 +814,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void changedFromLazyRouteAnnotatedClass_updateRouteRegistry_routeIsRemovedInRegistry() {
+    void changedFromLazyRouteAnnotatedClass_updateRouteRegistry_routeIsRemovedInRegistry() {
         // given
         @Route(value = "a")
         class A extends Component {
@@ -843,7 +843,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void modifiedLazyRouteAnnotatedClass_updateRouteRegistry_existingRoutesArePreserved() {
+    void modifiedLazyRouteAnnotatedClass_updateRouteRegistry_existingRoutesArePreserved() {
         // given
         @Route(value = "a", registerAtStartup = false)
         class A extends Component {
@@ -874,7 +874,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void deannotatedRouteClass_updateRouteRegistry_routeIsRemovedFromRegistry() {
+    void deannotatedRouteClass_updateRouteRegistry_routeIsRemovedFromRegistry() {
         // given
         class A extends Component {
         }
@@ -901,7 +901,7 @@ class RouteUtilTest {
     // change. MODIFY wins over CREATE and REMOVE
 
     @Test
-    public void routeAnnotatedClassAddedModifiedAndRemoved_updateRouteRegistry_routeIsAddedToRegistry() {
+    void routeAnnotatedClassAddedModifiedAndRemoved_updateRouteRegistry_routeIsAddedToRegistry() {
         // given
         @Route("a")
         class A extends Component {
@@ -924,7 +924,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void newLayoutAnnotatedComponent_updateRouteRegistry_routeIsUpdated() {
+    void newLayoutAnnotatedComponent_updateRouteRegistry_routeIsUpdated() {
         MockVaadinServletService service = new MockVaadinServletService() {
             @Override
             public VaadinContext getContext() {
@@ -950,7 +950,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void removeAnnotationsFromLayoutAnnotatedComponent_updateRouteRegistry_routeIsUpdated() {
+    void removeAnnotationsFromLayoutAnnotatedComponent_updateRouteRegistry_routeIsUpdated() {
 
         MockVaadinServletService service = new MockVaadinServletService() {
             @Override
@@ -980,7 +980,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void layoutAnnotatedComponent_modifiedValue_updateRouteRegistry_routeIsUpdated() {
+    void layoutAnnotatedComponent_modifiedValue_updateRouteRegistry_routeIsUpdated() {
 
         MockVaadinServletService service = new MockVaadinServletService() {
             @Override
@@ -1021,7 +1021,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void clientHasMappedLayout_validateNoClientRouteCollisions() {
+    void clientHasMappedLayout_validateNoClientRouteCollisions() {
         Map<String, AvailableViewInfo> clientRoutes = new HashMap<>();
 
         clientRoutes.put("", new AvailableViewInfo("public", null, false, "",
@@ -1060,7 +1060,7 @@ class RouteUtilTest {
     }
 
     @Test
-    public void clientHasOverlappingTarget_validateClientRouteCollision() {
+    void clientHasOverlappingTarget_validateClientRouteCollision() {
         Map<String, AvailableViewInfo> clientRoutes = new HashMap<>();
 
         clientRoutes.put("", new AvailableViewInfo("public", null, false, "",

--- a/flow-server/src/test/java/com/vaadin/flow/server/AbstractConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/AbstractConfigurationTest.java
@@ -48,23 +48,22 @@ class AbstractConfigurationTest {
     };
 
     @Test
-    public void getProjectFolder_mavenProject_detected() throws IOException {
+    void getProjectFolder_mavenProject_detected() throws IOException {
         assertProjectFolderDetected("pom.xml");
     }
 
     @Test
-    public void getProjectFolder_gradleProject_detected() throws IOException {
+    void getProjectFolder_gradleProject_detected() throws IOException {
         assertProjectFolderDetected("build.gradle");
     }
 
     @Test
-    public void getProjectFolder_gradleKotlinProject_detected()
-            throws IOException {
+    void getProjectFolder_gradleKotlinProject_detected() throws IOException {
         assertProjectFolderDetected("build.gradle.kts");
     }
 
     @Test
-    public void getProjectFolder_unknownProject_throws() throws IOException {
+    void getProjectFolder_unknownProject_throws() throws IOException {
         withTemporaryUserDir(() -> {
             IllegalStateException exception = assertThrows(
                     IllegalStateException.class,

--- a/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class AbstractDeploymentConfigurationTest {
 
     @Test
-    public void getUIClass_returnsUIParameterPropertyValue() {
+    void getUIClass_returnsUIParameterPropertyValue() {
         String ui = UUID.randomUUID().toString();
         DeploymentConfiguration config = getConfig(InitParameters.UI_PARAMETER,
                 ui);
@@ -46,7 +46,7 @@ class AbstractDeploymentConfigurationTest {
     }
 
     @Test
-    public void getClassLoader_returnsClassloaderPropertyValue() {
+    void getClassLoader_returnsClassloaderPropertyValue() {
         String classLoader = UUID.randomUUID().toString();
         DeploymentConfiguration config = getConfig("ClassLoader", classLoader);
         assertEquals(classLoader, config.getClassLoaderName(),

--- a/flow-server/src/test/java/com/vaadin/flow/server/AppShellRegistryAuraAutoLoadTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/AppShellRegistryAuraAutoLoadTest.java
@@ -48,7 +48,7 @@ class AppShellRegistryAuraAutoLoadTest {
     private VaadinServletService service;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         Map<String, Object> attributeMap = new HashMap<>();
         ServletContext servletContext = Mockito.mock(ServletContext.class);
         Mockito.when(servletContext.getAttribute(Mockito.anyString()))
@@ -78,12 +78,12 @@ class AppShellRegistryAuraAutoLoadTest {
     }
 
     @AfterEach
-    public void teardown() {
+    void teardown() {
         AppShellRegistry.getInstance(context).reset();
     }
 
     @Test
-    public void noAppShellConfigurator_auraAvailable_auraIsAutoLoaded() {
+    void noAppShellConfigurator_auraAvailable_auraIsAutoLoaded() {
         // Do not set any shell class - leave appShellClass as null
         AppShellRegistry registry = AppShellRegistry.getInstance(context);
 
@@ -105,7 +105,7 @@ class AppShellRegistryAuraAutoLoadTest {
     }
 
     @Test
-    public void noAppShellConfigurator_auraNotAvailable_auraNotLoaded() {
+    void noAppShellConfigurator_auraNotAvailable_auraNotLoaded() {
         // Do not set any shell class - leave appShellClass as null
         AppShellRegistry registry = AppShellRegistry.getInstance(context);
 
@@ -122,7 +122,7 @@ class AppShellRegistryAuraAutoLoadTest {
     }
 
     @Test
-    public void appShellConfiguratorExists_auraNotAutoLoaded() {
+    void appShellConfiguratorExists_auraNotAutoLoaded() {
         AppShellRegistry registry = AppShellRegistry.getInstance(context);
         registry.setShell(MyAppShell.class);
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/AppShellRegistryStyleSheetDataFilePathTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/AppShellRegistryStyleSheetDataFilePathTest.java
@@ -47,7 +47,7 @@ class AppShellRegistryStyleSheetDataFilePathTest {
     private Document document;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         mocks = new MockServletServiceSessionSetup();
         context = new VaadinServletContext(mocks.getServletContext());
         // Set current service for potential instantiation
@@ -56,14 +56,13 @@ class AppShellRegistryStyleSheetDataFilePathTest {
     }
 
     @AfterEach
-    public void teardown() throws Exception {
+    void teardown() throws Exception {
         AppShellRegistry.getInstance(context).reset();
         mocks.cleanup();
     }
 
     @Test
-    public void modifyIndex_addsDataFilePathAttributes_normalized()
-            throws Exception {
+    void modifyIndex_addsDataFilePathAttributes_normalized() throws Exception {
         // Register our shell class directly in the registry
         AppShellRegistry registry = AppShellRegistry.getInstance(context);
         registry.setShell(MyShell.class);
@@ -100,7 +99,7 @@ class AppShellRegistryStyleSheetDataFilePathTest {
     }
 
     @Test
-    public void productionMode_hrefContainsHash_dataFilePathUnchanged()
+    void productionMode_hrefContainsHash_dataFilePathUnchanged()
             throws Exception {
         mocks.getDeploymentConfiguration().setProductionMode(true);
 
@@ -165,7 +164,7 @@ class AppShellRegistryStyleSheetDataFilePathTest {
     }
 
     @Test
-    public void productionMode_missingResource_fallsBackToOriginalUrl()
+    void productionMode_missingResource_fallsBackToOriginalUrl()
             throws Exception {
         mocks.getDeploymentConfiguration().setProductionMode(true);
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/BootstrapContextTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/BootstrapContextTest.java
@@ -70,7 +70,7 @@ class BootstrapContextTest {
     }
 
     @BeforeEach
-    public void setUp() throws ServiceException {
+    void setUp() throws ServiceException {
         MockVaadinSession session = new MockVaadinSession();
         session.lock();
         ui = new UI();
@@ -78,7 +78,7 @@ class BootstrapContextTest {
     }
 
     @Test
-    public void getPushAnnotation_routeTargetPresents_pushFromTheClassDefinitionIsUsed() {
+    void getPushAnnotation_routeTargetPresents_pushFromTheClassDefinitionIsUsed() {
         ui.getInternals().getRouter().getRegistry().setRoute("foo",
                 MainView.class, Collections.emptyList());
         Mockito.when(request
@@ -97,7 +97,7 @@ class BootstrapContextTest {
     }
 
     @Test
-    public void getPushAnnotation_routeTargetPresents_pushDefinedOnParentLayout_pushFromTheClassDefinitionIsUsed() {
+    void getPushAnnotation_routeTargetPresents_pushDefinedOnParentLayout_pushFromTheClassDefinitionIsUsed() {
         ui.getInternals().getRouter().getRegistry().setRoute("foo",
                 OtherView.class, Collections.singletonList(MainView.class));
         Mockito.when(request
@@ -116,7 +116,7 @@ class BootstrapContextTest {
     }
 
     @Test
-    public void getPushAnnotation_routeTargetIsAbsent_pushFromTheErrorNavigationTargetIsUsed() {
+    void getPushAnnotation_routeTargetIsAbsent_pushFromTheErrorNavigationTargetIsUsed() {
         Mockito.when(request
                 .getParameter(ApplicationConstants.REQUEST_LOCATION_PARAMETER))
                 .thenReturn("bar");
@@ -138,7 +138,7 @@ class BootstrapContextTest {
     }
 
     @Test
-    public void getPushAnnotation_routeTargetIsAbsent_pushIsDefinedOnParentLayout_pushFromTheErrorNavigationTargetParentLayoutIsUsed() {
+    void getPushAnnotation_routeTargetIsAbsent_pushIsDefinedOnParentLayout_pushFromTheErrorNavigationTargetParentLayoutIsUsed() {
         Mockito.when(request
                 .getParameter(ApplicationConstants.REQUEST_LOCATION_PARAMETER))
                 .thenReturn("bar");

--- a/flow-server/src/test/java/com/vaadin/flow/server/ConstantsUsageStatsEnvTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/ConstantsUsageStatsEnvTest.java
@@ -62,31 +62,31 @@ class ConstantsUsageStatsEnvTest {
     }
 
     @Test
-    public void whenEnvNotSet_statsEnabledByDefault() throws Exception {
+    void whenEnvNotSet_statsEnabledByDefault() throws Exception {
         String out = runIsolated(false, null);
         assertEquals("true", out);
     }
 
     @Test
-    public void whenEnvFalse_statsDisabled() throws Exception {
+    void whenEnvFalse_statsDisabled() throws Exception {
         String out = runIsolated(true, "false");
         assertEquals("false", out);
     }
 
     @Test
-    public void whenEnvFALSE_statsDisabled() throws Exception {
+    void whenEnvFALSE_statsDisabled() throws Exception {
         String out = runIsolated(true, "FALSE");
         assertEquals("false", out);
     }
 
     @Test
-    public void whenEnvTrue_statsEnabled() throws Exception {
+    void whenEnvTrue_statsEnabled() throws Exception {
         String out = runIsolated(true, "true");
         assertEquals("true", out);
     }
 
     @Test
-    public void whenEnvRandom_statsEnabled() throws Exception {
+    void whenEnvRandom_statsEnabled() throws Exception {
         String out = runIsolated(true, "random-value");
         assertEquals("true", out);
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/CustomUIClassLoaderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/CustomUIClassLoaderTest.java
@@ -66,7 +66,7 @@ class CustomUIClassLoaderTest {
      *             if thrown
      */
     @Test
-    public void testWithDefaultClassLoader() throws Exception {
+    void testWithDefaultClassLoader() throws Exception {
         VaadinSession application = createStubApplication();
 
         Class<? extends UI> uiClass = BootstrapHandler
@@ -115,7 +115,7 @@ class CustomUIClassLoaderTest {
      *             if thrown
      */
     @Test
-    public void testWithClassLoader() throws Exception {
+    void testWithClassLoader() throws Exception {
         LoggingClassLoader loggingClassLoader = new LoggingClassLoader();
 
         Class<? extends UI> uiClass = BootstrapHandler

--- a/flow-server/src/test/java/com/vaadin/flow/server/DefaultDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DefaultDeploymentConfigurationTest.java
@@ -53,12 +53,12 @@ class DefaultDeploymentConfigurationTest {
     VaadinContext context;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         context = new MockVaadinContext();
     }
 
     @Test
-    public void testGetSystemPropertyForDefaultPackage()
+    void testGetSystemPropertyForDefaultPackage()
             throws ClassNotFoundException {
         Class<?> clazz = Class.forName("ClassInDefaultPackage");
         String value = "value";
@@ -74,7 +74,7 @@ class DefaultDeploymentConfigurationTest {
     }
 
     @Test
-    public void testGetSystemProperty() {
+    void testGetSystemProperty() {
         String value = "value";
         String prop = "prop";
         System.setProperty(
@@ -92,7 +92,7 @@ class DefaultDeploymentConfigurationTest {
     }
 
     @Test
-    public void booleanValueReadIgnoreTheCase_true() {
+    void booleanValueReadIgnoreTheCase_true() {
         Properties initParameters = new Properties();
         initParameters.setProperty(
                 InitParameters.SERVLET_PARAMETER_SEND_URLS_AS_PARAMETERS,
@@ -105,7 +105,7 @@ class DefaultDeploymentConfigurationTest {
     }
 
     @Test
-    public void booleanValueReadIgnoreTheCase_false() {
+    void booleanValueReadIgnoreTheCase_false() {
         Properties initParameters = new Properties();
         initParameters.setProperty(
                 InitParameters.SERVLET_PARAMETER_SEND_URLS_AS_PARAMETERS,
@@ -119,7 +119,7 @@ class DefaultDeploymentConfigurationTest {
     }
 
     @Test
-    public void booleanValueRead_emptyIsTrue() {
+    void booleanValueRead_emptyIsTrue() {
         Properties initParameters = new Properties();
         initParameters.setProperty(
                 InitParameters.SERVLET_PARAMETER_SEND_URLS_AS_PARAMETERS, "");
@@ -132,7 +132,7 @@ class DefaultDeploymentConfigurationTest {
     }
 
     @Test
-    public void defaultPushServletMapping() {
+    void defaultPushServletMapping() {
         Properties initParameters = new Properties();
         DefaultDeploymentConfiguration config = createDeploymentConfig(
                 initParameters);
@@ -140,7 +140,7 @@ class DefaultDeploymentConfigurationTest {
     }
 
     @Test
-    public void pushUrl() {
+    void pushUrl() {
         Properties initParameters = new Properties();
         initParameters.setProperty(
                 InitParameters.SERVLET_PARAMETER_PUSH_SERVLET_MAPPING,
@@ -152,7 +152,7 @@ class DefaultDeploymentConfigurationTest {
     }
 
     @Test
-    public void booleanValueRead_exceptionOnNonBooleanValue() {
+    void booleanValueRead_exceptionOnNonBooleanValue() {
         Properties initParameters = new Properties();
         initParameters.setProperty(
                 InitParameters.SERVLET_PARAMETER_SEND_URLS_AS_PARAMETERS,
@@ -163,7 +163,7 @@ class DefaultDeploymentConfigurationTest {
     }
 
     @Test
-    public void maxMessageSuspendTimeout_validValue_accepted() {
+    void maxMessageSuspendTimeout_validValue_accepted() {
         Properties initParameters = new Properties();
         initParameters.setProperty(
                 InitParameters.SERVLET_PARAMETER_MAX_MESSAGE_SUSPEND_TIMEOUT,
@@ -174,7 +174,7 @@ class DefaultDeploymentConfigurationTest {
     }
 
     @Test
-    public void maxMessageSuspendTimeout_invalidValue_defaultValue() {
+    void maxMessageSuspendTimeout_invalidValue_defaultValue() {
         Properties initParameters = new Properties();
         initParameters.setProperty(
                 InitParameters.SERVLET_PARAMETER_MAX_MESSAGE_SUSPEND_TIMEOUT,
@@ -185,7 +185,7 @@ class DefaultDeploymentConfigurationTest {
     }
 
     @Test
-    public void isProductionMode_productionModeIsSetViaParentOnly_productionModeIsTakenFromParent() {
+    void isProductionMode_productionModeIsSetViaParentOnly_productionModeIsTakenFromParent() {
         ApplicationConfiguration appConfig = setupAppConfig();
         Mockito.when(appConfig.isProductionMode()).thenReturn(true);
 
@@ -201,7 +201,7 @@ class DefaultDeploymentConfigurationTest {
     }
 
     @Test
-    public void isProductionMode_productionModeIsSetViaPropertiesAndViaParent_productionModeIsTakenFromProperties() {
+    void isProductionMode_productionModeIsSetViaPropertiesAndViaParent_productionModeIsTakenFromProperties() {
         ApplicationConfiguration appConfig = setupAppConfig();
         Mockito.when(appConfig.isProductionMode()).thenReturn(false);
 
@@ -217,7 +217,7 @@ class DefaultDeploymentConfigurationTest {
     }
 
     @Test
-    public void isXsrfProtectionEnabled_valueIsSetViaParentOnly_valueIsTakenFromParent() {
+    void isXsrfProtectionEnabled_valueIsSetViaParentOnly_valueIsTakenFromParent() {
         ApplicationConfiguration appConfig = setupAppConfig();
         Mockito.when(appConfig.isXsrfProtectionEnabled()).thenReturn(true);
 
@@ -234,7 +234,7 @@ class DefaultDeploymentConfigurationTest {
     }
 
     @Test
-    public void isXsrfProtectionEnabled_valueIsSetViaParentOnlyAndViaParent_valueIsTakenFromParent() {
+    void isXsrfProtectionEnabled_valueIsSetViaParentOnlyAndViaParent_valueIsTakenFromParent() {
         ApplicationConfiguration appConfig = setupAppConfig();
         Mockito.when(appConfig.isXsrfProtectionEnabled()).thenReturn(false);
 
@@ -251,7 +251,7 @@ class DefaultDeploymentConfigurationTest {
     }
 
     @Test
-    public void frontendHotdeployParameter_developmentBundle_resetsFrontendHotdeployToFalse() {
+    void frontendHotdeployParameter_developmentBundle_resetsFrontendHotdeployToFalse() {
         DefaultDeploymentConfiguration config = createDeploymentConfig(
                 new Properties());
         assertEquals(Mode.DEVELOPMENT_BUNDLE, config.getMode(),
@@ -265,7 +265,7 @@ class DefaultDeploymentConfigurationTest {
     }
 
     @Test
-    public void frontendHotdeploy_defaultsToParentConfiguration() {
+    void frontendHotdeploy_defaultsToParentConfiguration() {
         ApplicationConfiguration appConfig = setupAppConfig();
         Mockito.when(appConfig.getMode())
                 .thenReturn(Mode.DEVELOPMENT_FRONTEND_LIVERELOAD);
@@ -277,7 +277,7 @@ class DefaultDeploymentConfigurationTest {
     }
 
     @Test
-    public void checkLockStrategy_defaultsToAssert() {
+    void checkLockStrategy_defaultsToAssert() {
         Properties init = new Properties();
         DefaultDeploymentConfiguration config = createDeploymentConfig(init);
 
@@ -286,7 +286,7 @@ class DefaultDeploymentConfigurationTest {
     }
 
     @Test
-    public void checkLockStrategy_configurableViaPropertyParameter() {
+    void checkLockStrategy_configurableViaPropertyParameter() {
         Properties init = new Properties();
         init.put(InitParameters.SERVLET_PARAMETER_SESSION_LOCK_CHECK_STRATEGY,
                 "throw");
@@ -297,7 +297,7 @@ class DefaultDeploymentConfigurationTest {
     }
 
     @Test
-    public void productionModeTrue_frontendHotdeployTrue_frontendHotdeployReturnsFalse() {
+    void productionModeTrue_frontendHotdeployTrue_frontendHotdeployReturnsFalse() {
         Properties init = new Properties();
         init.put(InitParameters.FRONTEND_HOTDEPLOY, "true");
         init.put(InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE, "true");
@@ -309,7 +309,7 @@ class DefaultDeploymentConfigurationTest {
     }
 
     @Test
-    public void hillaViewInLegacyFrontendFolderExists_shouldUseLegacyFolderAndHotdeploy()
+    void hillaViewInLegacyFrontendFolderExists_shouldUseLegacyFolderAndHotdeploy()
             throws IOException {
         File projectRoot = tempFolder.toFile();
         File legacyFrontend = Files

--- a/flow-server/src/test/java/com/vaadin/flow/server/DefaultErrorHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DefaultErrorHandlerTest.java
@@ -35,7 +35,7 @@ class DefaultErrorHandlerTest {
     Logger logger;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         logger = Mockito
                 .spy(LoggerFactory.getLogger(DefaultErrorHandler.class));
         loggerFactory = Mockito.mockStatic(LoggerFactory.class);
@@ -47,12 +47,12 @@ class DefaultErrorHandlerTest {
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         loggerFactory.close();
     }
 
     @Test
-    public void error_acceptedException_errorHandled() {
+    void error_acceptedException_errorHandled() {
         DefaultErrorHandler errorHandler = Mockito
                 .spy(new DefaultErrorHandler(Set.of(IOException.class.getName(),
                         MalformedURLException.class.getName())));
@@ -67,7 +67,7 @@ class DefaultErrorHandlerTest {
     }
 
     @Test
-    public void error_ignoredException_notHandled() {
+    void error_ignoredException_notHandled() {
         DefaultErrorHandler errorHandler = Mockito
                 .spy(new DefaultErrorHandler(Set.of(IOException.class.getName(),
                         MalformedURLException.class.getName(),
@@ -83,7 +83,7 @@ class DefaultErrorHandlerTest {
     }
 
     @Test
-    public void error_subclassOfIgnoredException_errorHandled() {
+    void error_subclassOfIgnoredException_errorHandled() {
         DefaultErrorHandler errorHandler = Mockito.spy(
                 new DefaultErrorHandler(Set.of(IOException.class.getName())));
 
@@ -93,7 +93,7 @@ class DefaultErrorHandlerTest {
     }
 
     @Test
-    public void error_loggerAtDebugLevel_errorHandled() {
+    void error_loggerAtDebugLevel_errorHandled() {
         Mockito.reset(logger);
         Mockito.doReturn(true).when(logger).isDebugEnabled();
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/DeploymentConfigurationFactoryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DeploymentConfigurationFactoryTest.java
@@ -87,7 +87,7 @@ class DeploymentConfigurationFactoryTest {
     }
 
     @BeforeEach
-    public void setup() throws IOException {
+    void setup() throws IOException {
         System.setProperty("user.dir",
                 temporaryFolder.toFile().getAbsolutePath());
         tokenFile = new File(temporaryFolder.toFile(),
@@ -100,24 +100,24 @@ class DeploymentConfigurationFactoryTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         tokenFile.delete();
     }
 
     @BeforeAll
-    public static void setupBeforeClass() {
+    static void setupBeforeClass() {
         globalUserDirValue = System.getProperty("user.dir");
     }
 
     @AfterAll
-    public static void tearDownAfterClass() {
+    static void tearDownAfterClass() {
         if (globalUserDirValue != null) {
             System.setProperty("user.dir", globalUserDirValue);
         }
     }
 
     @Test
-    public void servletWithEnclosingUI_hasItsNameInConfig() throws Exception {
+    void servletWithEnclosingUI_hasItsNameInConfig() throws Exception {
         Class<TestUI.ServletWithEnclosingUi> servlet = TestUI.ServletWithEnclosingUi.class;
 
         Map<String, String> servletConfigParams = new HashMap<>(
@@ -140,8 +140,7 @@ class DeploymentConfigurationFactoryTest {
     }
 
     @Test
-    public void servletWithNoEnclosingUI_hasDefaultUiInConfig()
-            throws Exception {
+    void servletWithNoEnclosingUI_hasDefaultUiInConfig() throws Exception {
         Class<NoSettings> servlet = NoSettings.class;
 
         Map<String, String> servletConfigParams = new HashMap<>(
@@ -161,7 +160,7 @@ class DeploymentConfigurationFactoryTest {
     }
 
     @Test
-    public void servletConfigParametersOverrideServletContextParameters()
+    void servletConfigParametersOverrideServletContextParameters()
             throws Exception {
         Class<NoSettings> servlet = NoSettings.class;
 
@@ -199,7 +198,7 @@ class DeploymentConfigurationFactoryTest {
     }
 
     @Test
-    public void servletConfigParameters_nullValues_ignored() throws Exception {
+    void servletConfigParameters_nullValues_ignored() throws Exception {
         Class<NoSettings> servlet = NoSettings.class;
 
         Map<String, String> servletConfigParams = new HashMap<>(
@@ -220,7 +219,7 @@ class DeploymentConfigurationFactoryTest {
     }
 
     @Test
-    public void should_readConfigurationFromTokenFile() throws Exception {
+    void should_readConfigurationFromTokenFile() throws Exception {
         FileUtils.writeLines(tokenFile,
                 Arrays.asList("{", "\"productionMode\": true", "}"));
 
@@ -230,7 +229,7 @@ class DeploymentConfigurationFactoryTest {
     }
 
     @Test
-    public void shouldThrow_tokenFileContainsNonExistingNpmFolderInDevMode()
+    void shouldThrow_tokenFileContainsNonExistingNpmFolderInDevMode()
             throws Exception {
         FileUtils.writeLines(tokenFile,
                 Arrays.asList("{", "\"productionMode\": false,",
@@ -246,7 +245,7 @@ class DeploymentConfigurationFactoryTest {
     }
 
     @Test
-    public void shouldThrow_tokenFileContainsNonExistingFrontendFolderNoNpmFolder()
+    void shouldThrow_tokenFileContainsNonExistingFrontendFolderNoNpmFolder()
             throws Exception {
         FileUtils.writeLines(tokenFile,
                 Arrays.asList("{", "\"productionMode\": false,",
@@ -260,7 +259,7 @@ class DeploymentConfigurationFactoryTest {
     }
 
     @Test
-    public void shouldThrow_tokenFileContainsNonExistingFrontendFolderOutsideNpmSubFolder()
+    void shouldThrow_tokenFileContainsNonExistingFrontendFolderOutsideNpmSubFolder()
             throws Exception {
         java.nio.file.Files.createDirectories(temporaryFolder.resolve("npm"));
         String tempFolder = temporaryFolder.toFile().getAbsolutePath()
@@ -278,8 +277,7 @@ class DeploymentConfigurationFactoryTest {
     }
 
     @Test
-    public void shouldNotThrow_tokenFileFrontendFolderInDevMode()
-            throws Exception {
+    void shouldNotThrow_tokenFileFrontendFolderInDevMode() throws Exception {
         java.nio.file.Files.createDirectories(temporaryFolder.resolve("npm"))
                 .toFile();
         String tempFolder = temporaryFolder.toFile().getAbsolutePath()
@@ -295,7 +293,7 @@ class DeploymentConfigurationFactoryTest {
     }
 
     @Test
-    public void shouldNotThrow_tokenFileFoldersExist() throws Exception {
+    void shouldNotThrow_tokenFileFoldersExist() throws Exception {
         java.nio.file.Files.createDirectories(temporaryFolder.resolve("npm"))
                 .toFile();
         java.nio.file.Files
@@ -314,7 +312,7 @@ class DeploymentConfigurationFactoryTest {
     }
 
     @Test
-    public void createInitParameters_valuesFromContextAreIgnored_valuesAreTakenFromservletConfig() {
+    void createInitParameters_valuesFromContextAreIgnored_valuesAreTakenFromservletConfig() {
         DeploymentConfigurationFactory factory = new DeploymentConfigurationFactory();
 
         VaadinContext context = Mockito.mock(VaadinContext.class);
@@ -347,7 +345,7 @@ class DeploymentConfigurationFactoryTest {
     }
 
     @Test
-    public void createInitParameters_valuesAreTakenFromservletConfigAndTokenFile_valuesFromTokenFileOverridenByServletConfig()
+    void createInitParameters_valuesAreTakenFromservletConfigAndTokenFile_valuesFromTokenFileOverridenByServletConfig()
             throws Exception {
         DeploymentConfigurationFactory factory = new DeploymentConfigurationFactory();
 
@@ -457,7 +455,7 @@ class DeploymentConfigurationFactoryTest {
     }
 
     @Test
-    public void createInitParameters_tokenFileIsSetViaContext_externalStatsUrlIsReadFromTokenFile_predefinedProperties()
+    void createInitParameters_tokenFileIsSetViaContext_externalStatsUrlIsReadFromTokenFile_predefinedProperties()
             throws Exception {
         DeploymentConfigurationFactory factory = new DeploymentConfigurationFactory();
 
@@ -480,7 +478,7 @@ class DeploymentConfigurationFactoryTest {
     }
 
     @Test
-    public void createInitParameters_tokenFileIsSetViaContext_externalStatsFileIsReadFromTokenFile_predefinedProperties()
+    void createInitParameters_tokenFileIsSetViaContext_externalStatsFileIsReadFromTokenFile_predefinedProperties()
             throws Exception {
         DeploymentConfigurationFactory factory = new DeploymentConfigurationFactory();
 
@@ -501,7 +499,7 @@ class DeploymentConfigurationFactoryTest {
     }
 
     @Test
-    public void createInitParameters_tokenFileIsSetViaContext_setPropertyFromTokenFile()
+    void createInitParameters_tokenFileIsSetViaContext_setPropertyFromTokenFile()
             throws Exception {
         DeploymentConfigurationFactory factory = new DeploymentConfigurationFactory();
 
@@ -556,7 +554,7 @@ class DeploymentConfigurationFactoryTest {
     }
 
     @Test
-    public void externalStatsFileTrue_predefinedValuesAreNotOverridden_productionMode()
+    void externalStatsFileTrue_predefinedValuesAreNotOverridden_productionMode()
             throws Exception {
         // note that this situation shouldn't happen that the other
         // settings would be against the external usage.
@@ -578,7 +576,7 @@ class DeploymentConfigurationFactoryTest {
     }
 
     @Test
-    public void createInitParameters_readDevModeProperties() throws Exception {
+    void createInitParameters_readDevModeProperties() throws Exception {
         FileUtils.writeLines(tokenFile, Arrays.asList("{",
                 "\"pnpm.enable\": true,", "\"require.home.node\": true", "}"));
 
@@ -592,7 +590,7 @@ class DeploymentConfigurationFactoryTest {
     }
 
     @Test
-    public void createInitParameters_initParamtersAreSet_tokenDevModePropertiesAreNotSet()
+    void createInitParameters_initParamtersAreSet_tokenDevModePropertiesAreNotSet()
             throws Exception {
         FileUtils.writeLines(tokenFile, Arrays.asList("{",
                 "\"pnpm.enable\": true,", "\"require.home.node\": true", "}"));

--- a/flow-server/src/test/java/com/vaadin/flow/server/DevToolsTokenTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DevToolsTokenTest.java
@@ -38,7 +38,7 @@ class DevToolsTokenTest {
     private String systemTempDir;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         configuration = Mockito.mock(DeploymentConfiguration.class);
         Mockito.when(configuration.getProjectFolder())
                 .thenReturn(projectFolder.toFile());
@@ -52,13 +52,13 @@ class DevToolsTokenTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         overwriteToken(initialToken);
         System.setProperty("java.io.tmpdir", systemTempDir);
     }
 
     @Test
-    public void init_tokenFileNotExising_createTokenFile() {
+    void init_tokenFileNotExising_createTokenFile() {
         DevToolsToken.init(service);
         assertEquals(initialToken, DevToolsToken.getToken());
 
@@ -70,7 +70,7 @@ class DevToolsTokenTest {
     }
 
     @Test
-    public void init_nullProjectFolder_useInMemoryToken() {
+    void init_nullProjectFolder_useInMemoryToken() {
         Mockito.when(configuration.getProjectFolder()).thenReturn(null);
 
         String testToken = UUID.randomUUID().toString();

--- a/flow-server/src/test/java/com/vaadin/flow/server/ErrorHandlerUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/ErrorHandlerUtilTest.java
@@ -116,7 +116,7 @@ class ErrorHandlerUtilTest {
     }
 
     @BeforeEach
-    public void init() {
+    void init() {
         MockitoAnnotations.initMocks(this);
 
         ErrorView.setError = false;
@@ -164,13 +164,13 @@ class ErrorHandlerUtilTest {
     }
 
     @AfterEach
-    public void cleanup() {
+    void cleanup() {
         VaadinService.setCurrent(null);
         UI.setCurrent(null);
     }
 
     @Test
-    public void nullPointerException_executesErrorView() {
+    void nullPointerException_executesErrorView() {
         registry.setErrorNavigationTargets(
                 Collections.singleton(ErrorView.class));
 
@@ -188,7 +188,7 @@ class ErrorHandlerUtilTest {
     }
 
     @Test
-    public void illegalArgumentException_doesNotExecuteErrorView() {
+    void illegalArgumentException_doesNotExecuteErrorView() {
         registry.setErrorNavigationTargets(
                 Collections.singleton(ErrorView.class));
 
@@ -206,7 +206,7 @@ class ErrorHandlerUtilTest {
     }
 
     @Test
-    public void redrawnExceptionView_alsoInitializesParent() {
+    void redrawnExceptionView_alsoInitializesParent() {
         registry.setErrorNavigationTargets(
                 Collections.singleton(ErrorWithParentView.class));
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/HandlerHelperTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/HandlerHelperTest.java
@@ -52,7 +52,7 @@ class HandlerHelperTest {
     }
 
     @Test
-    public void isFrameworkInternalRequest_validType_nullPathInfo() {
+    void isFrameworkInternalRequest_validType_nullPathInfo() {
         HttpServletRequest request = createRequest(null, RequestType.INIT);
 
         assertTrue(HandlerHelper.isFrameworkInternalRequest("/", request));
@@ -63,7 +63,7 @@ class HandlerHelperTest {
     }
 
     @Test
-    public void isFrameworkInternalRequest_validType_emptyPathinfo() {
+    void isFrameworkInternalRequest_validType_emptyPathinfo() {
         HttpServletRequest request = createRequest("", RequestType.INIT);
 
         assertTrue(HandlerHelper.isFrameworkInternalRequest("/", request));
@@ -74,7 +74,7 @@ class HandlerHelperTest {
     }
 
     @Test
-    public void isFrameworkInternalRequest_validType_slashPathinfo() {
+    void isFrameworkInternalRequest_validType_slashPathinfo() {
         // This is how requests to /vaadinServlet/ are interpreted
         HttpServletRequest request = createRequest("/", RequestType.INIT);
 
@@ -86,7 +86,7 @@ class HandlerHelperTest {
     }
 
     @Test
-    public void isFrameworkInternalRequest_unknownType() {
+    void isFrameworkInternalRequest_unknownType() {
         HttpServletRequest request = createRequest(null, "unknown");
 
         assertTrue(HandlerHelper.isFrameworkInternalRequest("/", request));
@@ -98,7 +98,7 @@ class HandlerHelperTest {
     }
 
     @Test
-    public void isFrameworkInternalRequest_noType() {
+    void isFrameworkInternalRequest_noType() {
         HttpServletRequest request = createRequest(null, (RequestType) null);
 
         assertFalse(HandlerHelper.isFrameworkInternalRequest("/", request));
@@ -110,7 +110,7 @@ class HandlerHelperTest {
     }
 
     @Test
-    public void isFrameworkInternalRequest_validType_withPath() {
+    void isFrameworkInternalRequest_validType_withPath() {
         HttpServletRequest request = createRequest("hello", RequestType.INIT);
 
         assertFalse(HandlerHelper.isFrameworkInternalRequest("/", request));
@@ -124,7 +124,7 @@ class HandlerHelperTest {
     }
 
     @Test
-    public void isFrameworkInternalRequest_validType_withServletMappingAndPath() {
+    void isFrameworkInternalRequest_validType_withServletMappingAndPath() {
         HttpServletRequest request = createRequest("", RequestType.INIT);
         Mockito.when(request.getServletPath()).thenReturn("/servlet");
 
@@ -135,7 +135,7 @@ class HandlerHelperTest {
     }
 
     @Test
-    public void isFrameworkInternalRequest_noType_withServletMappingAndPath() {
+    void isFrameworkInternalRequest_noType_withServletMappingAndPath() {
         HttpServletRequest request = createRequest("/", (RequestType) null);
         Mockito.when(request.getServletPath()).thenReturn("/servlet");
 
@@ -145,21 +145,21 @@ class HandlerHelperTest {
     }
 
     @Test
-    public void isFrameworkInternalRequest_vaadinRequest_servletRoot() {
+    void isFrameworkInternalRequest_vaadinRequest_servletRoot() {
         VaadinRequest request = createVaadinRequest("", "/*", RequestType.INIT);
 
         assertTrue(BootstrapHandler.isFrameworkInternalRequest(request));
     }
 
     @Test
-    public void isFrameworkInternalRequest_vaadinRequest_servletRoot_noType() {
+    void isFrameworkInternalRequest_vaadinRequest_servletRoot_noType() {
         VaadinRequest request = createVaadinRequest("", "/*", null);
 
         assertFalse(BootstrapHandler.isFrameworkInternalRequest(request));
     }
 
     @Test
-    public void isFrameworkInternalRequest_vaadinRequest_pathInsideServlet() {
+    void isFrameworkInternalRequest_vaadinRequest_pathInsideServlet() {
         VaadinRequest request = createVaadinRequest("/foo", "/*",
                 RequestType.INIT);
 
@@ -167,14 +167,14 @@ class HandlerHelperTest {
     }
 
     @Test
-    public void isFrameworkInternalRequest_vaadinRequest_pathInsideServlet_noType() {
+    void isFrameworkInternalRequest_vaadinRequest_pathInsideServlet_noType() {
         VaadinRequest request = createVaadinRequest("/foo", "/*", null);
 
         assertFalse(BootstrapHandler.isFrameworkInternalRequest(request));
     }
 
     @Test
-    public void isFrameworkInternalRequest_vaadinRequest_nonRootServlet() {
+    void isFrameworkInternalRequest_vaadinRequest_nonRootServlet() {
         VaadinRequest request = createVaadinRequest("", "/myservlet/",
                 RequestType.INIT);
 
@@ -182,7 +182,7 @@ class HandlerHelperTest {
     }
 
     @Test
-    public void isFrameworkInternalRequest_vaadinRequest_nonRootServlet_pathInsideServlet() {
+    void isFrameworkInternalRequest_vaadinRequest_nonRootServlet_pathInsideServlet() {
         VaadinRequest request = createVaadinRequest("/hello", "/myservlet",
                 null);
 
@@ -190,7 +190,7 @@ class HandlerHelperTest {
     }
 
     @Test
-    public void isFrameworkInternalRequest_uploadUrl() {
+    void isFrameworkInternalRequest_uploadUrl() {
         VaadinServletRequest request = createVaadinRequest(
                 "VAADIN/dynamic/resource/1/e83d6b6d-2b75-4960-8922-5431f4a23e49/upload",
                 "", null);
@@ -200,7 +200,7 @@ class HandlerHelperTest {
     }
 
     @Test
-    public void isFrameworkInternalRequest_dynamicResourceUrl_withoutPostfix() {
+    void isFrameworkInternalRequest_dynamicResourceUrl_withoutPostfix() {
         // Test for ElementRequestHandler requests without URL postfix
         VaadinServletRequest request = createVaadinRequest(
                 "VAADIN/dynamic/resource/1/e83d6b6d-2b75-4960-8922-5431f4a23e49/",
@@ -211,7 +211,7 @@ class HandlerHelperTest {
     }
 
     @Test
-    public void isFrameworkInternalRequest_dynamicResourceUrl_withCustomPostfix() {
+    void isFrameworkInternalRequest_dynamicResourceUrl_withCustomPostfix() {
         // Test for ElementRequestHandler requests with custom postfix
         VaadinServletRequest request = createVaadinRequest(
                 "VAADIN/dynamic/resource/1/e83d6b6d-2b75-4960-8922-5431f4a23e49/custom.pdf",
@@ -222,7 +222,7 @@ class HandlerHelperTest {
     }
 
     @Test
-    public void isFrameworkInternalRequest_hillaPushUrl() {
+    void isFrameworkInternalRequest_hillaPushUrl() {
         VaadinServletRequest request = createVaadinRequest("HILLA/push", "",
                 null);
 
@@ -231,7 +231,7 @@ class HandlerHelperTest {
     }
 
     @Test
-    public void isFrameworkInternalRequest_vaadinServletMapping_hillaPushUrl() {
+    void isFrameworkInternalRequest_vaadinServletMapping_hillaPushUrl() {
         VaadinServletRequest request = createVaadinRequest("HILLA/push", "",
                 null);
 
@@ -240,7 +240,7 @@ class HandlerHelperTest {
     }
 
     @Test
-    public void isFrameworkInternalRequest_flowPushUrl() {
+    void isFrameworkInternalRequest_flowPushUrl() {
         VaadinServletRequest request = createVaadinRequest("VAADIN/push", "",
                 RequestType.PUSH);
 
@@ -249,7 +249,7 @@ class HandlerHelperTest {
     }
 
     @Test
-    public void isFrameworkInternalRequest_vaadinServletMapping_flowPushUrl() {
+    void isFrameworkInternalRequest_vaadinServletMapping_flowPushUrl() {
         VaadinServletRequest request = createVaadinRequest("/VAADIN/push",
                 "/ui", RequestType.PUSH);
 
@@ -258,7 +258,7 @@ class HandlerHelperTest {
     }
 
     @Test
-    public void isFrameworkInternalRequest_fakeUploadUrl() {
+    void isFrameworkInternalRequest_fakeUploadUrl() {
         VaadinServletRequest request = createVaadinRequest(
                 "VAADIN/dynamic/resource/../../../upload", "", null);
 
@@ -267,7 +267,7 @@ class HandlerHelperTest {
     }
 
     @Test
-    public void isFrameworkInternalRequest_staticFileUrl() {
+    void isFrameworkInternalRequest_staticFileUrl() {
         VaadinServletRequest request = createVaadinRequest(
                 "VAADIN/static/file.png", "", null);
 
@@ -276,7 +276,7 @@ class HandlerHelperTest {
     }
 
     @Test
-    public void getPathIfInsideServlet_default_servlet() {
+    void getPathIfInsideServlet_default_servlet() {
         String servletMapping = "/*";
         assertEquals(Optional.of(""),
                 HandlerHelper.getPathIfInsideServlet(servletMapping, ""));
@@ -289,7 +289,7 @@ class HandlerHelperTest {
     }
 
     @Test
-    public void getPathIfInsideServlet_root_only_servlet() {
+    void getPathIfInsideServlet_root_only_servlet() {
         String servletMapping = "";
         assertEquals(Optional.of(""),
                 HandlerHelper.getPathIfInsideServlet(servletMapping, ""));
@@ -302,7 +302,7 @@ class HandlerHelperTest {
     }
 
     @Test
-    public void getPathIfInsideServlet_all_urls_servlet() {
+    void getPathIfInsideServlet_all_urls_servlet() {
         String servletMapping = "/";
         assertEquals(Optional.of(""),
                 HandlerHelper.getPathIfInsideServlet(servletMapping, ""));
@@ -315,7 +315,7 @@ class HandlerHelperTest {
     }
 
     @Test
-    public void getPathIfInsideServlet_sevlet_using_single_path() {
+    void getPathIfInsideServlet_sevlet_using_single_path() {
         String servletMapping = "/foo";
         assertEquals(Optional.empty(),
                 HandlerHelper.getPathIfInsideServlet(servletMapping, ""));
@@ -332,7 +332,7 @@ class HandlerHelperTest {
     }
 
     @Test
-    public void getPathIfInsideServlet_sevlet_with_context_path() {
+    void getPathIfInsideServlet_sevlet_with_context_path() {
         String servletMapping = "/foo/*";
         assertEquals(Optional.empty(),
                 HandlerHelper.getPathIfInsideServlet(servletMapping, ""));
@@ -370,7 +370,7 @@ class HandlerHelperTest {
     }
 
     @Test
-    public void publicResources() {
+    void publicResources() {
         Set<String> expected = new HashSet<>();
         expected.add("/manifest.webmanifest");
         expected.add("/sw.js");

--- a/flow-server/src/test/java/com/vaadin/flow/server/HttpStatusCodeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/HttpStatusCodeTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class HttpStatusCodeTest {
 
     @Test
-    public void isValidStatusCode_invalidCode_returnsFalse() {
+    void isValidStatusCode_invalidCode_returnsFalse() {
         Set<Integer> validCodes = Stream.of(HttpStatusCode.values())
                 .map(HttpStatusCode::getCode).collect(Collectors.toSet());
 
@@ -39,7 +39,7 @@ class HttpStatusCodeTest {
     }
 
     @Test
-    public void isValidStatusCode_validCode_returnsTrue() {
+    void isValidStatusCode_validCode_returnsTrue() {
         Stream.of(HttpStatusCode.values()).mapToInt(HttpStatusCode::getCode)
                 .forEach(sc -> assertTrue(HttpStatusCode.isValidStatusCode(sc),
                         sc + " should be valid, but was not"));

--- a/flow-server/src/test/java/com/vaadin/flow/server/InitParametersTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/InitParametersTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class InitParametersTest {
     @Test
-    public void publicMembersAreStringConstants() {
+    void publicMembersAreStringConstants() {
         for (Field field : InitParameters.class.getDeclaredFields()) {
             int modifiers = field.getModifiers();
             if (Modifier.isPublic(modifiers)) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/PlatformTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/PlatformTest.java
@@ -37,18 +37,18 @@ class PlatformTest {
     Path temporary;
 
     @BeforeEach
-    public void rememberContextClassLoader() {
+    void rememberContextClassLoader() {
         oldContextClassLoader = Thread.currentThread().getContextClassLoader();
     }
 
     @AfterEach
-    public void restoreContextClassLoader() {
+    void restoreContextClassLoader() {
         Thread.currentThread().setContextClassLoader(oldContextClassLoader);
     }
 
     @BeforeEach
     @AfterEach
-    public void cleanMemoizedValues() {
+    void cleanMemoizedValues() {
         Platform.hillaVersion = null;
         Platform.vaadinVersion = null;
     }
@@ -90,12 +90,12 @@ class PlatformTest {
     }
 
     @Test
-    public void testGetVaadinVersionReturnsEmptyOptionalWhenVaadinNotOnClasspath() {
+    void testGetVaadinVersionReturnsEmptyOptionalWhenVaadinNotOnClasspath() {
         assertEquals(Optional.empty(), Platform.getVaadinVersion());
     }
 
     @Test
-    public void testGetVaadinVersionReturnsProperVersionWhenVaadinOnClasspath()
+    void testGetVaadinVersionReturnsProperVersionWhenVaadinOnClasspath()
             throws Exception {
         fakeVaadinHilla("24.1.0", null);
         assertEquals(Optional.of("24.1.0"), Platform.getVaadinVersion());
@@ -106,12 +106,12 @@ class PlatformTest {
     }
 
     @Test
-    public void testGetHillaVersionReturnsEmptyOptionalWhenHillaNotOnClasspath() {
+    void testGetHillaVersionReturnsEmptyOptionalWhenHillaNotOnClasspath() {
         assertEquals(Optional.empty(), Platform.getHillaVersion());
     }
 
     @Test
-    public void testGetHillaVersionReturnsProperVersionWhenHillaOnClasspath()
+    void testGetHillaVersionReturnsProperVersionWhenHillaOnClasspath()
             throws Exception {
         fakeVaadinHilla(null, "2.1.0");
         assertEquals(Optional.of("2.1.0"), Platform.getHillaVersion());
@@ -122,7 +122,7 @@ class PlatformTest {
     }
 
     @Test
-    public void testGetVaadinHillaVersionReturnsProperVersionWhenBothVaadinAndHillaOnClasspath()
+    void testGetVaadinHillaVersionReturnsProperVersionWhenBothVaadinAndHillaOnClasspath()
             throws Exception {
         fakeVaadinHilla("24.0.0", "2.1.0");
         assertEquals(Optional.of("2.1.0"), Platform.getHillaVersion());

--- a/flow-server/src/test/java/com/vaadin/flow/server/PropertyDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/PropertyDeploymentConfigurationTest.java
@@ -35,7 +35,7 @@ class PropertyDeploymentConfigurationTest {
     Path tempFolder;
 
     @Test
-    public void isProductionMode_modeIsProvidedViaParentOnly_valueFromParentIsReturned() {
+    void isProductionMode_modeIsProvidedViaParentOnly_valueFromParentIsReturned() {
         ApplicationConfiguration appConfig = mockAppConfig();
         Mockito.when(appConfig.isProductionMode()).thenReturn(true);
         PropertyDeploymentConfiguration config = createConfiguration(appConfig,
@@ -46,7 +46,7 @@ class PropertyDeploymentConfigurationTest {
     }
 
     @Test
-    public void isProductionMode_modeIsProvidedViaPropertiesAndParent_valueFromPropertiesIsReturned() {
+    void isProductionMode_modeIsProvidedViaPropertiesAndParent_valueFromPropertiesIsReturned() {
         ApplicationConfiguration appConfig = mockAppConfig();
         Mockito.when(appConfig.isProductionMode()).thenReturn(false);
 
@@ -60,7 +60,7 @@ class PropertyDeploymentConfigurationTest {
     }
 
     @Test
-    public void reuseDevServer_valueIsProvidedViaPropertiesAndParent_valueFromPropertiesIsReturned() {
+    void reuseDevServer_valueIsProvidedViaPropertiesAndParent_valueFromPropertiesIsReturned() {
         ApplicationConfiguration appConfig = mockAppConfig();
         Mockito.when(appConfig.reuseDevServer()).thenReturn(false);
 
@@ -74,7 +74,7 @@ class PropertyDeploymentConfigurationTest {
     }
 
     @Test
-    public void reuseDevServer_valueIsProvidedViaParentOnly_valueFromParentIsReturned() {
+    void reuseDevServer_valueIsProvidedViaParentOnly_valueFromParentIsReturned() {
         ApplicationConfiguration appConfig = mockAppConfig();
         Mockito.when(appConfig.reuseDevServer()).thenReturn(true);
         PropertyDeploymentConfiguration config = createConfiguration(appConfig,
@@ -85,7 +85,7 @@ class PropertyDeploymentConfigurationTest {
     }
 
     @Test
-    public void isPnpmEnabled_valueIsProvidedViaParentOnly_valueFromParentIsReturned() {
+    void isPnpmEnabled_valueIsProvidedViaParentOnly_valueFromParentIsReturned() {
         ApplicationConfiguration appConfig = mockAppConfig();
         Mockito.when(appConfig.isPnpmEnabled()).thenReturn(true);
         PropertyDeploymentConfiguration config = createConfiguration(appConfig,
@@ -96,7 +96,7 @@ class PropertyDeploymentConfigurationTest {
     }
 
     @Test
-    public void isPnpmEnabled_valueIsProvidedViaPropertiesAndParent_valueFromPropertiesIsReturned() {
+    void isPnpmEnabled_valueIsProvidedViaPropertiesAndParent_valueFromPropertiesIsReturned() {
         ApplicationConfiguration appConfig = mockAppConfig();
         Mockito.when(appConfig.isPnpmEnabled()).thenReturn(false);
 
@@ -110,7 +110,7 @@ class PropertyDeploymentConfigurationTest {
     }
 
     @Test
-    public void isXsrfProtectionEnabled_valueIsProvidedViaParentOnly_valueFromParentIsReturned() {
+    void isXsrfProtectionEnabled_valueIsProvidedViaParentOnly_valueFromParentIsReturned() {
         ApplicationConfiguration appConfig = mockAppConfig();
         Mockito.when(appConfig.isXsrfProtectionEnabled()).thenReturn(true);
         PropertyDeploymentConfiguration config = createConfiguration(appConfig,
@@ -121,7 +121,7 @@ class PropertyDeploymentConfigurationTest {
     }
 
     @Test
-    public void isXsrfProtectionEnabled_valueIsProvidedViaPropertiesAndParent_valueFromPropertiesIsReturned() {
+    void isXsrfProtectionEnabled_valueIsProvidedViaPropertiesAndParent_valueFromPropertiesIsReturned() {
         ApplicationConfiguration appConfig = mockAppConfig();
         Mockito.when(appConfig.isXsrfProtectionEnabled()).thenReturn(false);
 
@@ -135,7 +135,7 @@ class PropertyDeploymentConfigurationTest {
     }
 
     @Test
-    public void getApplicationProperty_propertyIsDefinedInParentOnly_valueFromParentIsReturned() {
+    void getApplicationProperty_propertyIsDefinedInParentOnly_valueFromParentIsReturned() {
         ApplicationConfiguration appConfig = mockAppConfig();
 
         Mockito.when(appConfig.getStringProperty("foo", null))
@@ -150,7 +150,7 @@ class PropertyDeploymentConfigurationTest {
     }
 
     @Test
-    public void getApplicationProperty_propertyIsDefinedInPropertiesAndParent_valueFromPropertiesIsReturned() {
+    void getApplicationProperty_propertyIsDefinedInPropertiesAndParent_valueFromPropertiesIsReturned() {
         ApplicationConfiguration appConfig = mockAppConfig();
 
         Mockito.when(appConfig.getStringProperty("foo", null))
@@ -167,7 +167,7 @@ class PropertyDeploymentConfigurationTest {
     }
 
     @Test
-    public void isProductionMode_modeIsProvidedViaParentOnly_propertyIsSetToAnotherValue_valueFromParentIsReturnedViaAPI() {
+    void isProductionMode_modeIsProvidedViaParentOnly_propertyIsSetToAnotherValue_valueFromParentIsReturnedViaAPI() {
         ApplicationConfiguration appConfig = mockAppConfig();
 
         // The property value is provided via API
@@ -195,7 +195,7 @@ class PropertyDeploymentConfigurationTest {
     }
 
     @Test
-    public void isPnpmEnabled_valueIsProvidedViaParentOnly_propertyIsSetToAnotherValue_valueFromParentIsReturnedViaAPI() {
+    void isPnpmEnabled_valueIsProvidedViaParentOnly_propertyIsSetToAnotherValue_valueFromParentIsReturnedViaAPI() {
         ApplicationConfiguration appConfig = mockAppConfig();
 
         // The property value is provided via API
@@ -223,7 +223,7 @@ class PropertyDeploymentConfigurationTest {
     }
 
     @Test
-    public void reuseDevServer_valueIsProvidedViaParentOnly_propertyIsSetToAnotherValue_valueFromParentIsReturnedViaAPI() {
+    void reuseDevServer_valueIsProvidedViaParentOnly_propertyIsSetToAnotherValue_valueFromParentIsReturnedViaAPI() {
         ApplicationConfiguration appConfig = mockAppConfig();
 
         // The property value is provided via API
@@ -251,7 +251,7 @@ class PropertyDeploymentConfigurationTest {
     }
 
     @Test
-    public void isXsrfProtectionEnabled_valueIsProvidedViaParentOnly_propertyIsSetToAnotherValue_valueFromParentIsReturnedViaAPI() {
+    void isXsrfProtectionEnabled_valueIsProvidedViaParentOnly_propertyIsSetToAnotherValue_valueFromParentIsReturnedViaAPI() {
         ApplicationConfiguration appConfig = mockAppConfig();
 
         // The property value is provided via API
@@ -279,7 +279,7 @@ class PropertyDeploymentConfigurationTest {
     }
 
     @Test
-    public void getInitParameters_prorprtiesAreMergedFromParentAndDeploymentConfig() {
+    void getInitParameters_prorprtiesAreMergedFromParentAndDeploymentConfig() {
         ApplicationConfiguration appConfig = Mockito
                 .mock(ApplicationConfiguration.class);
         Mockito.when(appConfig.getPropertyNames()).thenReturn(
@@ -299,7 +299,7 @@ class PropertyDeploymentConfigurationTest {
     }
 
     @Test
-    public void allDefaultAbstractConfigurationMethodsAreOverridden() {
+    void allDefaultAbstractConfigurationMethodsAreOverridden() {
         Method[] methods = PropertyDeploymentConfiguration.class.getMethods();
         for (Method method : methods) {
             String methodName = method.getName();

--- a/flow-server/src/test/java/com/vaadin/flow/server/PwaConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/PwaConfigurationTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 class PwaConfigurationTest {
     @Test
     // For https://github.com/vaadin/flow/issues/10148
-    public void pwaDefaultStartUrl_should_BeDotInsteadOfEmptyString() {
+    void pwaDefaultStartUrl_should_BeDotInsteadOfEmptyString() {
         PwaConfiguration pwaConfiguration = new PwaConfiguration();
         assertEquals(PwaConfiguration.DEFAULT_START_URL,
                 pwaConfiguration.getStartUrl());
@@ -34,7 +34,7 @@ class PwaConfigurationTest {
     }
 
     @Test
-    public void pwaOfflinePathEmpty_should_beDisabled() {
+    void pwaOfflinePathEmpty_should_beDisabled() {
         PwaConfiguration pwaConfiguration = new PwaConfiguration(
                 App.class.getAnnotation(PWA.class));
         assertFalse(pwaConfiguration.isOfflinePathEnabled());

--- a/flow-server/src/test/java/com/vaadin/flow/server/PwaRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/PwaRegistryTest.java
@@ -49,7 +49,7 @@ class PwaRegistryTest {
     private static List<PwaIcon> splashIconsForAppleDevices;
 
     @BeforeAll
-    public static void initPwaWithCustomIconPath() throws IOException {
+    static void initPwaWithCustomIconPath() throws IOException {
         PwaRegistry registry = preparePwaRegistry(
                 PwaWithCustomIconPath.class.getAnnotation(PWA.class));
         splashIconsForAppleDevices = registry.getIcons().stream().filter(
@@ -58,7 +58,7 @@ class PwaRegistryTest {
     }
 
     @Test
-    public void pwaIconIsGeneratedBasedOnClasspathIcon_servletContextHasNoResources()
+    void pwaIconIsGeneratedBasedOnClasspathIcon_servletContextHasNoResources()
             throws IOException {
         // PWA annotation has default value for "iconPath" but servlet context
         // has no resource for that path, in that case the ClassPath URL will be
@@ -111,12 +111,12 @@ class PwaRegistryTest {
     }
 
     @Test
-    public void pwaWithCustomBaseIconPath_splashScreenIconForAllSupportedAppleDevicesAndOrientationsAreGenerated() {
+    void pwaWithCustomBaseIconPath_splashScreenIconForAllSupportedAppleDevicesAndOrientationsAreGenerated() {
         assertEquals(26, splashIconsForAppleDevices.size());
     }
 
     @Test
-    public void pwaWithCustomBaseIconPath_splashScreenIconForAppleDevices_areGeneratedBasedOnIconPath() {
+    void pwaWithCustomBaseIconPath_splashScreenIconForAppleDevices_areGeneratedBasedOnIconPath() {
         boolean customBaseNameUsedInIconGeneration = splashIconsForAppleDevices
                 .stream().allMatch(
                         icon -> icon.getHref().startsWith("icons/splash/foo"));
@@ -124,7 +124,7 @@ class PwaRegistryTest {
     }
 
     @Test
-    public void pwaWithCustomBaseIconPath_splashScreenIconForIPadDevices_includeBothOrientations() {
+    void pwaWithCustomBaseIconPath_splashScreenIconForIPadDevices_includeBothOrientations() {
         // iPad Pro 12.9
         Predicate<PwaIcon> iPadPro129 = icon -> (icon.getWidth() == 2048
                 && icon.getHeight() == 2732)
@@ -192,7 +192,7 @@ class PwaRegistryTest {
     }
 
     @Test
-    public void pwaWithCustomBaseIconPath_splashScreenIconForIPhoneDevices_includeBothOrientations() {
+    void pwaWithCustomBaseIconPath_splashScreenIconForIPhoneDevices_includeBothOrientations() {
         // iPhone 13 Pro Max, iPhone 12 Pro Max
         Predicate<PwaIcon> iPhone13ProMaxAnd12ProMax = icon -> (icon
                 .getWidth() == 1284 && icon.getHeight() == 2778)
@@ -299,7 +299,7 @@ class PwaRegistryTest {
     }
 
     @Test
-    public void pwaWithCustomOfflinePath_getRuntimeServiceWorkerJsContainsCustomOfflinePath()
+    void pwaWithCustomOfflinePath_getRuntimeServiceWorkerJsContainsCustomOfflinePath()
             throws IOException {
         PwaRegistry registry = preparePwaRegistry(
                 PwaWithCustomOfflinePath.class.getAnnotation(PWA.class));
@@ -310,7 +310,7 @@ class PwaRegistryTest {
     }
 
     @Test
-    public void pwaWithoutCustomOfflinePath_getRuntimeServiceWorkerJsContainsCustomOfflinePath()
+    void pwaWithoutCustomOfflinePath_getRuntimeServiceWorkerJsContainsCustomOfflinePath()
             throws IOException {
         PwaRegistry registry = preparePwaRegistry(
                 PwaRegistryTest.class.getAnnotation(PWA.class));

--- a/flow-server/src/test/java/com/vaadin/flow/server/SessionRouteRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/SessionRouteRegistryTest.java
@@ -83,7 +83,7 @@ class SessionRouteRegistryTest {
     private VaadinSession session;
 
     @BeforeEach
-    public void init() {
+    void init() {
         registry = ApplicationRouteRegistry.getInstance(
                 new VaadinServletContext(Mockito.mock(ServletContext.class)));
 
@@ -118,7 +118,7 @@ class SessionRouteRegistryTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         CurrentInstance.clearAll();
     }
 
@@ -140,7 +140,7 @@ class SessionRouteRegistryTest {
     }
 
     @Test
-    public void addSameClassForMultipleRoutes_removalOfRouteClassClearsRegisttry() {
+    void addSameClassForMultipleRoutes_removalOfRouteClassClearsRegisttry() {
         SessionRouteRegistry registry = getRegistry(session);
 
         registry.setRoute("home", MyRoute.class, Collections.emptyList());
@@ -158,7 +158,7 @@ class SessionRouteRegistryTest {
     }
 
     @Test
-    public void addMultipleClassesToSameRoute_removeClassLeavesRoute() {
+    void addMultipleClassesToSameRoute_removeClassLeavesRoute() {
         SessionRouteRegistry registry = getRegistry(session);
 
         registry.setRoute("home", MyRoute.class, Collections.emptyList());
@@ -196,7 +196,7 @@ class SessionRouteRegistryTest {
     }
 
     @Test
-    public void sessionRegistryOverridesParentRegistryForGetTargetUrl_globalRouteStillAccessible() {
+    void sessionRegistryOverridesParentRegistryForGetTargetUrl_globalRouteStillAccessible() {
         registry.setRoute("MyRoute", MyRoute.class, Collections.emptyList());
         SessionRouteRegistry sessionRegistry = getRegistry(session);
         sessionRegistry.setRoute("alternate", MyRoute.class,
@@ -213,7 +213,7 @@ class SessionRouteRegistryTest {
     }
 
     @Test
-    public void sessionRegistryOverridesParentRegistryWithOwnClass_globalRouteReturnedAfterClassRemoval() {
+    void sessionRegistryOverridesParentRegistryWithOwnClass_globalRouteReturnedAfterClassRemoval() {
         registry.setRoute("MyRoute", MyRoute.class, Collections.emptyList());
         SessionRouteRegistry sessionRegistry = getRegistry(session);
         sessionRegistry.setRoute("MyRoute", Secondary.class,
@@ -231,7 +231,7 @@ class SessionRouteRegistryTest {
     }
 
     @Test
-    public void registerRouteWithAliases_routeAliasesRegisteredAsExpected() {
+    void registerRouteWithAliases_routeAliasesRegisteredAsExpected() {
 
         SessionRouteRegistry sessionRegistry = getRegistry(session);
 
@@ -253,7 +253,7 @@ class SessionRouteRegistryTest {
     }
 
     @Test
-    public void routesWithParentLayouts_parentLayoutReturnsAsExpected() {
+    void routesWithParentLayouts_parentLayoutReturnsAsExpected() {
         SessionRouteRegistry sessionRegistry = getRegistry(session);
 
         sessionRegistry.setRoute("MyRoute", MyRouteWithAliases.class,
@@ -278,7 +278,7 @@ class SessionRouteRegistryTest {
     }
 
     @Test
-    public void registeredParentLayouts_changingListDoesntChangeRegistration() {
+    void registeredParentLayouts_changingListDoesntChangeRegistration() {
         SessionRouteRegistry registry = getRegistry(session);
 
         List<Class<? extends RouterLayout>> parentChain = new ArrayList<>(
@@ -295,7 +295,7 @@ class SessionRouteRegistryTest {
     }
 
     @Test
-    public void registeredParentLayouts_returnedListInSameOrder() {
+    void registeredParentLayouts_returnedListInSameOrder() {
         SessionRouteRegistry registry = getRegistry(session);
 
         List<Class<? extends RouterLayout>> parentChain = new ArrayList<>(
@@ -310,7 +310,7 @@ class SessionRouteRegistryTest {
     }
 
     @Test
-    public void routeRegisteredOnMultiplePaths_removalOfDefaultPathUpdatesDefaultPath() {
+    void routeRegisteredOnMultiplePaths_removalOfDefaultPathUpdatesDefaultPath() {
         SessionRouteRegistry sessionRegistry = getRegistry(session);
 
         // register route and have default path "MyRoute"
@@ -356,7 +356,7 @@ class SessionRouteRegistryTest {
     }
 
     @Test
-    public void manuallyRegisteredAliases_RouteDataIsReturnedCorrectly() {
+    void manuallyRegisteredAliases_RouteDataIsReturnedCorrectly() {
 
         SessionRouteRegistry sessionRegistry = getRegistry(session);
         sessionRegistry.setRoute("main", Secondary.class,
@@ -393,7 +393,7 @@ class SessionRouteRegistryTest {
     }
 
     @Test
-    public void registeredRouteWithAliasGlobally_sessionRegistryReturnsFromGlobal() {
+    void registeredRouteWithAliasGlobally_sessionRegistryReturnsFromGlobal() {
         registry.setRoute("MyRoute", MyRouteWithAliases.class,
                 Collections.emptyList());
         registry.setRoute("info", MyRouteWithAliases.class,
@@ -420,7 +420,7 @@ class SessionRouteRegistryTest {
     }
 
     @Test
-    public void registeredRouteWithAliasGlobally_sessionRegistryOverridesMainUrl() {
+    void registeredRouteWithAliasGlobally_sessionRegistryOverridesMainUrl() {
         registry.setRoute("MyRoute", MyRouteWithAliases.class,
                 Collections.emptyList());
         registry.setRoute("info", MyRouteWithAliases.class,
@@ -454,7 +454,7 @@ class SessionRouteRegistryTest {
     }
 
     @Test
-    public void setSameRouteValueFromDifferentThreads_ConcurrencyTest()
+    void setSameRouteValueFromDifferentThreads_ConcurrencyTest()
             throws InterruptedException, ExecutionException {
         final int THREADS = 5;
 
@@ -503,7 +503,7 @@ class SessionRouteRegistryTest {
     }
 
     @Test
-    public void useRouteResolutionFromDifferentThreads_ConcurrencyTest()
+    void useRouteResolutionFromDifferentThreads_ConcurrencyTest()
             throws InterruptedException, ExecutionException {
         final int THREADS = 5;
 
@@ -552,7 +552,7 @@ class SessionRouteRegistryTest {
     }
 
     @Test
-    public void updateRoutesFromMultipleThreads_allRoutesAreRegistered()
+    void updateRoutesFromMultipleThreads_allRoutesAreRegistered()
             throws InterruptedException, ExecutionException {
 
         List<Callable<Result>> callables = new ArrayList<>();
@@ -613,7 +613,7 @@ class SessionRouteRegistryTest {
     }
 
     @Test
-    public void updateAndRemoveFromMultipleThreads_endResultAsExpected()
+    void updateAndRemoveFromMultipleThreads_endResultAsExpected()
             throws InterruptedException, ExecutionException {
 
         getRegistry(session).setRoute("home", MyRoute.class,
@@ -686,7 +686,7 @@ class SessionRouteRegistryTest {
     }
 
     @Test
-    public void settingSessionRouteRegistryOfAnotherSession_getRegistryFails() {
+    void settingSessionRouteRegistryOfAnotherSession_getRegistryFails() {
         SessionRouteRegistry registry = getRegistry(session);
 
         VaadinSession anotherSession = new MockVaadinSession(vaadinService) {
@@ -719,7 +719,7 @@ class SessionRouteRegistryTest {
     }
 
     @Test
-    public void lockingConfiguration_configurationIsUpdatedOnlyAfterUnlockk() {
+    void lockingConfiguration_configurationIsUpdatedOnlyAfterUnlockk() {
         CountDownLatch waitReaderThread = new CountDownLatch(1);
         CountDownLatch waitUpdaterThread = new CountDownLatch(2);
 
@@ -760,7 +760,7 @@ class SessionRouteRegistryTest {
     }
 
     @Test
-    public void routeChangeListener_correctChangesAreReturned() {
+    void routeChangeListener_correctChangesAreReturned() {
         SessionRouteRegistry registry = getRegistry(session);
 
         List<RouteBaseData> added = new ArrayList<>();
@@ -801,7 +801,7 @@ class SessionRouteRegistryTest {
     }
 
     @Test
-    public void routeChangeListener_blockChangesAreGivenCorrectlyInEvent() {
+    void routeChangeListener_blockChangesAreGivenCorrectlyInEvent() {
         SessionRouteRegistry registry = getRegistry(session);
 
         registry.setRoute("", MyRoute.class, Collections.emptyList());
@@ -844,7 +844,7 @@ class SessionRouteRegistryTest {
     }
 
     @Test
-    public void routeWithAliases_eventShowsCorrectlyAsRemoved() {
+    void routeWithAliases_eventShowsCorrectlyAsRemoved() {
         SessionRouteRegistry sessionRegistry = getRegistry(session);
 
         List<RouteBaseData> added = new ArrayList<>();
@@ -878,7 +878,7 @@ class SessionRouteRegistryTest {
     }
 
     @Test
-    public void maskedPathsInParent_eventContainsOnlyChangesVisibleForSession() {
+    void maskedPathsInParent_eventContainsOnlyChangesVisibleForSession() {
         registry.setRoute("main", MyRoute.class, Collections.emptyList());
 
         SessionRouteRegistry sessionRegistry = getRegistry(session);
@@ -919,7 +919,7 @@ class SessionRouteRegistryTest {
     }
 
     @Test
-    public void removeListener_noEventsAreGottenForAnyRegistry() {
+    void removeListener_noEventsAreGottenForAnyRegistry() {
 
         SessionRouteRegistry sessionRegistry = getRegistry(session);
 
@@ -956,8 +956,7 @@ class SessionRouteRegistryTest {
     }
 
     @Test
-    public void serialize_deserialize_parentRegistryIsANewOne()
-            throws Throwable {
+    void serialize_deserialize_parentRegistryIsANewOne() throws Throwable {
         session = new MockVaadinSession(vaadinService);
 
         TestSessionRouteRegistry registry = new TestSessionRouteRegistry(
@@ -987,7 +986,7 @@ class SessionRouteRegistryTest {
     }
 
     @Test
-    public void getTargetUrl_annotatedRoute_rootIsAlias_mainRouteIsNotRoot_mainRouteIsReturned() {
+    void getTargetUrl_annotatedRoute_rootIsAlias_mainRouteIsNotRoot_mainRouteIsReturned() {
         SessionRouteRegistry registry = getRegistry(session);
         RouteConfiguration configuration = RouteConfiguration
                 .forRegistry(registry);
@@ -1002,7 +1001,7 @@ class SessionRouteRegistryTest {
     }
 
     @Test
-    public void getTargetUrl_annotatedRoute_rootIsAlias_mainRouteIsParamerterized_routeAliasIsReturned() {
+    void getTargetUrl_annotatedRoute_rootIsAlias_mainRouteIsParamerterized_routeAliasIsReturned() {
         SessionRouteRegistry registry = getRegistry(session);
         RouteConfiguration configuration = RouteConfiguration
                 .forRegistry(registry);
@@ -1017,7 +1016,7 @@ class SessionRouteRegistryTest {
     }
 
     @Test
-    public void sessionScopeContainsTemplateRoute_applicationRegistryExactMatchIsReturned() {
+    void sessionScopeContainsTemplateRoute_applicationRegistryExactMatchIsReturned() {
         registry.setRoute(":first/:second", Templated.class,
                 Collections.emptyList());
         registry.setRoute("other/view", NonTemplated.class,
@@ -1055,7 +1054,7 @@ class SessionRouteRegistryTest {
     }
 
     @Test
-    public void sessionScopeContainsTemplateRoute_applicationRegistryBetterMatchIsReturned() {
+    void sessionScopeContainsTemplateRoute_applicationRegistryBetterMatchIsReturned() {
         registry.setRoute("other/view/parent", NonTemplated.class,
                 Collections.emptyList());
         registry.setRoute("other/alias/:extra?", Templated.class,

--- a/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
@@ -133,13 +133,13 @@ class StaticFileServerTest implements Serializable {
     }
 
     @BeforeAll
-    public static void beforeClass() {
+    static void beforeClass() {
         // must be cleared before running this class
         CurrentInstance.clearAll();
     }
 
     @BeforeEach
-    public void setUp() throws IOException {
+    void setUp() throws IOException {
         request = Mockito.mock(HttpServletRequest.class);
         response = Mockito.mock(HttpServletResponse.class);
         // No header == getDateHeader returns -1 (Mockito default is 0)
@@ -205,7 +205,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void getRequestFilename() {
+    void getRequestFilename() {
         // Context path should not affect the filename in any way
         for (String contextPath : new String[] { "", "/foo", "/foo/bar" }) {
             // /* servlet
@@ -233,7 +233,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void getRequestFilename_shouldAlwaysBeResolvedAsRootResourceForServiceWorkerRequest() {
+    void getRequestFilename_shouldAlwaysBeResolvedAsRootResourceForServiceWorkerRequest() {
         for (String swFile : new String[] { "/sw.js", "/sw.js.gz" }) {
             assertEquals(swFile, getRequestFilename("", "", swFile));
             assertEquals(swFile, getRequestFilename("", "/foo", swFile));
@@ -289,7 +289,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void isResourceRequest() throws Exception {
+    void isResourceRequest() throws Exception {
         fileServer.writeResponse = false;
         setupRequestURI("", "/static", "/file.png");
         Mockito.when(servletService.getStaticResource("/static/file.png"))
@@ -298,7 +298,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void isResourceRequestWithContextPath() throws Exception {
+    void isResourceRequestWithContextPath() throws Exception {
         fileServer.writeResponse = false;
         setupRequestURI("/foo", "/static", "/file.png");
         Mockito.when(servletService.getStaticResource("/static/file.png"))
@@ -307,14 +307,14 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void isNotResourceRequest() throws Exception {
+    void isNotResourceRequest() throws Exception {
         setupRequestURI("", "", null);
         Mockito.when(servletContext.getResource("/")).thenReturn(null);
         assertFalse(fileServer.serveStaticResource(request, response));
     }
 
     @Test
-    public void directoryIsNotResourceRequest() throws Exception {
+    void directoryIsNotResourceRequest() throws Exception {
         fileServer.writeResponse = false;
         final Path folder = Files.createTempDirectory("test");
 
@@ -361,7 +361,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void isStaticResource_jarWarFileScheme_detectsAsStaticResources()
+    void isStaticResource_jarWarFileScheme_detectsAsStaticResources()
             throws IOException {
         fileServer.writeResponse = false;
         assertTrue(StaticFileServer.openFileSystems.isEmpty(),
@@ -395,7 +395,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void isStaticResource_jarInAJar_detectsAsStaticResources()
+    void isStaticResource_jarInAJar_detectsAsStaticResources()
             throws IOException {
         fileServer.writeResponse = false;
         assertTrue(StaticFileServer.openFileSystems.isEmpty(),
@@ -468,7 +468,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void openFileServerExistsForZip_openingNewDoesNotFail()
+    void openFileServerExistsForZip_openingNewDoesNotFail()
             throws IOException, URISyntaxException {
         assertTrue(StaticFileServer.openFileSystems.isEmpty(),
                 "Can not run concurrently with other test");
@@ -496,7 +496,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void openingJarFileSystemForDifferentFilesInSameJar_existingFileSystemIsUsed()
+    void openingJarFileSystemForDifferentFilesInSameJar_existingFileSystemIsUsed()
             throws IOException, URISyntaxException {
         assertTrue(StaticFileServer.openFileSystems.isEmpty(),
                 "Can not run concurrently with other test");
@@ -538,9 +538,8 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void concurrentRequestsToJarResources_checksAreCorrect()
-            throws IOException, InterruptedException, ExecutionException,
-            URISyntaxException {
+    void concurrentRequestsToJarResources_checksAreCorrect() throws IOException,
+            InterruptedException, ExecutionException, URISyntaxException {
         fileServer.writeResponse = false;
         assertTrue(StaticFileServer.openFileSystems.isEmpty(),
                 "Can not run concurrently with other test");
@@ -665,7 +664,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void isNotResourceRequestWithContextPath() throws Exception {
+    void isNotResourceRequestWithContextPath() throws Exception {
         setupRequestURI("/context", "", "/");
         Mockito.when(servletContext.getResource("/")).thenReturn(new URL("file",
                 "", -1,
@@ -684,7 +683,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void writeModificationTimestampBrowserHasLatest()
+    void writeModificationTimestampBrowserHasLatest()
             throws MalformedURLException {
         fileServer.overrideBrowserHasNewestVersion = true;
         Long modificationTimestamp = writeModificationTime();
@@ -692,7 +691,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void writeModificationTimestampBrowserDoesNotHaveLatest()
+    void writeModificationTimestampBrowserDoesNotHaveLatest()
             throws MalformedURLException {
         fileServer.overrideBrowserHasNewestVersion = false;
         Long modificationTimestamp = writeModificationTime();
@@ -722,19 +721,19 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void browserHasNewestVersionUnknownModificiationTime() {
+    void browserHasNewestVersionUnknownModificiationTime() {
         assertFalse(fileServer.browserHasNewestVersion(request, -1));
     }
 
     @Test
-    public void browserHasNewestVersionInvalidModificiationTime() {
+    void browserHasNewestVersionInvalidModificiationTime() {
         assertThrows(AssertionError.class, () -> {
             fileServer.browserHasNewestVersion(request, -2);
         });
     }
 
     @Test
-    public void browserHasNewestVersionNoIfModifiedSinceHeader() {
+    void browserHasNewestVersionNoIfModifiedSinceHeader() {
         long fileModifiedTime = 0;
 
         assertFalse(
@@ -742,7 +741,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void browserHasNewestVersionOlderIfModifiedSinceHeader() {
+    void browserHasNewestVersionOlderIfModifiedSinceHeader() {
         long browserIfModifiedSince = 123L;
         long fileModifiedTime = 124L;
         Mockito.when(request.getDateHeader("If-Modified-Since"))
@@ -753,7 +752,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void browserHasNewestVersionNewerIfModifiedSinceHeader() {
+    void browserHasNewestVersionNewerIfModifiedSinceHeader() {
         long browserIfModifiedSince = 125L;
         long fileModifiedTime = 124L;
         Mockito.when(request.getDateHeader("If-Modified-Since"))
@@ -764,14 +763,14 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void writeCacheHeadersCacheResource() {
+    void writeCacheHeadersCacheResource() {
         fileServer.overrideCacheTime = 12;
         fileServer.writeCacheHeaders("/folder/myfile.txt", response);
         assertTrue(headers.get("Cache-Control").contains("max-age=12"));
     }
 
     @Test
-    public void nonProductionMode_writeCacheHeadersCacheResource_noCache() {
+    void nonProductionMode_writeCacheHeadersCacheResource_noCache() {
         Mockito.when(configuration.isProductionMode()).thenReturn(false);
 
         fileServer.overrideCacheTime = 12;
@@ -780,7 +779,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void writeCacheHeadersDoNotCacheResource() {
+    void writeCacheHeadersDoNotCacheResource() {
         fileServer.overrideCacheTime = 0;
         fileServer.writeCacheHeaders("/folder/myfile.txt", response);
         assertTrue(headers.get("Cache-Control").contains("max-age=0"));
@@ -788,7 +787,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void nonProductionMode_writeCacheHeadersDoNotCacheResource() {
+    void nonProductionMode_writeCacheHeadersDoNotCacheResource() {
         Mockito.when(configuration.isProductionMode()).thenReturn(false);
 
         fileServer.overrideCacheTime = 0;
@@ -797,7 +796,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void productionMode_writeCacheHeaders_withVersionParam_oneYearCache() {
+    void productionMode_writeCacheHeaders_withVersionParam_oneYearCache() {
         Mockito.when(configuration.isProductionMode()).thenReturn(true);
         Mockito.when(request
                 .getParameter(ApplicationConstants.CONTENT_HASH_PARAMETER))
@@ -809,7 +808,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void getCacheTime() {
+    void getCacheTime() {
         int oneYear = 60 * 60 * 24 * 365;
         assertEquals(oneYear, fileServer.getCacheTime("somefile.cache.js"));
         assertEquals(oneYear,
@@ -821,14 +820,14 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void serveNonExistingStaticResource() throws IOException {
+    void serveNonExistingStaticResource() throws IOException {
         setupRequestURI("", "", "/nonexisting/file.js");
 
         assertFalse(fileServer.serveStaticResource(request, response));
     }
 
     @Test
-    public void serveStaticResource() throws IOException {
+    void serveStaticResource() throws IOException {
         setupRequestURI("", "/some", "/file.js");
         String fileData = "function() {eval('foo');};";
 
@@ -841,7 +840,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void contextAndServletPath_serveStaticBundleBuildResource()
+    void contextAndServletPath_serveStaticBundleBuildResource()
             throws IOException {
         String pathInfo = "/VAADIN/build/vaadin-bundle-1234.cache.js";
         setupRequestURI("/context", "/servlet", pathInfo);
@@ -849,52 +848,49 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void ServletPath_serveStaticBundleBuildResource()
-            throws IOException {
+    void ServletPath_serveStaticBundleBuildResource() throws IOException {
         String pathInfo = "/VAADIN/build/vaadin-bundle-1234.cache.js";
         setupRequestURI("", "/servlet", pathInfo);
         assertBundleBuildResource(pathInfo);
     }
 
     @Test
-    public void contextPath_serveStaticBundleBuildResource()
-            throws IOException {
+    void contextPath_serveStaticBundleBuildResource() throws IOException {
         String pathInfo = "/VAADIN/build/vaadin-bundle-1234.cache.js";
         setupRequestURI("/context", "", pathInfo);
         assertBundleBuildResource(pathInfo);
     }
 
     @Test
-    public void serveStaticBundleBuildResource() throws IOException {
+    void serveStaticBundleBuildResource() throws IOException {
         String pathInfo = "/VAADIN/build/vaadin-bundle-1234.cache.js";
         setupRequestURI("", "", pathInfo);
         assertBundleBuildResource(pathInfo);
     }
 
     @Test
-    public void contextAndServletPath_serveStaticFileResource()
-            throws IOException {
+    void contextAndServletPath_serveStaticFileResource() throws IOException {
         String pathInfo = "/VAADIN/static/img/bg.jpg";
         setupRequestURI("/context", "/servlet", pathInfo);
         assertBundleBuildResource(pathInfo);
     }
 
     @Test
-    public void ServletPath_serveStaticFileResource() throws IOException {
+    void ServletPath_serveStaticFileResource() throws IOException {
         String pathInfo = "/VAADIN/static/img/bg.jpg";
         setupRequestURI("", "/servlet", pathInfo);
         assertBundleBuildResource(pathInfo);
     }
 
     @Test
-    public void contextPath_serveStaticFileResource() throws IOException {
+    void contextPath_serveStaticFileResource() throws IOException {
         String pathInfo = "/VAADIN/static/img/bg.jpg";
         setupRequestURI("/context", "", pathInfo);
         assertBundleBuildResource(pathInfo);
     }
 
     @Test
-    public void serveStaticFileResource() throws IOException {
+    void serveStaticFileResource() throws IOException {
         String pathInfo = "/VAADIN/static/img/bg.jpg";
         setupRequestURI("", "", pathInfo);
         assertBundleBuildResource(pathInfo);
@@ -945,64 +941,63 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void serveStaticResource_uriWithDirectoryChangeWithSlash_returnsImmediatelyAndSetsBadRequestStatus()
+    void serveStaticResource_uriWithDirectoryChangeWithSlash_returnsImmediatelyAndSetsBadRequestStatus()
             throws IOException {
         staticBuildResourceWithDirectoryChange_nothingServed(
                 "/VAADIN/build/../vaadin-bundle-1234.cache.js");
     }
 
     @Test
-    public void serveStaticResource_uriWithDirectoryChangeWithBackslash_returnsImmediatelyAndSetsBadRequestStatus()
+    void serveStaticResource_uriWithDirectoryChangeWithBackslash_returnsImmediatelyAndSetsBadRequestStatus()
             throws IOException {
         staticBuildResourceWithDirectoryChange_nothingServed(
                 "/VAADIN/build/something\\..\\vaadin-bundle-1234.cache.js");
     }
 
     @Test
-    public void serveStaticResource_uriWithDirectoryChangeWithEncodedBackslashUpperCase_returnsImmediatelyAndSetsBadRequestStatus()
+    void serveStaticResource_uriWithDirectoryChangeWithEncodedBackslashUpperCase_returnsImmediatelyAndSetsBadRequestStatus()
             throws IOException {
         staticBuildResourceWithDirectoryChange_nothingServed(
                 "/VAADIN/build/something%5C..%5Cvaadin-bundle-1234.cache.js");
     }
 
     @Test
-    public void serveStaticResource_uriWithDirectoryChangeWithEncodedBackslashLowerCase_returnsImmediatelyAndSetsBadRequestStatus()
+    void serveStaticResource_uriWithDirectoryChangeWithEncodedBackslashLowerCase_returnsImmediatelyAndSetsBadRequestStatus()
             throws IOException {
         staticBuildResourceWithDirectoryChange_nothingServed(
                 "/VAADIN/build/something%5c..%5cvaadin-bundle-1234.cache.js");
     }
 
     @Test
-    public void serveStaticResource_uriWithDirectoryChangeInTheEndWithSlash_returnsImmediatelyAndSetsBadRequestStatus()
+    void serveStaticResource_uriWithDirectoryChangeInTheEndWithSlash_returnsImmediatelyAndSetsBadRequestStatus()
             throws IOException {
         staticBuildResourceWithDirectoryChange_nothingServed(
                 "/VAADIN/build/..");
     }
 
     @Test
-    public void serveStaticResource_uriWithDirectoryChangeInTheEndWithBackslash_returnsImmediatelyAndSetsBadRequestStatus()
+    void serveStaticResource_uriWithDirectoryChangeInTheEndWithBackslash_returnsImmediatelyAndSetsBadRequestStatus()
             throws IOException {
         staticBuildResourceWithDirectoryChange_nothingServed(
                 "/VAADIN/build/something\\..");
     }
 
     @Test
-    public void serveStaticResource_uriWithDirectoryChangeInTheEndWithEncodedBackslashUpperCase_returnsImmediatelyAndSetsBadRequestStatus()
+    void serveStaticResource_uriWithDirectoryChangeInTheEndWithEncodedBackslashUpperCase_returnsImmediatelyAndSetsBadRequestStatus()
             throws IOException {
         staticBuildResourceWithDirectoryChange_nothingServed(
                 "/VAADIN/build/something%5C..");
     }
 
     @Test
-    public void serveStaticResource_uriWithDirectoryChangeInTheEndWithEncodedBackslashLowerCase_returnsImmediatelyAndSetsBadRequestStatus()
+    void serveStaticResource_uriWithDirectoryChangeInTheEndWithEncodedBackslashLowerCase_returnsImmediatelyAndSetsBadRequestStatus()
             throws IOException {
         staticBuildResourceWithDirectoryChange_nothingServed(
                 "/VAADIN/build/something%5c..");
     }
 
     @Test
-    public void serveStaticResource_uriWithPercent_isServed()
-            throws IOException {
+    void serveStaticResource_uriWithPercent_isServed() throws IOException {
         String pathInfo = "/VAADIN/build/100%.pdf";
         setupRequestURI("", "", pathInfo);
         String fileData = "contents";
@@ -1021,7 +1016,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void customStaticBuildResource_isServed() throws IOException {
+    void customStaticBuildResource_isServed() throws IOException {
         String pathInfo = "/VAADIN/build/my-text.txt";
         setupRequestURI("", "", pathInfo);
         String fileData = "function() {eval('foo');};";
@@ -1040,7 +1035,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void nonexistingStaticBuildResource_notServed() throws IOException {
+    void nonexistingStaticBuildResource_notServed() throws IOException {
         String pathInfo = "/VAADIN/build/my-text.txt";
         setupRequestURI("", "", pathInfo);
         ClassLoader mockLoader = Mockito.mock(ClassLoader.class);
@@ -1053,7 +1048,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void staticManifestPathResource_isServed() throws IOException {
+    void staticManifestPathResource_isServed() throws IOException {
         String pathInfo = "/sw.js";
         setupRequestURI("", "", pathInfo);
         String fileData = "function() {eval('foo');};";
@@ -1069,8 +1064,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void staticManifestPathIndexHtmlResource_notServed()
-            throws IOException {
+    void staticManifestPathIndexHtmlResource_notServed() throws IOException {
         String pathInfo = "/index.html";
         setupRequestURI("", "", pathInfo);
         String fileData = "function() {eval('foo');};";
@@ -1085,7 +1079,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void customStatsJson_isServedFromServlet() throws IOException {
+    void customStatsJson_isServedFromServlet() throws IOException {
         String pathInfo = "/VAADIN/build/stats.json";
         setupRequestURI("", "/servlet", pathInfo);
         String fileData = "function() {eval('foo');};";
@@ -1129,7 +1123,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void serveStaticResourceBrowserHasLatest() throws IOException {
+    void serveStaticResourceBrowserHasLatest() throws IOException {
         long browserLatest = 123L;
         long fileModified = 123L;
 
@@ -1148,8 +1142,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void serveStaticResourceFromWebjarWithIncorrectPath()
-            throws IOException {
+    void serveStaticResourceFromWebjarWithIncorrectPath() throws IOException {
         Mockito.when(configuration.getBooleanProperty(
                 StaticFileServer.PROPERTY_FIX_INCORRECT_WEBJAR_PATHS, false))
                 .thenReturn(true);
@@ -1165,7 +1158,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void serveStaticResourceFromWebjarWithIncorrectPathAndFixingDisabled()
+    void serveStaticResourceFromWebjarWithIncorrectPathAndFixingDisabled()
             throws IOException {
         Mockito.when(configuration.getBooleanProperty(
                 StaticFileServer.PROPERTY_FIX_INCORRECT_WEBJAR_PATHS, false))
@@ -1181,7 +1174,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void getStaticResource_delegateToVaadinService()
+    void getStaticResource_delegateToVaadinService()
             throws MalformedURLException {
         URL url = new URL("http://bar");
         Mockito.when(servletService.getStaticResource("foo")).thenReturn(url);
@@ -1192,7 +1185,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void serveStaticResource_projectThemeResourceRequest_serveFromFrontend()
+    void serveStaticResource_projectThemeResourceRequest_serveFromFrontend()
             throws IOException {
         File projectRootFolder = Files
                 .createTempDirectory(temporaryFolder, "temp").toFile();
@@ -1213,7 +1206,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void serveStaticResource_externalThemeResourceRequest_serveFromBundle()
+    void serveStaticResource_externalThemeResourceRequest_serveFromBundle()
             throws IOException {
         File projectRootFolder = Files
                 .createTempDirectory(temporaryFolder, "temp").toFile();
@@ -1234,7 +1227,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void serveStaticResource_themeResourceRequest_productionMode_notServeFromBundleNorFromFrontend()
+    void serveStaticResource_themeResourceRequest_productionMode_notServeFromBundleNorFromFrontend()
             throws IOException {
         File projectRootFolder = Files
                 .createTempDirectory(temporaryFolder, "temp").toFile();
@@ -1252,7 +1245,7 @@ class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void frameworkStaticFolder_withoutEndingSlash_doesNotServeStaticResource()
+    void frameworkStaticFolder_withoutEndingSlash_doesNotServeStaticResource()
             throws IOException {
         // Test framework static folders without / at the end,
         // that they do not return a result

--- a/flow-server/src/test/java/com/vaadin/flow/server/StreamResourceRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/StreamResourceRegistryTest.java
@@ -46,7 +46,7 @@ class StreamResourceRegistryTest {
     private VaadinSession session;
 
     @BeforeEach
-    public void setUp() throws ServletException, ServiceException {
+    void setUp() throws ServletException, ServiceException {
         service = new MockVaadinServletService();
         session = new VaadinSession(service) {
             @Override
@@ -61,12 +61,12 @@ class StreamResourceRegistryTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         CurrentInstance.clearAll();
     }
 
     @Test
-    public void registerResource_registrationResultCanBeFound() {
+    void registerResource_registrationResultCanBeFound() {
         StreamResourceRegistry registry = new StreamResourceRegistry(session);
 
         StreamResource resource = new StreamResource("name",
@@ -86,7 +86,7 @@ class StreamResourceRegistryTest {
     }
 
     @Test
-    public void registerElementResourceHandler_registrationResultCanBeFound() {
+    void registerElementResourceHandler_registrationResultCanBeFound() {
         StreamResourceRegistry registry = new StreamResourceRegistry(session);
 
         ElementRequestHandler handler = (request, response, session, owner) -> {
@@ -106,7 +106,7 @@ class StreamResourceRegistryTest {
     }
 
     @Test
-    public void unregisterResource_resourceIsRemoved() {
+    void unregisterResource_resourceIsRemoved() {
         StreamResourceRegistry registry = new StreamResourceRegistry(session);
 
         StreamResource resource = new StreamResource("name",
@@ -127,7 +127,7 @@ class StreamResourceRegistryTest {
     }
 
     @Test
-    public void unregisterElementResourceHandler_resourceIsRemoved() {
+    void unregisterElementResourceHandler_resourceIsRemoved() {
         StreamResourceRegistry registry = new StreamResourceRegistry(session);
 
         ElementRequestHandler handler = (request, response, session, owner) -> {
@@ -151,7 +151,7 @@ class StreamResourceRegistryTest {
     }
 
     @Test
-    public void registerTwoResourcesWithSameName_resourcesHasDifferentURI() {
+    void registerTwoResourcesWithSameName_resourcesHasDifferentURI() {
         StreamResourceRegistry registry = new StreamResourceRegistry(session);
 
         StreamResource resource1 = new StreamResource("name",
@@ -175,17 +175,17 @@ class StreamResourceRegistryTest {
     }
 
     @Test
-    public void getResourceUriIsEncoded_withQueryParams() {
+    void getResourceUriIsEncoded_withQueryParams() {
         assertResourceUriIsEncoded("a?b=c d&e", "a%3Fb%3Dc%20d%26e");
     }
 
     @Test
-    public void getResourceUriIsEncoded_withContainingPlus() {
+    void getResourceUriIsEncoded_withContainingPlus() {
         assertResourceUriIsEncoded("image++.svg", "image%2B%2B.svg");
     }
 
     @Test
-    public void getResourceUriIsEncoded_withSimpleSpace() {
+    void getResourceUriIsEncoded_withSimpleSpace() {
         assertResourceUriIsEncoded("my file.png", "my%20file.png");
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/StreamResourceTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/StreamResourceTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 class StreamResourceTest {
 
     @Test
-    public void getDefaultContentTypeResolver() {
+    void getDefaultContentTypeResolver() {
         StreamResource resource = new StreamResource("foo",
                 () -> makeEmptyStream());
         ContentTypeResolver resolver = resource.getContentTypeResolver();
@@ -43,7 +43,7 @@ class StreamResourceTest {
     }
 
     @Test
-    public void setContentTypeResolver() {
+    void setContentTypeResolver() {
         StreamResource resource = new StreamResource("foo",
                 () -> makeEmptyStream());
         resource.setContentTypeResolver((res, context) -> "bar");
@@ -54,7 +54,7 @@ class StreamResourceTest {
     }
 
     @Test
-    public void setContentType() {
+    void setContentType() {
         StreamResource resource = new StreamResource("foo",
                 () -> makeEmptyStream());
         resource.setContentType("bar");
@@ -65,7 +65,7 @@ class StreamResourceTest {
     }
 
     @Test
-    public void setHeader_headerIsInHeadersListAndGetterReturnsTheValue() {
+    void setHeader_headerIsInHeadersListAndGetterReturnsTheValue() {
         StreamResource resource = new StreamResource("foo",
                 () -> makeEmptyStream());
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/SystemMessagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/SystemMessagesTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class SystemMessagesTest {
 
     @Test
-    public void syncError_defaultValues() {
+    void syncError_defaultValues() {
         SystemMessages messages = new CustomizedSystemMessages();
 
         assertNull(messages.getSyncErrorURL(), "Default URL should be null");
@@ -40,7 +40,7 @@ class SystemMessagesTest {
     }
 
     @Test
-    public void syncError_notificationEnabled_returnsCaptionAndMessage() {
+    void syncError_notificationEnabled_returnsCaptionAndMessage() {
         SystemMessages messages = new CustomizedSystemMessages();
 
         // By default, notification is enabled
@@ -50,7 +50,7 @@ class SystemMessagesTest {
     }
 
     @Test
-    public void customizedSyncError_notificationDisabled_returnsNullCaptionAndMessage() {
+    void customizedSyncError_notificationDisabled_returnsNullCaptionAndMessage() {
         CustomizedSystemMessages messages = new CustomizedSystemMessages();
 
         messages.setSyncErrorNotificationEnabled(false);
@@ -66,7 +66,7 @@ class SystemMessagesTest {
     }
 
     @Test
-    public void customizedSyncError_urlNotAffectedByNotificationEnabled() {
+    void customizedSyncError_urlNotAffectedByNotificationEnabled() {
         CustomizedSystemMessages messages = new CustomizedSystemMessages();
 
         messages.setSyncErrorURL("/redirect-url");

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinRequestTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinRequestTest.java
@@ -25,7 +25,7 @@ class VaadinRequestTest {
     }
 
     @Test
-    public void getContentLengthLong_delegateToGetContentLength() {
+    void getContentLengthLong_delegateToGetContentLength() {
         TestVaadinRequest request = Mockito.spy(TestVaadinRequest.class);
         request.getContentLengthLong();
         Mockito.verify(request).getContentLength();

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServiceSignalsInitializationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServiceSignalsInitializationTest.java
@@ -45,12 +45,12 @@ class VaadinServiceSignalsInitializationTest {
 
     @BeforeEach
     @AfterEach
-    public void clearTestEnvironment() {
+    void clearTestEnvironment() {
         CurrentInstance.clearAll();
     }
 
     @Test
-    public void init_flowSignalEnvironmentInitialized()
+    void init_flowSignalEnvironmentInitialized()
             throws InterruptedException, TimeoutException {
 
         var service = new MockVaadinServletService();
@@ -108,7 +108,7 @@ class VaadinServiceSignalsInitializationTest {
     }
 
     @Test
-    public void resultNotifier_ownerUiIsClosing_taskNotScheduled()
+    void resultNotifier_ownerUiIsClosing_taskNotScheduled()
             throws InterruptedException {
         var service = new MockVaadinServletService();
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServiceTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServiceTest.java
@@ -165,12 +165,12 @@ class VaadinServiceTest {
 
     @BeforeEach
     @AfterEach
-    public void clearCurrentInstances() {
+    void clearCurrentInstances() {
         CurrentInstance.clearAll();
     }
 
     @Test
-    public void requestEnd_serviceFailure_threadLocalsCleared() {
+    void requestEnd_serviceFailure_threadLocalsCleared() {
         MockVaadinServletService service = new MockVaadinServletService() {
             @Override
             void cleanupSession(VaadinSession session) {
@@ -204,7 +204,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void requestEnd_interceptorFailure_allInterceptorsInvoked_doNotThrowAndThreadLocalsCleared() {
+    void requestEnd_interceptorFailure_allInterceptorsInvoked_doNotThrowAndThreadLocalsCleared() {
         VaadinRequestInterceptor interceptor1 = Mockito
                 .mock(VaadinRequestInterceptor.class);
         VaadinRequestInterceptor interceptor2 = Mockito
@@ -254,7 +254,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void should_reported_routing_server() {
+    void should_reported_routing_server() {
 
         // this test needs a fresh empty statistics, so we need to clear
         // them for resusing forks for unit tests
@@ -277,7 +277,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void should_reported_routing_hybrid() {
+    void should_reported_routing_hybrid() {
         UsageStatistics.resetEntries();
         VaadinServiceInitListener initListener = event -> {
             RouteConfiguration.forApplicationScope().setRoute("test",
@@ -304,7 +304,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void should_reported_auto_layout_server() {
+    void should_reported_auto_layout_server() {
         UsageStatistics.resetEntries();
         @Layout
         class AutoLayout extends Component implements RouterLayout {
@@ -332,7 +332,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void should_reported_auto_layout_client() {
+    void should_reported_auto_layout_client() {
         UsageStatistics.resetEntries();
         @Layout
         class AutoLayout extends Component implements RouterLayout {
@@ -358,7 +358,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void should_reported_auto_layout_routes_not_used() {
+    void should_reported_auto_layout_routes_not_used() {
         UsageStatistics.resetEntries();
         @Route(value = "not-in-auto-layout")
         @Tag("div")
@@ -412,7 +412,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void testFireSessionDestroy() {
+    void testFireSessionDestroy() {
         VaadinService service = createService();
 
         TestSessionDestroyListener listener = new TestSessionDestroyListener();
@@ -435,7 +435,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void testSessionDestroyListenerCalled_whenAnotherListenerThrows() {
+    void testSessionDestroyListenerCalled_whenAnotherListenerThrows() {
         VaadinService service = createService();
 
         ThrowingSessionDestroyListener throwingListener = new ThrowingSessionDestroyListener();
@@ -459,7 +459,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void testSessionDestroyListenerCalled_andOtherUiDetachCalled_whenUiClosingThrows() {
+    void testSessionDestroyListenerCalled_andOtherUiDetachCalled_whenUiClosingThrows() {
         VaadinService service = createService();
 
         TestSessionDestroyListener listener = new TestSessionDestroyListener();
@@ -516,7 +516,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void testServiceDestroyListenerCalled_whenAnotherListenerThrows() {
+    void testServiceDestroyListenerCalled_whenAnotherListenerThrows() {
         VaadinService service = createService();
 
         ThrowingServiceDestroyListener throwingListener = new ThrowingServiceDestroyListener();
@@ -532,7 +532,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void captionIsSetToACriticalNotification() {
+    void captionIsSetToACriticalNotification() {
         String notification = createCriticalNotification("foobar", "message",
                 "details", "url");
 
@@ -540,7 +540,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void nullCaptionIsSetToACriticalNotification() {
+    void nullCaptionIsSetToACriticalNotification() {
         String notification = createCriticalNotification(null, "message",
                 "details", "url");
 
@@ -548,7 +548,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void messageWithDetailsIsSetToACriticalNotification() {
+    void messageWithDetailsIsSetToACriticalNotification() {
         String notification = createCriticalNotification("caption", "foo",
                 "bar", "url");
 
@@ -556,7 +556,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void nullMessageSentAsNullInACriticalNotification() {
+    void nullMessageSentAsNullInACriticalNotification() {
         String notification = createCriticalNotification("caption", null,
                 "foobar", "url");
 
@@ -564,7 +564,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void nullMessageIsSetToACriticalNotification() {
+    void nullMessageIsSetToACriticalNotification() {
         String notification = createCriticalNotification("caption", null, null,
                 "url");
 
@@ -572,7 +572,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void messageSetToACriticalNotification() {
+    void messageSetToACriticalNotification() {
         String notification = createCriticalNotification("caption", "foobar",
                 null, "url");
 
@@ -580,7 +580,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void urlIsSetToACriticalNotification() {
+    void urlIsSetToACriticalNotification() {
         String notification = createCriticalNotification("caption", "message",
                 "details", "foobar");
 
@@ -588,7 +588,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void nullUrlIsSetToACriticalNotification() {
+    void nullUrlIsSetToACriticalNotification() {
         String notification = createCriticalNotification("caption", "message",
                 "details", null);
 
@@ -596,7 +596,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void serviceContainsStreamRequestHandler()
+    void serviceContainsStreamRequestHandler()
             throws ServiceException, ServletException {
         ServletConfig servletConfig = new MockServletConfig();
         Lookup lookup = Mockito.mock(Lookup.class);
@@ -620,7 +620,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void currentInstancesAfterPendingAccessTasks() {
+    void currentInstancesAfterPendingAccessTasks() {
         VaadinService service = createService();
 
         MockVaadinSession session = new MockVaadinSession(service);
@@ -636,7 +636,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void testServiceInitListener_accessApplicationRouteRegistry_registryAvailable() {
+    void testServiceInitListener_accessApplicationRouteRegistry_registryAvailable() {
 
         VaadinServiceInitListener initListener = event -> {
             assertNotNull(VaadinService.getCurrent(),
@@ -668,7 +668,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void dependencyFilterOrder_bundeFiltersAfterApplicationFilters() {
+    void dependencyFilterOrder_bundeFiltersAfterApplicationFilters() {
         DependencyFilter applicationFilter = (dependencies,
                 service) -> dependencies;
 
@@ -691,7 +691,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void loadInstantiators_instantiatorIsLoadedUsingFactoryFromLookup()
+    void loadInstantiators_instantiatorIsLoadedUsingFactoryFromLookup()
             throws ServiceException {
         MockVaadinServletService service = createService();
 
@@ -710,7 +710,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void loadInstantiators_twoFactoriesInLookup_throws()
+    void loadInstantiators_twoFactoriesInLookup_throws()
             throws ServiceException {
         MockVaadinServletService service = createService();
 
@@ -726,7 +726,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void createRequestHandlers_pwaHandlerIsInList_webComponentHandlersAreInList()
+    void createRequestHandlers_pwaHandlerIsInList_webComponentHandlersAreInList()
             throws ServiceException {
         TestVaadinService service = Mockito.mock(TestVaadinService.class);
         I18NProvider i18NProvider = Mockito.mock(DefaultI18NProvider.class);
@@ -744,7 +744,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void fireSessionDestroy_sessionStateIsSetToClosed() {
+    void fireSessionDestroy_sessionStateIsSetToClosed() {
         VaadinService service = createService();
 
         AtomicReference<VaadinSessionState> stateRef = new AtomicReference<>();
@@ -761,7 +761,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void removeFromHttpSession_setExplicitSessionCloseAttribute()
+    void removeFromHttpSession_setExplicitSessionCloseAttribute()
             throws ServiceException {
         WrappedSession httpSession = Mockito.mock(WrappedSession.class);
         VaadinSession session = Mockito.mock(VaadinSession.class);
@@ -782,7 +782,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void reinitializeSession_setVaadinSessionAttriuteWithLock() {
+    void reinitializeSession_setVaadinSessionAttriuteWithLock() {
         VaadinRequest request = Mockito.mock(VaadinRequest.class);
 
         VaadinSession vaadinSession = Mockito.mock(VaadinSession.class);
@@ -806,8 +806,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void getExecutor_getsDefaultVaadinExecutor()
-            throws InterruptedException {
+    void getExecutor_getsDefaultVaadinExecutor() throws InterruptedException {
         VaadinService service = createService();
         Executor executor = service.getExecutor();
         AtomicReference<String> threadName = new AtomicReference<>();
@@ -824,7 +823,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void serviceDestroy_defaultExecutor_executorStopped() {
+    void serviceDestroy_defaultExecutor_executorStopped() {
         VaadinService service = createService();
         Executor executor = service.getExecutor();
         assertTrue(executor instanceof ExecutorService,
@@ -837,7 +836,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void getExecutor_customExecutorProvided_getsCustomExecutor()
+    void getExecutor_customExecutorProvided_getsCustomExecutor()
             throws InterruptedException {
         AtomicBoolean taskSubmitted = new AtomicBoolean(false);
         Executor executor = command -> {
@@ -860,7 +859,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void serviceDestroy_customExecutorProvided_executorNotStopped() {
+    void serviceDestroy_customExecutorProvided_executorNotStopped() {
         ExecutorService executor = Executors.newSingleThreadExecutor();
         VaadinServiceInitListener initListener = event -> {
             event.setExecutor(executor);
@@ -879,7 +878,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void getExecutor_nullExecutorProvided_resetsToDefaultVaadinExecutor() {
+    void getExecutor_nullExecutorProvided_resetsToDefaultVaadinExecutor() {
         Executor executor = command -> {
         };
         VaadinServiceInitListener setExecutorInitListener = event -> {
@@ -897,7 +896,7 @@ class VaadinServiceTest {
     }
 
     @Test
-    public void init_nullExecutor_throws() {
+    void init_nullExecutor_throws() {
         RuntimeException error = assertThrows(RuntimeException.class, () -> {
             // init method is called by the mock service constructor
             new MockVaadinServletService() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletConfigTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletConfigTest.java
@@ -41,7 +41,7 @@ class VaadinServletConfigTest {
     private Map<String, String> properties;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         ServletConfig servletConfig = Mockito.mock(ServletConfig.class);
         servletContext = Mockito.mock(ServletContext.class);
 
@@ -69,7 +69,7 @@ class VaadinServletConfigTest {
     }
 
     @Test
-    public void getPropertyNames_returnsExpectedProperties() {
+    void getPropertyNames_returnsExpectedProperties() {
         List<String> list = Collections.list(config.getConfigParameterNames());
         assertEquals(properties.size(), list.size(),
                 "Context should return only keys defined in ServletContext");
@@ -82,7 +82,7 @@ class VaadinServletConfigTest {
     }
 
     @Test
-    public void vaadinContextThroughConfig_setAndGetAttribute() {
+    void vaadinContextThroughConfig_setAndGetAttribute() {
         String value = "my-attribute";
         config.getVaadinContext().setAttribute(value);
         String result = config.getVaadinContext().getAttribute(String.class);

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletContextTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletContextTest.java
@@ -48,7 +48,7 @@ class VaadinServletContextTest {
     private Map<String, String> properties;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         ServletContext servletContext = Mockito.mock(ServletContext.class);
         Mockito.when(servletContext.getAttribute(Mockito.anyString()))
                 .then(invocationOnMock -> attributeMap
@@ -76,7 +76,7 @@ class VaadinServletContextTest {
     }
 
     @Test
-    public void getAttributeWithProvider() {
+    void getAttributeWithProvider() {
         assertNull(context.getAttribute(String.class));
 
         String value = context.getAttribute(String.class,
@@ -89,20 +89,20 @@ class VaadinServletContextTest {
     }
 
     @Test
-    public void setNullAttributeNotAllowed() {
+    void setNullAttributeNotAllowed() {
         assertThrows(AssertionError.class, () -> {
             context.setAttribute(null);
         });
     }
 
     @Test
-    public void getMissingAttributeWithoutProvider() {
+    void getMissingAttributeWithoutProvider() {
         String value = context.getAttribute(String.class);
         assertNull(value);
     }
 
     @Test
-    public void setAndGetAttribute() {
+    void setAndGetAttribute() {
         String value = testAttributeProvider();
         context.setAttribute(value);
         String result = context.getAttribute(String.class);
@@ -120,7 +120,7 @@ class VaadinServletContextTest {
     }
 
     @Test
-    public void setValueBasedOnSuperType_implicitClass_notFound() {
+    void setValueBasedOnSuperType_implicitClass_notFound() {
         String value = testAttributeProvider();
         context.setAttribute(value);
 
@@ -130,7 +130,7 @@ class VaadinServletContextTest {
     }
 
     @Test
-    public void setValueBasedOnSuperType_explicitClass_found() {
+    void setValueBasedOnSuperType_explicitClass_found() {
         String value = testAttributeProvider();
         context.setAttribute(CharSequence.class, value);
 
@@ -140,7 +140,7 @@ class VaadinServletContextTest {
     }
 
     @Test
-    public void removeValue_removeMethod_valueIsRemoved() {
+    void removeValue_removeMethod_valueIsRemoved() {
         context.setAttribute(testAttributeProvider());
         context.removeAttribute(String.class);
 
@@ -149,7 +149,7 @@ class VaadinServletContextTest {
     }
 
     @Test
-    public void removeValue_setWithClass_valueIsRemoved() {
+    void removeValue_setWithClass_valueIsRemoved() {
         context.setAttribute(testAttributeProvider());
         context.setAttribute(String.class, null);
 
@@ -158,7 +158,7 @@ class VaadinServletContextTest {
     }
 
     @Test
-    public void getPropertyNames_returnsExpectedProperties() {
+    void getPropertyNames_returnsExpectedProperties() {
         List<String> list = Collections
                 .list(context.getContextParameterNames());
         assertEquals(properties.size(), list.size(),

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletRequestTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletRequestTest.java
@@ -23,7 +23,7 @@ import org.mockito.Mockito;
 class VaadinServletRequestTest {
 
     @Test
-    public void getContentLengthLong_delegateToServletRequestGetContentLengthLong() {
+    void getContentLengthLong_delegateToServletRequestGetContentLengthLong() {
         HttpServletRequest servletRequest = Mockito
                 .mock(HttpServletRequest.class);
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletServiceTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletServiceTest.java
@@ -69,7 +69,7 @@ class VaadinServletServiceTest {
     private VaadinServlet servlet;
 
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() throws Exception {
         mocks = new MockServletServiceSessionSetup();
         service = mocks.getService();
 
@@ -77,12 +77,12 @@ class VaadinServletServiceTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         mocks.cleanup();
     }
 
     @Test
-    public void resolveNullThrows() {
+    void resolveNullThrows() {
         try {
             service.resolveResource(null);
             fail("null should not resolve");
@@ -92,14 +92,14 @@ class VaadinServletServiceTest {
     }
 
     @Test
-    public void resolveResource() {
+    void resolveResource() {
         assertEquals("", service.resolveResource(""));
         assertEquals("foo", service.resolveResource("foo"));
         assertEquals("/foo", service.resolveResource("context://foo"));
     }
 
     @Test
-    public void resolveResourceNPM_production() {
+    void resolveResourceNPM_production() {
         mocks.setProductionMode(true);
 
         assertEquals("", service.resolveResource(""));
@@ -108,7 +108,7 @@ class VaadinServletServiceTest {
     }
 
     @Test
-    public void getContextRootRelativePath_useVariousContextPathAndServletPathsAndPathInfo()
+    void getContextRootRelativePath_useVariousContextPathAndServletPathsAndPathInfo()
             throws Exception {
         String location;
 
@@ -145,8 +145,7 @@ class VaadinServletServiceTest {
     }
 
     @Test
-    public void init_classLoaderIsSetUsingServletContext()
-            throws ServiceException {
+    void init_classLoaderIsSetUsingServletContext() throws ServiceException {
         VaadinServlet servlet = Mockito.mock(VaadinServlet.class);
         ServletContext context = Mockito.mock(ServletContext.class);
         when(servlet.getServletContext()).thenReturn(context);
@@ -177,7 +176,7 @@ class VaadinServletServiceTest {
     }
 
     @Test
-    public void getPwaRegistry_servletInitialized_getsRegistry() {
+    void getPwaRegistry_servletInitialized_getsRegistry() {
         MockServletServiceSessionSetup.TestVaadinServlet vaadinServlet = Mockito
                 .spy(mocks.getServlet());
         // Restore original behavior of getServletContext
@@ -189,7 +188,7 @@ class VaadinServletServiceTest {
     }
 
     @Test
-    public void getPwaRegistry_servletNotInitialized_getsNull() {
+    void getPwaRegistry_servletNotInitialized_getsNull() {
         MockServletServiceSessionSetup.TestVaadinServlet vaadinServlet = Mockito
                 .spy(mocks.getServlet());
         // Restore original behavior of getServletContext
@@ -288,7 +287,7 @@ class VaadinServletServiceTest {
     }
 
     @Test
-    public void filtersAreCalledWhenHandlingARequest() throws Exception {
+    void filtersAreCalledWhenHandlingARequest() throws Exception {
         mocks = new MockServletServiceSessionSetup() {
             @Override
             public TestVaadinServlet createVaadinServlet() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletTest.java
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class VaadinServletTest {
 
     @Test
-    public void testGetLastPathParameter() {
+    void testGetLastPathParameter() {
         assertEquals("",
                 VaadinServlet.getLastPathParameter("http://myhost.com"));
         assertEquals(";a",
@@ -83,7 +83,7 @@ class VaadinServletTest {
     }
 
     @Test
-    public void init_superInitCalledOnce() throws ServletException {
+    void init_superInitCalledOnce() throws ServletException {
         AtomicBoolean called = new AtomicBoolean();
         VaadinServlet servlet = new VaadinServlet() {
 
@@ -105,8 +105,7 @@ class VaadinServletTest {
     }
 
     @Test
-    public void init_passDifferentConfigInstance_throws()
-            throws ServletException {
+    void init_passDifferentConfigInstance_throws() throws ServletException {
         VaadinServlet servlet = new VaadinServlet();
 
         ServletConfig config = mockConfig();
@@ -117,8 +116,7 @@ class VaadinServletTest {
     }
 
     @Test
-    public void init_noLookup_servletIsNotInitialized()
-            throws ServletException {
+    void init_noLookup_servletIsNotInitialized() throws ServletException {
         AtomicBoolean called = new AtomicBoolean();
         VaadinServlet servlet = new VaadinServlet() {
 
@@ -135,8 +133,7 @@ class VaadinServletTest {
     }
 
     @Test
-    public void init_contextHasLookup_servletIsInitialized()
-            throws ServletException {
+    void init_contextHasLookup_servletIsInitialized() throws ServletException {
         AtomicBoolean called = new AtomicBoolean();
         VaadinServlet servlet = new VaadinServlet() {
 
@@ -168,7 +165,7 @@ class VaadinServletTest {
     }
 
     @Test
-    public void init_initServlet_CurrentInstanceClearAllIsCalled()
+    void init_initServlet_CurrentInstanceClearAllIsCalled()
             throws ServletException {
         try {
             VaadinServlet servlet = new VaadinServlet() {
@@ -212,7 +209,7 @@ class VaadinServletTest {
     }
 
     @Test
-    public void init_initOnlyConfig_CurrentInstanceClearAllIsCalled()
+    void init_initOnlyConfig_CurrentInstanceClearAllIsCalled()
             throws ServletException {
         try {
             VaadinServlet servlet = new VaadinServlet() {
@@ -234,7 +231,7 @@ class VaadinServletTest {
     }
 
     @Test
-    public void init_appClassLoaderIsSet() throws ServletException {
+    void init_appClassLoaderIsSet() throws ServletException {
         VaadinServlet servlet = new VaadinServlet();
 
         ServletConfig config = mockConfig();
@@ -254,7 +251,7 @@ class VaadinServletTest {
     }
 
     @Test
-    public void init_contextInitializationIsExecuted() throws ServletException {
+    void init_contextInitializationIsExecuted() throws ServletException {
         VaadinServlet servlet = new VaadinServlet();
 
         ServletConfig config = mockConfig();
@@ -276,7 +273,7 @@ class VaadinServletTest {
     }
 
     @Test
-    public void init_initIsCalledAfterDestroy_passDifferentConfigInstance_servletIsInitialized()
+    void init_initIsCalledAfterDestroy_passDifferentConfigInstance_servletIsInitialized()
             throws ServletException {
         VaadinServlet servlet = new VaadinServlet();
 
@@ -294,7 +291,7 @@ class VaadinServletTest {
     }
 
     @Test
-    public void destroy_servletIsInitializedBeforeDestroy_servletConfigIsNullAfterDestroy()
+    void destroy_servletIsInitializedBeforeDestroy_servletConfigIsNullAfterDestroy()
             throws ServletException {
         VaadinServlet servlet = new VaadinServlet();
 
@@ -308,7 +305,7 @@ class VaadinServletTest {
     }
 
     @Test
-    public void createStaticFileHandler_delegateToStaticFileHandlerFactory() {
+    void createStaticFileHandler_delegateToStaticFileHandlerFactory() {
         VaadinServlet servlet = new VaadinServlet();
         VaadinService service = Mockito.mock(VaadinService.class);
         VaadinContext context = Mockito.mock(VaadinContext.class);
@@ -332,7 +329,7 @@ class VaadinServletTest {
     }
 
     @Test
-    public void destroy_servletConfigAvailableInServbiceDestroy()
+    void destroy_servletConfigAvailableInServbiceDestroy()
             throws ServletException {
         VaadinServletService service = Mockito.mock(VaadinServletService.class);
         VaadinServlet servlet = new VaadinServlet() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinSessionLocaleSignalTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinSessionLocaleSignalTest.java
@@ -36,7 +36,7 @@ class VaadinSessionLocaleSignalTest extends SignalsUnitTest {
     }
 
     @Test
-    public void localeSignal_initialValue_matchesGetLocale() {
+    void localeSignal_initialValue_matchesGetLocale() {
         VaadinSession session = getSession();
         Signal<Locale> signal = session.localeSignal();
 
@@ -46,7 +46,7 @@ class VaadinSessionLocaleSignalTest extends SignalsUnitTest {
     }
 
     @Test
-    public void localeSignal_setLocale_signalUpdated() {
+    void localeSignal_setLocale_signalUpdated() {
         VaadinSession session = getSession();
         Signal<Locale> signal = session.localeSignal();
 
@@ -67,7 +67,7 @@ class VaadinSessionLocaleSignalTest extends SignalsUnitTest {
     }
 
     @Test
-    public void localeSignal_multipleLocaleChanges_signalFollows() {
+    void localeSignal_multipleLocaleChanges_signalFollows() {
         VaadinSession session = getSession();
         Signal<Locale> signal = session.localeSignal();
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinSessionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinSessionTest.java
@@ -113,7 +113,7 @@ class VaadinSessionTest {
     private Lock httpSessionLock;
 
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() throws Exception {
         httpSessionLock = new ReentrantLock();
         mockService = new MockVaadinServletService();
         mockServlet = mockService.getServlet();
@@ -203,7 +203,7 @@ class VaadinSessionTest {
      * Test for issue #6349
      */
     @Test
-    public void testCurrentInstancePollution() throws InterruptedException {
+    void testCurrentInstancePollution() throws InterruptedException {
 
         // Create a sync object
         final AtomicInteger state = new AtomicInteger();
@@ -267,7 +267,7 @@ class VaadinSessionTest {
      */
     @Test
     @Tag("com.vaadin.flow.testcategory.SlowTests")
-    public void testInvalidationDeadlock() {
+    void testInvalidationDeadlock() {
 
         // this simulates servlet container's session invalidation from another
         // thread
@@ -295,7 +295,7 @@ class VaadinSessionTest {
     }
 
     @Test
-    public void threadLocalsAfterUnderlyingSessionTimeout()
+    void threadLocalsAfterUnderlyingSessionTimeout()
             throws InterruptedException {
 
         final AtomicBoolean detachCalled = new AtomicBoolean(false);
@@ -319,7 +319,7 @@ class VaadinSessionTest {
 
     @Test
     @Tag("com.vaadin.flow.testcategory.SlowTests")
-    public void threadLocalsAfterSessionDestroy() throws InterruptedException {
+    void threadLocalsAfterSessionDestroy() throws InterruptedException {
         final AtomicBoolean detachCalled = new AtomicBoolean(false);
         ui.addDetachListener(e -> {
             detachCalled.set(true);
@@ -341,7 +341,7 @@ class VaadinSessionTest {
     }
 
     @Test
-    public void testValueUnbound() {
+    void testValueUnbound() {
         MockVaadinSession vaadinSession = new MockVaadinSession(mockService);
 
         vaadinSession.valueUnbound(Mockito.mock(HttpSessionBindingEvent.class));
@@ -373,7 +373,7 @@ class VaadinSessionTest {
 
     @Test
     @Tag("com.vaadin.flow.testcategory.SlowTests")
-    public void threadLocalsWhenDeserializing() throws Exception {
+    void threadLocalsWhenDeserializing() throws Exception {
         ApplicationConfiguration configuration = Mockito
                 .mock(ApplicationConfiguration.class);
 
@@ -426,7 +426,7 @@ class VaadinSessionTest {
     }
 
     @Test
-    public void setLocale_setLocaleForAllUIs() {
+    void setLocale_setLocaleForAllUIs() {
         UI anotherUI = new UI();
 
         anotherUI.getInternals().setSession(session);
@@ -455,7 +455,7 @@ class VaadinSessionTest {
     }
 
     @Test
-    public void setLocale_uiLocaleOverride_sessionAndOtherUIUnaffected() {
+    void setLocale_uiLocaleOverride_sessionAndOtherUIUnaffected() {
         UI anotherUI = new UI();
         anotherUI.getInternals().setSession(session);
         anotherUI.doInit(vaadinRequest, session.getNextUIid(), "foo");
@@ -477,7 +477,7 @@ class VaadinSessionTest {
     }
 
     @Test
-    public void valueUnbound_explicitVaadinSessionClose_wrappedSessionIsNotCleanedUp() {
+    void valueUnbound_explicitVaadinSessionClose_wrappedSessionIsNotCleanedUp() {
         ReentrantLock lock = Mockito.mock(ReentrantLock.class);
         Mockito.when(lock.isHeldByCurrentThread()).thenReturn(true);
         mockService = new MockVaadinServletService() {
@@ -515,7 +515,7 @@ class VaadinSessionTest {
     }
 
     @Test
-    public void valueUnbound_implicitVaadinSessionClose_wrappedSessionIsCleanedUp() {
+    void valueUnbound_implicitVaadinSessionClose_wrappedSessionIsCleanedUp() {
         ReentrantLock lock = Mockito.mock(ReentrantLock.class);
         Mockito.when(lock.isHeldByCurrentThread()).thenReturn(true);
         mockService = new MockVaadinServletService() {
@@ -550,7 +550,7 @@ class VaadinSessionTest {
     }
 
     @Test
-    public void setState_closedState_sessionFieldIsCleanedUp() {
+    void setState_closedState_sessionFieldIsCleanedUp() {
         ReentrantLock lock = Mockito.mock(ReentrantLock.class);
         Mockito.when(lock.isHeldByCurrentThread()).thenReturn(true);
         mockService = new MockVaadinServletService() {
@@ -571,7 +571,7 @@ class VaadinSessionTest {
     }
 
     @Test
-    public void valueUnbound_sessionIsNotInitialized_noAnyInteractions() {
+    void valueUnbound_sessionIsNotInitialized_noAnyInteractions() {
         VaadinSession session = Mockito.spy(TestVaadinSession.class);
 
         try {
@@ -601,7 +601,7 @@ class VaadinSessionTest {
     }
 
     @Test
-    public void findComponent_existingComponentFound() {
+    void findComponent_existingComponentFound() {
         TestComponent testComponent = createTestComponentInSession();
         int nodeId = testComponent.getElement().getNode().getId();
         int uiId = testComponent.getUI().get().getUIId();
@@ -611,7 +611,7 @@ class VaadinSessionTest {
     }
 
     @Test
-    public void findComponent_nonExistingNodeIdThrows() {
+    void findComponent_nonExistingNodeIdThrows() {
         TestComponent testComponent = createTestComponentInSession();
         int nodeId = testComponent.getElement().getNode().getId();
         int uiId = testComponent.getUI().get().getUIId();
@@ -622,7 +622,7 @@ class VaadinSessionTest {
     }
 
     @Test
-    public void findComponent_nonExistingAppIdThrows() {
+    void findComponent_nonExistingAppIdThrows() {
         TestComponent testComponent = createTestComponentInSession();
         int nodeId = testComponent.getElement().getNode().getId();
         VaadinSession session = testComponent.getUI().get().getSession();
@@ -638,7 +638,7 @@ class VaadinSessionTest {
     }
 
     @Test
-    public void checkHasLock_noCheckInDevMode() {
+    void checkHasLock_noCheckInDevMode() {
         assumeTrue(session.hasLock());
         assumeFalse(session.getConfiguration().isProductionMode());
         assertEquals(SessionLockCheckStrategy.ASSERT,
@@ -658,7 +658,7 @@ class VaadinSessionTest {
     }
 
     @Test
-    public void checkHasLock_assert() {
+    void checkHasLock_assert() {
         final MockDeploymentConfiguration configuration = (MockDeploymentConfiguration) session
                 .getConfiguration();
         configuration.setProductionMode(true);
@@ -679,7 +679,7 @@ class VaadinSessionTest {
     }
 
     @Test
-    public void checkHasLock_throw() {
+    void checkHasLock_throw() {
         final MockDeploymentConfiguration configuration = (MockDeploymentConfiguration) session
                 .getConfiguration();
         configuration.setProductionMode(true);
@@ -699,7 +699,7 @@ class VaadinSessionTest {
     }
 
     @Test
-    public void checkHasLock_log() {
+    void checkHasLock_log() {
         final MockDeploymentConfiguration configuration = (MockDeploymentConfiguration) session
                 .getConfiguration();
         configuration.setProductionMode(true);

--- a/flow-server/src/test/java/com/vaadin/flow/server/WebBrowserTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/WebBrowserTest.java
@@ -28,42 +28,42 @@ class WebBrowserTest {
     private WebBrowser browser = new WebBrowser();
 
     @Test
-    public void isLinux_noDetails_returnsFalse() {
+    void isLinux_noDetails_returnsFalse() {
         assertFalse(browser.isLinux());
     }
 
     @Test
-    public void isMacOSX_noDetails_returnsFalse() {
+    void isMacOSX_noDetails_returnsFalse() {
         assertFalse(browser.isMacOSX());
     }
 
     @Test
-    public void isWindows_noDetails_returnsFalse() {
+    void isWindows_noDetails_returnsFalse() {
         assertFalse(browser.isWindows());
     }
 
     @Test
-    public void isWindowsPhone_noDetails_returnsFalse() {
+    void isWindowsPhone_noDetails_returnsFalse() {
         assertFalse(browser.isWindowsPhone());
     }
 
     @Test
-    public void isAndroid_noDetails_returnsFalse() {
+    void isAndroid_noDetails_returnsFalse() {
         assertFalse(browser.isAndroid());
     }
 
     @Test
-    public void isIPhone_noDetails_returnsFalse() {
+    void isIPhone_noDetails_returnsFalse() {
         assertFalse(browser.isIPhone());
     }
 
     @Test
-    public void isChromeOS_noDetails_returnsFalse() {
+    void isChromeOS_noDetails_returnsFalse() {
         assertFalse(browser.isChromeOS());
     }
 
     @Test
-    public void isSafariOnMac_userDetails_returnsTrue() {
+    void isSafariOnMac_userDetails_returnsTrue() {
         VaadinRequest request = initRequest(
                 "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_6_2) AppleWebKit/611.3.10.1.5 (KHTML, like Gecko) Version/14.1.2 Safari/611.3.10.1.5");
 
@@ -73,7 +73,7 @@ class WebBrowserTest {
     }
 
     @Test
-    public void isChromeOnWindows_userDetails_returnsTrue() {
+    void isChromeOnWindows_userDetails_returnsTrue() {
         VaadinRequest request = initRequest(
                 "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36");
 
@@ -83,7 +83,7 @@ class WebBrowserTest {
     }
 
     @Test
-    public void isOperaOnWindows_userDetails_returnsTrue() {
+    void isOperaOnWindows_userDetails_returnsTrue() {
         VaadinRequest request = initRequest(
                 "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36 OPR/115.0.0.0");
 
@@ -93,7 +93,7 @@ class WebBrowserTest {
     }
 
     @Test
-    public void isFirefoxOnAndroid_userDetails_returnsTrue() {
+    void isFirefoxOnAndroid_userDetails_returnsTrue() {
         VaadinRequest request = initRequest(
                 "Mozilla/5.0 (Android; Tablet; rv:33.0) Gecko/33.0 Firefox/33.0");
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/auth/AccessAnnotationCheckerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/auth/AccessAnnotationCheckerTest.java
@@ -76,7 +76,7 @@ class AccessAnnotationCheckerTest {
     private AccessAnnotationChecker accessAnnotationChecker;
 
     @BeforeEach
-    public void before() {
+    void before() {
         accessAnnotationChecker = new AccessAnnotationChecker();
     }
 
@@ -95,7 +95,7 @@ class AccessAnnotationCheckerTest {
     }
 
     @Test
-    public void should_ReturnEnclosingClassAsSecurityTarget_When_NoSecurityAnnotationsPresent()
+    void should_ReturnEnclosingClassAsSecurityTarget_When_NoSecurityAnnotationsPresent()
             throws Exception {
         class Test {
             public void test() {
@@ -106,7 +106,7 @@ class AccessAnnotationCheckerTest {
     }
 
     @Test
-    public void should_ReturnEnclosingClassAsSecurityTarget_When_OnlyClassHasSecurityAnnotations()
+    void should_ReturnEnclosingClassAsSecurityTarget_When_OnlyClassHasSecurityAnnotations()
             throws Exception {
         @AnonymousAllowed
         class Test {
@@ -118,7 +118,7 @@ class AccessAnnotationCheckerTest {
     }
 
     @Test
-    public void should_ReturnMethodAsSecurityTarget_When_OnlyMethodHasSecurityAnnotations()
+    void should_ReturnMethodAsSecurityTarget_When_OnlyMethodHasSecurityAnnotations()
             throws Exception {
         class Test {
             @AnonymousAllowed
@@ -131,7 +131,7 @@ class AccessAnnotationCheckerTest {
     }
 
     @Test
-    public void should_ReturnMethodAsSecurityTarget_When_BothClassAndMethodHaveSecurityAnnotations()
+    void should_ReturnMethodAsSecurityTarget_When_BothClassAndMethodHaveSecurityAnnotations()
             throws Exception {
         @AnonymousAllowed
         class Test {
@@ -145,7 +145,7 @@ class AccessAnnotationCheckerTest {
     }
 
     @Test
-    public void specialViewsMustBeAccessible() {
+    void specialViewsMustBeAccessible() {
         CurrentInstance.set(VaadinRequest.class,
                 new VaadinServletRequest(createRequest(null), null));
         assertTrue(
@@ -156,7 +156,7 @@ class AccessAnnotationCheckerTest {
     }
 
     @Test
-    public void anonymousAccessAllowed() throws Exception {
+    void anonymousAccessAllowed() throws Exception {
         HttpServletRequest anonRequest = createRequest(null);
 
         verifyMethodAccessAllowed(AnonymousAllowedClass.class, anonRequest,
@@ -184,7 +184,7 @@ class AccessAnnotationCheckerTest {
     }
 
     @Test
-    public void loggedInUserAccessAllowed() throws Exception {
+    void loggedInUserAccessAllowed() throws Exception {
         HttpServletRequest loggedInURequest = createRequest(USER_PRINCIPAL);
 
         verifyMethodAccessAllowed(AnonymousAllowedClass.class, loggedInURequest,
@@ -213,7 +213,7 @@ class AccessAnnotationCheckerTest {
     }
 
     @Test
-    public void userRoleAccessAllowed() throws Exception {
+    void userRoleAccessAllowed() throws Exception {
         HttpServletRequest userRoleRequest = createRequest(USER_PRINCIPAL,
                 "user");
 
@@ -249,7 +249,7 @@ class AccessAnnotationCheckerTest {
     }
 
     @Test
-    public void userAndAdminRoleAccessAllowed() throws Exception {
+    void userAndAdminRoleAccessAllowed() throws Exception {
         HttpServletRequest adminRoleRequest = createRequest(USER_PRINCIPAL,
                 "user", "admin");
 
@@ -292,7 +292,7 @@ class AccessAnnotationCheckerTest {
     }
 
     @Test
-    public void adminRoleAccessAllowed() throws Exception {
+    void adminRoleAccessAllowed() throws Exception {
         HttpServletRequest adminRoleRequest = createRequest(USER_PRINCIPAL,
                 "admin");
 
@@ -329,7 +329,7 @@ class AccessAnnotationCheckerTest {
     }
 
     @Test
-    public void hasClassAccessNoCurrentRequest() {
+    void hasClassAccessNoCurrentRequest() {
         assertThrows(IllegalStateException.class, () -> {
             CurrentInstance.clearAll();
             accessAnnotationChecker.hasAccess(AnonymousAllowedClass.class);
@@ -337,7 +337,7 @@ class AccessAnnotationCheckerTest {
     }
 
     @Test
-    public void hasMethodAccessNoCurrentRequest() throws Exception {
+    void hasMethodAccessNoCurrentRequest() throws Exception {
         assertThrows(IllegalStateException.class, () -> {
             CurrentInstance.clearAll();
             accessAnnotationChecker.hasAccess(
@@ -346,7 +346,7 @@ class AccessAnnotationCheckerTest {
     }
 
     @Test
-    public void hasClassAccessUsingCurrentRequest() {
+    void hasClassAccessUsingCurrentRequest() {
         try {
             CurrentInstance.set(VaadinRequest.class, new VaadinServletRequest(
                     createRequest(USER_PRINCIPAL), null));
@@ -357,7 +357,7 @@ class AccessAnnotationCheckerTest {
     }
 
     @Test
-    public void hasMethodAccessUsingCurrentRequest() throws Exception {
+    void hasMethodAccessUsingCurrentRequest() throws Exception {
         try {
             CurrentInstance.set(VaadinRequest.class, new VaadinServletRequest(
                     createRequest(USER_PRINCIPAL), null));

--- a/flow-server/src/test/java/com/vaadin/flow/server/auth/AccessCheckResultTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/auth/AccessCheckResultTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class AccessCheckResultTest {
 
     @Test
-    public void create_getsResultInstance() {
+    void create_getsResultInstance() {
         for (AccessCheckDecision decision : AccessCheckDecision.values()) {
             AccessCheckResult result = AccessCheckResult.create(decision,
                     decision.name());
@@ -33,31 +33,31 @@ class AccessCheckResultTest {
     }
 
     @Test
-    public void create_nullReason_throws() {
+    void create_nullReason_throws() {
         assertThrows(IllegalArgumentException.class,
                 () -> AccessCheckResult.create(null, "Something"));
     }
 
     @Test
-    public void create_denyWithoutReason_throws() {
+    void create_denyWithoutReason_throws() {
         assertThrows(IllegalArgumentException.class,
                 () -> AccessCheckResult.create(AccessCheckDecision.DENY, null));
     }
 
     @Test
-    public void create_rejectWithoutReason_throws() {
+    void create_rejectWithoutReason_throws() {
         assertThrows(IllegalArgumentException.class, () -> AccessCheckResult
                 .create(AccessCheckDecision.REJECT, null));
     }
 
     @Test
-    public void deny_noReason_throws() {
+    void deny_noReason_throws() {
         assertThrows(IllegalArgumentException.class,
                 () -> AccessCheckResult.deny(null));
     }
 
     @Test
-    public void reject_noReason_throws() {
+    void reject_noReason_throws() {
         assertThrows(IllegalArgumentException.class,
                 () -> AccessCheckResult.reject(null));
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/auth/AnnotatedViewAccessCheckerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/auth/AnnotatedViewAccessCheckerTest.java
@@ -72,67 +72,67 @@ class AnnotatedViewAccessCheckerTest {
     private final AnnotatedViewAccessChecker viewAccessChecker = new AnnotatedViewAccessChecker();
 
     @Test
-    public void anonymousAccessToAnonymousViewAllowed() {
+    void anonymousAccessToAnonymousViewAllowed() {
         AccessCheckResult result = checkAccess(AnonymousAllowedView.class,
                 null);
         assertEquals(AccessCheckResult.allow(), result);
     }
 
     @Test
-    public void anonymousAccessToNoAnnotationViewDenied() {
+    void anonymousAccessToNoAnnotationViewDenied() {
         AccessCheckResult result = checkAccess(NoAnnotationView.class, null);
         assertEquals(AccessCheckDecision.DENY, result.decision());
     }
 
     @Test
-    public void anonymousAccessToPermitAllViewDenied() {
+    void anonymousAccessToPermitAllViewDenied() {
         AccessCheckResult result = checkAccess(PermitAllView.class, null);
         assertEquals(AccessCheckDecision.DENY, result.decision());
     }
 
     @Test
-    public void anonymousAccessToDenyAllViewDenied() {
+    void anonymousAccessToDenyAllViewDenied() {
         AccessCheckResult result = checkAccess(DenyAllView.class, null);
         assertEquals(AccessCheckDecision.DENY, result.decision());
     }
 
     @Test
-    public void anonymousAccessToRolesAllowedUserViewDenied() {
+    void anonymousAccessToRolesAllowedUserViewDenied() {
         AccessCheckResult result = checkAccess(RolesAllowedUserView.class,
                 null);
         assertEquals(AccessCheckDecision.DENY, result.decision());
     }
 
     @Test
-    public void anonymousAccessToRolesAllowedAdminViewDenied() {
+    void anonymousAccessToRolesAllowedAdminViewDenied() {
         AccessCheckResult result = checkAccess(RolesAllowedAdminView.class,
                 null);
         assertEquals(AccessCheckDecision.DENY, result.decision());
     }
 
     @Test
-    public void loggedInNoRolesAccessToAnonymousViewAllowed() {
+    void loggedInNoRolesAccessToAnonymousViewAllowed() {
         AccessCheckResult result = checkAccess(AnonymousAllowedView.class,
                 User.USER_NO_ROLES);
         assertEquals(AccessCheckResult.allow(), result);
     }
 
     @Test
-    public void loggedInNoRolesAccessToNoAnnotationViewDenied() {
+    void loggedInNoRolesAccessToNoAnnotationViewDenied() {
         AccessCheckResult result = checkAccess(NoAnnotationView.class,
                 User.USER_NO_ROLES);
         assertEquals(AccessCheckDecision.DENY, result.decision());
     }
 
     @Test
-    public void loggedInNoRolesAccessToPermitAllViewAllowed() {
+    void loggedInNoRolesAccessToPermitAllViewAllowed() {
         AccessCheckResult result = checkAccess(PermitAllView.class,
                 User.USER_NO_ROLES);
         assertEquals(AccessCheckResult.allow(), result);
     }
 
     @Test
-    public void loggedInNoRolesAccessToPermitAllViewWithNonAnnotatedParentDenied() {
+    void loggedInNoRolesAccessToPermitAllViewWithNonAnnotatedParentDenied() {
         NavigationContext context = setupNavigationContext(
                 AccessControlTestClasses.PermitAllWithEmptyParentView.class,
                 User.USER_NO_ROLES);
@@ -153,110 +153,110 @@ class AnnotatedViewAccessCheckerTest {
     }
 
     @Test
-    public void loggedInNoRolesAccessToDenyAllViewDenied() {
+    void loggedInNoRolesAccessToDenyAllViewDenied() {
         AccessCheckResult result = checkAccess(DenyAllView.class,
                 User.USER_NO_ROLES);
         assertEquals(AccessCheckDecision.DENY, result.decision());
     }
 
     @Test
-    public void loggedInNoRolesAccessToRolesAllowedUserViewDenied() {
+    void loggedInNoRolesAccessToRolesAllowedUserViewDenied() {
         AccessCheckResult result = checkAccess(RolesAllowedUserView.class,
                 User.USER_NO_ROLES);
         assertEquals(AccessCheckDecision.DENY, result.decision());
     }
 
     @Test
-    public void loggedInNoRolesAccessToRolesAllowedAdminViewDenied() {
+    void loggedInNoRolesAccessToRolesAllowedAdminViewDenied() {
         AccessCheckResult result = checkAccess(RolesAllowedAdminView.class,
                 User.USER_NO_ROLES);
         assertEquals(AccessCheckDecision.DENY, result.decision());
     }
 
     @Test
-    public void loggedInUserRoleAccessToAnonymousViewAllowed() {
+    void loggedInUserRoleAccessToAnonymousViewAllowed() {
         AccessCheckResult result = checkAccess(AnonymousAllowedView.class,
                 User.NORMAL_USER);
         assertEquals(AccessCheckResult.allow(), result);
     }
 
     @Test
-    public void loggedInUserRoleAccessToNoAnnotationViewDenied() {
+    void loggedInUserRoleAccessToNoAnnotationViewDenied() {
         AccessCheckResult result = checkAccess(NoAnnotationView.class,
                 User.NORMAL_USER);
         assertEquals(AccessCheckDecision.DENY, result.decision());
     }
 
     @Test
-    public void loggedInUserRoleAccessToPermitAllViewAllowed() {
+    void loggedInUserRoleAccessToPermitAllViewAllowed() {
         AccessCheckResult result = checkAccess(PermitAllView.class,
                 User.NORMAL_USER);
         assertEquals(AccessCheckResult.allow(), result);
     }
 
     @Test
-    public void loggedInUserRoleAccessToDenyAllViewDenied() {
+    void loggedInUserRoleAccessToDenyAllViewDenied() {
         AccessCheckResult result = checkAccess(DenyAllView.class,
                 User.NORMAL_USER);
         assertEquals(AccessCheckDecision.DENY, result.decision());
     }
 
     @Test
-    public void loggedInUserRoleAccessToRolesAllowedUserViewAllowed() {
+    void loggedInUserRoleAccessToRolesAllowedUserViewAllowed() {
         AccessCheckResult result = checkAccess(RolesAllowedUserView.class,
                 User.NORMAL_USER);
         assertEquals(AccessCheckResult.allow(), result);
     }
 
     @Test
-    public void loggedInUserRoleAccessToRolesAllowedAdminViewDenied() {
+    void loggedInUserRoleAccessToRolesAllowedAdminViewDenied() {
         AccessCheckResult result = checkAccess(RolesAllowedAdminView.class,
                 User.NORMAL_USER);
         assertEquals(AccessCheckDecision.DENY, result.decision());
     }
 
     @Test
-    public void loggedInAdminRoleAccessToAnonymousViewAllowed() {
+    void loggedInAdminRoleAccessToAnonymousViewAllowed() {
         AccessCheckResult result = checkAccess(AnonymousAllowedView.class,
                 User.ADMIN);
         assertEquals(AccessCheckResult.allow(), result);
     }
 
     @Test
-    public void loggedInAdminRoleAccessToNoAnnotationViewDenied() {
+    void loggedInAdminRoleAccessToNoAnnotationViewDenied() {
         AccessCheckResult result = checkAccess(NoAnnotationView.class,
                 User.ADMIN);
         assertEquals(AccessCheckDecision.DENY, result.decision());
     }
 
     @Test
-    public void loggedInAdminRoleAccessToPermitAllViewAllowed() {
+    void loggedInAdminRoleAccessToPermitAllViewAllowed() {
         AccessCheckResult result = checkAccess(PermitAllView.class, User.ADMIN);
         assertEquals(AccessCheckResult.allow(), result);
     }
 
     @Test
-    public void loggedInAdminRoleAccessToDenyAllViewDenied() {
+    void loggedInAdminRoleAccessToDenyAllViewDenied() {
         AccessCheckResult result = checkAccess(DenyAllView.class, User.ADMIN);
         assertEquals(AccessCheckDecision.DENY, result.decision());
     }
 
     @Test
-    public void loggedInAdminRoleAccessToRolesAllowedUserViewDenied() {
+    void loggedInAdminRoleAccessToRolesAllowedUserViewDenied() {
         AccessCheckResult result = checkAccess(RolesAllowedUserView.class,
                 User.ADMIN);
         assertEquals(AccessCheckDecision.DENY, result.decision());
     }
 
     @Test
-    public void loggedInAdminRoleAccessToRolesAllowedAdminViewAllowed() {
+    void loggedInAdminRoleAccessToRolesAllowedAdminViewAllowed() {
         AccessCheckResult result = checkAccess(RolesAllowedAdminView.class,
                 User.ADMIN);
         assertEquals(AccessCheckResult.allow(), result);
     }
 
     @Test
-    public void openingNoAnnotationViewShowsReasonAndHint() {
+    void openingNoAnnotationViewShowsReasonAndHint() {
         AccessCheckResult result = checkAccess(NoAnnotationView.class,
                 User.NORMAL_USER);
         assertEquals(AccessCheckResult
@@ -267,49 +267,49 @@ class AnnotatedViewAccessCheckerTest {
     }
 
     @Test
-    public void anonymousAccess_to_noAnnotationAnonymousAllowedByParent_allowed() {
+    void anonymousAccess_to_noAnnotationAnonymousAllowedByParent_allowed() {
         AccessCheckResult result = checkAccess(
                 NoAnnotationAnonymousAllowedByParentView.class, null);
         assertEquals(AccessCheckResult.allow(), result);
     }
 
     @Test
-    public void anonymousAccess_to_noAnnotationAnonymousAllowedByGrandParent_allowed() {
+    void anonymousAccess_to_noAnnotationAnonymousAllowedByGrandParent_allowed() {
         AccessCheckResult result = checkAccess(
                 NoAnnotationAnonymousAllowedByGrandParentView.class, null);
         assertEquals(AccessCheckResult.allow(), result);
     }
 
     @Test
-    public void anonymousAccess_to_noAnnotationPermitAllByGrandParentView_denied() {
+    void anonymousAccess_to_noAnnotationPermitAllByGrandParentView_denied() {
         AccessCheckResult result = checkAccess(
                 NoAnnotationPermitAllByGrandParentView.class, null);
         assertEquals(AccessCheckDecision.DENY, result.decision());
     }
 
     @Test
-    public void anonymousAccess_to_noAnnotationDenyAllByGrandParentView_denied() {
+    void anonymousAccess_to_noAnnotationDenyAllByGrandParentView_denied() {
         AccessCheckResult result = checkAccess(
                 NoAnnotationDenyAllByGrandParentView.class, null);
         assertEquals(AccessCheckDecision.DENY, result.decision());
     }
 
     @Test
-    public void anonymousAccess_to_noAnnotationRolesAllowedUserByGrandParentView_denied() {
+    void anonymousAccess_to_noAnnotationRolesAllowedUserByGrandParentView_denied() {
         AccessCheckResult result = checkAccess(
                 NoAnnotationRolesAllowedUserByGrandParentView.class, null);
         assertEquals(AccessCheckDecision.DENY, result.decision());
     }
 
     @Test
-    public void anonymousAccess_to_noAnnotationRolesAllowedAdminByGrandParentView_denied() {
+    void anonymousAccess_to_noAnnotationRolesAllowedAdminByGrandParentView_denied() {
         AccessCheckResult result = checkAccess(
                 NoAnnotationRolesAllowedAdminByGrandParentView.class, null);
         assertEquals(AccessCheckDecision.DENY, result.decision());
     }
 
     @Test
-    public void loggedInNoRolesAccess_to_noAnnotationAnonymousAllowedByGrandParentView_allowed() {
+    void loggedInNoRolesAccess_to_noAnnotationAnonymousAllowedByGrandParentView_allowed() {
         AccessCheckResult result = checkAccess(
                 NoAnnotationAnonymousAllowedByGrandParentView.class,
                 User.USER_NO_ROLES);
@@ -317,7 +317,7 @@ class AnnotatedViewAccessCheckerTest {
     }
 
     @Test
-    public void loggedInNoRolesAccess_to_noAnnotationPermitAllByGrandParentView_allowed() {
+    void loggedInNoRolesAccess_to_noAnnotationPermitAllByGrandParentView_allowed() {
         AccessCheckResult result = checkAccess(
                 NoAnnotationPermitAllByGrandParentView.class,
                 User.USER_NO_ROLES);
@@ -325,14 +325,14 @@ class AnnotatedViewAccessCheckerTest {
     }
 
     @Test
-    public void loggedInNoRolesAccess_to_noAnnotationDenyAllByGrandParentView_denied() {
+    void loggedInNoRolesAccess_to_noAnnotationDenyAllByGrandParentView_denied() {
         AccessCheckResult result = checkAccess(
                 NoAnnotationDenyAllByGrandParentView.class, User.USER_NO_ROLES);
         assertEquals(AccessCheckDecision.DENY, result.decision());
     }
 
     @Test
-    public void loggedInNoRolesAccess_to_noAnnotationRolesAllowedUserByGrandParentView_denied() {
+    void loggedInNoRolesAccess_to_noAnnotationRolesAllowedUserByGrandParentView_denied() {
         AccessCheckResult result = checkAccess(
                 NoAnnotationRolesAllowedUserByGrandParentView.class,
                 User.USER_NO_ROLES);
@@ -340,7 +340,7 @@ class AnnotatedViewAccessCheckerTest {
     }
 
     @Test
-    public void loggedInNoRolesAccess_to_noAnnotationRolesAllowedAdminByGrandParentView_denied() {
+    void loggedInNoRolesAccess_to_noAnnotationRolesAllowedAdminByGrandParentView_denied() {
         AccessCheckResult result = checkAccess(
                 NoAnnotationRolesAllowedAdminByGrandParentView.class,
                 User.USER_NO_ROLES);
@@ -348,7 +348,7 @@ class AnnotatedViewAccessCheckerTest {
     }
 
     @Test
-    public void loggedInUserRoleAccess_to_noAnnotationAnonymousAllowedByGrandParentView_allowed() {
+    void loggedInUserRoleAccess_to_noAnnotationAnonymousAllowedByGrandParentView_allowed() {
         AccessCheckResult result = checkAccess(
                 NoAnnotationAnonymousAllowedByGrandParentView.class,
                 User.NORMAL_USER);
@@ -356,21 +356,21 @@ class AnnotatedViewAccessCheckerTest {
     }
 
     @Test
-    public void loggedInUserRoleAccess_to_noAnnotationPermitAllByGrandParentView_allowed() {
+    void loggedInUserRoleAccess_to_noAnnotationPermitAllByGrandParentView_allowed() {
         AccessCheckResult result = checkAccess(
                 NoAnnotationPermitAllByGrandParentView.class, User.NORMAL_USER);
         assertEquals(AccessCheckResult.allow(), result);
     }
 
     @Test
-    public void loggedInUserRoleAccess_to_noAnnotationDenyAllByGrandParentView_denied() {
+    void loggedInUserRoleAccess_to_noAnnotationDenyAllByGrandParentView_denied() {
         AccessCheckResult result = checkAccess(
                 NoAnnotationDenyAllByGrandParentView.class, User.NORMAL_USER);
         assertEquals(AccessCheckDecision.DENY, result.decision());
     }
 
     @Test
-    public void loggedInUserRoleAccess_to_noAnnotationRolesAllowedUserByGrandParentView_allowed() {
+    void loggedInUserRoleAccess_to_noAnnotationRolesAllowedUserByGrandParentView_allowed() {
         AccessCheckResult result = checkAccess(
                 NoAnnotationRolesAllowedUserByGrandParentView.class,
                 User.NORMAL_USER);
@@ -378,7 +378,7 @@ class AnnotatedViewAccessCheckerTest {
     }
 
     @Test
-    public void loggedInUserRoleAccess_to_noAnnotationRolesAllowedAdminByGrandParentView_denied() {
+    void loggedInUserRoleAccess_to_noAnnotationRolesAllowedAdminByGrandParentView_denied() {
         AccessCheckResult result = checkAccess(
                 NoAnnotationRolesAllowedAdminByGrandParentView.class,
                 User.NORMAL_USER);
@@ -386,7 +386,7 @@ class AnnotatedViewAccessCheckerTest {
     }
 
     @Test
-    public void loggedInAdminRoleAccess_to_noAnnotationAnonymousAllowedByGrandParentView_allowed() {
+    void loggedInAdminRoleAccess_to_noAnnotationAnonymousAllowedByGrandParentView_allowed() {
         AccessCheckResult result = checkAccess(
                 NoAnnotationAnonymousAllowedByGrandParentView.class,
                 User.ADMIN);
@@ -394,21 +394,21 @@ class AnnotatedViewAccessCheckerTest {
     }
 
     @Test
-    public void loggedInAdminRoleAccess_to_noAnnotationPermitAllByGrandParentView_allowed() {
+    void loggedInAdminRoleAccess_to_noAnnotationPermitAllByGrandParentView_allowed() {
         AccessCheckResult result = checkAccess(
                 NoAnnotationPermitAllByGrandParentView.class, User.ADMIN);
         assertEquals(AccessCheckResult.allow(), result);
     }
 
     @Test
-    public void loggedInAdminRoleAccess_to_noAnnotationDenyAllByGrandParentView_denied() {
+    void loggedInAdminRoleAccess_to_noAnnotationDenyAllByGrandParentView_denied() {
         AccessCheckResult result = checkAccess(
                 NoAnnotationDenyAllByGrandParentView.class, User.ADMIN);
         assertEquals(AccessCheckDecision.DENY, result.decision());
     }
 
     @Test
-    public void loggedInAdminRoleAccess_to_noAnnotationRolesAllowedUserByGrandParentView_denied() {
+    void loggedInAdminRoleAccess_to_noAnnotationRolesAllowedUserByGrandParentView_denied() {
         AccessCheckResult result = checkAccess(
                 NoAnnotationRolesAllowedUserByGrandParentView.class,
                 User.ADMIN);
@@ -416,7 +416,7 @@ class AnnotatedViewAccessCheckerTest {
     }
 
     @Test
-    public void loggedInAdminRoleAccess_To_noAnnotationRolesAllowedAdminByGrandParentView_allowed() {
+    void loggedInAdminRoleAccess_To_noAnnotationRolesAllowedAdminByGrandParentView_allowed() {
         AccessCheckResult result = checkAccess(
                 NoAnnotationRolesAllowedAdminByGrandParentView.class,
                 User.ADMIN);
@@ -424,7 +424,7 @@ class AnnotatedViewAccessCheckerTest {
     }
 
     @Test
-    public void anyAccess_to_noAnnotationDenyAllAsInterfacesIgnoredView_denied() {
+    void anyAccess_to_noAnnotationDenyAllAsInterfacesIgnoredView_denied() {
         assertEquals(AccessCheckDecision.DENY,
                 checkAccess(NoAnnotationDenyAllAsInterfacesIgnoredView.class,
                         null).decision());
@@ -443,7 +443,7 @@ class AnnotatedViewAccessCheckerTest {
     }
 
     @Test
-    public void anonymousAccess_to_noAnnotationPermitAllByGrandParentAsInterfacesIgnoredView_denied() {
+    void anonymousAccess_to_noAnnotationPermitAllByGrandParentAsInterfacesIgnoredView_denied() {
         AccessCheckResult result = checkAccess(
                 NoAnnotationPermitAllByGrandParentAsInterfacesIgnoredView.class,
                 null);
@@ -451,7 +451,7 @@ class AnnotatedViewAccessCheckerTest {
     }
 
     @Test
-    public void loggedInNoRolesAccess_to_noAnnotationPermitAllByGrandParentAsInterfacesIgnoredView_allowed() {
+    void loggedInNoRolesAccess_to_noAnnotationPermitAllByGrandParentAsInterfacesIgnoredView_allowed() {
         AccessCheckResult result = checkAccess(
                 NoAnnotationPermitAllByGrandParentAsInterfacesIgnoredView.class,
                 User.USER_NO_ROLES);
@@ -459,20 +459,20 @@ class AnnotatedViewAccessCheckerTest {
     }
 
     @Test
-    public void rerouteToError_defaultErrorHandler_allowed() {
+    void rerouteToError_defaultErrorHandler_allowed() {
         AccessCheckResult result = checkAccess(RouteNotFoundError.class, null);
         assertEquals(AccessCheckResult.allow(), result);
     }
 
     @Test
-    public void rerouteToError_customAnonymousErrorHandler_allowed() {
+    void rerouteToError_customAnonymousErrorHandler_allowed() {
         AccessCheckResult result = checkAccess(
                 AccessControlTestClasses.CustomErrorView.class, null);
         assertEquals(AccessCheckResult.allow(), result);
     }
 
     @Test
-    public void rerouteToError_customNotAnnotatedErrorHandler_deny() {
+    void rerouteToError_customNotAnnotatedErrorHandler_deny() {
         AccessCheckResult result = checkAccess(
                 AccessControlTestClasses.NotAnnotatedCustomErrorView.class,
                 null);
@@ -480,7 +480,7 @@ class AnnotatedViewAccessCheckerTest {
     }
 
     @Test
-    public void routeWithNoAnnotationLayout_deny() {
+    void routeWithNoAnnotationLayout_deny() {
         NavigationContext context = setupNavigationContext(
                 AccessControlTestClasses.AnonymousAllowedView.class, null);
         RouteRegistry registry = context.getRouter().getRegistry();
@@ -492,7 +492,7 @@ class AnnotatedViewAccessCheckerTest {
     }
 
     @Test
-    public void routeWithNoAnnotationsAllowedLayout_allowed() {
+    void routeWithNoAnnotationsAllowedLayout_allowed() {
         NavigationContext context = setupNavigationContext(
                 AccessControlTestClasses.AnonymousAllowedView.class, null);
         RouteRegistry registry = context.getRouter().getRegistry();
@@ -504,7 +504,7 @@ class AnnotatedViewAccessCheckerTest {
     }
 
     @Test
-    public void routeWithNoAnnotationsAllowed_LayoutWithAllowed_denied() {
+    void routeWithNoAnnotationsAllowed_LayoutWithAllowed_denied() {
         NavigationContext context = setupNavigationContext(
                 AccessControlTestClasses.NoAnnotationView.class, null);
         RouteRegistry registry = context.getRouter().getRegistry();
@@ -554,7 +554,7 @@ class AnnotatedViewAccessCheckerTest {
     }
 
     @Test
-    public void layoutDenial_viewBroaderThanLayout_logsWarn() {
+    void layoutDenial_viewBroaderThanLayout_logsWarn() {
         // AnonymousAllowed view (level 3) + PermitAll layout (level 2)
         // = misconfiguration → WARN with "configuration error" message
         String logOutput = captureLogOutput(() -> {
@@ -571,7 +571,7 @@ class AnnotatedViewAccessCheckerTest {
     }
 
     @Test
-    public void layoutDenial_sameAccessLevel_navigating_devMode_logsInfo() {
+    void layoutDenial_sameAccessLevel_navigating_devMode_logsInfo() {
         // PermitAll view + PermitAll layout, navigating=true, devMode=true
         // anonymous user → layout denies, view not broader → INFO
         String logOutput = captureLogOutput(() -> {
@@ -592,7 +592,7 @@ class AnnotatedViewAccessCheckerTest {
     }
 
     @Test
-    public void layoutDenial_securityProbe_notNavigating_noWarnOrInfo() {
+    void layoutDenial_securityProbe_notNavigating_noWarnOrInfo() {
         // PermitAll view + PermitAll layout, navigating=false (security probe)
         // → DEBUG (not visible at default INFO level)
         String logOutput = captureLogOutput(() -> {
@@ -610,7 +610,7 @@ class AnnotatedViewAccessCheckerTest {
     }
 
     @Test
-    public void layoutDenial_navigating_productionMode_noWarnOrInfo() {
+    void layoutDenial_navigating_productionMode_noWarnOrInfo() {
         // PermitAll view + PermitAll layout, navigating=true, prodMode=true
         // → DEBUG (not visible at default INFO level)
         String logOutput = captureLogOutput(() -> {
@@ -627,7 +627,7 @@ class AnnotatedViewAccessCheckerTest {
     }
 
     @Test
-    public void layoutDenial_parentLayout_viewBroaderThanLayout_logsWarn() {
+    void layoutDenial_parentLayout_viewBroaderThanLayout_logsWarn() {
         // PermitAll view (level 2) with no-annotation parent layout (level 0)
         // = misconfiguration → WARN
         String logOutput = captureLogOutput(() -> {

--- a/flow-server/src/test/java/com/vaadin/flow/server/auth/DefaultInstantiatorMenuAccessControlTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/auth/DefaultInstantiatorMenuAccessControlTest.java
@@ -44,7 +44,7 @@ class DefaultInstantiatorMenuAccessControlTest {
     private ClassLoader classLoader;
 
     @BeforeEach
-    public void init() throws NoSuchFieldException, IllegalAccessException,
+    void init() throws NoSuchFieldException, IllegalAccessException,
             ClassNotFoundException {
         clearMenuAccessControlField();
         contextClassLoader = Thread.currentThread().getContextClassLoader();
@@ -56,12 +56,12 @@ class DefaultInstantiatorMenuAccessControlTest {
     }
 
     @AfterEach
-    public void destroy() throws NoSuchFieldException, IllegalAccessException {
+    void destroy() throws NoSuchFieldException, IllegalAccessException {
         Thread.currentThread().setContextClassLoader(contextClassLoader);
     }
 
     @Test
-    public void defaultInstantiator_getMenuAccessControl_defaultMenuAccessControl()
+    void defaultInstantiator_getMenuAccessControl_defaultMenuAccessControl()
             throws ClassNotFoundException {
         VaadinService service = Mockito.mock(VaadinService.class);
         mockLookup(service);
@@ -76,7 +76,7 @@ class DefaultInstantiatorMenuAccessControlTest {
     }
 
     @Test
-    public void defaultInstantiator_getMenuAccessControl_customMenuAccessControl()
+    void defaultInstantiator_getMenuAccessControl_customMenuAccessControl()
             throws ClassNotFoundException {
         String customMenuAccessControlClassName = "com.vaadin.flow.server.auth.CustomMenuAccessControl";
 
@@ -100,7 +100,7 @@ class DefaultInstantiatorMenuAccessControlTest {
     }
 
     @Test
-    public void defaultInstantiator_getMenuAccessControlWithInvalidType_throwException() {
+    void defaultInstantiator_getMenuAccessControlWithInvalidType_throwException() {
         VaadinService service = Mockito.mock(VaadinService.class);
         mockLookup(service);
         DefaultInstantiator defaultInstantiator = new DefaultInstantiator(

--- a/flow-server/src/test/java/com/vaadin/flow/server/auth/NavigationAccessControlTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/auth/NavigationAccessControlTest.java
@@ -80,7 +80,7 @@ class NavigationAccessControlTest {
     NavigationAccessChecker checker3;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         checker1 = Mockito.mock(NavigationAccessChecker.class);
         checker2 = Mockito.mock(NavigationAccessChecker.class);
         checker3 = Mockito.mock(NavigationAccessChecker.class);
@@ -89,7 +89,7 @@ class NavigationAccessControlTest {
     }
 
     @Test
-    public void beforeEnter_principalAndRoleCheckerProvidedToCheckers() {
+    void beforeEnter_principalAndRoleCheckerProvidedToCheckers() {
         mockCheckerResult(checker2, AccessCheckDecision.ALLOW);
         mockCheckerResult(checker3, AccessCheckDecision.ALLOW);
 
@@ -109,7 +109,7 @@ class NavigationAccessControlTest {
     }
 
     @Test
-    public void beforeEnter_anonymous_allCheckersAllowAccess_allowNavigation() {
+    void beforeEnter_anonymous_allCheckersAllowAccess_allowNavigation() {
         mockCheckerResult(checker1, AccessCheckDecision.ALLOW);
         mockCheckerResult(checker2, AccessCheckDecision.ALLOW);
         mockCheckerResult(checker3, AccessCheckDecision.ALLOW);
@@ -118,7 +118,7 @@ class NavigationAccessControlTest {
     }
 
     @Test
-    public void beforeEnter_anonymous_allowAndNeutralCheckers_allowNavigation() {
+    void beforeEnter_anonymous_allowAndNeutralCheckers_allowNavigation() {
         mockCheckerResult(checker1, AccessCheckDecision.ALLOW);
         mockCheckerResult(checker2, AccessCheckDecision.NEUTRAL);
         mockCheckerResult(checker3, AccessCheckDecision.NEUTRAL);
@@ -127,7 +127,7 @@ class NavigationAccessControlTest {
     }
 
     @Test
-    public void beforeEnter_anonymous_allCheckersDenyAccess_rerouteToNotFound() {
+    void beforeEnter_anonymous_allCheckersDenyAccess_rerouteToNotFound() {
         mockCheckerResult(checker1, AccessCheckDecision.DENY);
         mockCheckerResult(checker2, AccessCheckDecision.DENY);
         mockCheckerResult(checker3, AccessCheckDecision.DENY);
@@ -140,7 +140,7 @@ class NavigationAccessControlTest {
     }
 
     @Test
-    public void beforeEnter_anonymous_denyAndNeutralCheckers_allowNavigation() {
+    void beforeEnter_anonymous_denyAndNeutralCheckers_allowNavigation() {
         mockCheckerResult(checker1, AccessCheckDecision.DENY);
         mockCheckerResult(checker2, AccessCheckDecision.NEUTRAL);
         mockCheckerResult(checker3, AccessCheckDecision.NEUTRAL);
@@ -154,7 +154,7 @@ class NavigationAccessControlTest {
     }
 
     @Test
-    public void beforeEnter_anonymous_allCheckersNeutral_rerouteToNotFound() {
+    void beforeEnter_anonymous_allCheckersNeutral_rerouteToNotFound() {
         mockCheckerResult(checker1, AccessCheckDecision.NEUTRAL);
         mockCheckerResult(checker2, AccessCheckDecision.NEUTRAL);
         mockCheckerResult(checker3, AccessCheckDecision.NEUTRAL);
@@ -167,7 +167,7 @@ class NavigationAccessControlTest {
     }
 
     @Test
-    public void beforeEnter_developmentMode_anonymous_mixedCheckersConsensus_exceptionThrown() {
+    void beforeEnter_developmentMode_anonymous_mixedCheckersConsensus_exceptionThrown() {
         mockCheckerResult(checker1, AccessCheckDecision.ALLOW);
         mockCheckerResult(checker2, AccessCheckDecision.NEUTRAL);
         mockCheckerResult(checker3, AccessCheckDecision.DENY);
@@ -201,7 +201,7 @@ class NavigationAccessControlTest {
     }
 
     @Test
-    public void beforeEnter_productionMode_mixedCheckersConsensus_routeNotFoundWithNoReasonsExposed() {
+    void beforeEnter_productionMode_mixedCheckersConsensus_routeNotFoundWithNoReasonsExposed() {
         mockCheckerResult(checker1, AccessCheckDecision.ALLOW);
         mockCheckerResult(checker2, AccessCheckDecision.NEUTRAL);
         mockCheckerResult(checker3, AccessCheckDecision.DENY);
@@ -222,7 +222,7 @@ class NavigationAccessControlTest {
     }
 
     @Test
-    public void beforeEnter_productionMode_allCheckersDenyAccess_routeNotFoundWithNoReasonsExposed() {
+    void beforeEnter_productionMode_allCheckersDenyAccess_routeNotFoundWithNoReasonsExposed() {
         mockCheckerResult(checker1, AccessCheckDecision.DENY);
         mockCheckerResult(checker2, AccessCheckDecision.DENY);
         mockCheckerResult(checker3, AccessCheckDecision.DENY);
@@ -233,7 +233,7 @@ class NavigationAccessControlTest {
     }
 
     @Test
-    public void beforeEnter_productionMode_allCheckersNeutral_routeNotFoundWithNoReasonsExposed() {
+    void beforeEnter_productionMode_allCheckersNeutral_routeNotFoundWithNoReasonsExposed() {
         mockCheckerResult(checker1, AccessCheckDecision.NEUTRAL);
         mockCheckerResult(checker2, AccessCheckDecision.NEUTRAL);
         mockCheckerResult(checker3, AccessCheckDecision.NEUTRAL);
@@ -244,7 +244,7 @@ class NavigationAccessControlTest {
     }
 
     @Test
-    public void beforeEnter_errorHandlingViewReroute_allCheckersNeutral_allowNavigation() {
+    void beforeEnter_errorHandlingViewReroute_allCheckersNeutral_allowNavigation() {
         mockCheckerResult(checker1, AccessCheckDecision.NEUTRAL);
         mockCheckerResult(checker2, AccessCheckDecision.NEUTRAL);
         mockCheckerResult(checker3, AccessCheckDecision.NEUTRAL);
@@ -256,7 +256,7 @@ class NavigationAccessControlTest {
     }
 
     @Test
-    public void setLoginViewStringCannotBeCalledAfterSettingClass() {
+    void setLoginViewStringCannotBeCalledAfterSettingClass() {
         assertThrows(IllegalStateException.class, () -> {
             accessControl.setLoginView(TestLoginView.class);
             accessControl.setLoginView("/foo");
@@ -264,7 +264,7 @@ class NavigationAccessControlTest {
     }
 
     @Test
-    public void setLoginViewClassCannotBeCalledAfterSettingClass() {
+    void setLoginViewClassCannotBeCalledAfterSettingClass() {
         assertThrows(IllegalStateException.class, () -> {
             accessControl.setLoginView(TestLoginView.class);
             accessControl.setLoginView(
@@ -273,7 +273,7 @@ class NavigationAccessControlTest {
     }
 
     @Test
-    public void setLoginViewStringCannotBeCalledAfterSettingString() {
+    void setLoginViewStringCannotBeCalledAfterSettingString() {
         assertThrows(IllegalStateException.class, () -> {
             accessControl.setLoginView("/foo");
             accessControl.setLoginView("/bar");
@@ -281,7 +281,7 @@ class NavigationAccessControlTest {
     }
 
     @Test
-    public void setLoginViewClassCannotBeCalledAfterSettingString() {
+    void setLoginViewClassCannotBeCalledAfterSettingString() {
         assertThrows(IllegalStateException.class, () -> {
             accessControl.setLoginView("/foo");
             accessControl.setLoginView(TestLoginView.class);
@@ -289,7 +289,7 @@ class NavigationAccessControlTest {
     }
 
     @Test
-    public void setLoginViewStringShouldNotThrowWithSameString() {
+    void setLoginViewStringShouldNotThrowWithSameString() {
         accessControl.setLoginView("/foo");
         accessControl.setLoginView("/foo");
         accessControl.setLoginView(new String("/foo"));
@@ -297,7 +297,7 @@ class NavigationAccessControlTest {
     }
 
     @Test
-    public void beforeEnter_loginView_accessToLoginViewAlwaysAllowed() {
+    void beforeEnter_loginView_accessToLoginViewAlwaysAllowed() {
         mockCheckerResult(checker1, AccessCheckDecision.DENY);
         mockCheckerResult(checker2, AccessCheckDecision.DENY);
         mockCheckerResult(checker3, AccessCheckDecision.DENY);
@@ -313,7 +313,7 @@ class NavigationAccessControlTest {
     }
 
     @Test
-    public void beforeEnter_loginUrl_accessToLoginUrlAlwaysAllowed() {
+    void beforeEnter_loginUrl_accessToLoginUrlAlwaysAllowed() {
         mockCheckerResult(checker1, AccessCheckDecision.DENY);
         mockCheckerResult(checker2, AccessCheckDecision.DENY);
         mockCheckerResult(checker3, AccessCheckDecision.DENY);
@@ -329,7 +329,7 @@ class NavigationAccessControlTest {
     }
 
     @Test
-    public void beforeEnter_loginView_anonymousUser_accessDenied_forwardToLoginView() {
+    void beforeEnter_loginView_anonymousUser_accessDenied_forwardToLoginView() {
         mockCheckerResult(checker1, AccessCheckDecision.DENY);
         mockCheckerResult(checker2, AccessCheckDecision.DENY);
         mockCheckerResult(checker3, AccessCheckDecision.DENY);
@@ -340,7 +340,7 @@ class NavigationAccessControlTest {
     }
 
     @Test
-    public void beforeEnter_loginUrl_anonymousUser_accessDenied_forwardToLoginUrl() {
+    void beforeEnter_loginUrl_anonymousUser_accessDenied_forwardToLoginUrl() {
         mockCheckerResult(checker1, AccessCheckDecision.DENY);
         mockCheckerResult(checker2, AccessCheckDecision.DENY);
         mockCheckerResult(checker3, AccessCheckDecision.DENY);
@@ -351,7 +351,7 @@ class NavigationAccessControlTest {
     }
 
     @Test
-    public void beforeEnter_loginView_authenticatedUser_accessDenied() {
+    void beforeEnter_loginView_authenticatedUser_accessDenied() {
         mockCheckerResult(checker1, AccessCheckDecision.DENY);
         mockCheckerResult(checker2, AccessCheckDecision.DENY);
         mockCheckerResult(checker3, AccessCheckDecision.DENY);
@@ -362,7 +362,7 @@ class NavigationAccessControlTest {
     }
 
     @Test
-    public void beforeEnter_loginUrl_authenticatedUser_accessDenied() {
+    void beforeEnter_loginUrl_authenticatedUser_accessDenied() {
         mockCheckerResult(checker1, AccessCheckDecision.DENY);
         mockCheckerResult(checker2, AccessCheckDecision.DENY);
         mockCheckerResult(checker3, AccessCheckDecision.DENY);
@@ -373,7 +373,7 @@ class NavigationAccessControlTest {
     }
 
     @Test
-    public void beforeEnter_redirectUrlStoredForAnonymousUsers() {
+    void beforeEnter_redirectUrlStoredForAnonymousUsers() {
         mockCheckerResult(checker1, AccessCheckDecision.DENY);
         mockCheckerResult(checker2, AccessCheckDecision.DENY);
         mockCheckerResult(checker3, AccessCheckDecision.DENY);
@@ -394,7 +394,7 @@ class NavigationAccessControlTest {
     }
 
     @Test
-    public void beforeEnter_redirectUrlNotStoredForLoggedInUsers() {
+    void beforeEnter_redirectUrlNotStoredForLoggedInUsers() {
         mockCheckerResult(checker1, AccessCheckDecision.DENY);
         mockCheckerResult(checker2, AccessCheckDecision.DENY);
         mockCheckerResult(checker3, AccessCheckDecision.DENY);
@@ -412,7 +412,7 @@ class NavigationAccessControlTest {
     }
 
     @Test
-    public void beforeEnter_disabledNavigationControl_alwaysPasses_rejectsWhenEnabled() {
+    void beforeEnter_disabledNavigationControl_alwaysPasses_rejectsWhenEnabled() {
         mockCheckerResult(checker1, AccessCheckDecision.DENY);
         mockCheckerResult(checker2, AccessCheckDecision.DENY);
         mockCheckerResult(checker3, AccessCheckDecision.DENY);
@@ -436,7 +436,7 @@ class NavigationAccessControlTest {
     }
 
     @Test
-    public void beforeEnter_noCheckersConfigured_alwaysPasses() {
+    void beforeEnter_noCheckersConfigured_alwaysPasses() {
         accessControl = new NavigationAccessControl(List.of());
         TestNavigationResult result = checkAccess(AnonymousAllowedView.class,
                 false, false, false);

--- a/flow-server/src/test/java/com/vaadin/flow/server/auth/RoutePathAccessCheckerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/auth/RoutePathAccessCheckerTest.java
@@ -67,14 +67,14 @@ class RoutePathAccessCheckerTest {
     private Function<Class<?>, Pair<String, RouteParameters>> eventDataFactory = this::getRouteData;
 
     @BeforeEach
-    public void init() {
+    void init() {
         this.accessPathChecker = Mockito.mock(AccessPathChecker.class);
         this.routePathAccessChecker = new RoutePathAccessChecker(
                 accessPathChecker);
     }
 
     @Test
-    public void permittedPath_anonymousAccessToAnonymousViewMainPath_accessAllowed() {
+    void permittedPath_anonymousAccessToAnonymousViewMainPath_accessAllowed() {
         Mockito.when(accessPathChecker.hasAccess(eq("anon"), any(), any()))
                 .thenReturn(true);
         AccessCheckResult result = checkAccess(AnonymousAllowedView.class,
@@ -84,7 +84,7 @@ class RoutePathAccessCheckerTest {
     }
 
     @Test
-    public void permittedPath_loggedInNoRolesAccessToAnonymousViewMainPath_accessAllowed() {
+    void permittedPath_loggedInNoRolesAccessToAnonymousViewMainPath_accessAllowed() {
         Mockito.when(accessPathChecker.hasAccess(eq("anon"), any(), any()))
                 .thenReturn(true);
         AccessCheckResult result = checkAccess(AnonymousAllowedView.class,
@@ -94,7 +94,7 @@ class RoutePathAccessCheckerTest {
     }
 
     @Test
-    public void permittedPath_loggedInNoRolesAccessToAnnotatedView_accessAllowed() {
+    void permittedPath_loggedInNoRolesAccessToAnnotatedView_accessAllowed() {
         Mockito.when(accessPathChecker.hasAccess(eq("permitall"), any(), any()))
                 .thenReturn(true);
         AccessCheckResult result = checkAccess(PermitAllView.class,
@@ -105,7 +105,7 @@ class RoutePathAccessCheckerTest {
     }
 
     @Test
-    public void permittedPath_accessToViewWithoutAliases_accessAllowed() {
+    void permittedPath_accessToViewWithoutAliases_accessAllowed() {
         Mockito.when(
                 accessPathChecker.hasAccess(eq("noannotation"), any(), any()))
                 .thenReturn(true);
@@ -117,7 +117,7 @@ class RoutePathAccessCheckerTest {
     }
 
     @Test
-    public void forbiddenPath_anonymousAccessToAnonymousViewMainPath_accessDenied() {
+    void forbiddenPath_anonymousAccessToAnonymousViewMainPath_accessDenied() {
         Mockito.when(accessPathChecker.hasAccess(any(), any(), any()))
                 .thenReturn(false);
         AccessCheckResult result = checkAccess(AnonymousAllowedView.class,
@@ -128,7 +128,7 @@ class RoutePathAccessCheckerTest {
     }
 
     @Test
-    public void forbiddenPath_anonymousAccessAnnotatedView_accessDenied() {
+    void forbiddenPath_anonymousAccessAnnotatedView_accessDenied() {
         Mockito.when(accessPathChecker.hasAccess(any(), any(), any()))
                 .thenReturn(false);
         AccessCheckResult result = checkAccess(PermitAllView.class, null);
@@ -138,7 +138,7 @@ class RoutePathAccessCheckerTest {
     }
 
     @Test
-    public void forbiddenPath_loggedInNoRolesAccessToAnonymousViewMainPath_accessDenied() {
+    void forbiddenPath_loggedInNoRolesAccessToAnonymousViewMainPath_accessDenied() {
         Mockito.when(accessPathChecker.hasAccess(any(), any(), any()))
                 .thenReturn(false);
         AccessCheckResult result = checkAccess(AnonymousAllowedView.class,
@@ -148,7 +148,7 @@ class RoutePathAccessCheckerTest {
     }
 
     @Test
-    public void forbiddenPath_loggedInNoRolesAccessToAnnotatedView_accessDenied() {
+    void forbiddenPath_loggedInNoRolesAccessToAnnotatedView_accessDenied() {
         Mockito.when(accessPathChecker.hasAccess(any(), any(), any()))
                 .thenReturn(false);
         AccessCheckResult result = checkAccess(PermitAllView.class,
@@ -159,7 +159,7 @@ class RoutePathAccessCheckerTest {
     }
 
     @Test
-    public void forbiddenPath_accessToViewWithoutAliases_accessDenied() {
+    void forbiddenPath_accessToViewWithoutAliases_accessDenied() {
         Mockito.when(
                 accessPathChecker.hasAccess(eq("noannotation"), any(), any()))
                 .thenReturn(false);
@@ -171,7 +171,7 @@ class RoutePathAccessCheckerTest {
     }
 
     @Test
-    public void openingForbiddenPath_showsReasonAndHintInDevelopmentMode() {
+    void openingForbiddenPath_showsReasonAndHintInDevelopmentMode() {
         Mockito.when(accessPathChecker.hasAccess(any(), any(), any()))
                 .thenReturn(false);
         AccessCheckResult result = checkAccess(AnonymousAllowedView.class,
@@ -183,7 +183,7 @@ class RoutePathAccessCheckerTest {
     }
 
     @Test
-    public void pathAlias_aliasPathAllowed_accessGranted() {
+    void pathAlias_aliasPathAllowed_accessGranted() {
         eventDataFactory = target -> new Pair<>("anon-alias",
                 RouteParameters.empty());
         Mockito.when(accessPathChecker.hasAccess(anyString(), any(), any()))
@@ -198,7 +198,7 @@ class RoutePathAccessCheckerTest {
     }
 
     @Test
-    public void pathAliasWithParent_aliasPathAllowed_accessGranted() {
+    void pathAliasWithParent_aliasPathAllowed_accessGranted() {
         eventDataFactory = target -> new Pair<>("parent/alias-with-parent",
                 RouteParameters.empty());
         Mockito.when(accessPathChecker.hasAccess(anyString(), any(), any()))
@@ -214,7 +214,7 @@ class RoutePathAccessCheckerTest {
     }
 
     @Test
-    public void wildcardPathAlias_aliasPathAllowed_accessGranted() {
+    void wildcardPathAlias_aliasPathAllowed_accessGranted() {
         eventDataFactory = target -> new Pair<>("anon-alias-wildcard/a/b/c",
                 new RouteParameters("path", "a/b/c"));
         Mockito.when(accessPathChecker.hasAccess(anyString(), any(), any()))
@@ -230,7 +230,7 @@ class RoutePathAccessCheckerTest {
     }
 
     @Test
-    public void templatePathAlias_aliasPathAllowed_accessGranted() {
+    void templatePathAlias_aliasPathAllowed_accessGranted() {
         eventDataFactory = target -> new Pair<>(
                 "anon-alias-template/ID-123/C0/resource/12345",
                 new RouteParameters(Map.of("identifier", "ID-123", "category",
@@ -249,7 +249,7 @@ class RoutePathAccessCheckerTest {
     }
 
     @Test
-    public void pathAlias_aliasPathForbidden_accessDenied() {
+    void pathAlias_aliasPathForbidden_accessDenied() {
         eventDataFactory = target -> new Pair<>("anon-alias",
                 RouteParameters.empty());
         Mockito.when(accessPathChecker.hasAccess(anyString(), any(), any()))
@@ -266,7 +266,7 @@ class RoutePathAccessCheckerTest {
     }
 
     @Test
-    public void wildcardPathAlias_aliasPathForbidden_accessDenied() {
+    void wildcardPathAlias_aliasPathForbidden_accessDenied() {
         eventDataFactory = target -> new Pair<>("anon-alias-wildcard/a/b/c",
                 new RouteParameters("path", "a/b/c"));
 
@@ -285,7 +285,7 @@ class RoutePathAccessCheckerTest {
     }
 
     @Test
-    public void pathAliasWithParent_aliasPathForbidden_accessDenied() {
+    void pathAliasWithParent_aliasPathForbidden_accessDenied() {
         eventDataFactory = target -> new Pair<>("parent/alias-with-parent",
                 RouteParameters.empty());
 
@@ -304,7 +304,7 @@ class RoutePathAccessCheckerTest {
     }
 
     @Test
-    public void templatePathAlias_aliasPathForbidden_accessDenied() {
+    void templatePathAlias_aliasPathForbidden_accessDenied() {
         eventDataFactory = target -> new Pair<>(
                 "anon-alias-template/ID-123/C0/resource/12345",
                 new RouteParameters(Map.of("identifier", "ID-123", "category",
@@ -324,7 +324,7 @@ class RoutePathAccessCheckerTest {
     }
 
     @Test
-    public void templateRoutePath_locationPathIsChecked() {
+    void templateRoutePath_locationPathIsChecked() {
         eventDataFactory = target -> new Pair<>(
                 "anon-template/ID-123/C0/resource/12345",
                 new RouteParameters(Map.of("identifier", "ID-123", "category",
@@ -340,7 +340,7 @@ class RoutePathAccessCheckerTest {
     }
 
     @Test
-    public void wildcardRoutePath_locationPathIsChecked() {
+    void wildcardRoutePath_locationPathIsChecked() {
         eventDataFactory = target -> new Pair<>("anon-wildcard/a/b/c",
                 new RouteParameters("path", "a/b/c"));
         Mockito.when(accessPathChecker.hasAccess(eq("anon-wildcard/a/b/c"),
@@ -353,7 +353,7 @@ class RoutePathAccessCheckerTest {
     }
 
     @Test
-    public void urlParameterPath_locationPathIsChecked() {
+    void urlParameterPath_locationPathIsChecked() {
         eventDataFactory = target -> new Pair<>("anon-url-parameter/a/b/c/d",
                 RouteParameters.empty());
         Mockito.when(accessPathChecker
@@ -367,7 +367,7 @@ class RoutePathAccessCheckerTest {
     }
 
     @Test
-    public void rerouteToError_neutral() {
+    void rerouteToError_neutral() {
         eventDataFactory = target -> new Pair<>("some-path",
                 RouteParameters.empty());
         AccessCheckResult result = checkAccess(RouteNotFoundError.class, null);

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/AtmospherePushConnectionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/AtmospherePushConnectionTest.java
@@ -60,17 +60,17 @@ class AtmospherePushConnectionTest {
     private AtmospherePushConnection connection;
 
     @BeforeAll
-    public static void initExecutor() {
+    static void initExecutor() {
         executor = Executors.newSingleThreadExecutor();
     }
 
     @AfterAll
-    public static void stopExecutor() {
+    static void stopExecutor() {
         executor.shutdown();
     }
 
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() throws Exception {
         vaadinSession = new MockVaadinSession();
         vaadinSession.lock();
         UI ui = new MockUI(vaadinSession);
@@ -95,7 +95,7 @@ class AtmospherePushConnectionTest {
     }
 
     @Test
-    public void testSerialization() throws Exception {
+    void testSerialization() throws Exception {
 
         UI ui = Mockito.mock(UI.class);
         AtmosphereResource resource = Mockito.mock(AtmosphereResource.class);
@@ -116,7 +116,7 @@ class AtmospherePushConnectionTest {
     }
 
     @Test
-    public void pushWhileDisconnect_disconnectedWithoutSendingMessage()
+    void pushWhileDisconnect_disconnectedWithoutSendingMessage()
             throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
         CompletableFuture.runAsync(() -> {
@@ -142,8 +142,7 @@ class AtmospherePushConnectionTest {
     }
 
     @Test
-    public void disconnectWhilePush_messageSentAndThenDisconnected()
-            throws Exception {
+    void disconnectWhilePush_messageSentAndThenDisconnected() throws Exception {
         CountDownLatch latch = new CountDownLatch(2);
         CompletableFuture.runAsync(() -> {
             try {
@@ -175,8 +174,7 @@ class AtmospherePushConnectionTest {
     }
 
     @Test
-    public void disconnect_concurrentRequests_preventDeadlocks()
-            throws Exception {
+    void disconnect_concurrentRequests_preventDeadlocks() throws Exception {
         // A deadlock may happen when an HTTP session is invalidated in a
         // thread, causing VaadinSession and UIs to be closed and push
         // connections to be disconnected, but a push disconnection is
@@ -253,7 +251,7 @@ class AtmospherePushConnectionTest {
     }
 
     @Test
-    public void pushWhileDisconnect_preventDeadlocks() throws Exception {
+    void pushWhileDisconnect_preventDeadlocks() throws Exception {
         // Similar motivation exposed in
         // disconnect_concurrentRequests_preventDeadlocks
         // but when a Vaadin session is unlocked as a consequence of HTTP

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/FragmentedMessageTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/FragmentedMessageTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class FragmentedMessageTest {
 
     @Test
-    public void shortMessageCompleteImmediately() throws IOException {
+    void shortMessageCompleteImmediately() throws IOException {
         FragmentedMessage msg = new FragmentedMessage();
         assertTrue(
                 msg.append(new StringReader("Hello".length() + "|" + "Hello")));
@@ -39,7 +39,7 @@ class FragmentedMessageTest {
     }
 
     @Test
-    public void longMessageConcatenated() throws IOException {
+    void longMessageConcatenated() throws IOException {
         FragmentedMessage msg = new FragmentedMessage();
         String text = "HelloWorld".repeat(1700);
         String textWithLength = text.length() + "|" + text;
@@ -61,7 +61,7 @@ class FragmentedMessageTest {
     }
 
     @Test
-    public void lengthEqualsLimitHandledCorrectly() throws IOException {
+    void lengthEqualsLimitHandledCorrectly() throws IOException {
         FragmentedMessage msg = new FragmentedMessage();
         int length = (PushConstants.WEBSOCKET_BUFFER_SIZE
                 - String.valueOf(PushConstants.WEBSOCKET_BUFFER_SIZE).length()

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/HeartbeatHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/HeartbeatHandlerTest.java
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.when;
 class HeartbeatHandlerTest {
 
     @Test
-    public void synchronizedHandleRequest_uiPresent_setLastHeartbeatTimestampIsCalledOnce()
+    void synchronizedHandleRequest_uiPresent_setLastHeartbeatTimestampIsCalledOnce()
             throws IOException {
         VaadinService service = mock(VaadinService.class);
         VaadinSession session = mock(VaadinSession.class);
@@ -59,7 +59,7 @@ class HeartbeatHandlerTest {
     }
 
     @Test
-    public void synchronizedHandleRequest_uiPresent_noCacheHeaderSetAndContentTypeNotSet()
+    void synchronizedHandleRequest_uiPresent_noCacheHeaderSetAndContentTypeNotSet()
             throws IOException {
         VaadinService service = mock(VaadinService.class);
         VaadinSession session = mock(VaadinSession.class);

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandlerTest.java
@@ -62,7 +62,7 @@ class JavaScriptBootstrapHandlerTest {
     }
 
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() throws Exception {
         mocks = new MockServletServiceSessionSetup();
         response = mocks.createResponse();
         session = mocks.getSession();
@@ -70,32 +70,31 @@ class JavaScriptBootstrapHandlerTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         mocks.cleanup();
     }
 
     @Test
-    public void should_handleRequest_when_initTypeRequest() throws Exception {
+    void should_handleRequest_when_initTypeRequest() throws Exception {
         VaadinRequest request = mocks.createRequest(mocks, "/", "v-r=init&foo");
         assertTrue(jsInitHandler.canHandleRequest(request));
     }
 
     @Test
-    public void should_not_handleRequest_when_pathInfo_set() throws Exception {
+    void should_not_handleRequest_when_pathInfo_set() throws Exception {
         VaadinRequest request = mocks.createRequest(mocks, "/foo",
                 "v-r=init&foo");
         assertFalse(jsInitHandler.canHandleRequest(request));
     }
 
     @Test
-    public void should_not_handleRequest_if_not_initTypeRequest()
-            throws Exception {
+    void should_not_handleRequest_if_not_initTypeRequest() throws Exception {
         VaadinRequest request = mocks.createRequest(mocks, "/", "v-r=bar");
         assertFalse(jsInitHandler.canHandleRequest(request));
     }
 
     @Test
-    public void should_produceValidJsonResponse() throws Exception {
+    void should_produceValidJsonResponse() throws Exception {
         VaadinRequest request = mocks.createRequest(mocks, "/",
                 "v-r=init&foo&location");
         jsInitHandler.handleRequest(session, request, response);
@@ -125,7 +124,7 @@ class JavaScriptBootstrapHandlerTest {
     }
 
     @Test
-    public void should_initialize_UI() throws Exception {
+    void should_initialize_UI() throws Exception {
         VaadinRequest request = mocks.createRequest(mocks, "/",
                 "v-r=init&foo&location=");
         jsInitHandler.handleRequest(session, request, response);
@@ -135,7 +134,7 @@ class JavaScriptBootstrapHandlerTest {
     }
 
     @Test
-    public void should_attachViewTo_UiContainer() throws Exception {
+    void should_attachViewTo_UiContainer() throws Exception {
         VaadinRequest request = mocks.createRequest(mocks, "/",
                 "v-r=init&foo&location=");
         jsInitHandler.handleRequest(session, request, response);
@@ -159,7 +158,7 @@ class JavaScriptBootstrapHandlerTest {
     }
 
     @Test
-    public void should_respondPushScript_when_enabledInDeploymentConfiguration()
+    void should_respondPushScript_when_enabledInDeploymentConfiguration()
             throws Exception {
         mocks.getDeploymentConfiguration().setPushMode(PushMode.AUTOMATIC);
 
@@ -177,8 +176,7 @@ class JavaScriptBootstrapHandlerTest {
     }
 
     @Test
-    public void should_respondPushScript_when_nonRootServletPath()
-            throws Exception {
+    void should_respondPushScript_when_nonRootServletPath() throws Exception {
         mocks.getDeploymentConfiguration().setPushMode(PushMode.AUTOMATIC);
 
         VaadinRequest request = mocks.createRequest(mocks, "/", "/vaadin/",
@@ -195,7 +193,7 @@ class JavaScriptBootstrapHandlerTest {
     }
 
     @Test
-    public void should_invoke_modifyPushConfiguration() throws Exception {
+    void should_invoke_modifyPushConfiguration() throws Exception {
         AppShellRegistry registry = Mockito.mock(AppShellRegistry.class);
         mocks.setAppShellRegistry(registry);
 
@@ -208,8 +206,7 @@ class JavaScriptBootstrapHandlerTest {
     }
 
     @Test
-    public void should_respondPushScript_when_annotatedInAppShell()
-            throws Exception {
+    void should_respondPushScript_when_annotatedInAppShell() throws Exception {
         VaadinServletContext context = new VaadinServletContext(
                 mocks.getServletContext());
         AppShellRegistry registry = AppShellRegistry.getInstance(context);
@@ -230,7 +227,7 @@ class JavaScriptBootstrapHandlerTest {
     }
 
     @Test
-    public void synchronizedHandleRequest_badLocation_noUiCreated()
+    void synchronizedHandleRequest_badLocation_noUiCreated()
             throws IOException {
         final JavaScriptBootstrapHandler bootstrapHandler = new JavaScriptBootstrapHandler();
 
@@ -252,7 +249,7 @@ class JavaScriptBootstrapHandlerTest {
     }
 
     @Test
-    public void synchronizedHandleRequest_noLocationParameter_noUiCreated()
+    void synchronizedHandleRequest_noLocationParameter_noUiCreated()
             throws IOException {
         final JavaScriptBootstrapHandler bootstrapHandler = new JavaScriptBootstrapHandler();
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/LongPollingCacheFilterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/LongPollingCacheFilterTest.java
@@ -53,7 +53,7 @@ class LongPollingCacheFilterTest {
     private AtmosphereResourceSessionFactory sessionFactory;
 
     @Test
-    public void filter_notPushMessage_continueWithCurrentMessage() {
+    void filter_notPushMessage_continueWithCurrentMessage() {
         setTransport(AtmosphereResource.TRANSPORT.LONG_POLLING);
         setSeenServerSyncIdHeader(5);
         simulatePushConnection();
@@ -66,7 +66,7 @@ class LongPollingCacheFilterTest {
     }
 
     @Test
-    public void filter_notLongPollingTransport_continueWithCurrentMessage() {
+    void filter_notLongPollingTransport_continueWithCurrentMessage() {
         setSeenServerSyncIdHeader(5);
         simulatePushConnection();
         Stream.of(AtmosphereResource.TRANSPORT.values())
@@ -84,7 +84,7 @@ class LongPollingCacheFilterTest {
     }
 
     @Test
-    public void filter_syncIdCheckDisabled_continueWithCurrentMessage() {
+    void filter_syncIdCheckDisabled_continueWithCurrentMessage() {
         setTransport(AtmosphereResource.TRANSPORT.LONG_POLLING);
         setSeenServerSyncIdHeader(-1);
         BroadcastAction action = filter.filter("broadcasterId", resource,
@@ -96,7 +96,7 @@ class LongPollingCacheFilterTest {
     }
 
     @Test
-    public void filter_missingLastSeenServerSyncId_continueWithCurrentMessage() {
+    void filter_missingLastSeenServerSyncId_continueWithCurrentMessage() {
         setTransport(AtmosphereResource.TRANSPORT.LONG_POLLING);
         simulatePushConnection();
         BroadcastAction action = filter.filter("broadcasterId", resource,
@@ -108,7 +108,7 @@ class LongPollingCacheFilterTest {
     }
 
     @Test
-    public void filter_messageAlreadySeen_abort() {
+    void filter_messageAlreadySeen_abort() {
         setTransport(AtmosphereResource.TRANSPORT.LONG_POLLING);
         setSeenServerSyncIdHeader(5, 6);
         simulatePushConnection();
@@ -133,7 +133,7 @@ class LongPollingCacheFilterTest {
     }
 
     @Test
-    public void filter_messageNotYetSeen_addToCacheAndContinue() {
+    void filter_messageNotYetSeen_addToCacheAndContinue() {
         setTransport(AtmosphereResource.TRANSPORT.LONG_POLLING);
         setSeenServerSyncIdHeader(2);
         simulatePushConnection();
@@ -150,7 +150,7 @@ class LongPollingCacheFilterTest {
     }
 
     @Test
-    public void onConnect_longPollingAndSeenServerSyncIdHeaderSent_sessionAttributeStored() {
+    void onConnect_longPollingAndSeenServerSyncIdHeaderSent_sessionAttributeStored() {
         int syncId = 5;
         setTransport(AtmosphereResource.TRANSPORT.LONG_POLLING);
         setSeenServerSyncIdHeader(syncId);
@@ -165,7 +165,7 @@ class LongPollingCacheFilterTest {
     }
 
     @Test
-    public void onConnect_seenServerSyncIdHeaderMissing_sessionAttributeNotSet() {
+    void onConnect_seenServerSyncIdHeaderMissing_sessionAttributeNotSet() {
         simulatePushConnection();
 
         AtmosphereResourceSession session = sessionFactory.getSession(resource,
@@ -175,7 +175,7 @@ class LongPollingCacheFilterTest {
     }
 
     @Test
-    public void onConnect_notLongPollingTransport_sessionAttributeNotSet() {
+    void onConnect_notLongPollingTransport_sessionAttributeNotSet() {
         setSeenServerSyncIdHeader(5);
         AtmosphereResourceSession session = sessionFactory.getSession(resource,
                 false);
@@ -192,7 +192,7 @@ class LongPollingCacheFilterTest {
     }
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         resource = Mockito.mock(AtmosphereResource.class);
         AtmosphereRequest request = Mockito.mock(AtmosphereRequest.class);
         Broadcaster broadcaster = Mockito.mock(Broadcaster.class);

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/MetadataWriterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/MetadataWriterTest.java
@@ -39,7 +39,7 @@ class MetadataWriterTest {
     private SystemMessages messages;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         ui = Mockito.mock(UI.class);
         session = Mockito.mock(VaadinSession.class);
         Mockito.when(ui.getSession()).thenReturn(session);
@@ -53,30 +53,30 @@ class MetadataWriterTest {
     }
 
     @Test
-    public void writeAsyncTag() throws Exception {
+    void writeAsyncTag() throws Exception {
         assertMetadataOutput(false, true, "{\"async\":true}");
     }
 
     @Test
-    public void writeRepaintTag() throws Exception {
+    void writeRepaintTag() throws Exception {
         assertMetadataOutput(true, false, "{\"repaintAll\":true}");
     }
 
     @Test
-    public void writeRepaintAndAsyncTag() throws Exception {
+    void writeRepaintAndAsyncTag() throws Exception {
         assertMetadataOutput(true, true,
                 "{\"repaintAll\":true,\"async\":true}");
     }
 
     @Test
-    public void writeRedirectWithExpiredSession() throws Exception {
+    void writeRedirectWithExpiredSession() throws Exception {
         disableSessionExpirationMessages(messages);
 
         assertMetadataOutput(false, false, "{}");
     }
 
     @Test
-    public void writeRedirectWithActiveSession() throws Exception {
+    void writeRedirectWithActiveSession() throws Exception {
         WrappedSession wrappedSession = mock(WrappedSession.class);
         when(session.getSession()).thenReturn(wrappedSession);
 
@@ -87,7 +87,7 @@ class MetadataWriterTest {
     }
 
     @Test
-    public void writeAsyncWithSystemMessages() throws IOException {
+    void writeAsyncWithSystemMessages() throws IOException {
         WrappedSession wrappedSession = mock(WrappedSession.class);
         when(session.getSession()).thenReturn(wrappedSession);
 
@@ -98,13 +98,13 @@ class MetadataWriterTest {
     }
 
     @Test
-    public void writeSessionExpiredTag_sessionIsOpen() throws Exception {
+    void writeSessionExpiredTag_sessionIsOpen() throws Exception {
         Mockito.when(session.getState()).thenReturn(VaadinSessionState.OPEN);
         assertMetadataOutput(false, false, "{}");
     }
 
     @Test
-    public void writeSessionExpiredTag_sessionIsClosing() throws Exception {
+    void writeSessionExpiredTag_sessionIsClosing() throws Exception {
         Mockito.when(session.getState()).thenReturn(VaadinSessionState.CLOSING);
         assertMetadataOutput(false, false, "{\"sessionExpired\":true}");
 
@@ -113,7 +113,7 @@ class MetadataWriterTest {
     }
 
     @Test
-    public void writeSessionExpiredTag_sessionIsClosed() throws Exception {
+    void writeSessionExpiredTag_sessionIsClosed() throws Exception {
         Mockito.when(session.getState()).thenReturn(VaadinSessionState.CLOSED);
         assertMetadataOutput(false, false, "{\"sessionExpired\":true}");
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/PushAtmosphereHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/PushAtmosphereHandlerTest.java
@@ -46,7 +46,7 @@ class PushAtmosphereHandlerTest {
     private PushAtmosphereHandler atmosphereHandler;
 
     @BeforeEach
-    public void setup() throws IOException {
+    void setup() throws IOException {
         request = Mockito.mock(AtmosphereRequest.class);
         response = Mockito.mock(AtmosphereResponse.class);
         printWriter = Mockito.mock(PrintWriter.class);
@@ -74,12 +74,12 @@ class PushAtmosphereHandlerTest {
     }
 
     @Test
-    public void writeSessionExpiredAsyncGet() throws Exception {
+    void writeSessionExpiredAsyncGet() throws Exception {
         writeSessionExpiredAsync("GET");
     }
 
     @Test
-    public void writeSessionExpiredAsyncPost() throws Exception {
+    void writeSessionExpiredAsyncPost() throws Exception {
         writeSessionExpiredAsync("POST");
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/PushHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/PushHandlerTest.java
@@ -55,7 +55,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class PushHandlerTest {
 
     @Test
-    public void onConnect_websocketTransport_requestStartIsCalledOnServiceInstance() {
+    void onConnect_websocketTransport_requestStartIsCalledOnServiceInstance() {
         VaadinServletService service = runTest((handler, resource) -> {
             Mockito.when(resource.transport()).thenReturn(TRANSPORT.WEBSOCKET);
             handler.onConnect(resource);
@@ -65,7 +65,7 @@ class PushHandlerTest {
     }
 
     @Test
-    public void onConnect_notWebsocketTransport_requestStartIsNotCalledOnServiceInstance() {
+    void onConnect_notWebsocketTransport_requestStartIsNotCalledOnServiceInstance() {
         VaadinServletService service = runTest((handler, resource) -> {
             Mockito.when(resource.transport()).thenReturn(TRANSPORT.AJAX);
             handler.onConnect(resource);
@@ -76,7 +76,7 @@ class PushHandlerTest {
     }
 
     @Test
-    public void onMessage_websocketTransport_requestStartIsCalledOnServiceInstance() {
+    void onMessage_websocketTransport_requestStartIsCalledOnServiceInstance() {
         VaadinServletService service = runTest((handler, resource) -> {
             Mockito.when(resource.transport()).thenReturn(TRANSPORT.WEBSOCKET);
             handler.onMessage(resource);
@@ -86,7 +86,7 @@ class PushHandlerTest {
     }
 
     @Test
-    public void onMessage_notWebsocketTransport_requestStartIsNotCalledOnServiceInstance() {
+    void onMessage_notWebsocketTransport_requestStartIsNotCalledOnServiceInstance() {
         VaadinServletService service = runTest((handler, resource) -> {
             Mockito.when(resource.transport()).thenReturn(TRANSPORT.AJAX);
             handler.onMessage(resource);
@@ -97,7 +97,7 @@ class PushHandlerTest {
     }
 
     @Test
-    public void onConnect_devMode_websocket_refreshConnection_onConnectIsCalled_callWithUIIsNotCalled()
+    void onConnect_devMode_websocket_refreshConnection_onConnectIsCalled_callWithUIIsNotCalled()
             throws ServiceException {
         MockVaadinServletService service = Mockito
                 .spy(MockVaadinServletService.class);
@@ -135,7 +135,7 @@ class PushHandlerTest {
     }
 
     @Test
-    public void onMessage_devMode_websocket_refreshConnection_callWithUIIsNotCalled()
+    void onMessage_devMode_websocket_refreshConnection_callWithUIIsNotCalled()
             throws ServiceException {
         MockVaadinServletService service = Mockito
                 .spy(MockVaadinServletService.class);
@@ -175,7 +175,7 @@ class PushHandlerTest {
     }
 
     @Test
-    public void onConnect_devMode_websocket_noRefreshConnection_delegteCallWithUI()
+    void onConnect_devMode_websocket_noRefreshConnection_delegteCallWithUI()
             throws ServiceException {
         MockVaadinServletService service = Mockito
                 .spy(MockVaadinServletService.class);
@@ -194,7 +194,7 @@ class PushHandlerTest {
     }
 
     @Test
-    public void onConnect_devMode_notWebsocket_refreshConnection_delegteCallWithUI()
+    void onConnect_devMode_notWebsocket_refreshConnection_delegteCallWithUI()
             throws ServiceException, SessionExpiredException {
         MockVaadinServletService service = Mockito
                 .spy(MockVaadinServletService.class);
@@ -213,7 +213,7 @@ class PushHandlerTest {
     }
 
     @Test
-    public void connectionLost_noSession_currentInstancesAreCleared()
+    void connectionLost_noSession_currentInstancesAreCleared()
             throws SessionExpiredException {
         try {
             mockConnectionLost(new MockVaadinSession(), false);
@@ -225,7 +225,7 @@ class PushHandlerTest {
     }
 
     @Test
-    public void connectionLost_sessionIsSetViaCurrent_currentInstancesAreCleared()
+    void connectionLost_sessionIsSetViaCurrent_currentInstancesAreCleared()
             throws SessionExpiredException {
         try {
             mockConnectionLost(new MockVaadinSession(), true);
@@ -236,7 +236,7 @@ class PushHandlerTest {
     }
 
     @Test
-    public void connect_noSession_sendNotification() {
+    void connect_noSession_sendNotification() {
         try {
             assertNull(VaadinSession.getCurrent());
             AtomicReference<AtmosphereResource> res = new AtomicReference<>();
@@ -255,7 +255,7 @@ class PushHandlerTest {
     }
 
     @Test
-    public void connectionLost_connectWithoutSession_doNotSendNotification() {
+    void connectionLost_connectWithoutSession_doNotSendNotification() {
         try {
             AtmosphereResource resource = Mockito
                     .mock(AtmosphereResource.class);
@@ -313,7 +313,7 @@ class PushHandlerTest {
     }
 
     @Test
-    public void debugWindowConnection_productionMode_mustNeverBeConnected()
+    void debugWindowConnection_productionMode_mustNeverBeConnected()
             throws Exception {
         MockVaadinServletService service = Mockito
                 .spy(MockVaadinServletService.class);

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/PwaHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/PwaHandlerTest.java
@@ -46,13 +46,13 @@ class PwaHandlerTest {
     private final VaadinResponse response = Mockito.mock(VaadinResponse.class);
 
     @Test
-    public void handleRequest_noPwaRegistry_returnsFalse() throws IOException {
+    void handleRequest_noPwaRegistry_returnsFalse() throws IOException {
         PwaHandler handler = new PwaHandler(() -> null);
         assertFalse(handler.handleRequest(session, request, response));
     }
 
     @Test
-    public void handleRequest_pwaRegistryConfigIsDisabled_returnsFalse()
+    void handleRequest_pwaRegistryConfigIsDisabled_returnsFalse()
             throws IOException {
         PwaRegistry registry = Mockito.mock(PwaRegistry.class);
         PwaConfiguration configuration = Mockito.mock(PwaConfiguration.class);
@@ -63,7 +63,7 @@ class PwaHandlerTest {
     }
 
     @Test
-    public void handleRequest_pwaRegistryConfigIsEnabled_pathIsPwaResource_returnsTrue()
+    void handleRequest_pwaRegistryConfigIsEnabled_pathIsPwaResource_returnsTrue()
             throws IOException {
         PwaRegistry registry = Mockito.mock(PwaRegistry.class);
         PwaConfiguration configuration = Mockito.mock(PwaConfiguration.class);
@@ -81,7 +81,7 @@ class PwaHandlerTest {
     }
 
     @Test
-    public void handleRequest_pwaRegistryConfigIsEnabled_handlerIsInitializedOnce()
+    void handleRequest_pwaRegistryConfigIsEnabled_handlerIsInitializedOnce()
             throws IOException {
 
         PwaRegistry registry = Mockito.mock(PwaRegistry.class);
@@ -103,7 +103,7 @@ class PwaHandlerTest {
     }
 
     @Test
-    public void handleRequest_writeIconOnResponseFailure_doesNotThrow()
+    void handleRequest_writeIconOnResponseFailure_doesNotThrow()
             throws Exception {
 
         PwaRegistry registry = Mockito.mock(PwaRegistry.class);

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/ServerRpcHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/ServerRpcHandlerTest.java
@@ -61,7 +61,7 @@ class ServerRpcHandlerTest {
     private DeploymentConfiguration deploymentConfiguration;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         request = Mockito.mock(VaadinRequest.class);
         service = Mockito.mock(VaadinService.class);
         session = Mockito.mock(VaadinSession.class);
@@ -91,7 +91,7 @@ class ServerRpcHandlerTest {
     }
 
     @Test
-    public void handleRpc_resynchronize_throwsExceptionAndDirtiesTreeAndClearsDependenciesSent()
+    void handleRpc_resynchronize_throwsExceptionAndDirtiesTreeAndClearsDependenciesSent()
             throws IOException,
             ServerRpcHandler.InvalidUIDLSecurityKeyException,
             ServerRpcHandler.MessageIdSyncException {
@@ -112,7 +112,7 @@ class ServerRpcHandlerTest {
     }
 
     @Test
-    public void handleRpc_duplicateMessage_throwsResendPayload()
+    void handleRpc_duplicateMessage_throwsResendPayload()
             throws InvalidUIDLSecurityKeyException,
             ServerRpcHandler.MessageIdSyncException {
         String msg = "{\"" + ApplicationConstants.CLIENT_TO_SERVER_ID + "\":1}";
@@ -128,7 +128,7 @@ class ServerRpcHandlerTest {
     }
 
     @Test
-    public void handleRpc_unexpectedMessage_throw()
+    void handleRpc_unexpectedMessage_throw()
             throws InvalidUIDLSecurityKeyException, IOException,
             ServerRpcHandler.MessageIdSyncException {
         String msg = "{\"" + ApplicationConstants.CLIENT_TO_SERVER_ID + "\":1}";
@@ -142,7 +142,7 @@ class ServerRpcHandlerTest {
     }
 
     @Test
-    public void handleRpc_unexpectedMessage_exceptionContainsCorrectIds()
+    void handleRpc_unexpectedMessage_exceptionContainsCorrectIds()
             throws InvalidUIDLSecurityKeyException, IOException {
         String msg = "{\"" + ApplicationConstants.CLIENT_TO_SERVER_ID + "\":5}";
         ServerRpcHandler handler = new ServerRpcHandler();
@@ -162,7 +162,7 @@ class ServerRpcHandlerTest {
     }
 
     @Test
-    public void handleRpc_dauEnforcement_throws()
+    void handleRpc_dauEnforcement_throws()
             throws InvalidUIDLSecurityKeyException, IOException,
             ServerRpcHandler.MessageIdSyncException {
         enableDau();
@@ -180,7 +180,7 @@ class ServerRpcHandlerTest {
     }
 
     @Test
-    public void handleRpc_dauEnforcement_pollEvent_doNoThrow()
+    void handleRpc_dauEnforcement_pollEvent_doNoThrow()
             throws InvalidUIDLSecurityKeyException, IOException,
             ServerRpcHandler.MessageIdSyncException {
         enableDau();
@@ -201,7 +201,7 @@ class ServerRpcHandlerTest {
     }
 
     @Test
-    public void handleRpc_dauEnforcement_pollEventMixedWithOtherEvents_throw()
+    void handleRpc_dauEnforcement_pollEventMixedWithOtherEvents_throw()
             throws InvalidUIDLSecurityKeyException, IOException,
             ServerRpcHandler.MessageIdSyncException {
         enableDau();
@@ -219,7 +219,7 @@ class ServerRpcHandlerTest {
     }
 
     @Test
-    public void handleRpc_dauEnforcement_resynchronization_doNoThrow()
+    void handleRpc_dauEnforcement_resynchronization_doNoThrow()
             throws InvalidUIDLSecurityKeyException, IOException,
             ServerRpcHandler.MessageIdSyncException {
         enableDau();
@@ -237,7 +237,7 @@ class ServerRpcHandlerTest {
     }
 
     @Test
-    public void handleRpc_dauEnforcement_unloadBeacon_doNoThrow()
+    void handleRpc_dauEnforcement_unloadBeacon_doNoThrow()
             throws InvalidUIDLSecurityKeyException, IOException,
             ServerRpcHandler.MessageIdSyncException {
         enableDau();
@@ -258,7 +258,7 @@ class ServerRpcHandlerTest {
     }
 
     @Test
-    public void handleRpc_dauEnforcement_returnChannelMessage_doNoThrow()
+    void handleRpc_dauEnforcement_returnChannelMessage_doNoThrow()
             throws InvalidUIDLSecurityKeyException, IOException,
             ServerRpcHandler.MessageIdSyncException {
         enableDau();
@@ -279,7 +279,7 @@ class ServerRpcHandlerTest {
     }
 
     @Test
-    public void handleRpc_dauEnforcement_returnChannelMessageMixedWithOtherEvents_throw()
+    void handleRpc_dauEnforcement_returnChannelMessageMixedWithOtherEvents_throw()
             throws InvalidUIDLSecurityKeyException, IOException,
             ServerRpcHandler.MessageIdSyncException {
         enableDau();

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/StreamReceiverHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/StreamReceiverHandlerTest.java
@@ -106,7 +106,7 @@ class StreamReceiverHandlerTest {
     private String xFilenameHeader;
 
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() throws Exception {
         contentLength = "6";
         inputStream = createInputStream("foobar");
         outputStream = mock(OutputStream.class);
@@ -270,7 +270,7 @@ class StreamReceiverHandlerTest {
     }
 
     @Test
-    public void doHandleXhrFilePost_outputStreamGetterThrows_responseStatusIs500()
+    void doHandleXhrFilePost_outputStreamGetterThrows_responseStatusIs500()
             throws IOException {
         Mockito.doThrow(RuntimeException.class).when(streamVariable)
                 .getOutputStream();
@@ -283,7 +283,7 @@ class StreamReceiverHandlerTest {
     }
 
     @Test
-    public void doHandleXhrFilePost_outputStreamThrowsOnWrite_responseStatusIs500()
+    void doHandleXhrFilePost_outputStreamThrowsOnWrite_responseStatusIs500()
             throws IOException {
 
         Mockito.doThrow(RuntimeException.class).when(outputStream)
@@ -297,7 +297,7 @@ class StreamReceiverHandlerTest {
     }
 
     @Test
-    public void doHandleXhrFilePost_happyPath_setContentTypeNoExplicitSetStatus()
+    void doHandleXhrFilePost_happyPath_setContentTypeNoExplicitSetStatus()
             throws IOException {
         handler.doHandleXhrFilePost(session, request, response, streamReceiver,
                 stateNode, 1);
@@ -308,7 +308,7 @@ class StreamReceiverHandlerTest {
     }
 
     @Test
-    public void doHandleMultipartFileUpload_noPart_uploadFailed_responseStatusIs500()
+    void doHandleMultipartFileUpload_noPart_uploadFailed_responseStatusIs500()
             throws IOException {
         handler.doHandleMultipartFileUpload(session, request, response,
                 streamReceiver, stateNode);
@@ -318,7 +318,7 @@ class StreamReceiverHandlerTest {
     }
 
     @Test
-    public void doHandleMultipartFileUpload_hasParts_uploadFailed_responseStatusIs500()
+    void doHandleMultipartFileUpload_hasParts_uploadFailed_responseStatusIs500()
             throws IOException {
         contentType = "multipart/form-data; boundary=----WebKitFormBoundary7NsWHeCJVZNwi6ll";
         inputStream = createInputStream(
@@ -346,7 +346,7 @@ class StreamReceiverHandlerTest {
      * (#10096)
      */
     @Test
-    public void exceptionIsThrownOnUnexpectedEnd() throws IOException {
+    void exceptionIsThrownOnUnexpectedEnd() throws IOException {
         contentType = "multipart/form-data; boundary=----WebKitFormBoundary7NsWHeCJVZNwi6ll";
         inputStream = createInputStream(
                 "------WebKitFormBoundary7NsWHeCJVZNwi6ll\n"
@@ -363,7 +363,7 @@ class StreamReceiverHandlerTest {
     }
 
     @Test
-    public void responseIsSentOnCorrectSecurityKey() throws IOException {
+    void responseIsSentOnCorrectSecurityKey() throws IOException {
         handler.handleRequest(session, request, response, streamReceiver,
                 String.valueOf(uiId), expectedSecurityKey);
 
@@ -371,7 +371,7 @@ class StreamReceiverHandlerTest {
     }
 
     @Test
-    public void responseIsNotSentOnIncorrectSecurityKey() throws IOException {
+    void responseIsNotSentOnIncorrectSecurityKey() throws IOException {
         when(streamReceiver.getId()).thenReturn("another key expected");
 
         handler.handleRequest(session, request, response, streamReceiver,
@@ -381,7 +381,7 @@ class StreamReceiverHandlerTest {
     }
 
     @Test
-    public void responseIsNotSentOnMissingSecurityKey() throws IOException {
+    void responseIsNotSentOnMissingSecurityKey() throws IOException {
         when(streamReceiver.getId()).thenReturn(null);
 
         handler.handleRequest(session, request, response, streamReceiver,
@@ -391,8 +391,7 @@ class StreamReceiverHandlerTest {
     }
 
     @Test // Vaadin Spring #381
-    public void partsAreUsedDirectlyIfPresentWithoutParsingInput()
-            throws IOException {
+    void partsAreUsedDirectlyIfPresentWithoutParsingInput() throws IOException {
         contentType = "multipart/form-data; boundary=----WebKitFormBoundary7NsWHeCJVZNwi6ll";
         inputStream = createInputStream(
                 "------WebKitFormBoundary7NsWHeCJVZNwi6ll\n"
@@ -428,7 +427,7 @@ class StreamReceiverHandlerTest {
     }
 
     @Test
-    public void handleFileUploadValidationAndData_inputStreamThrowsIOException_exceptionIsNotRethrown_exceptionIsNotHandlerByErrorHandler()
+    void handleFileUploadValidationAndData_inputStreamThrowsIOException_exceptionIsNotRethrown_exceptionIsNotHandlerByErrorHandler()
             throws UploadException {
         InputStream inputStream = new InputStream() {
 
@@ -445,7 +444,7 @@ class StreamReceiverHandlerTest {
     }
 
     @Test
-    public void handleFileUploadValidationAndData_inputStreamThrowsIOExceptionOnClose_exceptionIsNotRethrown_exceptionIsNotHandlerByErrorHandler()
+    void handleFileUploadValidationAndData_inputStreamThrowsIOExceptionOnClose_exceptionIsNotRethrown_exceptionIsNotHandlerByErrorHandler()
             throws UploadException {
         InputStream inputStream = new InputStream() {
             @Override
@@ -465,7 +464,7 @@ class StreamReceiverHandlerTest {
     }
 
     @Test
-    public void doHandleMultipartFileUpload_IOExceptionIsThrown_exceptionIsNotRethrown_exceptionIsNotHandlerByErrorHandler()
+    void doHandleMultipartFileUpload_IOExceptionIsThrown_exceptionIsNotRethrown_exceptionIsNotHandlerByErrorHandler()
             throws IOException, ServletException {
         VaadinServletRequest request = Mockito.mock(VaadinServletRequest.class);
         Mockito.doThrow(IOException.class).when(request).getParts();
@@ -475,7 +474,7 @@ class StreamReceiverHandlerTest {
     }
 
     @Test
-    public void doHandleXhrFilePost_filenameFromHeader_extractedCorrectly()
+    void doHandleXhrFilePost_filenameFromHeader_extractedCorrectly()
             throws IOException {
         xFilenameHeader = "test.txt";
         outputStream = new ByteArrayOutputStream();
@@ -491,7 +490,7 @@ class StreamReceiverHandlerTest {
     }
 
     @Test
-    public void doHandleXhrFilePost_encodedFilename_decodedCorrectly()
+    void doHandleXhrFilePost_encodedFilename_decodedCorrectly()
             throws IOException {
         // encodeURIComponent("my file åäö.txt") in JavaScript
         xFilenameHeader = "my%20file%20%C3%A5%C3%A4%C3%B6.txt";
@@ -509,7 +508,7 @@ class StreamReceiverHandlerTest {
     }
 
     @Test
-    public void doHandleXhrFilePost_contentTypeFromHeader_extractedCorrectly()
+    void doHandleXhrFilePost_contentTypeFromHeader_extractedCorrectly()
             throws IOException {
         xFilenameHeader = "test.txt";
         contentType = "text/plain";
@@ -526,7 +525,7 @@ class StreamReceiverHandlerTest {
     }
 
     @Test
-    public void doHandleXhrFilePost_missingContentTypeHeader_defaultsToUnknown()
+    void doHandleXhrFilePost_missingContentTypeHeader_defaultsToUnknown()
             throws IOException {
         xFilenameHeader = "test.txt";
         contentType = null;
@@ -543,7 +542,7 @@ class StreamReceiverHandlerTest {
     }
 
     @Test
-    public void doHandleXhrFilePost_missingFilenameHeader_defaultsToUnknown()
+    void doHandleXhrFilePost_missingFilenameHeader_defaultsToUnknown()
             throws IOException {
         xFilenameHeader = null;
         outputStream = new ByteArrayOutputStream();

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/StreamRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/StreamRequestHandlerTest.java
@@ -62,7 +62,7 @@ class StreamRequestHandlerTest {
     private UI ui;
 
     @BeforeEach
-    public void setUp() throws ServletException, ServiceException {
+    void setUp() throws ServletException, ServiceException {
         VaadinService service = new MockVaadinServletService();
 
         session = new AlwaysLockedVaadinSession(service) {
@@ -83,87 +83,87 @@ class StreamRequestHandlerTest {
     }
 
     @AfterEach
-    public void cleanup() {
+    void cleanup() {
         CurrentInstance.clearAll();
     }
 
     @Test
-    public void streamResourceNameEndsWithPluses_streamFactory_resourceIsStreamed()
+    void streamResourceNameEndsWithPluses_streamFactory_resourceIsStreamed()
             throws IOException {
         testStreamResourceInputStreamFactory("end with multiple pluses",
                 "readme++.md");
     }
 
     @Test
-    public void streamResourceNameEndsWithPluses_resourceWriter_resourceIsStreamed()
+    void streamResourceNameEndsWithPluses_resourceWriter_resourceIsStreamed()
             throws IOException {
         testStreamResourceStreamResourceWriter("end with multiple pluses",
                 "readme++.md");
     }
 
     @Test
-    public void streamResourceNameContainsSpaceEndsWithPluses_streamFactory_resourceIsStreamed()
+    void streamResourceNameContainsSpaceEndsWithPluses_streamFactory_resourceIsStreamed()
             throws IOException {
         testStreamResourceInputStreamFactory(
                 "end with space and multiple pluses", "readme ++.md");
     }
 
     @Test
-    public void streamResourceNameContainsSpaceEndsWithPluses_resourceWriter_resourceIsStreamed()
+    void streamResourceNameContainsSpaceEndsWithPluses_resourceWriter_resourceIsStreamed()
             throws IOException {
         testStreamResourceStreamResourceWriter(
                 "end with space and multiple pluses", "readme ++.md");
     }
 
     @Test
-    public void streamResourceNameEndsInPlus_streamFactory_resourceIsStreamed()
+    void streamResourceNameEndsInPlus_streamFactory_resourceIsStreamed()
             throws IOException {
         testStreamResourceInputStreamFactory("end in plus", "readme+.md");
     }
 
     @Test
-    public void streamResourceNameEndsInPlus_resourceWriter_resourceIsStreamed()
+    void streamResourceNameEndsInPlus_resourceWriter_resourceIsStreamed()
             throws IOException {
         testStreamResourceStreamResourceWriter("end in plus", "readme+.md");
     }
 
     @Test
-    public void streamResourceNameContainsPlus_streamFactory_resourceIsStreamed()
+    void streamResourceNameContainsPlus_streamFactory_resourceIsStreamed()
             throws IOException {
         testStreamResourceInputStreamFactory("plus in middle",
                 "readme+mine.md");
     }
 
     @Test
-    public void streamResourceNameContainsPlus_resourceWriter_resourceIsStreamed()
+    void streamResourceNameContainsPlus_resourceWriter_resourceIsStreamed()
             throws IOException {
         testStreamResourceStreamResourceWriter("plus in middle",
                 "readme+mine.md");
     }
 
     @Test
-    public void streamResourceNameContainsPlusAndSpaces_streamFactory_resourceIsStreamed()
+    void streamResourceNameContainsPlusAndSpaces_streamFactory_resourceIsStreamed()
             throws IOException {
         testStreamResourceInputStreamFactory("plus surrounded by spaces",
                 "readme + mine.md");
     }
 
     @Test
-    public void streamResourceNameContainsPlusAndSpaces_resourceWriter_resourceIsStreamed()
+    void streamResourceNameContainsPlusAndSpaces_resourceWriter_resourceIsStreamed()
             throws IOException {
         testStreamResourceStreamResourceWriter("plus surrounded by spaces",
                 "readme + mine.md");
     }
 
     @Test
-    public void stateNodeStates_handlerMustNotReplyWhenNodeDisabled()
+    void stateNodeStates_handlerMustNotReplyWhenNodeDisabled()
             throws IOException {
         stateNodeStatesTestInternal(false, true);
         Mockito.verify(response).sendError(403, "Resource not available");
     }
 
     @Test
-    public void nodeDisabled_shouldReplyForDisabledUpdateModeAlways()
+    void nodeDisabled_shouldReplyForDisabledUpdateModeAlways()
             throws IOException {
         TestElementHandlerBuilder builder = new TestElementHandlerBuilder()
                 .withDisabledUpdateMode(DisabledUpdateMode.ALWAYS);
@@ -173,8 +173,7 @@ class StreamRequestHandlerTest {
     }
 
     @Test
-    public void nodeInert_shouldRespondWithResourceNotAvailable()
-            throws IOException {
+    void nodeInert_shouldRespondWithResourceNotAvailable() throws IOException {
         TestElementHandlerBuilder builder = new TestElementHandlerBuilder()
                 .withInert(true);
         stateNodeStatesTestInternal(builder);
@@ -182,7 +181,7 @@ class StreamRequestHandlerTest {
     }
 
     @Test
-    public void nodeInert_handlerShouldReplyForAllowInert() throws IOException {
+    void nodeInert_handlerShouldReplyForAllowInert() throws IOException {
         TestElementHandlerBuilder builder = new TestElementHandlerBuilder()
                 .withInert(true).withAllowInert(true);
         stateNodeStatesTestInternal(builder);
@@ -191,8 +190,7 @@ class StreamRequestHandlerTest {
     }
 
     @Test
-    public void nodeHidden_shouldRespondWithResourceNotAvailable()
-            throws IOException {
+    void nodeHidden_shouldRespondWithResourceNotAvailable() throws IOException {
         TestElementHandlerBuilder builder = new TestElementHandlerBuilder()
                 .withVisible(false);
         stateNodeStatesTestInternal(builder);
@@ -200,14 +198,14 @@ class StreamRequestHandlerTest {
     }
 
     @Test
-    public void stateNodeStates_handlerMustNotReplyWhenNodeDetached()
+    void stateNodeStates_handlerMustNotReplyWhenNodeDetached()
             throws IOException {
         stateNodeStatesTestInternal(true, false);
         Mockito.verify(response).sendError(403, "Resource not available");
     }
 
     @Test
-    public void stateNodeStates_handlerMustReplyWhenNodeAttachedAndEnabled()
+    void stateNodeStates_handlerMustReplyWhenNodeAttachedAndEnabled()
             throws IOException {
         stateNodeStatesTestInternal(true, true);
         Mockito.verify(response, Mockito.never()).sendError(Mockito.anyInt(),

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/StreamResourceHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/StreamResourceHandlerTest.java
@@ -48,7 +48,7 @@ class StreamResourceHandlerTest {
     private VaadinServletResponse response;
 
     @BeforeEach
-    public void setUp() throws ServletException, ServiceException {
+    void setUp() throws ServletException, ServiceException {
         VaadinService service = new MockVaadinServletService();
 
         session = new AlwaysLockedVaadinSession(service);
@@ -59,7 +59,7 @@ class StreamResourceHandlerTest {
     }
 
     @Test
-    public void inputStreamFactoryThrowsException_responseStatusIs500()
+    void inputStreamFactoryThrowsException_responseStatusIs500()
             throws IOException {
         StreamResource res = new StreamResource("readme.md",
                 (InputStreamFactory) () -> {
@@ -76,7 +76,7 @@ class StreamResourceHandlerTest {
     }
 
     @Test
-    public void inputStreamResourceWriterThrows_responseStatusIs500()
+    void inputStreamResourceWriterThrows_responseStatusIs500()
             throws IOException {
         StreamResource res = new StreamResource("readme.md",
                 (StreamResourceWriter) (stream, session) -> {
@@ -93,7 +93,7 @@ class StreamResourceHandlerTest {
     }
 
     @Test
-    public void inputStreamResourceWriterIsNull_responseStatusIs500()
+    void inputStreamResourceWriterIsNull_responseStatusIs500()
             throws IOException {
         @SuppressWarnings("serial")
         StreamResource res = new StreamResource("readme.md",
@@ -113,7 +113,7 @@ class StreamResourceHandlerTest {
     }
 
     @Test
-    public void inputStreamResourceWriterAndResponseThrows_streamResourceWriterExceptionIsPropagated()
+    void inputStreamResourceWriterAndResponseThrows_streamResourceWriterExceptionIsPropagated()
             throws IOException {
         ServletOutputStream servletOutputStream = Mockito
                 .mock(ServletOutputStream.class);
@@ -135,8 +135,7 @@ class StreamResourceHandlerTest {
     }
 
     @Test
-    public void inputStreamResourceHasHeader_headerIsWritten()
-            throws IOException {
+    void inputStreamResourceHasHeader_headerIsWritten() throws IOException {
         StreamResource res = new StreamResource("readme.md",
                 () -> new ByteArrayInputStream(new byte[0]));
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/UidlRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/UidlRequestHandlerTest.java
@@ -67,7 +67,7 @@ class UidlRequestHandlerTest {
     private UidlRequestHandler handler;
 
     @BeforeEach
-    public void setup() throws IOException {
+    void setup() throws IOException {
         request = Mockito.mock(VaadinRequest.class);
         response = Mockito.mock(VaadinResponse.class);
         outputStream = Mockito.mock(OutputStream.class);
@@ -77,7 +77,7 @@ class UidlRequestHandlerTest {
     }
 
     @Test
-    public void writeSessionExpired() throws Exception {
+    void writeSessionExpired() throws Exception {
         ApplicationConfiguration config = Mockito
                 .mock(ApplicationConfiguration.class);
         Mockito.when(config.getPropertyNames())
@@ -105,7 +105,7 @@ class UidlRequestHandlerTest {
     }
 
     @Test
-    public void writeSessionExpired_whenUINotFound() throws IOException {
+    void writeSessionExpired_whenUINotFound() throws IOException {
 
         VaadinService service = mock(VaadinService.class);
         VaadinSession session = mock(VaadinSession.class);
@@ -126,7 +126,7 @@ class UidlRequestHandlerTest {
     }
 
     @Test
-    public void clientRequestsPreviousIdAndPayload_resendPreviousResponse()
+    void clientRequestsPreviousIdAndPayload_resendPreviousResponse()
             throws IOException {
 
         UI ui = getUi();
@@ -188,7 +188,7 @@ class UidlRequestHandlerTest {
     }
 
     @Test
-    public void should_modifyUidl_when_MPR() throws Exception {
+    void should_modifyUidl_when_MPR() throws Exception {
         UI ui = getUi();
 
         handler = spy(new UidlRequestHandler());
@@ -209,7 +209,7 @@ class UidlRequestHandlerTest {
     }
 
     @Test
-    public void should_changeURL_when_v7LocationProvided() throws Exception {
+    void should_changeURL_when_v7LocationProvided() throws Exception {
         UI ui = getUi();
 
         handler = spy(new UidlRequestHandler());
@@ -229,8 +229,7 @@ class UidlRequestHandlerTest {
     }
 
     @Test
-    public void should_updateHash_when_v7LocationNotProvided()
-            throws Exception {
+    void should_updateHash_when_v7LocationNotProvided() throws Exception {
         UI ui = getUi();
 
         handler = spy(new UidlRequestHandler());
@@ -250,7 +249,7 @@ class UidlRequestHandlerTest {
     }
 
     @Test
-    public void should_not_modify_non_MPR_Uidl() throws Exception {
+    void should_not_modify_non_MPR_Uidl() throws Exception {
         UI ui = getUi();
 
         handler = spy(new UidlRequestHandler());
@@ -274,7 +273,7 @@ class UidlRequestHandlerTest {
     }
 
     @Test
-    public void should_not_update_browser_history_if_no_hash_in_location()
+    void should_not_update_browser_history_if_no_hash_in_location()
             throws Exception {
         UI ui = getUi();
 
@@ -292,7 +291,7 @@ class UidlRequestHandlerTest {
     }
 
     @Test
-    public void synchronizedHandleRequest_DauEnforcementException_setsStatusCode503()
+    void synchronizedHandleRequest_DauEnforcementException_setsStatusCode503()
             throws IOException {
         VaadinService service = mock(VaadinService.class);
         VaadinSession session = mock(VaadinSession.class);
@@ -323,7 +322,7 @@ class UidlRequestHandlerTest {
     }
 
     @Test
-    public void synchronizedHandleRequest_MessageIdSyncException_returnsSyncErrorResponse()
+    void synchronizedHandleRequest_MessageIdSyncException_returnsSyncErrorResponse()
             throws IOException {
         VaadinService service = mock(VaadinService.class);
         VaadinSession session = mock(VaadinSession.class);
@@ -369,7 +368,7 @@ class UidlRequestHandlerTest {
     }
 
     @Test
-    public void synchronizedHandleRequest_MessageIdSyncException_usesCustomMessages()
+    void synchronizedHandleRequest_MessageIdSyncException_usesCustomMessages()
             throws IOException {
         VaadinService service = mock(VaadinService.class);
         VaadinSession session = mock(VaadinSession.class);
@@ -418,7 +417,7 @@ class UidlRequestHandlerTest {
     }
 
     @Test
-    public void synchronizedHandleRequest_MessageIdSyncException_notificationDisabled_silentRefresh()
+    void synchronizedHandleRequest_MessageIdSyncException_notificationDisabled_silentRefresh()
             throws IOException {
         VaadinService service = mock(VaadinService.class);
         VaadinSession session = mock(VaadinSession.class);

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/UidlWriterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/UidlWriterTest.java
@@ -165,14 +165,14 @@ class UidlWriterTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         if (mocks != null) {
             mocks.cleanup();
         }
     }
 
     @Test
-    public void testEncodeExecuteJavaScript_npmMode() {
+    void testEncodeExecuteJavaScript_npmMode() {
         Element element = ElementFactory.createDiv();
 
         JavaScriptInvocation invocation1 = new JavaScriptInvocation(
@@ -202,7 +202,7 @@ class UidlWriterTest {
     }
 
     @Test
-    public void componentDependencies_npmMode() throws Exception {
+    void componentDependencies_npmMode() throws Exception {
         UI ui = initializeUIForDependenciesTest(new TestUI());
         UidlWriter uidlWriter = new UidlWriter();
         addInitialComponentDependencies(ui, uidlWriter);
@@ -215,7 +215,7 @@ class UidlWriterTest {
     }
 
     @Test
-    public void componentDependencies_productionMode_scanForParentClasses()
+    void componentDependencies_productionMode_scanForParentClasses()
             throws Exception {
         UI ui = initializeUIForDependenciesTest(new TestUI());
         mocks.getDeploymentConfiguration().setProductionMode(true);
@@ -243,7 +243,7 @@ class UidlWriterTest {
     }
 
     @Test
-    public void componentDependencies_developmentMode_onlySendComponentSpecificChunks()
+    void componentDependencies_developmentMode_onlySendComponentSpecificChunks()
             throws Exception {
         UidlWriter uidlWriter = new UidlWriter();
         UI ui = initializeUIForDependenciesTest(new TestUI());
@@ -267,7 +267,7 @@ class UidlWriterTest {
     }
 
     @Test
-    public void testComponentInterfaceDependencies_npmMode() throws Exception {
+    void testComponentInterfaceDependencies_npmMode() throws Exception {
         UI ui = initializeUIForDependenciesTest(new TestUI());
         UidlWriter uidlWriter = new UidlWriter();
 
@@ -293,7 +293,7 @@ class UidlWriterTest {
     }
 
     @Test
-    public void checkAllTypesOfDependencies_npmMode() throws Exception {
+    void checkAllTypesOfDependencies_npmMode() throws Exception {
         UI ui = initializeUIForDependenciesTest(new TestUI());
         UidlWriter uidlWriter = new UidlWriter();
         addInitialComponentDependencies(ui, uidlWriter);
@@ -348,7 +348,7 @@ class UidlWriterTest {
     }
 
     @Test
-    public void productionMode_stylesheetDependency_urlContainsHash()
+    void productionMode_stylesheetDependency_urlContainsHash()
             throws Exception {
         UI ui = initializeUIForDependenciesTest(new TestUI());
         mocks.getDeploymentConfiguration().setProductionMode(true);
@@ -411,7 +411,7 @@ class UidlWriterTest {
     }
 
     @Test
-    public void resynchronizationRequested_responseFieldContainsResynchronize()
+    void resynchronizationRequested_responseFieldContainsResynchronize()
             throws Exception {
         UI ui = initializeUIForDependenciesTest(new TestUI());
         UidlWriter uidlWriter = new UidlWriter();
@@ -426,7 +426,7 @@ class UidlWriterTest {
     }
 
     @Test
-    public void createUidl_allChangesCollected_uiIsNotDirty() throws Exception {
+    void createUidl_allChangesCollected_uiIsNotDirty() throws Exception {
         UI ui = initializeUIForDependenciesTest(new TestUI());
 
         ComponentsContainer container = new ComponentsContainer();
@@ -444,7 +444,7 @@ class UidlWriterTest {
     }
 
     @Test
-    public void createUidl_collectChangesUIStillDirty_shouldNotLoopEndlessly()
+    void createUidl_collectChangesUIStillDirty_shouldNotLoopEndlessly()
             throws Exception {
         UI ui = initializeUIForDependenciesTest(spy(new TestUI()));
         StateTree stateTree = spy(ui.getInternals().getStateTree());

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/UploadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/UploadHandlerTest.java
@@ -114,7 +114,7 @@ class UploadHandlerTest {
     private TestComponent component;
 
     @BeforeEach
-    public void setUp() throws ServletException, ServiceException {
+    void setUp() throws ServletException, ServiceException {
         VaadinService service = new MockVaadinServletService();
         ui = new MockUI() {
             @Override
@@ -152,12 +152,12 @@ class UploadHandlerTest {
     }
 
     @AfterEach
-    public void cleanup() {
+    void cleanup() {
         CurrentInstance.clearAll();
     }
 
     @Test
-    public void doUploadHandleXhrFilePost_happyPath_setContentTypeAndResponseHandled()
+    void doUploadHandleXhrFilePost_happyPath_setContentTypeAndResponseHandled()
             throws IOException {
         UploadHandler handler = (event) -> {
             event.getResponse().setContentType("text/html; charset=utf-8");
@@ -171,8 +171,7 @@ class UploadHandlerTest {
     }
 
     @Test
-    public void xhrUpload_filenameFromHeader_extractedCorrectly()
-            throws IOException {
+    void xhrUpload_filenameFromHeader_extractedCorrectly() throws IOException {
         final String[] capturedFilename = new String[1];
 
         UploadHandler handler = (event) -> {
@@ -187,8 +186,7 @@ class UploadHandlerTest {
     }
 
     @Test
-    public void xhrUpload_encodedFilename_decodedCorrectly()
-            throws IOException {
+    void xhrUpload_encodedFilename_decodedCorrectly() throws IOException {
         final String[] capturedFilename = new String[1];
 
         UploadHandler handler = (event) -> {
@@ -205,7 +203,7 @@ class UploadHandlerTest {
     }
 
     @Test
-    public void xhrUpload_contentTypeFromHeader_extractedCorrectly()
+    void xhrUpload_contentTypeFromHeader_extractedCorrectly()
             throws IOException {
         final String[] capturedContentType = new String[1];
 
@@ -223,7 +221,7 @@ class UploadHandlerTest {
     }
 
     @Test
-    public void xhrUpload_missingContentTypeHeader_defaultsToUnknown()
+    void xhrUpload_missingContentTypeHeader_defaultsToUnknown()
             throws IOException {
         final String[] capturedContentType = new String[1];
 
@@ -240,7 +238,7 @@ class UploadHandlerTest {
     }
 
     @Test
-    public void doUploadHandleXhrFilePost_unhappyPath_responseHandled()
+    void doUploadHandleXhrFilePost_unhappyPath_responseHandled()
             throws IOException {
         UploadHandler handler = (event) -> {
             throw new RuntimeException("Exception in xrh upload");
@@ -252,7 +250,7 @@ class UploadHandlerTest {
     }
 
     @Test
-    public void createUploadHandlerToCopyStream_streamMatchesInput()
+    void createUploadHandlerToCopyStream_streamMatchesInput()
             throws IOException {
         String testString = "Test string for upload";
 
@@ -286,8 +284,7 @@ class UploadHandlerTest {
     }
 
     @Test
-    public void createInMemoryUploadHandler_streamMatchesInput()
-            throws IOException {
+    void createInMemoryUploadHandler_streamMatchesInput() throws IOException {
         String testString = "Test string for upload";
 
         final byte[] testBytes = testString.getBytes();
@@ -319,8 +316,7 @@ class UploadHandlerTest {
     }
 
     @Test
-    public void createTempFileUploadHandler_streamMatchesInput()
-            throws IOException {
+    void createTempFileUploadHandler_streamMatchesInput() throws IOException {
         String testString = "Test string for upload";
 
         final byte[] testBytes = testString.getBytes();
@@ -355,8 +351,7 @@ class UploadHandlerTest {
     }
 
     @Test
-    public void createFileUploadHandler_streamMatchesInput()
-            throws IOException {
+    void createFileUploadHandler_streamMatchesInput() throws IOException {
         String testString = "Test string for upload";
 
         final byte[] testBytes = testString.getBytes();
@@ -394,7 +389,7 @@ class UploadHandlerTest {
     }
 
     @Test
-    public void mulitpartData_forInputIterator_dataIsGottenCorrectly()
+    void mulitpartData_forInputIterator_dataIsGottenCorrectly()
             throws IOException, ServletException {
         List<String> outList = new ArrayList<>(2);
         List<String> fileNames = new ArrayList<>(2);
@@ -433,7 +428,7 @@ class UploadHandlerTest {
     }
 
     @Test
-    public void mulitpartData_asParts_dataIsGottenCorrectly()
+    void mulitpartData_asParts_dataIsGottenCorrectly()
             throws IOException, ServletException {
         String testContent = "testBytes";
 
@@ -482,7 +477,7 @@ class UploadHandlerTest {
     }
 
     @Test
-    public void responseHandled_calledAfterAllPartsHaveBeenHandled()
+    void responseHandled_calledAfterAllPartsHaveBeenHandled()
             throws IOException, ServletException {
 
         String testContent = "testBytes";
@@ -524,7 +519,7 @@ class UploadHandlerTest {
     }
 
     @Test
-    public void responseHandled_calledAfterWholeStreamHasBeenHandled()
+    void responseHandled_calledAfterWholeStreamHasBeenHandled()
             throws IOException, ServletException {
 
         AtomicBoolean handled = new AtomicBoolean(false);
@@ -556,7 +551,7 @@ class UploadHandlerTest {
     }
 
     @Test
-    public void multipartRequest_responseHandled_calledWhenExceptionIsThrown()
+    void multipartRequest_responseHandled_calledWhenExceptionIsThrown()
             throws IOException, ServletException {
 
         String testContent = "testBytes";
@@ -597,7 +592,7 @@ class UploadHandlerTest {
     }
 
     @Test
-    public void multipartStreamRequest_responseHandled_calledWhenExceptionIsThrown()
+    void multipartStreamRequest_responseHandled_calledWhenExceptionIsThrown()
             throws IOException, ServletException {
 
         AtomicBoolean handled = new AtomicBoolean(false);
@@ -629,14 +624,14 @@ class UploadHandlerTest {
     }
 
     @Test
-    public void doesNotRequireToCatchIOException() {
+    void doesNotRequireToCatchIOException() {
         UploadHandler handler = event -> {
             new FileInputStream(new File("foo"));
         };
     }
 
     @Test
-    public void singleUpload_startAndComplete_firesInternalEvents()
+    void singleUpload_startAndComplete_firesInternalEvents()
             throws IOException, ServletException {
         AtomicBoolean startFired = new AtomicBoolean(false);
         AtomicBoolean completeFired = new AtomicBoolean(false);
@@ -672,7 +667,7 @@ class UploadHandlerTest {
     }
 
     @Test
-    public void multipartStreamRequest_startAndComplete_firesInternalEvents()
+    void multipartStreamRequest_startAndComplete_firesInternalEvents()
             throws IOException, ServletException {
         AtomicInteger startFired = new AtomicInteger(0);
         AtomicInteger completeFired = new AtomicInteger(0);
@@ -699,7 +694,7 @@ class UploadHandlerTest {
     }
 
     @Test
-    public void multipartRequest_startAndComplete_firesInternalEvents()
+    void multipartRequest_startAndComplete_firesInternalEvents()
             throws IOException, ServletException {
         List<Part> parts = new ArrayList<>();
         parts.add(createPart(createInputStream("one"), MULTIPART_CONTENT_TYPE,
@@ -734,21 +729,21 @@ class UploadHandlerTest {
     }
 
     @Test
-    public void fileUploadCallback_doesNotRequireCatch() {
+    void fileUploadCallback_doesNotRequireCatch() {
         new FileUploadHandler((meta, file) -> {
             new FileInputStream(file);
         }, uploadMetadata -> new File("foo"));
     }
 
     @Test
-    public void tmpUploadCallback_doesNotRequireCatch() {
+    void tmpUploadCallback_doesNotRequireCatch() {
         new TemporaryFileUploadHandler((meta, file) -> {
             new FileInputStream(file);
         });
     }
 
     @Test
-    public void inmemoryUploadCallback_doesNotRequireCatch() {
+    void inmemoryUploadCallback_doesNotRequireCatch() {
         new InMemoryUploadHandler((meta, data) -> {
             ByteArrayInputStream stream = new ByteArrayInputStream(data);
             stream.close();
@@ -756,8 +751,7 @@ class UploadHandlerTest {
     }
 
     @Test
-    public void xhrUpload_earlyRejection_returns422WithJson()
-            throws IOException {
+    void xhrUpload_earlyRejection_returns422WithJson() throws IOException {
         UploadHandler handler = (event) -> {
             if (!event.getFileName().endsWith(".png")) {
                 event.reject("Only PNG files are accepted");
@@ -775,7 +769,7 @@ class UploadHandlerTest {
     }
 
     @Test
-    public void xhrUpload_noRejection_returns200() throws IOException {
+    void xhrUpload_noRejection_returns200() throws IOException {
         UploadHandler handler = (event) -> {
             // Accept the file
         };
@@ -788,7 +782,7 @@ class UploadHandlerTest {
     }
 
     @Test
-    public void xhrUpload_rejectionWithDefaultMessage_usesDefaultMessage()
+    void xhrUpload_rejectionWithDefaultMessage_usesDefaultMessage()
             throws IOException {
         AtomicBoolean rejected = new AtomicBoolean(false);
 
@@ -810,7 +804,7 @@ class UploadHandlerTest {
     }
 
     @Test
-    public void multipartUpload_mixedAcceptReject_returns207WithJson()
+    void multipartUpload_mixedAcceptReject_returns207WithJson()
             throws IOException, ServletException {
         List<Part> parts = new ArrayList<>();
         parts.add(createPart(createInputStream("one"), MULTIPART_CONTENT_TYPE,
@@ -858,7 +852,7 @@ class UploadHandlerTest {
     }
 
     @Test
-    public void multipartUpload_allRejected_returns422()
+    void multipartUpload_allRejected_returns422()
             throws IOException, ServletException {
         List<Part> parts = new ArrayList<>();
         parts.add(createPart(createInputStream("one"), MULTIPART_CONTENT_TYPE,
@@ -890,7 +884,7 @@ class UploadHandlerTest {
     }
 
     @Test
-    public void multipartUpload_allAccepted_returns200()
+    void multipartUpload_allAccepted_returns200()
             throws IOException, ServletException {
         List<Part> parts = new ArrayList<>();
         parts.add(createPart(createInputStream("one"), MULTIPART_CONTENT_TYPE,
@@ -919,7 +913,7 @@ class UploadHandlerTest {
     }
 
     @Test
-    public void multipartUpload_earlyRejection_fileNotProcessed()
+    void multipartUpload_earlyRejection_fileNotProcessed()
             throws IOException, ServletException {
         List<Part> parts = new ArrayList<>();
         Part rejectedPart = createPart(createInputStream("content"),

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandlerViteTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandlerViteTest.java
@@ -74,7 +74,7 @@ class WebComponentBootstrapHandlerViteTest {
     private DeploymentConfiguration deploymentConfiguration;
 
     @BeforeEach
-    public void init() throws IOException {
+    void init() throws IOException {
         projectRootFolder = Files.createTempDirectory(temporaryFolder, "temp")
                 .toFile();
         TestUtil.createWebComponentHtmlStub(projectRootFolder);
@@ -99,7 +99,7 @@ class WebComponentBootstrapHandlerViteTest {
     }
 
     @Test
-    public void writeBootstrapPage_skipMetaAndStyleHeaderElements()
+    void writeBootstrapPage_skipMetaAndStyleHeaderElements()
             throws IOException {
         WebComponentBootstrapHandler handler = new WebComponentBootstrapHandler();
 
@@ -133,7 +133,7 @@ class WebComponentBootstrapHandlerViteTest {
     }
 
     @Test
-    public void writeBootstrapPage_scriptSrcHasNoDoubleQuotes_attributeIsTransferred()
+    void writeBootstrapPage_scriptSrcHasNoDoubleQuotes_attributeIsTransferred()
             throws IOException {
         WebComponentBootstrapHandler handler = new WebComponentBootstrapHandler();
 
@@ -154,7 +154,7 @@ class WebComponentBootstrapHandlerViteTest {
     }
 
     @Test
-    public void writeBootstrapPage_scriptSrcHasDoubleQuotes_throws()
+    void writeBootstrapPage_scriptSrcHasDoubleQuotes_throws()
             throws IOException {
         assertThrows(IllegalStateException.class, () -> {
             WebComponentBootstrapHandler handler = new WebComponentBootstrapHandler();
@@ -173,8 +173,7 @@ class WebComponentBootstrapHandlerViteTest {
     }
 
     @Test
-    public void writeBootstrapPage_noPWA()
-            throws IOException, ServiceException {
+    void writeBootstrapPage_noPWA() throws IOException, ServiceException {
         TestWebComponentBootstrapHandler handler = new TestWebComponentBootstrapHandler();
 
         PwaRegistry registry = Mockito.mock(PwaRegistry.class);
@@ -232,7 +231,7 @@ class WebComponentBootstrapHandlerViteTest {
     }
 
     @Test
-    public void writeBootstrapPage_devToolsDisabled()
+    void writeBootstrapPage_devToolsDisabled()
             throws IOException, ServiceException {
         TestWebComponentBootstrapHandler handler = new TestWebComponentBootstrapHandler();
         VaadinServletService service = new MockVaadinServletService() {
@@ -268,7 +267,7 @@ class WebComponentBootstrapHandlerViteTest {
     }
 
     @Test
-    public void writeBootstrapPage_spepe() throws Exception {
+    void writeBootstrapPage_spepe() throws Exception {
         WebComponentBootstrapHandler handler = new WebComponentBootstrapHandler();
 
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
@@ -282,7 +281,7 @@ class WebComponentBootstrapHandlerViteTest {
     }
 
     @Test
-    public void canHandleRequest_hasNoWebComponentConfigPathIsWebComponentUI_returnsFalse() {
+    void canHandleRequest_hasNoWebComponentConfigPathIsWebComponentUI_returnsFalse() {
         WebComponentBootstrapHandler handler = new WebComponentBootstrapHandler();
 
         VaadinRequest request = mockRequest(false);
@@ -290,7 +289,7 @@ class WebComponentBootstrapHandlerViteTest {
     }
 
     @Test
-    public void canHandleRequest_hasWebComponentConfigPathIsWebComponentUI_returnsTrue() {
+    void canHandleRequest_hasWebComponentConfigPathIsWebComponentUI_returnsTrue() {
         WebComponentBootstrapHandler handler = new WebComponentBootstrapHandler();
 
         VaadinRequest request = mockRequest(true);
@@ -299,7 +298,7 @@ class WebComponentBootstrapHandlerViteTest {
 
     @Disabled
     @Test
-    public void writeBootstrapPage_withExportChunk()
+    void writeBootstrapPage_withExportChunk()
             throws IOException, ServiceException {
         TestWebComponentBootstrapHandler handler = new TestWebComponentBootstrapHandler();
         VaadinServletService service = new MockVaadinServletService() {
@@ -333,7 +332,7 @@ class WebComponentBootstrapHandlerViteTest {
 
     @Disabled
     @Test
-    public void writeBootstrapPage_noExportChunk()
+    void writeBootstrapPage_noExportChunk()
             throws IOException, ServiceException {
         TestWebComponentBootstrapHandler handler = new TestWebComponentBootstrapHandler();
         VaadinServletService service = new MockVaadinServletService() {
@@ -367,7 +366,7 @@ class WebComponentBootstrapHandlerViteTest {
     }
 
     @Test
-    public void usageStatistics() throws IOException {
+    void usageStatistics() throws IOException {
         TestWebComponentBootstrapHandler handler = new TestWebComponentBootstrapHandler();
         VaadinServletService service = new MockVaadinServletService();
         VaadinSession session = new MockVaadinSession(service);

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/WebComponentProviderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/WebComponentProviderTest.java
@@ -90,7 +90,7 @@ class WebComponentProviderTest {
 
     @BeforeEach
     @SuppressWarnings("java:S1872") // FeatureFlagsWrapper is protected class
-    public void init() {
+    void init() {
         MockitoAnnotations.initMocks(this);
         registry = setUpRegistry(); // same code as used for local variables in
                                     // some tests
@@ -133,12 +133,12 @@ class WebComponentProviderTest {
     }
 
     @AfterEach
-    public void cleanUp() {
+    void cleanUp() {
         CurrentInstance.clearAll();
     }
 
     @Test
-    public void nonHandledPaths_handlerInformsNotHandled() throws IOException {
+    void nonHandledPaths_handlerInformsNotHandled() throws IOException {
         Mockito.when(request.getPathInfo()).thenReturn(null);
         assertFalse(provider.canHandleRequest(request),
                 "Provider shouldn't handle null path");
@@ -153,7 +153,7 @@ class WebComponentProviderTest {
     }
 
     @Test
-    public void faultyTag_handlerInformsNotHandled() throws IOException {
+    void faultyTag_handlerInformsNotHandled() throws IOException {
         Mockito.when(request.getPathInfo())
                 .thenReturn("/web-component" + "/extensionless-component");
 
@@ -177,7 +177,7 @@ class WebComponentProviderTest {
     }
 
     @Test
-    public void webComponentNotPresent_responseReturns404() throws IOException {
+    void webComponentNotPresent_responseReturns404() throws IOException {
         ServletContext servletContext = Mockito.mock(ServletContext.class);
 
         Mockito.when(request.getServletContext()).thenReturn(servletContext);
@@ -192,7 +192,7 @@ class WebComponentProviderTest {
     }
 
     @Test
-    public void webComponentGenerator_responseGetsResult() throws IOException {
+    void webComponentGenerator_responseGetsResult() throws IOException {
         registry = setupConfigurations(MyComponentExporter.class);
 
         ByteArrayOutputStream out = Mockito.spy(new ByteArrayOutputStream());
@@ -220,7 +220,7 @@ class WebComponentProviderTest {
     }
 
     @Test
-    public void providesDifferentGeneratedHTMLForEachExportedComponent()
+    void providesDifferentGeneratedHTMLForEachExportedComponent()
             throws IOException {
         ArgumentCaptor<byte[]> captor = ArgumentCaptor.forClass(byte[].class);
 
@@ -259,7 +259,7 @@ class WebComponentProviderTest {
     }
 
     @Test
-    public void setExporters_exportersHasVariousPushes_throws() {
+    void setExporters_exportersHasVariousPushes_throws() {
         assertThrows(IllegalStateException.class, () -> {
             WebComponentConfigurationRegistry registry = setupConfigurations(
                     ThemedComponentExporter.class,
@@ -268,7 +268,7 @@ class WebComponentProviderTest {
     }
 
     @Test
-    public void setExporters_exportersHasOnePush_pushIsSet() {
+    void setExporters_exportersHasOnePush_pushIsSet() {
         WebComponentConfigurationRegistry registry = setupConfigurations(
                 ThemedComponentExporter.class, MyComponentExporter.class);
         assertTrue(registry.getEmbeddedApplicationAnnotation(Push.class)
@@ -276,7 +276,7 @@ class WebComponentProviderTest {
     }
 
     @Test
-    public void setExporters_exportersHasSamePushDeclarations_pushIsSet() {
+    void setExporters_exportersHasSamePushDeclarations_pushIsSet() {
         WebComponentConfigurationRegistry registry = setupConfigurations(
                 ThemedComponentExporter.class,
                 SameThemedComponentExporter.class);
@@ -287,7 +287,7 @@ class WebComponentProviderTest {
     }
 
     @Test
-    public void canHandleRequest_hasNoWebComponentConfigPathIsWebComponentUI_returnsFalse() {
+    void canHandleRequest_hasNoWebComponentConfigPathIsWebComponentUI_returnsFalse() {
         WebComponentProvider handler = new WebComponentProvider();
 
         VaadinRequest request = mockRequest(false);
@@ -295,7 +295,7 @@ class WebComponentProviderTest {
     }
 
     @Test
-    public void canHandleRequest_hasWebComponentConfigPathIsWebComponentUI_returnsTrue() {
+    void canHandleRequest_hasWebComponentConfigPathIsWebComponentUI_returnsTrue() {
         WebComponentProvider handler = new WebComponentProvider();
 
         VaadinRequest request = mockRequest(true);

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/AbstractRpcInvocationHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/AbstractRpcInvocationHandlerTest.java
@@ -70,7 +70,7 @@ class AbstractRpcInvocationHandlerTest {
     private TestRpcInvocationHandler handler = new TestRpcInvocationHandler();
 
     @Test
-    public void handleVisibleAndEnabledNode_nodeIsHandled() {
+    void handleVisibleAndEnabledNode_nodeIsHandled() {
         UI ui = new UI();
 
         Element element = createRpcInvocationData(ui, null);
@@ -79,7 +79,7 @@ class AbstractRpcInvocationHandlerTest {
     }
 
     @Test
-    public void handleInactiveNode_nodeIsNotHandled() {
+    void handleInactiveNode_nodeIsNotHandled() {
         UI ui = new UI();
 
         createRpcInvocationData(ui, elem -> {
@@ -92,7 +92,7 @@ class AbstractRpcInvocationHandlerTest {
     }
 
     @Test
-    public void handleInertNode_nodeIsNotHandled() {
+    void handleInertNode_nodeIsNotHandled() {
         UI ui = new UI();
 
         createRpcInvocationData(ui, elem -> {
@@ -106,7 +106,7 @@ class AbstractRpcInvocationHandlerTest {
     }
 
     @Test
-    public void inertUI_passingNoPollingPayload_ignoresPollingInvocation() {
+    void inertUI_passingNoPollingPayload_ignoresPollingInvocation() {
 
         UI ui = createInertUIWithPollInterval();
         JsonNode invocationJson = createNonPollingRpcInvocationPayload(ui);
@@ -116,7 +116,7 @@ class AbstractRpcInvocationHandlerTest {
     }
 
     @Test
-    public void inertUIWithPollingInterval_passingLegitimatePollingPayload_doesNotIgnorePolling() {
+    void inertUIWithPollingInterval_passingLegitimatePollingPayload_doesNotIgnorePolling() {
 
         UI ui = createInertUI();
 
@@ -135,7 +135,7 @@ class AbstractRpcInvocationHandlerTest {
     }
 
     @Test
-    public void inertUIWithPollingInterval_passingIllegitimateKeysForPollingPayload_ignoresInvocation() {
+    void inertUIWithPollingInterval_passingIllegitimateKeysForPollingPayload_ignoresInvocation() {
 
         UI ui = createInertUIWithPollInterval();
         JsonNode invocationJson = createIllegitimatePayloadKeysPollingRpcInvocationPayload(
@@ -146,7 +146,7 @@ class AbstractRpcInvocationHandlerTest {
     }
 
     @Test
-    public void inertUIWithPollingInterval_passingIllegitimateGreaterNumberOfKeysForPollingPayload_ignoresInvocation() {
+    void inertUIWithPollingInterval_passingIllegitimateGreaterNumberOfKeysForPollingPayload_ignoresInvocation() {
 
         UI ui = createInertUIWithPollInterval();
         JsonNode invocationJson = createIllegitimatePayloadWithGreaterSizePollingRpcInvocationPayload(
@@ -157,7 +157,7 @@ class AbstractRpcInvocationHandlerTest {
     }
 
     @Test
-    public void inertUIWithPollingInterval_passingIllegitimateSmallerNumberOfKeysForPollingPayload_ignoresInvocation() {
+    void inertUIWithPollingInterval_passingIllegitimateSmallerNumberOfKeysForPollingPayload_ignoresInvocation() {
 
         UI ui = createInertUIWithPollInterval();
         JsonNode invocationJson = createIllegitimatePayloadWithSmallerSizePollingRpcInvocationPayload(
@@ -168,7 +168,7 @@ class AbstractRpcInvocationHandlerTest {
     }
 
     @Test
-    public void inertUIWithPollingInterval_passingIllegitimateNoNodeKeyForPollingPayload_throwsAssertionError() {
+    void inertUIWithPollingInterval_passingIllegitimateNoNodeKeyForPollingPayload_throwsAssertionError() {
 
         UI ui = createInertUIWithPollInterval();
         JsonNode invocationJson = createIllegitimatePayloadNoNodeKeyForPollingRpcInvocationPayload();
@@ -177,7 +177,7 @@ class AbstractRpcInvocationHandlerTest {
     }
 
     @Test
-    public void inertUIWithPollingInterval_passingIllegitimateNonRootNodeIdForPollingPayload_ignoresInvocation() {
+    void inertUIWithPollingInterval_passingIllegitimateNonRootNodeIdForPollingPayload_ignoresInvocation() {
 
         UI ui = createInertUIWithPollInterval();
         JsonNode invocationJson = createIllegitimatePayloadWithNonRootNodePollingRpcInvocationPayload(
@@ -188,7 +188,7 @@ class AbstractRpcInvocationHandlerTest {
     }
 
     @Test
-    public void inertUIWithoutPollInterval_passingLegitimatePollingPayload_logsIgnoredPayloadInDebugLevel() {
+    void inertUIWithoutPollInterval_passingLegitimatePollingPayload_logsIgnoredPayloadInDebugLevel() {
 
         Logger logger = spy(Logger.class);
         try (MockedStatic<LoggerFactory> mockedLoggerFactory = mockStatic(
@@ -209,7 +209,7 @@ class AbstractRpcInvocationHandlerTest {
     }
 
     @Test
-    public void inertUIWithPollingInterval_passingIllegitimatePollingPayload_logsIgnoredPayloadInDebugLevel() {
+    void inertUIWithPollingInterval_passingIllegitimatePollingPayload_logsIgnoredPayloadInDebugLevel() {
 
         Logger logger = spy(Logger.class);
         try (MockedStatic<LoggerFactory> mockedLoggerFactory = mockStatic(

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/AttachExistingElementRpcHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/AttachExistingElementRpcHandlerTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 class AttachExistingElementRpcHandlerTest {
 
     @Test
-    public void handleNode_error() {
+    void handleNode_error() {
         AttachExistingElementRpcHandler handler = new AttachExistingElementRpcHandler();
 
         int requestedId = 1;
@@ -66,7 +66,7 @@ class AttachExistingElementRpcHandlerTest {
     }
 
     @Test
-    public void handleNode_requestedIdEqualsAssignedId() {
+    void handleNode_requestedIdEqualsAssignedId() {
         AttachExistingElementRpcHandler handler = new AttachExistingElementRpcHandler();
 
         int requestedId = 1;
@@ -104,7 +104,7 @@ class AttachExistingElementRpcHandlerTest {
     }
 
     @Test
-    public void handleNode_requestedIdAndAssignedIdAreDifferent() {
+    void handleNode_requestedIdAndAssignedIdAreDifferent() {
         AttachExistingElementRpcHandler handler = new AttachExistingElementRpcHandler();
 
         int requestedId = 1;

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/AttachTemplateChildRpcHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/AttachTemplateChildRpcHandlerTest.java
@@ -33,35 +33,35 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class AttachTemplateChildRpcHandlerTest {
 
     @Test
-    public void handleNode_attachById_elementNotFound() {
+    void handleNode_attachById_elementNotFound() {
         assertThrows(IllegalStateException.class, () -> {
             doHandleNode_attach_elementNotFound(JacksonUtils.createNode("id"));
         });
     }
 
     @Test
-    public void handleNode_attachCustomElement_elementNotFound() {
+    void handleNode_attachCustomElement_elementNotFound() {
         assertThrows(IllegalStateException.class, () -> {
             doHandleNode_attach_elementNotFound(JacksonUtils.nullNode());
         });
     }
 
     @Test
-    public void handleNode_attachByIdExistingRequest_throwReservedId() {
+    void handleNode_attachByIdExistingRequest_throwReservedId() {
         assertThrows(IllegalStateException.class, () -> {
             doHandleNode_attach_throwReservedId(JacksonUtils.createNode(2));
         });
     }
 
     @Test
-    public void handleNode_attachCustonElementCustomId_throwReservedId() {
+    void handleNode_attachCustonElementCustomId_throwReservedId() {
         assertThrows(IllegalStateException.class, () -> {
             doHandleNode_attach_throwReservedId(JacksonUtils.nullNode());
         });
     }
 
     @Test
-    public void handleNode_success_throwIllegalInvocation() {
+    void handleNode_success_throwIllegalInvocation() {
         assertThrows(IllegalArgumentException.class, () -> {
             assertHandleNode(1, JacksonUtils.createNode("id"));
         });

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/ClientCallableBeanSupportTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/ClientCallableBeanSupportTest.java
@@ -148,7 +148,7 @@ class ClientCallableBeanSupportTest {
     }
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         mocks = new MockServletServiceSessionSetup();
         VaadinService service = mocks.getService();
         service.init();
@@ -161,12 +161,12 @@ class ClientCallableBeanSupportTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         mocks.cleanup();
     }
 
     @Test
-    public void testSimpleBeanParameter() throws Exception {
+    void testSimpleBeanParameter() throws Exception {
         ComponentWithClientCallableMethods component = new ComponentWithClientCallableMethods();
         ui.add(component);
 
@@ -193,7 +193,7 @@ class ClientCallableBeanSupportTest {
     }
 
     @Test
-    public void testBeanListParameter() throws Exception {
+    void testBeanListParameter() throws Exception {
         ComponentWithClientCallableMethods component = new ComponentWithClientCallableMethods();
         ui.add(component);
 
@@ -235,7 +235,7 @@ class ClientCallableBeanSupportTest {
     }
 
     @Test
-    public void testNestedBeanParameter() throws Exception {
+    void testNestedBeanParameter() throws Exception {
         ComponentWithClientCallableMethods component = new ComponentWithClientCallableMethods();
         ui.add(component);
 
@@ -268,7 +268,7 @@ class ClientCallableBeanSupportTest {
     }
 
     @Test
-    public void testIntegerListParameter() throws Exception {
+    void testIntegerListParameter() throws Exception {
         ComponentWithClientCallableMethods component = new ComponentWithClientCallableMethods();
         ui.add(component);
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/EnumDecoderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/EnumDecoderTest.java
@@ -33,31 +33,31 @@ class EnumDecoderTest {
     }
 
     @Test
-    public void isApplicable_applicableToStringAndEnum() {
+    void isApplicable_applicableToStringAndEnum() {
         assertTrue(decoder.isApplicable(JacksonUtils.createNode("foo"),
                 Title.class));
     }
 
     @Test
-    public void isApplicable_notApplicableToBooleanAndEnum() {
+    void isApplicable_notApplicableToBooleanAndEnum() {
         assertFalse(decoder.isApplicable(JacksonUtils.createNode(true),
                 Enum.class));
     }
 
     @Test
-    public void isApplicable_notApplicableToStringAndString() {
+    void isApplicable_notApplicableToStringAndString() {
         assertFalse(decoder.isApplicable(JacksonUtils.createNode("foo"),
                 String.class));
     }
 
     @Test
-    public void isApplicable_notApplicableToStringAndAbstractEnum() {
+    void isApplicable_notApplicableToStringAndAbstractEnum() {
         assertFalse(decoder.isApplicable(JacksonUtils.createNode("foo"),
                 Enum.class));
     }
 
     @Test
-    public void stringToEnum_convertableString_valueIsConverted()
+    void stringToEnum_convertableString_valueIsConverted()
             throws RpcDecodeException {
         Title title = Title.MRS;
         Title decoded = decoder.decode(JacksonUtils.createNode(title.name()),
@@ -66,7 +66,7 @@ class EnumDecoderTest {
     }
 
     @Test
-    public void stringToEnum_nonConvertableString_valueIsConverted()
+    void stringToEnum_nonConvertableString_valueIsConverted()
             throws RpcDecodeException {
         assertThrows(IllegalArgumentException.class, () -> {
             decoder.decode(JacksonUtils.createNode("foo"), Title.class);

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/EventRpcHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/EventRpcHandlerTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class EventRpcHandlerTest {
 
     @Test
-    public void testElementEventNoData() throws Exception {
+    void testElementEventNoData() throws Exception {
         TestComponent c = new TestComponent();
         Element element = c.getElement();
         UI ui = new UI();
@@ -49,7 +49,7 @@ class EventRpcHandlerTest {
     }
 
     @Test
-    public void testElementEventData() throws Exception {
+    void testElementEventData() throws Exception {
         TestComponent c = new TestComponent();
         Element element = c.getElement();
         UI ui = new UI();

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/MapSyncRpcHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/MapSyncRpcHandlerTest.java
@@ -69,7 +69,7 @@ class MapSyncRpcHandlerTest {
     }
 
     @Test
-    public void testSynchronizeProperty() throws Exception {
+    void testSynchronizeProperty() throws Exception {
         TestComponent c = new TestComponent();
         Element element = c.getElement();
         ElementPropertyMap.getModel(element.getNode())
@@ -85,7 +85,7 @@ class MapSyncRpcHandlerTest {
     }
 
     @Test
-    public void syncJSON_jsonIsForStateNodeInList_propertySetToStateNodeCopy()
+    void syncJSON_jsonIsForStateNodeInList_propertySetToStateNodeCopy()
             throws Exception {
         // Let's use element's ElementPropertyMap for testing.
         TestComponent component = new TestComponent();
@@ -127,7 +127,7 @@ class MapSyncRpcHandlerTest {
     }
 
     @Test
-    public void syncJSON_jsonIsPropertyValueOfStateNode_propertySetToNode()
+    void syncJSON_jsonIsPropertyValueOfStateNode_propertySetToNode()
             throws Exception {
         // Let's use element's ElementPropertyMap for testing.
         TestComponent component = new TestComponent();
@@ -164,7 +164,7 @@ class MapSyncRpcHandlerTest {
     }
 
     @Test
-    public void syncJSON_jsonIsNotListItemAndNotPropertyValue_propertySetToJSON()
+    void syncJSON_jsonIsNotListItemAndNotPropertyValue_propertySetToJSON()
             throws Exception {
         // Let's use element's ElementPropertyMap for testing.
         TestComponent component = new TestComponent();
@@ -196,8 +196,7 @@ class MapSyncRpcHandlerTest {
     }
 
     @Test
-    public void disabledElement_updateDisallowed_updateIsNotDone()
-            throws Exception {
+    void disabledElement_updateDisallowed_updateIsNotDone() throws Exception {
         Element element = ElementFactory.createDiv();
         UI ui = new UI();
         ui.getElement().appendChild(element);
@@ -212,7 +211,7 @@ class MapSyncRpcHandlerTest {
     }
 
     @Test
-    public void disabledElement_updateIsAllowedBySynchronizeProperty_updateIsDone()
+    void disabledElement_updateIsAllowedBySynchronizeProperty_updateIsDone()
             throws Exception {
         Element element = ElementFactory.createDiv();
         UI ui = new UI();
@@ -228,7 +227,7 @@ class MapSyncRpcHandlerTest {
     }
 
     @Test
-    public void disabledElement_updateIsAllowedByEventListener_updateIsDone()
+    void disabledElement_updateIsAllowedByEventListener_updateIsDone()
             throws Exception {
         Element element = ElementFactory.createDiv();
         UI ui = new UI();
@@ -245,7 +244,7 @@ class MapSyncRpcHandlerTest {
     }
 
     @Test
-    public void implicitlyDisabledElement_updateIsAllowedBySynchronizeProperty_updateIsDone()
+    void implicitlyDisabledElement_updateIsAllowedBySynchronizeProperty_updateIsDone()
             throws Exception {
         Element element = ElementFactory.createDiv();
         UI ui = new UI();
@@ -261,7 +260,7 @@ class MapSyncRpcHandlerTest {
     }
 
     @Test
-    public void implicitlyDisabledElement_updateIsAllowedByEventListener_updateIsDone()
+    void implicitlyDisabledElement_updateIsAllowedByEventListener_updateIsDone()
             throws Exception {
         Element element = ElementFactory.createDiv();
         UI ui = new UI();
@@ -278,7 +277,7 @@ class MapSyncRpcHandlerTest {
     }
 
     @Test
-    public void noSyncPropertiesFeature_noExplicitAllow_throws() {
+    void noSyncPropertiesFeature_noExplicitAllow_throws() {
         assertThrows(IllegalArgumentException.class, () -> {
             StateNode noSyncProperties = new StateNode(
                     ElementPropertyMap.class);
@@ -295,7 +294,7 @@ class MapSyncRpcHandlerTest {
     }
 
     @Test
-    public void propertyIsNotExplicitlyAllowed_throwsWithElementTagInfo() {
+    void propertyIsNotExplicitlyAllowed_throwsWithElementTagInfo() {
         IllegalArgumentException thrown = assertThrows(
                 IllegalArgumentException.class, () -> {
                     Element element = new Element("foo");
@@ -309,7 +308,7 @@ class MapSyncRpcHandlerTest {
     }
 
     @Test
-    public void propertyIsNotExplicitlyAllowed_throwsWithComponentInfo() {
+    void propertyIsNotExplicitlyAllowed_throwsWithComponentInfo() {
         IllegalArgumentException thrown = assertThrows(
                 IllegalArgumentException.class, () -> {
                     TestComponent component = new TestComponent();
@@ -325,7 +324,7 @@ class MapSyncRpcHandlerTest {
     }
 
     @Test
-    public void propertyIsNotExplicitlyAllowed_subproperty_throwsWithComponentInfo() {
+    void propertyIsNotExplicitlyAllowed_subproperty_throwsWithComponentInfo() {
         IllegalArgumentException thrown = assertThrows(
                 IllegalArgumentException.class, () -> {
                     TestComponent component = new TestComponent();
@@ -346,7 +345,7 @@ class MapSyncRpcHandlerTest {
     }
 
     @Test
-    public void handleNode_callsElementPropertyMapDeferredUpdateFromClient() {
+    void handleNode_callsElementPropertyMapDeferredUpdateFromClient() {
         AtomicInteger deferredUpdateInvocations = new AtomicInteger();
         AtomicReference<String> deferredKey = new AtomicReference<>();
         StateNode node = new StateNode(ElementPropertyMap.class) {
@@ -380,7 +379,7 @@ class MapSyncRpcHandlerTest {
     }
 
     @Test
-    public void handleNode_stateNodePropertyDefaultValueNotSet_doesNotWarnForUnsetDisabledPropertyChange() {
+    void handleNode_stateNodePropertyDefaultValueNotSet_doesNotWarnForUnsetDisabledPropertyChange() {
 
         ElementPropertyMap map = mock(ElementPropertyMap.class);
         when(map.getProperty(anyString())).thenReturn(null);
@@ -406,7 +405,7 @@ class MapSyncRpcHandlerTest {
     }
 
     @Test
-    public void handleNode_stateNodePropertyDefaultValueSet_warnsForSetDisabledPropertyChange() {
+    void handleNode_stateNodePropertyDefaultValueSet_warnsForSetDisabledPropertyChange() {
 
         ElementPropertyMap map = mock(ElementPropertyMap.class);
         when(map.getProperty(anyString())).thenReturn(NEW_VALUE);

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/NavigationRpcHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/NavigationRpcHandlerTest.java
@@ -34,7 +34,7 @@ class NavigationRpcHandlerTest {
     private ObjectNode invocation;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         ui = new UI();
         historyStateChangeHandler = Mockito
                 .mock(History.HistoryStateChangeHandler.class);
@@ -50,7 +50,7 @@ class NavigationRpcHandlerTest {
     }
 
     @Test
-    public void handleRouterLinkClick_navigationTriggered() {
+    void handleRouterLinkClick_navigationTriggered() {
         invocation.put(JsonConstants.RPC_NAVIGATION_ROUTERLINK, true);
         rpcHandler.handle(ui, invocation);
 
@@ -60,7 +60,7 @@ class NavigationRpcHandlerTest {
     }
 
     @Test
-    public void handleRouterLinkClick_uiIsInert_navigationTriggered() {
+    void handleRouterLinkClick_uiIsInert_navigationTriggered() {
         ui.addModal(new RouterLink());
         ui.getInternals().getStateTree().collectChanges(nodeChange -> {
         });
@@ -74,7 +74,7 @@ class NavigationRpcHandlerTest {
     }
 
     @Test
-    public void handleHistoryChange_uiIsInert_navigationTriggered() {
+    void handleHistoryChange_uiIsInert_navigationTriggered() {
         ui.addModal(new RouterLink());
         rpcHandler.handle(ui, invocation);
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/PublishedServerEventHandlerRpcHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/PublishedServerEventHandlerRpcHandlerTest.java
@@ -201,7 +201,7 @@ class PublishedServerEventHandlerRpcHandlerTest {
     }
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         assertNull(System.getSecurityManager());
 
         MockServletServiceSessionSetup setup = new MockServletServiceSessionSetup();
@@ -219,13 +219,13 @@ class PublishedServerEventHandlerRpcHandlerTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         service = null;
         VaadinService.setCurrent(null);
     }
 
     @Test
-    public void methodIsInvoked() {
+    void methodIsInvoked() {
         ComponentWithCompute component = new ComponentWithCompute();
         PublishedServerEventHandlerRpcHandler.invokeMethod(component,
                 component.getClass(), "method", JacksonUtils.createArrayNode(),
@@ -235,7 +235,7 @@ class PublishedServerEventHandlerRpcHandlerTest {
     }
 
     @Test
-    public void methodIsNotInvokedWhenInert() {
+    void methodIsNotInvokedWhenInert() {
         ComponentWithCompute component = new ComponentWithCompute();
         PublishedServerEventHandlerRpcHandler.invokeMethod(component,
                 component.getClass(), "method", JacksonUtils.createArrayNode(),
@@ -245,7 +245,7 @@ class PublishedServerEventHandlerRpcHandlerTest {
     }
 
     @Test
-    public void methodIsInvokedWhenInertAndInertAllowed() {
+    void methodIsInvokedWhenInertAndInertAllowed() {
         ComponentWithCompute component = new ComponentWithCompute();
         PublishedServerEventHandlerRpcHandler.invokeMethod(component,
                 component.getClass(), "methodThatCanBeCalledWhenInert",
@@ -255,7 +255,7 @@ class PublishedServerEventHandlerRpcHandlerTest {
     }
 
     @Test
-    public void methodIsInvokedOnCompositeContent() {
+    void methodIsInvokedOnCompositeContent() {
         CompositeOfComponentWithCompute composite = new CompositeOfComponentWithCompute();
         ComponentWithCompute component = composite.getContent();
         PublishedServerEventHandlerRpcHandler.invokeMethod(composite,
@@ -266,7 +266,7 @@ class PublishedServerEventHandlerRpcHandlerTest {
     }
 
     @Test
-    public void methodIsInvokectOnCompositeOfComposite() {
+    void methodIsInvokectOnCompositeOfComposite() {
         CompositeOfComposite composite = new CompositeOfComposite();
         ComponentWithCompute component = composite.getContent().getContent();
         PublishedServerEventHandlerRpcHandler.invokeMethod(composite,
@@ -277,7 +277,7 @@ class PublishedServerEventHandlerRpcHandlerTest {
     }
 
     @Test
-    public void methodWithDecoderParameters_convertableValues_methodIsInvoked() {
+    void methodWithDecoderParameters_convertableValues_methodIsInvoked() {
         ArrayNode params = JacksonUtils.createArrayNode();
         params.add("264");
         params.add("MRS");
@@ -295,7 +295,7 @@ class PublishedServerEventHandlerRpcHandlerTest {
     }
 
     @Test
-    public void methodWithDecoderParameters_nonConvertableValues_methodIsInvoked() {
+    void methodWithDecoderParameters_nonConvertableValues_methodIsInvoked() {
         assertThrows(IllegalArgumentException.class, () -> {
             ArrayNode params = JacksonUtils.createArrayNode();
             params.add("264.1");
@@ -312,7 +312,7 @@ class PublishedServerEventHandlerRpcHandlerTest {
     }
 
     @Test
-    public void methodWithoutArgs_argsProvided() {
+    void methodWithoutArgs_argsProvided() {
         assertThrows(IllegalArgumentException.class, () -> {
             ArrayNode args = JacksonUtils.createArrayNode();
             args.add(true);
@@ -323,7 +323,7 @@ class PublishedServerEventHandlerRpcHandlerTest {
     }
 
     @Test
-    public void promiseSuccess() {
+    void promiseSuccess() {
         int promiseId = 4;
 
         ArrayNode args = JacksonUtils.createArrayNode();
@@ -365,7 +365,7 @@ class PublishedServerEventHandlerRpcHandlerTest {
     }
 
     @Test
-    public void promiseFailure() {
+    void promiseFailure() {
         int promiseId = 4;
 
         ArrayNode args = JacksonUtils.createArrayNode();
@@ -410,7 +410,7 @@ class PublishedServerEventHandlerRpcHandlerTest {
     }
 
     @Test
-    public void methodWithVarArg_acceptNoValues() {
+    void methodWithVarArg_acceptNoValues() {
         ArrayNode array = JacksonUtils.createArrayNode();
 
         MethodWithVarArgParameter component = new MethodWithVarArgParameter();
@@ -421,7 +421,7 @@ class PublishedServerEventHandlerRpcHandlerTest {
     }
 
     @Test
-    public void methodWithJsonValueIsInvoked() {
+    void methodWithJsonValueIsInvoked() {
         ArrayNode array = JacksonUtils.createArrayNode();
 
         ObjectNode json = JacksonUtils.createObjectNode();
@@ -438,7 +438,7 @@ class PublishedServerEventHandlerRpcHandlerTest {
     }
 
     @Test
-    public void methodWithJacksonJsonValueIsInvoked() {
+    void methodWithJacksonJsonValueIsInvoked() {
         ArrayNode array = JacksonUtils.createArrayNode();
 
         ObjectNode json = JacksonUtils.createObjectNode();
@@ -455,7 +455,7 @@ class PublishedServerEventHandlerRpcHandlerTest {
     }
 
     @Test
-    public void methodWithSeveralArgsAndVarArg_acceptNoValues() {
+    void methodWithSeveralArgsAndVarArg_acceptNoValues() {
         ArrayNode array = JacksonUtils.createArrayNode();
 
         ArrayNode firstArg = JacksonUtils.createArrayNode();
@@ -476,7 +476,7 @@ class PublishedServerEventHandlerRpcHandlerTest {
     }
 
     @Test
-    public void methodWithVarArg_acceptOneValue() {
+    void methodWithVarArg_acceptOneValue() {
         ArrayNode array = JacksonUtils.createArrayNode();
 
         array.add("foo");
@@ -490,7 +490,7 @@ class PublishedServerEventHandlerRpcHandlerTest {
     }
 
     @Test
-    public void methodWithVarArg_arrayIsCorrectlyHandled() {
+    void methodWithVarArg_arrayIsCorrectlyHandled() {
         ArrayNode array = JacksonUtils.createArrayNode();
 
         ArrayNode value = JacksonUtils.createArrayNode();
@@ -506,7 +506,7 @@ class PublishedServerEventHandlerRpcHandlerTest {
     }
 
     @Test
-    public void nullValueShouldReturnZeroForPrimitive() {
+    void nullValueShouldReturnZeroForPrimitive() {
         ArrayNode array = JacksonUtils.createArrayNode();
         array.add(JacksonUtils.nullNode());
         MethodWithParameters component = new MethodWithParameters();
@@ -522,7 +522,7 @@ class PublishedServerEventHandlerRpcHandlerTest {
     }
 
     @Test
-    public void noClientCallableMethodException() {
+    void noClientCallableMethodException() {
         assertThrows(IllegalStateException.class, () -> {
             ComponentWithNoClientCallableMethod component = new ComponentWithNoClientCallableMethod();
             PublishedServerEventHandlerRpcHandler.invokeMethod(component,
@@ -532,7 +532,7 @@ class PublishedServerEventHandlerRpcHandlerTest {
     }
 
     @Test
-    public void noMethodException() {
+    void noMethodException() {
         assertThrows(IllegalStateException.class, () -> {
             ComponentWithNoClientCallableMethod component = new ComponentWithNoClientCallableMethod();
             PublishedServerEventHandlerRpcHandler.invokeMethod(component,
@@ -542,7 +542,7 @@ class PublishedServerEventHandlerRpcHandlerTest {
     }
 
     @Test
-    public void enabledElement_methodIsInvoked() {
+    void enabledElement_methodIsInvoked() {
         UI ui = new UI();
         ComponentWithCompute component = new ComponentWithCompute();
         ui.add(component);
@@ -553,7 +553,7 @@ class PublishedServerEventHandlerRpcHandlerTest {
     }
 
     @Test
-    public void disabledElement_ClientCallableIsNotInvoked() {
+    void disabledElement_ClientCallableIsNotInvoked() {
         UI ui = new UI();
         ComponentWithCompute component = new ComponentWithCompute();
         ui.add(component);
@@ -566,7 +566,7 @@ class PublishedServerEventHandlerRpcHandlerTest {
     }
 
     @Test
-    public void disabledElement_clientDelegateAllowsRPC_methodIsInvoked() {
+    void disabledElement_clientDelegateAllowsRPC_methodIsInvoked() {
         UI ui = new UI();
         EnabledHandler component = new EnabledHandler();
         ui.add(component);

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/ReturnChannelHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/ReturnChannelHandlerTest.java
@@ -53,7 +53,7 @@ class ReturnChannelHandlerTest {
     private ArrayNode args = JacksonUtils.createArrayNode();
 
     @Test
-    public void happyPath_everythingWorks() {
+    void happyPath_everythingWorks() {
         ReturnChannelRegistration registration = registerUiChannel();
 
         handleMessage(registration);
@@ -63,7 +63,7 @@ class ReturnChannelHandlerTest {
     }
 
     @Test
-    public void noReturnChannelMap_invocationIgnored() {
+    void noReturnChannelMap_invocationIgnored() {
         StateNode nodeWithoutMap = new StateNode();
 
         ui.getElement().getNode().getFeature(ElementChildrenList.class).add(0,
@@ -75,7 +75,7 @@ class ReturnChannelHandlerTest {
     }
 
     @Test
-    public void returnChannelMapNotInitialized_noInitializedAfterInvocation() {
+    void returnChannelMapNotInitialized_noInitializedAfterInvocation() {
         handleMessage(ui.getElement().getNode().getId(), 0);
 
         assertFalse(ui.getElement().getNode()
@@ -84,7 +84,7 @@ class ReturnChannelHandlerTest {
     }
 
     @Test
-    public void unregisteredChannel_invocationIgnored() {
+    void unregisteredChannel_invocationIgnored() {
         ReturnChannelRegistration registration = registerUiChannel();
         registration.remove();
 
@@ -95,7 +95,7 @@ class ReturnChannelHandlerTest {
     }
 
     @Test
-    public void disabledElement_defaultRegistration_invocationIgnored() {
+    void disabledElement_defaultRegistration_invocationIgnored() {
         ReturnChannelRegistration registration = registerUiChannel();
 
         ui.setEnabled(false);
@@ -107,7 +107,7 @@ class ReturnChannelHandlerTest {
     }
 
     @Test
-    public void disabledElement_registrationAlwaysAllowed_invocationProcessed() {
+    void disabledElement_registrationAlwaysAllowed_invocationProcessed() {
         ReturnChannelRegistration registration = registerUiChannel();
         registration.setDisabledUpdateMode(DisabledUpdateMode.ALWAYS);
 
@@ -120,7 +120,7 @@ class ReturnChannelHandlerTest {
     }
 
     @Test
-    public void modalComponent_registrationExists_invocationProcessed() {
+    void modalComponent_registrationExists_invocationProcessed() {
         ReturnChannelRegistration registration = registerUiChannel();
 
         Div modal = new Div();
@@ -133,7 +133,7 @@ class ReturnChannelHandlerTest {
     }
 
     @Test
-    public void modalComponent_unregisteredChannel_invocationIgnored() {
+    void modalComponent_unregisteredChannel_invocationIgnored() {
         ReturnChannelRegistration registration = registerUiChannel();
         registration.remove();
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/StringToNumberDecoderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/StringToNumberDecoderTest.java
@@ -31,37 +31,37 @@ class StringToNumberDecoderTest {
     private StringToNumberDecoder decoder = new StringToNumberDecoder();
 
     @Test
-    public void isApplicable_applicableToStringAndNumber() {
+    void isApplicable_applicableToStringAndNumber() {
         assertTrue(decoder.isApplicable(JacksonUtils.createNode("foo"),
                 Number.class));
     }
 
     @Test
-    public void isApplicable_notApplicableToBooleanAndNumber() {
+    void isApplicable_notApplicableToBooleanAndNumber() {
         assertFalse(decoder.isApplicable(JacksonUtils.createNode(true),
                 Number.class));
     }
 
     @Test
-    public void isApplicable_notApplicableToStringAndString() {
+    void isApplicable_notApplicableToStringAndString() {
         assertFalse(decoder.isApplicable(JacksonUtils.createNode("foo"),
                 String.class));
     }
 
     @Test
-    public void isApplicable_notApplicableToStringAndAtomicInteger() {
+    void isApplicable_notApplicableToStringAndAtomicInteger() {
         assertFalse(decoder.isApplicable(JacksonUtils.createNode("foo"),
                 AtomicInteger.class));
     }
 
     @Test
-    public void isApplicable_applicableToStringAndLong() {
+    void isApplicable_applicableToStringAndLong() {
         assertTrue(decoder.isApplicable(JacksonUtils.createNode("foo"),
                 Long.class));
     }
 
     @Test
-    public void stringToInteger_convertableString_valueIsConverted()
+    void stringToInteger_convertableString_valueIsConverted()
             throws RpcDecodeException {
         Integer expected = 37;
         Integer value = decoder.decode(
@@ -71,7 +71,7 @@ class StringToNumberDecoderTest {
     }
 
     @Test
-    public void stringToInteger_nonConvertableString_exceptionIsThrown()
+    void stringToInteger_nonConvertableString_exceptionIsThrown()
             throws RpcDecodeException {
         assertThrows(RpcDecodeException.class, () -> {
             decoder.decode(JacksonUtils.createNode("abc"), Integer.class);
@@ -79,7 +79,7 @@ class StringToNumberDecoderTest {
     }
 
     @Test
-    public void stringToInteger_doubleString_exceptionIsThrown()
+    void stringToInteger_doubleString_exceptionIsThrown()
             throws RpcDecodeException {
         assertThrows(RpcDecodeException.class, () -> {
             decoder.decode(JacksonUtils.createNode("4.2"), Integer.class);
@@ -87,7 +87,7 @@ class StringToNumberDecoderTest {
     }
 
     @Test
-    public void stringToInteger_longString_exceptionIsThrown()
+    void stringToInteger_longString_exceptionIsThrown()
             throws RpcDecodeException {
         assertThrows(RpcDecodeException.class, () -> {
             decoder.decode(
@@ -97,7 +97,7 @@ class StringToNumberDecoderTest {
     }
 
     @Test
-    public void stringToLong_convertableString_valueIsConverted()
+    void stringToLong_convertableString_valueIsConverted()
             throws RpcDecodeException {
         Long expected = 37l;
         Long value = decoder.decode(
@@ -106,7 +106,7 @@ class StringToNumberDecoderTest {
     }
 
     @Test
-    public void stringToLong_nonConvertableString_exceptionIsThrown()
+    void stringToLong_nonConvertableString_exceptionIsThrown()
             throws RpcDecodeException {
         assertThrows(RpcDecodeException.class, () -> {
             decoder.decode(JacksonUtils.createNode("abc"), Long.class);
@@ -114,7 +114,7 @@ class StringToNumberDecoderTest {
     }
 
     @Test
-    public void stringToLong_doubleString_exceptionIsThrown()
+    void stringToLong_doubleString_exceptionIsThrown()
             throws RpcDecodeException {
         assertThrows(RpcDecodeException.class, () -> {
             decoder.decode(JacksonUtils.createNode("4.2"), Long.class);
@@ -122,7 +122,7 @@ class StringToNumberDecoderTest {
     }
 
     @Test
-    public void stringToShort_convertableString_valueIsConverted()
+    void stringToShort_convertableString_valueIsConverted()
             throws RpcDecodeException {
         Short expected = 37;
         Short value = decoder.decode(
@@ -131,7 +131,7 @@ class StringToNumberDecoderTest {
     }
 
     @Test
-    public void stringToShort_nonConvertableString_exceptionIsThrown()
+    void stringToShort_nonConvertableString_exceptionIsThrown()
             throws RpcDecodeException {
         assertThrows(RpcDecodeException.class, () -> {
             decoder.decode(JacksonUtils.createNode("abc"), Short.class);
@@ -139,8 +139,7 @@ class StringToNumberDecoderTest {
     }
 
     @Test
-    public void stringToShort_intString_exceptionIsThrown()
-            throws RpcDecodeException {
+    void stringToShort_intString_exceptionIsThrown() throws RpcDecodeException {
         assertThrows(RpcDecodeException.class, () -> {
             decoder.decode(JacksonUtils.createNode(Integer.MAX_VALUE),
                     Short.class);
@@ -148,7 +147,7 @@ class StringToNumberDecoderTest {
     }
 
     @Test
-    public void stringToShort_doubleString_exceptionIsThrown()
+    void stringToShort_doubleString_exceptionIsThrown()
             throws RpcDecodeException {
         assertThrows(RpcDecodeException.class, () -> {
             decoder.decode(JacksonUtils.createNode("4.2"), Short.class);
@@ -156,7 +155,7 @@ class StringToNumberDecoderTest {
     }
 
     @Test
-    public void stringToByte_convertableString_valueIsConverted()
+    void stringToByte_convertableString_valueIsConverted()
             throws RpcDecodeException {
         Byte expected = 37;
         Byte value = decoder.decode(
@@ -165,7 +164,7 @@ class StringToNumberDecoderTest {
     }
 
     @Test
-    public void stringToByte_nonConvertableString_exceptionIsThrown()
+    void stringToByte_nonConvertableString_exceptionIsThrown()
             throws RpcDecodeException {
         assertThrows(RpcDecodeException.class, () -> {
             decoder.decode(JacksonUtils.createNode("abc"), Byte.class);
@@ -173,8 +172,7 @@ class StringToNumberDecoderTest {
     }
 
     @Test
-    public void stringToByte_intString_exceptionIsThrown()
-            throws RpcDecodeException {
+    void stringToByte_intString_exceptionIsThrown() throws RpcDecodeException {
         assertThrows(RpcDecodeException.class, () -> {
             decoder.decode(JacksonUtils.createNode(Short.MAX_VALUE),
                     Byte.class);
@@ -182,7 +180,7 @@ class StringToNumberDecoderTest {
     }
 
     @Test
-    public void stringToByte_doubleString_exceptionIsThrown()
+    void stringToByte_doubleString_exceptionIsThrown()
             throws RpcDecodeException {
         assertThrows(RpcDecodeException.class, () -> {
             decoder.decode(JacksonUtils.createNode("4.2"), Byte.class);
@@ -190,7 +188,7 @@ class StringToNumberDecoderTest {
     }
 
     @Test
-    public void stringToFloat_convertableString_valueIsConverted()
+    void stringToFloat_convertableString_valueIsConverted()
             throws RpcDecodeException {
         Float expected = 37.72f;
         Float value = decoder.decode(
@@ -199,7 +197,7 @@ class StringToNumberDecoderTest {
     }
 
     @Test
-    public void stringToFloat_doubleString_exceptionIsThrown()
+    void stringToFloat_doubleString_exceptionIsThrown()
             throws RpcDecodeException {
         assertThrows(RpcDecodeException.class, () -> {
             decoder.decode(
@@ -209,7 +207,7 @@ class StringToNumberDecoderTest {
     }
 
     @Test
-    public void stringToFloat_nonConvertableString_exceptionIsThrown()
+    void stringToFloat_nonConvertableString_exceptionIsThrown()
             throws RpcDecodeException {
         assertThrows(RpcDecodeException.class, () -> {
             decoder.decode(JacksonUtils.createNode("abc"), Float.class);
@@ -217,7 +215,7 @@ class StringToNumberDecoderTest {
     }
 
     @Test
-    public void stringToDouble_convertableString_valueIsConverted()
+    void stringToDouble_convertableString_valueIsConverted()
             throws RpcDecodeException {
         Double expected = 823.6349d;
         Double value = decoder.decode(
@@ -227,7 +225,7 @@ class StringToNumberDecoderTest {
     }
 
     @Test
-    public void stringToDouble_minDoubleString_valueIsConverted()
+    void stringToDouble_minDoubleString_valueIsConverted()
             throws RpcDecodeException {
         // the value is represented in the specific notation. Check that it's
         // not a problem
@@ -239,7 +237,7 @@ class StringToNumberDecoderTest {
     }
 
     @Test
-    public void stringToDoublet_nonConvertableString_exceptionIsThrown()
+    void stringToDoublet_nonConvertableString_exceptionIsThrown()
             throws RpcDecodeException {
         assertThrows(RpcDecodeException.class, () -> {
             decoder.decode(JacksonUtils.createNode("abc"), Double.class);
@@ -247,7 +245,7 @@ class StringToNumberDecoderTest {
     }
 
     @Test
-    public void stringToNumber_convertableString_valueIsConverted()
+    void stringToNumber_convertableString_valueIsConverted()
             throws RpcDecodeException {
         Double expected = 823.6349d;
         Number value = decoder.decode(

--- a/flow-server/src/test/java/com/vaadin/flow/server/dau/DAUUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/dau/DAUUtilsTest.java
@@ -59,13 +59,13 @@ class DAUUtilsTest {
     private String subscriptionKey;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         subscriptionKey = System.getProperty("vaadin.subscriptionKey");
         System.setProperty("vaadin.subscriptionKey", "sub-1234");
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         if (subscriptionKey != null) {
             System.setProperty("vaadin.subscriptionKey", subscriptionKey);
         } else {
@@ -74,7 +74,7 @@ class DAUUtilsTest {
     }
 
     @Test
-    public void trackUser_uidlRequest_deferTracking() {
+    void trackUser_uidlRequest_deferTracking() {
         VaadinRequest request = Mockito.mock(VaadinRequest.class);
         Mockito.when(request
                 .getParameter(ApplicationConstants.REQUEST_TYPE_PARAMETER))
@@ -105,7 +105,7 @@ class DAUUtilsTest {
     }
 
     @Test
-    public void trackUser_notUidlRequest_track() {
+    void trackUser_notUidlRequest_track() {
         VaadinRequest request = Mockito.mock(VaadinRequest.class);
         Mockito.when(request
                 .getParameter(ApplicationConstants.REQUEST_TYPE_PARAMETER))
@@ -136,7 +136,7 @@ class DAUUtilsTest {
     }
 
     @Test
-    public void jsonEnforcementResponse_noDauCustomizer_defaultMessages() {
+    void jsonEnforcementResponse_noDauCustomizer_defaultMessages() {
         try (MockedStatic<DauIntegration> dauIntegrationMock = Mockito
                 .mockStatic(DauIntegration.class)) {
             VaadinService service = VaadinServiceDauTest
@@ -162,7 +162,7 @@ class DAUUtilsTest {
     }
 
     @Test
-    public void jsonEnforcementResponse_customMessages() {
+    void jsonEnforcementResponse_customMessages() {
         try (MockedStatic<DauIntegration> dauIntegrationMock = Mockito
                 .mockStatic(DauIntegration.class)) {
             EnforcementNotificationMessages expectedMessages = new EnforcementNotificationMessages(
@@ -196,7 +196,7 @@ class DAUUtilsTest {
     }
 
     @Test
-    public void trackDAU_trackingIntegratedWithRequest_noEnforcement() {
+    void trackDAU_trackingIntegratedWithRequest_noEnforcement() {
         MocksForTrackDAU mocks = new MocksForTrackDAU();
         VaadinService service = mocks.service;
         HttpServletRequest request = mocks.request;
@@ -220,7 +220,7 @@ class DAUUtilsTest {
     }
 
     @Test
-    public void trackDAU_trackingIntegratedWithRequest_enforcement() {
+    void trackDAU_trackingIntegratedWithRequest_enforcement() {
         MocksForTrackDAU mocks = new MocksForTrackDAU();
         VaadinService service = mocks.service;
         HttpServletRequest request = mocks.request;

--- a/flow-server/src/test/java/com/vaadin/flow/server/dau/DAUVaadinRequestInterceptorTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/dau/DAUVaadinRequestInterceptorTest.java
@@ -59,7 +59,7 @@ class DAUVaadinRequestInterceptorTest {
     private String originalSubscriptionKey;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         configuration = new MockDeploymentConfiguration();
         configuration.setApplicationOrSystemProperty(
                 InitParameters.APPLICATION_IDENTIFIER, APP_ID);
@@ -71,7 +71,7 @@ class DAUVaadinRequestInterceptorTest {
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    void tearDown() throws Exception {
         if (originalSubscriptionKey != null) {
             System.setProperty("vaadin.subscriptionKey",
                     originalSubscriptionKey);
@@ -81,7 +81,7 @@ class DAUVaadinRequestInterceptorTest {
     }
 
     @Test
-    public void requestStart_initRequest_dauCookieAbsent_createCookie() {
+    void requestStart_initRequest_dauCookieAbsent_createCookie() {
         assertCookieCreated(request -> {
             Mockito.when(request.getPathInfo()).thenReturn("");
             Mockito.when(request.getMethod()).thenReturn("GET");
@@ -92,7 +92,7 @@ class DAUVaadinRequestInterceptorTest {
     }
 
     @Test
-    public void requestStart_uidlRequest_dauCookieAbsent_createCookie() {
+    void requestStart_uidlRequest_dauCookieAbsent_createCookie() {
         assertCookieCreated(request -> {
             Mockito.when(request.getPathInfo()).thenReturn("");
             Mockito.when(request.getMethod()).thenReturn("POST");
@@ -103,7 +103,7 @@ class DAUVaadinRequestInterceptorTest {
     }
 
     @Test
-    public void requestStart_indexHtmlRequest_dauCookieAbsent_createCookie() {
+    void requestStart_indexHtmlRequest_dauCookieAbsent_createCookie() {
         assertCookieCreated(request -> {
             Mockito.when(request.getPathInfo()).thenReturn("");
             Mockito.when(request.getMethod()).thenReturn("GET");
@@ -119,7 +119,7 @@ class DAUVaadinRequestInterceptorTest {
     }
 
     @Test
-    public void requestStart_trackableRequest_dauCookieAbsent_pushWebsocket_doNotCreateCookie() {
+    void requestStart_trackableRequest_dauCookieAbsent_pushWebsocket_doNotCreateCookie() {
         VaadinRequest request = Mockito.mock(VaadinRequest.class);
         VaadinResponse response = Mockito.mock(VaadinResponse.class);
         Mockito.when(request
@@ -140,7 +140,7 @@ class DAUVaadinRequestInterceptorTest {
     }
 
     @Test
-    public void requestStart_notTrackableRequest_dauCookieAbsent_doNotCreateCookie() {
+    void requestStart_notTrackableRequest_dauCookieAbsent_doNotCreateCookie() {
         assertCookieNotCreated(request -> {
             Mockito.when(request
                     .getParameter(ApplicationConstants.REQUEST_TYPE_PARAMETER))
@@ -164,7 +164,7 @@ class DAUVaadinRequestInterceptorTest {
     }
 
     @Test
-    public void requestStart_notTrackableInternalRequests_dauCookieAbsent_doNotCreateCookie() {
+    void requestStart_notTrackableInternalRequests_dauCookieAbsent_doNotCreateCookie() {
         assertCookieNotCreated(request -> {
             Mockito.when(request.getPathInfo()).thenReturn("/VAADIN/something");
             Mockito.when(request.getMethod()).thenReturn("GET");
@@ -186,7 +186,7 @@ class DAUVaadinRequestInterceptorTest {
     }
 
     @Test
-    public void requestStart_notTrackableStaticResourceRequest_dauCookieAbsent_doNotCreateCookie() {
+    void requestStart_notTrackableStaticResourceRequest_dauCookieAbsent_doNotCreateCookie() {
         for (String resourcePath : HandlerHelper.getPublicResources()) {
             assertCookieNotCreated(request -> {
                 Mockito.when(request.getPathInfo()).thenReturn(resourcePath);
@@ -208,7 +208,7 @@ class DAUVaadinRequestInterceptorTest {
     }
 
     @Test
-    public void requestStart_notTrackablePWAIconsRequests_dauCookieAbsent_doNotCreateCookie() {
+    void requestStart_notTrackablePWAIconsRequests_dauCookieAbsent_doNotCreateCookie() {
         Lookup lookup = Mockito.mock(Lookup.class);
         MockVaadinServletService service = new MockVaadinServletService() {
             @Override
@@ -239,7 +239,7 @@ class DAUVaadinRequestInterceptorTest {
     }
 
     @Test
-    public void serviceInit_shouldStartDauTracking() {
+    void serviceInit_shouldStartDauTracking() {
         try (MockedStatic<DauIntegration> dauIntegration = Mockito
                 .mockStatic(DauIntegration.class)) {
             interceptor.serviceInit(new ServiceInitEvent(vaadinService));
@@ -248,7 +248,7 @@ class DAUVaadinRequestInterceptorTest {
     }
 
     @Test
-    public void serviceDestroy_shouldStopDauTracking() {
+    void serviceDestroy_shouldStopDauTracking() {
         try (MockedStatic<DauIntegration> dauIntegration = Mockito
                 .mockStatic(DauIntegration.class)) {
             interceptor.serviceDestroy(new ServiceDestroyEvent(vaadinService));
@@ -257,7 +257,7 @@ class DAUVaadinRequestInterceptorTest {
     }
 
     @Test
-    public void serviceInit_shouldInstallServiceDestroyListenerToStopDauTrackingOnShutdown() {
+    void serviceInit_shouldInstallServiceDestroyListenerToStopDauTrackingOnShutdown() {
         try (MockedStatic<DauIntegration> dauIntegration = Mockito
                 .mockStatic(DauIntegration.class)) {
             interceptor.serviceInit(new ServiceInitEvent(vaadinService));
@@ -268,7 +268,7 @@ class DAUVaadinRequestInterceptorTest {
     }
 
     @Test
-    public void requestStart_dauCookiePresent_activeUser_trackUser() {
+    void requestStart_dauCookiePresent_activeUser_trackUser() {
         VaadinRequest request = Mockito.mock(VaadinRequest.class);
         VaadinResponse response = Mockito.mock(VaadinResponse.class);
         Mockito.when(request
@@ -292,7 +292,7 @@ class DAUVaadinRequestInterceptorTest {
     }
 
     @Test
-    public void requestStart_dauCookiePresent_activeUser_identitySupplier_trackUser() {
+    void requestStart_dauCookiePresent_activeUser_identitySupplier_trackUser() {
         String userIdentity = "user";
         UserIdentitySupplier identitySupplier = userIdentityContext -> Optional
                 .of(userIdentity);
@@ -328,7 +328,7 @@ class DAUVaadinRequestInterceptorTest {
     }
 
     @Test
-    public void requestStart_dauCookiePresent_notActiveUser_trackUser() {
+    void requestStart_dauCookiePresent_notActiveUser_trackUser() {
         VaadinRequest request = Mockito.mock(VaadinRequest.class);
         VaadinResponse response = Mockito.mock(VaadinResponse.class);
         Mockito.when(request
@@ -353,7 +353,7 @@ class DAUVaadinRequestInterceptorTest {
     }
 
     @Test
-    public void requestStart_invalidCookie_doNotTrack() {
+    void requestStart_invalidCookie_doNotTrack() {
         VaadinRequest request = Mockito.mock(VaadinRequest.class);
         VaadinResponse response = Mockito.mock(VaadinResponse.class);
         Mockito.when(request
@@ -379,7 +379,7 @@ class DAUVaadinRequestInterceptorTest {
     }
 
     @Test
-    public void requestStart_dauCookiePresent_notActiveUser_enforcement_tracksUser() {
+    void requestStart_dauCookiePresent_notActiveUser_enforcement_tracksUser() {
         VaadinRequest request = Mockito.mock(VaadinRequest.class);
         VaadinResponse response = Mockito.mock(VaadinResponse.class);
         Mockito.when(request
@@ -408,7 +408,7 @@ class DAUVaadinRequestInterceptorTest {
     }
 
     @Test
-    public void requestStart_noDauCookie_notActiveUser_enforcement_tracksUser() {
+    void requestStart_noDauCookie_notActiveUser_enforcement_tracksUser() {
         VaadinRequest request = Mockito.mock(VaadinRequest.class);
         VaadinResponse response = Mockito.mock(VaadinResponse.class);
         Mockito.when(request

--- a/flow-server/src/test/java/com/vaadin/flow/server/dau/FlowDauIntegrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/dau/FlowDauIntegrationTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class FlowDauIntegrationTest {
 
     @Test
-    public void generateNewCookie_setsUpExpectedParameters() {
+    void generateNewCookie_setsUpExpectedParameters() {
         try (MockedStatic<DauIntegration> key = Mockito
                 .mockStatic(DauIntegration.class)) {
             key.when(DauIntegration::newTrackingHash).thenReturn("hash");
@@ -51,7 +51,7 @@ class FlowDauIntegrationTest {
     }
 
     @Test
-    public void generateNewCookie_notSecureRequest_cookieNotSecure() {
+    void generateNewCookie_notSecureRequest_cookieNotSecure() {
         try (MockedStatic<DauIntegration> key = Mockito
                 .mockStatic(DauIntegration.class)) {
             key.when(DauIntegration::newTrackingHash).thenReturn("hash");

--- a/flow-server/src/test/java/com/vaadin/flow/server/menu/AvailableViewInfoTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/menu/AvailableViewInfoTest.java
@@ -47,7 +47,7 @@ class AvailableViewInfoTest {
     String detailAsString;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         mapper = new ObjectMapper();
         menuData = new MenuData("title", 1.0, false, "icon", null);
         badge = new Badge("New!", "green");
@@ -56,13 +56,13 @@ class AvailableViewInfoTest {
     }
 
     @Test
-    public void testEquality() {
+    void testEquality() {
         assertEquals(createInfo(true, true), createInfo(true, true),
                 "Two instance created the same way are not equal");
     }
 
     @Test
-    public void testSerialization() throws IOException, ClassNotFoundException {
+    void testSerialization() throws IOException, ClassNotFoundException {
         var info = createInfo(true, true);
 
         var baos = new ByteArrayOutputStream();
@@ -79,7 +79,7 @@ class AvailableViewInfoTest {
     }
 
     @Test
-    public void testJsonSerialization() throws JacksonException {
+    void testJsonSerialization() throws JacksonException {
         var info = createInfo(true, true);
         var json = mapper.writeValueAsString(info);
         assertEquals(info, mapper.readValue(json, AvailableViewInfo.class),
@@ -87,7 +87,7 @@ class AvailableViewInfoTest {
     }
 
     @Test
-    public void testJsonSerializationNull() throws JacksonException {
+    void testJsonSerializationNull() throws JacksonException {
         var info = createInfo(true, false);
         var json = mapper.writeValueAsString(info);
         assertEquals(info, mapper.readValue(json, AvailableViewInfo.class),

--- a/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuConfigurationTest.java
@@ -89,7 +89,7 @@ class MenuConfigurationTest {
     private AutoCloseable closeable;
 
     @BeforeEach
-    public void init() {
+    void init() {
         closeable = MockitoAnnotations.openMocks(this);
         servletContext = new MockServletContext();
         vaadinContext = new MockVaadinContext(servletContext);
@@ -127,13 +127,13 @@ class MenuConfigurationTest {
     }
 
     @AfterEach
-    public void cleanup() throws Exception {
+    void cleanup() throws Exception {
         closeable.close();
         CurrentInstance.clearAll();
     }
 
     @Test
-    public void testWithLoggedInUser_userHasRoles() throws IOException {
+    void testWithLoggedInUser_userHasRoles() throws IOException {
         Mockito.when(request.getUserPrincipal())
                 .thenReturn(Mockito.mock(Principal.class));
         Mockito.when(request.isUserInRole(Mockito.anyString()))
@@ -155,7 +155,7 @@ class MenuConfigurationTest {
     }
 
     @Test
-    public void getMenuItemsList_returnsCorrectPaths() throws IOException {
+    void getMenuItemsList_returnsCorrectPaths() throws IOException {
         File generated = Files.createDirectories(tmpDir.resolve(GENERATED))
                 .toFile();
         File clientFiles = new File(generated, FILE_ROUTES_JSON_NAME);
@@ -187,7 +187,7 @@ class MenuConfigurationTest {
     }
 
     @Test
-    public void getMenuItemsList_assertOrder() {
+    void getMenuItemsList_assertOrder() {
         RouteConfiguration routeConfiguration = RouteConfiguration
                 .forRegistry(registry);
         Arrays.asList(MenuRegistryTest.TestRouteA.class,
@@ -206,7 +206,7 @@ class MenuConfigurationTest {
     }
 
     @Test
-    public void getPageHeader_serverSideRoutes_withContentComponent_pageHeadersFromAnnotationAndName() {
+    void getPageHeader_serverSideRoutes_withContentComponent_pageHeadersFromAnnotationAndName() {
         RouteConfiguration routeConfiguration = RouteConfiguration
                 .forRegistry(registry);
         Arrays.asList(NormalRoute.class, NormalRouteWithPageTitle.class,
@@ -264,7 +264,7 @@ class MenuConfigurationTest {
     }
 
     @Test
-    public void getPageHeader_serverSideRoutes_noContentComponent_pageHeadersOnlyForMenuEntries() {
+    void getPageHeader_serverSideRoutes_noContentComponent_pageHeadersOnlyForMenuEntries() {
         RouteConfiguration routeConfiguration = RouteConfiguration
                 .forRegistry(registry);
         Arrays.asList(NormalRoute.class, NormalRouteWithPageTitle.class,
@@ -315,7 +315,7 @@ class MenuConfigurationTest {
     }
 
     @Test
-    public void testGetPageHeader_clientViews_pageHeaderFromTitle()
+    void testGetPageHeader_clientViews_pageHeaderFromTitle()
             throws IOException {
         Mockito.when(request.getUserPrincipal())
                 .thenReturn(Mockito.mock(Principal.class));

--- a/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuRegistryTest.java
@@ -95,7 +95,7 @@ class MenuRegistryTest {
     private MockedStatic<FrontendUtils> frontendUtils;
 
     @BeforeEach
-    public void init() {
+    void init() {
         closeable = MockitoAnnotations.openMocks(this);
         servletContext = new MockServletContext();
         vaadinContext = new MockVaadinContext(servletContext);
@@ -137,14 +137,14 @@ class MenuRegistryTest {
     }
 
     @AfterEach
-    public void cleanup() throws Exception {
+    void cleanup() throws Exception {
         frontendUtils.close();
         closeable.close();
         CurrentInstance.clearAll();
     }
 
     @Test
-    public void getMenuItemsContainsExpectedClientPaths() throws IOException {
+    void getMenuItemsContainsExpectedClientPaths() throws IOException {
         File generated = Files.createDirectories(tmpDir.resolve(GENERATED))
                 .toFile();
         File clientFiles = new File(generated, FILE_ROUTES_JSON_NAME);
@@ -158,8 +158,7 @@ class MenuRegistryTest {
     }
 
     @Test
-    public void getMenuItemsWithNestedFiltering_doesNotThrow()
-            throws IOException {
+    void getMenuItemsWithNestedFiltering_doesNotThrow() throws IOException {
         File generated = Files.createDirectories(tmpDir.resolve(GENERATED))
                 .toFile();
         File clientFiles = new File(generated, FILE_ROUTES_JSON_NAME);
@@ -172,8 +171,7 @@ class MenuRegistryTest {
     }
 
     @Test
-    public void getMenuItemsNoFilteringContainsAllClientPaths()
-            throws IOException {
+    void getMenuItemsNoFilteringContainsAllClientPaths() throws IOException {
         File generated = Files.createDirectories(tmpDir.resolve(GENERATED))
                 .toFile();
         File clientFiles = new File(generated, FILE_ROUTES_JSON_NAME);
@@ -188,7 +186,7 @@ class MenuRegistryTest {
     }
 
     @Test
-    public void testNonCollidingServerAndClientRoutesDoesNotThrow()
+    void testNonCollidingServerAndClientRoutesDoesNotThrow()
             throws IOException {
         File generated = Files.createDirectories(tmpDir.resolve(GENERATED))
                 .toFile();
@@ -209,8 +207,7 @@ class MenuRegistryTest {
     }
 
     @Test
-    public void testCollidingServerAndClientRouteDoesThrow()
-            throws IOException {
+    void testCollidingServerAndClientRouteDoesThrow() throws IOException {
         assertThrows(InvalidRouteConfigurationException.class, () -> {
             File generated = Files.createDirectories(tmpDir.resolve(GENERATED))
                     .toFile();
@@ -226,7 +223,7 @@ class MenuRegistryTest {
     }
 
     @Test
-    public void productionMode_getMenuItemsContainsExpectedClientPaths()
+    void productionMode_getMenuItemsContainsExpectedClientPaths()
             throws IOException {
         Mockito.when(deploymentConfiguration.isProductionMode())
                 .thenReturn(true);
@@ -258,7 +255,7 @@ class MenuRegistryTest {
     }
 
     @Test
-    public void getMenuItemsContainsExpectedServerPaths() {
+    void getMenuItemsContainsExpectedServerPaths() {
         RouteConfiguration routeConfiguration = RouteConfiguration
                 .forRegistry(registry);
         Arrays.asList(MyRoute.class, MyInfo.class)
@@ -272,8 +269,7 @@ class MenuRegistryTest {
     }
 
     @Test
-    public void getMenuItemsContainBothClientAndServerPaths()
-            throws IOException {
+    void getMenuItemsContainBothClientAndServerPaths() throws IOException {
         File generated = Files.createDirectories(tmpDir.resolve(GENERATED))
                 .toFile();
         File clientFiles = new File(generated, FILE_ROUTES_JSON_NAME);
@@ -293,7 +289,7 @@ class MenuRegistryTest {
     }
 
     @Test
-    public void collectMenuItems_returnsCorrectPaths() throws IOException {
+    void collectMenuItems_returnsCorrectPaths() throws IOException {
         File generated = Files.createDirectories(tmpDir.resolve(GENERATED))
                 .toFile();
         File clientFiles = new File(generated, FILE_ROUTES_JSON_NAME);
@@ -316,7 +312,7 @@ class MenuRegistryTest {
     }
 
     @Test
-    public void testWithLoggedInUser_userHasRoles() throws IOException {
+    void testWithLoggedInUser_userHasRoles() throws IOException {
         Mockito.when(request.getUserPrincipal())
                 .thenReturn(Mockito.mock(Principal.class));
         Mockito.when(request.isUserInRole(Mockito.anyString()))
@@ -345,7 +341,7 @@ class MenuRegistryTest {
     }
 
     @Test
-    public void testWithLoggedInUser_noMatchingRoles() throws IOException {
+    void testWithLoggedInUser_noMatchingRoles() throws IOException {
         Mockito.when(request.getUserPrincipal())
                 .thenReturn(Mockito.mock(Principal.class));
         Mockito.when(request.isUserInRole(Mockito.anyString()))
@@ -364,7 +360,7 @@ class MenuRegistryTest {
     }
 
     @Test
-    public void getMenuItemsList_returnsCorrectPaths() throws IOException {
+    void getMenuItemsList_returnsCorrectPaths() throws IOException {
         File generated = Files.createDirectories(tmpDir.resolve(GENERATED))
                 .toFile();
         File clientFiles = new File(generated, FILE_ROUTES_JSON_NAME);
@@ -393,7 +389,7 @@ class MenuRegistryTest {
     }
 
     @Test
-    public void getMenuItemsList_assertOrder() {
+    void getMenuItemsList_assertOrder() {
         RouteConfiguration routeConfiguration = RouteConfiguration
                 .forRegistry(registry);
         Arrays.asList(TestRouteA.class, TestRouteB.class, TestRouteC.class,
@@ -407,7 +403,7 @@ class MenuRegistryTest {
     }
 
     @Test
-    public void hasHillaAutoLayout_fileRoutesHasSingleRootLayout_true()
+    void hasHillaAutoLayout_fileRoutesHasSingleRootLayout_true()
             throws IOException {
         ArrayNode fileRoutes = (ArrayNode) JacksonUtils.getMapper()
                 .readTree(testClientRouteFile);
@@ -419,7 +415,7 @@ class MenuRegistryTest {
     }
 
     @Test
-    public void hasHillaAutoLayout_fileRoutesHasEmptyChildren_true()
+    void hasHillaAutoLayout_fileRoutesHasEmptyChildren_true()
             throws IOException {
         ArrayNode fileRoutes = (ArrayNode) JacksonUtils.getMapper()
                 .readTree(emptyChildren);
@@ -432,7 +428,7 @@ class MenuRegistryTest {
     }
 
     @Test
-    public void hasHillaAutoLayout_fileRoutesHasSingleRootRoute_false()
+    void hasHillaAutoLayout_fileRoutesHasSingleRootRoute_false()
             throws IOException {
         assertFalse(singleRoute.contains("\"children\""));
 
@@ -440,13 +436,13 @@ class MenuRegistryTest {
     }
 
     @Test
-    public void hasHillaAutoLayout_fileRoutesHasMultipleRootRoutes_false()
+    void hasHillaAutoLayout_fileRoutesHasMultipleRootRoutes_false()
             throws IOException {
         assertHasHillaMainLayout(multipleRootRoutes, false);
     }
 
     @Test
-    public void hasHillaAutoLayout_fileRoutesHasNonEmptyRoute_false()
+    void hasHillaAutoLayout_fileRoutesHasNonEmptyRoute_false()
             throws IOException {
         assertHasHillaMainLayout(nonEmptyRoute, false);
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/AbstractRouteRegistryInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/AbstractRouteRegistryInitializerTest.java
@@ -127,7 +127,7 @@ class AbstractRouteRegistryInitializerTest {
     }
 
     @Test
-    public void routeAndParentLayout_notRouterLayout_throws() {
+    void routeAndParentLayout_notRouterLayout_throws() {
         assertThrows(InvalidRouteLayoutConfigurationException.class, () -> {
             initializer.validateRouteClasses(context,
                     Stream.of(RouteAndParentLayout.class));
@@ -135,7 +135,7 @@ class AbstractRouteRegistryInitializerTest {
     }
 
     @Test
-    public void validateRouteClasses_annotationOnNonComponentClass_throws() {
+    void validateRouteClasses_annotationOnNonComponentClass_throws() {
         InvalidRouteConfigurationException exception = assertThrows(
                 InvalidRouteConfigurationException.class,
                 () -> initializer.validateRouteClasses(context,
@@ -147,7 +147,7 @@ class AbstractRouteRegistryInitializerTest {
     }
 
     @Test
-    public void validateRouteClasses_samePathForRouteAndAlias_throws() {
+    void validateRouteClasses_samePathForRouteAndAlias_throws() {
         InvalidRouteConfigurationException exception = assertThrows(
                 InvalidRouteConfigurationException.class,
                 () -> initializer.validateRouteClasses(context,
@@ -161,7 +161,7 @@ class AbstractRouteRegistryInitializerTest {
     }
 
     @Test
-    public void validateRouteClasses_samePathForRepeatableAlias_throws() {
+    void validateRouteClasses_samePathForRepeatableAlias_throws() {
         InvalidRouteConfigurationException exception = assertThrows(
                 InvalidRouteConfigurationException.class,
                 () -> initializer.validateRouteClasses(context,
@@ -178,7 +178,7 @@ class AbstractRouteRegistryInitializerTest {
     }
 
     @Test
-    public void validateRouteClasses_samePathForRouteAndAlias_sameLayoutPrefix_throws() {
+    void validateRouteClasses_samePathForRouteAndAlias_sameLayoutPrefix_throws() {
         InvalidRouteConfigurationException exception = assertThrows(
                 InvalidRouteConfigurationException.class,
                 () -> initializer.validateRouteClasses(context, Stream
@@ -192,7 +192,7 @@ class AbstractRouteRegistryInitializerTest {
     }
 
     @Test
-    public void validateRouteClasses_samePathForRouteAndAlias_sameNestedLayoutPrefix_throws() {
+    void validateRouteClasses_samePathForRouteAndAlias_sameNestedLayoutPrefix_throws() {
         InvalidRouteConfigurationException exception = assertThrows(
                 InvalidRouteConfigurationException.class,
                 () -> initializer.validateRouteClasses(context, Stream.of(
@@ -206,7 +206,7 @@ class AbstractRouteRegistryInitializerTest {
     }
 
     @Test
-    public void validateRouteClasses_samePathForRouteAndAlias_differentLayoutPrefix_doNotThrow() {
+    void validateRouteClasses_samePathForRouteAndAlias_differentLayoutPrefix_doNotThrow() {
         Set<Class<? extends Component>> classes = initializer
                 .validateRouteClasses(context, Stream.of(
                         RouteAndAliasWithSamePathDifferentLayoutPrefix.class));
@@ -216,7 +216,7 @@ class AbstractRouteRegistryInitializerTest {
     }
 
     @Test
-    public void routeAndParentLayout_routerLayout_returnsValidatedClass() {
+    void routeAndParentLayout_routerLayout_returnsValidatedClass() {
         Set<Class<? extends Component>> classes = initializer
                 .validateRouteClasses(context,
                         Stream.of(RouteAndParentRouterLayout.class));

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/AnnotationValidatorTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/AnnotationValidatorTest.java
@@ -52,7 +52,7 @@ class AnnotationValidatorTest {
     private ServletContext servletContext;
 
     @BeforeEach
-    public void init() {
+    void init() {
         annotationValidator = new AnnotationValidator();
         servletContext = Mockito.mock(ServletContext.class);
     }
@@ -97,7 +97,7 @@ class AnnotationValidatorTest {
     }
 
     @Test
-    public void onStartUp_all_failing_anotations_are_reported()
+    void onStartUp_all_failing_anotations_are_reported()
             throws ServletException {
         InvalidApplicationConfigurationException thrown = assertThrows(
                 InvalidApplicationConfigurationException.class,
@@ -128,7 +128,7 @@ class AnnotationValidatorTest {
     }
 
     @Test
-    public void onStartUp_all_failing_annotations_are_marked_for_class()
+    void onStartUp_all_failing_annotations_are_marked_for_class()
             throws ServletException {
         InvalidApplicationConfigurationException thrown = assertThrows(
                 InvalidApplicationConfigurationException.class,
@@ -144,7 +144,7 @@ class AnnotationValidatorTest {
     }
 
     @Test
-    public void onStartUp_no_exception_is_thrown_for_correctly_setup_classes()
+    void onStartUp_no_exception_is_thrown_for_correctly_setup_classes()
             throws ServletException {
         annotationValidator
                 .process(Stream.of(MultiAnnotation.class, AbstractMain.class)
@@ -191,7 +191,7 @@ class AnnotationValidatorTest {
     }
 
     @Test
-    public void selfReferencesAreRemoved() {
+    void selfReferencesAreRemoved() {
         HandlesTypesTest annotationTest = new HandlesTypesTest();
         assertTypes(annotationTest, Set.of(Viewport.class), Set.of());
         assertTypes(annotationTest,

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/ApplicationConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/ApplicationConfigurationTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class ApplicationConfigurationTest {
 
     @Test
-    public void get_contextHasNoLookup_iseIsThrown() {
+    void get_contextHasNoLookup_iseIsThrown() {
         assertThrows(IllegalStateException.class, () -> {
             VaadinContext context = Mockito.spy(VaadinContext.class);
             Mockito.when(context.getAttribute(Lookup.class)).thenReturn(null);

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/ApplicationRouteRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/ApplicationRouteRegistryTest.java
@@ -52,19 +52,19 @@ class ApplicationRouteRegistryTest extends RouteRegistryTestBase {
     private ApplicationRouteRegistry registry;
 
     @BeforeEach
-    public void init() {
+    void init() {
         registry = ApplicationRouteRegistry.getInstance(
                 new VaadinServletContext(Mockito.mock(ServletContext.class)));
     }
 
     @Test
-    public void assertApplicationRegistry() {
+    void assertApplicationRegistry() {
         assertEquals(ApplicationRouteRegistry.class,
                 getTestedRegistry().getClass());
     }
 
     @Test
-    public void updateRoutesFromMultipleThreads_allRoutesAreRegistered()
+    void updateRoutesFromMultipleThreads_allRoutesAreRegistered()
             throws InterruptedException, ExecutionException {
 
         List<Callable<Result>> callables = new ArrayList<>();
@@ -125,7 +125,7 @@ class ApplicationRouteRegistryTest extends RouteRegistryTestBase {
     }
 
     @Test
-    public void updateAndRemoveFromMultipleThreads_endResultAsExpected()
+    void updateAndRemoveFromMultipleThreads_endResultAsExpected()
             throws InterruptedException, ExecutionException {
 
         getTestedRegistry().setRoute("home", MyRoute.class,
@@ -204,7 +204,7 @@ class ApplicationRouteRegistryTest extends RouteRegistryTestBase {
     }
 
     @Test
-    public void lockingConfiguration_newConfigurationIsGottenOnlyAfterUnlock() {
+    void lockingConfiguration_newConfigurationIsGottenOnlyAfterUnlock() {
         CountDownLatch waitReaderThread = new CountDownLatch(1);
         CountDownLatch waitUpdaterThread = new CountDownLatch(2);
 
@@ -246,7 +246,7 @@ class ApplicationRouteRegistryTest extends RouteRegistryTestBase {
     }
 
     @Test
-    public void routeChangeListener_correctChangesAreReturned() {
+    void routeChangeListener_correctChangesAreReturned() {
         List<RouteBaseData> added = new ArrayList<>();
         List<RouteBaseData> removed = new ArrayList<>();
 
@@ -287,7 +287,7 @@ class ApplicationRouteRegistryTest extends RouteRegistryTestBase {
     }
 
     @Test
-    public void routeChangeListener_blockChangesAreGivenCorrectlyInEvent() {
+    void routeChangeListener_blockChangesAreGivenCorrectlyInEvent() {
         getTestedRegistry().setRoute("", MyRoute.class,
                 Collections.emptyList());
 
@@ -331,7 +331,7 @@ class ApplicationRouteRegistryTest extends RouteRegistryTestBase {
     }
 
     @Test
-    public void routeWithAliases_eventShowsCorrectlyAsRemoved() {
+    void routeWithAliases_eventShowsCorrectlyAsRemoved() {
         List<RouteBaseData> added = new ArrayList<>();
         List<RouteBaseData> removed = new ArrayList<>();
 
@@ -363,7 +363,7 @@ class ApplicationRouteRegistryTest extends RouteRegistryTestBase {
     }
 
     @Test
-    public void setErrorNavigationTargets_abstractClassesAreIgnored() {
+    void setErrorNavigationTargets_abstractClassesAreIgnored() {
         registry.setErrorNavigationTargets(new HashSet<>(
                 Arrays.asList(ErrorView.class, AbstractErrorView.class)));
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/BaseLicenseCheckerServiceInitListenerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/BaseLicenseCheckerServiceInitListenerTest.java
@@ -60,7 +60,7 @@ class BaseLicenseCheckerServiceInitListenerTest {
     ServiceInitEvent event = new ServiceInitEvent(service);
 
     @Test
-    public void serviceInit_productionMode_licenseNotChecked() {
+    void serviceInit_productionMode_licenseNotChecked() {
         config.setProductionMode(true);
         try (MockedStatic<LicenseChecker> licenseChecker = Mockito
                 .mockStatic(LicenseChecker.class)) {
@@ -70,7 +70,7 @@ class BaseLicenseCheckerServiceInitListenerTest {
     }
 
     @Test
-    public void serviceInit_devToolsDisabled_validLicense_noAction() {
+    void serviceInit_devToolsDisabled_validLicense_noAction() {
         config.setProductionMode(false);
         config.setDevToolsEnabled(false);
         try (MockedStatic<LicenseChecker> licenseChecker = Mockito
@@ -89,7 +89,7 @@ class BaseLicenseCheckerServiceInitListenerTest {
     }
 
     @Test
-    public void serviceInit_devToolsDisabled_missingOrInvalid_throws() {
+    void serviceInit_devToolsDisabled_missingOrInvalid_throws() {
         config.setProductionMode(false);
         config.setDevToolsEnabled(false);
         try (MockedStatic<LicenseChecker> licenseChecker = Mockito
@@ -115,7 +115,7 @@ class BaseLicenseCheckerServiceInitListenerTest {
     }
 
     @Test
-    public void serviceInit_devToolsEnabled_missingLicense_delegateHandlingToDevTools() {
+    void serviceInit_devToolsEnabled_missingLicense_delegateHandlingToDevTools() {
         config.setProductionMode(false);
         config.setDevToolsEnabled(true);
         try (MockedStatic<LicenseChecker> licenseChecker = Mockito
@@ -157,7 +157,7 @@ class BaseLicenseCheckerServiceInitListenerTest {
     }
 
     @Test
-    public void serviceInit_devToolsEnabled_missingLicense_multipleListenersCollectedIntoSingleScript() {
+    void serviceInit_devToolsEnabled_missingLicense_multipleListenersCollectedIntoSingleScript() {
         config.setProductionMode(false);
         config.setDevToolsEnabled(true);
         try (MockedStatic<LicenseChecker> licenseChecker = Mockito
@@ -212,7 +212,7 @@ class BaseLicenseCheckerServiceInitListenerTest {
     }
 
     @Test
-    public void serviceInit_devToolsEnabled_invalidLicense_throws() {
+    void serviceInit_devToolsEnabled_invalidLicense_throws() {
         config.setProductionMode(false);
         config.setDevToolsEnabled(true);
         try (MockedStatic<LicenseChecker> licenseChecker = Mockito

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/CustomElementsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/CustomElementsTest.java
@@ -39,19 +39,19 @@ class CustomElementsTest {
     private CustomElements customElements;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         customElements = new CustomElements();
     }
 
     @Test
-    public void addSingleElement() {
+    void addSingleElement() {
         addElementsAndCheckResults(
                 Collections.singletonList(CustomElement.class),
                 Collections.singletonList(CustomElement.class));
     }
 
     @Test
-    public void addDifferentElements() {
+    void addDifferentElements() {
         assertThrows(IllegalStateException.class, () -> {
             addElementsAndCheckResults(
                     Arrays.asList(Tag2_Extend.class, Tag2_NotExtend.class),
@@ -60,7 +60,7 @@ class CustomElementsTest {
     }
 
     @Test
-    public void addExtendingElements_superclassFirst() {
+    void addExtendingElements_superclassFirst() {
         addElementsAndCheckResults(
                 Arrays.asList(CustomElement.class, Tag1_Extend1.class,
                         Tag1_Extend2.class, Tag1_Extend3.class),
@@ -68,7 +68,7 @@ class CustomElementsTest {
     }
 
     @Test
-    public void addExtendingElements_superclassLast() {
+    void addExtendingElements_superclassLast() {
         addElementsAndCheckResults(
                 Arrays.asList(Tag1_Extend1.class, Tag1_Extend2.class,
                         Tag1_Extend3.class, CustomElement.class),
@@ -76,7 +76,7 @@ class CustomElementsTest {
     }
 
     @Test
-    public void addTwoExtendingWithDifferentTag() {
+    void addTwoExtendingWithDifferentTag() {
         addElementsAndCheckResults(
                 Arrays.asList(Tag1_Extend1.class, Tag2_Extend.class),
                 Arrays.asList(Tag1_Extend1.class, Tag2_Extend.class));

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DefaultApplicationConfigurationFactoryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DefaultApplicationConfigurationFactoryTest.java
@@ -55,7 +55,7 @@ class DefaultApplicationConfigurationFactoryTest {
     Path temporaryFolder;
 
     @Test
-    public void create_tokenFileIsReadFromClassloader_externalStatsFileIsReadFromTokenFile_predefinedContext()
+    void create_tokenFileIsReadFromClassloader_externalStatsFileIsReadFromTokenFile_predefinedContext()
             throws MalformedURLException, IOException {
         VaadinContext context = Mockito.mock(VaadinContext.class);
         VaadinConfig config = Mockito.mock(VaadinConfig.class);
@@ -78,7 +78,7 @@ class DefaultApplicationConfigurationFactoryTest {
     }
 
     @Test
-    public void create_tokenFileIsSetViaContext_externalStatsFileIsReadFromTokenFile_predefinedContext()
+    void create_tokenFileIsSetViaContext_externalStatsFileIsReadFromTokenFile_predefinedContext()
             throws MalformedURLException, IOException {
         String content = "{ \"externalStatsFile\":true }";
         VaadinContext context = mockTokenFileViaContextParam(content);
@@ -95,7 +95,7 @@ class DefaultApplicationConfigurationFactoryTest {
     }
 
     @Test
-    public void create_tokenFileIsSetViaContext_externalStatsUrlIsReadFromTokenFile_predefinedContext()
+    void create_tokenFileIsSetViaContext_externalStatsUrlIsReadFromTokenFile_predefinedContext()
             throws MalformedURLException, IOException {
         String content = "{ \"externalStatsUrl\": \"http://my.server/static/stats.json\"}";
         VaadinContext context = mockTokenFileViaContextParam(content);
@@ -114,7 +114,7 @@ class DefaultApplicationConfigurationFactoryTest {
     }
 
     @Test
-    public void create_tokenFileIsReadFromClassloader_externalStatsUrlIsReadFromTokenFile_predefinedContext()
+    void create_tokenFileIsReadFromClassloader_externalStatsUrlIsReadFromTokenFile_predefinedContext()
             throws IOException {
         VaadinContext context = Mockito.mock(VaadinContext.class);
         VaadinConfig config = Mockito.mock(VaadinConfig.class);
@@ -139,7 +139,7 @@ class DefaultApplicationConfigurationFactoryTest {
     }
 
     @Test
-    public void create_propertiesAreReadFromContext() throws IOException {
+    void create_propertiesAreReadFromContext() throws IOException {
         VaadinContext context = Mockito.mock(VaadinContext.class);
         VaadinConfig config = Mockito.mock(VaadinConfig.class);
         ResourceProvider resourceProvider = mockResourceProvider(config,
@@ -162,22 +162,21 @@ class DefaultApplicationConfigurationFactoryTest {
     }
 
     @Test
-    public void create_tokenFileWithPremiumFlag_premiumFlagIsPropagatedToDeploymentConfiguration()
+    void create_tokenFileWithPremiumFlag_premiumFlagIsPropagatedToDeploymentConfiguration()
             throws IOException {
         assertTokenAttributeIsPropagatedToDeploymentConfiguration(
                 Constants.PREMIUM_FEATURES, true);
     }
 
     @Test
-    public void create_tokenFileWithCommercialBannerFlag_commercialBannerFlagIsPropagatedToDeploymentConfiguration()
+    void create_tokenFileWithCommercialBannerFlag_commercialBannerFlagIsPropagatedToDeploymentConfiguration()
             throws IOException {
         assertTokenAttributeIsPropagatedToDeploymentConfiguration(
                 Constants.COMMERCIAL_BANNER_TOKEN, true);
     }
 
     @Test
-    public void getMode_returnsLivereload_tailwindCssIsEnabled()
-            throws IOException {
+    void getMode_returnsLivereload_tailwindCssIsEnabled() throws IOException {
         VaadinContext context = Mockito.mock(VaadinContext.class);
         VaadinConfig config = Mockito.mock(VaadinConfig.class);
         ResourceProvider resourceProvider = mockResourceProvider(config,

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/LookupServletContainerInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/LookupServletContainerInitializerTest.java
@@ -116,7 +116,7 @@ class LookupServletContainerInitializerTest {
     }
 
     @Test
-    public void processLookupServletContainerInitializer_resourceProviderIsProvidedAsScannedClass_lookupReturnsTheProviderInstance()
+    void processLookupServletContainerInitializer_resourceProviderIsProvidedAsScannedClass_lookupReturnsTheProviderInstance()
             throws ServletException {
         Lookup lookup = mockLookup(TestResourceProvider.class);
 
@@ -133,7 +133,7 @@ class LookupServletContainerInitializerTest {
     }
 
     @Test
-    public void processLookupServletContainerInitializer_polymerPublishedEventHandlerIsProvidedAsScannedClass_lookupReturnsTheProviderInstance()
+    void processLookupServletContainerInitializer_polymerPublishedEventHandlerIsProvidedAsScannedClass_lookupReturnsTheProviderInstance()
             throws ServletException {
         Lookup lookup = mockLookup(TestPolymerPublishedEventHandler.class);
 
@@ -152,7 +152,7 @@ class LookupServletContainerInitializerTest {
     }
 
     @Test
-    public void processLookupServletContainerInitializer_routePathProviderIsProvidedAsScannedClass_lookupReturnsTheProviderInstance()
+    void processLookupServletContainerInitializer_routePathProviderIsProvidedAsScannedClass_lookupReturnsTheProviderInstance()
             throws ServletException {
         Lookup lookup = mockLookup(TestRoutePathProvider.class);
 
@@ -169,7 +169,7 @@ class LookupServletContainerInitializerTest {
     }
 
     @Test
-    public void processLookupServletContainerInitializer_contextHasDeferredInitializers_runInitializersAndClearAttribute()
+    void processLookupServletContainerInitializer_contextHasDeferredInitializers_runInitializersAndClearAttribute()
             throws ServletException {
         ServletContext context = Mockito.mock(ServletContext.class);
         DeferredServletContextInitializers deferredInitializers = Mockito
@@ -185,7 +185,7 @@ class LookupServletContainerInitializerTest {
     }
 
     @Test
-    public void processApplicationConfigurationFactory_factoryIsProvided_providedFactoryIsCreated()
+    void processApplicationConfigurationFactory_factoryIsProvided_providedFactoryIsCreated()
             throws ServletException {
         Lookup lookup = mockLookup(DefaultApplicationConfigurationFactory.class,
                 TestApplicationConfigurationFactory.class);
@@ -197,7 +197,7 @@ class LookupServletContainerInitializerTest {
     }
 
     @Test
-    public void process_customLookupInitializerIsProvided_servicesHasCustomImpls_customInitializerIsCalledWithProvidedImpls()
+    void process_customLookupInitializerIsProvided_servicesHasCustomImpls_customInitializerIsCalledWithProvidedImpls()
             throws ServletException {
         Lookup lookup = mockLookup(TestPolymerPublishedEventHandler.class,
                 TestResourceProvider.class,
@@ -218,7 +218,7 @@ class LookupServletContainerInitializerTest {
     }
 
     @Test
-    public void getServiceTypes_getServiceTypesIsInvoked_initializerIsInvokdedWithProvidedServices()
+    void getServiceTypes_getServiceTypesIsInvoked_initializerIsInvokdedWithProvidedServices()
             throws ServletException {
         initializer = new LookupServletContainerInitializer() {
             @Override
@@ -243,7 +243,7 @@ class LookupServletContainerInitializerTest {
     }
 
     @Test
-    public void process_classSetIsNull_throws() throws ServletException {
+    void process_classSetIsNull_throws() throws ServletException {
         assertThrows(ServletException.class, () -> {
             initializer.process(null, Mockito.mock(ServletContext.class));
         });

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/RouteRegistryInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/RouteRegistryInitializerTest.java
@@ -94,7 +94,7 @@ class RouteRegistryInitializerTest {
     private RoutePathProvider pathProvider;
 
     @BeforeEach
-    public void init() {
+    void init() {
         pathProvider = Mockito.mock(RoutePathProvider.class);
         routeRegistryInitializer = new RouteRegistryInitializer();
         registry = new TestRouteRegistry();
@@ -122,7 +122,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void process() throws ServletException {
+    void process() throws ServletException {
         routeRegistryInitializer.process(
                 Stream.of(NavigationTarget.class, NavigationTargetFoo.class,
                         NavigationTargetBar.class).collect(Collectors.toSet()),
@@ -140,7 +140,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void process_no_exception_with_null_arguments() {
+    void process_no_exception_with_null_arguments() {
         try {
             routeRegistryInitializer.process(null, servletContext);
         } catch (Exception e) {
@@ -149,7 +149,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void process_duplicate_routes_throws() throws ServletException {
+    void process_duplicate_routes_throws() throws ServletException {
         assertThrows(ServletException.class, () -> {
             routeRegistryInitializer.process(Stream
                     .of(NavigationTargetFoo.class, NavigationTargetFoo2.class)
@@ -158,8 +158,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void process_duplicate_routesViaAlias_throws()
-            throws ServletException {
+    void process_duplicate_routesViaAlias_throws() throws ServletException {
         assertThrows(ServletException.class, () -> {
             routeRegistryInitializer.process(Stream
                     .of(NavigationTargetBar.class, NavigationTargetBar2.class)
@@ -168,7 +167,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void routeRegistry_fails_for_multiple_registration_of_same_route() {
+    void routeRegistry_fails_for_multiple_registration_of_same_route() {
         InvalidRouteConfigurationException thrown = assertThrows(
                 InvalidRouteConfigurationException.class, () -> {
                     RouteConfiguration.forRegistry(registry)
@@ -190,7 +189,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void routeRegistry_registers_correctly_route_with_parentLayout()
+    void routeRegistry_registers_correctly_route_with_parentLayout()
             throws ServletException {
         routeRegistryInitializer.process(Stream
                 .of(NavigationTarget.class, NavigationTargetFoo.class,
@@ -205,8 +204,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void routeRegistry_fails_on_aloneRouteAlias()
-            throws ServletException {
+    void routeRegistry_fails_on_aloneRouteAlias() throws ServletException {
         assertThrows(InvalidRouteLayoutConfigurationException.class, () -> {
             routeRegistryInitializer.process(
                     Stream.of(NavigationTarget.class, NavigationTargetFoo.class,
@@ -216,7 +214,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void routeRegistry_stores_whole_path_with_parent_route_prefix()
+    void routeRegistry_stores_whole_path_with_parent_route_prefix()
             throws ServletException {
         routeRegistryInitializer.process(
                 Stream.of(ExtendingPrefix.class).collect(Collectors.toSet()),
@@ -232,7 +230,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void routeRegistry_route_with_absolute_ignores_parent_route_prefix()
+    void routeRegistry_route_with_absolute_ignores_parent_route_prefix()
             throws ServletException {
         routeRegistryInitializer.process(
                 Stream.of(AbsoluteRoute.class).collect(Collectors.toSet()),
@@ -248,7 +246,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void routeRegistry_route_with_absolute_parent_prefix_ignores_remaining_parent_route_prefixes()
+    void routeRegistry_route_with_absolute_parent_prefix_ignores_remaining_parent_route_prefixes()
             throws ServletException {
         routeRegistryInitializer.process(
                 Stream.of(MultiLevelRoute.class).collect(Collectors.toSet()),
@@ -259,7 +257,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void routeRegistry_routeWithAlias_parentRoutePrefix()
+    void routeRegistry_routeWithAlias_parentRoutePrefix()
             throws ServletException {
         routeRegistryInitializer.process(Stream.of(MultiLevelRouteAlias.class)
                 .collect(Collectors.toSet()), servletContext);
@@ -279,7 +277,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void routeRegistry_routeWithAlias_parent_prefix_ignores_remaining_parent_route_prefixes()
+    void routeRegistry_routeWithAlias_parent_prefix_ignores_remaining_parent_route_prefixes()
             throws ServletException {
         routeRegistryInitializer.process(Stream.of(MultiLevelRouteAlias.class)
                 .collect(Collectors.toSet()), servletContext);
@@ -288,8 +286,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void routeRegistry_routeWithAlias_absoluteRoute()
-            throws ServletException {
+    void routeRegistry_routeWithAlias_absoluteRoute() throws ServletException {
         routeRegistryInitializer.process(Stream.of(MultiLevelRouteAlias.class)
                 .collect(Collectors.toSet()), servletContext);
 
@@ -298,8 +295,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void routeRegistry_routeWithAlias_noParent()
-            throws ServletException {
+    void routeRegistry_routeWithAlias_noParent() throws ServletException {
         routeRegistryInitializer.process(Stream.of(MultiLevelRouteAlias.class)
                 .collect(Collectors.toSet()), servletContext);
 
@@ -308,7 +304,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void routeRegistry_routeWithAlias_twoParentLevels()
+    void routeRegistry_routeWithAlias_twoParentLevels()
             throws ServletException {
         routeRegistryInitializer.process(Stream.of(MultiLevelRouteAlias.class)
                 .collect(Collectors.toSet()), servletContext);
@@ -318,7 +314,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void routeRegistry_route_returns_registered_string_for_get_url()
+    void routeRegistry_route_returns_registered_string_for_get_url()
             throws ServletException {
         routeRegistryInitializer.process(Stream
                 .of(NavigationTarget.class, NavigationTargetFoo.class,
@@ -335,7 +331,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void routeRegistry_routes_with_parameters_return_parameter_type_for_target_url()
+    void routeRegistry_routes_with_parameters_return_parameter_type_for_target_url()
             throws ServletException {
         routeRegistryInitializer.process(
                 Stream.of(ParameterRoute.class, StringParameterRoute.class)
@@ -354,7 +350,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void routeRegistry_route_returns_string_not_ending_in_dash()
+    void routeRegistry_route_returns_string_not_ending_in_dash()
             throws ServletException {
         routeRegistryInitializer.process(Stream
                 .of(NavigationRootWithParent.class).collect(Collectors.toSet()),
@@ -366,7 +362,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void registration_fails_for_navigation_target_with_duplicate_title()
+    void registration_fails_for_navigation_target_with_duplicate_title()
             throws ServletException {
         DuplicateNavigationTitleException thrown = assertThrows(
                 DuplicateNavigationTitleException.class, () -> {
@@ -381,7 +377,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void registration_fails_for_navigation_target_with_inherited_dynamic_title()
+    void registration_fails_for_navigation_target_with_inherited_dynamic_title()
             throws ServletException {
         DuplicateNavigationTitleException thrown = assertThrows(
                 DuplicateNavigationTitleException.class, () -> {
@@ -396,7 +392,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void registration_succeeds_for_navigation_target_with_inherited_title_annotation()
+    void registration_succeeds_for_navigation_target_with_inherited_title_annotation()
             throws ServletException {
         routeRegistryInitializer.process(
                 Collections.singleton(ChildWithDynamicTitle.class),
@@ -622,8 +618,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void process_wrong_position_view_layout_throws()
-            throws ServletException {
+    void process_wrong_position_view_layout_throws() throws ServletException {
         InvalidRouteLayoutConfigurationException thrown = assertThrows(
                 InvalidRouteLayoutConfigurationException.class, () -> {
                     routeRegistryInitializer
@@ -638,7 +633,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void process_check_only_one_viewport_in_route_chain()
+    void process_check_only_one_viewport_in_route_chain()
             throws ServletException {
         InvalidRouteLayoutConfigurationException thrown = assertThrows(
                 InvalidRouteLayoutConfigurationException.class, () -> {
@@ -655,7 +650,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void process_route_can_not_contain_viewport_if_has_parent()
+    void process_route_can_not_contain_viewport_if_has_parent()
             throws ServletException {
         InvalidRouteLayoutConfigurationException thrown = assertThrows(
                 InvalidRouteLayoutConfigurationException.class, () -> {
@@ -672,7 +667,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void process_one_viewport_in_chain_and_one_for_route_passes()
+    void process_one_viewport_in_chain_and_one_for_route_passes()
             throws ServletException {
         routeRegistryInitializer.process(
                 Stream.of(SingleNavigationTarget.class, RootWithParent.class)
@@ -681,8 +676,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void process_check_also_faulty_alias_route()
-            throws ServletException {
+    void process_check_also_faulty_alias_route() throws ServletException {
         InvalidRouteLayoutConfigurationException thrown = assertThrows(
                 InvalidRouteLayoutConfigurationException.class, () -> {
                     routeRegistryInitializer
@@ -697,7 +691,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void process_valid_alias_does_not_throw() throws ServletException {
+    void process_valid_alias_does_not_throw() throws ServletException {
         routeRegistryInitializer.process(
                 Stream.of(AliasView.class).collect(Collectors.toSet()),
                 servletContext);
@@ -764,7 +758,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void process_wrong_position_body_size_view_layout_throws()
+    void process_wrong_position_body_size_view_layout_throws()
             throws ServletException {
         InvalidRouteLayoutConfigurationException thrown = assertThrows(
                 InvalidRouteLayoutConfigurationException.class, () -> {
@@ -781,7 +775,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void process_check_only_one_body_size_in_route_chain()
+    void process_check_only_one_body_size_in_route_chain()
             throws ServletException {
         InvalidRouteLayoutConfigurationException thrown = assertThrows(
                 InvalidRouteLayoutConfigurationException.class, () -> {
@@ -798,7 +792,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void process_route_can_not_contain_body_size_if_has_parent()
+    void process_route_can_not_contain_body_size_if_has_parent()
             throws ServletException {
         InvalidRouteLayoutConfigurationException thrown = assertThrows(
                 InvalidRouteLayoutConfigurationException.class, () -> {
@@ -815,7 +809,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void process_one_body_size_in_chain_and_one_for_route_passes()
+    void process_one_body_size_in_chain_and_one_for_route_passes()
             throws ServletException {
         routeRegistryInitializer.process(
                 Stream.of(BodySingleNavigationTarget.class,
@@ -824,7 +818,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void process_check_also_faulty_body_size_alias_route()
+    void process_check_also_faulty_body_size_alias_route()
             throws ServletException {
         InvalidRouteLayoutConfigurationException thrown = assertThrows(
                 InvalidRouteLayoutConfigurationException.class, () -> {
@@ -841,7 +835,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void process_valid_body_size_alias_does_not_throw()
+    void process_valid_body_size_alias_does_not_throw()
             throws ServletException {
         routeRegistryInitializer.process(
                 Stream.of(BodyAliasView.class).collect(Collectors.toSet()),
@@ -927,8 +921,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void layout_annotation_on_non_routelayout_throws()
-            throws ServletException {
+    void layout_annotation_on_non_routelayout_throws() throws ServletException {
         InvalidRouteLayoutConfigurationException thrown = assertThrows(
                 InvalidRouteLayoutConfigurationException.class, () -> {
                     routeRegistryInitializer
@@ -943,7 +936,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void same_layout_annotation_values_throws() {
+    void same_layout_annotation_values_throws() {
         StringBuilder messageBuilder = new StringBuilder(
                 "Found duplicate @Layout values in classes:");
         messageBuilder.append("\n").append(" - ")
@@ -962,7 +955,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void process_wrong_position_inline_view_layout_throws()
+    void process_wrong_position_inline_view_layout_throws()
             throws ServletException {
         InvalidRouteLayoutConfigurationException thrown = assertThrows(
                 InvalidRouteLayoutConfigurationException.class, () -> {
@@ -979,7 +972,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void process_check_only_one_inline_in_route_chain()
+    void process_check_only_one_inline_in_route_chain()
             throws ServletException {
         InvalidRouteLayoutConfigurationException thrown = assertThrows(
                 InvalidRouteLayoutConfigurationException.class, () -> {
@@ -996,7 +989,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void process_route_can_not_contain_inline_if_has_parent()
+    void process_route_can_not_contain_inline_if_has_parent()
             throws ServletException {
         InvalidRouteLayoutConfigurationException thrown = assertThrows(
                 InvalidRouteLayoutConfigurationException.class, () -> {
@@ -1012,7 +1005,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void process_one_inline_in_chain_and_one_for_route_passes()
+    void process_one_inline_in_chain_and_one_for_route_passes()
             throws ServletException {
         routeRegistryInitializer.process(
                 Stream.of(InlineSingleNavigationTarget.class,
@@ -1021,7 +1014,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void process_check_also_faulty_inline_alias_route()
+    void process_check_also_faulty_inline_alias_route()
             throws ServletException {
         InvalidRouteLayoutConfigurationException thrown = assertThrows(
                 InvalidRouteLayoutConfigurationException.class, () -> {
@@ -1038,8 +1031,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void process_valid_inline_alias_does_not_throw()
-            throws ServletException {
+    void process_valid_inline_alias_does_not_throw() throws ServletException {
         routeRegistryInitializer.process(
                 Stream.of(InlineAliasView.class).collect(Collectors.toSet()),
                 servletContext);
@@ -1048,8 +1040,7 @@ class RouteRegistryInitializerTest {
     /* RouteData tests */
 
     @Test
-    public void routeData_returns_all_registered_routes()
-            throws ServletException {
+    void routeData_returns_all_registered_routes() throws ServletException {
         Set<Class<?>> routes = Stream.of(NavigationTarget.class,
                 NavigationTargetFoo.class, NavigationTargetBar.class)
                 .collect(Collectors.toSet());
@@ -1068,8 +1059,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void routeData_gets_correct_urls_for_targets()
-            throws ServletException {
+    void routeData_gets_correct_urls_for_targets() throws ServletException {
         routeRegistryInitializer.process(Stream.of(NavigationTarget.class,
                 NavigationRootWithParent.class, AbsoluteRoute.class,
                 ExtendingPrefix.class, StringParameterRoute.class,
@@ -1105,8 +1095,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void routeData_gets_correct_parents_for_targets()
-            throws ServletException {
+    void routeData_gets_correct_parents_for_targets() throws ServletException {
         routeRegistryInitializer.process(Stream.of(NavigationTarget.class,
                 NavigationRootWithParent.class, AbsoluteRoute.class,
                 ExtendingPrefix.class, StringParameterRoute.class,
@@ -1143,7 +1132,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void routeData_gets_correct_parameters_for_targets()
+    void routeData_gets_correct_parameters_for_targets()
             throws ServletException {
         routeRegistryInitializer.process(Stream.of(NavigationTarget.class,
                 NavigationRootWithParent.class, AbsoluteRoute.class,
@@ -1187,7 +1176,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void routeData_for_alias_data_is_correct() throws ServletException {
+    void routeData_for_alias_data_is_correct() throws ServletException {
         routeRegistryInitializer.process(Stream.of(MultiLevelRouteAlias.class)
                 .collect(Collectors.toSet()), servletContext);
 
@@ -1265,7 +1254,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void routeFilter_ignoresRoutes()
+    void routeFilter_ignoresRoutes()
             throws InvalidRouteConfigurationException, ServletException {
         routeRegistryInitializer
                 .process(Stream.of(IgnoredView.class, NavigationTarget.class)
@@ -1287,7 +1276,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void routeFilter_ignoresErrorTargets()
+    void routeFilter_ignoresErrorTargets()
             throws InvalidRouteConfigurationException {
         registry.setErrorNavigationTargets(
                 Stream.of(IgnoredErrorView.class, FileNotFound.class)
@@ -1304,7 +1293,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void registerClassesWithSameRoute_abstractClass_subclass_subclassIsRegistered()
+    void registerClassesWithSameRoute_abstractClass_subclass_subclassIsRegistered()
             throws ServletException {
         LinkedHashSet<Class<?>> classes = new LinkedHashSet<>();
         classes.add(AbstractRouteTarget.class);
@@ -1316,7 +1305,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void registerClassesWithSameRoute_class_abstractSuperClass_subclassIsRegistered()
+    void registerClassesWithSameRoute_class_abstractSuperClass_subclassIsRegistered()
             throws ServletException {
         LinkedHashSet<Class<?>> classes = new LinkedHashSet<>();
         classes.add(BaseRouteTarget.class);
@@ -1328,7 +1317,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void registerClassesWithSameRoute_class_subclass_subclassIsRegistered()
+    void registerClassesWithSameRoute_class_subclass_subclassIsRegistered()
             throws ServletException {
         LinkedHashSet<Class<?>> classes = new LinkedHashSet<>();
         classes.add(BaseRouteTarget.class);
@@ -1340,7 +1329,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void registerClassesWithSameRoute_class_superClass_subclassIsRegistered()
+    void registerClassesWithSameRoute_class_superClass_subclassIsRegistered()
             throws ServletException {
         LinkedHashSet<Class<?>> classes = new LinkedHashSet<>();
         classes.add(SuperRouteTarget.class);
@@ -1352,7 +1341,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void registerClassesWithSameRoute_absatrctClass_unrelatedClass_throws()
+    void registerClassesWithSameRoute_absatrctClass_unrelatedClass_throws()
             throws ServletException {
         assertThrows(ServletException.class, () -> {
             LinkedHashSet<Class<?>> classes = new LinkedHashSet<>();
@@ -1363,7 +1352,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void registerClassesWithSameRoute_unrelatedClass_abstractClass_throws()
+    void registerClassesWithSameRoute_unrelatedClass_abstractClass_throws()
             throws ServletException {
         assertThrows(ServletException.class, () -> {
             LinkedHashSet<Class<?>> classes = new LinkedHashSet<>();
@@ -1374,7 +1363,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void registerClassesWithSameRoute_class_unrelatedClass_throws()
+    void registerClassesWithSameRoute_class_unrelatedClass_throws()
             throws ServletException {
         assertThrows(ServletException.class, () -> {
             LinkedHashSet<Class<?>> classes = new LinkedHashSet<>();
@@ -1385,7 +1374,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void registerClassesWithSameRoute_unrelatedClass_class_throws()
+    void registerClassesWithSameRoute_unrelatedClass_class_throws()
             throws ServletException {
         assertThrows(ServletException.class, () -> {
             LinkedHashSet<Class<?>> classes = new LinkedHashSet<>();
@@ -1396,7 +1385,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void initialize_predicateReturnsTrue_noPrevopusStaticRoutes_cleanIsNotCalled_removeMethodIsNotCalled()
+    void initialize_predicateReturnsTrue_noPrevopusStaticRoutes_cleanIsNotCalled_removeMethodIsNotCalled()
             throws VaadinInitializerException {
         Mockito.when(lookup.lookup(OneTimeInitializerPredicate.class))
                 .thenReturn(() -> true);
@@ -1412,7 +1401,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void initialize_predicateReturnsTrue_sameRouteIsReadded_eventHasNoReaddedRoute()
+    void initialize_predicateReturnsTrue_sameRouteIsReadded_eventHasNoReaddedRoute()
             throws VaadinInitializerException {
         Mockito.when(lookup.lookup(OneTimeInitializerPredicate.class))
                 .thenReturn(() -> true);
@@ -1438,7 +1427,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void initialize_noPredicate_noPrevopusStaticRoutes_cleanIsNotCalled_removeMethodIsNotCalled()
+    void initialize_noPredicate_noPrevopusStaticRoutes_cleanIsNotCalled_removeMethodIsNotCalled()
             throws VaadinInitializerException {
         TestApplicationRouteRegistry registry = new TestApplicationRouteRegistry();
         Mockito.when(servletContext
@@ -1452,7 +1441,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void initialize_noPredicate_hasPrevopusStaticRoutes_previousRoutesAreRemoved()
+    void initialize_noPredicate_hasPrevopusStaticRoutes_previousRoutesAreRemoved()
             throws VaadinInitializerException {
         ApplicationRouteRegistry registry = firstInitRouteRegistry();
 
@@ -1465,7 +1454,7 @@ class RouteRegistryInitializerTest {
     }
 
     @Test
-    public void initialize_noPredicate_hasPrevopusStaticRoutes_addRouteManually_previousRoutesAreRemoved_addedRouteIsPreserved()
+    void initialize_noPredicate_hasPrevopusStaticRoutes_addRouteManually_previousRoutesAreRemoved_addedRouteIsPreserved()
             throws VaadinInitializerException {
         ApplicationRouteRegistry registry = firstInitRouteRegistry();
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/RouteRegistryMenuAccessTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/RouteRegistryMenuAccessTest.java
@@ -54,21 +54,21 @@ class RouteRegistryMenuAccessTest {
     private VaadinRequest vaadinRequest;
 
     @BeforeEach
-    public void init() {
+    void init() {
         registry = ApplicationRouteRegistry.getInstance(
                 new VaadinServletContext(mock(ServletContext.class)));
         this.vaadinRequest = mock(VaadinRequest.class);
     }
 
     @Test
-    public void getRegisteredAccessibleMenuRoutes_withoutRequest_returnEmpty() {
+    void getRegisteredAccessibleMenuRoutes_withoutRequest_returnEmpty() {
         assertEquals(0,
                 registry.getRegisteredAccessibleMenuRoutes(null, null).size(),
                 "No accessible menu routes should be available without VaadinService.");
     }
 
     @Test
-    public void getRegisteredAccessibleMenuRoutes_withoutVaadinService_returnEmpty() {
+    void getRegisteredAccessibleMenuRoutes_withoutVaadinService_returnEmpty() {
         when(vaadinRequest.getService()).thenReturn(null);
         assertEquals(0,
                 registry.getRegisteredAccessibleMenuRoutes(vaadinRequest, null)
@@ -77,7 +77,7 @@ class RouteRegistryMenuAccessTest {
     }
 
     @Test
-    public void getRegisteredAccessibleMenuRoutes_withoutNavAccessControl_noMenuRoutes() {
+    void getRegisteredAccessibleMenuRoutes_withoutNavAccessControl_noMenuRoutes() {
         mockInstantiator(MenuAccessControl.PopulateClientMenu.ALWAYS);
         registry.clean();
         registry.setRoute("home", MyRoute.class, Collections.emptyList());
@@ -90,7 +90,7 @@ class RouteRegistryMenuAccessTest {
     }
 
     @Test
-    public void getRegisteredAccessibleMenuRoutes_populateClientSideMenuIsFalse_noMenuRoute() {
+    void getRegisteredAccessibleMenuRoutes_populateClientSideMenuIsFalse_noMenuRoute() {
         mockInstantiator(MenuAccessControl.PopulateClientMenu.NEVER);
         registry.clean();
         registry.setRoute("home", MyMenuRoute.class, Collections.emptyList());
@@ -102,7 +102,7 @@ class RouteRegistryMenuAccessTest {
     }
 
     @Test
-    public void getRegisteredAccessibleMenuRoutes_populateClientSideMenuIsAutomatic_oneMenuRoute() {
+    void getRegisteredAccessibleMenuRoutes_populateClientSideMenuIsAutomatic_oneMenuRoute() {
         mockInstantiator(MenuAccessControl.PopulateClientMenu.AUTOMATIC);
         registry.clean();
         registry.setRoute("home", MyMenuRoute.class, Collections.emptyList());
@@ -120,7 +120,7 @@ class RouteRegistryMenuAccessTest {
     }
 
     @Test
-    public void getRegisteredAccessibleMenuRoutes_withoutNavAccessControl_oneMenuRoute() {
+    void getRegisteredAccessibleMenuRoutes_withoutNavAccessControl_oneMenuRoute() {
         mockInstantiator(MenuAccessControl.PopulateClientMenu.ALWAYS);
         registry.clean();
         registry.setRoute("hasmenu", MyMenuRoute.class,
@@ -134,7 +134,7 @@ class RouteRegistryMenuAccessTest {
     }
 
     @Test
-    public void getRegisteredAccessibleMenuRoutes_withNavAccessControlWithoutRequest_noAccessibleMenuRoute() {
+    void getRegisteredAccessibleMenuRoutes_withNavAccessControlWithoutRequest_noAccessibleMenuRoute() {
         mockInstantiator(MenuAccessControl.PopulateClientMenu.ALWAYS);
         registry.clean();
         registry.setRoute("hasmenu", MyMenuRoute.class,
@@ -148,12 +148,12 @@ class RouteRegistryMenuAccessTest {
     }
 
     @Test
-    public void getRegisteredAccessibleMenuRoutes_withNavAccessControl_anonymous() {
+    void getRegisteredAccessibleMenuRoutes_withNavAccessControl_anonymous() {
         testAsAnonymous(new NavigationAccessControl());
     }
 
     @Test
-    public void getRegisteredAccessibleMenuRoutes_withNavAccessControl_admin() {
+    void getRegisteredAccessibleMenuRoutes_withNavAccessControl_admin() {
         testAsAdmin(new NavigationAccessControl());
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/RouteRegistryTestBase.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/RouteRegistryTestBase.java
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 abstract class RouteRegistryTestBase {
 
     @Test
-    public void initializedRoutes_routesCanBeAdded() {
+    void initializedRoutes_routesCanBeAdded() {
         getInitializationRegistry().clean();
 
         getInitializationRegistry().setRoute("home", MyRoute.class,
@@ -75,7 +75,7 @@ abstract class RouteRegistryTestBase {
     }
 
     @Test
-    public void registeringRouteWithAlias_RouteDataIsPopulatedCorrectly() {
+    void registeringRouteWithAlias_RouteDataIsPopulatedCorrectly() {
         getInitializationRegistry().clean();
 
         getInitializationRegistry().setRoute("home", MyRoute.class,
@@ -102,7 +102,7 @@ abstract class RouteRegistryTestBase {
     }
 
     @Test
-    public void registeredRouteWithAlias_removingClassRemovesAliases() {
+    void registeredRouteWithAlias_removingClassRemovesAliases() {
         getInitializationRegistry().clean();
 
         getInitializationRegistry().setRoute("withAliases",
@@ -133,7 +133,7 @@ abstract class RouteRegistryTestBase {
     }
 
     @Test
-    public void registeredRouteWithAlias_removingPathLeavesAliases() {
+    void registeredRouteWithAlias_removingPathLeavesAliases() {
         getInitializationRegistry().clean();
 
         getInitializationRegistry().setRoute("withAliases",
@@ -169,7 +169,7 @@ abstract class RouteRegistryTestBase {
     }
 
     @Test
-    public void routesWithParentLayouts_parentLayoutReturnsAsExpected() {
+    void routesWithParentLayouts_parentLayoutReturnsAsExpected() {
         getInitializationRegistry().clean();
 
         getInitializationRegistry().setRoute("MyRoute",
@@ -196,7 +196,7 @@ abstract class RouteRegistryTestBase {
     }
 
     @Test
-    public void registeredParentLayouts_changingListDoesntChangeRegistration() {
+    void registeredParentLayouts_changingListDoesntChangeRegistration() {
         getInitializationRegistry().clean();
 
         List<Class<? extends RouterLayout>> parentChain = new ArrayList<>(
@@ -214,7 +214,7 @@ abstract class RouteRegistryTestBase {
     }
 
     @Test
-    public void registeredParentLayouts_returnedListInSameOrder() {
+    void registeredParentLayouts_returnedListInSameOrder() {
         getInitializationRegistry().clean();
 
         List<Class<? extends RouterLayout>> parentChain = new ArrayList<>(

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/ServletContainerInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/ServletContainerInitializerTest.java
@@ -49,7 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ServletContainerInitializerTest extends ClassFinder {
 
     @Test
-    public void servletContextHasNoLookup_deferredServletContextInitializersAttributeIsSet_processIsNotExecuted()
+    void servletContextHasNoLookup_deferredServletContextInitializersAttributeIsSet_processIsNotExecuted()
             throws ServletException {
         AtomicBoolean processIsExecuted = new AtomicBoolean();
         ClassLoaderAwareServletContainerInitializer initializer = new ClassLoaderAwareServletContainerInitializer() {
@@ -72,7 +72,7 @@ class ServletContainerInitializerTest extends ClassFinder {
     }
 
     @Test
-    public void servletContextHasLookup_deferredServletContextInitializersAttributeIsNotSet_processIsExecuted()
+    void servletContextHasLookup_deferredServletContextInitializersAttributeIsNotSet_processIsExecuted()
             throws ServletException {
         AtomicBoolean processIsExecuted = new AtomicBoolean();
         ClassLoaderAwareServletContainerInitializer initializer = new ClassLoaderAwareServletContainerInitializer() {
@@ -100,7 +100,7 @@ class ServletContainerInitializerTest extends ClassFinder {
     }
 
     @Test
-    public void anyServletContainerInitializerSubclassImplementsFixedServletContainerInitializer()
+    void anyServletContainerInitializerSubclassImplementsFixedServletContainerInitializer()
             throws IOException {
         List<String> rawClasspathEntries = getRawClasspathEntries();
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/ServletDeployerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/ServletDeployerTest.java
@@ -97,14 +97,14 @@ class ServletDeployerTest {
     }
 
     @BeforeEach
-    public void clearCaptures() {
+    void clearCaptures() {
         servletNames = new ArrayList<>();
         servletMappings = new ArrayList<>();
         servletLoadOnStartup = new ArrayList<>();
     }
 
     @Test
-    public void automaticallyRegisterTwoServletsWhenNoServletsPresent()
+    void automaticallyRegisterTwoServletsWhenNoServletsPresent()
             throws Exception {
         deployer.contextInitialized(getContextEvent());
 
@@ -114,8 +114,7 @@ class ServletDeployerTest {
     }
 
     @Test
-    public void doNotRegisterAnythingIfRegistrationIsDisabled()
-            throws Exception {
+    void doNotRegisterAnythingIfRegistrationIsDisabled() throws Exception {
         disableAutomaticServletRegistration = true;
         deployer.contextInitialized(getContextEvent(
                 getServletRegistration("testServlet", TestServlet.class,
@@ -125,7 +124,7 @@ class ServletDeployerTest {
     }
 
     @Test
-    public void registeredNonVaadinServlets_vaadinServletsAreRegistered()
+    void registeredNonVaadinServlets_vaadinServletsAreRegistered()
             throws Exception {
         deployer.contextInitialized(getContextEvent(
                 getServletRegistration("testServlet", TestServlet.class,
@@ -136,7 +135,7 @@ class ServletDeployerTest {
     }
 
     @Test
-    public void frontendServletIsNotRegisteredWhenProductionModeIsActive()
+    void frontendServletIsNotRegisteredWhenProductionModeIsActive()
             throws Exception {
         deployer.contextInitialized(getContextEvent(getServletRegistration(
                 "testServlet", TestServlet.class, singletonList("/test/*"),
@@ -149,7 +148,7 @@ class ServletDeployerTest {
     }
 
     @Test
-    public void frontendServletIsNotRegistered_whenMainServletIsRegistered()
+    void frontendServletIsNotRegistered_whenMainServletIsRegistered()
             throws Exception {
         deployer.contextInitialized(getContextEvent());
 
@@ -159,8 +158,7 @@ class ServletDeployerTest {
     }
 
     @Test
-    public void servletsWithoutClassName_registrationDoesNotFail()
-            throws Exception {
+    void servletsWithoutClassName_registrationDoesNotFail() throws Exception {
         deployer.contextInitialized(getContextEvent(getServletRegistration(
                 "test", null, singletonList("/WEB-INF/test.jsp"),
                 Collections.emptyMap())));
@@ -171,7 +169,7 @@ class ServletDeployerTest {
     }
 
     @Test
-    public void servletIsNotRegisteredWhenAnotherHasTheSamePathMapping_mainServlet()
+    void servletIsNotRegisteredWhenAnotherHasTheSamePathMapping_mainServlet()
             throws Exception {
         deployer.contextInitialized(getContextEvent(
                 getServletRegistration("test", TestServlet.class,
@@ -181,7 +179,7 @@ class ServletDeployerTest {
     }
 
     @Test
-    public void servletIsNotRegisteredWhenAnotherHasTheSamePathMapping_frontendServlet()
+    void servletIsNotRegisteredWhenAnotherHasTheSamePathMapping_frontendServlet()
             throws Exception {
         deployer.contextInitialized(getContextEvent(
                 getServletRegistration("test", TestServlet.class,

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/WebComponentConfigurationRegistryInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/WebComponentConfigurationRegistryInitializerTest.java
@@ -68,7 +68,7 @@ class WebComponentConfigurationRegistryInitializerTest {
     private VaadinContext context;
 
     @BeforeEach
-    public void init() {
+    void init() {
         MockitoAnnotations.initMocks(this);
         Mockito.when(vaadinService.getContext()).thenReturn(context);
         Mockito.when(
@@ -89,12 +89,12 @@ class WebComponentConfigurationRegistryInitializerTest {
     }
 
     @AfterEach
-    public void cleanUp() {
+    void cleanUp() {
         CurrentInstance.clearAll();
     }
 
     @Test
-    public void process() throws ServletException {
+    void process() throws ServletException {
         initializer.process(
                 Stream.of(MyComponentExporter.class, UserBoxExporter.class,
                         ExporterFactory.class).collect(Collectors.toSet()),
@@ -113,7 +113,7 @@ class WebComponentConfigurationRegistryInitializerTest {
     }
 
     @Test
-    public void process_noExceptionWithNullArguments() {
+    void process_noExceptionWithNullArguments() {
         try {
             initializer.process(null, servletContext);
         } catch (Exception e) {
@@ -125,7 +125,7 @@ class WebComponentConfigurationRegistryInitializerTest {
     }
 
     @Test
-    public void process_noExceptionForMultipleCorrectExportsOfTheSameComponent() {
+    void process_noExceptionForMultipleCorrectExportsOfTheSameComponent() {
         try {
             initializer.process(
                     Stream.of(MyComponentExporter.class, SiblingExporter.class)
@@ -138,7 +138,7 @@ class WebComponentConfigurationRegistryInitializerTest {
     }
 
     @Test
-    public void emptySet_noExceptionAndWebComponentsSet() {
+    void emptySet_noExceptionAndWebComponentsSet() {
         try {
             initializer.process(Collections.emptySet(), servletContext);
         } catch (Exception e) {
@@ -148,7 +148,7 @@ class WebComponentConfigurationRegistryInitializerTest {
     }
 
     @Test
-    public void duplicateNamesFoundprocess_exceptionIsThrown()
+    void duplicateNamesFoundprocess_exceptionIsThrown()
             throws ServletException {
         ServletException thrown = assertThrows(ServletException.class, () -> {
             initializer.process(Stream
@@ -162,7 +162,7 @@ class WebComponentConfigurationRegistryInitializerTest {
     }
 
     @Test
-    public void invalidCustomElementName_initializerThrowsException()
+    void invalidCustomElementName_initializerThrowsException()
             throws ServletException {
         ServletException thrown = assertThrows(ServletException.class, () -> {
             initializer.process(
@@ -179,7 +179,7 @@ class WebComponentConfigurationRegistryInitializerTest {
     }
 
     @Test
-    public void duplicatePropertyRegistration_doesNotCauseIssues()
+    void duplicatePropertyRegistration_doesNotCauseIssues()
             throws ServletException {
         initializer.process(
                 Collections.singleton(DuplicatePropertyExporter.class),
@@ -187,7 +187,7 @@ class WebComponentConfigurationRegistryInitializerTest {
     }
 
     @Test
-    public void duplicatePropertyRegistrationBetweenParentAndChild_doesNotCauseIssues()
+    void duplicatePropertyRegistrationBetweenParentAndChild_doesNotCauseIssues()
             throws ServletException {
         initializer.process(Collections.singleton(ExtendingExporter.class),
                 servletContext);

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/WebComponentExporterAwareValidatorTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/WebComponentExporterAwareValidatorTest.java
@@ -50,7 +50,7 @@ class WebComponentExporterAwareValidatorTest {
     private ServletContext servletContext;
 
     @BeforeEach
-    public void init() {
+    void init() {
         annotationValidator = new WebComponentExporterAwareValidator();
         servletContext = Mockito.mock(ServletContext.class);
     }
@@ -90,7 +90,7 @@ class WebComponentExporterAwareValidatorTest {
     }
 
     @Test
-    public void process_no_exception_is_thrown_for_correctly_setup_classes()
+    void process_no_exception_is_thrown_for_correctly_setup_classes()
             throws ServletException {
         annotationValidator
                 .process(Stream.of(AbstractMain.class, WCExporter.class)
@@ -98,8 +98,7 @@ class WebComponentExporterAwareValidatorTest {
     }
 
     @Test
-    public void process_all_failing_anotations_are_reported()
-            throws ServletException {
+    void process_all_failing_anotations_are_reported() throws ServletException {
         try {
             annotationValidator.process(
                     Collections.singleton(ThemeViewportWithParent.class),
@@ -112,7 +111,7 @@ class WebComponentExporterAwareValidatorTest {
     }
 
     @Test
-    public void process_non_linked_push_throws() throws ServletException {
+    void process_non_linked_push_throws() throws ServletException {
         assertNon_linked_theme_throws(NonRoutePush.class, Push.class);
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/AbstractDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/AbstractDownloadHandlerTest.java
@@ -68,7 +68,7 @@ class AbstractDownloadHandlerTest {
     private UI ui;
 
     @BeforeEach
-    public void setUp() throws IOException {
+    void setUp() throws IOException {
         request = Mockito.mock(VaadinRequest.class);
         response = Mockito.mock(VaadinResponse.class);
         session = Mockito.mock(VaadinSession.class);
@@ -107,7 +107,7 @@ class AbstractDownloadHandlerTest {
     }
 
     @Test
-    public void addTransferProgressListener_listenerAdded_listenerInvoked_listenerRemoved_listenerNotInvoked() {
+    void addTransferProgressListener_listenerAdded_listenerInvoked_listenerRemoved_listenerNotInvoked() {
         Registration registration = handler
                 .addTransferProgressListener(listener);
         handler.getListeners().forEach(l -> l.onStart(mockContext));
@@ -120,7 +120,7 @@ class AbstractDownloadHandlerTest {
     }
 
     @Test
-    public void whenStart_onStartCalled() {
+    void whenStart_onStartCalled() {
         SerializableRunnable startHandler = Mockito
                 .mock(SerializableRunnable.class);
         handler.whenStart(startHandler);
@@ -130,7 +130,7 @@ class AbstractDownloadHandlerTest {
     }
 
     @Test
-    public void whenProgress_onProgressCalled() {
+    void whenProgress_onProgressCalled() {
         SerializableBiConsumer<Long, Long> onProgressHandler = Mockito
                 .mock(SerializableBiConsumer.class);
         handler.onProgress(onProgressHandler);
@@ -141,7 +141,7 @@ class AbstractDownloadHandlerTest {
     }
 
     @Test
-    public void multipleHooks_multipleListenersAdded_InvokedInOrder() {
+    void multipleHooks_multipleListenersAdded_InvokedInOrder() {
         List<String> executionOrder = new ArrayList<>();
         handler.whenStart(() -> executionOrder.add("first"));
         handler.whenStart(() -> executionOrder.add("second"));
@@ -152,7 +152,7 @@ class AbstractDownloadHandlerTest {
     }
 
     @Test
-    public void whenComplete() {
+    void whenComplete() {
         SerializableConsumer<Boolean> completeHandler = Mockito
                 .mock(SerializableConsumer.class);
         handler.whenComplete(completeHandler);
@@ -165,7 +165,7 @@ class AbstractDownloadHandlerTest {
     }
 
     @Test
-    public void transferProgressListener_transfer_sessionNotLocked()
+    void transferProgressListener_transfer_sessionNotLocked()
             throws IOException {
         ByteArrayInputStream inputStream = new ByteArrayInputStream(
                 "Hello".getBytes(StandardCharsets.UTF_8));
@@ -179,7 +179,7 @@ class AbstractDownloadHandlerTest {
     }
 
     @Test
-    public void customHandlerWithShorthandCompleteListener_noErrorInTransfer_success_errorInTransfer_failure()
+    void customHandlerWithShorthandCompleteListener_noErrorInTransfer_success_errorInTransfer_failure()
             throws IOException {
         AtomicBoolean successAtomic = new AtomicBoolean(false);
         AbstractDownloadHandler customHandler = new AbstractDownloadHandler<>() {
@@ -219,25 +219,25 @@ class AbstractDownloadHandlerTest {
     }
 
     @Test
-    public void doesNotRequireToCatchIOException() {
+    void doesNotRequireToCatchIOException() {
         DownloadHandler handler = event -> {
             new FileInputStream(new File("foo"));
         };
     }
 
     @Test
-    public void inline_attachmentUsedByDefault() {
+    void inline_attachmentUsedByDefault() {
         assertFalse(handler.isInline());
     }
 
     @Test
-    public void inline_inlinedWhenExplicitlyCalled() {
+    void inline_inlinedWhenExplicitlyCalled() {
         handler.inline();
         assertTrue(handler.isInline());
     }
 
     @Test
-    public void getTransferContext_returnsExpectedContextFromEvent() {
+    void getTransferContext_returnsExpectedContextFromEvent() {
         VaadinRequest request = Mockito.mock(VaadinRequest.class);
         VaadinResponse response = Mockito.mock(VaadinResponse.class);
         VaadinSession session = Mockito.mock(VaadinSession.class);
@@ -263,7 +263,7 @@ class AbstractDownloadHandlerTest {
     }
 
     @Test
-    public void whenStartWithContext_onStartCalled() {
+    void whenStartWithContext_onStartCalled() {
         AtomicBoolean invoked = new AtomicBoolean(false);
         handler.whenStart((context) -> invoked.set(true));
         handler.getListeners()
@@ -272,7 +272,7 @@ class AbstractDownloadHandlerTest {
     }
 
     @Test
-    public void whenProgressWithContext_onProgressCalled() {
+    void whenProgressWithContext_onProgressCalled() {
         AtomicBoolean invoked = new AtomicBoolean(false);
         handler.onProgress((context, current, total) -> invoked.set(true),
                 1024);
@@ -282,7 +282,7 @@ class AbstractDownloadHandlerTest {
     }
 
     @Test
-    public void whenProgressWithContextNoInterval_onProgressCalled() {
+    void whenProgressWithContextNoInterval_onProgressCalled() {
         AtomicBoolean invoked = new AtomicBoolean(false);
         handler.onProgress((context, current, total) -> invoked.set(true));
         handler.getListeners().forEach(listener -> listener
@@ -292,7 +292,7 @@ class AbstractDownloadHandlerTest {
     }
 
     @Test
-    public void whenCompleteWithContext() {
+    void whenCompleteWithContext() {
         AtomicBoolean invoked = new AtomicBoolean(false);
         handler.whenComplete((context, success) -> invoked.set(true));
         handler.getListeners().forEach(listener -> {

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/ClassDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/ClassDownloadHandlerTest.java
@@ -54,7 +54,7 @@ class ClassDownloadHandlerTest {
     private UI ui;
 
     @BeforeEach
-    public void setUp() throws IOException {
+    void setUp() throws IOException {
         request = Mockito.mock(VaadinRequest.class);
         response = Mockito.mock(VaadinResponse.class);
         session = Mockito.mock(VaadinSession.class);
@@ -83,7 +83,7 @@ class ClassDownloadHandlerTest {
     }
 
     @Test
-    public void transferProgressListener_addListener_listenersInvoked()
+    void transferProgressListener_addListener_listenersInvoked()
             throws URISyntaxException, IOException {
         List<String> invocations = new ArrayList<>();
         List<Long> transferredBytesRecords = new ArrayList<>();
@@ -135,7 +135,7 @@ class ClassDownloadHandlerTest {
     }
 
     @Test
-    public void transferProgressListener_addListener_errorOccured_errorlistenerInvoked()
+    void transferProgressListener_addListener_errorOccured_errorlistenerInvoked()
             throws URISyntaxException, IOException {
         DownloadEvent event = Mockito.mock(DownloadEvent.class);
         Mockito.when(event.getSession()).thenReturn(session);
@@ -186,7 +186,7 @@ class ClassDownloadHandlerTest {
     }
 
     @Test
-    public void inline_setFileNameInvokedByDefault() throws IOException {
+    void inline_setFileNameInvokedByDefault() throws IOException {
         DownloadHandler handler = DownloadHandler.forClassResource(
                 this.getClass(), PATH_TO_FILE, "my-download.pdf");
 
@@ -207,7 +207,7 @@ class ClassDownloadHandlerTest {
     }
 
     @Test
-    public void attachment_doesNotSetFileNameWhenInlined() throws IOException {
+    void attachment_doesNotSetFileNameWhenInlined() throws IOException {
         DownloadHandler handler = DownloadHandler.forClassResource(
                 this.getClass(), PATH_TO_FILE, "my-download.pdf").inline();
 
@@ -228,7 +228,7 @@ class ClassDownloadHandlerTest {
     }
 
     @Test
-    public void handleSetToInline_contentDispositionIsInlineWithFilename()
+    void handleSetToInline_contentDispositionIsInlineWithFilename()
             throws IOException {
         DownloadHandler handler = DownloadHandler.forClassResource(
                 this.getClass(), PATH_TO_FILE, "my-download.pdf").inline();

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/DownloadEventTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/DownloadEventTest.java
@@ -32,14 +32,14 @@ class DownloadEventTest {
     private VaadinSession session;
 
     @BeforeEach
-    public void setUp() throws IOException {
+    void setUp() throws IOException {
         request = Mockito.mock(VaadinRequest.class);
         response = Mockito.mock(VaadinResponse.class);
         session = Mockito.mock(VaadinSession.class);
     }
 
     @Test
-    public void setFileName_nonEmptyFileName_setsContentDispositionFilenameQuotedToResponse() {
+    void setFileName_nonEmptyFileName_setsContentDispositionFilenameQuotedToResponse() {
         DownloadEvent downloadEvent = new DownloadEvent(request, response,
                 session, null);
         String fileName = "test.txt";
@@ -49,7 +49,7 @@ class DownloadEventTest {
     }
 
     @Test
-    public void setFileName_nonEmptyFileName_setsContentDispositionEncodedFilenameQuotedToResponse() {
+    void setFileName_nonEmptyFileName_setsContentDispositionEncodedFilenameQuotedToResponse() {
         DownloadEvent downloadEvent = new DownloadEvent(request, response,
                 session, null);
         String fileName = "test üñîçødë.txt";
@@ -60,7 +60,7 @@ class DownloadEventTest {
     }
 
     @Test
-    public void setFileName_emptyFileName_setsContentDispositionToResponse() {
+    void setFileName_emptyFileName_setsContentDispositionToResponse() {
         DownloadEvent downloadEvent = new DownloadEvent(request, response,
                 session, null);
         String fileName = "";
@@ -69,7 +69,7 @@ class DownloadEventTest {
     }
 
     @Test
-    public void setFileName_blankFileName_setsContentDispositionToResponse() {
+    void setFileName_blankFileName_setsContentDispositionToResponse() {
         DownloadEvent downloadEvent = new DownloadEvent(request, response,
                 session, null);
         String fileName = "   ";
@@ -78,7 +78,7 @@ class DownloadEventTest {
     }
 
     @Test
-    public void setFileName_nullFileName_doesNotSetContentDispositionToResponse() {
+    void setFileName_nullFileName_doesNotSetContentDispositionToResponse() {
         DownloadEvent downloadEvent = new DownloadEvent(request, response,
                 session, null);
         downloadEvent.setFileName(null);
@@ -87,7 +87,7 @@ class DownloadEventTest {
     }
 
     @Test
-    public void setFileName_headerAlreadySet_doesNotOverrideHeader() {
+    void setFileName_headerAlreadySet_doesNotOverrideHeader() {
         Mockito.when(response.containsHeader("Content-Disposition"))
                 .thenReturn(true);
         DownloadEvent downloadEvent = new DownloadEvent(request, response,
@@ -98,7 +98,7 @@ class DownloadEventTest {
     }
 
     @Test
-    public void inline_noFileName_setsContentDispositionInlineToResponse() {
+    void inline_noFileName_setsContentDispositionInlineToResponse() {
         DownloadEvent downloadEvent = new DownloadEvent(request, response,
                 session, null);
         downloadEvent.inline();
@@ -106,7 +106,7 @@ class DownloadEventTest {
     }
 
     @Test
-    public void inline_withASCIIFileName_setsContentDispositionInlineWithFilenameToResponse() {
+    void inline_withASCIIFileName_setsContentDispositionInlineWithFilenameToResponse() {
         DownloadEvent downloadEvent = new DownloadEvent(request, response,
                 session, null);
         String fileName = "document.pdf";
@@ -116,7 +116,7 @@ class DownloadEventTest {
     }
 
     @Test
-    public void inline_withNonASCIIFileName_setsContentDispositionInlineWithEncodedFilenameToResponse() {
+    void inline_withNonASCIIFileName_setsContentDispositionInlineWithEncodedFilenameToResponse() {
         DownloadEvent downloadEvent = new DownloadEvent(request, response,
                 session, null);
         String fileName = "dökümänt üñîçødë.pdf";
@@ -128,7 +128,7 @@ class DownloadEventTest {
     }
 
     @Test
-    public void inline_nullFileName_setsContentDispositionInlineToResponse() {
+    void inline_nullFileName_setsContentDispositionInlineToResponse() {
         DownloadEvent downloadEvent = new DownloadEvent(request, response,
                 session, null);
         downloadEvent.inline(null);
@@ -136,7 +136,7 @@ class DownloadEventTest {
     }
 
     @Test
-    public void inline_emptyFileName_setsContentDispositionInlineToResponse() {
+    void inline_emptyFileName_setsContentDispositionInlineToResponse() {
         DownloadEvent downloadEvent = new DownloadEvent(request, response,
                 session, null);
         downloadEvent.inline("");
@@ -144,7 +144,7 @@ class DownloadEventTest {
     }
 
     @Test
-    public void inline_blankFileName_setsContentDispositionInlineToResponse() {
+    void inline_blankFileName_setsContentDispositionInlineToResponse() {
         DownloadEvent downloadEvent = new DownloadEvent(request, response,
                 session, null);
         downloadEvent.inline("   ");
@@ -152,7 +152,7 @@ class DownloadEventTest {
     }
 
     @Test
-    public void inline_headerAlreadySet_doesNotOverrideHeader() {
+    void inline_headerAlreadySet_doesNotOverrideHeader() {
         Mockito.when(response.containsHeader("Content-Disposition"))
                 .thenReturn(true);
         DownloadEvent downloadEvent = new DownloadEvent(request, response,
@@ -163,7 +163,7 @@ class DownloadEventTest {
     }
 
     @Test
-    public void inline_withFileNameHeaderAlreadySet_doesNotOverrideHeader() {
+    void inline_withFileNameHeaderAlreadySet_doesNotOverrideHeader() {
         Mockito.when(response.containsHeader("Content-Disposition"))
                 .thenReturn(true);
         DownloadEvent downloadEvent = new DownloadEvent(request, response,
@@ -174,7 +174,7 @@ class DownloadEventTest {
     }
 
     @Test
-    public void setContentType_setsContentTypeToResponse() {
+    void setContentType_setsContentTypeToResponse() {
         DownloadEvent downloadEvent = new DownloadEvent(request, response,
                 session, null);
         String contentType = "application/pdf";
@@ -183,7 +183,7 @@ class DownloadEventTest {
     }
 
     @Test
-    public void setContentLenght_setsContentLengthToResponse() {
+    void setContentLenght_setsContentLengthToResponse() {
         DownloadEvent downloadEvent = new DownloadEvent(request, response,
                 session, null);
         int contentLength = 1024;
@@ -192,7 +192,7 @@ class DownloadEventTest {
     }
 
     @Test
-    public void setContentLenght_unknownLength_doesNotSetContentLengthToResponse() {
+    void setContentLenght_unknownLength_doesNotSetContentLengthToResponse() {
         DownloadEvent downloadEvent = new DownloadEvent(request, response,
                 session, null);
         int contentLength = -1;

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/FileDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/FileDownloadHandlerTest.java
@@ -59,7 +59,7 @@ class FileDownloadHandlerTest {
     private Element owner;
 
     @BeforeEach
-    public void setUp() throws IOException {
+    void setUp() throws IOException {
         request = Mockito.mock(VaadinRequest.class);
         response = Mockito.mock(VaadinResponse.class);
         session = Mockito.mock(VaadinSession.class);
@@ -88,7 +88,7 @@ class FileDownloadHandlerTest {
     }
 
     @Test
-    public void transferProgressListener_addListener_listenersInvoked()
+    void transferProgressListener_addListener_listenersInvoked()
             throws URISyntaxException, IOException {
         List<String> invocations = new ArrayList<>();
         List<Long> transferredBytesRecords = new ArrayList<>();
@@ -142,7 +142,7 @@ class FileDownloadHandlerTest {
     }
 
     @Test
-    public void transferProgressListener_addListener_errorOccured_errorlistenerInvoked()
+    void transferProgressListener_addListener_errorOccured_errorlistenerInvoked()
             throws URISyntaxException {
         List<String> invocations = new ArrayList<>();
         DownloadHandler handler = DownloadHandler.forFile(
@@ -193,7 +193,7 @@ class FileDownloadHandlerTest {
     }
 
     @Test
-    public void inline_setFileNameInvokedByDefault()
+    void inline_setFileNameInvokedByDefault()
             throws IOException, URISyntaxException {
         URL resource = getClass().getClassLoader().getResource(PATH_TO_FILE);
         DownloadHandler handler = DownloadHandler
@@ -217,7 +217,7 @@ class FileDownloadHandlerTest {
     }
 
     @Test
-    public void attachment_doesNotSetFileNameWhenInlined()
+    void attachment_doesNotSetFileNameWhenInlined()
             throws IOException, URISyntaxException {
         URL resource = getClass().getClassLoader().getResource(PATH_TO_FILE);
         DownloadHandler handler = DownloadHandler
@@ -242,7 +242,7 @@ class FileDownloadHandlerTest {
     }
 
     @Test
-    public void handleSetToInline_contentDispositionIsInlineWithFilename()
+    void handleSetToInline_contentDispositionIsInlineWithFilename()
             throws IOException, URISyntaxException {
         URL resource = getClass().getClassLoader().getResource(PATH_TO_FILE);
         DownloadHandler handler = DownloadHandler

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/InputStreamDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/InputStreamDownloadHandlerTest.java
@@ -58,7 +58,7 @@ class InputStreamDownloadHandlerTest {
     private UI ui;
 
     @BeforeEach
-    public void setUp() throws IOException {
+    void setUp() throws IOException {
         request = Mockito.mock(VaadinRequest.class);
         response = Mockito.mock(VaadinResponse.class);
         session = Mockito.mock(VaadinSession.class);
@@ -87,7 +87,7 @@ class InputStreamDownloadHandlerTest {
     }
 
     @Test
-    public void transferProgressListener_addListener_listenersInvoked()
+    void transferProgressListener_addListener_listenersInvoked()
             throws URISyntaxException, IOException {
         List<String> invocations = new ArrayList<>();
         List<Long> transferredBytesRecords = new ArrayList<>();
@@ -140,7 +140,7 @@ class InputStreamDownloadHandlerTest {
     }
 
     @Test
-    public void transferProgressListener_addListener_errorOccurred_errorListenerInvoked()
+    void transferProgressListener_addListener_errorOccurred_errorListenerInvoked()
             throws IOException {
         DownloadEvent event = Mockito.mock(DownloadEvent.class);
         Mockito.when(event.getSession()).thenReturn(session);
@@ -178,7 +178,7 @@ class InputStreamDownloadHandlerTest {
     }
 
     @Test
-    public void transferProgressListener_addListener_callbackIOExceptionOccurred_errorListenerInvoked() {
+    void transferProgressListener_addListener_callbackIOExceptionOccurred_errorListenerInvoked() {
         DownloadEvent event = Mockito.mock(DownloadEvent.class);
         Mockito.when(event.getSession()).thenReturn(session);
         Mockito.when(event.getResponse()).thenReturn(response);
@@ -210,7 +210,7 @@ class InputStreamDownloadHandlerTest {
     }
 
     @Test
-    public void transferProgressListener_addListener_callbackUncheckedExceptionOccurred_errorListenerInvoked() {
+    void transferProgressListener_addListener_callbackUncheckedExceptionOccurred_errorListenerInvoked() {
         DownloadEvent event = Mockito.mock(DownloadEvent.class);
         Mockito.when(event.getSession()).thenReturn(session);
         Mockito.when(event.getResponse()).thenReturn(response);
@@ -242,7 +242,7 @@ class InputStreamDownloadHandlerTest {
     }
 
     @Test
-    public void transferProgressListener_addListener_callbackResponseError_errorListenerInvoked()
+    void transferProgressListener_addListener_callbackResponseError_errorListenerInvoked()
             throws IOException {
         DownloadEvent event = Mockito.mock(DownloadEvent.class);
         Mockito.when(event.getSession()).thenReturn(session);
@@ -271,7 +271,7 @@ class InputStreamDownloadHandlerTest {
     }
 
     @Test
-    public void transferProgressListener_addListener_callbackResponseException_errorListenerInvoked()
+    void transferProgressListener_addListener_callbackResponseException_errorListenerInvoked()
             throws IOException {
         DownloadEvent event = Mockito.mock(DownloadEvent.class);
         Mockito.when(event.getSession()).thenReturn(session);
@@ -310,7 +310,7 @@ class InputStreamDownloadHandlerTest {
     }
 
     @Test
-    public void inline_setFileNameInvokedByDefault() throws IOException {
+    void inline_setFileNameInvokedByDefault() throws IOException {
         DownloadEvent event = Mockito.mock(DownloadEvent.class);
         DownloadHandler handler = DownloadHandler.fromInputStream(request -> {
             Mockito.verify(event, Mockito.times(0))
@@ -341,7 +341,7 @@ class InputStreamDownloadHandlerTest {
     }
 
     @Test
-    public void attachment_doesNotSetFileNameWhenInlined() throws IOException {
+    void attachment_doesNotSetFileNameWhenInlined() throws IOException {
         DownloadHandler handler = DownloadHandler.fromInputStream(request -> {
             byte[] data = getBytes();
             ByteArrayInputStream inputStream = new ByteArrayInputStream(data);
@@ -368,7 +368,7 @@ class InputStreamDownloadHandlerTest {
     }
 
     @Test
-    public void inputStreamDownloadCallback_doesNotRequireCatch() {
+    void inputStreamDownloadCallback_doesNotRequireCatch() {
         new InputStreamDownloadHandler(event -> {
             try (InputStream inputStream = new ByteArrayInputStream(
                     getBytes())) {
@@ -379,8 +379,7 @@ class InputStreamDownloadHandlerTest {
     }
 
     @Test
-    public void downloadResponseHasContentType_contentTypeUsed()
-            throws IOException {
+    void downloadResponseHasContentType_contentTypeUsed() throws IOException {
         String contentType = "custom";
         InputStreamDownloadHandler handler = new InputStreamDownloadHandler(
                 event -> {
@@ -400,8 +399,7 @@ class InputStreamDownloadHandlerTest {
     }
 
     @Test
-    public void downloadResponseNullContentType_fileTypeIsUsed()
-            throws IOException {
+    void downloadResponseNullContentType_fileTypeIsUsed() throws IOException {
         String contentType = "file/pdf";
 
         Mockito.when(service.getMimeType("report.pdf")).thenReturn(contentType);
@@ -423,7 +421,7 @@ class InputStreamDownloadHandlerTest {
     }
 
     @Test
-    public void handleSetToInline_contentDispositionIsInlineWithFilename()
+    void handleSetToInline_contentDispositionIsInlineWithFilename()
             throws IOException {
         InputStream stream = Mockito.mock(InputStream.class);
         Mockito.when(
@@ -448,8 +446,7 @@ class InputStreamDownloadHandlerTest {
     }
 
     @Test
-    public void contentLengthProvided_contentLengthHeaderSet()
-            throws IOException {
+    void contentLengthProvided_contentLengthHeaderSet() throws IOException {
         long expectedContentLength = 12345L;
         InputStream stream = Mockito.mock(InputStream.class);
         Mockito.when(

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/ServletResourceDownloadHandlerTest.java
@@ -59,7 +59,7 @@ class ServletResourceDownloadHandlerTest {
     private UI ui;
 
     @BeforeEach
-    public void setUp() throws IOException, URISyntaxException {
+    void setUp() throws IOException, URISyntaxException {
         request = Mockito.mock(VaadinRequest.class);
         response = Mockito.mock(VaadinResponse.class);
         session = Mockito.mock(VaadinSession.class);
@@ -100,7 +100,7 @@ class ServletResourceDownloadHandlerTest {
     }
 
     @Test
-    public void transferProgressListener_addListener_listenersInvoked()
+    void transferProgressListener_addListener_listenersInvoked()
             throws URISyntaxException, IOException {
         List<String> invocations = new ArrayList<>();
         List<Long> transferredBytesRecords = new ArrayList<>();
@@ -151,7 +151,7 @@ class ServletResourceDownloadHandlerTest {
     }
 
     @Test
-    public void transferProgressListener_addListener_errorOccured_errorlistenerInvoked()
+    void transferProgressListener_addListener_errorOccured_errorlistenerInvoked()
             throws URISyntaxException, IOException {
         DownloadEvent downloadEvent = Mockito.mock(DownloadEvent.class);
         Mockito.when(downloadEvent.getRequest()).thenReturn(request);
@@ -204,7 +204,7 @@ class ServletResourceDownloadHandlerTest {
     }
 
     @Test
-    public void inline_setFileNameInvokedByDefault() throws IOException {
+    void inline_setFileNameInvokedByDefault() throws IOException {
         DownloadHandler handler = DownloadHandler
                 .forServletResource(PATH_TO_FILE, "my-download.bin");
 
@@ -227,7 +227,7 @@ class ServletResourceDownloadHandlerTest {
     }
 
     @Test
-    public void attachment_doesNotSetFileNameWhenInlined() throws IOException {
+    void attachment_doesNotSetFileNameWhenInlined() throws IOException {
         DownloadHandler handler = DownloadHandler
                 .forServletResource(PATH_TO_FILE, "my-download.bin").inline();
 
@@ -250,7 +250,7 @@ class ServletResourceDownloadHandlerTest {
     }
 
     @Test
-    public void handleSetToInline_contentDispositionIsInlineWithFilename()
+    void handleSetToInline_contentDispositionIsInlineWithFilename()
             throws IOException {
         DownloadHandler handler = DownloadHandler
                 .forServletResource(PATH_TO_FILE, "my-download.bin").inline();

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/UploadEventTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/UploadEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2025 Vaadin Ltd.
+ * Copyright 2000-2026 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -45,7 +45,7 @@ class UploadEventTest {
     private Element owner;
 
     @BeforeEach
-    public void setUp() throws IOException {
+    void setUp() throws IOException {
         request = Mockito.mock(VaadinRequest.class);
         response = Mockito.mock(VaadinResponse.class);
         session = Mockito.mock(VaadinSession.class);
@@ -56,7 +56,7 @@ class UploadEventTest {
     }
 
     @Test
-    public void testInitialState_notRejected() {
+    void testInitialState_notRejected() {
         UploadEvent event = new UploadEvent(request, response, session,
                 "test.txt", 100L, "text/plain", owner, null);
 
@@ -67,7 +67,7 @@ class UploadEventTest {
     }
 
     @Test
-    public void testReject_withDefaultMessage() {
+    void testReject_withDefaultMessage() {
         UploadEvent event = new UploadEvent(request, response, session,
                 "test.txt", 100L, "text/plain", owner, null);
 
@@ -79,7 +79,7 @@ class UploadEventTest {
     }
 
     @Test
-    public void testReject_withCustomMessage() {
+    void testReject_withCustomMessage() {
         UploadEvent event = new UploadEvent(request, response, session,
                 "test.zip", 100L, "application/zip", owner, null);
 
@@ -92,7 +92,7 @@ class UploadEventTest {
     }
 
     @Test
-    public void testGetInputStream_rejectedUpload_throwsException() {
+    void testGetInputStream_rejectedUpload_throwsException() {
         UploadEvent event = new UploadEvent(request, response, session,
                 "test.txt", 100L, "text/plain", owner, null);
 
@@ -110,7 +110,7 @@ class UploadEventTest {
     }
 
     @Test
-    public void testGetInputStream_beforeRejection_works() {
+    void testGetInputStream_beforeRejection_works() {
         UploadEvent event = new UploadEvent(request, response, session,
                 "test.txt", 100L, "text/plain", owner, null);
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/UploadTransferProgressTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/UploadTransferProgressTest.java
@@ -69,7 +69,7 @@ class UploadTransferProgressTest {
     Path temporaryFolder;
 
     @BeforeEach
-    public void setUp() throws ServletException, ServiceException {
+    void setUp() throws ServletException, ServiceException {
         VaadinService service = new MockVaadinServletService();
         session = new AlwaysLockedVaadinSession(service) {
             @Override
@@ -115,7 +115,7 @@ class UploadTransferProgressTest {
     }
 
     @Test
-    public void transferProgressListener_toFile_addListener_listenersInvoked()
+    void transferProgressListener_toFile_addListener_listenersInvoked()
             throws URISyntaxException, IOException {
         AtomicReference<File> actualFile = new AtomicReference<>();
         AtomicReference<File> expectedFile = new AtomicReference<>();
@@ -143,7 +143,7 @@ class UploadTransferProgressTest {
     }
 
     @Test
-    public void transferProgressListener_toFile_addListener_errorOccured_errorlistenerInvoked()
+    void transferProgressListener_toFile_addListener_errorOccured_errorlistenerInvoked()
             throws URISyntaxException {
         List<String> invocations = new ArrayList<>();
         UploadHandler handler = UploadHandler.toFile((meta, file) -> {
@@ -160,7 +160,7 @@ class UploadTransferProgressTest {
     }
 
     @Test
-    public void transferProgressListener_toTempFile_addListener_listenersInvoked()
+    void transferProgressListener_toTempFile_addListener_listenersInvoked()
             throws URISyntaxException, IOException {
         List<String> invocations = new ArrayList<>();
         List<Long> transferredBytesRecords = new ArrayList<>();
@@ -175,7 +175,7 @@ class UploadTransferProgressTest {
     }
 
     @Test
-    public void transferProgressListener_toTempFile_addListener_errorOccured_errorlistenerInvoked()
+    void transferProgressListener_toTempFile_addListener_errorOccured_errorlistenerInvoked()
             throws URISyntaxException, IOException {
         List<String> invocations = new ArrayList<>();
 
@@ -197,7 +197,7 @@ class UploadTransferProgressTest {
     }
 
     @Test
-    public void transferProgressListener_inMemory_addListener_listenersInvoked()
+    void transferProgressListener_inMemory_addListener_listenersInvoked()
             throws URISyntaxException, IOException {
         List<String> invocations = new ArrayList<>();
         List<Long> transferredBytesRecords = new ArrayList<>();
@@ -212,7 +212,7 @@ class UploadTransferProgressTest {
     }
 
     @Test
-    public void transferProgressListener_inMemory_addListener_errorOccured_errorlistenerInvoked()
+    void transferProgressListener_inMemory_addListener_errorOccured_errorlistenerInvoked()
             throws URISyntaxException, IOException {
         List<String> invocations = new ArrayList<>();
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/PropertyConfigurationImplTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/PropertyConfigurationImplTest.java
@@ -30,13 +30,13 @@ class PropertyConfigurationImplTest {
     PropertyConfigurationImpl<MyComponent, Integer> intPropertyConf;
 
     @BeforeEach
-    public void init() {
+    void init() {
         intPropertyConf = new PropertyConfigurationImpl<>(MyComponent.class,
                 "int", Integer.class, 1);
     }
 
     @Test
-    public void onChange() {
+    void onChange() {
         intPropertyConf.onChange(MyComponent::setInt);
 
         MyComponent myComponent = new MyComponent();
@@ -48,7 +48,7 @@ class PropertyConfigurationImplTest {
     }
 
     @Test
-    public void onChange_throwsIfCalledTwice() {
+    void onChange_throwsIfCalledTwice() {
         assertThrows(IllegalStateException.class, () -> {
             intPropertyConf.onChange(MyComponent::setInt);
             intPropertyConf.onChange(MyComponent::setInt);
@@ -56,7 +56,7 @@ class PropertyConfigurationImplTest {
     }
 
     @Test
-    public void readOnly() {
+    void readOnly() {
         intPropertyConf.readOnly();
 
         PropertyData<Integer> data = intPropertyConf.getPropertyData();

--- a/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/WebComponentBindingTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/WebComponentBindingTest.java
@@ -35,7 +35,7 @@ class WebComponentBindingTest {
     private WebComponentBinding binding;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         component = new MyComponent();
         binding = new WebComponentBinding<>(component);
         PropertyConfigurationImpl<MyComponent, Integer> integerProperty = new PropertyConfigurationImpl<>(
@@ -49,12 +49,12 @@ class WebComponentBindingTest {
     }
 
     @Test
-    public void getComponent() {
+    void getComponent() {
         assertEquals(component, binding.getComponent());
     }
 
     @Test
-    public void getPropertyType() {
+    void getPropertyType() {
         assertEquals(Integer.class, binding.getPropertyType("int"));
         assertEquals(ObjectNode.class, binding.getPropertyType("json"));
 
@@ -62,7 +62,7 @@ class WebComponentBindingTest {
     }
 
     @Test
-    public void hasProperty() {
+    void hasProperty() {
         assertTrue(binding.hasProperty("int"));
         assertTrue(binding.hasProperty("json"));
 
@@ -70,7 +70,7 @@ class WebComponentBindingTest {
     }
 
     @Test
-    public void updateValue() {
+    void updateValue() {
         binding.updateProperty("int", 5);
         assertEquals(5, component.integer);
 
@@ -82,7 +82,7 @@ class WebComponentBindingTest {
     }
 
     @Test
-    public void updateValueJackson() {
+    void updateValueJackson() {
         binding.updateProperty("int", 5);
         assertEquals(5, component.integer);
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/WebComponentConfigurationRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/WebComponentConfigurationRegistryTest.java
@@ -68,7 +68,7 @@ class WebComponentConfigurationRegistryTest {
     }
 
     @BeforeEach
-    public void init() {
+    void init() {
         VaadinService service = mock(VaadinService.class);
         context = mock(VaadinContext.class);
         VaadinService.setCurrent(service);
@@ -84,19 +84,19 @@ class WebComponentConfigurationRegistryTest {
     }
 
     @Test
-    public void assertWebComponentRegistry() {
+    void assertWebComponentRegistry() {
         assertNotNull(registry);
     }
 
     @Test
-    public void assertRegistryIsSingleton() {
+    void assertRegistryIsSingleton() {
         assertSame(registry,
                 WebComponentConfigurationRegistry.getInstance(context),
                 "WebComponentConfigurationRegistry instance should be singleton");
     }
 
     @Test
-    public void setConfigurations_allCanBeFoundInRegistry() {
+    void setConfigurations_allCanBeFoundInRegistry() {
         assertTrue(
                 registry.setConfigurations(createConfigurations(
                         MyComponentExporter.class, UserBoxExporter.class)),
@@ -118,7 +118,7 @@ class WebComponentConfigurationRegistryTest {
     }
 
     @Test
-    public void setConfigurations_getConfigurationsCallDoesNotChangeSetProtection() {
+    void setConfigurations_getConfigurationsCallDoesNotChangeSetProtection() {
         registry.setConfigurations(
                 createConfigurations(MyComponentExporter.class));
 
@@ -137,7 +137,7 @@ class WebComponentConfigurationRegistryTest {
     }
 
     @Test
-    public void getWebComponentConfigurationsForComponent() {
+    void getWebComponentConfigurationsForComponent() {
         registry.setConfigurations(
                 createConfigurations(MyComponentExporter.class,
                         MyComponentExporter2.class, UserBoxExporter.class));
@@ -155,7 +155,7 @@ class WebComponentConfigurationRegistryTest {
     }
 
     @Test
-    public void setConfigurationsTwice_onlyFirstSetIsAccepted() {
+    void setConfigurationsTwice_onlyFirstSetIsAccepted() {
         Set<WebComponentConfiguration<? extends Component>> configs1st = createConfigurations(
                 MyComponentExporter.class);
 
@@ -178,7 +178,7 @@ class WebComponentConfigurationRegistryTest {
     }
 
     @Test
-    public void getConfigurations_uninitializedReturnsEmptySet() {
+    void getConfigurations_uninitializedReturnsEmptySet() {
         WebComponentConfigurationRegistry uninitializedRegistry = new WebComponentConfigurationRegistry();
 
         Set<?> set = uninitializedRegistry.getConfigurations();
@@ -187,7 +187,7 @@ class WebComponentConfigurationRegistryTest {
     }
 
     @Test
-    public void hasConfigurations() {
+    void hasConfigurations() {
         registry.setConfigurations(
                 createConfigurations(MyComponentExporter.class,
                         MyComponentExporter2.class, UserBoxExporter.class));
@@ -197,7 +197,7 @@ class WebComponentConfigurationRegistryTest {
     }
 
     @Test
-    public void hasConfigurations_noConfigurations() {
+    void hasConfigurations_noConfigurations() {
         assertFalse(registry.hasConfigurations(),
                 "New registry should have no configurations");
 
@@ -208,7 +208,7 @@ class WebComponentConfigurationRegistryTest {
     }
 
     @Test
-    public void setSameRouteValueFromDifferentThreads_ConcurrencyTest()
+    void setSameRouteValueFromDifferentThreads_ConcurrencyTest()
             throws InterruptedException, ExecutionException {
         final int THREADS = 10;
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/WebComponentExporterUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/WebComponentExporterUtilsTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class WebComponentExporterUtilsTest {
 
     @Test
-    public void getFactories_notEligibleExportersAreFiltered_factoriesAreReturned() {
+    void getFactories_notEligibleExportersAreFiltered_factoriesAreReturned() {
 
         Set<WebComponentExporterFactory> factories = WebComponentExporterUtils
                 .getFactories(new HashSet<>(Arrays.asList(GoodExporter.class,

--- a/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/WebComponentGeneratorTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/WebComponentGeneratorTest.java
@@ -33,12 +33,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class WebComponentGeneratorTest {
 
     @Test
-    public void generatedReplacementMapContainsExpectedEntriesIncludingUi() {
+    void generatedReplacementMapContainsExpectedEntriesIncludingUi() {
         assertGeneratedReplacementMapContainsExpectedEntries(true);
     }
 
     @Test
-    public void generatedReplacementMapContainsExpectedEntriesExcludingUi() {
+    void generatedReplacementMapContainsExpectedEntriesExcludingUi() {
         assertGeneratedReplacementMapContainsExpectedEntries(false);
     }
 
@@ -133,7 +133,7 @@ class WebComponentGeneratorTest {
     }
 
     @Test
-    public void providesJSModulesInNpmMode() {
+    void providesJSModulesInNpmMode() {
         String module = WebComponentGenerator.generateModule(
                 new DefaultWebComponentExporterFactory<MyComponent>(
                         MyComponentExporter.class),
@@ -155,7 +155,7 @@ class WebComponentGeneratorTest {
     }
 
     @Test
-    public void providedJSModuleContainsCorrectThemeReplacements() {
+    void providedJSModuleContainsCorrectThemeReplacements() {
         String module = WebComponentGenerator
                 .generateModule(new DefaultWebComponentExporterFactory<>(
                         MyComponentExporter.class), "", "my-theme");

--- a/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/WebComponentModulesWriterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/WebComponentModulesWriterTest.java
@@ -48,7 +48,7 @@ class WebComponentModulesWriterTest {
     }
 
     @Test
-    public void directoryWriter_generateWebComponentsToDirectory_canCallMethodReflectively_js() {
+    void directoryWriter_generateWebComponentsToDirectory_canCallMethodReflectively_js() {
         Set<File> files = WebComponentModulesWriter.DirectoryWriter
                 .generateWebComponentsToDirectory(
                         WebComponentModulesWriter.class,
@@ -61,7 +61,7 @@ class WebComponentModulesWriterTest {
     }
 
     @Test
-    public void directoryWriter_generateWebComponentsToDirectoryUsingFactory_canCallMethodReflectively_js() {
+    void directoryWriter_generateWebComponentsToDirectoryUsingFactory_canCallMethodReflectively_js() {
         Set<File> files = WebComponentModulesWriter.DirectoryWriter
                 .generateWebComponentsToDirectory(
                         WebComponentModulesWriter.class,
@@ -74,7 +74,7 @@ class WebComponentModulesWriterTest {
     }
 
     @Test
-    public void directoryWriter_generateWebComponentsToDirectory_zeroExportersCreatesZeroFiles() {
+    void directoryWriter_generateWebComponentsToDirectory_zeroExportersCreatesZeroFiles() {
         Set<File> files = WebComponentModulesWriter.DirectoryWriter
                 .generateWebComponentsToDirectory(
                         WebComponentModulesWriter.class, new HashSet<>(),
@@ -84,7 +84,7 @@ class WebComponentModulesWriterTest {
     }
 
     @Test
-    public void directoryWriter_generateWebComponentsToDirectory_nonWriterClassThrows() {
+    void directoryWriter_generateWebComponentsToDirectory_nonWriterClassThrows() {
         var ex = assertThrows(IllegalArgumentException.class, () -> {
             WebComponentModulesWriter.DirectoryWriter
                     .generateWebComponentsToDirectory(MyComponent.class,
@@ -95,7 +95,7 @@ class WebComponentModulesWriterTest {
     }
 
     @Test
-    public void directoryWriter_generateWebComponentsToDirectory_nullWriterThrows() {
+    void directoryWriter_generateWebComponentsToDirectory_nullWriterThrows() {
         assertThrows(NullPointerException.class, () -> {
             WebComponentModulesWriter.DirectoryWriter
                     .generateWebComponentsToDirectory(null, new HashSet<>(),
@@ -104,7 +104,7 @@ class WebComponentModulesWriterTest {
     }
 
     @Test
-    public void directoryWriter_generateWebComponentsToDirectory_nullExporterSetThrows() {
+    void directoryWriter_generateWebComponentsToDirectory_nullExporterSetThrows() {
         assertThrows(NullPointerException.class, () -> {
             WebComponentModulesWriter.DirectoryWriter
                     .generateWebComponentsToDirectory(
@@ -114,7 +114,7 @@ class WebComponentModulesWriterTest {
     }
 
     @Test
-    public void directoryWriter_generateWebComponentsToDirectory_nullOutputDirectoryThrows() {
+    void directoryWriter_generateWebComponentsToDirectory_nullOutputDirectoryThrows() {
         assertThrows(NullPointerException.class, () -> {
             WebComponentModulesWriter.DirectoryWriter
                     .generateWebComponentsToDirectory(

--- a/flow-server/src/test/java/com/vaadin/flow/shared/BrowserDetailsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/shared/BrowserDetailsTest.java
@@ -115,7 +115,7 @@ class BrowserDetailsTest {
     private static final String DUCK_DUCK_BOT_3 = "DuckDuckGo/0.26.3 CFNetwork/1331.0.7 Darwin/21.4.0";
 
     @Test
-    public void testSafari3() {
+    void testSafari3() {
         BrowserDetails bd = new BrowserDetails(SAFARI3_WINDOWS);
         assertWebKit(bd);
         assertSafari(bd);
@@ -126,7 +126,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testSafari4() {
+    void testSafari4() {
         BrowserDetails bd = new BrowserDetails(SAFARI4_MAC);
         assertWebKit(bd);
         assertSafari(bd);
@@ -137,7 +137,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testSafari10() {
+    void testSafari10() {
         BrowserDetails bd = new BrowserDetails(SAFARI10_WINDOWS);
         assertWebKit(bd);
         assertSafari(bd);
@@ -148,7 +148,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testSafari11() {
+    void testSafari11() {
         BrowserDetails bd = new BrowserDetails(SAFARI11_MAC);
         assertWebKit(bd);
         assertSafari(bd);
@@ -159,7 +159,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testIPhoneIOS6Homescreen() {
+    void testIPhoneIOS6Homescreen() {
         BrowserDetails bd = new BrowserDetails(
                 IPHONE_IOS_6_1_HOMESCREEN_SIMULATOR);
         assertWebKit(bd);
@@ -170,7 +170,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testIPhoneIOS5() {
+    void testIPhoneIOS5() {
         BrowserDetails bd = new BrowserDetails(IPHONE_IOS_5_1);
         assertWebKit(bd);
         assertSafari(bd);
@@ -182,7 +182,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testIPhoneIOS4() {
+    void testIPhoneIOS4() {
         BrowserDetails bd = new BrowserDetails(IPHONE_IOS_4_0);
         assertWebKit(bd);
         assertSafari(bd);
@@ -193,7 +193,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testIPadIOS4() {
+    void testIPadIOS4() {
         BrowserDetails bd = new BrowserDetails(IPAD_IOS_4_3_1);
         assertWebKit(bd);
         assertSafari(bd);
@@ -203,7 +203,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testAndroid21() {
+    void testAndroid21() {
         BrowserDetails bd = new BrowserDetails(ANDROID_HTC_2_1);
         assertWebKit(bd);
         assertSafari(bd);
@@ -215,7 +215,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testAndroid22() {
+    void testAndroid22() {
         BrowserDetails bd = new BrowserDetails(ANDROID_GOOGLE_NEXUS_2_2);
         assertWebKit(bd);
         assertSafari(bd);
@@ -227,7 +227,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testAndroid30() {
+    void testAndroid30() {
         BrowserDetails bd = new BrowserDetails(ANDROID_MOTOROLA_3_0);
         assertWebKit(bd);
         assertSafari(bd);
@@ -239,7 +239,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testAndroid40Chrome() {
+    void testAndroid40Chrome() {
         BrowserDetails bd = new BrowserDetails(
                 ANDROID_GALAXY_NEXUS_4_0_4_CHROME);
         assertWebKit(bd);
@@ -252,7 +252,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testAndroidCallpodKeeper() {
+    void testAndroidCallpodKeeper() {
         BrowserDetails bd = new BrowserDetails(ANDROID_CALLPOD_KEEPER);
         assertOSMajorVersion(bd, 6);
         assertOSMinorVersion(bd, 0);
@@ -269,7 +269,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testChrome3() {
+    void testChrome3() {
         BrowserDetails bd = new BrowserDetails(CHROME3_MAC);
         assertWebKit(bd);
         assertChrome(bd);
@@ -281,7 +281,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testChrome4() {
+    void testChrome4() {
         BrowserDetails bd = new BrowserDetails(CHROME4_WINDOWS);
         assertWebKit(bd);
         assertChrome(bd);
@@ -293,7 +293,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testChromeIOS() {
+    void testChromeIOS() {
         BrowserDetails bd = new BrowserDetails(CHROME_IOS);
         assertWebKit(bd);
         assertChrome(bd);
@@ -303,7 +303,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testChromeIOSDesktopSiteFeature() {
+    void testChromeIOSDesktopSiteFeature() {
         BrowserDetails bd = new BrowserDetails(CHROME_IOS_DESKTOP);
         assertWebKit(bd);
         assertChrome(bd);
@@ -313,7 +313,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testChromeChromeOS() {
+    void testChromeChromeOS() {
         BrowserDetails bd = new BrowserDetails(CHROME_40_ON_CHROMEOS);
         assertWebKit(bd);
         assertChrome(bd);
@@ -325,7 +325,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testChrome100Windows() {
+    void testChrome100Windows() {
         BrowserDetails bd = new BrowserDetails(CHROME100_WINDOWS);
         assertWebKit(bd);
         assertChrome(bd);
@@ -336,7 +336,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testFirefox100Windows() {
+    void testFirefox100Windows() {
         BrowserDetails bd = new BrowserDetails(FIREFOX_100_WIN64);
         assertGecko(bd);
         assertFirefox(bd);
@@ -347,7 +347,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testFirefox100Windows32() {
+    void testFirefox100Windows32() {
         BrowserDetails bd = new BrowserDetails(FIREFOX_100_WIN32);
         assertGecko(bd);
         assertFirefox(bd);
@@ -358,7 +358,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testFirefox100MacOs() {
+    void testFirefox100MacOs() {
         BrowserDetails bd = new BrowserDetails(FIREFOX_100_MACOS);
         assertGecko(bd);
         assertFirefox(bd);
@@ -369,7 +369,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testFirefox100Linux() {
+    void testFirefox100Linux() {
         BrowserDetails bd = new BrowserDetails(FIREFOX_100_LINUX);
         assertGecko(bd);
         assertFirefox(bd);
@@ -380,7 +380,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testFirefox3() {
+    void testFirefox3() {
         BrowserDetails bd = new BrowserDetails(FIREFOX30_WINDOWS);
         assertGecko(bd);
         assertFirefox(bd);
@@ -400,7 +400,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testFirefox33Android() {
+    void testFirefox33Android() {
         BrowserDetails bd = new BrowserDetails(FIREFOX33_ANDROID);
         assertGecko(bd);
         assertFirefox(bd);
@@ -411,7 +411,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testFirefox35() {
+    void testFirefox35() {
         BrowserDetails bd = new BrowserDetails(FIREFOX35_WINDOWS);
         assertGecko(bd);
         assertFirefox(bd);
@@ -423,7 +423,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testFirefox36() {
+    void testFirefox36() {
         BrowserDetails bd = new BrowserDetails(FIREFOX36_WINDOWS);
         assertGecko(bd);
         assertFirefox(bd);
@@ -435,7 +435,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testFirefox30b5() {
+    void testFirefox30b5() {
         BrowserDetails bd = new BrowserDetails(FIREFOX_30B5_MAC);
         assertGecko(bd);
         assertFirefox(bd);
@@ -447,7 +447,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testFirefox40b11() {
+    void testFirefox40b11() {
         BrowserDetails bd = new BrowserDetails(FIREFOX_40B11_WIN);
         assertGecko(bd);
         assertFirefox(bd);
@@ -459,7 +459,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testFirefox40b7() {
+    void testFirefox40b7() {
         BrowserDetails bd = new BrowserDetails(FIREFOX_40B7_WIN);
         assertGecko(bd);
         assertFirefox(bd);
@@ -471,14 +471,14 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testKonquerorLinux() {
+    void testKonquerorLinux() {
         // Just ensure detection does not crash
         BrowserDetails bd = new BrowserDetails(KONQUEROR_LINUX);
         assertLinux(bd);
     }
 
     @Test
-    public void testFirefox36b() {
+    void testFirefox36b() {
         BrowserDetails bd = new BrowserDetails(FIREFOX36B_MAC);
         assertGecko(bd);
         assertFirefox(bd);
@@ -490,7 +490,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testOpera964() {
+    void testOpera964() {
         BrowserDetails bd = new BrowserDetails(OPERA964_WINDOWS);
         assertPresto(bd);
         assertOpera(bd);
@@ -501,7 +501,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testOpera1010() {
+    void testOpera1010() {
         BrowserDetails bd = new BrowserDetails(OPERA1010_WINDOWS);
         assertPresto(bd);
         assertOpera(bd);
@@ -512,7 +512,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testOpera1050() {
+    void testOpera1050() {
         BrowserDetails bd = new BrowserDetails(OPERA1050_WINDOWS);
         assertPresto(bd);
         assertOpera(bd);
@@ -523,7 +523,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testIE6() {
+    void testIE6() {
         BrowserDetails bd = new BrowserDetails(IE6_WINDOWS);
         assertEngineVersion(bd, -1);
         assertIE(bd);
@@ -534,7 +534,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testIE7() {
+    void testIE7() {
         BrowserDetails bd = new BrowserDetails(IE7_WINDOWS);
         assertEngineVersion(bd, -1);
         assertIE(bd);
@@ -545,7 +545,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testIE8() {
+    void testIE8() {
         BrowserDetails bd = new BrowserDetails(IE8_WINDOWS);
         assertTrident(bd);
         assertEngineVersion(bd, 4);
@@ -557,7 +557,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testIE9() {
+    void testIE9() {
         BrowserDetails bd = new BrowserDetails(IE9_BETA_WINDOWS_7);
         assertTrident(bd);
         assertEngineVersion(bd, 5);
@@ -569,7 +569,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testIE9InIE7CompatibilityMode() {
+    void testIE9InIE7CompatibilityMode() {
         BrowserDetails bd = new BrowserDetails(IE9_IN_IE7_MODE_WINDOWS_7);
 
         assertTrident(bd);
@@ -583,7 +583,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testIE9InIE8CompatibilityMode() {
+    void testIE9InIE8CompatibilityMode() {
         BrowserDetails bd = new BrowserDetails(IE9_BETA_IN_IE8_MODE_WINDOWS_7);
 
         /*
@@ -601,7 +601,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testIE10() {
+    void testIE10() {
         BrowserDetails bd = new BrowserDetails(IE10_WINDOWS_8);
         assertTrident(bd);
         assertEngineVersion(bd, 6);
@@ -613,7 +613,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testIE11() {
+    void testIE11() {
         BrowserDetails bd = new BrowserDetails(IE11_WINDOWS_7);
         assertTrident(bd);
         assertEngineVersion(bd, 7);
@@ -625,7 +625,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testIE11Windows7CompatibilityViewIE7() {
+    void testIE11Windows7CompatibilityViewIE7() {
         BrowserDetails bd = new BrowserDetails(IE11_IN_IE7_MODE_WINDOWS_7);
         assertTrident(bd);
         assertEngineVersion(bd, 7);
@@ -637,7 +637,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testIE11Windows10CompatibilityViewIE7() {
+    void testIE11Windows10CompatibilityViewIE7() {
         BrowserDetails bd = new BrowserDetails(IE11_IN_IE7_MODE_WINDOWS_10);
         assertTrident(bd);
         assertEngineVersion(bd, 7);
@@ -649,7 +649,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testIE11LaunchDayWindows10CompatibilityViewIE7() {
+    void testIE11LaunchDayWindows10CompatibilityViewIE7() {
         BrowserDetails bd = new BrowserDetails(
                 IE11_IN_IE7_MODE_LAUNCH_DAY_WINDOWS_10);
         assertTrident(bd);
@@ -668,7 +668,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testIE11WindowsPhone81Update() {
+    void testIE11WindowsPhone81Update() {
         BrowserDetails bd = new BrowserDetails(IE11_WINDOWS_PHONE_8_1_UPDATE);
         assertTrident(bd);
         assertEngineVersion(bd, 7);
@@ -680,7 +680,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testEdgeWindows10() {
+    void testEdgeWindows10() {
         BrowserDetails bd = new BrowserDetails(EDGE_12_WINDOWS_10);
         assertEdge(bd);
         assertBrowserMajorVersion(bd, 12);
@@ -689,7 +689,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testEdgeWindows11() {
+    void testEdgeWindows11() {
         BrowserDetails bd = new BrowserDetails(EDGE_100);
         assertEdge(bd);
         assertBrowserMajorVersion(bd, 100);
@@ -698,7 +698,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testEdgeMac() {
+    void testEdgeMac() {
         BrowserDetails bd = new BrowserDetails(EDGE_99_MAC);
         assertEdge(bd);
         assertBrowserMajorVersion(bd, 99);
@@ -707,7 +707,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testEdgeAndroid() {
+    void testEdgeAndroid() {
         BrowserDetails bd = new BrowserDetails(EDGE_97_ANDROID);
         assertEdge(bd);
         assertBrowserMajorVersion(bd, 97);
@@ -716,7 +716,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testEdgeIOS() {
+    void testEdgeIOS() {
         BrowserDetails bd = new BrowserDetails(EDGE_97_IOS);
         assertEdge(bd);
         assertBrowserMajorVersion(bd, 97);
@@ -725,7 +725,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testEclipseMac_safari91() {
+    void testEclipseMac_safari91() {
         BrowserDetails bd = new BrowserDetails(ECLIPSE_MAC_SAFARI_91);
         assertWebKit(bd);
         assertSafari(bd);
@@ -737,7 +737,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testEclipseMac_safari90() {
+    void testEclipseMac_safari90() {
         BrowserDetails bd = new BrowserDetails(ECLIPSE_MAC_SAFARI_90);
         assertWebKit(bd);
         assertSafari(bd);
@@ -749,7 +749,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testHeadlessChrome() {
+    void testHeadlessChrome() {
         String userAgent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/60.0.3112.101 Safari/537.36";
         BrowserDetails bd = new BrowserDetails(userAgent);
         assertWebKit(bd);
@@ -761,7 +761,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testOpera65() {
+    void testOpera65() {
         String userAgent = OPERA115_WINDOWS;
         BrowserDetails bd = new BrowserDetails(userAgent);
         assertWebKit(bd);
@@ -773,21 +773,21 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testIos11FacebookBrowser() {
+    void testIos11FacebookBrowser() {
         BrowserDetails bd = new BrowserDetails(IPHONE_IOS_11_FACEBOOK_BROWSER);
         assertWebKit(bd);
         assertEngineVersion(bd, 605.1f);
     }
 
     @Test
-    public void testIos11Firefox() {
+    void testIos11Firefox() {
         BrowserDetails bd = new BrowserDetails(IPHONE_IOS_11_FIREFOX);
         assertWebKit(bd);
         assertEngineVersion(bd, 604.3f);
     }
 
     @Test
-    public void testCommonDesktopUserAgents() throws IOException {
+    void testCommonDesktopUserAgents() throws IOException {
         UserAgent[] agents = getUserAgentDetails(
                 "common-desktop-useragents.json");
 
@@ -795,14 +795,14 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testMobileUserAgents() throws IOException {
+    void testMobileUserAgents() throws IOException {
         UserAgent[] agents = getUserAgentDetails("mobile-useragents.json");
 
         assertAgentDetails(agents);
     }
 
     @Test
-    public void testByteSpiderWebCrawler() {
+    void testByteSpiderWebCrawler() {
         BrowserDetails bd = new BrowserDetails(BYTE_SPIDER);
         assertWebKit(bd);
         assertSafari(bd);
@@ -813,7 +813,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testDuckDuckBot1() {
+    void testDuckDuckBot1() {
         BrowserDetails bd = new BrowserDetails(DUCK_DUCK_BOT);
         assertUnspecifiedBrowser(bd);
         assertBrowserMajorVersion(bd, -1);
@@ -823,7 +823,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testDuckDuckBot2() {
+    void testDuckDuckBot2() {
         BrowserDetails bd = new BrowserDetails(DUCK_DUCK_BOT_2);
         assertBrowserMajorVersion(bd, 130);
         assertBrowserMinorVersion(bd, 0);
@@ -832,7 +832,7 @@ class BrowserDetailsTest {
     }
 
     @Test
-    public void testDuckDuckBot3() {
+    void testDuckDuckBot3() {
         BrowserDetails bd = new BrowserDetails(DUCK_DUCK_BOT_3);
         assertUnspecifiedBrowser(bd);
         assertBrowserMajorVersion(bd, -1);

--- a/flow-server/src/test/java/com/vaadin/flow/shared/RegistrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/shared/RegistrationTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RegistrationTest {
     @Test
-    public void once_onlyCalledOnce() {
+    void once_onlyCalledOnce() {
         AtomicBoolean invoked = new AtomicBoolean();
         Command action = () -> {
             boolean calledPreviously = invoked.getAndSet(true);
@@ -51,7 +51,7 @@ class RegistrationTest {
     }
 
     @Test
-    public void combine_removesAll() {
+    void combine_removesAll() {
         AtomicBoolean firstRemoved = new AtomicBoolean();
         AtomicBoolean secondRemoved = new AtomicBoolean();
 
@@ -68,7 +68,7 @@ class RegistrationTest {
     }
 
     @Test
-    public void addAndRemove_addsAndRemoves() {
+    void addAndRemove_addsAndRemoves() {
         Collection<Object> collection = new ArrayList<>();
         Object o1 = new Object();
         Object o2 = new Object();

--- a/flow-server/src/test/java/com/vaadin/flow/shared/VaadinUriResolverTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/shared/VaadinUriResolverTest.java
@@ -28,7 +28,7 @@ class VaadinUriResolverTest {
     }
 
     @Test
-    public void testContextProtocol() {
+    void testContextProtocol() {
         NullContextVaadinUriResolver resolver = new NullContextVaadinUriResolver();
         assertEquals("http://someplace/my-component.html",
                 resolver.resolveVaadinUri("context://my-component.html"));

--- a/flow-server/src/test/java/com/vaadin/flow/shared/ui/DependencyTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/shared/ui/DependencyTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.core.Is.is;
 class DependencyTest {
 
     @Test
-    public void checkJsonSerialization_3ArgsCTor() {
+    void checkJsonSerialization_3ArgsCTor() {
         Dependency dependency = new Dependency(Dependency.Type.JAVASCRIPT,
                 "url", LoadMode.INLINE);
 
@@ -39,7 +39,7 @@ class DependencyTest {
     }
 
     @Test
-    public void dynamicDependency_hasLazyMode() {
+    void dynamicDependency_hasLazyMode() {
         Dependency dependency = new Dependency(Dependency.Type.DYNAMIC_IMPORT,
                 "foo");
 
@@ -53,7 +53,7 @@ class DependencyTest {
     }
 
     @Test
-    public void checkJsonSerialization_2ArgsCTor() {
+    void checkJsonSerialization_2ArgsCTor() {
         Dependency dependency = new Dependency(Dependency.Type.DYNAMIC_IMPORT,
                 "foo");
 

--- a/flow-server/src/test/java/com/vaadin/flow/shared/util/SharedUtilTests.java
+++ b/flow-server/src/test/java/com/vaadin/flow/shared/util/SharedUtilTests.java
@@ -27,32 +27,32 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class SharedUtilTests {
 
     @Test
-    public void trailingSlashIsTrimmed() {
+    void trailingSlashIsTrimmed() {
         assertThat(SharedUtil.trimTrailingSlashes("/path/"), is("/path"));
     }
 
     @Test
-    public void noTrailingSlashForTrimming() {
+    void noTrailingSlashForTrimming() {
         assertThat(SharedUtil.trimTrailingSlashes("/path"), is("/path"));
     }
 
     @Test
-    public void trailingSlashesAreTrimmed() {
+    void trailingSlashesAreTrimmed() {
         assertThat(SharedUtil.trimTrailingSlashes("/path///"), is("/path"));
     }
 
     @Test
-    public void emptyStringIsHandled() {
+    void emptyStringIsHandled() {
         assertThat(SharedUtil.trimTrailingSlashes(""), is(""));
     }
 
     @Test
-    public void rootSlashIsTrimmed() {
+    void rootSlashIsTrimmed() {
         assertThat(SharedUtil.trimTrailingSlashes("/"), is(""));
     }
 
     @Test
-    public void camelCaseToHumanReadable() {
+    void camelCaseToHumanReadable() {
         assertEquals("First Name",
                 SharedUtil.camelCaseToHumanFriendly("firstName"));
         assertEquals("First Name",
@@ -75,7 +75,7 @@ class SharedUtilTests {
     }
 
     @Test
-    public void splitCamelCase() {
+    void splitCamelCase() {
         assertCamelCaseSplit("firstName", "first", "Name");
         assertCamelCaseSplit("fooBar", "foo", "Bar");
         assertCamelCaseSplit("fooBar", "foo", "Bar");
@@ -94,7 +94,7 @@ class SharedUtilTests {
     }
 
     @Test
-    public void join() {
+    void join() {
         String s1 = "foo-bar-baz";
         String s2 = "foo--bar";
 
@@ -106,7 +106,7 @@ class SharedUtilTests {
     }
 
     @Test
-    public void dashSeparatedToCamelCase() {
+    void dashSeparatedToCamelCase() {
         assertEquals(null, SharedUtil.dashSeparatedToCamelCase(null));
         assertEquals("", SharedUtil.dashSeparatedToCamelCase(""));
         assertEquals("foo", SharedUtil.dashSeparatedToCamelCase("foo"));
@@ -119,7 +119,7 @@ class SharedUtilTests {
     }
 
     @Test
-    public void camelCaseToDashSeparated() {
+    void camelCaseToDashSeparated() {
         assertEquals(null, SharedUtil.camelCaseToDashSeparated(null));
         assertEquals("", SharedUtil.camelCaseToDashSeparated(""));
         assertEquals("foo", SharedUtil.camelCaseToDashSeparated("foo"));
@@ -137,7 +137,7 @@ class SharedUtilTests {
     }
 
     @Test
-    public void upperCamelCaseToDashSeparatedLowerCase() {
+    void upperCamelCaseToDashSeparatedLowerCase() {
         assertEquals(null,
                 SharedUtil.upperCamelCaseToDashSeparatedLowerCase(null));
         assertEquals("", SharedUtil.upperCamelCaseToDashSeparatedLowerCase(""));
@@ -158,7 +158,7 @@ class SharedUtilTests {
     }
 
     @Test
-    public void methodUppercaseWithTurkishLocale() {
+    void methodUppercaseWithTurkishLocale() {
         Locale defaultLocale = Locale.getDefault();
         try {
             Locale.setDefault(new Locale("tr", "TR"));
@@ -183,7 +183,7 @@ class SharedUtilTests {
     };
 
     @Test
-    public void testParameterAdding() {
+    void testParameterAdding() {
         String[] urisWithAbcdParam = new String[] {
                 "http://demo.vaadin.com/?a=b&c=d",
                 "https://demo.vaadin.com/?a=b&c=d",

--- a/flow-server/src/test/java/com/vaadin/flow/shared/util/UniqueSerializableTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/shared/util/UniqueSerializableTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class UniqueSerializableTest implements Serializable {
 
     @Test
-    public void testUniqueness() {
+    void testUniqueness() {
         UniqueSerializable o1 = new UniqueSerializable() {
         };
         UniqueSerializable o2 = new UniqueSerializable() {
@@ -36,7 +36,7 @@ class UniqueSerializableTest implements Serializable {
     }
 
     @Test
-    public void testSerialization() {
+    void testSerialization() {
         UniqueSerializable o1 = new UniqueSerializable() {
         };
         UniqueSerializable d1 = (UniqueSerializable) SerializationUtils

--- a/flow-server/src/test/java/com/vaadin/flow/signals/IdTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/IdTest.java
@@ -24,7 +24,7 @@ import tools.jackson.databind.ObjectMapper;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-public class IdTest {
+class IdTest {
     @Test
     void randomId_isRandom() {
         // Test will fail once every 18 quintillion times or so

--- a/flow-server/src/test/java/com/vaadin/flow/signals/SignalCommandTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/SignalCommandTest.java
@@ -32,7 +32,7 @@ import com.vaadin.flow.signals.shared.SharedListSignal.ListPosition;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class SignalCommandTest {
+class SignalCommandTest {
     private final ObjectMapper mapper = new ObjectMapper();
     private Set<Class<?>> assertedTypes = new HashSet<>();
 

--- a/flow-server/src/test/java/com/vaadin/flow/signals/SignalEnvironmentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/SignalEnvironmentTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class SignalEnvironmentTest extends SignalTestBase {
+class SignalEnvironmentTest extends SignalTestBase {
 
     @Test
     void registerAndUnregister_environmentIsUsedUntilUnregistered() {

--- a/flow-server/src/test/java/com/vaadin/flow/signals/impl/ComputedSignalNullabilityTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/impl/ComputedSignalNullabilityTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * <p>
  * The tests also pass at runtime as basic smoke tests.
  */
-public class ComputedSignalNullabilityTest extends SignalTestBase {
+class ComputedSignalNullabilityTest extends SignalTestBase {
 
     @Test
     void map_returnsNullable() {

--- a/flow-server/src/test/java/com/vaadin/flow/signals/impl/ComputedSignalTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/impl/ComputedSignalTest.java
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * reasons, this class tests both cached signals and the "new" computed signals
  * that do no caching.
  */
-public class ComputedSignalTest extends SignalTestBase {
+class ComputedSignalTest extends SignalTestBase {
 
     @Test
     void cached_constantCallback_throws() {

--- a/flow-server/src/test/java/com/vaadin/flow/signals/impl/EffectTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/impl/EffectTest.java
@@ -37,7 +37,7 @@ import com.vaadin.flow.signals.shared.SharedValueSignalTest.AsyncSharedValueSign
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class EffectTest extends SignalTestBase {
+class EffectTest extends SignalTestBase {
 
     @Test
     void newEffect_noSignalUsage_throws() {

--- a/flow-server/src/test/java/com/vaadin/flow/signals/impl/TransactionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/impl/TransactionTest.java
@@ -50,7 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class TransactionTest {
+class TransactionTest {
     @Test
     void getCurrentTransaction_noTransaction_rootTransaction() {
         SynchronousSignalTree tree = new SynchronousSignalTree(false);

--- a/flow-server/src/test/java/com/vaadin/flow/signals/impl/UsageTrackerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/impl/UsageTrackerTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class UsageTrackerTest extends SignalTestBase {
+class UsageTrackerTest extends SignalTestBase {
     @Test
     void hasChanges_runInTransaction_readsFromTransaction() {
         SharedValueSignal<String> signal = new SharedValueSignal<>("initial");

--- a/flow-server/src/test/java/com/vaadin/flow/signals/local/ListSignalNullabilityTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/local/ListSignalNullabilityTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <p>
  * The tests also pass at runtime as basic smoke tests.
  */
-public class ListSignalNullabilityTest extends SignalTestBase {
+class ListSignalNullabilityTest extends SignalTestBase {
 
     @Test
     void get_returnsNonNullList() {

--- a/flow-server/src/test/java/com/vaadin/flow/signals/local/ListSignalTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/local/ListSignalTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ListSignalTest extends SignalTestBase {
+class ListSignalTest extends SignalTestBase {
 
     @Test
     void constructor_empty_emptyList() {

--- a/flow-server/src/test/java/com/vaadin/flow/signals/local/LocalSignalSerializationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/local/LocalSignalSerializationTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class LocalSignalSerializationTest {
+class LocalSignalSerializationTest {
 
     private void assertSerializeAndDeserialize(Object obj) {
         try {
@@ -62,7 +62,7 @@ public class LocalSignalSerializationTest {
     }
 
     @Test
-    public void valueSignal_serializable() {
+    void valueSignal_serializable() {
         ValueSignal<String> signal = new ValueSignal<>("");
         assertSerializeAndDeserialize(signal);
 

--- a/flow-server/src/test/java/com/vaadin/flow/signals/local/LocalSignalSessionCheckTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/local/LocalSignalSessionCheckTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class LocalSignalSessionCheckTest extends SignalTestBase {
+class LocalSignalSessionCheckTest extends SignalTestBase {
 
     @AfterEach
     void clearSession() {

--- a/flow-server/src/test/java/com/vaadin/flow/signals/local/ValueSignalHelperTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/local/ValueSignalHelperTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class ValueSignalHelperTest extends SignalTestBase {
+class ValueSignalHelperTest extends SignalTestBase {
 
     record ImmutablePerson(String name, int age) {
         ImmutablePerson withName(String name) {

--- a/flow-server/src/test/java/com/vaadin/flow/signals/local/ValueSignalNullabilityTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/local/ValueSignalNullabilityTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  * <p>
  * The tests also pass at runtime as basic smoke tests.
  */
-public class ValueSignalNullabilityTest extends SignalTestBase {
+class ValueSignalNullabilityTest extends SignalTestBase {
 
     @Test
     void get_returnsNullable() {

--- a/flow-server/src/test/java/com/vaadin/flow/signals/local/ValueSignalTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/local/ValueSignalTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class ValueSignalTest extends SignalTestBase {
+class ValueSignalTest extends SignalTestBase {
 
     @Test
     void constructor_initialValue_initialValueUsed() {

--- a/flow-server/src/test/java/com/vaadin/flow/signals/shared/SharedListSignalNullabilityTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/shared/SharedListSignalNullabilityTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <p>
  * The tests also pass at runtime as basic smoke tests.
  */
-public class SharedListSignalNullabilityTest extends SignalTestBase {
+class SharedListSignalNullabilityTest extends SignalTestBase {
 
     @Test
     void get_returnsNonNullList() {

--- a/flow-server/src/test/java/com/vaadin/flow/signals/shared/SharedListSignalTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/shared/SharedListSignalTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SharedListSignalTest extends SignalTestBase {
+class SharedListSignalTest extends SignalTestBase {
     @Test
     void constructor_initialValue_isEmpty() {
         SharedListSignal<String> signal = new SharedListSignal<>(String.class);

--- a/flow-server/src/test/java/com/vaadin/flow/signals/shared/SharedMapSignalNullabilityTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/shared/SharedMapSignalNullabilityTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <p>
  * The tests also pass at runtime as basic smoke tests.
  */
-public class SharedMapSignalNullabilityTest extends SignalTestBase {
+class SharedMapSignalNullabilityTest extends SignalTestBase {
 
     @Test
     void get_returnsNonNullMap() {

--- a/flow-server/src/test/java/com/vaadin/flow/signals/shared/SharedMapSignalTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/shared/SharedMapSignalTest.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SharedMapSignalTest extends SignalTestBase {
+class SharedMapSignalTest extends SignalTestBase {
 
     @Test
     void constructor_initialValue_isEmpty() {

--- a/flow-server/src/test/java/com/vaadin/flow/signals/shared/SharedNodeSignalTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/shared/SharedNodeSignalTest.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SharedNodeSignalTest extends SignalTestBase {
+class SharedNodeSignalTest extends SignalTestBase {
 
     @Test
     void constructor_initialValue_isEmpty() {

--- a/flow-server/src/test/java/com/vaadin/flow/signals/shared/SharedNumberSignalNullabilityTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/shared/SharedNumberSignalNullabilityTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * <p>
  * The tests also pass at runtime as basic smoke tests.
  */
-public class SharedNumberSignalNullabilityTest extends SignalTestBase {
+class SharedNumberSignalNullabilityTest extends SignalTestBase {
 
     @Test
     void get_returnsNonNull() {

--- a/flow-server/src/test/java/com/vaadin/flow/signals/shared/SharedNumberSignalTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/shared/SharedNumberSignalTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class SharedNumberSignalTest extends SignalTestBase {
+class SharedNumberSignalTest extends SignalTestBase {
     @Test
     void constructor_noArgs_zeroValue() {
         SharedNumberSignal signal = new SharedNumberSignal();

--- a/flow-server/src/test/java/com/vaadin/flow/signals/shared/SharedValueSignalHelperTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/shared/SharedValueSignalHelperTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class SharedValueSignalHelperTest extends SignalTestBase {
+class SharedValueSignalHelperTest extends SignalTestBase {
 
     record ImmutablePerson(String name, int age) {
         ImmutablePerson withName(String name) {

--- a/flow-server/src/test/java/com/vaadin/flow/signals/shared/SharedValueSignalNullabilityTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/shared/SharedValueSignalNullabilityTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  * <p>
  * The tests also pass at runtime as basic smoke tests.
  */
-public class SharedValueSignalNullabilityTest extends SignalTestBase {
+class SharedValueSignalNullabilityTest extends SignalTestBase {
 
     @Test
     void get_returnsNullable() {

--- a/flow-server/src/test/java/com/vaadin/flow/signals/shared/SignalUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/shared/SignalUtilsTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 
-public class SignalUtilsTest {
+class SignalUtilsTest {
 
     @Test
     void treeOf_returnsSignalsUnderlyingTree() {

--- a/flow-server/src/test/java/com/vaadin/flow/signals/shared/impl/CommandResultTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/shared/impl/CommandResultTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class CommandResultTest {
+class CommandResultTest {
 
     @Test
     void rejectAll() {

--- a/flow-server/src/test/java/com/vaadin/flow/signals/shared/impl/LocalAsynchronousSignalTreeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/shared/impl/LocalAsynchronousSignalTreeTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class LocalAsynchronousSignalTreeTest extends SignalTestBase {
+class LocalAsynchronousSignalTreeTest extends SignalTestBase {
 
     @Test
     void type_isAsynchronous() {

--- a/flow-server/src/test/java/com/vaadin/flow/signals/shared/impl/MutableTreeRevisionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/shared/impl/MutableTreeRevisionTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class MutableTreeRevisionTest {
+class MutableTreeRevisionTest {
     private final MutableTreeRevision revision = new MutableTreeRevision(
             new Snapshot(Id.random(), false));
     private final Id commandId = Id.random();

--- a/flow-server/src/test/java/com/vaadin/flow/signals/shared/impl/SnapshotTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/shared/impl/SnapshotTest.java
@@ -25,7 +25,7 @@ import com.vaadin.flow.signals.Node;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class SnapshotTest {
+class SnapshotTest {
 
     @Test
     void emptyConstructor_withoutMaxNode_hasOnlyZeroNode() {

--- a/flow-server/src/test/java/com/vaadin/flow/signals/shared/impl/StagedTransactionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/shared/impl/StagedTransactionTest.java
@@ -50,7 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class StagedTransactionTest {
+class StagedTransactionTest {
     /*
      * Note that much of the logic in this test only interacts with API in
      * Transaction and in that way tests logic from StagedTransaction.

--- a/flow-server/src/test/java/com/vaadin/flow/signals/shared/impl/SynchronousSignalTreeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/shared/impl/SynchronousSignalTreeTest.java
@@ -48,7 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SynchronousSignalTreeTest {
+class SynchronousSignalTreeTest {
 
     @Test
     void constructor_false_regularSyncTree() {

--- a/flow-server/src/test/java/com/vaadin/flow/signals/shared/impl/TreeRevisionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/shared/impl/TreeRevisionTest.java
@@ -29,7 +29,7 @@ import com.vaadin.flow.signals.shared.SharedListSignal.ListPosition;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class TreeRevisionTest {
+class TreeRevisionTest {
     private static class MutableTestRevision extends TreeRevision {
         public MutableTestRevision() {
             super(Id.ZERO,

--- a/flow-server/src/test/java/com/vaadin/packaging/SplitPackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/packaging/SplitPackagesTest.java
@@ -46,7 +46,7 @@ class SplitPackagesTest {
      * package contains classes from multiple modules.
      */
     @Test
-    public void findSplitPackages() throws IOException {
+    void findSplitPackages() throws IOException {
         Collection<File> modules = findModules();
         Map<String, Set<File>> packageToModules = mapPackagesToModules(modules);
         String errors = collectErrors(packageToModules);

--- a/flow-server/src/test/java/com/vaadin/tests/server/AssertionsEnabledTest.java
+++ b/flow-server/src/test/java/com/vaadin/tests/server/AssertionsEnabledTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AssertionsEnabledTest {
     @Test
-    public void testAssertionsEnabled() {
+    void testAssertionsEnabled() {
         boolean assertFailed = false;
         try {
             assert false;

--- a/flow-server/src/test/java/com/vaadin/tests/server/AtmosphereVersionTest.java
+++ b/flow-server/src/test/java/com/vaadin/tests/server/AtmosphereVersionTest.java
@@ -28,7 +28,7 @@ class AtmosphereVersionTest {
      * classpath
      */
     @Test
-    public void testAtmosphereVersion() {
+    void testAtmosphereVersion() {
         assertEquals(Constants.REQUIRED_ATMOSPHERE_RUNTIME_VERSION,
                 Version.getRawVersion());
     }

--- a/flow-server/src/test/java/com/vaadin/tests/server/SerializationTest.java
+++ b/flow-server/src/test/java/com/vaadin/tests/server/SerializationTest.java
@@ -60,7 +60,7 @@ class SerializationTest {
     Runnable cleaner;
 
     @BeforeEach
-    public void enabledSerializationDebugInfo() {
+    void enabledSerializationDebugInfo() {
         String extendedDebugInfo = System
                 .getProperty("sun.io.serialization.extendedDebugInfo");
         System.setProperty("sun.io.serialization.extendedDebugInfo", "true");
@@ -75,15 +75,14 @@ class SerializationTest {
     }
 
     @AfterEach
-    public void restore() {
+    void restore() {
         if (cleaner != null) {
             cleaner.run();
         }
     }
 
     @Test
-    public void testSerializeVaadinSession_accessQueueIsRecreated()
-            throws Exception {
+    void testSerializeVaadinSession_accessQueueIsRecreated() throws Exception {
         VaadinService vaadinService = new MockVaadinService(true);
         VaadinSession session = new VaadinSession(vaadinService);
 
@@ -94,7 +93,7 @@ class SerializationTest {
     }
 
     @Test
-    public void testSerializeVaadinSession_notProductionMode_disableDevModeSerialization_deserializedSessionHasNoUIs()
+    void testSerializeVaadinSession_notProductionMode_disableDevModeSerialization_deserializedSessionHasNoUIs()
             throws Exception {
         VaadinSession session = serializeAndDeserializeWithUI(false);
 
@@ -105,7 +104,7 @@ class SerializationTest {
     }
 
     @Test
-    public void testSerializeVaadinSession_notProductionMode_disableDevModeSerialization_streamResources_deserializedSessionHasNoUIs()
+    void testSerializeVaadinSession_notProductionMode_disableDevModeSerialization_streamResources_deserializedSessionHasNoUIs()
             throws Exception {
 
         VaadinService vaadinService = new MockVaadinService(false, false);
@@ -141,7 +140,7 @@ class SerializationTest {
     }
 
     @Test
-    public void testSerializeVaadinSession_notProductionMode_enableDevModeSerialization_deserializedSessionHasUI()
+    void testSerializeVaadinSession_notProductionMode_enableDevModeSerialization_deserializedSessionHasUI()
             throws Exception {
         VaadinSession session = serializeAndDeserializeWithUI(true);
 
@@ -154,7 +153,7 @@ class SerializationTest {
     }
 
     @Test
-    public void testSerializeVaadinSession_notProductionMode_canSerializeWithoutTransients()
+    void testSerializeVaadinSession_notProductionMode_canSerializeWithoutTransients()
             throws Exception {
         VaadinService vaadinService = new MockVaadinService(false, true);
         VaadinSession session = Mockito.spy(new VaadinSession(vaadinService));
@@ -172,8 +171,7 @@ class SerializationTest {
     // Covers serialization of UI scoped beans, e.g. in Kubernetes Kit
     // https://github.com/vaadin/flow/issues/19967
     // https://github.com/vaadin/kubernetes-kit/issues/140
-    public void serializeUI_currentUI_availableDuringSerialization()
-            throws Exception {
+    void serializeUI_currentUI_availableDuringSerialization() throws Exception {
         VaadinSession deserializeSession = serializeAndDeserializeWithUI(true,
                 true, ui -> ui.add(new MyComponent()));
         MyComponent deserializedComponent = deserializeSession.getUIs()
@@ -190,7 +188,7 @@ class SerializationTest {
     // Covers serialization of UI scoped beans, e.g. in Kubernetes Kit
     // https://github.com/vaadin/flow/issues/19967
     // https://github.com/vaadin/kubernetes-kit/issues/140
-    public void serializeUI_currentVaadinSession_availableDuringSerialization()
+    void serializeUI_currentVaadinSession_availableDuringSerialization()
             throws Exception {
         VaadinSession deserializeSession = serializeAndDeserializeWithUI(true,
                 true,

--- a/flow-server/src/test/java/com/vaadin/tests/server/component/FlowClassesSerializableTest.java
+++ b/flow-server/src/test/java/com/vaadin/tests/server/component/FlowClassesSerializableTest.java
@@ -56,7 +56,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 class FlowClassesSerializableTest extends ClassesSerializableTest {
 
     @AfterEach
-    public void cleanup() {
+    void cleanup() {
         CurrentInstance.clearAll();
     }
 
@@ -65,7 +65,7 @@ class FlowClassesSerializableTest extends ClassesSerializableTest {
      * generic test because of their constructors
      */
     @Test
-    public void htmlComponentAndHtmlContainer() throws Throwable {
+    void htmlComponentAndHtmlContainer() throws Throwable {
         Component[] components = { new HtmlComponent("dummy-tag"),
                 new HtmlContainer("dummy-tag") };
         for (Component component : components) {
@@ -84,7 +84,7 @@ class FlowClassesSerializableTest extends ClassesSerializableTest {
      * see the workaround in ElementAttributeMap#deferRegistration
      */
     @Test
-    public void streamResource() throws Throwable {
+    void streamResource() throws Throwable {
         UI ui = new UI();
         UI.setCurrent(ui);
         try {
@@ -149,7 +149,7 @@ class FlowClassesSerializableTest extends ClassesSerializableTest {
     }
 
     @Test
-    public void localSignalSerializable() {
+    void localSignalSerializable() {
         MockUI ui = setupForSignalSerializationTest();
         VaadinSession session = ui.getSession();
         VaadinService service = session.getService();
@@ -227,7 +227,7 @@ class FlowClassesSerializableTest extends ClassesSerializableTest {
     }
 
     @Test
-    public void sharedSignalNotSerializable() {
+    void sharedSignalNotSerializable() {
         MockUI ui = setupForSignalSerializationTest();
         VaadinSession session = ui.getSession();
         VaadinService service = session.getService();
@@ -255,7 +255,7 @@ class FlowClassesSerializableTest extends ClassesSerializableTest {
     }
 
     @Test
-    public void sharedSignalNotSerializable_twoSessionsSharingSignal_onlyOneSessionAttemptedToSerialize() {
+    void sharedSignalNotSerializable_twoSessionsSharingSignal_onlyOneSessionAttemptedToSerialize() {
         // Create both services before touching any CurrentInstance state so
         // neither service's construction clobbers the other's ThreadLocals.
         CurrentInstance.clearAll();

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/DevModeInitializerTestBase.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/DevModeInitializerTestBase.java
@@ -57,7 +57,7 @@ import static org.mockito.ArgumentMatchers.any;
  * Base class for DevModeInitializer tests. It is an independent class so as it
  * can be created and executed with custom classloaders.
  */
-public class DevModeInitializerTestBase extends AbstractDevModeTest {
+class DevModeInitializerTestBase extends AbstractDevModeTest {
 
     DevModeStartupListener devModeStartupListener;
 


### PR DESCRIPTION
JUnit Jupiter does not require public visibility on test classes or methods. Remove public from test class declarations and annotated test/lifecycle methods across all modules except flow-tests.

Classes referenced across packages retain public visibility.