### PR TITLE
fix(flow-build-tools): re-enable upgrading override versions

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -170,6 +170,8 @@ public class TaskUpdatePackages extends NodeUpdater {
             }
         }
 
+        final ObjectNode overridesSection = getOverridesSection(packageJson);
+
         // Flatten overrides to simplify diffing
         final Map<String, String> flatVaadinOverrides = flattenOverrides(
                 vaadinOverrides);
@@ -181,7 +183,6 @@ public class TaskUpdatePackages extends NodeUpdater {
 
         boolean versionLockingUpdated = false;
         // Update overrides based on diff between current and last overrides
-        final ObjectNode overridesSection = getOverridesSection(packageJson);
         for (final Map.Entry<String, String> entryToUpdate : flatVaadinOverrides
                 .entrySet()) {
             final String lastValue = flatLastVaadinOverrides
@@ -200,11 +201,22 @@ public class TaskUpdatePackages extends NodeUpdater {
                 lastUserValue = JacksonUtils.getNestedKey(overridesSection,
                         keyPath);
             }
-            boolean optOut = !Objects.equals(StringNode.valueOf(lastValue),
-                    lastUserValue);
+            boolean optOut;
+            if (lastValue == null) {
+                // Old-style package.json did not have Vaadin overrides.
+                // We generally cannot detect opt-out except for one case:
+                // prevent unpinning with relative version when the user has
+                // existing non-relative override.
+                optOut = lastUserValue != null
+                        && entryToUpdate.getValue().startsWith("$")
+                        && !lastUserValue.stringValue().startsWith("$");
+            } else {
+                // Detect opt-out: the actual override value is different from
+                // last Vaadin override:
+                optOut = !StringNode.valueOf(lastValue).equals(lastUserValue);
+            }
             if (optOut) {
-                // Actual override value is different from last Vaadin override:
-                // assume user opt-out and skip.
+                // Skip due to user opt-out using a custom override
                 continue;
             }
             versionLockingUpdated = true;

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/NodeUpdatePackagesNpmVersionLockingTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/NodeUpdatePackagesNpmVersionLockingTest.java
@@ -56,6 +56,7 @@ class NodeUpdatePackagesNpmVersionLockingTest extends NodeUpdateTestUtil {
     private static final String OVERRIDES = "overrides";
     private static final String PLATFORM_PINNED_DEPENDENCY_VERSION = "3.2.17";
     private static final String USER_PINNED_DEPENDENCY_VERSION = "1.0";
+    private static final String RELATIVE_DEPENDENCY_VERSION = "$@vaadin/vaadin-overlay";
 
     @TempDir
     File temporaryFolder;
@@ -133,6 +134,27 @@ class NodeUpdatePackagesNpmVersionLockingTest extends NodeUpdateTestUtil {
         packageUpdater.lockVersionForNpm(packageJson);
 
         assertEquals(USER_PINNED_DEPENDENCY_VERSION,
+                packageJson.get(OVERRIDES).get(TEST_DEPENDENCY).stringValue());
+    }
+
+    @Test
+    void shouldUpdatesOverrides_whenNoVaadinOverrides_changingVersion()
+            throws IOException {
+        TaskUpdatePackages packageUpdater = createPackageUpdater(false,
+                JacksonUtils.createObjectNode().put(TEST_DEPENDENCY,
+                        PLATFORM_PINNED_DEPENDENCY_VERSION));
+        ObjectNode packageJson = packageUpdater.getPackageJson();
+        ObjectNode overridesSection = JacksonUtils.createObjectNode();
+        packageJson.set(OVERRIDES, overridesSection);
+
+        ((ObjectNode) packageJson.get(DEPENDENCIES)).put(TEST_DEPENDENCY,
+                USER_PINNED_DEPENDENCY_VERSION);
+        overridesSection.put(TEST_DEPENDENCY, USER_PINNED_DEPENDENCY_VERSION);
+
+        packageUpdater.generateVersionsJson(packageJson);
+        packageUpdater.lockVersionForNpm(packageJson);
+
+        assertEquals(PLATFORM_PINNED_DEPENDENCY_VERSION,
                 packageJson.get(OVERRIDES).get(TEST_DEPENDENCY).stringValue());
     }
 


### PR DESCRIPTION
Adjust user opt-out override detection for `package.json` without explicitly stored previous Vaadin overrides to still upgrade old override versions of Vaadin managed dependencies.

Fixes the build issues for https://github.com/vaadin/patient-portal-demo-flow
