### PR TITLE
fix: remove type parameter from Signal.effect

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/signals/Signal.java
+++ b/flow-server/src/main/java/com/vaadin/flow/signals/Signal.java
@@ -149,8 +149,7 @@ public interface Signal<T extends @Nullable Object> extends Serializable {
      * @return a {@link Registration} that can be used to remove the effect
      *         function
      */
-    static Registration effect(Component owner,
-            EffectAction effectFunction) {
+    static Registration effect(Component owner, EffectAction effectFunction) {
         return ElementEffect.effect(owner.getElement(), effectFunction);
     }
 


### PR DESCRIPTION
The removal is binary-compatible and source-compatible. The erased signature was already `effect(Component, ...)` since `C extends Component` erases to `Component`, so existing compiled bytecode links without recompilation. On the source side, no caller specifies `<C>` explicitly, they all use `Signal.effect(myComponent, () -> ...)` which compiles identically against the new signature. The only theoretical breakage would be `Signal.<MyComponent>effect(...)`, which serves no purpose since `C` never appeared in the return type.

Fixes: #23973