### PR TITLE
fix: Prevent stale JAR cache in `Reflector` under Maven daemon (mvnd) (#23863) (CP: 25.0)

### DIFF
--- a/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/Reflector.java
+++ b/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/Reflector.java
@@ -15,8 +15,10 @@
  */
 package com.vaadin.flow.plugin.maven;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.lang.ref.Cleaner;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.net.URL;
@@ -48,7 +50,7 @@ import com.vaadin.flow.utils.FlowFileUtils;
 /**
  * Helper class to deal with classloading of Flow plugin mojos.
  */
-public final class Reflector {
+public final class Reflector implements Closeable {
 
     public static final String INCLUDE_FROM_COMPILE_DEPS_REGEX = ".*(/|\\\\)(portlet-api|javax\\.servlet-api)-.+jar$";
     private static final Set<String> DEPENDENCIES_GROUP_EXCLUSIONS = Set.of(
@@ -60,6 +62,7 @@ public final class Reflector {
             "org.zeroturnaround:zt-exec:jar");
     private static final ScopeArtifactFilter PRODUCTION_SCOPE_FILTER = new ScopeArtifactFilter(
             Artifact.SCOPE_COMPILE_PLUS_RUNTIME);
+    private static final Cleaner CLEANER = Cleaner.create();
 
     private final URLClassLoader isolatedClassLoader;
     private List<String> dependenciesIncompatibility;
@@ -73,6 +76,17 @@ public final class Reflector {
      */
     public Reflector(URLClassLoader isolatedClassLoader) {
         this.isolatedClassLoader = isolatedClassLoader;
+        // Best-effort cleanup: close classloader when Reflector is GC'd.
+        // Under mvnd, abandoned Reflectors from previous builds leak
+        // URLClassLoader handles until GC collects them.
+        URLClassLoader cl = isolatedClassLoader;
+        CLEANER.register(this, () -> {
+            try {
+                cl.close();
+            } catch (IOException e) {
+                // ignore
+            }
+        });
     }
 
     private Reflector(URLClassLoader isolatedClassLoader, Object classFinder,
@@ -165,6 +179,19 @@ public final class Reflector {
      */
     public URL getResource(String name) {
         return isolatedClassLoader.getResource(name);
+    }
+
+    /**
+     * Closes the isolated class loader, releasing file handles on JARs.
+     * Idempotent: safe to call multiple times.
+     */
+    @Override
+    public void close() {
+        try {
+            isolatedClassLoader.close();
+        } catch (IOException e) {
+            // ignore
+        }
     }
 
     /**
@@ -396,7 +423,7 @@ public final class Reflector {
             if (url == null) {
                 url = ClassLoader.getPlatformClassLoader().getResource(name);
             }
-            return url;
+            return ReflectionsClassFinder.disableJarCaching(url);
         }
 
         @Override
@@ -406,13 +433,15 @@ public final class Reflector {
             // Collect resources from all classloaders
             Enumeration<URL> resources = super.getResources(name);
             while (resources.hasMoreElements()) {
-                allResources.add(resources.nextElement());
+                allResources.add(ReflectionsClassFinder
+                        .disableJarCaching(resources.nextElement()));
             }
 
             if (delegate != null) {
                 resources = delegate.getResources(name);
                 while (resources.hasMoreElements()) {
-                    URL url = resources.nextElement();
+                    URL url = ReflectionsClassFinder
+                            .disableJarCaching(resources.nextElement());
                     if (!allResources.contains(url)) {
                         allResources.add(url);
                     }
@@ -421,7 +450,8 @@ public final class Reflector {
 
             resources = ClassLoader.getPlatformClassLoader().getResources(name);
             while (resources.hasMoreElements()) {
-                URL url = resources.nextElement();
+                URL url = ReflectionsClassFinder
+                        .disableJarCaching(resources.nextElement());
                 if (!allResources.contains(url)) {
                     allResources.add(url);
                 }

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -430,8 +430,10 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
      * @return true if Hilla is available, false otherwise
      */
     public static boolean isHillaAvailable(MavenProject mavenProject) {
-        return Reflector.of(mavenProject, null, null).getResource(
-                "com/vaadin/hilla/EndpointController.class") != null;
+        try (Reflector reflector = Reflector.of(mavenProject, null, null)) {
+            return reflector.getResource(
+                    "com/vaadin/hilla/EndpointController.class") != null;
+        }
     }
 
     /**

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/Reflector.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/Reflector.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.plugin.maven;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.lang.annotation.Documented;
@@ -22,6 +23,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.lang.ref.Cleaner;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.net.URL;
@@ -61,7 +63,7 @@ import com.vaadin.flow.utils.FlowFileUtils;
 /**
  * Helper class to deal with classloading of Flow plugin mojos.
  */
-public final class Reflector {
+public final class Reflector implements Closeable {
 
     public static final String INCLUDE_FROM_COMPILE_DEPS_REGEX = ".*(/|\\\\)(portlet-api|javax\\.servlet-api)-.+jar$";
     private static final Set<String> DEPENDENCIES_GROUP_EXCLUSIONS = Set.of(
@@ -73,6 +75,7 @@ public final class Reflector {
             "org.zeroturnaround:zt-exec:jar");
     private static final ScopeArtifactFilter PRODUCTION_SCOPE_FILTER = new ScopeArtifactFilter(
             Artifact.SCOPE_COMPILE_PLUS_RUNTIME);
+    private static final Cleaner CLEANER = Cleaner.create();
     private static final Logger log = LoggerFactory.getLogger(Reflector.class);
 
     private final URLClassLoader isolatedClassLoader;
@@ -87,6 +90,17 @@ public final class Reflector {
      */
     Reflector(URLClassLoader isolatedClassLoader) {
         this.isolatedClassLoader = isolatedClassLoader;
+        // Best-effort cleanup: close classloader when Reflector is GC'd.
+        // Under mvnd, abandoned Reflectors from previous builds leak
+        // URLClassLoader handles until GC collects them.
+        URLClassLoader cl = isolatedClassLoader;
+        CLEANER.register(this, () -> {
+            try {
+                cl.close();
+            } catch (IOException e) {
+                // ignore
+            }
+        });
     }
 
     private Reflector(URLClassLoader isolatedClassLoader, Object classFinder,
@@ -179,6 +193,19 @@ public final class Reflector {
      */
     public URL getResource(String name) {
         return isolatedClassLoader.getResource(name);
+    }
+
+    /**
+     * Closes the isolated class loader, releasing file handles on JARs.
+     * Idempotent: safe to call multiple times.
+     */
+    @Override
+    public void close() {
+        try {
+            isolatedClassLoader.close();
+        } catch (IOException e) {
+            log.debug("Error closing isolated class loader", e);
+        }
     }
 
     /**
@@ -468,7 +495,7 @@ public final class Reflector {
             if (url == null) {
                 url = ClassLoader.getPlatformClassLoader().getResource(name);
             }
-            return url;
+            return ReflectionsClassFinder.disableJarCaching(url);
         }
 
         @Override
@@ -478,13 +505,15 @@ public final class Reflector {
             // Collect resources from all classloaders
             Enumeration<URL> resources = super.getResources(name);
             while (resources.hasMoreElements()) {
-                allResources.add(resources.nextElement());
+                allResources.add(ReflectionsClassFinder
+                        .disableJarCaching(resources.nextElement()));
             }
 
             if (delegate != null) {
                 resources = delegate.getResources(name);
                 while (resources.hasMoreElements()) {
-                    URL url = resources.nextElement();
+                    URL url = ReflectionsClassFinder
+                            .disableJarCaching(resources.nextElement());
                     if (!allResources.contains(url)) {
                         allResources.add(url);
                     }
@@ -493,7 +522,8 @@ public final class Reflector {
 
             resources = ClassLoader.getPlatformClassLoader().getResources(name);
             while (resources.hasMoreElements()) {
-                URL url = resources.nextElement();
+                URL url = ReflectionsClassFinder
+                        .disableJarCaching(resources.nextElement());
                 if (!allResources.contains(url)) {
                     allResources.add(url);
                 }

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/ReflectorTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/ReflectorTest.java
@@ -20,6 +20,7 @@ import javax.inject.Inject;
 import java.io.File;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.net.URLConnection;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -294,6 +295,55 @@ public class ReflectorTest {
                 "com.vaadin-flow-server-1.0.jar");
         assertThatIsolatedClassLoaderHasFilteredScanUrls(scanner,
                 expectedArtifacts);
+    }
+
+    @Test
+    public void close_isIdempotent() {
+        reflector.close();
+        reflector.close(); // second close should not throw
+    }
+
+    @Test
+    public void getResource_jarUrlDisablesCaching() throws Exception {
+        // The reflector's isolated classloader delegates to maven.api realm
+        // which contains the test JAR
+        MavenProject project = new MavenProject();
+        project.setGroupId("com.vaadin.test");
+        project.setArtifactId("reflector-tests");
+        project.setBuild(new Build());
+        project.getBuild().setOutputDirectory(PROJECT_TARGET_FOLDER);
+        project.setArtifacts(Set.of());
+
+        MojoExecution exec = new MojoExecution(new MojoDescriptor());
+        PluginDescriptor pluginDescriptor = new PluginDescriptor();
+        exec.getMojoDescriptor().setPluginDescriptor(pluginDescriptor);
+        pluginDescriptor.setGroupId("com.vaadin.test");
+        pluginDescriptor.setArtifactId("test-plugin");
+        pluginDescriptor.setArtifacts(List.of());
+        ClassWorld classWorld = new ClassWorld("maven.api", null);
+        classWorld.getRealm("maven.api")
+                .addURL(Path
+                        .of("src", "test", "resources",
+                                "jar-without-frontend-resources.jar")
+                        .toUri().toURL());
+        pluginDescriptor.setClassRealm(classWorld.newRealm("maven-plugin"));
+
+        Reflector execReflector = Reflector.of(project, exec, null);
+        try {
+            URL resource = execReflector.getIsolatedClassLoader()
+                    .getResource("org/json/CookieList.class");
+            Assert.assertNotNull("Resource should be found in JAR", resource);
+            Assert.assertEquals("jar", resource.getProtocol());
+
+            URLConnection conn = resource.openConnection();
+            Assert.assertFalse(
+                    "jar: URL connections should have caching disabled "
+                            + "to prevent stale JarFileFactory entries "
+                            + "under mvnd",
+                    conn.getUseCaches());
+        } finally {
+            execReflector.close();
+        }
     }
 
     @Test

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/server/scanner/ReflectionsClassFinder.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/server/scanner/ReflectionsClassFinder.java
@@ -119,14 +119,23 @@ public class ReflectionsClassFinder implements ClassFinder, AutoCloseable {
 
     @Override
     public URL getResource(String name) {
-        URL url = classLoader.getResource(name);
+        return disableJarCaching(classLoader.getResource(name));
+    }
+
+    /**
+     * Wraps a {@code jar:} URL with a handler that disables JVM-level JAR
+     * caching. Prevents {@code JarFileFactory} from caching stale
+     * {@code JarFile} instances across daemon builds (Gradle daemon, mvnd).
+     *
+     * @param url
+     *            the URL to wrap, may be {@code null}
+     * @return a wrapped URL with caching disabled for {@code jar:} protocol, or
+     *         the original URL for other protocols or {@code null} input
+     */
+    public static URL disableJarCaching(URL url) {
         if (url == null || !"jar".equals(url.getProtocol())) {
             return url;
         }
-        // Wrap jar: URLs with a handler that disables JVM-level JAR caching.
-        // Without this, JarFileFactory keeps a static cache of JarFile
-        // instances that become stale when JARs are rewritten between Gradle
-        // daemon builds, causing ZipException ("invalid LOC header").
         try {
             return new URL(null, url.toExternalForm(), new URLStreamHandler() {
                 @Override


### PR DESCRIPTION
Mirror the Gradle daemon fix (33fa374) in the Maven plugin's `Reflector` and `ReflectorClassLoader`/`CombinedClassLoader`:

- Extract `ReflectionsClassFinder.disableJarCaching()` as a public utility so both plugins can reuse it.
- Wrap `jar:` URLs in `ReflectorClassLoader.getResource()` and `getResources()` (flow-maven-plugin) and `CombinedClassLoader` (flow-dev-bundle-plugin) with `useCaches(false)` to prevent stale `JarFileFactory` entries across daemon builds.
- Make `Reflector` implement `Closeable` with a `close()` method that releases the `URLClassLoader` file handles, and register a `Cleaner` action for best-effort GC cleanup of abandoned instances.
- Close the temporary `Reflector` in `FlowModeAbstractMojo.isHillaAvailable(MavenProject)` via try-with-resources.

Releated to #15458