### PR TITLE
test: fix postinstall tests failing on non-existent npm package version

### DIFF
--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -26,8 +26,6 @@ import java.util.Comparator;
 import java.util.List;
 
 import net.jcip.annotations.NotThreadSafe;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -57,7 +55,6 @@ import static com.vaadin.flow.server.frontend.NodeUpdater.DEV_DEPENDENCIES;
 import static com.vaadin.flow.server.frontend.NodeUpdater.HASH_KEY;
 import static com.vaadin.flow.server.frontend.NodeUpdater.PROJECT_FOLDER;
 import static com.vaadin.flow.server.frontend.NodeUpdater.VAADIN_DEP_KEY;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -288,7 +285,7 @@ class TaskRunNpmInstallTest {
 
         final File localHashFile = new File(options.getNodeModulesFolder(),
                 ".vaadin/vaadin.json");
-        FileUtils.forceMkdirParent(localHashFile);
+        Files.createDirectories(localHashFile.toPath().getParent());
         getNodeUpdater().writePackageFile(localHash, localHashFile);
     }
 
@@ -332,8 +329,7 @@ class TaskRunNpmInstallTest {
         assertTrue(localHashFile.exists(),
                 "Local has file was not created after install.");
 
-        String fileContent = FileUtils.readFileToString(localHashFile,
-                UTF_8.name());
+        String fileContent = Files.readString(localHashFile.toPath());
         JsonNode localHash = JacksonUtils.readTree(fileContent);
         assertNotEquals("", localHash.get(HASH_KEY).asString(),
                 "We should have a non empty hash key");
@@ -362,39 +358,48 @@ class TaskRunNpmInstallTest {
         nodeModules.mkdir();
         getNodeUpdater().modified = false;
 
-        // Fake that we have installed "@vaadin/vaadin-usage-statistics"
-        // (in the default postinstall list)
+        // Pre-populate node_modules/@vaadin/vaadin-usage-statistics/ so that
+        // shouldRunNpmInstall() sees a non-empty node_modules directory.
+        // Note: cleanUp() deletes node_modules before the actual install runs,
+        // so this copy won't survive — the install source is fake-stats/ below.
         File statsDir = new File(nodeModules,
                 "@vaadin/vaadin-usage-statistics");
         statsDir.mkdirs();
         File statsPackageJson = new File(statsDir, "package.json");
-        String statsPackageJsonContents = IOUtils.toString(
-                getClass().getResourceAsStream(
-                        "fake-package-with-postinstall.json"),
-                StandardCharsets.UTF_8);
-        FileUtils.write(statsPackageJson, statsPackageJsonContents,
-                StandardCharsets.UTF_8);
+        String statsPackageJsonContents = new String(getClass()
+                .getResourceAsStream("fake-package-with-postinstall.json")
+                .readAllBytes(), StandardCharsets.UTF_8);
+        Files.writeString(statsPackageJson.toPath(), statsPackageJsonContents);
+
+        // Local install source for "@vaadin/vaadin-usage-statistics".
+        // Must live outside node_modules/ because cleanUp() deletes it
+        // before npm/pnpm install. Using a local path avoids fetching a
+        // non-existent version from the registry.
+        File fakeStatsPackageJson = new File(
+                new File(nodeModules.getParentFile(), "fake-stats"),
+                "package.json");
+        fakeStatsPackageJson.getParentFile().mkdirs();
+        Files.writeString(fakeStatsPackageJson.toPath(),
+                statsPackageJsonContents);
 
         // Fake that we have installed "foo" (not in the default postinstall
         // list unless explicitly added)
         File fooPackageJson = new File(
                 new File(nodeModules.getParentFile(), "fake-foo"),
                 "package.json");
-        String fooPackageJsonContents = IOUtils.toString(
-                getClass().getResourceAsStream(
-                        "fake-package-with-postinstall.json"),
-                StandardCharsets.UTF_8);
-        FileUtils.write(fooPackageJson, fooPackageJsonContents,
-                StandardCharsets.UTF_8);
+        String fooPackageJsonContents = new String(getClass()
+                .getResourceAsStream("fake-package-with-postinstall.json")
+                .readAllBytes(), StandardCharsets.UTF_8);
+        fooPackageJson.getParentFile().mkdirs();
+        Files.writeString(fooPackageJson.toPath(), fooPackageJsonContents);
 
         File packageJsonFile = ensurePackageJson();
         JsonNode packageJson = getNodeUpdater().getPackageJson();
         ((ObjectNode) packageJson.get(DEV_DEPENDENCIES))
-                .put("@vaadin/vaadin-usage-statistics", "0.0.1");
+                .put("@vaadin/vaadin-usage-statistics", "./fake-stats");
         ((ObjectNode) packageJson.get(DEV_DEPENDENCIES)).put("foo",
                 "./fake-foo");
-        FileUtils.write(packageJsonFile, packageJson.toString(),
-                StandardCharsets.UTF_8);
+        Files.writeString(packageJsonFile.toPath(), packageJson.toString());
 
     }
 
@@ -404,19 +409,28 @@ class TaskRunNpmInstallTest {
         setupPostinstallPackages();
 
         // Remove postinstall script from "@vaadin/vaadin-usage-statistics"
-        File statsPackageJson = new File(
+        // in both the source directory and the node_modules copy, so that
+        // even after npm/pnpm re-installs from source, no postinstall exists
+        JsonNode statsPackageJsonContents = JacksonUtils
+                .readTree(new String(getClass()
+                        .getResourceAsStream(
+                                "fake-package-with-postinstall.json")
+                        .readAllBytes(), StandardCharsets.UTF_8));
+        ((ObjectNode) statsPackageJsonContents.get("scripts"))
+                .remove("postinstall");
+        String noPostinstallContent = statsPackageJsonContents.toString();
+
+        File statsSourcePackageJson = new File(
+                new File(options.getNpmFolder(), "fake-stats"), "package.json");
+        Files.writeString(statsSourcePackageJson.toPath(),
+                noPostinstallContent);
+
+        File statsNodeModulesPackageJson = new File(
                 new File(options.getNodeModulesFolder(),
                         "@vaadin/vaadin-usage-statistics"),
                 "package.json");
-        JsonNode statsPackageJsonContents = JacksonUtils
-                .readTree(IOUtils.toString(
-                        getClass().getResourceAsStream(
-                                "fake-package-with-postinstall.json"),
-                        StandardCharsets.UTF_8));
-        ((ObjectNode) statsPackageJsonContents.get("scripts"))
-                .remove("postinstall");
-        FileUtils.write(statsPackageJson, statsPackageJsonContents.toString(),
-                StandardCharsets.UTF_8);
+        Files.writeString(statsNodeModulesPackageJson.toPath(),
+                noPostinstallContent);
 
         logger = new MockLogger();
         assertTrue(logger.isDebugEnabled());
@@ -475,12 +489,11 @@ class TaskRunNpmInstallTest {
         File fooPackageJson = new File(
                 new File(nodeModules.getParentFile(), "fake-foo"),
                 "package.json");
-        String fooPackageJsonContents = IOUtils.toString(
-                getClass().getResourceAsStream(
-                        "fake-package-with-postinstall-writing-to-console.json"),
-                StandardCharsets.UTF_8);
-        FileUtils.write(fooPackageJson, fooPackageJsonContents,
-                StandardCharsets.UTF_8);
+        String fooPackageJsonContents = new String(getClass()
+                .getResourceAsStream(
+                        "fake-package-with-postinstall-writing-to-console.json")
+                .readAllBytes(), StandardCharsets.UTF_8);
+        Files.writeString(fooPackageJson.toPath(), fooPackageJsonContents);
 
         task = createTask(List.of("foo"));
         task.execute();
@@ -501,14 +514,12 @@ class TaskRunNpmInstallTest {
         vaadinJson.put(HASH_KEY, packageJsonHash);
         vaadinJson.put(PROJECT_FOLDER, npmFolder.getAbsolutePath());
         File vaadinJsonFile = getNodeUpdater().getVaadinJsonFile();
-
-        FileUtils.writeStringToFile(vaadinJsonFile, vaadinJson.toString(),
-                UTF_8);
+        Files.createDirectories(vaadinJsonFile.toPath().getParent());
+        Files.writeString(vaadinJsonFile.toPath(), vaadinJson.toString());
 
         assertFalse(task.isVaadinHashOrProjectFolderUpdated());
         vaadinJson.put(PROJECT_FOLDER, npmFolder.getAbsolutePath() + "foo");
-        FileUtils.writeStringToFile(vaadinJsonFile, vaadinJson.toString(),
-                UTF_8);
+        Files.writeString(vaadinJsonFile.toPath(), vaadinJson.toString());
         assertTrue(task.isVaadinHashOrProjectFolderUpdated());
     }
 
@@ -560,7 +571,7 @@ class TaskRunNpmInstallTest {
                                     + "/node.exe"
                             : "node-" + FrontendTools.DEFAULT_NODE_VERSION
                                     + "/bin/node");
-            FileUtils.forceMkdir(node);
+            Files.createDirectories(node.toPath());
 
             assertTrue(node.isDirectory(),
                     "node executable should be a directory");
@@ -638,8 +649,7 @@ class TaskRunNpmInstallTest {
                   "packages": {}
                 }
                 """;
-        FileUtils.write(packageLockFile, packageLockContent,
-                StandardCharsets.UTF_8);
+        Files.writeString(packageLockFile.toPath(), packageLockContent);
 
         task.verifyPackageLockAndClean();
 
@@ -662,8 +672,7 @@ class TaskRunNpmInstallTest {
                   "packages": {}
                 }
                 """;
-        FileUtils.write(packageLockFile, packageLockContent,
-                StandardCharsets.UTF_8);
+        Files.writeString(packageLockFile.toPath(), packageLockContent);
 
         task.verifyPackageLockAndClean();
 
@@ -686,8 +695,7 @@ class TaskRunNpmInstallTest {
                   "dependencies": {}
                 }
                 """;
-        FileUtils.write(packageLockFile, packageLockContent,
-                StandardCharsets.UTF_8);
+        Files.writeString(packageLockFile.toPath(), packageLockContent);
 
         task.verifyPackageLockAndClean();
 
@@ -708,8 +716,7 @@ class TaskRunNpmInstallTest {
                   "packages": {}
                 }
                 """;
-        FileUtils.write(packageLockFile, packageLockContent,
-                StandardCharsets.UTF_8);
+        Files.writeString(packageLockFile.toPath(), packageLockContent);
 
         task.verifyPackageLockAndClean();
 
@@ -733,8 +740,7 @@ class TaskRunNpmInstallTest {
                   "packages": {}
                 }
                 """;
-        FileUtils.write(packageLockFile, packageLockContent,
-                StandardCharsets.UTF_8);
+        Files.writeString(packageLockFile.toPath(), packageLockContent);
 
         task.verifyPackageLockAndClean();
 

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -19,12 +19,11 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
 import net.jcip.annotations.NotThreadSafe;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -62,8 +61,7 @@ class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
 
         // create an empty package.json so as pnpm can be run without
         // error
-        FileUtils.write(new File(npmFolder, PACKAGE_JSON), "{}",
-                StandardCharsets.UTF_8);
+        Files.writeString(new File(npmFolder, PACKAGE_JSON).toPath(), "{}");
     }
 
     @Override
@@ -71,7 +69,7 @@ class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
     void runNpmInstall_toolIsChanged_nodeModulesIsRemoved()
             throws ExecutionFailedException, IOException {
         File nodeModules = options.getNodeModulesFolder();
-        FileUtils.forceMkdir(nodeModules);
+        Files.createDirectories(nodeModules.toPath());
 
         // create a fake file in the node modules dir to check that it's
         // removed
@@ -94,9 +92,8 @@ class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         // create some package.json file so pnpm does some installation
         // into
         // node_modules folder
-        FileUtils.write(packageJson,
-                "{\"dependencies\": {" + "\"pnpm\": \"5.15.1\"}}",
-                StandardCharsets.UTF_8);
+        Files.writeString(packageJson.toPath(),
+                "{\"dependencies\": {" + "\"pnpm\": \"5.15.1\"}}");
 
         getNodeUpdater().modified = true;
         createTask().execute();
@@ -119,18 +116,18 @@ class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         packageJson.createNewFile();
 
         // Write package json file
-        FileUtils.write(packageJson, "{}", StandardCharsets.UTF_8);
+        Files.writeString(packageJson.toPath(), "{}");
 
         File versions = File.createTempFile("tmp", null, temporaryFolder);
         // Platform defines a pinned version
         // @formatter:off
-        FileUtils.write(versions, String.format(
+        Files.writeString(versions.toPath(), String.format(
                 "{"
                   + "\"vaadin-overlay\": {"
                     + "\"npmName\": \"@vaadin/vaadin-overlay\","
                     + "\"jsVersion\": \"%s\""
                   + "}"
-                + "}", PINNED_VERSION), StandardCharsets.UTF_8);
+                + "}", PINNED_VERSION));
         // @formatter:on
 
         JsonNode object = getGeneratedVersionsContent(versions, packageJson);
@@ -153,7 +150,7 @@ class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         String notificationVersion = "1.4.0";
         String uploadVersion = "4.2.0";
         // @formatter:off
-        FileUtils.write(packageJson, String.format(
+        Files.writeString(packageJson.toPath(), String.format(
                 "{"
                     + "\"vaadin\": {"
                       + "\"dependencies\": {"
@@ -172,7 +169,7 @@ class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
                 + "}",
                 loginVersion, "1.0.0", notificationVersion,
                 "4.0.0", loginVersion, menuVersion, notificationVersion,
-                uploadVersion), StandardCharsets.UTF_8);
+                uploadVersion));
         // @formatter:on
         // Platform defines a pinned version
 
@@ -183,7 +180,7 @@ class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
 
         File versions = File.createTempFile("tmp", null, temporaryFolder);
         // @formatter:off
-        FileUtils.write(versions,String.format(
+        Files.writeString(versions.toPath(), String.format(
                 "{"
                     + "\"vaadin-login\": {"
                         + "\"npmName\": \"@vaadin/vaadin-login\","
@@ -203,7 +200,7 @@ class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
                     + "}"
                 + "}",
                 versionsLoginVersion, versionsMenuBarVersion,
-                versionsNotificationVersion, versionsUploadVersion), StandardCharsets.UTF_8);
+                versionsNotificationVersion, versionsUploadVersion));
         // @formatter:on
 
         JsonNode generatedVersions = getGeneratedVersionsContent(versions,
@@ -225,8 +222,7 @@ class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
 
         File npmRcFile = new File(npmFolder, ".npmrc");
         assertTrue(npmRcFile.exists());
-        String content = FileUtils.readFileToString(npmRcFile,
-                StandardCharsets.UTF_8);
+        String content = Files.readString(npmRcFile.toPath());
         assertTrue(content.contains("shamefully-hoist"));
     }
 
@@ -239,16 +235,14 @@ class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
                 + "shamefully-hoist=true\n"
                 + "symlink=true\n";
         // @formatter:on
-        FileUtils.writeStringToFile(oldNpmRcFile, originalContent,
-                StandardCharsets.UTF_8);
+        Files.writeString(oldNpmRcFile.toPath(), originalContent);
 
         TaskRunNpmInstall task = createTask();
         task.execute();
 
         File newNpmRcFile = new File(npmFolder, ".npmrc");
         assertTrue(newNpmRcFile.exists());
-        String content = FileUtils.readFileToString(newNpmRcFile,
-                StandardCharsets.UTF_8);
+        String content = Files.readString(newNpmRcFile.toPath());
         assertTrue(content.contains("shamefully-hoist"));
         assertFalse(content.contains("symlink=true"));
     }
@@ -261,16 +255,14 @@ class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         String originalContent = "# A custom npmrc file for my project\n"
                 + "symlink=true\n";
         // @formatter:on
-        FileUtils.writeStringToFile(oldNpmRcFile, originalContent,
-                StandardCharsets.UTF_8);
+        Files.writeString(oldNpmRcFile.toPath(), originalContent);
 
         TaskRunNpmInstall task = createTask();
         task.execute();
 
         File newNpmRcFile = new File(npmFolder, ".npmrc");
         assertTrue(newNpmRcFile.exists());
-        String content = FileUtils.readFileToString(newNpmRcFile,
-                StandardCharsets.UTF_8);
+        String content = Files.readString(newNpmRcFile.toPath());
         assertEquals(originalContent, content);
     }
 
@@ -291,8 +283,7 @@ class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
                 + "}"
             + "}";
         // @formatter:on
-        FileUtils.write(packageJson, packageJsonContent,
-                StandardCharsets.UTF_8);
+        Files.writeString(packageJson.toPath(), packageJsonContent);
 
         final VersionsJsonFilter versionsJsonFilter = new VersionsJsonFilter(
                 JacksonUtils.readTree(packageJsonContent),
@@ -310,8 +301,8 @@ class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
                 "@vaadin/vaadin-overlay/package.json");
 
         // The resulting version should be the one specified by the user
-        JsonNode overlayPackage = JacksonUtils.readTree(FileUtils
-                .readFileToString(overlayPackageJson, StandardCharsets.UTF_8));
+        JsonNode overlayPackage = JacksonUtils
+                .readTree(Files.readString(overlayPackageJson.toPath()));
         assertEquals(customOverlayVersion,
                 overlayPackage.get("version").asString());
     }
@@ -365,12 +356,11 @@ class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         File fooPackageJson = new File(
                 new File(nodeModules.getParentFile(), "fake-foo"),
                 "package.json");
-        String fooPackageJsonContents = IOUtils.toString(
-                getClass().getResourceAsStream(
-                        "fake-package-with-postinstall-writing-to-console.json"),
-                StandardCharsets.UTF_8);
-        FileUtils.write(fooPackageJson, fooPackageJsonContents,
-                StandardCharsets.UTF_8);
+        String fooPackageJsonContents = new String(getClass()
+                .getResourceAsStream(
+                        "fake-package-with-postinstall-writing-to-console.json")
+                .readAllBytes(), StandardCharsets.UTF_8);
+        Files.writeString(fooPackageJson.toPath(), fooPackageJsonContents);
 
         TaskRunNpmInstall task = createTask(List.of("foo"));
         task.execute();
@@ -481,8 +471,8 @@ class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
                 classFinder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(versions.toURI().toURL());
 
-        ObjectNode packageJson = JacksonUtils.readTree(FileUtils
-                .readFileToString(packageJsonFile, StandardCharsets.UTF_8));
+        ObjectNode packageJson = JacksonUtils
+                .readTree(Files.readString(packageJsonFile.toPath()));
         getNodeUpdater().generateVersionsJson(packageJson);
         return getNodeUpdater().versionsJson;
     }


### PR DESCRIPTION
Commit 8a6ddde3f8 changed `setupPostinstallPackages()` to reference `@vaadin/vaadin-usage-statistics` at version `0.0.1`, which does not exist on the npm registry. When `shouldRunNpmInstall()` returns true (no vaadin.json hash file), `cleanUp()` deletes the pre-populated node_modules and pnpm/npm install tries to fetch the non-existent version, failing with ERR_PNPM_NO_MATCHING_VERSION.

Use a local file path (`./fake-stats`) instead of a registry version, matching the pattern already used for the `foo` test package. The `fake-stats/` directory lives outside node_modules/ so it survives the `cleanUp()` deletion and serves as the install source.

Also replace Apache Commons IO (`FileUtils`, `IOUtils`) with standard Java APIs (`Files.writeString`, `Files.readString`, `readAllBytes`) in both `TaskRunNpmInstallTest` and `TaskRunPnpmInstallTest`.
