### PR TITLE
test: Remove unused login import from CSS importing test

### DIFF
--- a/flow-tests/test-ccdm/src/main/frontend/css-importing-test.ts
+++ b/flow-tests/test-ccdm/src/main/frontend/css-importing-test.ts
@@ -1,6 +1,5 @@
 import { LitElement } from 'lit';
 
-import '@vaadin/vaadin-login/vaadin-login-overlay';
 import styles from './test-styles.css?inline';
 
 // Regression test for flow#9167 (`styles` assignment will cause a type


### PR DESCRIPTION
The side-effect import of @vaadin/vaadin-login was not needed for this test, which only verifies that .css imports produce valid CSSResultGroup types (regression test for flow#9167). The login package is not a declared dependency of this test module, so it fails in CI with TS6's stricter TS2882 check for side-effect imports without type declarations.
