### PR TITLE
fix: Add popover attribute to system error container

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/SystemErrorHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/SystemErrorHandler.java
@@ -313,15 +313,14 @@ public class SystemErrorHandler {
         } else {
             document.getBody().appendChild(systemErrorContainer);
         }
-        showErrorPopover();
+        showPopover(systemErrorContainer);
 
         return systemErrorContainer;
     }
 
     // @formatter:off
-    private native void showErrorPopover() 
+    private native void showErrorPopover(Element el) 
     /*-{
-        var el = document.querySelector(".v-system-error");
         el.showPopover();
     }-*/;
     // @formatter:on

--- a/flow-client/src/main/java/com/vaadin/client/SystemErrorHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/SystemErrorHandler.java
@@ -319,7 +319,7 @@ public class SystemErrorHandler {
     }
 
     // @formatter:off
-    private native void showErrorPopover(Element el) 
+    private native void showPopover(Element el) 
     /*-{
         el.showPopover();
     }-*/;

--- a/flow-client/src/main/java/com/vaadin/client/SystemErrorHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/SystemErrorHandler.java
@@ -275,6 +275,8 @@ public class SystemErrorHandler {
             String querySelector) {
         Document document = Browser.getDocument();
         Element systemErrorContainer = document.createDivElement();
+        // Set the popover attribute for native popovers.
+        systemErrorContainer.setAttribute("popover", "manual");
         systemErrorContainer.setClassName("v-system-error");
 
         if (caption != null) {

--- a/flow-client/src/main/java/com/vaadin/client/SystemErrorHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/SystemErrorHandler.java
@@ -313,14 +313,15 @@ public class SystemErrorHandler {
         } else {
             document.getBody().appendChild(systemErrorContainer);
         }
-        showPopover(systemErrorContainer);
+        showErrorPopover();
 
         return systemErrorContainer;
     }
 
     // @formatter:off
-    private native void showPopover(Element el) 
+    private native void showErrorPopover() 
     /*-{
+        var el = document.querySelector(".v-system-error");
         el.showPopover();
     }-*/;
     // @formatter:on

--- a/flow-client/src/main/java/com/vaadin/client/SystemErrorHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/SystemErrorHandler.java
@@ -321,8 +321,10 @@ public class SystemErrorHandler {
     // @formatter:off
     private native void showPopover(Element el) 
     /*-{
-        var fn = el.showPopover;
-        fn.call(el);
+        var fn = el && el.showPopover;
+        if (typeof fn === "function") {
+            fn.call(el);
+        }
     }-*/;
     // @formatter:on
 

--- a/flow-client/src/main/java/com/vaadin/client/SystemErrorHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/SystemErrorHandler.java
@@ -321,7 +321,8 @@ public class SystemErrorHandler {
     // @formatter:off
     private native void showPopover(Element el) 
     /*-{
-        el.showPopover();
+        var fn = el.showPopover;
+        fn.call(el);
     }-*/;
     // @formatter:on
 

--- a/flow-client/src/main/java/com/vaadin/client/SystemErrorHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/SystemErrorHandler.java
@@ -313,9 +313,17 @@ public class SystemErrorHandler {
         } else {
             document.getBody().appendChild(systemErrorContainer);
         }
+        showPopover(systemErrorContainer);
 
         return systemErrorContainer;
     }
+
+    // @formatter:off
+    private native void showPopover(Element el) 
+    /*-{
+        el.showPopover();
+    }-*/;
+    // @formatter:on
 
     private static Throwable unwrapUmbrellaException(Throwable e) {
         if (e instanceof UmbrellaException) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -1566,7 +1566,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                 "color: black;" +
                 "background: white;" +
                 "top: 1em;" +
-                "right: 1em;" +
+                "margin-right: 1em;" +
                 "border: 1px solid black;" +
                 "padding: 1em;" +
                 "z-index: 10000;" +

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -1565,7 +1565,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                 "position: absolute;" +
                 "color: black;" +
                 "background: white;" +
-                "top: 1em;" +
+                "margin-top: 1em;" +
                 "margin-right: 1em;" +
                 "border: 1px solid black;" +
                 "padding: 1em;" +

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/InternalErrorView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/InternalErrorView.java
@@ -18,7 +18,9 @@ package com.vaadin.flow.uitest.ui;
 import java.io.IOException;
 
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H3;
 import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.dom.Style;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.CustomizedSystemMessages;
 import com.vaadin.flow.server.DefaultSystemMessagesProvider;
@@ -57,9 +59,15 @@ public class InternalErrorView extends AbstractDivView {
                 "Reset system messages", "reset-system-messages",
                 event -> resetSystemMessages());
 
+        Div popover = createPopover();
+        NativeButton openPopoverButton = new NativeButton("Open popover");
+        openPopoverButton.setId("open-popover");
+        popover.getId().ifPresent(popoverId -> openPopoverButton.getElement()
+                .setAttribute("popovertarget", popoverId));
+
         add(message, updateMessageButton, closeSessionButton,
                 enableNotificationButton, causeExceptionButton,
-                resetSystemMessagesButton);
+                openPopoverButton, resetSystemMessagesButton, popover);
     }
 
     private void showInternalError() {
@@ -99,4 +107,20 @@ public class InternalErrorView extends AbstractDivView {
         VaadinService.getCurrent()
                 .setSystemMessagesProvider(DefaultSystemMessagesProvider.get());
     }
+
+    private Div createPopover() {
+        Div popover = new Div();
+        popover.setId("popover-div");
+        popover.getElement().setAttribute("popover", "manual");
+        popover.setSizeFull();
+        popover.getStyle().setPosition(Style.Position.ABSOLUTE);
+        popover.getStyle().setPadding("10px");
+        popover.getStyle().setBorder("2px solid black");
+        popover.add(new H3("Modal dialog"));
+        NativeButton causeExceptionButton = createButton("Cause exception",
+                "cause-exception-popover", event -> showInternalError());
+        popover.add(causeExceptionButton);
+        return popover;
+    }
+
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/InternalErrorIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/InternalErrorIT.java
@@ -210,7 +210,7 @@ public class InternalErrorIT extends ChromeBrowserTest {
         if (notification == null) {
             return false;
         }
-        return getErrorNotification().getAttribute("innerHTML").contains(text);
+        return notification.getText().contains(text);
     }
 
     private WebElement getErrorNotification() {

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/InternalErrorIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/InternalErrorIT.java
@@ -116,7 +116,7 @@ public class InternalErrorIT extends ChromeBrowserTest {
                         + "a server-side exception",
                 isInternalErrorNotificationPresent());
 
-        getErrorNotification().click();
+        clickErrorNotification();
         try {
             waitUntil(driver -> !isMessageUpdated());
         } catch (TimeoutException e) {
@@ -154,6 +154,33 @@ public class InternalErrorIT extends ChromeBrowserTest {
                 isInternalErrorNotificationPresent());
     }
 
+    @Test
+    public void popover_showNotification_notificationInteractable() {
+        clickButton(UPDATE);
+
+        clickButton("open-popover");
+        waitForElementPresent(By.id("cause-exception-popover"));
+        clickButton("cause-exception-popover");
+
+        Assert.assertTrue("The page should not be immediately refreshed after "
+                + "a server-side exception", isMessageUpdated());
+        Assert.assertTrue(
+                "'Internal error' notification should be present after "
+                        + "a server-side exception",
+                isInternalErrorNotificationPresent());
+
+        clickErrorNotification();
+        try {
+            waitUntil(driver -> !isMessageUpdated());
+        } catch (TimeoutException e) {
+            Assert.fail("After internal error, clicking the notification "
+                    + "should refresh the page, resetting the state of the UI.");
+        }
+        Assert.assertFalse(
+                "'Internal error' notification should be gone after refreshing",
+                isInternalErrorNotificationPresent());
+    }
+
     @After
     public void resetSystemMessages() {
         waitUntil(ExpectedConditions
@@ -177,6 +204,12 @@ public class InternalErrorIT extends ChromeBrowserTest {
         if (!isElementPresent(By.className("v-system-error"))) {
             return false;
         }
+        WebElement notification = getErrorNotification();
+        notification = ExpectedConditions.elementToBeClickable(notification)
+                .apply(driver);
+        if (notification == null) {
+            return false;
+        }
         return getErrorNotification().getAttribute("innerHTML").contains(text);
     }
 
@@ -187,4 +220,12 @@ public class InternalErrorIT extends ChromeBrowserTest {
     private void clickButton(String id) {
         findElement(By.id(id)).click();
     }
+
+    private void clickErrorNotification() {
+        // Do not use click() because it currently invokes JavaScript function
+        // instead of clicking on the element
+        new Actions(getDriver()).click(getErrorNotification()).build()
+                .perform();
+    }
+
 }


### PR DESCRIPTION
E.g. Dialog can obscure the message

Fixes https://github.com/vaadin/flow/issues/24094
