### PR TITLE
fix: add missing `registerStyles` import to generated app-shell-imports.js (#23975) (CP: 25.0)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -340,10 +340,12 @@ abstract class AbstractUpdateImports implements Runnable {
 
     // Move all import lines to the top, before any non-import lines
     private static void moveImportsToTop(List<String> lines) {
-        List<String> imports = new ArrayList<>(lines);
-        imports.removeIf(line -> !line.startsWith("import "));
-        lines.removeIf(line -> line.startsWith("import "));
-        lines.addAll(0, imports);
+        if (!lines.isEmpty()) {
+            List<String> imports = new ArrayList<>(lines);
+            imports.removeIf(line -> !line.startsWith("import "));
+            lines.removeIf(line -> line.startsWith("import "));
+            lines.addAll(0, imports);
+        }
     }
 
     private void writeWebComponentImports(List<String> lines) {
@@ -486,6 +488,7 @@ abstract class AbstractUpdateImports implements Runnable {
         cssLineOffset += appShellCssLines.size();
         if (!appShellCssLines.isEmpty()) {
             appShellLines.add(IMPORT_INJECT);
+            appShellLines.add(THEMABLE_MIXIN_IMPORT);
             appShellLines.addAll(appShellCssLines);
         }
         if (FrontendUtils.isTailwindCssEnabled(options)) {
@@ -497,6 +500,7 @@ abstract class AbstractUpdateImports implements Runnable {
                     + "/" + FrontendUtils.TAILWIND_JS;
             appShellLines.add(String.format(IMPORT_TEMPLATE, importPath));
         }
+        moveImportsToTop(appShellLines);
         files.put(appShellImports, appShellLines);
         files.put(appShellDefinitions, Collections.singletonList("export {}"));
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
@@ -113,6 +113,11 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
     }
 
     @CssImport("./foo.css")
+    @CssImport("./bar.css")
+    public static class MultiCssImportAppShell implements AppShellConfigurator {
+    }
+
+    @CssImport("./foo.css")
     public static class CssImportExporter
             extends WebComponentExporter<FooCssImport> {
         public CssImportExporter() {
@@ -434,6 +439,8 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
         // AppShell and @Theme CSS imports are expected to be generated in
         // the dedicated file.
         List<String> expectedAppShellImports = List.of(
+                "import \\{ injectGlobalCss \\}.*",
+                "import \\{ css, unsafeCSS, registerStyles \\}.*",
                 "import \\$cssFromFile_\\d from 'lumo-css-import.css\\?inline';",
                 "injectGlobalCss\\(\\$cssFromFile_\\d.toString\\(\\), 'CSSImport end', document\\);");
 
@@ -945,6 +952,20 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
 
         List<String> lines = updater.webComponentImports;
         Assert.assertNotNull("Web component imports should have been generated",
+                lines);
+        assertImportsBeforeNonImportLines(lines);
+    }
+
+    @Test
+    public void generatedAppShellImports_importsAreOnTopBeforeOtherInstructions()
+            throws Exception {
+        Class<?>[] testClasses = { MultiCssImportAppShell.class };
+        ClassFinder classFinder = getClassFinder(testClasses);
+        updater = new UpdateImports(getScanner(classFinder), options);
+        updater.run();
+
+        List<String> lines = updater.getOutput().get(updater.appShellImports);
+        Assert.assertNotNull("App shell imports should have been generated",
                 lines);
         assertImportsBeforeNonImportLines(lines);
     }


### PR DESCRIPTION
The generated `app-shell-imports.js` file was missing the `THEMABLE_MIXIN_IMPORT` line (`import { css, unsafeCSS, registerStyles }`), causing `ReferenceError: registerStyles is not defined` at startup in production mode when `@CssImport` with `themeFor` was used on an `AppShellConfigurator`.

Also ensures import statements are moved to the top of the generated app shell file, consistent with other generated import files.

Fixes #23689