### PR TITLE
Add nullSafeConverter method to Converter interface

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/converter/Converter.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/converter/Converter.java
@@ -173,4 +173,48 @@ public interface Converter<PRESENTATION, MODEL> extends Serializable {
         };
     }
 
+    /**
+     * Wraps the given {@code converter} with a converter that handles both null
+     * presentation and null model values:
+     * <ul>
+     * <li>If the model value is null, the converter returns null. Otherwise, it
+     * delegates to the wrapped converter.</li>
+     * <li>If the presentation value is null, the converter returns null.
+     * Otherwise, it delegates to the wrapped converter.</li>
+     * </ul>
+     * Example use:
+     * 
+     * <pre>
+     * {@code
+     * Converter<String, LocalDate> converter = Converter
+     *         .nullSafeConverter(Converter.from(LocalDate::parse,
+     *                 LocalDate::toString, Exception::getMessage));
+     * }
+     * </pre>
+     *
+     * @param <P>
+     *            the presentation type
+     * @param <M>
+     *            the model type
+     * @param converter
+     *            the converter to delegate to when the value being converted is
+     *            not null
+     * @return a converter that handles both null presentation and null model
+     *         values
+     */
+    static <P, M> Converter<P, M> nullSafeConverter(Converter<P, M> converter) {
+        return new Converter<P, M>() {
+            @Override
+            public Result<M> convertToModel(P value, ValueContext context) {
+                return value == null ? Result.ok(null)
+                        : converter.convertToModel(value, context);
+            }
+
+            @Override
+            public P convertToPresentation(M value, ValueContext context) {
+                return value == null ? null
+                        : converter.convertToPresentation(value, context);
+            }
+        };
+    }
 }

--- a/flow-data/src/test/java/com/vaadin/flow/data/converter/NullSafeConverterTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/converter/NullSafeConverterTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.data.converter;
+
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.data.binder.ValueContext;
+
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class NullSafeConverterTest {
+
+    record ValueObject(String value) {
+        ValueObject {
+            requireNonNull(value);
+        }
+    }
+
+    private final Converter<String, ValueObject> converter = Converter
+            .nullSafeConverter(Converter.from(ValueObject::new,
+                    ValueObject::value, Exception::getMessage));
+
+    @Test
+    void nullPresentationConvertsToNullModel() {
+        var result = converter.convertToModel(null, new ValueContext());
+        assertFalse(result.isError());
+        assertNull(result.getOrThrow(RuntimeException::new));
+    }
+
+    @Test
+    void nonNullPresentationConvertsToNonNullModel() {
+        var result = converter.convertToModel("hello", new ValueContext());
+        assertFalse(result.isError());
+        assertEquals(new ValueObject("hello"),
+                result.getOrThrow(RuntimeException::new));
+    }
+
+    @Test
+    void nullModelConvertsToNullPresentation() {
+        var result = converter.convertToPresentation(null, new ValueContext());
+        assertNull(result);
+    }
+
+    @Test
+    void nonNullModelConvertsToNonNullPresentation() {
+        var result = converter.convertToPresentation(new ValueObject("hello"),
+                new ValueContext());
+        assertEquals("hello", result);
+    }
+}


### PR DESCRIPTION
## Description

When writing converters, there are already methods provided for using mapper functions that map between the model and presentation values. This is useful, but these functions, like `LocalDate::parse` or `LocalDate::toString` always assume a non-null input. Since converters work with both null inputs and outputs, you virtually always have to write your own custom validators to handle nulls.

This helper function allows you to write converters like this:

```java
Converter<String, LocalDate> converter = Converter.nullSafeConverter(
    Converter.from(LocalDate::parse, LocalDate::toString, Exception::getMessage)
);
```

## Type of change

- [ ] Bugfix
- [x] Feature
