### PR TITLE
test: fix flaky PreserveOnRefreshIT by waiting for page reload

### DIFF
--- a/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/routescope/PreserveOnRefreshIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/routescope/PreserveOnRefreshIT.java
@@ -18,6 +18,8 @@ package com.vaadin.flow.spring.test.routescope;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import com.vaadin.flow.spring.test.AbstractSpringTest;
 
@@ -32,10 +34,15 @@ public class PreserveOnRefreshIT extends AbstractSpringTest {
     public void routeScopedBeanIsPreservedAfterViewRefresh() {
         open();
 
-        String beanCall = findElement(By.id("preserve-on-refresh")).getText();
+        WebElement element = findElement(By.id("preserve-on-refresh"));
+        String beanCall = element.getText();
 
         // refresh
         getDriver().navigate().refresh();
+        // Wait for the old element to become stale (page unloads)
+        waitUntil(ExpectedConditions.stalenessOf(element));
+        // Wait for the new page to load and the element to reappear
+        waitForElementPresent(By.id("preserve-on-refresh"));
 
         Assert.assertEquals("Bean is not preserved after refresh", beanCall,
                 findElement(By.id("preserve-on-refresh")).getText());


### PR DESCRIPTION
After calling getDriver().navigate().refresh(), the test immediately queried for the element without waiting for the page to actually reload. This caused a NoSuchElementException when the DOM was in a transitional state. The fix waits for the old element to become stale (confirming the page has started unloading) and then waits for the new element to appear before asserting on it.
