### PR TITLE
fix: add missing `registerStyles` import to generated app-shell-imports.js

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -342,10 +342,12 @@ abstract class AbstractUpdateImports implements Runnable {
 
     // Move all import lines to the top, before any non-import lines
     private static void moveImportsToTop(List<String> lines) {
-        List<String> imports = new ArrayList<>(lines);
-        imports.removeIf(line -> !line.startsWith("import "));
-        lines.removeIf(line -> line.startsWith("import "));
-        lines.addAll(0, imports);
+        if (!lines.isEmpty()) {
+            List<String> imports = new ArrayList<>(lines);
+            imports.removeIf(line -> !line.startsWith("import "));
+            lines.removeIf(line -> line.startsWith("import "));
+            lines.addAll(0, imports);
+        }
     }
 
     private void writeWebComponentImports(List<String> lines) {
@@ -488,6 +490,7 @@ abstract class AbstractUpdateImports implements Runnable {
         cssLineOffset += appShellCssLines.size();
         if (!appShellCssLines.isEmpty()) {
             appShellLines.add(IMPORT_INJECT);
+            appShellLines.add(THEMABLE_MIXIN_IMPORT);
             appShellLines.addAll(appShellCssLines);
         }
         if (FrontendBuildUtils.isTailwindCssEnabled(options)) {
@@ -499,6 +502,7 @@ abstract class AbstractUpdateImports implements Runnable {
                     + "/" + FrontendUtils.TAILWIND_JS;
             appShellLines.add(String.format(IMPORT_TEMPLATE, importPath));
         }
+        moveImportsToTop(appShellLines);
         files.put(appShellImports, appShellLines);
         files.put(appShellDefinitions, Collections.singletonList("export {}"));
 

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
@@ -113,6 +113,11 @@ abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
     }
 
     @CssImport("./foo.css")
+    @CssImport("./bar.css")
+    public static class MultiCssImportAppShell implements AppShellConfigurator {
+    }
+
+    @CssImport("./foo.css")
     public static class CssImportExporter
             extends WebComponentExporter<FooCssImport> {
         public CssImportExporter() {
@@ -432,6 +437,8 @@ abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
         // AppShell and @Theme CSS imports are expected to be generated in
         // the dedicated file.
         List<String> expectedAppShellImports = List.of(
+                "import \\{ injectGlobalCss \\}.*",
+                "import \\{ css, unsafeCSS, registerStyles \\}.*",
                 "import \\$cssFromFile_\\d from 'lumo-css-import.css\\?inline';",
                 "injectGlobalCss\\(\\$cssFromFile_\\d.toString\\(\\), 'CSSImport end', document\\);");
 
@@ -931,6 +938,19 @@ abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
         List<String> lines = updater.webComponentImports;
         assertNotNull(lines,
                 "Web component imports should have been generated");
+        assertImportsBeforeNonImportLines(lines);
+    }
+
+    @Test
+    void generatedAppShellImports_importsAreOnTopBeforeOtherInstructions()
+            throws Exception {
+        Class<?>[] testClasses = { MultiCssImportAppShell.class };
+        ClassFinder classFinder = getClassFinder(testClasses);
+        updater = new UpdateImports(getScanner(classFinder), options);
+        updater.run();
+
+        List<String> lines = updater.getOutput().get(updater.appShellImports);
+        assertNotNull(lines, "App shell imports should have been generated");
         assertImportsBeforeNonImportLines(lines);
     }
 


### PR DESCRIPTION
The generated `app-shell-imports.js` file was missing the `THEMABLE_MIXIN_IMPORT` line (`import { css, unsafeCSS, registerStyles }`), causing `ReferenceError: registerStyles is not defined` at startup in production mode when `@CssImport` with `themeFor` was used on an `AppShellConfigurator`.

Also ensures import statements are moved to the top of the generated app shell file, consistent with other generated import files.

Fixes #23689