### PR TITLE
chore: update default npm version

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -68,7 +68,7 @@ public class FrontendTools {
     /**
      * This is the version shipped with the default Node version.
      */
-    public static final String DEFAULT_NPM_VERSION = "11.8.0";
+    public static final String DEFAULT_NPM_VERSION = "11.11.0";
 
     public static final String DEFAULT_PNPM_VERSION = "10.30.2";
 


### PR DESCRIPTION
Default npm version for node 24.14.1 is 11.11.0
