### PR TITLE
chore: update default npm version (24.10)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -68,7 +68,7 @@ public class FrontendTools {
     /**
      * This is the version shipped with the default Node version.
      */
-    public static final String DEFAULT_NPM_VERSION = "10.9.4";
+    public static final String DEFAULT_NPM_VERSION = "10.9.7";
 
     public static final String DEFAULT_PNPM_VERSION = "8.6.11";
 


### PR DESCRIPTION
Default npm version for node 22.22.2 is 10.9.7
