### PR TITLE
test: add empty collection test for SharedListSignal.insertAllFirst

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/signals/local/ListSignal.java
+++ b/flow-server/src/main/java/com/vaadin/flow/signals/local/ListSignal.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.signals.local;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -199,6 +200,107 @@ public class ListSignal<T extends @Nullable Object>
         newEntries.add(index, entry);
         setSignalValue(Collections.unmodifiableList(newEntries));
         return entry;
+    }
+
+    private List<ValueSignal<T>> createSignals(Collection<? extends T> values) {
+        List<ValueSignal<T>> signals = new ArrayList<>(values.size());
+        for (T value : values) {
+            signals.add(new ValueSignal<>(value, equalityChecker));
+        }
+        return signals;
+    }
+
+    /**
+     * Inserts all values as the last entries in this list. All entries are
+     * added with a single change notification.
+     * <p>
+     * Individual null values are permitted if the element type allows null.
+     *
+     * @param values
+     *            the values to insert, not <code>null</code>
+     * @return an unmodifiable list of signals for the inserted entries
+     */
+    public List<ValueSignal<T>> insertAllLast(Collection<? extends T> values) {
+        Objects.requireNonNull(values, "Values must not be null");
+        if (values.isEmpty()) {
+            return List.of();
+        }
+        lock();
+        try {
+            checkPreconditions();
+            return insertAllAtInternal(
+                    Objects.requireNonNull(getSignalValue()).size(), values);
+        } finally {
+            unlock();
+        }
+    }
+
+    /**
+     * Inserts all values as the first entries in this list, preserving the
+     * order of the provided collection. All entries are added with a single
+     * change notification.
+     * <p>
+     * Individual null values are permitted if the element type allows null.
+     *
+     * @param values
+     *            the values to insert, not <code>null</code>
+     * @return an unmodifiable list of signals for the inserted entries
+     */
+    public List<ValueSignal<T>> insertAllFirst(Collection<? extends T> values) {
+        return insertAllAt(0, values);
+    }
+
+    /**
+     * Inserts all values at the given index in this list, preserving the order
+     * of the provided collection. All entries are added with a single change
+     * notification.
+     * <p>
+     * Individual null values are permitted if the element type allows null.
+     * <p>
+     * <b>Note:</b> This method should only be used in non-concurrent cases
+     * where the list structure is not being modified by other threads. The
+     * index is sensitive to concurrent modifications and may lead to unexpected
+     * results if the list is modified between determining the index and calling
+     * this method.
+     *
+     * @param index
+     *            the index at which to insert (0 for first, size() for last)
+     * @param values
+     *            the values to insert, not <code>null</code>
+     * @return an unmodifiable list of signals for the inserted entries
+     * @throws IndexOutOfBoundsException
+     *             if index is negative or greater than size()
+     */
+    public List<ValueSignal<T>> insertAllAt(int index,
+            Collection<? extends T> values) {
+        Objects.requireNonNull(values, "Values must not be null");
+        if (values.isEmpty()) {
+            return List.of();
+        }
+        lock();
+        try {
+            checkPreconditions();
+            List<ValueSignal<T>> currentEntries = Objects
+                    .requireNonNull(getSignalValue());
+            if (index < 0 || index > currentEntries.size()) {
+                throw new IndexOutOfBoundsException(
+                        "Index: " + index + ", Size: " + currentEntries.size());
+            }
+            return insertAllAtInternal(index, values);
+        } finally {
+            unlock();
+        }
+    }
+
+    private List<ValueSignal<T>> insertAllAtInternal(int index,
+            Collection<? extends T> values) {
+        assertLockHeld();
+        List<ValueSignal<T>> created = createSignals(values);
+        List<ValueSignal<T>> newEntries = new ArrayList<>(
+                Objects.requireNonNull(getSignalValue()));
+        newEntries.addAll(index, created);
+        setSignalValue(Collections.unmodifiableList(newEntries));
+        return Collections.unmodifiableList(created);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/signals/shared/SharedListSignal.java
+++ b/flow-server/src/main/java/com/vaadin/flow/signals/shared/SharedListSignal.java
@@ -15,6 +15,9 @@
  */
 package com.vaadin.flow.signals.shared;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -297,6 +300,79 @@ public class SharedListSignal<T extends @Nullable Object>
                 new SignalCommand.InsertCommand(Id.random(), id(), null,
                         toJson(value), Objects.requireNonNull(at)),
                 this::child);
+    }
+
+    /**
+     * Inserts all values as the last entries in this list. All inserts are
+     * performed within a single transaction for atomicity.
+     * <p>
+     * Individual null values are permitted if the element type allows null.
+     *
+     * @param values
+     *            the values to insert, not <code>null</code>
+     * @return an unmodifiable list of insert operations for the inserted
+     *         entries
+     */
+    public List<InsertOperation<SharedValueSignal<T>>> insertAllLast(
+            Collection<? extends T> values) {
+        return insertAllAt(values, ListPosition.last());
+    }
+
+    /**
+     * Inserts all values as the first entries in this list, preserving the
+     * order of the provided collection. All inserts are performed within a
+     * single transaction for atomicity.
+     * <p>
+     * Individual null values are permitted if the element type allows null.
+     *
+     * @param values
+     *            the values to insert, not <code>null</code>
+     * @return an unmodifiable list of insert operations for the inserted
+     *         entries
+     */
+    public List<InsertOperation<SharedValueSignal<T>>> insertAllFirst(
+            Collection<? extends T> values) {
+        return insertAllAt(values, ListPosition.first());
+    }
+
+    /**
+     * Inserts all values at the given position in this list, preserving the
+     * order of the provided collection. All inserts are performed within a
+     * single transaction for atomicity.
+     * <p>
+     * Each element is inserted immediately after the previously inserted
+     * element, so the final order matches the iteration order of the provided
+     * collection.
+     * <p>
+     * Individual null values are permitted if the element type allows null.
+     *
+     * @param values
+     *            the values to insert, not <code>null</code>
+     * @param at
+     *            the position at which to insert the first value, not
+     *            <code>null</code>
+     * @return an unmodifiable list of insert operations for the inserted
+     *         entries
+     */
+    public List<InsertOperation<SharedValueSignal<T>>> insertAllAt(
+            Collection<? extends T> values, ListPosition at) {
+        Objects.requireNonNull(values, "Values must not be null");
+        Objects.requireNonNull(at, "Position must not be null");
+        if (values.isEmpty()) {
+            return List.of();
+        }
+        return Objects.requireNonNull(Signal.runInTransaction(() -> {
+            List<InsertOperation<SharedValueSignal<T>>> ops = new ArrayList<>(
+                    values.size());
+            ListPosition currentPos = at;
+            for (T value : values) {
+                InsertOperation<SharedValueSignal<T>> op = insertAt(value,
+                        currentPos);
+                ops.add(op);
+                currentPos = ListPosition.after(op.signal());
+            }
+            return Collections.unmodifiableList(ops);
+        }).returnValue());
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/signals/local/ListSignalTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/local/ListSignalTest.java
@@ -702,6 +702,100 @@ class ListSignalTest extends SignalTestBase {
         assertThrows(IllegalStateException.class, () -> stream.toList());
     }
 
+    @Test
+    void insertAllLast_multipleValues_valuesAppended() {
+        ListSignal<String> signal = new ListSignal<>();
+        signal.insertLast("existing");
+
+        List<ValueSignal<String>> created = signal
+                .insertAllLast(List.of("a", "b", "c"));
+
+        assertEquals(3, created.size());
+        assertValues(signal, "existing", "a", "b", "c");
+    }
+
+    @Test
+    void insertAllLast_emptyCollection_noChange() {
+        ListSignal<String> signal = new ListSignal<>();
+        signal.insertLast("existing");
+
+        AtomicBoolean changed = new AtomicBoolean(false);
+        Usage usage = UsageTracker.track(signal::get);
+        usage.onNextChange(initial -> {
+            changed.set(true);
+            return false;
+        });
+
+        List<ValueSignal<String>> created = signal.insertAllLast(List.of());
+
+        assertTrue(created.isEmpty());
+        assertFalse(changed.get());
+        assertValues(signal, "existing");
+    }
+
+    @Test
+    void insertAllLast_singleNotification() {
+        ListSignal<String> signal = new ListSignal<>();
+
+        AtomicInteger changeCount = new AtomicInteger();
+        Usage usage = UsageTracker.track(signal::get);
+        usage.onNextChange(initial -> {
+            changeCount.incrementAndGet();
+            return true;
+        });
+
+        signal.insertAllLast(List.of("a", "b", "c"));
+
+        assertEquals(1, changeCount.get());
+    }
+
+    @Test
+    void insertAllFirst_multipleValues_valuesAtStart() {
+        ListSignal<String> signal = new ListSignal<>();
+        signal.insertLast("existing");
+
+        List<ValueSignal<String>> created = signal
+                .insertAllFirst(List.of("a", "b", "c"));
+
+        assertEquals(3, created.size());
+        assertValues(signal, "a", "b", "c", "existing");
+    }
+
+    @Test
+    void insertAllAt_validIndex_valuesInserted() {
+        ListSignal<String> signal = new ListSignal<>();
+        signal.insertLast("first");
+        signal.insertLast("last");
+
+        List<ValueSignal<String>> created = signal.insertAllAt(1,
+                List.of("a", "b"));
+
+        assertEquals(2, created.size());
+        assertValues(signal, "first", "a", "b", "last");
+    }
+
+    @Test
+    void insertAllAt_invalidIndex_throwsException() {
+        ListSignal<String> signal = new ListSignal<>();
+        signal.insertLast("existing");
+
+        assertThrows(IndexOutOfBoundsException.class,
+                () -> signal.insertAllAt(5, List.of("a")));
+        assertThrows(IndexOutOfBoundsException.class,
+                () -> signal.insertAllAt(-1, List.of("a")));
+    }
+
+    @Test
+    void insertAllLast_insideExplicitTransaction_throwsException() {
+        ListSignal<String> signal = new ListSignal<>();
+
+        assertThrows(IllegalStateException.class, () -> {
+            Transaction.runInTransaction(() -> {
+                signal.insertAllLast(List.of("a", "b"));
+            });
+        });
+    }
+
     private static void assertValues(ListSignal<String> signal,
             String... expectedValues) {
         List<String> values = signal.peek().stream().map(ValueSignal::peek)

--- a/flow-server/src/test/java/com/vaadin/flow/signals/shared/SharedListSignalTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/shared/SharedListSignalTest.java
@@ -464,6 +464,107 @@ class SharedListSignalTest extends SignalTestBase {
         assertThrows(IllegalStateException.class, () -> stream.toList());
     }
 
+    @Test
+    void insertAllLast_multipleValues_valuesAppended() {
+        SharedListSignal<String> signal = new SharedListSignal<>(String.class);
+        signal.insertLast("existing");
+
+        List<InsertOperation<SharedValueSignal<String>>> ops = signal
+                .insertAllLast(List.of("a", "b", "c"));
+
+        assertEquals(3, ops.size());
+        assertChildren(signal, "existing", "a", "b", "c");
+    }
+
+    @Test
+    void insertAllLast_emptyCollection_noChange() {
+        SharedListSignal<String> signal = new SharedListSignal<>(String.class);
+        signal.insertLast("existing");
+
+        List<InsertOperation<SharedValueSignal<String>>> ops = signal
+                .insertAllLast(List.of());
+
+        assertTrue(ops.isEmpty());
+        assertChildren(signal, "existing");
+    }
+
+    @Test
+    void insertAllLast_singleNotification() {
+        SharedListSignal<String> signal = new SharedListSignal<>(String.class);
+
+        AtomicInteger changeCount = new AtomicInteger();
+        Usage usage = UsageTracker.track(signal::get);
+        usage.onNextChange(initial -> {
+            changeCount.incrementAndGet();
+            return true;
+        });
+
+        signal.insertAllLast(List.of("a", "b", "c"));
+
+        assertEquals(1, changeCount.get());
+    }
+
+    @Test
+    void insertAllAt_validPosition_valuesInserted() {
+        SharedListSignal<String> signal = new SharedListSignal<>(String.class);
+        SharedValueSignal<String> first = signal.insertLast("first").signal();
+        signal.insertLast("last");
+
+        List<InsertOperation<SharedValueSignal<String>>> ops = signal
+                .insertAllAt(List.of("a", "b"), ListPosition.after(first));
+
+        assertEquals(2, ops.size());
+        assertChildren(signal, "first", "a", "b", "last");
+    }
+
+    @Test
+    void insertAllFirst_emptyCollection_noChange() {
+        SharedListSignal<String> signal = new SharedListSignal<>(String.class);
+        signal.insertLast("existing");
+
+        List<InsertOperation<SharedValueSignal<String>>> ops = signal
+                .insertAllFirst(List.of());
+
+        assertTrue(ops.isEmpty());
+        assertChildren(signal, "existing");
+    }
+
+    @Test
+    void insertAllFirst_multipleValues_valuesAtStart() {
+        SharedListSignal<String> signal = new SharedListSignal<>(String.class);
+        signal.insertLast("existing");
+
+        List<InsertOperation<SharedValueSignal<String>>> ops = signal
+                .insertAllFirst(List.of("a", "b", "c"));
+
+        assertEquals(3, ops.size());
+        assertChildren(signal, "a", "b", "c", "existing");
+    }
+
+    @Test
+    void insertAllLast_insideExplicitTransaction_valuesAppended() {
+        SharedListSignal<String> signal = new SharedListSignal<>(String.class);
+        signal.insertLast("existing");
+
+        Signal.runInTransaction(() -> {
+            signal.insertAllLast(List.of("a", "b"));
+        });
+
+        assertChildren(signal, "existing", "a", "b");
+    }
+
+    @Test
+    void insertAllFirst_insideExplicitTransaction_valuesAtStart() {
+        SharedListSignal<String> signal = new SharedListSignal<>(String.class);
+        signal.insertLast("existing");
+
+        Signal.runInTransaction(() -> {
+            signal.insertAllFirst(List.of("a", "b"));
+        });
+
+        assertChildren(signal, "a", "b", "existing");
+    }
+
     static void assertChildren(SharedListSignal<String> signal,
             String... expectedValue) {
         List<String> value = signal.peek().stream().map(SharedValueSignal::peek)


### PR DESCRIPTION
test: verify SharedListSignal bulk inserts work inside explicit transactions
docs: document that null elements are permitted in bulk insert methods
refactor: delegate insertAllFirst to insertAllAt for consistent structure
refactor: simplify SharedListSignal insertAllFirst and insertAllLast
feat: add insertAllAt to SharedListSignal for positional bulk insert
refactor: extract common helpers to reduce duplication in ListSignal bulk insert methods
feat: add bulk insert methods to ListSignal and SharedListSignal