### PR TITLE
fix: respect user opt-out when adding overrides

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -191,25 +191,29 @@ public class TaskUpdatePackages extends NodeUpdater {
                 // Override value didn't change, skipping.
                 continue;
             }
+            final JsonNode lastUserValue;
+            final List<String> keyPath = List
+                    .of(entryToUpdate.getKey().split(">"));
+            if (enablePnpm) {
+                lastUserValue = overridesSection.get(entryToUpdate.getKey());
+            } else {
+                lastUserValue = JacksonUtils.getNestedKey(overridesSection, keyPath);
+            }
+            boolean optOut = !Objects.equals(StringNode.valueOf(lastValue), lastUserValue);
+            if (optOut) {
+                // Actual override value is different from last Vaadin override:
+                // assume user opt-out and skip.
+                continue;
+            }
             versionLockingUpdated = true;
             if (enablePnpm) {
                 // Use flat format for pnpm
                 overridesSection.put(entryToUpdate.getKey(),
                         entryToUpdate.getValue());
-                continue;
+            } else {
+                putNestedOverride(overridesSection, keyPath,
+                        entryToUpdate.getValue());
             }
-            // Handle possibly nested overrides object
-            final List<String> keyPath = List
-                    .of(entryToUpdate.getKey().split(">"));
-            final JsonNode lastValueNode = StringNode.valueOf(lastValue);
-            if (lastValueNode != null && !lastValueNode.equals(
-                    JacksonUtils.getNestedKey(overridesSection, keyPath))) {
-                // Actual override value is different from last Vaadin override:
-                // assume opt-out and skip.
-                continue;
-            }
-            putNestedOverride(overridesSection, keyPath,
-                    entryToUpdate.getValue());
         }
         for (final Map.Entry<String, String> entryToRemove : flatLastVaadinOverrides
                 .entrySet()) {

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -197,9 +197,11 @@ public class TaskUpdatePackages extends NodeUpdater {
             if (enablePnpm) {
                 lastUserValue = overridesSection.get(entryToUpdate.getKey());
             } else {
-                lastUserValue = JacksonUtils.getNestedKey(overridesSection, keyPath);
+                lastUserValue = JacksonUtils.getNestedKey(overridesSection,
+                        keyPath);
             }
-            boolean optOut = !Objects.equals(StringNode.valueOf(lastValue), lastUserValue);
+            boolean optOut = !Objects.equals(StringNode.valueOf(lastValue),
+                    lastUserValue);
             if (optOut) {
                 // Actual override value is different from last Vaadin override:
                 // assume user opt-out and skip.

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/NodeUpdatePackagesNpmVersionLockingTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/NodeUpdatePackagesNpmVersionLockingTest.java
@@ -192,7 +192,7 @@ class NodeUpdatePackagesNpmVersionLockingTest extends NodeUpdateTestUtil {
         packageUpdater.lockVersionForNpm(packageJson);
 
         // Verify flat override stays flat
-        JsonNode overrides = packageJson.get(PNPM).get(OVERRIDES);
+        JsonNode overrides = packageJson.get(OVERRIDES);
         assertTrue(overrides.has("flat-dep"),
                 "Flat override should remain unchanged");
         assertEquals("3.0.0", overrides.get("flat-dep").stringValue());

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
@@ -39,6 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.StringNode;
 
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.server.Constants;
@@ -46,7 +47,6 @@ import com.vaadin.flow.server.PwaConfiguration;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
 import com.vaadin.tests.util.MockOptions;
-import tools.jackson.databind.node.StringNode;
 
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 import static com.vaadin.flow.server.Constants.TARGET;
@@ -236,7 +236,10 @@ class TaskUpdatePackagesNpmTest {
         packageJson.set(OVERRIDES, JacksonUtils.createObjectNode());
         ((ObjectNode) packageJson.get(OVERRIDES)).put("@vaadin/aura", "1.0");
         // Assuming Vaadin added the override, set Vaadin overrides accordingly
-        JacksonUtils.setNestedKey(packageJson, List.of(VAADIN_DEP_KEY, OVERRIDES, "@vaadin/aura"), StringNode.valueOf("1.0"), (nonObjectNode) -> JacksonUtils.createObjectNode());
+        JacksonUtils.setNestedKey(packageJson,
+                List.of(VAADIN_DEP_KEY, OVERRIDES, "@vaadin/aura"),
+                StringNode.valueOf("1.0"),
+                (nonObjectNode) -> JacksonUtils.createObjectNode());
 
         FileUtils.writeStringToFile(new File(npmFolder, PACKAGE_JSON),
                 packageJson.toPrettyString(), StandardCharsets.UTF_8);

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
@@ -46,6 +46,7 @@ import com.vaadin.flow.server.PwaConfiguration;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
 import com.vaadin.tests.util.MockOptions;
+import tools.jackson.databind.node.StringNode;
 
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 import static com.vaadin.flow.server.Constants.TARGET;
@@ -234,6 +235,8 @@ class TaskUpdatePackagesNpmTest {
         ObjectNode packageJson = getOrCreatePackageJson();
         packageJson.set(OVERRIDES, JacksonUtils.createObjectNode());
         ((ObjectNode) packageJson.get(OVERRIDES)).put("@vaadin/aura", "1.0");
+        // Assuming Vaadin added the override, set Vaadin overrides accordingly
+        JacksonUtils.setNestedKey(packageJson, List.of(VAADIN_DEP_KEY, OVERRIDES, "@vaadin/aura"), StringNode.valueOf("1.0"), (nonObjectNode) -> JacksonUtils.createObjectNode());
 
         FileUtils.writeStringToFile(new File(npmFolder, PACKAGE_JSON),
                 packageJson.toPrettyString(), StandardCharsets.UTF_8);


### PR DESCRIPTION
Adjust the checks for user opt-out in package.json overrides, so that an existing override for new entries added by Vaadin is considered as an opt-out, so that the existing user value is kept. This behavior satisfies the previously existing `NodeUpdatePackagesNpmVersionLockingTest.shouldNotUpdatesOverrides_whenHasUserModification`
test.
