### PR TITLE
feat: add help goal for maven plugin

### DIFF
--- a/flow-plugins/flow-maven-plugin/pom.xml
+++ b/flow-plugins/flow-maven-plugin/pom.xml
@@ -97,7 +97,6 @@
             <execution>
               <id>default-descriptor</id>
               <goals>
-                <goal>helpmojo</goal>
                 <goal>descriptor</goal>
               </goals>
             </execution>

--- a/flow-plugins/flow-maven-plugin/pom.xml
+++ b/flow-plugins/flow-maven-plugin/pom.xml
@@ -85,11 +85,19 @@
             <goalPrefix>flow</goalPrefix>
             <requiredJavaVersion>${maven.compiler.release}</requiredJavaVersion>
             <requiredMavenVersion>3.8</requiredMavenVersion>
+            <helpPackageName>com.vaadin.flow.plugin.maven</helpPackageName>
           </configuration>
           <executions>
             <execution>
-              <id>mojo-descriptor</id>
+              <id>generated-helpmojo</id>
               <goals>
+                <goal>helpmojo</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>default-descriptor</id>
+              <goals>
+                <goal>helpmojo</goal>
                 <goal>descriptor</goal>
               </goals>
             </execution>


### PR DESCRIPTION
Adds generation of help goal for the Flow maven plugin. Also renamed execution identifier to avoid double execution of the descriptor goal