### PR TITLE
fix: encode location query parameter in init request to preserve +

### DIFF
--- a/flow-client/src/main/frontend/Flow.ts
+++ b/flow-client/src/main/frontend/Flow.ts
@@ -431,9 +431,9 @@ export class Flow {
         ? `&v-browserDetails=${encodeURIComponent(JSON.stringify(browserDetails))}`
         : '';
 
-      const requestPath = `?v-r=init&location=${this.getFlowRoutePath(location)}&query=${encodeURIComponent(
-        this.getFlowRouteQuery(location)
-      )}${browserDetailsParam}`;
+      const requestPath = `?v-r=init&location=${encodeURIComponent(
+        this.getFlowRoutePath(location)
+      )}&query=${encodeURIComponent(this.getFlowRouteQuery(location))}${browserDetailsParam}`;
 
       httpRequest.open('GET', requestPath);
 

--- a/flow-tests/test-router-custom-context/src/main/java/com/vaadin/flow/contexttest/ui/PlusInRouteParameterView.java
+++ b/flow-tests/test-router-custom-context/src/main/java/com/vaadin/flow/contexttest/ui/PlusInRouteParameterView.java
@@ -26,8 +26,9 @@ public class PlusInRouteParameterView extends Div
 
     public static final String TENANT_ID = "tenant_content";
 
+    private final Div tenantDiv = new Div();
+
     public PlusInRouteParameterView() {
-        Div tenantDiv = new Div();
         tenantDiv.setId(TENANT_ID);
         add(tenantDiv);
     }
@@ -35,6 +36,6 @@ public class PlusInRouteParameterView extends Div
     @Override
     public void beforeEnter(BeforeEnterEvent event) {
         String tenant = event.getRouteParameters().get("tenant").orElse("");
-        ((Div) getChildren().findFirst().orElseThrow()).setText(tenant);
+        tenantDiv.setText(tenant);
     }
 }

--- a/flow-tests/test-router-custom-context/src/main/java/com/vaadin/flow/contexttest/ui/PlusInRouteParameterView.java
+++ b/flow-tests/test-router-custom-context/src/main/java/com/vaadin/flow/contexttest/ui/PlusInRouteParameterView.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.contexttest.ui;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.BeforeEnterObserver;
+import com.vaadin.flow.router.Route;
+
+@Route(":tenant/plus-test")
+public class PlusInRouteParameterView extends Div
+        implements BeforeEnterObserver {
+
+    public static final String TENANT_ID = "tenant_content";
+
+    public PlusInRouteParameterView() {
+        Div tenantDiv = new Div();
+        tenantDiv.setId(TENANT_ID);
+        add(tenantDiv);
+    }
+
+    @Override
+    public void beforeEnter(BeforeEnterEvent event) {
+        String tenant = event.getRouteParameters().get("tenant").orElse("");
+        ((Div) getChildren().findFirst().orElseThrow()).setText(tenant);
+    }
+}

--- a/flow-tests/test-router-custom-context/src/test/java/com/vaadin/flow/contexttest/ui/PlusInParameterIT.java
+++ b/flow-tests/test-router-custom-context/src/test/java/com/vaadin/flow/contexttest/ui/PlusInParameterIT.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.contexttest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+import static com.vaadin.flow.contexttest.ui.PlusInRouteParameterView.TENANT_ID;
+
+public class PlusInParameterIT extends ChromeBrowserTest {
+
+    static final String JETTY_CONTEXT = System.getProperty(
+            "vaadin.test.jettyContextPath", "/custom-context-router");
+
+    @Override
+    protected String getTestPath() {
+        return JETTY_CONTEXT + "/+/plus-test";
+    }
+
+    @Test
+    public void literalPlusAsFirstPathSegment_isPreserved() {
+        open();
+        waitForElementPresent(By.id(TENANT_ID));
+        WebElement element = findElement(By.id(TENANT_ID));
+
+        Assert.assertEquals(
+                "Literal + in URL path should be preserved as route parameter.",
+                "+", element.getText());
+    }
+}


### PR DESCRIPTION
Re-add encodeURIComponent() around the location parameter in the init request query string. Without encoding, a literal + in the URL path (e.g. /+/dashboard) is interpreted as a space by the servlet container's query parameter decoding, resulting in InvalidLocationException: Relative path cannot start with /

The encodeURIComponent was removed in #22791 to preserve %2F in wildcard parameters, but this is not needed: double-encoding (%2F becomes %252F) is correctly undone by the servlet's single query parameter decode.
