### PR TITLE
test: fix flaky PageIT.testReload by waiting for page reload

### DIFF
--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PageIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PageIT.java
@@ -24,9 +24,9 @@ import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.Keys;
-import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import com.vaadin.flow.component.html.testbench.DivElement;
 import com.vaadin.flow.component.html.testbench.InputTextElement;
@@ -93,14 +93,7 @@ public class PageIT extends ChromeBrowserTest {
         WebElement oldInput = findElement(By.id("input"));
         $(DivElement.class).id("reload").click();
         // Wait for the old element to become stale (page unloads)
-        waitUntil(driver -> {
-            try {
-                oldInput.isDisplayed();
-                return false;
-            } catch (StaleElementReferenceException e) {
-                return true;
-            }
-        });
+        waitUntil(ExpectedConditions.stalenessOf(oldInput));
         // Wait for the new page to load and the input element to reappear
         waitForElementPresent(By.id("input"));
         input = $(InputTextElement.class).id("input");


### PR DESCRIPTION
After clicking the reload button, the test immediately queried for the input element without waiting for the page to actually reload. This caused a NoSuchElementException when the DOM was in a transitional state. The fix waits for the old element to become stale (confirming the page has started unloading) and then waits for the new input element to appear before asserting on it.