### PR TITLE
fix: Prevent duplicated CSS imports in web component generated file

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -92,6 +93,8 @@ abstract class AbstractUpdateImports implements Runnable {
             + "<style%s>${$css_%1$d}</style>" + CSS_POST;
     private static final String INJECT_CSS = CSS_IMPORT
             + "%ninjectGlobalCss($cssFromFile_%1$d.toString(), 'CSSImport end', document);%n";
+    private static final Pattern CSS_IMPORT_PATTERN = Pattern
+            .compile("import \\$cssFromFile_(\\d+) from '(.+?)'");
     private static final Pattern INJECT_CSS_PATTERN = Pattern
             .compile("^\\s*injectGlobalCss\\(([^,]+),.*$");
     private static final String INJECT_WC_CSS = "injectGlobalWebcomponentCss(%s);";
@@ -269,10 +272,72 @@ abstract class AbstractUpdateImports implements Runnable {
                 Collections.emptyList()));
         merged.addAll(outputFiles.getOrDefault(generatedFlowImports,
                 Collections.emptyList()));
+        return removeDuplicateCssImports(merged);
+    }
+
+    /**
+     * Removes duplicate CSS imports from the merged web component output. Moves
+     * imports to the top, then scans for CSS import lines that share the same
+     * file path but have different variable indices (from different output
+     * files). Keeps only the first import for each path, remaps variable
+     * references in duplicate processing lines to use the kept index, and
+     * deduplicates lines that became identical after remapping.
+     * <p>
+     * Note: the same CSS file can be imported multiple times with different
+     * processing instructions (e.g. {@code @CssImport(value="bar.css",
+     * themeFor="x")} producing {@code registerStyles('x', $css_5, ...)} and
+     * {@code @CssImport(value="bar.css", include="y")} producing
+     * {@code addCssBlock(`<style include="y">${$css_5}</style>`)}). After
+     * remapping, these lines remain distinct because their content differs, so
+     * both registrations are preserved.
+     */
+    private static List<String> removeDuplicateCssImports(List<String> lines) {
+        // Deduplicate identical lines and move imports to the top
         List<String> result = new ArrayList<>(
-                merged.stream().distinct().toList());
+                lines.stream().distinct().toList());
         moveImportsToTop(result);
-        return result;
+
+        Map<String, String> pathToFirstIndex = new LinkedHashMap<>();
+        Map<String, String> remappedIndices = new LinkedHashMap<>();
+
+        // Remove duplicate import lines immediately
+        Iterator<String> it = result.iterator();
+        while (it.hasNext()) {
+            String line = it.next();
+            if (!line.startsWith("import ") && !line.isBlank()) {
+                break;
+            }
+            Matcher m = CSS_IMPORT_PATTERN.matcher(line);
+            if (m.find()) {
+                String first = pathToFirstIndex.putIfAbsent(m.group(2),
+                        m.group(1));
+                if (first != null) {
+                    remappedIndices.put(m.group(1), first);
+                    it.remove();
+                }
+            }
+        }
+
+        if (remappedIndices.isEmpty()) {
+            return result;
+        }
+
+        // Build a single pattern matching all duplicate indices.
+        // (?!\d) prevents _1 from matching _10
+        String indexAlt = String.join("|", remappedIndices.keySet());
+        Pattern pattern = Pattern
+                .compile("(\\$cssFromFile_|\\$css_|flow_css_mod_)(" + indexAlt
+                        + ")(?!\\d)");
+
+        // Remap processing lines and deduplicate results
+        LinkedHashSet<String> deduplicated = new LinkedHashSet<>();
+        for (String line : result) {
+            String remapped = pattern.matcher(line)
+                    .replaceAll(mr -> Matcher.quoteReplacement(
+                            mr.group(1) + remappedIndices.get(mr.group(2))));
+            deduplicated.add(remapped);
+        }
+        return new ArrayList<>(deduplicated);
     }
 
     // Move all import lines to the top, before any non-import lines

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
@@ -26,8 +26,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -120,6 +122,20 @@ abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
         @Override
         public void configureInstance(WebComponent<FooCssImport> webComponent,
                 FooCssImport component) {
+        }
+    }
+
+    @CssImport(value = "./foo.css", themeFor = "something")
+    public static class ThemeForCssImportExporter
+            extends WebComponentExporter<ThemeForCssImport> {
+        public ThemeForCssImportExporter() {
+            super("themefor-css-import-exporter");
+        }
+
+        @Override
+        public void configureInstance(
+                WebComponent<ThemeForCssImport> webComponent,
+                ThemeForCssImport component) {
         }
     }
 
@@ -511,18 +527,36 @@ abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
                         .noneMatch(lumoGlobalsMatcher),
                 "Import for web-components should not contain lumo global imports");
 
-        // Check that imports other than lumo globals are the same
-        flowImports.removeAll(updater.webComponentImports);
+        // Compare lines ignoring CSS variable index differences caused
+        // by deduplication across merged output files
+        Set<String> flowNormalized = normalizeCssIndices(flowImports);
+        Set<String> wcNormalized = normalizeCssIndices(
+                updater.webComponentImports);
 
-        // webComponent only has injectGlobalWebcomponentCss and not
-        // injectGlobalCss'
-        Predicate<String> injectGlobal = Pattern.compile("injectGlobalCss.*")
-                .asPredicate();
-        flowImports.removeIf(injectGlobal);
+        Set<String> difference = new LinkedHashSet<>(flowNormalized);
+        difference.removeAll(wcNormalized);
+        // Remove injectGlobalCss (webComponent uses
+        // injectGlobalWebcomponentCss instead)
+        difference.removeIf(Pattern.compile("injectGlobalCss.*").asPredicate());
 
-        assertTrue(flowImports.stream().allMatch(lumoGlobalsMatcher),
-                "Flow and web-component imports must be the same, except for lumo globals");
+        List<String> unexpected = difference.stream()
+                .filter(lumoGlobalsMatcher.negate()).toList();
+        assertTrue(unexpected.isEmpty(),
+                "Flow and web-component imports must be the same, except for lumo globals. Unexpected: "
+                        + unexpected);
+    }
 
+    private Set<String> normalizeCssIndices(List<String> lines) {
+        Set<String> normalized = new LinkedHashSet<>();
+        for (String line : lines) {
+            if (!line.isBlank()) {
+                normalized.add(line
+                        .replaceAll("\\$cssFromFile_\\d+", "\\$cssFromFile_N")
+                        .replaceAll("\\$css_\\d+", "\\$css_N")
+                        .replaceAll("flow_css_mod_\\d+", "flow_css_mod_N"));
+            }
+        }
+        return normalized;
     }
 
     @Test
@@ -898,6 +932,52 @@ abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
         assertNotNull(lines,
                 "Web component imports should have been generated");
         assertImportsBeforeNonImportLines(lines);
+    }
+
+    @Test
+    void duplicateCssImportInWebComponentAndEager_importedOnlyOnce()
+            throws Exception {
+        Class<?>[] testClasses = { CssImportExporter.class, FooCssImport.class,
+                UI.class, AllEagerAppConf.class };
+        ClassFinder classFinder = getClassFinder(testClasses);
+        updater = new UpdateImports(getScanner(classFinder), options);
+        updater.run();
+
+        List<String> lines = updater.webComponentImports;
+        assertNotNull(lines,
+                "Web component imports should have been generated");
+        assertOnce("from 'Frontend/foo.css?inline';", lines);
+    }
+
+    @Test
+    void duplicateThemeForCssImportInWebComponentAndEager_importedOnlyOnce()
+            throws Exception {
+        Class<?>[] testClasses = { ThemeForCssImportExporter.class,
+                ThemeForCssImport.class, UI.class, AllEagerAppConf.class };
+        ClassFinder classFinder = getClassFinder(testClasses);
+        updater = new UpdateImports(getScanner(classFinder), options);
+        updater.run();
+
+        List<String> lines = updater.webComponentImports;
+        assertNotNull(lines,
+                "Web component imports should have been generated");
+        assertOnce("from 'Frontend/foo.css?inline';", lines);
+        assertOnce("registerStyles('something'", lines);
+    }
+
+    @Test
+    void duplicateCssImportInAppShellAndEager_importedOnlyOnce()
+            throws Exception {
+        Class<?>[] testClasses = { ThemeCssImport.class, FooCssImport.class,
+                CssImportExporter.class, UI.class };
+        ClassFinder classFinder = getClassFinder(testClasses);
+        updater = new UpdateImports(getScanner(classFinder), options);
+        updater.run();
+
+        List<String> lines = updater.webComponentImports;
+        assertNotNull(lines,
+                "Web component imports should have been generated");
+        assertOnce("from 'Frontend/foo.css?inline';", lines);
     }
 
     private void assertImportsBeforeNonImportLines(List<String> lines) {


### PR DESCRIPTION
When a CSS file is referenced by both a regular component and a WebComponentExporter (or AppShellConfigurator), the generated web component imports file contained duplicate import statements and duplicate style registrations for the same CSS. This happened because the web component output merges multiple independently generated files, and the existing string-based deduplication could not recognize that two imports for the same file were equivalent.

The fix detects duplicate CSS file imports after merging and unifies their variable references so that identical style registrations are properly deduplicated, while preserving distinct registrations when the same CSS file is intentionally used with different configurations.

Fixes #23689
