### PR TITLE
fix: prevent deletion of app-shell-imports by frontend cleanup task (#24118) (CP: 25.0)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRemoveOldFrontendGeneratedFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRemoveOldFrontendGeneratedFiles.java
@@ -147,6 +147,10 @@ public class TaskRemoveOldFrontendGeneratedFiles implements FallibleCommand {
                 frontendGeneratedFolder.resolve(FrontendUtils.ROUTES_TSX)));
         knownFiles.add(normalizePath(
                 frontendGeneratedFolder.resolve(FrontendUtils.ROUTES_TS)));
+        knownFiles.add(normalizePath(frontendGeneratedFolder
+                .resolve(FrontendUtils.APP_SHELL_IMPORTS_NAME)));
+        knownFiles.add(normalizePath(frontendGeneratedFolder
+                .resolve(FrontendUtils.APP_SHELL_IMPORTS_D_TS_NAME)));
         knownFiles.add(normalizePath(
                 frontendGeneratedFolder.resolve("file-routes.ts")));
         knownFiles.add(normalizePath(

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRemoveOldFrontendGeneratedFilesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRemoveOldFrontendGeneratedFilesTest.java
@@ -150,26 +150,50 @@ public class TaskRemoveOldFrontendGeneratedFilesTest {
 
     @Test
     public void execute_knownFiles_notDeleted() throws Exception {
+        Path hillaGeneratedFilesIndex = generatedFolder.toPath()
+                .resolve("generated-file-list.txt");
         Set<File> knownFiles = Set.of(generatedFolder.toPath()
-                .resolve(Path.of("flow", "generated-flow-imports.js")).toFile(),
+                .resolve(Path.of("flow", FrontendUtils.IMPORTS_NAME)).toFile(),
                 generatedFolder.toPath()
-                        .resolve(Path.of("flow", "generated-flow-imports.d.ts"))
+                        .resolve(Path.of("flow",
+                                FrontendUtils.IMPORTS_D_TS_NAME))
                         .toFile(),
                 generatedFolder.toPath()
                         .resolve(Path.of("flow",
-                                "generated-flow-webcomponent-imports.js"))
+                                FrontendUtils.IMPORTS_WEB_COMPONENT_NAME))
                         .toFile(),
-                new File(generatedFolder, "routes.tsx"),
-                new File(generatedFolder, "routes.ts"),
+                new File(generatedFolder, FrontendUtils.ROUTES_TSX),
+                new File(generatedFolder, FrontendUtils.ROUTES_TS),
                 generatedFolder.toPath().resolve(Path.of("flow", "Flow.tsx"))
                         .toFile(),
+                new File(generatedFolder,
+                        TaskGenerateReactFiles.JSX_TRANSFORM_DEV_RUNTIME),
+                new File(generatedFolder,
+                        TaskGenerateReactFiles.JSX_TRANSFORM_RUNTIME),
+                new File(generatedFolder,
+                        TaskGenerateReactFiles.JSX_TRANSFORM_INDEX),
+                new File(generatedFolder,
+                        FrontendUtils.APP_SHELL_IMPORTS_D_TS_NAME),
+                new File(generatedFolder, FrontendUtils.APP_SHELL_IMPORTS_NAME),
                 new File(generatedFolder, "file-routes.ts"),
+                new File(generatedFolder, "file-routes.json"),
                 new File(generatedFolder, "css.generated.js"),
-                new File(generatedFolder, "css.generated.d.ts"));
+                new File(generatedFolder, "css.generated.d.ts"),
+                hillaGeneratedFilesIndex.toFile(),
+                new File(generatedFolder, "hilla-1.js"),
+                new File(generatedFolder, "hilla-2.js"),
+                generatedFolder.toPath().resolve(Path.of("sub", "hilla-3.js"))
+                        .toFile());
+
         for (File file : knownFiles) {
             file.getParentFile().mkdirs();
             Files.writeString(file.toPath(), "TEST");
         }
+        Files.writeString(hillaGeneratedFilesIndex, """
+                hilla-1.js
+                hilla-2.js
+                sub/hilla-3.js
+                """);
 
         TaskRemoveOldFrontendGeneratedFiles task = new TaskRemoveOldFrontendGeneratedFiles(
                 options);


### PR DESCRIPTION
`TaskRemoveOldFrontendGeneratedFiles` deletes files in the frontend generated folder that are not recognized as known generated files. The `app-shell-imports.js` and `app-shell-imports.d.ts` files were missing from the known files list, causing them to be deleted when `vaadinPrepareFrontend` runs without the index generation task, for example when IntelliJ IDEA triggers a Gradle compilation while the dev server is running with hot deploy.

Add `APP_SHELL_IMPORTS_NAME` and `APP_SHELL_IMPORTS_D_TS_NAME` to the known files list. Also improve test coverage by verifying all known file types, including Hilla generated files.

Related to #24108