### PR TITLE
refactor!: stop auto-running `vaadinPrepareFrontend` in development mode

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
@@ -283,7 +283,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
 
         val build: BuildResult =
             testProject.build("-Pvaadin.productionMode=false", "bootJar")
-        build.expectTaskSucceded("vaadinPrepareFrontend")
+        build.expectTaskNotRan("vaadinPrepareFrontend")
         build.expectTaskNotRan("vaadinBuildFrontend")
 
         val jar: File = testProject.builtJar
@@ -291,13 +291,12 @@ class MiscSingleModuleTest : AbstractGradleTest() {
     }
 
     private fun doTestSpringProject() {
-        val springBootVersion = "3.3.4"
+        val springBootVersion = "4.0.5"
 
         testProject.settingsFile.writeText(
             """
             pluginManagement {
                 repositories {
-                  maven { url 'https://repo.spring.io/milestone' }
                   gradlePluginPortal()
                 }
               }
@@ -307,35 +306,27 @@ class MiscSingleModuleTest : AbstractGradleTest() {
             """
             plugins {
                 id 'org.springframework.boot' version '$springBootVersion'
-                id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+                id 'io.spring.dependency-management' version '1.1.7'
                 id 'java'
                 id("com.vaadin.flow")
             }
-            
+
             repositories {
                 mavenLocal()
                 mavenCentral()
                 maven { url 'https://maven.vaadin.com/vaadin-prereleases' }
-                maven { url 'https://repo.spring.io/milestone' }
             }
 
-            configurations {
-                developmentOnly
-                runtimeClasspath {
-                    extendsFrom developmentOnly
-                }
-            }
-            
             dependencies {
                 implementation('com.vaadin:flow:$flowVersion')
                 implementation('com.vaadin:vaadin-spring:$flowVersion')
-                implementation('org.springframework.boot:spring-boot-starter-web:$springBootVersion')
+                implementation('org.springframework.boot:spring-boot-starter-webmvc:$springBootVersion')
                 developmentOnly 'org.springframework.boot:spring-boot-devtools'
                 testImplementation('org.springframework.boot:spring-boot-starter-test') {
                     exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
                 }
             }
-            
+
             dependencyManagement {
                 imports {
                     mavenBom "com.vaadin:flow:$flowVersion"
@@ -565,6 +556,34 @@ class MiscSingleModuleTest : AbstractGradleTest() {
     }
 
     @Test
+    fun alwaysExecutePrepareFrontend_chainsToProcessResources() {
+        testProject.buildFile.writeText(
+            """
+            plugins {
+                id 'war'
+                id 'com.vaadin.flow'
+            }
+            repositories {
+                mavenLocal()
+                mavenCentral()
+                maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
+            }
+            dependencies {
+                implementation("com.vaadin:flow:$flowVersion")
+                providedCompile("jakarta.servlet:jakarta.servlet-api:6.0.0")
+                implementation("org.slf4j:slf4j-simple:$slf4jVersion")
+            }
+            vaadin {
+                alwaysExecutePrepareFrontend = true
+            }
+        """
+        )
+        val build: BuildResult = testProject.build("build")
+        build.expectTaskSucceded("vaadinPrepareFrontend")
+        build.expectTaskNotRan("vaadinBuildFrontend")
+    }
+
+    @Test
     fun testIncludeExclude() {
         testProject.buildFile.writeText("""
             plugins {
@@ -614,17 +633,17 @@ class MiscSingleModuleTest : AbstractGradleTest() {
             """
             plugins {
                 id 'java'
-                id 'org.springframework.boot' version '3.3.4'
-                id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+                id 'org.springframework.boot' version '4.0.5'
+                id 'io.spring.dependency-management' version '1.1.7'
                 id("com.vaadin.flow")
             }
-            
+
             repositories {
                 mavenLocal()
                 mavenCentral()
                 maven { url 'https://maven.vaadin.com/vaadin-prereleases' }
             }
-            
+
             sourceSets {
                 ui {
                     java
@@ -636,15 +655,15 @@ class MiscSingleModuleTest : AbstractGradleTest() {
                     }
                 }
             }
-            
+
             vaadin {
                 productionMode = true
                 sourceSetName = 'ui'
             }
-            
+
             dependencies {
                 uiImplementation('com.vaadin:flow:$flowVersion')
-                implementation('org.springframework.boot:spring-boot-starter-web')
+                implementation('org.springframework.boot:spring-boot-starter-webmvc')
             }
             
             jar {

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/TestUtils.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/TestUtils.kt
@@ -176,6 +176,10 @@ fun expectArchiveContainsVaadinBundle(
 /**
  * Asserts that given archive (jar/war) doesn't contain the Vaadin bundle:
  * the `META-INF/VAADIN/build/` directory.
+ *
+ * Since Vaadin 25, `vaadinPrepareFrontend` is no longer auto-triggered in
+ * development mode, so the token file (`flow-build-info.json`) is not
+ * expected in the archive.
  */
 fun expectArchiveDoesntContainVaadinBundle(archive: File,
                                            isSpringBootJar: Boolean) {
@@ -186,8 +190,8 @@ fun expectArchiveDoesntContainVaadinBundle(archive: File,
         isSpringBootJar -> "BOOT-INF/classes/"
         else -> ""
     }
-    expectArchiveContains("${resourcePackaging}META-INF/VAADIN/config/flow-build-info.json") { archive }
-    expectArchiveDoesntContain("${resourcePackaging}META-INF/VAADIN/config/stats.json",
+    expectArchiveDoesntContain("${resourcePackaging}META-INF/VAADIN/config/flow-build-info.json",
+            "${resourcePackaging}META-INF/VAADIN/config/stats.json",
             "${resourcePackaging}META-INF/VAADIN/webapp/VAADIN/build/*.gz",
             "${resourcePackaging}META-INF/VAADIN/webapp/VAADIN/build/*.js"
     ) { archive }
@@ -195,12 +199,6 @@ fun expectArchiveDoesntContainVaadinBundle(archive: File,
     if (!isStandaloneJar) {
         val libPrefix: String = if (isSpringBootJar) "BOOT-INF/lib" else "WEB-INF/lib"
         expectArchiveContains("$libPrefix/*.jar") { archive }
-    }
-
-    // make sure there is only one flow-build-info.json
-    val allFiles: List<String> = archive.zipListAllFiles()
-    expect(1, "Multiple flow-build-info.json found: ${allFiles.joinToString("\n")}") {
-        allFiles.count { it.contains("flow-build-info.json") }
     }
 }
 

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
@@ -78,11 +78,11 @@ class VaadinSmokeTest : AbstractGradleTest() {
     }
 
     @Test
-    fun `vaadinBuildFrontend not ran by default in development mode`() {
+    fun `vaadin tasks not ran by default in development mode`() {
         val result: BuildResult = testProject.build("build")
-        // let's explicitly check that vaadinPrepareFrontend has been run.
-        result.expectTaskOutcome("vaadinPrepareFrontend", TaskOutcome.SUCCESS)
-        // vaadinBuildFrontend should NOT have been executed automatically
+        // Since Vaadin 25, the dev server handles frontend preparation at
+        // runtime, so no vaadin tasks are chained to the build in dev mode.
+        result.expectTaskNotRan("vaadinPrepareFrontend")
         result.expectTaskNotRan("vaadinBuildFrontend")
 
         val build = File(testProject.dir, "build/resources/main/META-INF/VAADIN/webapp/VAADIN/build")

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/FlowPlugin.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/FlowPlugin.kt
@@ -83,10 +83,16 @@ public class FlowPlugin : Plugin<Project> {
                         svc?.ensureToken()
                     }
                 }
-            } else {
-                // In development mode, processResources copies stuff from
-                // build/vaadin-generated (which is populated by
-                // vaadinPrepareFrontend) and therefore must run after it.
+            } else if (config.alwaysExecutePrepareFrontend.get()) {
+                // In development mode, vaadinPrepareFrontend is not
+                // auto-triggered by default. Since Vaadin 25, the dev
+                // server handles frontend preparation at runtime, so
+                // running the task during every IDE-triggered build is
+                // unnecessary and can interfere with the running Vite
+                // dev server.
+                // However, if alwaysExecutePrepareFrontend is set,
+                // restore the old behavior and chain the task to
+                // processResources.
                 project.tasks.getByPath(config.processResourcesTaskName.get()).dependsOn("vaadinPrepareFrontend")
             }
 

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
@@ -300,6 +300,8 @@ public abstract class VaadinFlowPluginExtension @Inject constructor(private val 
      * will re-run every time it is called.
      *
      * Setting this to `true` allows to always execute `vaadinPrepareFrontend`.
+     * It also chains the task to `processResources`, which is no longer done
+     * by default since the dev server handles frontend preparation at runtime.
      *
      * Defaults to `false`, meaning that the task execution is skipped when its
      * outcomes are up-to-date, improving the overall build time.


### PR DESCRIPTION
IDE-triggered Gradle builds (e.g. IntelliJ compiling on file change) were running `vaadinPrepareFrontend` via `processResources`, which interfered with the running Vite dev server and broke hotdeploy.

Since Vaadin 25, the dev server handles frontend preparation at runtime, so the task no longer needs to run automatically. The previous behavior can be restored by setting `alwaysExecutePrepareFrontend = true`.

Fixes #24108