### PR TITLE
fix: remove duplicate CI run for main branch merges

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,7 +1,7 @@
 name: Flow Validation
 on:
   push:
-    branches: [main, '25.1', '25.0', '24.10', '24.9', '23.7', '23.6']
+    branches: ['25.1', '25.0', '24.10', '24.9', '23.7', '23.6']
   workflow_dispatch:
   pull_request_target:
     types: [opened, synchronize, reopened]


### PR DESCRIPTION
## Summary

- Remove `main` from the `push` trigger branches in `validation.yml` to avoid duplicate CI runs
- Since merge queue is enabled on `main`, every merge triggers both a `merge_group` and a `push` event for the same commit, causing two full CI runs (build + unit tests + integration tests)
- Direct pushes to `main` are not possible (branch protection), so the `push` trigger for `main` is redundant
- Other branches (25.1, 25.0, 24.10, etc.) still need the `push` trigger as they do not use merge queue

## Context

When a PR merges via the merge queue, GitHub fires two events for the same commit ([example](https://github.com/vaadin/flow/actions/runs/24084939598) vs [example](https://github.com/vaadin/flow/actions/runs/24085709302)). The concurrency groups differ between the two events (`gh-readonly-queue/main/...` vs `main`), so they do not cancel each other and both run to completion.

Note: Bender (snapshot build) matches jobs by commit hash. The `merge_group` workflow run uses the same commit hash as the merged commit, so Bender should be able to match against it. This should be verified after merging.