### PR TITLE
fix: Sanitize percent characters in resource URLs (#24031)(CP:24.10)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamRequestHandler.java
@@ -244,8 +244,29 @@ public class StreamRequestHandler implements RequestHandler {
      * @return generated URI string
      */
     public static String generateURI(String name, String id) {
+        // Replace '%' with '_' to avoid ambiguous percent-encoding (%25)
+        // rejected by Jetty 12. The actual download filename is preserved
+        // in the Content-Disposition header, so this only affects the URL
+        // path used for resource lookup.
+        String safeName = sanitizeNameForUrl(name);
         return DYN_RES_PREFIX + UI.getCurrent().getUIId() + PATH_SEPARATOR + id
-                + PATH_SEPARATOR + UrlUtil.encodeURIComponent(name);
+                + PATH_SEPARATOR + UrlUtil.encodeURIComponent(safeName);
+    }
+
+    /**
+     * Replaces characters that would produce ambiguous percent-encodings in URL
+     * path segments.
+     *
+     * @param name
+     *            the resource name to sanitize
+     * @return the sanitized name, or the original value if {@code null} or
+     *         empty
+     */
+    static String sanitizeNameForUrl(String name) {
+        if (name == null || name.isEmpty()) {
+            return name;
+        }
+        return name.replace("%", "_");
     }
 
     private static Optional<URI> getPathUri(String path) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/StreamRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/StreamRequestHandlerTest.java
@@ -140,6 +140,18 @@ public class StreamRequestHandlerTest {
     }
 
     @Test
+    public void streamResourceNameContainsPercent_streamFactory_resourceIsStreamed()
+            throws IOException {
+        testStreamResourceInputStreamFactory("percent in name", "file%.txt");
+    }
+
+    @Test
+    public void streamResourceNameContainsPercent_resourceWriter_resourceIsStreamed()
+            throws IOException {
+        testStreamResourceStreamResourceWriter("percent in name", "file%.txt");
+    }
+
+    @Test
     public void stateNodeStates_handlerMustNotReplyWhenNodeDisabled()
             throws IOException {
         stateNodeStatesTestInternal(false, true);
@@ -233,9 +245,10 @@ public class StreamRequestHandlerTest {
         ServletOutputStream outputStream = Mockito
                 .mock(ServletOutputStream.class);
         Mockito.when(response.getOutputStream()).thenReturn(outputStream);
-        Mockito.when(request.getPathInfo())
-                .thenReturn(String.format("/%s%s/%s/%s", DYN_RES_PREFIX,
-                        ui.getId().orElse("-1"), res.getId(), res.getName()));
+        Mockito.when(request.getPathInfo()).thenReturn(String.format(
+                "/%s%s/%s/%s", DYN_RES_PREFIX, ui.getId().orElse("-1"),
+                res.getId(),
+                StreamRequestHandler.sanitizeNameForUrl(res.getName())));
 
         handler.handleRequest(session, request, response);
 
@@ -254,9 +267,10 @@ public class StreamRequestHandlerTest {
         ServletOutputStream outputStream = Mockito
                 .mock(ServletOutputStream.class);
         Mockito.when(response.getOutputStream()).thenReturn(outputStream);
-        Mockito.when(request.getPathInfo())
-                .thenReturn(String.format("/%s%s/%s/%s", DYN_RES_PREFIX,
-                        ui.getId().orElse("-1"), res.getId(), res.getName()));
+        Mockito.when(request.getPathInfo()).thenReturn(String.format(
+                "/%s%s/%s/%s", DYN_RES_PREFIX, ui.getId().orElse("-1"),
+                res.getId(),
+                StreamRequestHandler.sanitizeNameForUrl(res.getName())));
 
         handler.handleRequest(session, request, response);
 
@@ -288,9 +302,10 @@ public class StreamRequestHandlerTest {
         ServletOutputStream outputStream = Mockito
                 .mock(ServletOutputStream.class);
         Mockito.when(response.getOutputStream()).thenReturn(outputStream);
-        Mockito.when(request.getPathInfo())
-                .thenReturn(String.format("/%s%s/%s/%s", DYN_RES_PREFIX,
-                        ui.getId().orElse("-1"), res.getId(), res.getName()));
+        Mockito.when(request.getPathInfo()).thenReturn(String.format(
+                "/%s%s/%s/%s", DYN_RES_PREFIX, ui.getId().orElse("-1"),
+                res.getId(),
+                StreamRequestHandler.sanitizeNameForUrl(res.getName())));
 
         handler.handleRequest(session, request, response);
 
@@ -303,6 +318,22 @@ public class StreamRequestHandlerTest {
                 argument.getValue());
         Mockito.verify(response).setCacheTime(Mockito.anyLong());
         Mockito.verify(response).setContentType("application/octet-stream");
+    }
+
+    @Test
+    public void sanitizeNameForUrl_percentIsReplaced() {
+        Assert.assertEquals("file_.txt",
+                StreamRequestHandler.sanitizeNameForUrl("file%.txt"));
+    }
+
+    @Test
+    public void sanitizeNameForUrl_nullReturnsNull() {
+        Assert.assertNull(StreamRequestHandler.sanitizeNameForUrl(null));
+    }
+
+    @Test
+    public void sanitizeNameForUrl_emptyReturnsEmpty() {
+        Assert.assertEquals("", StreamRequestHandler.sanitizeNameForUrl(""));
     }
 
     private static final class TestElementHandlerBuilder {

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DownloadHandlerView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DownloadHandlerView.java
@@ -130,10 +130,27 @@ public class DownloadHandlerView extends Div {
         inputStreamCallbackError
                 .setId("download-handler-input-stream-callback-error");
 
+        DownloadHandler percentDownloadHandler = new DownloadHandler() {
+            @Override
+            public void handleDownloadRequest(DownloadEvent event) {
+                event.getWriter().print("foo");
+            }
+
+            @Override
+            public String getUrlPostfix() {
+                return "file%.jpg";
+            }
+        };
+
+        Anchor percentDownload = new Anchor("", "Percent DownloadHandler");
+        percentDownload.setHref(percentDownloadHandler);
+        percentDownload.setId("download-handler-percent");
+
         add(handlerDownload, fileDownload, fileDownloadUnicodeName,
                 fileDownloadUnicodeNameWithQuote, classDownload,
                 servletDownload, inputStreamDownload, inputStreamErrorDownload,
-                inputStreamExceptionDownload, inputStreamCallbackError);
+                inputStreamExceptionDownload, inputStreamCallbackError,
+                percentDownload);
 
         NativeButton reattach = new NativeButton("Remove and add back",
                 event -> {

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DownloadHandlerIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DownloadHandlerIT.java
@@ -223,6 +223,13 @@ public class DownloadHandlerIT extends AbstractStreamResourceIT {
     }
 
     @Test
+    public void getDynamicDownloadHandlerPercentResource() throws IOException {
+        open();
+
+        assertDownloadedContent("download-handler-percent", "file_.jpg");
+    }
+
+    @Test
     public void detach_attachALink_getDynamicVaadinResource()
             throws IOException {
         open();

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/StreamResourceIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/StreamResourceIT.java
@@ -29,7 +29,6 @@ import java.util.stream.Collectors;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -57,14 +56,11 @@ public class StreamResourceIT extends AbstractStreamResourceIT {
         assertDownloadedContent("plus-link", "file%2B.jpg");
     }
 
-    // Ignored due to
-    // https://github.com/jetty/jetty.project/issues/9444#issuecomment-1677068428
     @Test
-    @Ignore
     public void getDynamicVaadinPercentResource() throws IOException {
         open();
 
-        assertDownloadedContent("percent-link", "file%25.jpg");
+        assertDownloadedContent("percent-link", "file_.jpg");
     }
 
     @Test


### PR DESCRIPTION
Cherry-pick of #24031

Jetty 12 rejects URLs containing %25 (percent-encoded percent) as ambiguous URI path encoding, causing downloads to fail with HTTP 400 when filenames contain "%" characters.

Add UrlUtil.sanitizeForUrl() that replaces "%" with "_" in the URL path segment. The actual download filename from Content-Disposition is unaffected since each resource has a unique ID for lookup.

Fixes #22677
