### PR TITLE
test: remove .ts extension from import in vite-pwa-production test

### DIFF
--- a/flow-tests/test-frontend/vite-pwa-production/src/main/frontend/index.ts
+++ b/flow-tests/test-frontend/vite-pwa-production/src/main/frontend/index.ts
@@ -1,5 +1,5 @@
 import './home-view';
-import './about-view.ts';
+import './about-view';
 import { Router } from '@vaadin/router';
 
 const router = new Router(document.querySelector('#outlet'));


### PR DESCRIPTION
TypeScript 6 requires 'allowImportingTsExtensions' for imports ending with .ts. Remove the extension since bundler module resolution resolves it automatically.
