### PR TITLE
fix: delete flow-build-info.json after Maven session via AbstractMavenLifecycleParticipant

### DIFF
--- a/flow-plugins/flow-maven-plugin/src/it/lifecycle-participant-delete-token-file/invoker.properties
+++ b/flow-plugins/flow-maven-plugin/src/it/lifecycle-participant-delete-token-file/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=-X -ntp clean package

--- a/flow-plugins/flow-maven-plugin/src/it/lifecycle-participant-delete-token-file/pom.xml
+++ b/flow-plugins/flow-maven-plugin/src/it/lifecycle-participant-delete-token-file/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.vaadin.test.maven</groupId>
+    <artifactId>lifecycle-participant-delete-token-file</artifactId>
+    <version>1.0</version>
+    <packaging>jar</packaging>
+
+    <description>
+        Tests that FlowLifecycleParticipant deletes flow-build-info.json after the Maven session
+        when the plugin is declared with extensions=true.
+    </description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>21</maven.compiler.release>
+        <maven.test.skip>true</maven.test.skip>
+        <flow.version>@project.version@</flow.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-server</artifactId>
+            <version>${flow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-client</artifactId>
+            <version>${flow.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>flow-maven-plugin</artifactId>
+                <version>${flow.version}</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build-frontend</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <forceProductionBuild>true</forceProductionBuild>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/flow-plugins/flow-maven-plugin/src/it/lifecycle-participant-delete-token-file/verify.bsh
+++ b/flow-plugins/flow-maven-plugin/src/it/lifecycle-participant-delete-token-file/verify.bsh
@@ -1,0 +1,18 @@
+import java.nio.file.*;
+
+logFile = basedir.toPath().resolve("build.log");
+if (!Files.exists(logFile, new LinkOption[0])) {
+    throw new RuntimeException("build.log not found");
+}
+logs = Files.readString(logFile);
+if (!logs.contains("Deleted flow-build-info.json from")) {
+    throw new RuntimeException(
+        "FlowLifecycleParticipant did not log deletion of flow-build-info.json.\n\n" + logs);
+}
+
+tokenFile = basedir.toPath().resolve(
+    "target/classes/META-INF/VAADIN/config/flow-build-info.json");
+if (Files.exists(tokenFile, new LinkOption[0])) {
+    throw new RuntimeException(
+        "flow-build-info.json was not deleted by FlowLifecycleParticipant: " + tokenFile);
+}

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -151,10 +151,11 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo
             throws MojoExecutionException, MojoFailureException {
         long start = System.nanoTime();
 
-        if (!BuildFrontendUtil.getTokenFile(this).exists()) {
+        File tokenFile = BuildFrontendUtil.getTokenFile(this);
+        if (!tokenFile.exists()) {
             // if not prepare-frontend token file exists propagate build info
             // to token file
-            File tokenFile = BuildFrontendUtil.propagateBuildInfo(this);
+            tokenFile = BuildFrontendUtil.propagateBuildInfo(this);
         }
 
         Options options = new Options(null, getClassFinder(), npmFolder())
@@ -217,10 +218,13 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo
         // build does not pick up a stale productionMode=true token.
         // Maven goals always re-execute so this does not affect
         // subsequent builds.
-        File tokenFile = BuildFrontendUtil.getTokenFile(this);
         if (tokenFile.exists()) {
             tokenFile.deleteOnExit();
         }
+
+        project.getProperties().setProperty(
+                FlowLifecycleParticipant.TOKEN_FILE_PATH_PROPERTY,
+                tokenFile.getAbsolutePath());
 
         long ms = (System.nanoTime() - start) / 1000000;
         getLog().info("Build frontend completed in " + ms + " ms.");

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowLifecycleParticipant.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowLifecycleParticipant.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.plugin.maven;
+
+import java.io.File;
+
+import org.apache.maven.AbstractMavenLifecycleParticipant;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.MavenProject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Maven lifecycle participant that deletes the production
+ * {@code flow-build-info.json} token file after each Maven session ends.
+ * <p>
+ * This supplements the {@code deleteOnExit()} call in
+ * {@code BuildFrontendUtil}, which only fires on JVM exit and therefore never
+ * runs when using the Maven Daemon (mvnd). By hooking into
+ * {@link #afterSessionEnd(MavenSession)}, the token file is cleaned up after
+ * every build invocation even when the daemon JVM stays alive between builds.
+ * <p>
+ * The exact token file path is written into the Maven project properties by
+ * {@code BuildFrontendMojo} under {@link #TOKEN_FILE_PATH_PROPERTY} so that a
+ * user-configured {@code resourceOutputDirectory} is always respected.
+ * <p>
+ * This participant is only active when the plugin is declared with
+ * {@code <extensions>true</extensions>} in the user's {@code pom.xml}.
+ * <p>
+ * The component is registered via {@code META-INF/plexus/components.xml} rather
+ * than annotations, since the {@code plexus-component-metadata} annotation
+ * processor is not part of this build.
+ */
+public class FlowLifecycleParticipant
+        extends AbstractMavenLifecycleParticipant {
+
+    /**
+     * Maven project property key under which {@code BuildFrontendMojo} stores
+     * the absolute path of the token file it wrote. Read by
+     * {@link #afterSessionEnd(MavenSession)} to delete the correct file.
+     */
+    public static final String TOKEN_FILE_PATH_PROPERTY = "vaadin.flow.tokenFilePath";
+
+    private static final Logger logger = LoggerFactory
+            .getLogger(FlowLifecycleParticipant.class);
+
+    @Override
+    public void afterSessionEnd(MavenSession session) {
+        for (MavenProject project : session.getProjects()) {
+            String tokenFilePath = project.getProperties()
+                    .getProperty(TOKEN_FILE_PATH_PROPERTY);
+            if (tokenFilePath == null) {
+                // build-frontend did not run in this session; nothing to clean
+                // up
+                continue;
+            }
+            File tokenFile = new File(tokenFilePath);
+            if (tokenFile.exists()) {
+                if (tokenFile.delete()) {
+                    logger.debug("Deleted flow-build-info.json from {}",
+                            tokenFilePath);
+                } else {
+                    logger.debug(
+                            "Failed to delete flow-build-info.json from {}",
+                            tokenFilePath);
+                }
+            }
+        }
+    }
+}

--- a/flow-plugins/flow-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/flow-plugins/flow-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,9 @@
+<component-set>
+  <components>
+    <component>
+      <role>org.apache.maven.AbstractMavenLifecycleParticipant</role>
+      <role-hint>vaadin</role-hint>
+      <implementation>com.vaadin.flow.plugin.maven.FlowLifecycleParticipant</implementation>
+    </component>
+  </components>
+</component-set>


### PR DESCRIPTION
`BuildFrontendUtil.updateBuildFile()` calls `deleteOnExit()` on the production token file, but this never fires when using the Maven Daemon (mvnd) because the JVM stays alive between builds. As a result, `flow-build-info.json` with `productionMode: true` persists in `target/classes/META-INF/VAADIN/config/` and causes incorrect production-mode behavior when starting the app from the IDE.

Adds `FlowLifecycleParticipant`, an `AbstractMavenLifecycleParticipant` that hooks into `afterSessionEnd()` to delete the token file after every build session. `BuildFrontendMojo` stores the resolved token file path in a Maven project property so the participant always uses the correct path even when `resourceOutputDirectory` is user-configured.

`AbstractMavenLifecycleParticipant` only activates when the plugin is declared as a Maven extension, so users must add
`<extensions>true</extensions>` to the plugin declaration in their `pom.xml` to benefit from this fix. The existing `deleteOnExit()` call acts as a transparent fallback for projects that do not opt in.

Fixes #21021
