### PR TITLE
fix: Run Babel pre-OXC so React source locations and signals transform work correctly

### DIFF
--- a/flow-build-tools/src/main/resources/plugins/react-function-location-plugin/react-function-location-plugin.js
+++ b/flow-build-tools/src/main/resources/plugins/react-function-location-plugin/react-function-location-plugin.js
@@ -1,5 +1,4 @@
 import * as t from '@babel/types';
-import { readFileSync } from 'fs';
 
 export function addFunctionComponentSourceLocationBabel() {
   function isReactFunctionName(name) {
@@ -7,128 +6,66 @@ export function addFunctionComponentSourceLocationBabel() {
     return name && name.match(/^[A-Z].*/);
   }
 
-  // Cache original file contents for finding correct line numbers.
-  // When running after OXC (enforce: 'post'), Babel's AST positions
-  // refer to the transformed code, not the original source. We read
-  // the original file to get correct positions.
-  const originalSources = {};
-
-  function getOriginalLines(filename) {
-    if (!originalSources[filename]) {
-      try {
-        originalSources[filename] = readFileSync(filename, 'utf-8').split('\n');
-      } catch {
-        originalSources[filename] = [];
-      }
-    }
-    return originalSources[filename];
-  }
-
-  function findFunctionLine(filename, functionName) {
-    const lines = getOriginalLines(filename);
-    for (let i = 0; i < lines.length; i++) {
-      // Match "function FunctionName(" or "const/let/var FunctionName ="
-      const funcMatch = lines[i].match(new RegExp(`\\bfunction\\s+${functionName}\\s*\\(`));
-      const constMatch = lines[i].match(new RegExp(`\\b(?:const|let|var)\\s+${functionName}\\s*=`));
-      if (funcMatch) {
-        // Find the opening brace of the function body
-        const braceCol = lines[i].indexOf('{', funcMatch.index + funcMatch[0].length);
-        if (braceCol >= 0) {
-          return { line: i + 1, column: braceCol + 1 };
-        }
-        // Brace might be on a following line
-        for (let j = i + 1; j < lines.length; j++) {
-          const bc = lines[j].indexOf('{');
-          if (bc >= 0) return { line: j + 1, column: bc + 1 };
-        }
-      }
-      if (constMatch) {
-        // Find arrow function body: look for => and then the body start
-        for (let j = i; j < Math.min(i + 5, lines.length); j++) {
-          const arrowIdx = lines[j].indexOf('=>');
-          if (arrowIdx >= 0) {
-            const afterArrow = lines[j].substring(arrowIdx + 2);
-            const trimmed = afterArrow.trim();
-            if (trimmed.length > 0) {
-              // Body starts on same line as =>
-              const bodyStart = arrowIdx + 2 + afterArrow.indexOf(trimmed.charAt(0));
-              return { line: j + 1, column: bodyStart + 1 };
-            }
-            // Body starts on next line
-            if (j + 1 < lines.length) {
-              return { line: j + 2, column: 1 };
-            }
-          }
-        }
-      }
-    }
-    return null;
-  }
-
   /**
-   * Writes debug info as Name.__debugSourceDefine={...} after the given statement ("path").
-   * This is used to make the source location of the function available in the browser in development mode.
-   * The name __debugSourceDefine is prefixed by __ to mark this is not a public API.
+   * Collects React function component locations during AST traversal and
+   * appends all `Name.__debugSourceDefine = {...}` statements at the end of
+   * the file in Program.exit. Appending at the end (rather than after each
+   * function) avoids shifting line numbers for subsequent transforms, so JSX
+   * source locations reported by OXC remain correct.
    *
-   * Uses the original source file to determine correct line numbers,
-   * since Babel may be running on OXC-transformed code with different positions.
+   * Must be combined with retainLines:true in Babel options so Babel's
+   * printer doesn't shift lines when regenerating the file.
    */
-  function addDebugInfo(path, name, filename) {
-    const loc = findFunctionLine(filename, name);
-    if (!loc) {
-      return;
-    }
-    const debugSourceMember = t.memberExpression(t.identifier(name), t.identifier('__debugSourceDefine'));
-    const debugSourceDefine = t.objectExpression([
-      t.objectProperty(t.identifier('fileName'), t.stringLiteral(filename)),
-      t.objectProperty(t.identifier('lineNumber'), t.numericLiteral(loc.line)),
-      t.objectProperty(t.identifier('columnNumber'), t.numericLiteral(loc.column))
-    ]);
-    const assignment = t.expressionStatement(t.assignmentExpression('=', debugSourceMember, debugSourceDefine));
-    const condition = t.binaryExpression(
-      '===',
-      t.unaryExpression('typeof', t.identifier(name)),
-      t.stringLiteral('function')
-    );
-    const ifFunction = t.ifStatement(condition, t.blockStatement([assignment]));
-    path.insertAfter(ifFunction);
-  }
-
   return {
     visitor: {
-      VariableDeclaration(path, state) {
-        // Finds declarations such as
-        // const Foo = () => <div/>
-        // export const Bar = () => <span/>
-
-        // and writes a Foo.__debugSourceDefine= {..} after it, referring to the start of the function body
-        path.node.declarations.forEach((declaration) => {
-          if (declaration.id.type !== 'Identifier') {
-            return;
-          }
-          const name = declaration?.id?.name;
-          if (!isReactFunctionName(name)) {
-            return;
-          }
-
+      Program: {
+        exit(path, state) {
           const filename = state.file.opts.filename;
-          addDebugInfo(path, name, filename);
-        });
-      },
+          const collected = [];
 
-      FunctionDeclaration(path, state) {
-        // Finds declarations such as
-        // function Foo() { return <div/>; }
-        // export function Bar() { return <span>Hello</span>;}
+          path.traverse({
+            FunctionDeclaration(p) {
+              // Matches: function Foo() { ... }
+              const name = p.node?.id?.name;
+              if (!isReactFunctionName(name)) return;
+              if (p.node.body.loc) {
+                collected.push({ name, loc: p.node.body.loc });
+              }
+            },
+            VariableDeclaration(p) {
+              // Matches: const Foo = () => <div/>
+              p.node.declarations.forEach((d) => {
+                if (d.id.type !== 'Identifier') return;
+                const name = d.id.name;
+                if (!isReactFunctionName(name)) return;
+                if (d.init?.body?.loc) {
+                  collected.push({ name, loc: d.init.body.loc });
+                }
+              });
+            }
+          });
 
-        // and writes a Foo.__debugSourceDefine= {..} after it, referring to the start of the function body
-        const node = path.node;
-        const name = node?.id?.name;
-        if (!isReactFunctionName(name)) {
-          return;
+          for (const { name, loc } of collected) {
+            const debugSourceMember = t.memberExpression(
+              t.identifier(name),
+              t.identifier('__debugSourceDefine')
+            );
+            const debugSourceDefine = t.objectExpression([
+              t.objectProperty(t.identifier('fileName'), t.stringLiteral(filename)),
+              t.objectProperty(t.identifier('lineNumber'), t.numericLiteral(loc.start.line)),
+              t.objectProperty(t.identifier('columnNumber'), t.numericLiteral(loc.start.column + 1))
+            ]);
+            const assignment = t.expressionStatement(
+              t.assignmentExpression('=', debugSourceMember, debugSourceDefine)
+            );
+            const condition = t.binaryExpression(
+              '===',
+              t.unaryExpression('typeof', t.identifier(name)),
+              t.stringLiteral('function')
+            );
+            path.pushContainer('body', t.ifStatement(condition, t.blockStatement([assignment])));
+          }
         }
-        const filename = state.file.opts.filename;
-        addDebugInfo(path, name, filename);
       }
     }
   };

--- a/flow-build-tools/src/main/resources/plugins/react-function-location-plugin/react-function-location-plugin.js
+++ b/flow-build-tools/src/main/resources/plugins/react-function-location-plugin/react-function-location-plugin.js
@@ -7,59 +7,73 @@ export function addFunctionComponentSourceLocationBabel() {
   }
 
   /**
-   * Collects React function component locations during AST traversal and
-   * appends all `Name.__debugSourceDefine = {...}` statements at the end of
-   * the file in Program.exit. Appending at the end (rather than after each
-   * function) avoids shifting line numbers for subsequent transforms, so JSX
-   * source locations reported by OXC remain correct.
+   * Writes debug info as Name.__debugSourceDefine={...} after the given statement ("path").
+   * This is used to make the source location of the function (defined by the loc parameter) available in the browser in development mode.
+   * The name __debugSourceDefine is prefixed by __ to mark this is not a public API.
    *
-   * Must be combined with retainLines:true in Babel options so Babel's
-   * printer doesn't shift lines when regenerating the file.
+   * Must be combined with retainLines:true in Babel options so the inserted
+   * statement doesn't shift subsequent lines when Babel regenerates the file.
+   * This keeps OXC's view of JSX source locations correct and also allows
+   * nested component functions (where insertAfter inserts into the enclosing
+   * function's scope so the component name is in scope).
    */
+  function addDebugInfo(path, name, filename, loc) {
+    const lineNumber = loc.start.line;
+    const columnNumber = loc.start.column + 1;
+    const debugSourceMember = t.memberExpression(t.identifier(name), t.identifier('__debugSourceDefine'));
+    const debugSourceDefine = t.objectExpression([
+      t.objectProperty(t.identifier('fileName'), t.stringLiteral(filename)),
+      t.objectProperty(t.identifier('lineNumber'), t.numericLiteral(lineNumber)),
+      t.objectProperty(t.identifier('columnNumber'), t.numericLiteral(columnNumber))
+    ]);
+    const assignment = t.expressionStatement(t.assignmentExpression('=', debugSourceMember, debugSourceDefine));
+    const condition = t.binaryExpression(
+      '===',
+      t.unaryExpression('typeof', t.identifier(name)),
+      t.stringLiteral('function')
+    );
+    const ifFunction = t.ifStatement(condition, t.blockStatement([assignment]));
+    path.insertAfter(ifFunction);
+  }
+
   return {
     visitor: {
-      Program: {
-        exit(path, state) {
-          const filename = state.file.opts.filename;
-          const collected = [];
+      VariableDeclaration(path, state) {
+        // Finds declarations such as
+        // const Foo = () => <div/>
+        // export const Bar = () => <span/>
 
-          path.traverse({
-            FunctionDeclaration(p) {
-              // Matches: function Foo() { ... }
-              const name = p.node?.id?.name;
-              if (!isReactFunctionName(name)) return;
-              if (p.node.body.loc) {
-                collected.push({ name, loc: p.node.body.loc });
-              }
-            },
-            VariableDeclaration(p) {
-              // Matches: const Foo = () => <div/>
-              p.node.declarations.forEach((d) => {
-                if (d.id.type !== 'Identifier') return;
-                const name = d.id.name;
-                if (!isReactFunctionName(name)) return;
-                if (d.init?.body?.loc) {
-                  collected.push({ name, loc: d.init.body.loc });
-                }
-              });
-            }
-          });
-
-          for (const { name, loc } of collected) {
-            const debugSourceMember = t.memberExpression(t.identifier(name), t.identifier('__debugSourceDefine'));
-            const debugSourceDefine = t.objectExpression([
-              t.objectProperty(t.identifier('fileName'), t.stringLiteral(filename)),
-              t.objectProperty(t.identifier('lineNumber'), t.numericLiteral(loc.start.line)),
-              t.objectProperty(t.identifier('columnNumber'), t.numericLiteral(loc.start.column + 1))
-            ]);
-            const assignment = t.expressionStatement(t.assignmentExpression('=', debugSourceMember, debugSourceDefine));
-            const condition = t.binaryExpression(
-              '===',
-              t.unaryExpression('typeof', t.identifier(name)),
-              t.stringLiteral('function')
-            );
-            path.pushContainer('body', t.ifStatement(condition, t.blockStatement([assignment])));
+        // and writes a Foo.__debugSourceDefine= {..} after it, referring to the start of the function body
+        path.node.declarations.forEach((declaration) => {
+          if (declaration.id.type !== 'Identifier') {
+            return;
           }
+          const name = declaration?.id?.name;
+          if (!isReactFunctionName(name)) {
+            return;
+          }
+
+          const filename = state.file.opts.filename;
+          if (declaration?.init?.body?.loc) {
+            addDebugInfo(path, name, filename, declaration.init.body.loc);
+          }
+        });
+      },
+
+      FunctionDeclaration(path, state) {
+        // Finds declarations such as
+        // function Foo() { return <div/>; }
+        // export function Bar() { return <span>Hello</span>;}
+
+        // and writes a Foo.__debugSourceDefine= {..} after it, referring to the start of the function body
+        const node = path.node;
+        const name = node?.id?.name;
+        if (!isReactFunctionName(name)) {
+          return;
+        }
+        const filename = state.file.opts.filename;
+        if (node.body.loc) {
+          addDebugInfo(path, name, filename, node.body.loc);
         }
       }
     }

--- a/flow-build-tools/src/main/resources/plugins/react-function-location-plugin/react-function-location-plugin.js
+++ b/flow-build-tools/src/main/resources/plugins/react-function-location-plugin/react-function-location-plugin.js
@@ -46,18 +46,13 @@ export function addFunctionComponentSourceLocationBabel() {
           });
 
           for (const { name, loc } of collected) {
-            const debugSourceMember = t.memberExpression(
-              t.identifier(name),
-              t.identifier('__debugSourceDefine')
-            );
+            const debugSourceMember = t.memberExpression(t.identifier(name), t.identifier('__debugSourceDefine'));
             const debugSourceDefine = t.objectExpression([
               t.objectProperty(t.identifier('fileName'), t.stringLiteral(filename)),
               t.objectProperty(t.identifier('lineNumber'), t.numericLiteral(loc.start.line)),
               t.objectProperty(t.identifier('columnNumber'), t.numericLiteral(loc.start.column + 1))
             ]);
-            const assignment = t.expressionStatement(
-              t.assignmentExpression('=', debugSourceMember, debugSourceDefine)
-            );
+            const assignment = t.expressionStatement(t.assignmentExpression('=', debugSourceMember, debugSourceDefine));
             const condition = t.binaryExpression(
               '===',
               t.unaryExpression('typeof', t.identifier(name)),

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -170,6 +170,7 @@ class NodeUpdaterTest {
         expectedDependencies.add("strip-css-comments");
         expectedDependencies.add("@babel/core");
         expectedDependencies.add("@babel/preset-react");
+        expectedDependencies.add("@rolldown/plugin-babel");
         expectedDependencies.add("@types/react");
         expectedDependencies.add("@types/react-dom");
         expectedDependencies.add("@preact/signals-react-transform");

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
@@ -16,6 +16,7 @@
     "@rollup/pluginutils": "5.3.0",
     "@babel/core": "7.29.0",
     "@babel/preset-react": "7.28.5",
+    "@rolldown/plugin-babel": "0.2.3",
     "rollup-plugin-visualizer": "7.0.1",
     "rollup-plugin-brotli": "3.1.0",
     "vite-plugin-checker": "0.12.0",

--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -32,7 +32,7 @@ export { default as useLocalWebComponents } from '#buildFolder#/plugins/vite-plu
 
 import { visualizer } from 'rollup-plugin-visualizer';
 import reactPlugin from '@vitejs/plugin-react';
-import { transformSync } from '@babel/core';
+import babel from '@rolldown/plugin-babel';
 //#tailwindcssVitePluginImport#
 
 //#vitePluginFileSystemRouterImport#
@@ -528,38 +528,32 @@ export const vaadinConfig: UserConfigFn = (env) => {
           new RegExp('.*/.*\\?html-proxy.*')
         ]
       }),
-      // The React plugin provides fast refresh and JSX transformation via OXC
+      // The React plugin provides fast refresh and JSX transformation via OXC.
+      // The custom jsxImportSource wraps React 19's jsxDEV to capture source
+      // locations on _debugInfo (since React 19 dropped _source).
       reactPlugin({
         include: '**/*.tsx',
         jsxImportSource: productionMode ? 'react' : 'Frontend/generated/jsx-dev-transform',
       }),
-      // Babel plugins for source location info and signals transform.
-      // Must run AFTER reactPlugin (OXC) so that source locations are correct.
-      // Uses a custom plugin instead of @rolldown/plugin-babel because that
-      // plugin hardcodes enforce:'pre' which cannot be overridden.
-      {
-        name: 'vaadin-babel-post',
-        enforce: 'post' as const,
-        transform(code: string, id: string) {
-          if (!id.endsWith('.tsx')) return null;
-          const result = transformSync(code, {
-            filename: id,
-            plugins: [
-              !productionMode && addFunctionComponentSourceLocationBabel(),
-              [
-                'module:@preact/signals-react-transform',
-                {
-                  mode: 'all' // Needed to include translations which do not use something.value
-                }
-              ]
-            ].filter(Boolean),
-            sourceMaps: true,
-            sourceFileName: id,
-          });
-          if (!result?.code) return null;
-          return { code: result.code, map: result.map };
-        },
-      },
+      // Babel runs with enforce:'pre' (default), so it sees the original source
+      // and all AST positions are correct for source location plugins.
+      // retainLines:true ensures Babel's printer doesn't shift line numbers,
+      // so OXC's JSX source locations remain correct. The source location
+      // plugin appends __debugSourceDefine statements at the end of the file
+      // rather than inserting in the middle, also avoiding line shifting.
+      babel({
+        include: '**/*.tsx',
+        retainLines: true,
+        plugins: [
+          !productionMode && addFunctionComponentSourceLocationBabel(),
+          [
+            'module:@preact/signals-react-transform',
+            {
+              mode: 'all' // Needed to include translations which do not use something.value
+            }
+          ]
+        ].filter(Boolean),
+      }),
       //#tailwindcssVitePlugin#
       productionMode && vaadinI18n({
         cwd: __dirname,


### PR DESCRIPTION
Flow's Vite config runs two Babel-based transforms on .tsx files: adding
__debugSourceDefine to React function components for dev tooling, and                     
@preact/signals-react-transform which wraps components to track signal                    
reads. Both currently run AFTER OXC (in a custom enforce:'post' Vite                      
plugin) which causes two problems:                                                        
                                                                                          
1. Babel AST loc values refer to OXC-transformed code, not the original                   
   source, so __debugSourceDefine gets wrong line numbers. A workaround                   
   read the original file from disk to find function positions via regex.                 
                                                                                          
2. @preact/signals-react-transform runs on already-transformed JSX calls                  
   and can no longer identify components reliably. Signal reads stop                      
   triggering re-renders.                                                                 
                                                                                          
Switch to @rolldown/plugin-babel with its default enforce:'pre' so Babel                  
sees the original source code. To prevent Babel's printer from shifting                   
lines (which would break OXC's subsequent JSX source locations), set                      
retainLines:true on the Babel transform. This keeps inserted statements                   
on the same line as nearby code, so the file layout OXC sees matches                      
the original.                                                                             
                                                                                          
The readFileSync workaround in the source location plugin is removed;                     
Babel AST loc is now accurate. Signals transform once again runs on                       
raw JSX and correctly wraps components.                            
