### PR TITLE
test: Import login package to be compatible with TS6

### DIFF
--- a/flow-tests/test-ccdm/src/main/frontend/css-importing-test.ts
+++ b/flow-tests/test-ccdm/src/main/frontend/css-importing-test.ts
@@ -1,6 +1,6 @@
 import { LitElement } from 'lit';
 
-import '@vaadin/vaadin-login/vaadin-login-overlay';
+import '@vaadin/login';
 import styles from './test-styles.css?inline';
 
 // Regression test for flow#9167 (`styles` assignment will cause a type


### PR DESCRIPTION
TypeScript 6 with moduleResolution "bundler" cannot resolve subpath imports like `@vaadin/vaadin-login/vaadin-login-overlay` when the package lacks an `exports` map in its package.json. Use the main entry point `@vaadin/login` instead, which resolves correctly via the package's `main` and `types` fields.
