### PR TITLE
fix: Have Babel do the JSX dev transform so source locations stay accurate

### DIFF
--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -169,6 +169,8 @@ class NodeUpdaterTest {
         expectedDependencies.add("transform-ast");
         expectedDependencies.add("strip-css-comments");
         expectedDependencies.add("@babel/core");
+        expectedDependencies
+                .add("@babel/plugin-transform-react-jsx-development");
         expectedDependencies.add("@babel/preset-react");
         expectedDependencies.add("@rolldown/plugin-babel");
         expectedDependencies.add("@types/react");

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
@@ -15,6 +15,7 @@
     "@rollup/plugin-replace": "6.0.3",
     "@rollup/pluginutils": "5.3.0",
     "@babel/core": "7.29.0",
+    "@babel/plugin-transform-react-jsx-development": "7.27.1",
     "@babel/preset-react": "7.28.5",
     "@rolldown/plugin-babel": "0.2.3",
     "rollup-plugin-visualizer": "7.0.1",

--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -528,23 +528,29 @@ export const vaadinConfig: UserConfigFn = (env) => {
           new RegExp('.*/.*\\?html-proxy.*')
         ]
       }),
-      // The React plugin provides fast refresh and JSX transformation via OXC.
-      // The custom jsxImportSource wraps React 19's jsxDEV to capture source
-      // locations on _debugInfo (since React 19 dropped _source).
+      // The React plugin provides fast refresh. In dev mode Babel (below)
+      // handles the JSX transform so OXC skips it — keeping all source
+      // locations derived from Babel's AST, which refers to the original
+      // source. In production OXC does the JSX transform.
       reactPlugin({
         include: '**/*.tsx',
-        jsxImportSource: productionMode ? 'react' : 'Frontend/generated/jsx-dev-transform',
+        jsxImportSource: productionMode ? 'react' : undefined,
       }),
-      // Babel runs with enforce:'pre' (default), so it sees the original source
-      // and all AST positions are correct for source location plugins.
-      // retainLines:true ensures Babel's printer doesn't shift line numbers,
-      // so OXC's JSX source locations remain correct. The source location
-      // plugin appends __debugSourceDefine statements at the end of the file
-      // rather than inserting in the middle, also avoiding line shifting.
+      // Babel runs with enforce:'pre' (default), so it sees the original
+      // source. All line/column values it embeds in the output come from
+      // the original AST — not affected by any formatting differences in
+      // Babel's printed output that follows.
+      //
+      // In dev mode Babel also does the JSX dev transform with the custom
+      // jsxImportSource, which captures JSX element locations in
+      // _debugInfo.source (React 19 no longer exposes _source on fibers).
       babel({
         include: '**/*.tsx',
-        retainLines: true,
         plugins: [
+          !productionMode && [
+            '@babel/plugin-transform-react-jsx-development',
+            { importSource: 'Frontend/generated/jsx-dev-transform' }
+          ],
           !productionMode && addFunctionComponentSourceLocationBabel(),
           [
             'module:@preact/signals-react-transform',

--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -534,7 +534,6 @@ export const vaadinConfig: UserConfigFn = (env) => {
       // source. In production OXC does the JSX transform.
       reactPlugin({
         include: '**/*.tsx',
-        jsxImportSource: productionMode ? 'react' : undefined,
       }),
       // Babel runs with enforce:'pre' (default), so it sees the original
       // source. All line/column values it embeds in the output come from

--- a/flow-tests/test-frontend/vite-basics/src/main/frontend/ReactComponents.tsx
+++ b/flow-tests/test-frontend/vite-basics/src/main/frontend/ReactComponents.tsx
@@ -1,26 +1,26 @@
 function MyComp() {
-    return <div data-expected="1_19">A component defined in a function</div>;
+    return <div data-expected="1_19" data-jsx-expected="2_12">A component defined in a function</div>;
   }
   export function MyCompExport() {
     return (
       <>
-        <div data-expected="4_34">A component defined in an exported function</div>
+        <div data-expected="4_34" data-jsx-expected="7_9">A component defined in an exported function</div>
       </>
     );
   }
-  const MyCompConst = () => <div data-expected="11_29">A component defined in a const</div>;
-  export const MyCompConstExport = () => <div data-expected="12_42">A component defined in an exported const</div>;
-  
+  const MyCompConst = () => <div data-expected="11_29" data-jsx-expected="11_29">A component defined in a const</div>;
+  export const MyCompConstExport = () => <div data-expected="12_42" data-jsx-expected="12_42">A component defined in an exported const</div>;
+
   const NotAComp = undefined;
-  
+
   export default function InProjectComponentView() {
     function Inner() {
-      return <div data-expected="17_22">A component defined using a function inside another component</div>;
+      return <div data-expected="17_22" data-jsx-expected="18_14">A component defined using a function inside another component</div>;
     }
-    const InnerConst = () => <div data-expected="20_30">A component defined using a const inside another component</div>;
-  
+    const InnerConst = () => <div data-expected="20_30" data-jsx-expected="20_30">A component defined using a const inside another component</div>;
+
     return (
-      <div data-expected="16_52">
+      <div data-expected="16_52" data-jsx-expected="23_7">
         default
         <Inner></Inner>
         <InnerConst />
@@ -31,4 +31,4 @@ function MyComp() {
       </div>
     );
   }
-  
+

--- a/flow-tests/test-frontend/vite-basics/src/test/java/com/vaadin/viteapp/ReactComponentsIT.java
+++ b/flow-tests/test-frontend/vite-basics/src/test/java/com/vaadin/viteapp/ReactComponentsIT.java
@@ -41,6 +41,9 @@ public class ReactComponentsIT extends ChromeBrowserTest {
 
     @Test
     public void functionLocationsAvailable() {
+        // data-expected="line_column" encodes the expected
+        // __debugSourceDefine on the component function that produced
+        // this element (i.e. the position of the function body start).
         List<TestBenchElement> elements = $("*").hasAttribute("data-expected")
                 .all();
         Assert.assertTrue(elements.size() > 5);
@@ -48,10 +51,7 @@ public class ReactComponentsIT extends ChromeBrowserTest {
             String expected = element.getAttribute("data-expected");
             Long line = Long.parseLong(expected.split("_")[0]);
             Long column = Long.parseLong(expected.split("_")[1]);
-            String filenameEnd = "vite-basics/src/main/frontend/ReactComponents.tsx";
-            if (FrontendUtils.isWindows()) {
-                filenameEnd = filenameEnd.replaceAll("/", "\\\\");
-            }
+            String filenameEnd = expectedFilenameEnd();
 
             Map<String, Object> result = (Map<String, Object>) executeScript(
                     """
@@ -61,10 +61,56 @@ public class ReactComponentsIT extends ChromeBrowserTest {
                             """,
                     element);
 
+            Assert.assertNotNull("__debugSourceDefine not set on component for "
+                    + element.getAttribute("data-expected"), result);
             Assert.assertTrue(
                     result.get("fileName").toString().endsWith(filenameEnd));
             Assert.assertSame(line, result.get("lineNumber"));
             Assert.assertSame(column, result.get("columnNumber"));
         }
+    }
+
+    @Test
+    public void jsxSourceLocationsAvailable() {
+        // data-jsx-expected="line_column" encodes the expected
+        // _debugInfo.source on the JSX element itself (i.e. the position
+        // of the `<` opening the element in the source). This is populated
+        // from the __source argument that the JSX dev transform embeds in
+        // _jsxDEV(...) calls, based on the original source AST. The test
+        // guards against regressions where the JSX transform runs on code
+        // whose line/column positions no longer match the original source
+        // (e.g. after a prior Babel pass has reformatted the file).
+        List<TestBenchElement> elements = $("*")
+                .hasAttribute("data-jsx-expected").all();
+        Assert.assertTrue(elements.size() > 5);
+        for (TestBenchElement element : elements) {
+            String expected = element.getAttribute("data-jsx-expected");
+            Long line = Long.parseLong(expected.split("_")[0]);
+            Long column = Long.parseLong(expected.split("_")[1]);
+            String filenameEnd = expectedFilenameEnd();
+
+            Map<String, Object> result = (Map<String, Object>) executeScript(
+                    """
+                            const key = Object.keys(arguments[0]).filter(a => a.startsWith("__reactFiber"))[0];
+                            const fiber = arguments[0][key];
+                            return fiber._debugInfo && fiber._debugInfo.source;
+                            """,
+                    element);
+
+            Assert.assertNotNull("_debugInfo.source not set on JSX element for "
+                    + element.getAttribute("data-jsx-expected"), result);
+            Assert.assertTrue(
+                    result.get("fileName").toString().endsWith(filenameEnd));
+            Assert.assertSame(line, result.get("lineNumber"));
+            Assert.assertSame(column, result.get("columnNumber"));
+        }
+    }
+
+    private static String expectedFilenameEnd() {
+        String filenameEnd = "vite-basics/src/main/frontend/ReactComponents.tsx";
+        if (FrontendUtils.isWindows()) {
+            filenameEnd = filenameEnd.replaceAll("/", "\\\\");
+        }
+        return filenameEnd;
     }
 }

--- a/flow-tests/test-frontend/vite-basics/src/test/java/com/vaadin/viteapp/ReactComponentsIT.java
+++ b/flow-tests/test-frontend/vite-basics/src/test/java/com/vaadin/viteapp/ReactComponentsIT.java
@@ -97,8 +97,10 @@ public class ReactComponentsIT extends ChromeBrowserTest {
                             """,
                     element);
 
-            Assert.assertNotNull("_debugInfo.source not set on JSX element for "
-                    + element.getAttribute("data-jsx-expected"), result);
+            Assert.assertNotNull(
+                    "_debugInfo.source not set on JSX element for "
+                            + element.getAttribute("data-jsx-expected"),
+                    result);
             Assert.assertTrue(
                     result.get("fileName").toString().endsWith(filenameEnd));
             Assert.assertSame(line, result.get("lineNumber"));


### PR DESCRIPTION
There are three parts here

1. The react JSX transform records information where in the source an element is used, e.g. <div>hello</div> 
2. We write location info for react components such as export default function HelloWorldView() { -> we add HelloWorldView.__debugSourceDefine= {...} with the source location of that function
3. We use a preact signal transform that wraps components to track signal reads


In Vite 8 the JSX transform (1.)  is run through the Vite react plugin through OXC.
We use Babel to run 2 and 3.

Both the JSX element source info and function source info need to be based on the original source file because Copilot uses it to find the source location to edit.

1. The first PR ran Babel before Vite 8 + OXC and we modified the source when storing `HelloWorldView..__debugSourceDefine` -> Element source info was wrong
2. The second PR changed Babel to run after Vite 8 + OXC  and did not use the result from Vite 8 but read the files again from disk -> both source infos correct but `@preact/signals-react-transform` got the OXC transformed result and its logic stopped working (signal updates did not re-render)
3. The third PR changed Babel to run before Vite 8 + OXC again, removed reading from disk as the locations are correct and then it used `retainLines` so it would not break Element source info -> Still breaks column info even though row info is retained and Copilot does not work
4. This PR runs Babel before Vite 8 + OXC but also make Babel do the React JSX transform. Then we are back to pretty much what we had with Vite 7 where it all happens in Babel and all info should be correct. 

Put more technically: 

Previous iterations had Babel run post-OXC, or pre-OXC with retainLines (both broken: retainLines preserves line numbers but not columns, so inserted statements push JSX to higher column numbers in Babel's output; the post-OXC approach saw already-transformed code).
    
Move the JSX dev transform into Babel itself via @babel/plugin-transform-react-jsx-development with the custom jsxImportSource. Babel now emits _jsxDEV(...) calls whose embedded lineNumber/columnNumber come straight from its AST loc — which refers to the original source. Babel's printer can freely reformat the file afterwards because OXC no longer looks at JSX source positions.

