### PR TITLE
feat: add support for accepting hidden fields in Binder

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -2014,7 +2014,7 @@ public class Binder<BEAN> implements Serializable {
             if (isAppliedPredicate != null) {
                 return isAppliedPredicate;
             }
-            if (getBinder().isAcceptHiddenFields()) {
+            if (getBinder().isApplyBindingsToHiddenFields()) {
                 return binding -> true;
             }
             return Binding.super.getIsAppliedPredicate();
@@ -2160,7 +2160,7 @@ public class Binder<BEAN> implements Serializable {
 
     private boolean changeDetectionEnabled = false;
 
-    private boolean acceptHiddenFields = false;
+    private boolean applyBindingsToHiddenFields = false;
 
     private ValueSignal<BinderValidationStatus<BEAN>> binderValidationStatusSignal;
 
@@ -4344,23 +4344,24 @@ public class Binder<BEAN> implements Serializable {
      * <p>
      * Defaults to {@literal false}.
      *
-     * @param acceptHiddenFields
+     * @param applyBindingsToHiddenFields
      *            {@literal true} to make all bindings apply to hidden fields,
      *            {@literal false} to skip hidden fields (the default)
      */
-    public void setAcceptHiddenFields(boolean acceptHiddenFields) {
-        this.acceptHiddenFields = acceptHiddenFields;
+    public void setApplyBindingsToHiddenFields(
+            boolean applyBindingsToHiddenFields) {
+        this.applyBindingsToHiddenFields = applyBindingsToHiddenFields;
     }
 
     /**
      * Returns whether all bindings of this Binder apply to fields that are not
      * currently visible.
      *
-     * @return {@literal true} if hidden fields are accepted by all bindings,
+     * @return {@literal true} if bindings are applied to hidden fields,
      *         {@literal false} if hidden fields are skipped (the default)
      */
-    public boolean isAcceptHiddenFields() {
-        return acceptHiddenFields;
+    public boolean isApplyBindingsToHiddenFields() {
+        return applyBindingsToHiddenFields;
     }
 
     /**

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -2011,9 +2011,13 @@ public class Binder<BEAN> implements Serializable {
         }
 
         public SerializablePredicate<Binding<BEAN, TARGET>> getIsAppliedPredicate() {
-            return isAppliedPredicate == null
-                    ? Binding.super.getIsAppliedPredicate()
-                    : isAppliedPredicate;
+            if (isAppliedPredicate != null) {
+                return isAppliedPredicate;
+            }
+            if (getBinder().isAcceptHiddenFields()) {
+                return binding -> true;
+            }
+            return Binding.super.getIsAppliedPredicate();
         }
 
         @Override
@@ -2155,6 +2159,8 @@ public class Binder<BEAN> implements Serializable {
     private boolean defaultValidatorsEnabled = true;
 
     private boolean changeDetectionEnabled = false;
+
+    private boolean acceptHiddenFields = false;
 
     private ValueSignal<BinderValidationStatus<BEAN>> binderValidationStatusSignal;
 
@@ -4322,6 +4328,39 @@ public class Binder<BEAN> implements Serializable {
      */
     public boolean isValidatorsDisabled() {
         return validatorsDisabled;
+    }
+
+    /**
+     * Sets whether all bindings of this Binder should be applied to fields that
+     * are not currently visible. By default, bindings whose field is a
+     * {@link Component} with {@link Component#isVisible()} returning
+     * {@literal false} are skipped during validation and when writing values to
+     * the bean. Enabling this setting restores the pre-Vaadin 25 behavior where
+     * hidden fields are validated and written just like visible ones.
+     * <p>
+     * This is a Binder-level fallback: any binding that has its own predicate
+     * set via {@link Binding#setIsAppliedPredicate(SerializablePredicate)}
+     * continues to use that predicate and is not affected by this flag.
+     * <p>
+     * Defaults to {@literal false}.
+     *
+     * @param acceptHiddenFields
+     *            {@literal true} to make all bindings apply to hidden fields,
+     *            {@literal false} to skip hidden fields (the default)
+     */
+    public void setAcceptHiddenFields(boolean acceptHiddenFields) {
+        this.acceptHiddenFields = acceptHiddenFields;
+    }
+
+    /**
+     * Returns whether all bindings of this Binder apply to fields that are not
+     * currently visible.
+     *
+     * @return {@literal true} if hidden fields are accepted by all bindings,
+     *         {@literal false} if hidden fields are skipped (the default)
+     */
+    public boolean isAcceptHiddenFields() {
+        return acceptHiddenFields;
     }
 
     /**

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -957,25 +957,64 @@ class BinderTest extends BinderTestBase<Binder<Person>, Person> {
     }
 
     @Test
-    void setAcceptHiddenFields_defaultsToFalse_appliesToHiddenFieldsWhenEnabled() {
+    void setApplyBindingsToHiddenFields_defaultsToFalse_appliesToHiddenFieldsWhenEnabled() {
         Binding<Person, String> nameBinding = binder.forField(nameField)
                 .withValidator(name -> false, "")
                 .bind(Person::getFirstName, Person::setFirstName);
         binder.setBean(item);
 
-        assertFalse(binder.isAcceptHiddenFields());
+        assertFalse(binder.isApplyBindingsToHiddenFields());
 
         ((Component) nameBinding.getField()).setVisible(false);
         assertTrue(binder.isValid(),
                 "Hidden field should be skipped by default");
 
-        binder.setAcceptHiddenFields(true);
+        binder.setApplyBindingsToHiddenFields(true);
         assertFalse(binder.isValid(),
-                "Hidden field should be validated when acceptHiddenFields is true");
+                "Hidden field should be validated when applyBindingsToHiddenFields is true");
 
         nameBinding.setIsAppliedPredicate(p -> false);
         assertTrue(binder.isValid(),
-                "Per-binding predicate should override Binder-level acceptHiddenFields");
+                "Per-binding predicate should override Binder-level applyBindingsToHiddenFields");
+    }
+
+    @Test
+    void writeBean_applyBindingsToHiddenFields_writesHiddenFieldsWhenEnabled()
+            throws ValidationException {
+        Binding<Person, String> nameBinding = binder.forField(nameField)
+                .bind(Person::getFirstName, Person::setFirstName);
+        binder.readBean(item);
+
+        nameField.setValue("NewName");
+        ((Component) nameBinding.getField()).setVisible(false);
+
+        binder.writeBean(item);
+        assertEquals("Johannes", item.getFirstName(),
+                "Hidden field should not be written by default");
+
+        binder.setApplyBindingsToHiddenFields(true);
+        binder.writeBean(item);
+        assertEquals("NewName", item.getFirstName(),
+                "Hidden field should be written when applyBindingsToHiddenFields is true");
+    }
+
+    @Test
+    void writeBeanIfValid_applyBindingsToHiddenFields_writesHiddenFieldsWhenEnabled() {
+        Binding<Person, String> nameBinding = binder.forField(nameField)
+                .bind(Person::getFirstName, Person::setFirstName);
+        binder.readBean(item);
+
+        nameField.setValue("NewName");
+        ((Component) nameBinding.getField()).setVisible(false);
+
+        assertTrue(binder.writeBeanIfValid(item));
+        assertEquals("Johannes", item.getFirstName(),
+                "Hidden field should not be written by default");
+
+        binder.setApplyBindingsToHiddenFields(true);
+        assertTrue(binder.writeBeanIfValid(item));
+        assertEquals("NewName", item.getFirstName(),
+                "Hidden field should be written when applyBindingsToHiddenFields is true");
     }
 
     @Test

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -957,6 +957,28 @@ class BinderTest extends BinderTestBase<Binder<Person>, Person> {
     }
 
     @Test
+    void setAcceptHiddenFields_defaultsToFalse_appliesToHiddenFieldsWhenEnabled() {
+        Binding<Person, String> nameBinding = binder.forField(nameField)
+                .withValidator(name -> false, "")
+                .bind(Person::getFirstName, Person::setFirstName);
+        binder.setBean(item);
+
+        assertFalse(binder.isAcceptHiddenFields());
+
+        ((Component) nameBinding.getField()).setVisible(false);
+        assertTrue(binder.isValid(),
+                "Hidden field should be skipped by default");
+
+        binder.setAcceptHiddenFields(true);
+        assertFalse(binder.isValid(),
+                "Hidden field should be validated when acceptHiddenFields is true");
+
+        nameBinding.setIsAppliedPredicate(p -> false);
+        assertTrue(binder.isValid(),
+                "Per-binding predicate should override Binder-level acceptHiddenFields");
+    }
+
+    @Test
     void writeBean_isAppliedIsEvaluated() {
         AtomicInteger invokes = new AtomicInteger();
 


### PR DESCRIPTION
Adds setAcceptHiddenFields(boolean) to Binder. setAcceptHiddenFields(true) makes Binder apply bindings for hidden fields by default in same way as with pre-Vaadin 25.

PartOf: #24109
