### PR TITLE
chore: upgrade serialize-javascript to 7.0.5

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/workbox/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/workbox/package.json
@@ -10,7 +10,7 @@
   },
   "overrides": {
     "workbox-build": {
-      "serialize-javascript": "7.0.4",
+      "serialize-javascript": "7.0.5",
       "@rollup/plugin-terser": "1.0.0",
       "glob": "13.0.6"
     }


### PR DESCRIPTION
to resolve https://nvd.nist.gov/vuln/detail/CVE-2026-34043