### PR TITLE
fix: add package.json overrides for workbox dependencies (#24008) (#24163) (CP:24.9)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/JacksonUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JacksonUtils.java
@@ -632,4 +632,103 @@ public final class JacksonUtils {
                         .withObjectFieldValueSpacing(Spacing.AFTER));
         return objectMapper.writer().with(filePrinter).writeValueAsString(node);
     }
+
+    /**
+     * Retrieves a nested JSON key from an object node based on a provided path.
+     *
+     * @param objectNode
+     *            the root object node to search within
+     * @param keyPath
+     *            the nested key path
+     * @return the value of the last key found, or {@code null}
+     */
+    public static JsonNode getNestedKey(ObjectNode objectNode,
+            List<String> keyPath) {
+        if (keyPath.isEmpty()) {
+            return null;
+        }
+        final String firstKey = keyPath.get(0);
+        final JsonNode value = objectNode.get(firstKey);
+        if (keyPath.size() == 1) {
+            return value;
+        } else if (value instanceof ObjectNode nestedObjectNode) {
+            return getNestedKey(nestedObjectNode,
+                    keyPath.subList(1, keyPath.size()));
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Sets a nested JSON key path in an {@code ObjectNode} with the provided
+     * value.
+     * <p>
+     * This method handles both direct and nested key assignments. If the
+     * current node at the specified top-level key does not exist not an
+     * {@code ObjectNode}, it converts it to one using the provided converter
+     * function, before proceeding with the remaining keys in the path.
+     *
+     * @param objectNode
+     *            the root object where the key path will be set
+     * @param keyPath
+     *            the nested key path
+     * @param valueNode
+     *            the value to be assigned
+     * @param plainValueConverter
+     *            a function that converts intermediate {@code null} and
+     *            non-{@code ObjectNode} values into {@code ObjectNode}s when
+     *            necessary for recursive traversal
+     */
+    public static void setNestedKey(ObjectNode objectNode, List<String> keyPath,
+            JsonNode valueNode,
+            Function<? super JsonNode, ? extends ObjectNode> plainValueConverter) {
+        if (keyPath.isEmpty()) {
+            return;
+        }
+        final String key = keyPath.get(0);
+        if (keyPath.size() == 1) {
+            objectNode.set(key, valueNode);
+            return;
+        }
+        final JsonNode currentValueNode = objectNode.get(key);
+        final ObjectNode nestedObjectNode;
+        if (currentValueNode instanceof ObjectNode currentObjectNode) {
+            nestedObjectNode = currentObjectNode;
+        } else {
+            nestedObjectNode = plainValueConverter.apply(currentValueNode);
+            objectNode.set(key, nestedObjectNode);
+        }
+        setNestedKey(nestedObjectNode, keyPath.subList(1, keyPath.size()),
+                valueNode, plainValueConverter);
+    }
+
+    /**
+     * Removes a nested key from an {@code ObjectNode} based on the provided
+     * path. Also removes nested objects, if they become empty after key
+     * removal.
+     *
+     * @param objectNode
+     *            the root object containing to process
+     * @param keyPath
+     *            the nested key path
+     */
+    public static void removeNestedKey(ObjectNode objectNode,
+            List<String> keyPath) {
+        if (keyPath.isEmpty()) {
+            return;
+        }
+        final String key = keyPath.get(0);
+        if (keyPath.size() == 1) {
+            objectNode.remove(key);
+            return;
+        }
+        final JsonNode currentValueNode = objectNode.get(key);
+        if (currentValueNode instanceof ObjectNode nestedObjectNode) {
+            removeNestedKey(nestedObjectNode,
+                    keyPath.subList(1, keyPath.size()));
+            if (nestedObjectNode.isEmpty()) {
+                objectNode.remove(key);
+            }
+        }
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -111,8 +111,6 @@ abstract class AbstractUpdateImports implements Runnable {
 
     private final Map<Path, List<String>> resolvedImportPathsCache = new HashMap<>();
 
-    private FrontendDependenciesScanner scanner;
-
     private ClassFinder classFinder;
 
     final File generatedFlowImports;
@@ -122,19 +120,17 @@ abstract class AbstractUpdateImports implements Runnable {
 
     private final GeneratedFilesSupport generatedFilesSupport;
 
-    AbstractUpdateImports(Options options,
-            FrontendDependenciesScanner scanner) {
-        this(options, scanner, new GeneratedFilesSupport());
+    AbstractUpdateImports(Options options) {
+        this(options, new GeneratedFilesSupport());
     }
 
-    AbstractUpdateImports(Options options, FrontendDependenciesScanner scanner,
+    AbstractUpdateImports(Options options,
             GeneratedFilesSupport generatedFilesSupport) {
         this.generatedFilesSupport = generatedFilesSupport;
         this.options = options;
-        this.scanner = scanner;
         this.classFinder = options.getClassFinder();
         this.themeToLocalPathConverter = createThemeToLocalPathConverter(
-                scanner.getTheme());
+                options.getFrontendDependenciesScanner().getTheme());
 
         generatedFlowImports = FrontendUtils
                 .getFlowGeneratedImports(options.getFrontendDirectory());
@@ -155,7 +151,8 @@ abstract class AbstractUpdateImports implements Runnable {
         getLogger().debug("Start updating imports file and chunk files.");
         long start = System.nanoTime();
 
-        Map<ChunkInfo, List<CssData>> css = scanner.getCss();
+        Map<ChunkInfo, List<CssData>> css = options
+                .getFrontendDependenciesScanner().getCss();
         Map<ChunkInfo, List<String>> javascript = getMergedJavascript();
 
         Map<File, List<String>> output = process(css, javascript);
@@ -172,6 +169,8 @@ abstract class AbstractUpdateImports implements Runnable {
         long start = System.nanoTime();
 
         Map<ChunkInfo, List<String>> javascript;
+        final FrontendDependenciesScanner scanner = options
+                .getFrontendDependenciesScanner();
         Map<ChunkInfo, List<String>> modules = scanner.getModules();
         Map<ChunkInfo, List<String>> scripts = scanner.getScripts();
 
@@ -571,7 +570,8 @@ abstract class AbstractUpdateImports implements Runnable {
         Set<String> npmNotFound = new HashSet<>();
         Set<String> resourceNotFound = new HashSet<>();
         Set<String> es6ImportPaths = new LinkedHashSet<>();
-        AbstractTheme theme = scanner.getTheme();
+        AbstractTheme theme = options.getFrontendDependenciesScanner()
+                .getTheme();
 
         Set<String> visited = new HashSet<>();
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleValidationUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/BundleValidationUtil.java
@@ -244,8 +244,7 @@ public final class BundleValidationUtil {
         ((ObjectNode) statsJson.get(FRONTEND_HASHES_STATS_KEY)).remove(
                 FrontendUtils.GENERATED + FrontendUtils.COMMERCIAL_BANNER_JS);
 
-        if (!BundleValidationUtil.frontendImportsFound(statsJson, options,
-                frontendDependencies)) {
+        if (!BundleValidationUtil.frontendImportsFound(statsJson, options)) {
             UsageStatistics.markAsUsed(
                     "flow/rebundle-reason-missing-frontend-import", null);
             return true;
@@ -324,8 +323,7 @@ public final class BundleValidationUtil {
     public static JsonNode getDefaultPackageJson(Options options,
             FrontendDependenciesScanner frontendDependencies,
             ObjectNode packageJson) {
-        NodeUpdater nodeUpdater = new NodeUpdater(frontendDependencies,
-                options) {
+        NodeUpdater nodeUpdater = new NodeUpdater(options) {
             @Override
             public void execute() {
             }
@@ -631,12 +629,11 @@ public final class BundleValidationUtil {
     }
 
     public static boolean frontendImportsFound(JsonNode statsJson,
-            Options options, FrontendDependenciesScanner frontendDependencies)
-            throws IOException {
+            Options options) throws IOException {
 
         // Validate frontend requirements in flow-generated-imports.js
         final GenerateMainImports generateMainImports = new GenerateMainImports(
-                frontendDependencies, options, statsJson);
+                options, statsJson);
         generateMainImports.run();
         final List<String> imports = generateMainImports.getLines().stream()
                 .filter(line -> line.startsWith("import"))

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/GenerateMainImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/GenerateMainImports.java
@@ -28,7 +28,6 @@ import org.slf4j.helpers.NOPLogger;
 
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.server.frontend.scanner.CssData;
-import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 
 /**
  * Collect generated-flow-imports content for project to use to determine if
@@ -43,9 +42,8 @@ public class GenerateMainImports extends AbstractUpdateImports {
     private JsonNode statsJson;
     private Map<File, List<String>> output;
 
-    public GenerateMainImports(FrontendDependenciesScanner frontendDepScanner,
-            Options options, JsonNode statsJson) {
-        super(options, frontendDepScanner);
+    public GenerateMainImports(Options options, JsonNode statsJson) {
+        super(options);
         this.statsJson = statsJson;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -197,8 +197,7 @@ public class NodeTasks implements FallibleCommand {
             TaskUpdatePackages packageUpdater = null;
             if (options.isEnablePackagesUpdate()
                     && options.getJarFrontendResourcesFolder() != null) {
-                packageUpdater = new TaskUpdatePackages(frontendDependencies,
-                        options);
+                packageUpdater = new TaskUpdatePackages(options);
                 commands.add(packageUpdater);
             }
 
@@ -235,7 +234,7 @@ public class NodeTasks implements FallibleCommand {
         // available)
         addEndpointServicesTasks(options);
 
-        commands.add(new TaskGenerateBootstrap(frontendDependencies, options));
+        commands.add(new TaskGenerateBootstrap(options));
 
         commands.add(new TaskGenerateFeatureFlags(options));
 
@@ -273,7 +272,7 @@ public class NodeTasks implements FallibleCommand {
         }
 
         if (options.isEnableImportsUpdate()) {
-            commands.add(new TaskUpdateImports(frontendDependencies, options));
+            commands.add(new TaskUpdateImports(options));
 
             commands.add(new TaskUpdateThemeImport(
                     frontendDependencies.getThemeDefinition(), options));

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -44,9 +44,8 @@ import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.internal.JsonDecodingException;
 import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.PwaConfiguration;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
-import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
-import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 import static com.vaadin.flow.server.Constants.PACKAGE_LOCK_JSON;
@@ -93,12 +92,6 @@ public abstract class NodeUpdater implements FallibleCommand {
     static final String VAADIN_VERSION = "vaadinVersion";
     static final String PROJECT_FOLDER = "projectFolder";
 
-    /**
-     * The {@link FrontendDependencies} object representing the application
-     * dependencies.
-     */
-    protected final FrontendDependenciesScanner frontDeps;
-
     final ClassFinder finder;
 
     boolean modified;
@@ -110,15 +103,11 @@ public abstract class NodeUpdater implements FallibleCommand {
     /**
      * Constructor.
      *
-     * @param frontendDependencies
-     *            a reusable frontend dependencies
      * @param options
      *            the task options
      */
-    protected NodeUpdater(FrontendDependenciesScanner frontendDependencies,
-            Options options) {
+    protected NodeUpdater(Options options) {
         this.finder = options.getClassFinder();
-        this.frontDeps = frontendDependencies;
         this.options = options;
     }
 
@@ -317,27 +306,38 @@ public abstract class NodeUpdater implements FallibleCommand {
         return dependencies;
     }
 
-    Map<String, String> readDependencies(String id, String packageJsonKey) {
+    JsonNode readPackageJsonKey(String id, String packageJsonKey) {
+        final JsonNode packageJson;
         try {
-            Map<String, String> map = new HashMap<>();
-            JsonNode dependencies = readPackageJson(id).get(packageJsonKey);
-            if (dependencies == null) {
-                log().error("Unable to find " + packageJsonKey + " from '" + id
-                        + "'");
-                return new HashMap<>();
-            }
-            for (String key : JacksonUtils.getKeys(dependencies)) {
-                map.put(key, dependencies.get(key).textValue());
-            }
-
-            return map;
+            packageJson = readPackageJson(id);
         } catch (IOException e) {
             log().error(
                     "Unable to read " + packageJsonKey + " from '" + id + "'",
                     e);
+            return null;
+        }
+        var value = packageJson.get(packageJsonKey);
+        if (value == null) {
+            log().error(
+                    "Unable to find " + packageJsonKey + " from '" + id + "'");
+        }
+        return value;
+    }
+
+    Map<String, String> readDependencies(String id, String packageJsonKey) {
+        Map<String, String> map = new HashMap<>();
+        JsonNode dependencies = readPackageJsonKey(id, packageJsonKey);
+        if (dependencies == null) {
+            log().error(
+                    "Unable to find " + packageJsonKey + " from '" + id + "'");
             return new HashMap<>();
         }
 
+        for (String key : JacksonUtils.getKeys(dependencies)) {
+            map.put(key, dependencies.get(key).textValue());
+        }
+
+        return map;
     }
 
     JsonNode readPackageJson(String id) throws IOException {
@@ -380,7 +380,32 @@ public abstract class NodeUpdater implements FallibleCommand {
             }
         }
 
+        // Add workbox dependencies only when PWA is enabled
+        final PwaConfiguration pwaConfiguration = options
+                .getFrontendDependenciesScanner().getPwaConfiguration();
+        if (pwaConfiguration != null && pwaConfiguration.isOfflineEnabled()) {
+            defaults.putAll(readDependencies("workbox", "devDependencies"));
+        }
+
         return defaults;
+    }
+
+    ObjectNode getDefaultOverrides() {
+        var overrides = JacksonUtils.createObjectNode();
+
+        final PwaConfiguration pwaConfiguration = options
+                .getFrontendDependenciesScanner().getPwaConfiguration();
+        // Currently, we only have overrides for workbox uses overrides, and
+        // only when PWA is enabled
+        final ObjectNode workboxOverrides = pwaConfiguration != null
+                && pwaConfiguration.isOfflineEnabled()
+                        ? (ObjectNode) readPackageJsonKey("workbox",
+                                "overrides")
+                        : null;
+        if (workboxOverrides != null) {
+            overrides = overrides.setAll(workboxOverrides);
+        }
+        return overrides;
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrap.java
@@ -24,7 +24,6 @@ import java.util.ServiceLoader;
 
 import org.slf4j.LoggerFactory;
 
-import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 import com.vaadin.flow.theme.ThemeDefinition;
 
 import static com.vaadin.flow.server.frontend.FrontendUtils.BOOTSTRAP_FILE_NAME;
@@ -47,13 +46,10 @@ public class TaskGenerateBootstrap extends AbstractTaskClientGenerator {
     static final String DEV_TOOLS_IMPORT = String.format(
             "import '%svaadin-dev-tools.js';%n",
             FrontendUtils.JAR_RESOURCES_IMPORT + "vaadin-dev-tools/");
-    private final FrontendDependenciesScanner frontDeps;
     private final Options options;
     private List<TypeScriptBootstrapModifier> modifiers;
 
-    TaskGenerateBootstrap(FrontendDependenciesScanner frontDeps,
-            Options options) {
-        this.frontDeps = frontDeps;
+    TaskGenerateBootstrap(Options options) {
         this.options = options;
         this.modifiers = new ArrayList<>();
         for (Class<? extends TypeScriptBootstrapModifier> modifierClass : options
@@ -84,7 +80,8 @@ public class TaskGenerateBootstrap extends AbstractTaskClientGenerator {
         lines.addAll(getThemeLines());
 
         for (TypeScriptBootstrapModifier modifier : modifiers) {
-            modifier.modify(lines, options, frontDeps);
+            modifier.modify(lines, options,
+                    options.getFrontendDependenciesScanner());
         }
         lines.add(0,
                 String.format("import './%s';%n", FEATURE_FLAGS_FILE_NAME));
@@ -100,7 +97,7 @@ public class TaskGenerateBootstrap extends AbstractTaskClientGenerator {
 
     @Override
     protected boolean shouldGenerate() {
-        return frontDeps != null;
+        return options.getFrontendDependenciesScanner() != null;
     }
 
     private String getIndexTsEntryPath() {
@@ -117,7 +114,8 @@ public class TaskGenerateBootstrap extends AbstractTaskClientGenerator {
 
     private Collection<String> getThemeLines() {
         Collection<String> lines = new ArrayList<>();
-        ThemeDefinition themeDef = frontDeps.getThemeDefinition();
+        ThemeDefinition themeDef = options.getFrontendDependenciesScanner()
+                .getThemeDefinition();
         if (themeDef != null && !"".equals(themeDef.getName())) {
             lines.add("import './theme-" + themeDef.getName()
                     + ".global.generated.js';");

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGeneratePackageJson.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGeneratePackageJson.java
@@ -36,7 +36,7 @@ public class TaskGeneratePackageJson extends NodeUpdater {
      *            build options
      */
     TaskGeneratePackageJson(Options options) {
-        super(null, options);
+        super(options);
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -19,7 +19,6 @@ import org.slf4j.Logger;
 
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.server.Constants;
-import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 import com.vaadin.flow.theme.Theme;
 
 /**
@@ -36,9 +35,8 @@ public class TaskUpdateImports extends NodeUpdater {
 
     private class UpdateMainImportsFile extends AbstractUpdateImports {
         UpdateMainImportsFile(Options options,
-                FrontendDependenciesScanner scanner,
                 GeneratedFilesSupport generatedFilesSupport) {
-            super(options, scanner, generatedFilesSupport);
+            super(options, generatedFilesSupport);
         }
 
         @Override
@@ -58,14 +56,11 @@ public class TaskUpdateImports extends NodeUpdater {
     /**
      * Create an instance of the updater given all configurable parameters.
      *
-     * @param frontendDepScanner
-     *            a reusable frontend dependencies scanner
      * @param options
      *            options for the task
      */
-    TaskUpdateImports(FrontendDependenciesScanner frontendDepScanner,
-            Options options) {
-        super(frontendDepScanner, options);
+    TaskUpdateImports(Options options) {
+        super(options);
     }
 
     @Override
@@ -76,7 +71,7 @@ public class TaskUpdateImports extends NodeUpdater {
     @Override
     public void execute() {
         UpdateMainImportsFile mainUpdate = new UpdateMainImportsFile(options,
-                frontDeps, generatedFilesSupport);
+                generatedFilesSupport);
         mainUpdate.run();
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -23,6 +23,8 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -31,8 +33,10 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.LoggerFactory;
@@ -69,14 +73,11 @@ public class TaskUpdatePackages extends NodeUpdater {
     /**
      * Create an instance of the updater given all configurable parameters.
      *
-     * @param frontendDependencies
-     *            a reusable frontend dependencies
      * @param options
      *            the task options
      */
-    TaskUpdatePackages(FrontendDependenciesScanner frontendDependencies,
-            Options options) {
-        super(frontendDependencies, options);
+    TaskUpdatePackages(Options options) {
+        super(options);
         this.jarResourcesFolder = options.getJarFrontendResourcesFolder();
         this.forceCleanUp = options.isCleanNpmFiles();
         this.enablePnpm = options.isEnablePnpm();
@@ -85,6 +86,8 @@ public class TaskUpdatePackages extends NodeUpdater {
     @Override
     public void execute() {
         try {
+            final FrontendDependenciesScanner frontDeps = options
+                    .getFrontendDependenciesScanner();
             Map<String, String> scannedApplicationDependencies = frontDeps
                     .getPackages();
             Map<String, String> scannedApplicationDevDependencies = frontDeps
@@ -94,9 +97,19 @@ public class TaskUpdatePackages extends NodeUpdater {
                     scannedApplicationDependencies,
                     scannedApplicationDevDependencies);
             generateVersionsJson(packageJson);
-            boolean npmVersionLockingUpdated = lockVersionForNpm(packageJson);
+            modified = lockVersionForNpm(packageJson) || modified;
 
-            if (modified || npmVersionLockingUpdated) {
+            // Recompute hash
+            final String finalHash = generatePackageJsonHash(packageJson);
+            final JsonNode hashNode = JacksonUtils.getNestedKey(packageJson,
+                    List.of(VAADIN_DEP_KEY, HASH_KEY));
+            modified = !finalHash
+                    .equals(hashNode != null ? hashNode.textValue() : "")
+                    || modified;
+            if (modified) {
+                ((ObjectNode) packageJson.get(VAADIN_DEP_KEY)).put(HASH_KEY,
+                        finalHash);
+
                 if (!packageJson.has("type") || !packageJson.get("type")
                         .textValue().equals("module")) {
                     packageJson.put("type", "module");
@@ -115,54 +128,26 @@ public class TaskUpdatePackages extends NodeUpdater {
     }
 
     boolean lockVersionForNpm(ObjectNode packageJson) throws IOException {
-        boolean versionLockingUpdated = false;
+        // Keep track of Vaadin overrides in the vaadin.overrides section,
+        // similar to vaadin.dependencies, in order to reduce conflicts with
+        // the user overrides.
 
-        ObjectNode overridesSection = getOverridesSection(packageJson);
+        // Collect all Vaadin overrides that need to be currently enabled
+        final ObjectNode vaadinOverrides = getDefaultOverrides();
+
+        // Add dependency locking overrides
         final JsonNode dependencies = packageJson.get(DEPENDENCIES);
-        ObjectNode fullPlatformDependencies = getFullPlatformDependencies();
-        // Clean platform overrides if override version less than new version.
-        for (String key : JacksonUtils.getKeys(fullPlatformDependencies)) {
-            if (overridesSection.has(key)
-                    && !overridesSection.get(key).textValue().startsWith("$")
-                    && new FrontendVersion(
-                            overridesSection.get(key).textValue()).isOlderThan(
-                                    new FrontendVersion(fullPlatformDependencies
-                                            .get(key).textValue()))) {
-                overridesSection.remove(key);
-            }
-        }
         for (String dependency : JacksonUtils.getKeys(versionsJson)) {
-            if (!overridesSection.has(dependency)
-                    && shouldLockDependencyVersion(dependency, dependencies,
-                            versionsJson)) {
-                overridesSection.put(dependency, "$" + dependency);
-                versionLockingUpdated = true;
-            }
-        }
-        final ObjectNode devDependencies = (ObjectNode) packageJson
-                .get(DEV_DEPENDENCIES);
-        for (String dependency : JacksonUtils.getKeys(overridesSection)) {
-            if (!dependencies.has(dependency)
-                    && !devDependencies.has(dependency) && overridesSection
-                            .get(dependency).textValue().startsWith("$")) {
-                overridesSection.remove(dependency);
-                versionLockingUpdated = true;
+            if (!vaadinOverrides.has(dependency) && shouldLockDependencyVersion(
+                    dependency, dependencies, versionsJson)) {
+                // Lock with a dependency reference
+                vaadinOverrides.put(dependency, "$" + dependency);
             }
         }
 
-        /*
-         * Remove platform dependencies for all existing dependencies and
-         * devDependencies
-         */
-        for (String dependency : JacksonUtils.getKeys(dependencies)) {
-            fullPlatformDependencies.remove(dependency);
-        }
-        for (String dependency : JacksonUtils.getKeys(devDependencies)) {
-            fullPlatformDependencies.remove(dependency);
-        }
-
-        // After removing any existing dependencies and devDependencies add all
-        // platform versions to overrides block
+        // Add platform versions
+        final ObjectNode fullPlatformDependencies = getFullPlatformDependencies();
+        final JsonNode devDependencies = packageJson.get(DEV_DEPENDENCIES);
         for (String dependency : JacksonUtils
                 .getKeys(fullPlatformDependencies)) {
             try {
@@ -171,15 +156,158 @@ public class TaskUpdatePackages extends NodeUpdater {
                 if ("SNAPSHOT".equals(frontendVersion.getBuildIdentifier())) {
                     continue;
                 }
-                overridesSection.set(dependency, JacksonUtils
-                        .createNode(frontendVersion.getFullVersion()));
-                versionLockingUpdated = true;
+                if (vaadinOverrides.has(dependency)
+                        && vaadinOverrides.get(dependency).isTextual()
+                        && vaadinOverrides.get(dependency).asText()
+                                .startsWith("$")) {
+                    // Already locked with a dependency reference, skip
+                    continue;
+                }
+                if (dependencies.has(dependency)
+                        || devDependencies.has(dependency)) {
+                    // Skip platform overrides for existing dependencies
+                    continue;
+                }
+                // Lock with a version number
+                vaadinOverrides.put(dependency,
+                        frontendVersion.getFullVersion());
             } catch (NumberFormatException nfe) {
                 continue;
             }
         }
 
+        final ObjectNode overridesSection = getOverridesSection(packageJson);
+
+        // Flatten overrides to simplify diffing
+        final Map<String, String> flatVaadinOverrides = flattenOverrides(
+                vaadinOverrides);
+        final ObjectNode lastVaadinOverrides = (ObjectNode) packageJson
+                .get(VAADIN_DEP_KEY).get(OVERRIDES);
+        final Map<String, String> flatLastVaadinOverrides = lastVaadinOverrides == null
+                ? Map.of()
+                : flattenOverrides(lastVaadinOverrides);
+
+        boolean versionLockingUpdated = false;
+        // Update overrides based on diff between current and last overrides
+        for (final Map.Entry<String, String> entryToUpdate : flatVaadinOverrides
+                .entrySet()) {
+            final String lastValue = flatLastVaadinOverrides
+                    .get(entryToUpdate.getKey());
+            if (entryToUpdate.getValue().equals(
+                    flatLastVaadinOverrides.get(entryToUpdate.getKey()))) {
+                // Override value didn't change, skipping.
+                continue;
+            }
+            final JsonNode lastUserValue;
+            final List<String> keyPath = List
+                    .of(entryToUpdate.getKey().split(">"));
+            if (enablePnpm) {
+                lastUserValue = overridesSection.get(entryToUpdate.getKey());
+            } else {
+                lastUserValue = JacksonUtils.getNestedKey(overridesSection,
+                        keyPath);
+            }
+            boolean optOut;
+            if (lastValue == null) {
+                // Old-style package.json did not have Vaadin overrides.
+                // We generally cannot detect opt-out except for one case:
+                // prevent unpinning with relative version when the user has
+                // existing non-relative override.
+                optOut = lastUserValue != null
+                        && entryToUpdate.getValue().startsWith("$")
+                        && !lastUserValue.textValue().startsWith("$");
+            } else {
+                // Detect opt-out: the actual override value is different from
+                // last Vaadin override:
+                optOut = !TextNode.valueOf(lastValue).equals(lastUserValue);
+            }
+            if (optOut) {
+                // Skip due to user opt-out using a custom override
+                continue;
+            }
+            versionLockingUpdated = true;
+            if (enablePnpm) {
+                // Use flat format for pnpm
+                overridesSection.put(entryToUpdate.getKey(),
+                        entryToUpdate.getValue());
+            } else {
+                putNestedOverride(overridesSection, keyPath,
+                        entryToUpdate.getValue());
+            }
+        }
+        for (final Map.Entry<String, String> entryToRemove : flatLastVaadinOverrides
+                .entrySet()) {
+            if (flatVaadinOverrides.containsKey(entryToRemove.getKey())) {
+                // Override continues to exist, skipping.
+                continue;
+            }
+            versionLockingUpdated = true;
+            if (enablePnpm) {
+                // Use flat format for pnpm
+                overridesSection.remove(entryToRemove.getKey());
+            }
+            // Handle possibly nested overrides object
+            final List<String> keyPath = List
+                    .of(entryToRemove.getKey().split(">"));
+            // Object format: { "dep": { ".": "1.0" } }
+            final List<String> keyPathDotNested = Stream
+                    .concat(keyPath.stream(), Stream.of(".")).toList();
+            if (JacksonUtils.getNestedKey(overridesSection,
+                    keyPathDotNested) != null) {
+                JacksonUtils.removeNestedKey(overridesSection,
+                        keyPathDotNested);
+            }
+            // Plain format: { "dep": "1.0" }
+            if (JacksonUtils.getNestedKey(overridesSection, keyPath) != null) {
+                JacksonUtils.removeNestedKey(overridesSection, keyPath);
+            }
+        }
+
+        if (lastVaadinOverrides == null) {
+            // Additional cleanup for overrides added before Vaadin overrides
+            // section was introduced in PR #24008. Find and remove any obsolete
+            // relative overrides.
+            for (String overrideDependency : JacksonUtils
+                    .getKeys(overridesSection)) {
+                final boolean relativeOverride = overridesSection
+                        .get(overrideDependency).asText("").startsWith("$");
+                if (relativeOverride && !dependencies.has(overrideDependency)) {
+                    overridesSection.remove(overrideDependency);
+                }
+            }
+        }
+
+        if (vaadinOverrides.isEmpty()) {
+            // Clean up empty Vaadin overrides section
+            ((ObjectNode) packageJson.get(VAADIN_DEP_KEY)).remove(OVERRIDES);
+        } else {
+            // Save Vaadin overrides section
+            ((ObjectNode) packageJson.get(VAADIN_DEP_KEY)).set(OVERRIDES,
+                    vaadinOverrides);
+        }
         return versionLockingUpdated;
+    }
+
+    private void putNestedOverride(ObjectNode overrides, List<String> keyPath,
+            String value) {
+        JsonNode existingNode = JacksonUtils.getNestedKey(overrides, keyPath);
+        if (existingNode != null && existingNode.isObject()) {
+            // Add as a "." property in existing object
+            ((ObjectNode) existingNode).put(".", value);
+            return;
+        }
+        JacksonUtils.setNestedKey(overrides, keyPath, TextNode.valueOf(value),
+                (plainValueNode) -> {
+                    // Create and use an intermediate nested object
+                    final ObjectNode objectNode = JacksonUtils
+                            .createObjectNode();
+                    if (plainValueNode != null && plainValueNode.isTextual()) {
+                        // Upgrade plain string override to nested object
+                        // { "dep": "1.0" } => { "dep" : { ".": "1.0" } }
+                        objectNode.set(".", plainValueNode);
+                    }
+                    return objectNode;
+                });
     }
 
     /**
@@ -281,40 +409,98 @@ public class TaskUpdatePackages extends NodeUpdater {
     }
 
     private ObjectNode getOverridesSection(ObjectNode packageJson) {
-        ObjectNode overridesSection = (ObjectNode) packageJson.get(OVERRIDES);
-        ObjectNode oldOverrides = null;
+        ObjectNode overridesSection;
+        ObjectNode oldOverrides;
         if (options.isEnablePnpm()) {
-            if (overridesSection != null) {
-                oldOverrides = overridesSection;
+            ObjectNode pnpm = (ObjectNode) packageJson.get(PNPM);
+            if (pnpm == null) {
+                pnpm = JacksonUtils.createObjectNode();
+                packageJson.set(PNPM, pnpm);
+            }
+            overridesSection = (ObjectNode) pnpm.get(OVERRIDES);
+            if (overridesSection == null) {
+                overridesSection = JacksonUtils.createObjectNode();
+                pnpm.set(OVERRIDES, overridesSection);
+            }
+            oldOverrides = (ObjectNode) packageJson.get(OVERRIDES);
+            if (oldOverrides != null) {
+                // convert npm overrides to flat format for pnpm
+                flattenOverrides(oldOverrides).forEach(overridesSection::put);
                 // remove npm overrides when moving to pnpm
                 packageJson.remove(OVERRIDES);
             }
-            JsonNode pnpm = packageJson.get(PNPM);
-            if (pnpm == null) {
-                overridesSection = null;
-            } else {
-                overridesSection = (ObjectNode) pnpm.get(OVERRIDES);
-            }
-        } else if (packageJson.has(PNPM)) {
-            oldOverrides = overridesSection;
-            // remove pnpm overrides for npm
-            ((ObjectNode) packageJson.get(PNPM)).remove(OVERRIDES);
+            return overridesSection;
         }
+        overridesSection = (ObjectNode) packageJson.get(OVERRIDES);
         if (overridesSection == null) {
-            overridesSection = oldOverrides == null
-                    ? JacksonUtils.createObjectNode()
-                    : oldOverrides;
-            if (options.isEnablePnpm()) {
-                ObjectNode pnpmNode = packageJson.has(PNPM)
-                        ? (ObjectNode) packageJson.get(PNPM)
-                        : JacksonUtils.createObjectNode();
-                packageJson.set(PNPM, pnpmNode);
-                pnpmNode.set(OVERRIDES, overridesSection);
-            } else {
-                packageJson.set(OVERRIDES, overridesSection);
+            overridesSection = JacksonUtils.createObjectNode();
+            packageJson.set(OVERRIDES, overridesSection);
+        }
+        if (packageJson.has(PNPM)) {
+            ObjectNode pnpm = (ObjectNode) packageJson.get(PNPM);
+            oldOverrides = (ObjectNode) pnpm.get(OVERRIDES);
+            // convert pnpm overrides to nested format for npm
+            final Iterator<String> fieldNames = oldOverrides.fieldNames();
+            while (fieldNames.hasNext()) {
+                final String key = fieldNames.next();
+                final List<String> keyPath = List.of(key.split(">"));
+                putNestedOverride(overridesSection, keyPath,
+                        oldOverrides.get(key).textValue());
+            }
+            // remove pnpm overrides when moving to npm
+            pnpm.remove(OVERRIDES);
+            if (pnpm.isEmpty()) {
+                packageJson.remove(PNPM);
             }
         }
         return overridesSection;
+    }
+
+    /**
+     * Converts npm nested overrides to pnpm flat format. pnpm uses a different
+     * syntax for nested dependency overrides, using '&gt;' as a separator.
+     * <p>
+     * Example: {"workbox-build": {"dep": "1.0"}} becomes
+     * {"workbox-build&gt;dep": "1.0"}
+     *
+     * @param nestedOverrides
+     *            the nested override structure (npm format)
+     * @return flattened override structure (pnpm format)
+     */
+    private Map<String, String> flattenOverrides(ObjectNode nestedOverrides) {
+        final Map<String, String> flatOverrides = new HashMap<>();
+        for (String key : JacksonUtils.getKeys(nestedOverrides)) {
+            JsonNode value = nestedOverrides.get(key);
+            if (value.isObject()) {
+                // "." refers to key dependency
+                if (value.has(".")) {
+                    flatOverrides.put(key, value.get(".").textValue());
+                    // Use a shallow value object copy without the "." property
+                    ObjectNode filtered = JacksonUtils.createObjectNode();
+                    final Iterator<String> fieldNames = value.fieldNames();
+                    while (fieldNames.hasNext()) {
+                        final String nestedProp = fieldNames.next();
+                        if (nestedProp.equals(".")) {
+                            continue;
+                        }
+                        filtered.set(nestedProp, value.get(nestedProp));
+                    }
+                    value = filtered;
+                }
+                // Nested override: {"workbox-build": {"dep": "1.0"}}
+                final Map<String, String> childOverrides = flattenOverrides(
+                        (ObjectNode) value);
+                for (Map.Entry<String, String> childEntry : childOverrides
+                        .entrySet()) {
+                    flatOverrides.put(key + ">" + childEntry.getKey(),
+                            childEntry.getValue());
+                }
+            } else {
+                // Already flat, keep as-is
+                flatOverrides.put(key, value.textValue());
+            }
+        }
+        return flatOverrides;
     }
 
     @Override
@@ -374,9 +560,10 @@ public class TaskUpdatePackages extends NodeUpdater {
         }
 
         // Add application dev dependencies.
+        int addedDev = 0;
         for (Entry<String, String> devDep : applicationDevDependencies
                 .entrySet()) {
-            added += addDependency(packageJson, DEV_DEPENDENCIES,
+            addedDev += addDependency(packageJson, DEV_DEPENDENCIES,
                     devDep.getKey(), devDep.getValue());
         }
 
@@ -400,6 +587,10 @@ public class TaskUpdatePackages extends NodeUpdater {
 
         if (added > 0) {
             log().debug("Added {} dependencies to main package.json", added);
+        }
+
+        if (addedDev > 0) {
+            log().debug("Added {} devDependencies to main package.json", added);
         }
 
         // Remove obsolete dependencies
@@ -438,14 +629,7 @@ public class TaskUpdatePackages extends NodeUpdater {
             cleanUp();
         }
 
-        String oldHash = packageJson.get(VAADIN_DEP_KEY).get(HASH_KEY)
-                .textValue();
-        String newHash = generatePackageJsonHash(packageJson);
-        // update packageJson hash value, if no changes it will not be written
-        ((ObjectNode) packageJson.get(VAADIN_DEP_KEY)).put(HASH_KEY, newHash);
-
-        return added > 0 || removed > 0 || removedDev > 0
-                || !oldHash.equals(newHash);
+        return added > 0 || addedDev > 0 || removed > 0 || removedDev > 0;
     }
 
     private int cleanDependencies(List<String> dependencyCollection,
@@ -660,7 +844,8 @@ public class TaskUpdatePackages extends NodeUpdater {
      *            JsonNode built in the same format as package.json
      * @return has for dependencies and devDependencies
      */
-    static String generatePackageJsonHash(JsonNode packageJson) {
+    static String generatePackageJsonHash(JsonNode packageJson)
+            throws JsonProcessingException {
         StringBuilder hashContent = new StringBuilder();
         if (packageJson.has(DEPENDENCIES)) {
             JsonNode dependencies = packageJson.get(DEPENDENCIES);
@@ -686,6 +871,42 @@ public class TaskUpdatePackages extends NodeUpdater {
                     .collect(Collectors.joining(",\n  "));
             hashContent.append(sortedDevDependencies);
             hashContent.append("}");
+        }
+        // Include npm overrides in hash
+        if (packageJson.has(OVERRIDES)) {
+            JsonNode overrides = packageJson.get(OVERRIDES);
+            // Only include overrides in hash if section has actual content
+            if (overrides.isObject() && !overrides.isEmpty()
+                    && !hashContent.isEmpty()) {
+                hashContent.append(",\n");
+                hashContent.append("\"overrides\": ");
+                final ObjectNode sortedOverrides = JacksonUtils
+                        .createObjectNode();
+                JacksonUtils.getKeys(overrides).stream()
+                        .sorted(String::compareToIgnoreCase)
+                        .forEachOrdered(key -> {
+                            sortedOverrides.set(key, overrides.get(key));
+                        });
+                hashContent.append(JacksonUtils.toFileJson(sortedOverrides));
+            }
+        }
+        // Include pnpm overrides in hash
+        if (packageJson.has(PNPM) && packageJson.get(PNPM).has(OVERRIDES)) {
+            JsonNode overrides = packageJson.get(PNPM).get(OVERRIDES);
+            // Only include overrides in hash if section has actual content
+            if (overrides.isObject() && !overrides.isEmpty()
+                    && !hashContent.isEmpty()) {
+                hashContent.append(",\n");
+                hashContent.append("\"pnpm.overrides\": ");
+                final ObjectNode sortedOverrides = JacksonUtils
+                        .createObjectNode();
+                JacksonUtils.getKeys(overrides).stream()
+                        .sorted(String::compareToIgnoreCase)
+                        .forEachOrdered(key -> {
+                            sortedOverrides.set(key, overrides.get(key));
+                        });
+                hashContent.append(JacksonUtils.toFileJson(sortedOverrides));
+            }
         }
         return StringUtil.getHash(hashContent.toString());
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateVite.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateVite.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.flow.server.frontend;
 
 import java.io.File;
@@ -32,6 +31,8 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.vaadin.flow.server.PwaConfiguration;
 
 /**
  * Updates the Vite configuration files according with current project settings.
@@ -121,6 +122,11 @@ public class TaskUpdateVite implements FallibleCommand, Serializable {
                 .getResource(FrontendUtils.VITE_GENERATED_CONFIG);
         String template = IOUtils.toString(resource, StandardCharsets.UTF_8);
 
+        // First apply plugin insertions that use #buildFolder# placeholder
+        template = updateServiceWorkerVitePlugin(template);
+        template = updateFileSystemRouterVitePlugin(template);
+
+        // Then replace placeholders with actual values
         template = template
                 .replace("#settingsImport#",
                         "./" + options.getBuildDirectoryName() + "/"
@@ -133,7 +139,6 @@ public class TaskUpdateVite implements FallibleCommand, Serializable {
                                 : String.join(";", webComponentTags))
                 .replace("#frontendExtraFileExtensions#",
                         getFrontendExtraFileExtensions());
-        template = updateFileSystemRouterVitePlugin(template);
 
         FileIOUtils.writeIfChanged(generatedConfigFile, template);
         log().debug("Created vite generated configuration file: '{}'",
@@ -151,6 +156,19 @@ public class TaskUpdateVite implements FallibleCommand, Serializable {
                     .collect(Collectors.joining("', '", ", '", "'"));
         }
         return "";
+    }
+
+    private String updateServiceWorkerVitePlugin(String template) {
+        final PwaConfiguration pwaConfiguration = options
+                .getFrontendDependenciesScanner().getPwaConfiguration();
+        if (pwaConfiguration != null && pwaConfiguration.isOfflineEnabled()) {
+            return template.replace("//#serviceWorkerPluginImport#",
+                    "import serviceWorkerPlugin from '#buildFolder#/plugins/vite-plugin-service-worker';")
+                    .replace("//#serviceWorkerPlugin#",
+                            "serviceWorkerPlugin({ srcPath: settings.clientServiceWorkerSource }),");
+        }
+        return template.replace("//#serviceWorkerPluginImport#", "")
+                .replace("//#serviceWorkerPlugin#", "");
     }
 
     private String updateFileSystemRouterVitePlugin(String template) {

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/default/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/default/package.json
@@ -10,8 +10,6 @@
   "devDependencies": {
     "glob": "13.0.6",
     "typescript": "5.8.3",
-    "workbox-core": "7.3.0",
-    "workbox-precaching": "7.3.0",
     "strip-css-comments": "5.0.0"
   }
 }

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
@@ -18,7 +18,6 @@
     "rollup-plugin-visualizer": "5.14.0",
     "rollup-plugin-brotli": "3.1.0",
     "vite-plugin-checker": "0.10.3",
-    "workbox-build": "7.3.0",
     "transform-ast": "2.4.4",
     "magic-string": "0.30.21"
   }

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/workbox/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/workbox/package.json
@@ -1,0 +1,18 @@
+{
+  "private": true,
+  "description": "Workbox dependencies for PWA support",
+  "devDependencies": {
+    "workbox-build": "7.4.0",
+    "workbox-core": "7.4.0",
+    "workbox-precaching": "7.4.0",
+    "workbox-routing": "7.4.0",
+    "workbox-strategies": "7.4.0"
+  },
+  "overrides": {
+    "workbox-build": {
+      "serialize-javascript": "7.0.4",
+      "@rollup/plugin-terser": "1.0.0",
+      "glob": "13.0.6"
+    }
+  }
+}

--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -28,8 +28,7 @@ import brotli from 'rollup-plugin-brotli';
 import checker from 'vite-plugin-checker';
 import postcssLit from '#buildFolder#/plugins/rollup-plugin-postcss-lit-custom/rollup-plugin-postcss-lit.js';
 import vaadinI18n from '#buildFolder#/plugins/rollup-plugin-vaadin-i18n/rollup-plugin-vaadin-i18n.js';
-import serviceWorkerPlugin from '#buildFolder#/plugins/vite-plugin-service-worker';
-
+//#serviceWorkerPluginImport#
 import { createRequire } from 'module';
 
 import { visualizer } from 'rollup-plugin-visualizer';
@@ -670,9 +669,7 @@ export const vaadinConfig: UserConfigFn = (env) => {
       productionMode && brotli(),
       devMode && vaadinBundlesPlugin(),
       devMode && showRecompileReason(),
-      settings.offlineEnabled && serviceWorkerPlugin({
-        srcPath: settings.clientServiceWorkerSource,
-      }),
+      //#serviceWorkerPlugin#
       !devMode && statsExtracterPlugin(),
       !productionMode && preserveUsageStats(),
       themePlugin({ devMode }),

--- a/flow-server/src/test/java/com/vaadin/flow/internal/BeanUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/BeanUtilTest.java
@@ -94,7 +94,9 @@ public class BeanUtilTest {
                 .orElse(null);
 
         Assert.assertNotNull("Should find 'value' property", valueDescriptor);
-        Assert.assertNotNull("Should have read method from parent interface", valueDescriptor.getReadMethod());
-        Assert.assertNotNull("Should have write method from child interface", valueDescriptor.getWriteMethod());
+        Assert.assertNotNull("Should have read method from parent interface",
+                valueDescriptor.getReadMethod());
+        Assert.assertNotNull("Should have write method from child interface",
+                valueDescriptor.getWriteMethod());
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/JacksonUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/JacksonUtilsTest.java
@@ -486,4 +486,269 @@ public class JacksonUtilsTest {
 
     }
 
+    @Test
+    public void getNestedKey_singleLevelKey_returnsValue() {
+        ObjectNode node = mapper.createObjectNode();
+        node.put("key", "value");
+
+        JsonNode result = JacksonUtils.getNestedKey(node, List.of("key"));
+
+        Assert.assertEquals("value", result.asText());
+    }
+
+    @Test
+    public void getNestedKey_multiLevelKey_returnsValue() {
+        ObjectNode node = mapper.createObjectNode();
+        ObjectNode nested = mapper.createObjectNode();
+        nested.put("inner", "value");
+        node.set("outer", nested);
+
+        JsonNode result = JacksonUtils.getNestedKey(node,
+                List.of("outer", "inner"));
+
+        Assert.assertEquals("value", result.asText());
+    }
+
+    @Test
+    public void getNestedKey_deeplyNestedKey_returnsValue() {
+        ObjectNode node = mapper.createObjectNode();
+        ObjectNode level1 = mapper.createObjectNode();
+        ObjectNode level2 = mapper.createObjectNode();
+        ObjectNode level3 = mapper.createObjectNode();
+        level3.put("deep", "found");
+        level2.set("c", level3);
+        level1.set("b", level2);
+        node.set("a", level1);
+
+        JsonNode result = JacksonUtils.getNestedKey(node,
+                List.of("a", "b", "c", "deep"));
+
+        Assert.assertEquals("found", result.asText());
+    }
+
+    @Test
+    public void getNestedKey_nonExistentKey_returnsNull() {
+        ObjectNode node = mapper.createObjectNode();
+        node.put("key", "value");
+
+        JsonNode result = JacksonUtils.getNestedKey(node,
+                List.of("nonexistent"));
+
+        Assert.assertEquals(null, result);
+    }
+
+    @Test
+    public void getNestedKey_nonExistentNestedKey_returnsNull() {
+        ObjectNode node = mapper.createObjectNode();
+        ObjectNode nested = mapper.createObjectNode();
+        nested.put("inner", "value");
+        node.set("outer", nested);
+
+        JsonNode result = JacksonUtils.getNestedKey(node,
+                List.of("outer", "nonexistent"));
+
+        Assert.assertEquals(null, result);
+    }
+
+    @Test
+    public void getNestedKey_pathWithNonObjectNode_returnsNull() {
+        ObjectNode node = mapper.createObjectNode();
+        node.put("key", "stringValue");
+
+        JsonNode result = JacksonUtils.getNestedKey(node,
+                List.of("key", "inner"));
+
+        Assert.assertEquals(null, result);
+    }
+
+    @Test
+    public void getNestedKey_emptyPath_returnsNull() {
+        ObjectNode node = mapper.createObjectNode();
+
+        JsonNode result = JacksonUtils.getNestedKey(node, List.of());
+
+        Assert.assertEquals(null, result);
+    }
+
+    @Test
+    public void setNestedKey_singleLevelKey_setsValue() {
+        ObjectNode node = mapper.createObjectNode();
+
+        JacksonUtils.setNestedKey(node, List.of("key"),
+                mapper.valueToTree("value"),
+                unused -> mapper.createObjectNode());
+
+        Assert.assertEquals("value", node.get("key").asText());
+    }
+
+    @Test
+    public void setNestedKey_multiLevelKey_createsIntermediateObjects() {
+        ObjectNode node = mapper.createObjectNode();
+
+        JacksonUtils.setNestedKey(node, List.of("outer", "inner"),
+                mapper.valueToTree("value"),
+                unused -> mapper.createObjectNode());
+
+        Assert.assertTrue(node.get("outer").isObject());
+        Assert.assertEquals("value", node.get("outer").get("inner").asText());
+    }
+
+    @Test
+    public void setNestedKey_deeplyNestedKey_createsAllIntermediates() {
+        ObjectNode node = mapper.createObjectNode();
+
+        JacksonUtils.setNestedKey(node, List.of("a", "b", "c", "d"),
+                mapper.valueToTree("deep"),
+                unused -> mapper.createObjectNode());
+
+        JsonNode result = JacksonUtils.getNestedKey(node,
+                List.of("a", "b", "c", "d"));
+        Assert.assertEquals("deep", result.asText());
+    }
+
+    @Test
+    public void setNestedKey_existingNestedValue_replacesValue() {
+        ObjectNode node = mapper.createObjectNode();
+        ObjectNode nested = mapper.createObjectNode();
+        nested.put("inner", "oldValue");
+        node.set("outer", nested);
+
+        JacksonUtils.setNestedKey(node, List.of("outer", "inner"),
+                mapper.valueToTree("newValue"),
+                unused -> mapper.createObjectNode());
+
+        Assert.assertEquals("newValue",
+                node.get("outer").get("inner").asText());
+    }
+
+    @Test
+    public void setNestedKey_plainValueConverterCalled_whenIntermediateIsString() {
+        ObjectNode node = mapper.createObjectNode();
+        node.put("key", "plainValue");
+
+        JacksonUtils.setNestedKey(node, List.of("key", "nested"),
+                mapper.valueToTree("value"), plainValueNode -> {
+                    ObjectNode objectNode = mapper.createObjectNode();
+                    if (plainValueNode.isTextual()) {
+                        objectNode.set(".", plainValueNode);
+                    }
+                    return objectNode;
+                });
+
+        Assert.assertTrue(node.get("key").isObject());
+        Assert.assertEquals("plainValue", node.get("key").get(".").asText());
+        Assert.assertEquals("value", node.get("key").get("nested").asText());
+    }
+
+    @Test
+    public void setNestedKey_emptyPath_doesNothing() {
+        ObjectNode node = mapper.createObjectNode();
+        node.put("existing", "value");
+
+        JacksonUtils.setNestedKey(node, List.of(),
+                mapper.valueToTree("ignored"),
+                unused -> mapper.createObjectNode());
+
+        Assert.assertEquals("value", node.get("existing").asText());
+        Assert.assertFalse(node.has("ignored"));
+    }
+
+    @Test
+    public void removeNestedKey_singleLevelKey_removesKey() {
+        ObjectNode node = mapper.createObjectNode();
+        node.put("key1", "value1");
+        node.put("key2", "value2");
+
+        JacksonUtils.removeNestedKey(node, List.of("key1"));
+
+        Assert.assertFalse(node.has("key1"));
+        Assert.assertTrue(node.has("key2"));
+    }
+
+    @Test
+    public void removeNestedKey_multiLevelKey_removesKey() {
+        ObjectNode node = mapper.createObjectNode();
+        ObjectNode nested = mapper.createObjectNode();
+        nested.put("inner", "value");
+        nested.put("other", "keep");
+        node.set("outer", nested);
+
+        JacksonUtils.removeNestedKey(node, List.of("outer", "inner"));
+
+        Assert.assertFalse(node.get("outer").has("inner"));
+        Assert.assertTrue(node.get("outer").has("other"));
+    }
+
+    @Test
+    public void removeNestedKey_removesEmptyParentObjects() {
+        ObjectNode node = mapper.createObjectNode();
+        ObjectNode nested = mapper.createObjectNode();
+        nested.put("inner", "value");
+        node.set("outer", nested);
+
+        JacksonUtils.removeNestedKey(node, List.of("outer", "inner"));
+
+        Assert.assertFalse(
+                "Parent object should be removed when it becomes empty",
+                node.has("outer"));
+    }
+
+    @Test
+    public void removeNestedKey_deeplyNested_removesEmptyIntermediates() {
+        ObjectNode node = mapper.createObjectNode();
+        ObjectNode level1 = mapper.createObjectNode();
+        ObjectNode level2 = mapper.createObjectNode();
+        ObjectNode level3 = mapper.createObjectNode();
+        level3.put("deep", "value");
+        level2.set("c", level3);
+        level1.set("b", level2);
+        node.set("a", level1);
+
+        JacksonUtils.removeNestedKey(node, List.of("a", "b", "c", "deep"));
+
+        Assert.assertFalse("All empty parent objects should be removed",
+                node.has("a"));
+    }
+
+    @Test
+    public void removeNestedKey_deeplyNested_keepsNonEmptyIntermediates() {
+        ObjectNode node = mapper.createObjectNode();
+        ObjectNode level1 = mapper.createObjectNode();
+        ObjectNode level2 = mapper.createObjectNode();
+        ObjectNode level3 = mapper.createObjectNode();
+        level3.put("deep", "value");
+        level3.put("keep", "this");
+        level2.set("c", level3);
+        level1.set("b", level2);
+        node.set("a", level1);
+
+        JacksonUtils.removeNestedKey(node, List.of("a", "b", "c", "deep"));
+
+        Assert.assertTrue(node.has("a"));
+        Assert.assertTrue(node.get("a").get("b").get("c").has("keep"));
+        Assert.assertFalse(node.get("a").get("b").get("c").has("deep"));
+    }
+
+    @Test
+    public void removeNestedKey_nonExistentKey_doesNothing() {
+        ObjectNode node = mapper.createObjectNode();
+        node.put("key", "value");
+
+        JacksonUtils.removeNestedKey(node, List.of("nonexistent"));
+
+        Assert.assertTrue(node.has("key"));
+        Assert.assertEquals("value", node.get("key").asText());
+    }
+
+    @Test
+    public void removeNestedKey_emptyPath_doesNothing() {
+        ObjectNode node = mapper.createObjectNode();
+        node.put("key", "value");
+
+        JacksonUtils.removeNestedKey(node, List.of());
+
+        Assert.assertTrue(node.has("key"));
+        Assert.assertEquals("value", node.get("key").asText());
+    }
+
 }

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
@@ -845,8 +845,9 @@ public class NavigationStateRendererTest {
         ConditionalForwardView.shouldForward = true;
         ui.refreshCurrentRoute(true);
 
-        Assert.assertEquals("Layout should be recreated by both refresh and forward",
-                2, RouteParentLayout.creationCount.get());
+        Assert.assertEquals(
+                "Layout should be recreated by both refresh and forward", 2,
+                RouteParentLayout.creationCount.get());
     }
 
     @Test
@@ -882,8 +883,9 @@ public class NavigationStateRendererTest {
         ConditionalRerouteView.shouldReroute = true;
         ui.refreshCurrentRoute(true);
 
-        Assert.assertEquals("Layout should be recreated by both refresh and reroute",
-                2, RouteParentLayout.creationCount.get());
+        Assert.assertEquals(
+                "Layout should be recreated by both refresh and reroute", 2,
+                RouteParentLayout.creationCount.get());
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdateImportsTest.java
@@ -80,8 +80,9 @@ public abstract class AbstractNodeUpdateImportsTest extends NodeUpdateTestUtil {
         Options options = new MockOptions(classFinder, tmpRoot)
                 .withFrontendDirectory(frontendDirectory)
                 .withBuildDirectory(TARGET).withProductionMode(true)
-                .withBundleBuild(true);
-        updater = new TaskUpdateImports(getScanner(classFinder), options) {
+                .withBundleBuild(true)
+                .withFrontendDependenciesScanner(getScanner(classFinder));
+        updater = new TaskUpdateImports(options) {
             @Override
             Logger log() {
                 return logger;

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Before;
@@ -52,9 +53,9 @@ import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 import static com.vaadin.flow.server.Constants.TARGET;
 import static com.vaadin.flow.server.frontend.NodeUpdater.DEP_NAME_FLOW_DEPS;
 import static com.vaadin.flow.server.frontend.NodeUpdater.DEP_NAME_FLOW_JARS;
+import static com.vaadin.flow.server.frontend.NodeUpdater.OVERRIDES;
 import static com.vaadin.flow.server.frontend.NodeUpdater.VAADIN_DEP_KEY;
 import static com.vaadin.flow.server.frontend.TaskUpdatePackages.VAADIN_APP_PACKAGE_HASH;
-import static elemental.json.impl.JsonUtil.stringify;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public abstract class AbstractNodeUpdatePackagesTest
@@ -87,7 +88,8 @@ public abstract class AbstractNodeUpdatePackagesTest
         FrontendStubs.createStubNode(true, true, baseDir.getAbsolutePath());
         classFinder = Mockito.spy(getClassFinder());
         options = new MockOptions(classFinder, baseDir)
-                .withBuildDirectory(TARGET).withBundleBuild(true);
+                .withBuildDirectory(TARGET).withBundleBuild(true)
+                .withFrontendDependenciesScanner(getScanner(classFinder));
         packageCreator = new TaskGeneratePackageJson(options);
         versions = temporaryFolder.newFile();
         FileUtils.write(versions, "{}", StandardCharsets.UTF_8);
@@ -95,8 +97,7 @@ public abstract class AbstractNodeUpdatePackagesTest
                 classFinder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(versions.toURI().toURL());
 
-        packageUpdater = new TaskUpdatePackages(getScanner(classFinder),
-                options);
+        packageUpdater = new TaskUpdatePackages(options);
         packageJson = new File(baseDir, PACKAGE_JSON);
 
         mainNodeModules = new File(baseDir, FrontendUtils.NODE_MODULES);
@@ -136,8 +137,7 @@ public abstract class AbstractNodeUpdatePackagesTest
     public void pnpmIsInUse_packageJsonContainsFlowDeps_removeFlowDeps()
             throws IOException {
         // use package updater with disabled PNPM
-        packageUpdater = new TaskUpdatePackages(getScanner(classFinder),
-                options);
+        packageUpdater = new TaskUpdatePackages(options);
         // Generate package json in a proper format first
         packageCreator.execute();
         packageUpdater.execute();
@@ -151,8 +151,7 @@ public abstract class AbstractNodeUpdatePackagesTest
                 Collections.singletonList(json.toString()));
 
         options.withEnablePnpm(true);
-        packageUpdater = new TaskUpdatePackages(getScanner(classFinder),
-                options);
+        packageUpdater = new TaskUpdatePackages(options);
         packageUpdater.execute();
 
         assertPackageJsonFlowDeps();
@@ -162,8 +161,7 @@ public abstract class AbstractNodeUpdatePackagesTest
     public void pnpmIsInUse_packageJsonContainsFlowFrontend_removeFlowFrontend()
             throws IOException {
         // use package updater with disabled PNPM
-        packageUpdater = new TaskUpdatePackages(getScanner(classFinder),
-                options);
+        packageUpdater = new TaskUpdatePackages(options);
         // Generate package json in a proper format first
         packageCreator.execute();
         packageUpdater.execute();
@@ -177,8 +175,7 @@ public abstract class AbstractNodeUpdatePackagesTest
                 Collections.singletonList(json.toString()));
 
         options.withEnablePnpm(true);
-        packageUpdater = new TaskUpdatePackages(getScanner(classFinder),
-                options);
+        packageUpdater = new TaskUpdatePackages(options);
         packageUpdater.execute();
 
         assertPackageJsonFlowDeps();
@@ -188,8 +185,7 @@ public abstract class AbstractNodeUpdatePackagesTest
     public void pnpmIsInUse_packageLockExists_removePackageLock()
             throws IOException {
         // use package updater with disabled PNPM
-        packageUpdater = new TaskUpdatePackages(getScanner(classFinder),
-                options);
+        packageUpdater = new TaskUpdatePackages(options);
         // Generate package json in a proper format first
         packageCreator.execute();
         packageUpdater.execute();
@@ -198,8 +194,7 @@ public abstract class AbstractNodeUpdatePackagesTest
 
         options.withEnablePnpm(true);
 
-        packageUpdater = new TaskUpdatePackages(getScanner(classFinder),
-                options);
+        packageUpdater = new TaskUpdatePackages(options);
         packageUpdater.execute();
         Assert.assertFalse("npm package-lock should be removed for pnpm",
                 packageLock.exists());
@@ -338,9 +333,10 @@ public abstract class AbstractNodeUpdatePackagesTest
     public void versionsDoNotMatch_inVaadinJson_cleanUpPnpm()
             throws IOException {
         options.withEnablePnpm(true);
+        options = options.withFrontendDependenciesScanner(
+                Mockito.mock(FrontendDependencies.class));
 
-        packageUpdater = new TaskUpdatePackages(
-                Mockito.mock(FrontendDependencies.class), options);
+        packageUpdater = new TaskUpdatePackages(options);
 
         // Generate package json in a proper format first
         packageCreator.execute();
@@ -377,8 +373,9 @@ public abstract class AbstractNodeUpdatePackagesTest
         // packages.put(VAADIN_CORE, "1.1.1");
 
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
+        options = options.withFrontendDependenciesScanner(frontendDependencies);
 
-        packageUpdater = new TaskUpdatePackages(frontendDependencies, options);
+        packageUpdater = new TaskUpdatePackages(options);
 
         // Generate package json in a proper format first
         packageCreator.execute();
@@ -406,8 +403,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         ClassFinder classFinder = getClassFinder();
         // create a new package updater, with forced clean up enabled
         options.enableNpmFileCleaning(true);
-        packageUpdater = new TaskUpdatePackages(getScanner(classFinder),
-                options);
+        packageUpdater = new TaskUpdatePackages(options);
         packageUpdater.execute();
 
         // clean up happened
@@ -427,8 +423,9 @@ public abstract class AbstractNodeUpdatePackagesTest
         packages.put("@vaadin/vaadin-time-picker", "2.0.2");
 
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
+        options = options.withFrontendDependenciesScanner(frontendDependencies);
 
-        packageUpdater = new TaskUpdatePackages(frontendDependencies, options);
+        packageUpdater = new TaskUpdatePackages(options);
 
         packageCreator.execute();
         packageUpdater.execute();
@@ -456,8 +453,9 @@ public abstract class AbstractNodeUpdatePackagesTest
         packages.put("@vaadin/vaadin-time-picker", "2.0.2");
 
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
+        options = options.withFrontendDependenciesScanner(frontendDependencies);
 
-        packageUpdater = new TaskUpdatePackages(frontendDependencies, options);
+        packageUpdater = new TaskUpdatePackages(options);
 
         packageCreator.execute();
         packageUpdater.execute();
@@ -500,8 +498,9 @@ public abstract class AbstractNodeUpdatePackagesTest
         packages.put("@vaadin/vaadin-time-picker", "2.0.2");
 
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
+        options = options.withFrontendDependenciesScanner(frontendDependencies);
 
-        packageUpdater = new TaskUpdatePackages(frontendDependencies, options);
+        packageUpdater = new TaskUpdatePackages(options);
 
         packageCreator.execute();
         packageUpdater.execute();
@@ -530,8 +529,9 @@ public abstract class AbstractNodeUpdatePackagesTest
         packages.put("@vaadin/vaadin-time-picker", "2.0.2");
 
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
+        options = options.withFrontendDependenciesScanner(frontendDependencies);
 
-        packageUpdater = new TaskUpdatePackages(frontendDependencies, options);
+        packageUpdater = new TaskUpdatePackages(options);
 
         packageCreator.execute();
         packageUpdater.execute();
@@ -552,8 +552,9 @@ public abstract class AbstractNodeUpdatePackagesTest
 
         Map<String, String> packages = new HashMap<>();
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
+        options = options.withFrontendDependenciesScanner(frontendDependencies);
 
-        packageUpdater = new TaskUpdatePackages(frontendDependencies, options);
+        packageUpdater = new TaskUpdatePackages(options);
 
         packageCreator.execute();
         packageUpdater.execute();
@@ -577,8 +578,9 @@ public abstract class AbstractNodeUpdatePackagesTest
 
         Map<String, String> packages = new HashMap<>();
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
+        options = options.withFrontendDependenciesScanner(frontendDependencies);
 
-        packageUpdater = new TaskUpdatePackages(frontendDependencies, options);
+        packageUpdater = new TaskUpdatePackages(options);
 
         packageCreator.execute();
         packageUpdater.execute();
@@ -604,8 +606,9 @@ public abstract class AbstractNodeUpdatePackagesTest
         packages.put("@vaadin/vaadin-time-picker", "2.0.2");
 
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
+        options = options.withFrontendDependenciesScanner(frontendDependencies);
 
-        packageUpdater = new TaskUpdatePackages(frontendDependencies, options);
+        packageUpdater = new TaskUpdatePackages(options);
 
         packageCreator.execute();
         JsonNode json = getPackageJson(packageJson);
@@ -630,8 +633,7 @@ public abstract class AbstractNodeUpdatePackagesTest
                 Collections.singletonList(legacyPackageContent));
         options.withEnablePnpm(true);
 
-        packageUpdater = new TaskUpdatePackages(getScanner(classFinder),
-                options);
+        packageUpdater = new TaskUpdatePackages(options);
         packageUpdater.execute();
 
         assertPackageJsonFlowDeps();
@@ -644,8 +646,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         Files.write(packageJson.toPath(),
                 Collections.singletonList(legacyPackageContent));
 
-        packageUpdater = new TaskUpdatePackages(getScanner(classFinder),
-                options);
+        packageUpdater = new TaskUpdatePackages(options);
         packageUpdater.execute();
 
         assertPackageJsonFlowDeps();
@@ -665,8 +666,9 @@ public abstract class AbstractNodeUpdatePackagesTest
         packages.put("@vaadin/vaadin-time-picker", "2.0.2");
 
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
+        options = options.withFrontendDependenciesScanner(frontendDependencies);
 
-        packageUpdater = new TaskUpdatePackages(frontendDependencies, options);
+        packageUpdater = new TaskUpdatePackages(options);
 
         packageCreator.execute();
         packageUpdater.execute();
@@ -709,8 +711,9 @@ public abstract class AbstractNodeUpdatePackagesTest
         packages.put("@vaadin/vaadin-time-picker", "2.0.2");
 
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
+        options = options.withFrontendDependenciesScanner(frontendDependencies);
 
-        packageUpdater = new TaskUpdatePackages(frontendDependencies, options);
+        packageUpdater = new TaskUpdatePackages(options);
 
         packageCreator.execute();
         packageUpdater.execute();
@@ -848,6 +851,350 @@ public abstract class AbstractNodeUpdatePackagesTest
     void writePackageJson(File packageJsonFile, JsonNode packageJson)
             throws IOException {
         FileIOUtils.writeIfChanged(packageJsonFile, packageJson.toString());
+    }
+
+    @Test
+    public void generatePackageJson_userOverridesChanged_updaterIsNotModified()
+            throws IOException {
+        FrontendDependencies frontendDependencies = Mockito
+                .mock(FrontendDependencies.class);
+
+        Map<String, String> packages = new HashMap<>();
+        packages.put("@polymer/iron-list", "3.0.2");
+        Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
+        options = options.withFrontendDependenciesScanner(frontendDependencies);
+
+        packageUpdater = new TaskUpdatePackages(options);
+
+        // Generate initial state
+        packageCreator.execute();
+        packageUpdater.execute();
+
+        // Run again to establish baseline (not modified)
+        packageUpdater.execute();
+        Assert.assertFalse(
+                "Modification flag should be false after second run.",
+                packageUpdater.modified);
+
+        // User adds an override to package.json
+        ObjectNode json = (ObjectNode) getPackageJson(packageJson);
+        ObjectNode overrides = JacksonUtils.createObjectNode();
+        overrides.put("some-dep", "$some-dep");
+        json.set(OVERRIDES, overrides);
+        writePackageJson(packageJson, json);
+
+        // Run again - should detect change due to overrides
+        packageUpdater.execute();
+
+        Assert.assertTrue(
+                "Modification flag should be true when user overrides are added.",
+                packageUpdater.modified);
+        // Verify the user's override is not removed
+        json = (ObjectNode) getPackageJson(packageJson);
+        overrides = (ObjectNode) json.get("overrides");
+        Assert.assertNotNull(overrides);
+        Assert.assertEquals("$some-dep", overrides.get("some-dep").asText());
+    }
+
+    @Test
+    public void generatePackageJson_vaadinOverridesChanged_updaterIsModified()
+            throws IOException {
+        FrontendDependencies frontendDependencies = Mockito
+                .mock(FrontendDependencies.class);
+
+        Map<String, String> packages = new HashMap<>();
+        packages.put("@polymer/iron-list", "3.0.2");
+        Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
+        options = options.withFrontendDependenciesScanner(frontendDependencies);
+
+        packageUpdater = new TaskUpdatePackages(options);
+
+        // Generate initial state
+        packageCreator.execute();
+        packageUpdater.execute();
+
+        // User adds an override to package.json
+        ObjectNode json = (ObjectNode) getPackageJson(packageJson);
+        ObjectNode overrides = JacksonUtils.createObjectNode();
+        overrides.put("some-dep", "$some-dep");
+        ObjectNode nestedOverride = JacksonUtils.createObjectNode();
+        nestedOverride.put("nested-dep", "1.0.0");
+        overrides.set("parent-package", nestedOverride);
+        json.set(OVERRIDES, overrides);
+        writePackageJson(packageJson, json);
+
+        // Run again to establish baseline (not modified)
+        packageUpdater.execute();
+
+        // Simulate Vaadin overrides change
+        packageUpdater = new TaskUpdatePackages(options) {
+            @Override
+            ObjectNode getDefaultOverrides() {
+                final ObjectNode defaultOverrides = super.getDefaultOverrides();
+                defaultOverrides.put("@vaadin/flat-override", "2.0.0");
+                defaultOverrides.set("@vaadin/nested-override",
+                        JacksonUtils.createObjectNode().put(".", "3.0.0")
+                                .put("dep", "4.0.0"));
+                return defaultOverrides;
+            }
+        };
+        // Run again - should detect change due to overrides
+        packageUpdater.execute();
+
+        Assert.assertTrue(
+                "Modification flag should be true when Vaadin overrides are added.",
+                packageUpdater.modified);
+
+        // Run again - should detect no change
+        packageUpdater.execute();
+
+        Assert.assertFalse(
+                "Modification flag should be false when overrides are unchanged.",
+                packageUpdater.modified);
+
+        // Verify the user's override is not removed
+        json = (ObjectNode) getPackageJson(packageJson);
+        overrides = (ObjectNode) json.get("overrides");
+        Assert.assertNotNull(overrides);
+        Assert.assertEquals("Flat user override should be preserved",
+                "$some-dep", overrides.get("some-dep").asText());
+        Assert.assertTrue("Nested user override should remain an object",
+                overrides.get("parent-package").isObject());
+        Assert.assertEquals("Nested user override value should be preserved",
+                "1.0.0",
+                overrides.get("parent-package").get("nested-dep").asText());
+
+        // Verify Vaadin overrides are present
+        Assert.assertEquals(TextNode.valueOf("2.0.0"),
+                overrides.get("@vaadin/flat-override"));
+        Assert.assertEquals(TextNode.valueOf("3.0.0"),
+                JacksonUtils.getNestedKey(overrides,
+                        List.of("@vaadin/nested-override", ".")));
+        Assert.assertEquals(TextNode.valueOf("4.0.0"),
+                JacksonUtils.getNestedKey(overrides,
+                        List.of("@vaadin/nested-override", "dep")));
+        // Verify Vaadin overrides are present
+        Assert.assertEquals(TextNode.valueOf("2.0.0"),
+                JacksonUtils.getNestedKey(json, List.of("vaadin", "overrides",
+                        "@vaadin/flat-override")));
+        Assert.assertEquals(TextNode.valueOf("3.0.0"),
+                JacksonUtils.getNestedKey(json, List.of("vaadin", "overrides",
+                        "@vaadin/nested-override", ".")));
+        Assert.assertEquals(TextNode.valueOf("4.0.0"),
+                JacksonUtils.getNestedKey(json, List.of("vaadin", "overrides",
+                        "@vaadin/nested-override", "dep")));
+    }
+
+    @Test
+    public void generatePackageJson_sameOverrides_updaterIsNotModified()
+            throws IOException {
+        FrontendDependencies frontendDependencies = Mockito
+                .mock(FrontendDependencies.class);
+
+        Map<String, String> packages = new HashMap<>();
+        packages.put("@polymer/iron-list", "3.0.2");
+        Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
+        options = options.withFrontendDependenciesScanner(frontendDependencies);
+
+        packageUpdater = new TaskUpdatePackages(options) {
+            @Override
+            ObjectNode getDefaultOverrides() {
+                final ObjectNode defaultOverrides = super.getDefaultOverrides();
+                defaultOverrides.put("@vaadin/flat-override", "2.0.0");
+                defaultOverrides.set("@vaadin/nested-override",
+                        JacksonUtils.createObjectNode().put(".", "3.0.0")
+                                .put("dep", "4.0.0"));
+                return defaultOverrides;
+            }
+        };
+
+        // Generate initial state
+        packageCreator.execute();
+        packageUpdater.execute();
+
+        // Add multiple types of overrides: flat, nested, and mixed
+        ObjectNode json = (ObjectNode) getPackageJson(packageJson);
+        ObjectNode overrides = JacksonUtils.createObjectNode();
+        overrides.put("some-dep", "$some-dep");
+        ObjectNode nestedOverride = JacksonUtils.createObjectNode();
+        nestedOverride.put("nested-dep", "1.0.0");
+        overrides.set("parent-package", nestedOverride);
+        json.set(OVERRIDES, overrides);
+        writePackageJson(packageJson, json);
+
+        // Run to register the override
+        packageUpdater.execute();
+
+        // Capture vaadin.overrides state after first run
+        json = (ObjectNode) getPackageJson(packageJson);
+        JsonNode vaadinOverridesAfterFirstRun = json.get(VAADIN_DEP_KEY)
+                .get(OVERRIDES);
+        Assert.assertNotNull("Vaadin overrides should be preserved.",
+                vaadinOverridesAfterFirstRun);
+
+        // Run again with same overrides - should not be modified
+        packageUpdater.execute();
+
+        Assert.assertFalse(
+                "Modification flag should be false when overrides are unchanged.",
+                packageUpdater.modified);
+
+        // Verify user overrides are preserved
+        json = (ObjectNode) getPackageJson(packageJson);
+        overrides = (ObjectNode) json.get(OVERRIDES);
+        Assert.assertNotNull(overrides);
+        Assert.assertEquals("Flat user override should be preserved",
+                "$some-dep", overrides.get("some-dep").asText());
+        Assert.assertTrue("Nested user override should remain an object",
+                overrides.get("parent-package").isObject());
+        Assert.assertEquals("Nested user override value should be preserved",
+                "1.0.0",
+                overrides.get("parent-package").get("nested-dep").asText());
+
+        // Run a third time to ensure stability
+        packageUpdater.execute();
+        Assert.assertFalse(
+                "Modification flag should remain false on third run.",
+                packageUpdater.modified);
+
+        // Verify vaadin.overrides consistency across runs
+        json = (ObjectNode) getPackageJson(packageJson);
+        JsonNode vaadinOverridesAfterThirdRun = json.get(VAADIN_DEP_KEY) != null
+                ? json.get(VAADIN_DEP_KEY).get(OVERRIDES)
+                : null;
+        Assert.assertTrue(
+                "vaadin.overrides should remain consistent across runs",
+                JacksonUtils.jsonEquals(vaadinOverridesAfterFirstRun,
+                        vaadinOverridesAfterThirdRun));
+
+        // Run a fourth time to ensure long-term stability
+        packageUpdater.execute();
+        Assert.assertFalse(
+                "Modification flag should remain false on fourth run.",
+                packageUpdater.modified);
+    }
+
+    @Test
+    public void generatePackageJson_userModifiesVaadinOverride_optOut()
+            throws IOException {
+        FrontendDependencies frontendDependencies = Mockito
+                .mock(FrontendDependencies.class);
+
+        Map<String, String> packages = new HashMap<>();
+        packages.put("@polymer/iron-list", "3.0.2");
+        Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
+        options = options.withFrontendDependenciesScanner(frontendDependencies);
+
+        packageUpdater = new TaskUpdatePackages(options) {
+            @Override
+            ObjectNode getDefaultOverrides() {
+                final ObjectNode defaultOverrides = super.getDefaultOverrides();
+                defaultOverrides.put("@vaadin/flat-override", "2.0.0");
+                defaultOverrides.set("@vaadin/nested-override",
+                        JacksonUtils.createObjectNode().put(".", "3.0.0")
+                                .put("dep", "4.0.0"));
+                return defaultOverrides;
+            }
+        };
+
+        packageCreator.execute();
+        packageUpdater.execute();
+
+        // Get initial state - Vaadin adds platform overrides
+        ObjectNode json = (ObjectNode) getPackageJson(packageJson);
+        ObjectNode overrides = (ObjectNode) json.get(OVERRIDES);
+
+        // Verify Vaadin added an override for a platform dependency
+        Assert.assertNotNull(
+                "Expected an override for Vaadin managed dependency",
+                overrides.get("@polymer/iron-list"));
+
+        // User modifies the Vaadin-managed overrides
+        overrides.put("@polymer/iron-list", "99.99.1");
+        overrides.put("@vaadin/flat-override", "99.99.2");
+        JacksonUtils.setNestedKey(overrides,
+                List.of("@vaadin/nested-override", "dep"),
+                TextNode.valueOf("99.99.3"),
+                (plainValue) -> JacksonUtils.createObjectNode());
+        writePackageJson(packageJson, json);
+
+        // Run updater again
+        packageUpdater.execute();
+
+        // Verify the user's modification is preserved (opt-out behavior)
+        json = (ObjectNode) getPackageJson(packageJson);
+        overrides = (ObjectNode) json.get(OVERRIDES);
+        Assert.assertEquals(
+                "User's modified override should be preserved (opted out)",
+                "99.99.1", overrides.get("@polymer/iron-list").asText());
+        Assert.assertEquals(
+                "User's modified override should be preserved (opted out)",
+                "99.99.2", overrides.get("@vaadin/flat-override").asText());
+        Assert.assertEquals(
+                "User's modified override should be preserved (opted out)",
+                TextNode.valueOf("99.99.3"), JacksonUtils.getNestedKey(
+                        overrides, List.of("@vaadin/nested-override", "dep")));
+    }
+
+    @Test
+    public void generatePackageJson_mixedOptOutAndUpdates_handledCorrectly()
+            throws IOException {
+        FrontendDependencies frontendDependencies = Mockito
+                .mock(FrontendDependencies.class);
+
+        Map<String, String> packages = new HashMap<>();
+        packages.put("@polymer/iron-list", "3.0.2");
+        packages.put("@polymer/paper-button", "3.0.2");
+        Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
+        options = options.withFrontendDependenciesScanner(frontendDependencies);
+
+        packageUpdater = new TaskUpdatePackages(options);
+
+        packageCreator.execute();
+        packageUpdater.execute();
+
+        // Set up initial state with multiple user overrides
+        ObjectNode json = (ObjectNode) getPackageJson(packageJson);
+        if (!json.has(OVERRIDES)) {
+            json.set(OVERRIDES, JacksonUtils.createObjectNode());
+        }
+        ObjectNode overrides = (ObjectNode) json.get(OVERRIDES);
+        overrides.put("dep-1", "1.0.0");
+        overrides.put("dep-2", "2.0.0");
+        overrides.put("user-dep", "3.0.0");
+        writePackageJson(packageJson, json);
+
+        // Register the overrides
+        packageUpdater.execute();
+
+        // User modifies one Vaadin override but leaves another alone
+        json = (ObjectNode) getPackageJson(packageJson);
+        overrides = (ObjectNode) json.get(OVERRIDES);
+        overrides.put("@polymer/iron-list", "99.0.0");
+        writePackageJson(packageJson, json);
+
+        // Run updater
+        packageUpdater.execute();
+
+        // Verify outcomes:
+        json = (ObjectNode) getPackageJson(packageJson);
+        overrides = (ObjectNode) json.get(OVERRIDES);
+
+        Assert.assertEquals(
+                "User-modified override should be preserved (opted out)",
+                "99.0.0", overrides.get("@polymer/iron-list").asText());
+
+        Assert.assertEquals("User's own override should always be preserved",
+                "3.0.0", overrides.get("user-dep").asText());
+
+        // Verify stability on subsequent runs
+        packageUpdater.execute();
+        json = (ObjectNode) getPackageJson(packageJson);
+        overrides = (ObjectNode) json.get(OVERRIDES);
+        Assert.assertEquals("Opted-out override should remain stable", "99.0.0",
+                overrides.get("@polymer/iron-list").asText());
+        Assert.assertEquals("User override should remain stable", "3.0.0",
+                overrides.get("user-dep").asText());
     }
 
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
@@ -12,9 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- *
  */
-
 package com.vaadin.flow.server.frontend;
 
 import java.io.File;
@@ -126,8 +124,8 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
         private Map<File, List<String>> output;
         private List<String> webComponentImports;
 
-        UpdateImports(FrontendDependenciesScanner scanner, Options options) {
-            super(options, scanner);
+        UpdateImports(Options options) {
+            super(options);
         }
 
         @Override
@@ -180,8 +178,9 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
         featureFlags = Mockito.mock(FeatureFlags.class);
         options = new MockOptions(classFinder, tmpRoot).withTokenFile(tokenFile)
                 .withProductionMode(true).withFeatureFlags(featureFlags)
-                .withBundleBuild(true);
-        updater = new UpdateImports(getScanner(classFinder), options);
+                .withBundleBuild(true)
+                .withFrontendDependenciesScanner(getScanner(classFinder));
+        updater = new UpdateImports(options);
         assertTrue(nodeModulesPath.mkdirs());
         createExpectedImports(frontendDirectory, nodeModulesPath);
         assertTrue(
@@ -245,7 +244,8 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
             throws Exception {
         ClassFinder classFinder = getClassFinder();
         options.withTokenFile(null);
-        updater = new UpdateImports(getScanner(classFinder), options);
+        updater = new UpdateImports(options
+                .withFrontendDependenciesScanner(getScanner(classFinder)));
 
         Files.move(frontendDirectory.toPath(),
                 new File(tmpRoot, "_frontend").toPath());
@@ -446,7 +446,8 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
         Class<?>[] testClasses = { FooCssImport.class, FooCssImport2.class,
                 UI.class, AllEagerAppConf.class };
         ClassFinder classFinder = getClassFinder(testClasses);
-        updater = new UpdateImports(getScanner(classFinder), options);
+        updater = new UpdateImports(options
+                .withFrontendDependenciesScanner(getScanner(classFinder)));
         updater.run();
 
         Pattern injectGlobalCssPattern = Pattern
@@ -491,7 +492,8 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
         Class<?>[] testClasses = { FooCssImport.class, FooCssImport2.class,
                 UI.class, AllEagerAppConf.class };
         ClassFinder classFinder = getClassFinder(testClasses);
-        updater = new UpdateImports(getScanner(classFinder), options);
+        updater = new UpdateImports(options
+                .withFrontendDependenciesScanner(getScanner(classFinder)));
         updater.run();
 
         Map<File, List<String>> output = updater.getOutput();
@@ -513,7 +515,8 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
         Class<?>[] testClasses = { FooCssImport.class, BarCssImport.class,
                 UI.class, AllEagerAppConf.class };
         ClassFinder classFinder = getClassFinder(testClasses);
-        updater = new UpdateImports(getScanner(classFinder), options);
+        updater = new UpdateImports(options
+                .withFrontendDependenciesScanner(getScanner(classFinder)));
         updater.run();
 
         Map<File, List<String>> output = updater.getOutput();
@@ -539,7 +542,8 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
     public void themeForCssImports_eagerLoaded() throws Exception {
         Class<?>[] testClasses = { ThemeForCssImport.class, UI.class };
         ClassFinder classFinder = getClassFinder(testClasses);
-        updater = new UpdateImports(getScanner(classFinder), options);
+        updater = new UpdateImports(options
+                .withFrontendDependenciesScanner(getScanner(classFinder)));
         updater.run();
 
         Map<File, List<String>> output = updater.getOutput();
@@ -656,7 +660,8 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
                 DevelopmentAndProductionDependencies.class);
 
         options.withProductionMode(productionMode);
-        updater = new UpdateImports(getScanner(classFinder), options);
+        updater = new UpdateImports(options
+                .withFrontendDependenciesScanner(getScanner(classFinder)));
         updater.run();
 
     }
@@ -697,7 +702,8 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
                 LumoTest.class };
         ClassFinder classFinder = getClassFinder(testClasses);
 
-        updater = new UpdateImports(getScanner(classFinder), options);
+        updater = new UpdateImports(options
+                .withFrontendDependenciesScanner(getScanner(classFinder)));
         updater.run();
         String output = String.join("\n", updater.getMergedOutput());
 
@@ -721,7 +727,8 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
         ClassFinder classFinder = getClassFinder(testClasses);
 
         options.withTokenFile(new File(tmpRoot, TOKEN_FILE));
-        updater = new UpdateImports(getScanner(classFinder), options);
+        updater = new UpdateImports(options
+                .withFrontendDependenciesScanner(getScanner(classFinder)));
         updater.run();
 
         // Imports are collected as

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/BundleValidationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/BundleValidationTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.flow.server.frontend;
 
 import java.io.File;
@@ -100,12 +115,16 @@ public class BundleValidationTest {
 
     private String bundleLocation;
 
+    private FrontendDependenciesScanner depScanner;
+
     @Before
     public void init() {
         finder = Mockito.spy(new ClassFinder.DefaultClassFinder(
                 this.getClass().getClassLoader()));
+        depScanner = Mockito.mock(FrontendDependenciesScanner.class);
         options = new MockOptions(finder, temporaryFolder.getRoot())
-                .withBuildDirectory("target");
+                .withBuildDirectory("target")
+                .withFrontendDependenciesScanner(depScanner);
         options.copyResources(Collections.emptySet());
         options.withProductionMode(mode.isProduction());
         bundleLocation = mode.isProduction() ? Constants.PROD_BUNDLE_NAME
@@ -152,8 +171,7 @@ public class BundleValidationTest {
         stats.set(THEME_JSON_CONTENTS, themeJsonContents);
         stats.put(PACKAGE_JSON_HASH, "aHash");
 
-        NodeUpdater nodeUpdater = new NodeUpdater(
-                Mockito.mock(FrontendDependenciesScanner.class), options) {
+        NodeUpdater nodeUpdater = new NodeUpdater(options) {
             @Override
             public void execute() {
                 // NO-OP
@@ -177,7 +195,7 @@ public class BundleValidationTest {
     @Test
     public void noDevBundle_bundleCompilationRequires() {
         final boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                Mockito.mock(FrontendDependenciesScanner.class), mode);
+                options.getFrontendDependenciesScanner(), mode);
         Assert.assertTrue("Bundle should require creation if not available",
                 needsBuild);
     }
@@ -192,7 +210,7 @@ public class BundleValidationTest {
                 .thenReturn(null);
 
         final boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                Mockito.mock(FrontendDependenciesScanner.class), mode);
+                options.getFrontendDependenciesScanner(), mode);
         Assert.assertTrue("Missing stats.json should require bundling",
                 needsBuild);
     }
@@ -208,8 +226,6 @@ public class BundleValidationTest {
                 + "\"@vaadin/router\": \"1.7.5\"}, \"vaadin\": { \"hash\": \"aHash\"} }",
                 StandardCharsets.UTF_8);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         Mockito.when(depScanner.getPackages())
                 .thenReturn(Collections.emptyMap());
 
@@ -237,8 +253,6 @@ public class BundleValidationTest {
                 + "\"@vaadin/router\": \"1.7.5\"}, \"vaadin\": { \"hash\": \"aHash\"} }",
                 StandardCharsets.UTF_8);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         Mockito.when(depScanner.getPackages())
                 .thenReturn(Collections.emptyMap());
 
@@ -270,8 +284,6 @@ public class BundleValidationTest {
                 + "\"@vaadin/router\": \"1.7.5\"}, \"vaadin\": { \"hash\": \"aHash\"} }",
                 StandardCharsets.UTF_8);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         Map<String, String> packages = new HashMap<>();
         packages.put("@vaadin/router", "1.7.5");
         packages.put("@vaadin/text", "1.0.0");
@@ -308,8 +320,6 @@ public class BundleValidationTest {
                 }
                 """, StandardCharsets.UTF_8);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         Mockito.when(depScanner.getPackages())
                 .thenReturn(Collections.emptyMap());
 
@@ -336,8 +346,6 @@ public class BundleValidationTest {
                 + "\"@vaadin/router\": \"1.7.5\"}, \"vaadin\": { \"hash\": \"aHash\"} }",
                 StandardCharsets.UTF_8);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         Mockito.when(depScanner.getPackages())
                 .thenReturn(Collections.singletonMap("@vaadin/text", "1.0.0"));
 
@@ -373,9 +381,6 @@ public class BundleValidationTest {
                   }
                 }
                 """, StandardCharsets.UTF_8);
-
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
 
         File versions = new File(temporaryFolder.getRoot(),
                 Constants.VAADIN_CORE_VERSIONS_JSON);
@@ -428,8 +433,6 @@ public class BundleValidationTest {
                 }
                 """, StandardCharsets.UTF_8);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         Map<String, String> packages = new HashMap<>();
         packages.put("@vaadin/router", "1.9.2");
         packages.put("@vaadin/text", "2.1.0");
@@ -468,8 +471,6 @@ public class BundleValidationTest {
                 }
                 """, StandardCharsets.UTF_8);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         Mockito.when(depScanner.getPackages())
                 .thenReturn(Collections.singletonMap("@vaadin/text", "1.0.0"));
 
@@ -510,8 +511,6 @@ public class BundleValidationTest {
                 }
                 """, StandardCharsets.UTF_8);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         Mockito.when(depScanner.getPackages())
                 .thenReturn(Collections.singletonMap("@vaadin/text", "1.0.0"));
 
@@ -546,8 +545,6 @@ public class BundleValidationTest {
                 }
                 """, StandardCharsets.UTF_8);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         Mockito.when(depScanner.getPackages())
                 .thenReturn(Collections.emptyMap());
 
@@ -582,8 +579,6 @@ public class BundleValidationTest {
                 }
                 """, StandardCharsets.UTF_8);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         Mockito.when(depScanner.getPackages())
                 .thenReturn(Collections.emptyMap());
 
@@ -626,8 +621,6 @@ public class BundleValidationTest {
                 }
                 """, StandardCharsets.UTF_8);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         Mockito.when(depScanner.getPackages())
                 .thenReturn(Collections.emptyMap());
 
@@ -676,8 +669,6 @@ public class BundleValidationTest {
                 }
                 """, StandardCharsets.UTF_8);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         Mockito.when(depScanner.getPackages())
                 .thenReturn(Collections.emptyMap());
 
@@ -696,8 +687,6 @@ public class BundleValidationTest {
 
     @Test
     public void noPackageJson_defaultPackagesAndModulesInStats_noBuildNeeded() {
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         Mockito.when(depScanner.getPackages())
                 .thenReturn(Collections.singletonMap("@vaadin/text", "1.0.0"));
 
@@ -723,8 +712,6 @@ public class BundleValidationTest {
 
     @Test
     public void noPackageJson_defaultPackagesInStats_missingNpmModules_buildNeeded() {
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         Mockito.when(depScanner.getPackages())
                 .thenReturn(Collections.singletonMap("@vaadin/text", "1.0.0"));
 
@@ -749,8 +736,6 @@ public class BundleValidationTest {
 
     @Test
     public void noPackageJson_defaultPackagesInStats_noBuildNeeded() {
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         Mockito.when(depScanner.getPackages())
                 .thenReturn(Collections.emptyMap());
 
@@ -790,8 +775,6 @@ public class BundleValidationTest {
                 }
                 """, StandardCharsets.UTF_8);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         Mockito.when(depScanner.getPackages())
                 .thenReturn(Collections.emptyMap());
         Mockito.when(depScanner.getModules())
@@ -834,8 +817,6 @@ public class BundleValidationTest {
                 }
                 """, StandardCharsets.UTF_8);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         Mockito.when(depScanner.getPackages())
                 .thenReturn(Collections.emptyMap());
         Mockito.when(depScanner.getModules())
@@ -879,8 +860,6 @@ public class BundleValidationTest {
                 }
                 """, StandardCharsets.UTF_8);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         Mockito.when(depScanner.getPackages())
                 .thenReturn(Collections.emptyMap());
         Mockito.when(depScanner.getModules()).thenReturn(
@@ -926,8 +905,6 @@ public class BundleValidationTest {
                 }
                 """, StandardCharsets.UTF_8);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         Mockito.when(depScanner.getModules()).thenReturn(Collections
                 .singletonMap(ChunkInfo.GLOBAL, Collections.singletonList(
                         "Frontend/generated/jar-resources/TodoTemplate.js")));
@@ -970,8 +947,6 @@ public class BundleValidationTest {
                 }
                 """, StandardCharsets.UTF_8);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         Mockito.when(depScanner.getModules()).thenReturn(Collections
                 .singletonMap(ChunkInfo.GLOBAL, Collections.singletonList(
                         "Frontend/generated/jar-resources/TodoTemplate.js")));
@@ -1019,8 +994,6 @@ public class BundleValidationTest {
                 }
                 """, StandardCharsets.UTF_8);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         Mockito.when(depScanner.getModules()).thenReturn(Collections
                 .singletonMap(ChunkInfo.GLOBAL, Collections.singletonList(
                         "Frontend/generated/jar-resources/TodoTemplate.js")));
@@ -1066,8 +1039,6 @@ public class BundleValidationTest {
         FileUtils.write(stylesheetFile, "body{color:yellow}",
                 StandardCharsets.UTF_8);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         Mockito.when(depScanner.getModules()).thenReturn(
                 Collections.singletonMap(ChunkInfo.GLOBAL, Collections
                         .singletonList("Frontend/my-styles.css?inline")));
@@ -1093,8 +1064,6 @@ public class BundleValidationTest {
         createPackageJsonStub(BLANK_PACKAGE_JSON_WITH_HASH);
         createProjectFrontendFileStub();
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         Mockito.when(depScanner.getModules()).thenReturn(
                 Collections.singletonMap(ChunkInfo.GLOBAL, Collections
                         .singletonList("Frontend/views/lit-view.ts")));
@@ -1119,8 +1088,6 @@ public class BundleValidationTest {
         createPackageJsonStub(BLANK_PACKAGE_JSON_WITH_HASH);
         createProjectFrontendFileStub();
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         Mockito.when(depScanner.getModules()).thenReturn(
                 Collections.singletonMap(ChunkInfo.GLOBAL, Collections
                         .singletonList("Frontend/views/lit-view.ts")));
@@ -1144,8 +1111,6 @@ public class BundleValidationTest {
     public void projectFrontendFileDeleted_bundleRebuild() throws IOException {
         createPackageJsonStub(BLANK_PACKAGE_JSON_WITH_HASH);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         Mockito.when(depScanner.getModules()).thenReturn(
                 Collections.singletonMap(ChunkInfo.GLOBAL, Collections
                         .singletonList("Frontend/views/lit-view.ts")));
@@ -1168,9 +1133,6 @@ public class BundleValidationTest {
     public void reusedTheme_noReusedThemes_noBundleRebuild()
             throws IOException {
         createPackageJsonStub(BLANK_PACKAGE_JSON_WITH_HASH);
-
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
 
         ObjectNode stats = getBasicStats();
         stats.remove(THEME_JSON_CONTENTS);
@@ -1197,9 +1159,6 @@ public class BundleValidationTest {
         boolean created = jarResourcesFolder.mkdirs();
         Assert.assertTrue(created);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
-
         setupFrontendUtilsMock(getBasicStats());
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
@@ -1217,9 +1176,6 @@ public class BundleValidationTest {
         File jarWithTheme = TestUtils
                 .getTestJar("jar-with-theme-json-and-assets.jar");
         options.copyResources(Collections.singleton(jarWithTheme));
-
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
 
         setupFrontendUtilsMock(getBasicStats());
 
@@ -1239,8 +1195,6 @@ public class BundleValidationTest {
                 .getTestJar("jar-with-theme-json-and-assets.jar");
         options.copyResources(Collections.singleton(jarWithTheme));
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         ObjectNode stats = getBasicStats();
         ((ObjectNode) stats.get(THEME_JSON_CONTENTS)).put("other-theme",
                 "other-theme-hash");
@@ -1263,9 +1217,6 @@ public class BundleValidationTest {
         File jarWithTheme = TestUtils
                 .getTestJar("jar-with-theme-json-and-assets.jar");
         options.copyResources(Collections.singleton(jarWithTheme));
-
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
 
         ObjectNode stats = getBasicStats();
         ((ObjectNode) stats.get(THEME_JSON_CONTENTS)).put("reusable-theme",
@@ -1298,9 +1249,6 @@ public class BundleValidationTest {
         File jarWithTheme = TestUtils
                 .getTestJar("jar-with-theme-json-and-assets.jar");
         options.copyResources(Collections.singleton(jarWithTheme));
-
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
 
         ObjectNode stats = getBasicStats();
         ((ObjectNode) stats.get(THEME_JSON_CONTENTS)).put("reusable-theme",
@@ -1336,8 +1284,6 @@ public class BundleValidationTest {
         createProjectThemeJsonStub("{\"lumoImports\": [\"typography\"]}",
                 "my-theme");
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         final ThemeDefinition themeDefinition = Mockito
                 .mock(ThemeDefinition.class);
         Mockito.when(themeDefinition.getName()).thenReturn("my-theme");
@@ -1365,8 +1311,6 @@ public class BundleValidationTest {
         new File(temporaryFolder.getRoot(),
                 DEFAULT_FRONTEND_DIR + "themes/my-parent-theme").mkdirs();
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         final ThemeDefinition themeDefinition = Mockito
                 .mock(ThemeDefinition.class);
         Mockito.when(themeDefinition.getName()).thenReturn("my-theme");
@@ -1391,8 +1335,6 @@ public class BundleValidationTest {
             throws IOException {
         createPackageJsonStub(BLANK_PACKAGE_JSON_WITH_HASH);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         final ThemeDefinition themeDefinition = Mockito
                 .mock(ThemeDefinition.class);
         Mockito.when(themeDefinition.getName()).thenReturn("my-theme");
@@ -1430,8 +1372,6 @@ public class BundleValidationTest {
                 }
                 """, "my-theme");
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         final ThemeDefinition themeDefinition = Mockito
                 .mock(ThemeDefinition.class);
         Mockito.when(themeDefinition.getName()).thenReturn("my-theme");
@@ -1482,8 +1422,6 @@ public class BundleValidationTest {
                         """,
                 "my-theme");
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         final ThemeDefinition themeDefinition = Mockito
                 .mock(ThemeDefinition.class);
         Mockito.when(themeDefinition.getName()).thenReturn("my-theme");
@@ -1525,8 +1463,6 @@ public class BundleValidationTest {
                         """,
                 "my-theme");
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         final ThemeDefinition themeDefinition = Mockito
                 .mock(ThemeDefinition.class);
         Mockito.when(themeDefinition.getName()).thenReturn("my-theme");
@@ -1564,8 +1500,6 @@ public class BundleValidationTest {
         createProjectThemeJsonStub("{\"lumoImports\": [\"typography\"]}",
                 "my-theme");
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         final ThemeDefinition themeDefinition = Mockito
                 .mock(ThemeDefinition.class);
         Mockito.when(themeDefinition.getName()).thenReturn("my-theme");
@@ -1593,8 +1527,6 @@ public class BundleValidationTest {
         createProjectThemeJsonStub("{\"parent\": \"parent-theme\"}",
                 "my-theme");
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         final ThemeDefinition themeDefinition = Mockito
                 .mock(ThemeDefinition.class);
         Mockito.when(themeDefinition.getName()).thenReturn("my-theme");
@@ -1791,9 +1723,6 @@ public class BundleValidationTest {
 
         FileUtils.write(indexTs, "window.alert('');", StandardCharsets.UTF_8);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
-
         ObjectNode stats = getBasicStats();
 
         setupFrontendUtilsMock(stats);
@@ -1815,9 +1744,6 @@ public class BundleValidationTest {
         indexTs.createNewFile();
 
         FileUtils.write(indexTs, "window.alert('');", StandardCharsets.UTF_8);
-
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
 
         ObjectNode stats = getBasicStats();
         ((ObjectNode) stats.get(FRONTEND_HASHES)).put(FrontendUtils.INDEX_TS,
@@ -1843,9 +1769,6 @@ public class BundleValidationTest {
     @Test
     public void indexTsDeleted_rebuildRequired() throws IOException {
         createPackageJsonStub(BLANK_PACKAGE_JSON_WITH_HASH);
-
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
 
         ObjectNode stats = getBasicStats();
         ((ObjectNode) stats.get(FRONTEND_HASHES)).put(FrontendUtils.INDEX_TS,
@@ -1877,9 +1800,6 @@ public class BundleValidationTest {
         ((ObjectNode) stats.get(FRONTEND_HASHES)).put(INDEX_HTML,
                 BundleValidationUtil.calculateHash(defaultIndexHtml));
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
-
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
@@ -1908,9 +1828,6 @@ public class BundleValidationTest {
         ObjectNode stats = getBasicStats();
         ((ObjectNode) stats.get(FRONTEND_HASHES)).put(INDEX_HTML,
                 BundleValidationUtil.calculateHash(defaultIndexHtml));
-
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
 
         setupFrontendUtilsMock(stats);
 
@@ -1942,9 +1859,6 @@ public class BundleValidationTest {
         ((ObjectNode) stats.get(FRONTEND_HASHES)).put(INDEX_HTML,
                 BundleValidationUtil.calculateHash(defaultIndexHtml));
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
-
         setupFrontendUtilsMock(stats);
 
         boolean needsBuild = BundleValidationUtil.needsBuild(options,
@@ -1958,9 +1872,6 @@ public class BundleValidationTest {
     public void standardVaadinComponent_notAddedToProjectAsJar_noRebuildRequired()
             throws IOException {
         createPackageJsonStub(BLANK_PACKAGE_JSON_WITH_HASH);
-
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
 
         ObjectNode stats = getBasicStats();
         ArrayNode bundleImports = (ArrayNode) stats.get(BUNDLE_IMPORTS);
@@ -1983,9 +1894,6 @@ public class BundleValidationTest {
     public void cssImport_cssInMetaInfResources_notThrow_bundleRequired()
             throws IOException {
         createPackageJsonStub(BLANK_PACKAGE_JSON_WITH_HASH);
-
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
 
         CssData cssData = new CssData("./addons-styles/my-styles.css", null,
                 null, null);
@@ -2012,9 +1920,6 @@ public class BundleValidationTest {
         createPackageJsonStub(
                 "{\"dependencies\": {\"@vaadin/flow-frontend\": \"./target/flow-frontend\"}, \"vaadin\": { \"hash\": \"aHash\"} }");
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
-
         ObjectNode stats = getBasicStats();
 
         setupFrontendUtilsMock(stats);
@@ -2031,9 +1936,6 @@ public class BundleValidationTest {
             throws IOException {
         createPackageJsonStub(
                 "{\"dependencies\": {\"my-pkg\": \"file:my-pkg\"}, \"vaadin\": { \"hash\": \"aHash\"} }");
-
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
 
         ObjectNode stats = getBasicStats();
         ((ObjectNode) stats.get(PACKAGE_JSON_DEPENDENCIES)).put("my-pkg",
@@ -2054,9 +1956,6 @@ public class BundleValidationTest {
         createPackageJsonStub(
                 "{\"dependencies\": {\"my-pkg\": \"file:my-pkg\"}, \"vaadin\": { \"hash\": \"aHash\"} }");
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
-
         ObjectNode stats = getBasicStats();
         ((ObjectNode) stats.get(PACKAGE_JSON_DEPENDENCIES)).put("my-pkg",
                 "./another-folder");
@@ -2076,9 +1975,6 @@ public class BundleValidationTest {
         createPackageJsonStub(
                 "{\"dependencies\": {\"my-pkg\": \"file:my-pkg\"}, \"vaadin\": { \"hash\": \"aHash\"} }");
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
-
         ObjectNode stats = getBasicStats();
         ((ObjectNode) stats.get(PACKAGE_JSON_DEPENDENCIES)).put("my-pkg",
                 "1.0.0");
@@ -2097,9 +1993,6 @@ public class BundleValidationTest {
             throws IOException {
         createPackageJsonStub(
                 "{\"dependencies\": {\"my-pkg\": \"1.0.0\"}, \"vaadin\": { \"hash\": \"aHash\"} }");
-
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
 
         ObjectNode stats = getBasicStats();
         ((ObjectNode) stats.get(PACKAGE_JSON_DEPENDENCIES)).put("my-pkg",
@@ -2134,8 +2027,6 @@ public class BundleValidationTest {
                 }
                 """, StandardCharsets.UTF_8);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         Mockito.when(depScanner.getPackages())
                 .thenReturn(Collections.emptyMap());
 
@@ -2157,7 +2048,7 @@ public class BundleValidationTest {
         options.withForceProductionBuild(true);
 
         final boolean needsBuild = BundleValidationUtil.needsBuild(options,
-                Mockito.mock(FrontendDependenciesScanner.class), mode);
+                depScanner, mode);
         Assert.assertTrue(
                 "Production bundle required due to force.production.bundle flag.",
                 needsBuild);
@@ -2182,8 +2073,6 @@ public class BundleValidationTest {
                 }
                 """, StandardCharsets.UTF_8);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         Mockito.when(depScanner.getPackages())
                 .thenReturn(Collections.emptyMap());
         Mockito.when(depScanner.getModules())
@@ -2237,8 +2126,6 @@ public class BundleValidationTest {
                 }
                 """, StandardCharsets.UTF_8);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         Mockito.when(depScanner.getPackages())
                 .thenReturn(Collections.emptyMap());
         Mockito.when(depScanner.getModules())
@@ -2290,8 +2177,6 @@ public class BundleValidationTest {
                 }
                 """, StandardCharsets.UTF_8);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         Mockito.when(depScanner.getPackages())
                 .thenReturn(Collections.emptyMap());
         Mockito.when(depScanner.getModules())
@@ -2349,9 +2234,6 @@ public class BundleValidationTest {
         FileUtils.write(packageJson, "{\"vaadin\": { \"hash\": \"aHash\"} }",
                 StandardCharsets.UTF_8);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
-
         ObjectNode stats = getBasicStats();
 
         URL url = Mockito.mock(URL.class);
@@ -2388,9 +2270,6 @@ public class BundleValidationTest {
                   }
                 }
                 """, StandardCharsets.UTF_8);
-
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
 
         ObjectNode stats = getBasicStats();
 
@@ -2431,8 +2310,6 @@ public class BundleValidationTest {
                 }
                 """, StandardCharsets.UTF_8);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         Mockito.when(depScanner.getPackages()).thenReturn(
                 Collections.singletonMap("@vaadin/button", "2.0.0"));
 
@@ -2491,9 +2368,6 @@ public class BundleValidationTest {
         FileUtils.write(packageJson, "{\"vaadin\": { \"hash\": \"aHash\"} }",
                 StandardCharsets.UTF_8);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
-
         ObjectNode stats = getBasicStats();
 
         URL url = Mockito.mock(URL.class);
@@ -2515,8 +2389,6 @@ public class BundleValidationTest {
         Assume.assumeTrue(mode.isProduction());
         options.withCommercialBanner(true);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         ObjectNode stats = getBasicStats();
         setupFrontendUtilsMock(stats);
 
@@ -2532,9 +2404,6 @@ public class BundleValidationTest {
             throws IOException {
         Assume.assumeTrue(mode.isProduction());
         options.withCommercialBanner(true);
-
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
 
         String defaultCommercialBannerJS = new String(getClass()
                 .getResourceAsStream(FrontendUtils.COMMERCIAL_BANNER_JS)
@@ -2560,9 +2429,6 @@ public class BundleValidationTest {
         Assume.assumeTrue(mode.isProduction());
         options.withCommercialBanner(true);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
-
         String defaultCommercialBannerJS = new String(getClass()
                 .getResourceAsStream(FrontendUtils.COMMERCIAL_BANNER_JS)
                 .readAllBytes(), StandardCharsets.UTF_8);
@@ -2584,9 +2450,6 @@ public class BundleValidationTest {
             throws IOException {
         Assume.assumeTrue(mode.isProduction());
         options.withCommercialBanner(false);
-
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
 
         File frontendGeneratedFolder = temporaryFolder.newFolder(
                 FrontendUtils.DEFAULT_FRONTEND_DIR, FrontendUtils.GENERATED);
@@ -2616,9 +2479,6 @@ public class BundleValidationTest {
         Assume.assumeTrue(!mode.isProduction());
         options.withCommercialBanner(true);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
-
         ObjectNode stats = getBasicStats();
         setupFrontendUtilsMock(stats);
 
@@ -2634,9 +2494,6 @@ public class BundleValidationTest {
             throws IOException {
         Assume.assumeTrue(!mode.isProduction());
         options.withCommercialBanner(true);
-
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
 
         String defaultCommercialBannerJS = new String(getClass()
                 .getResourceAsStream(FrontendUtils.COMMERCIAL_BANNER_JS)
@@ -2772,8 +2629,6 @@ public class BundleValidationTest {
         FileUtils.write(stylesheetFile, String.format(cssTemplate, "blue"),
                 StandardCharsets.UTF_8);
 
-        final FrontendDependenciesScanner depScanner = Mockito
-                .mock(FrontendDependenciesScanner.class);
         final ThemeDefinition themeDefinition = Mockito
                 .mock(ThemeDefinition.class);
         Mockito.when(themeDefinition.getName()).thenReturn("my-theme");

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/ComponentFlagsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/ComponentFlagsTest.java
@@ -148,8 +148,9 @@ public class ComponentFlagsTest extends NodeUpdateTestUtil {
 
         Options options = new MockOptions(classFinder, tmpRoot)
                 .withFrontendDirectory(frontendDirectory)
-                .withBuildDirectory(TARGET).withProductionMode(true);
-        return new TaskUpdateImports(getScanner(classFinder, featureFlags),
-                options);
+                .withBuildDirectory(TARGET).withProductionMode(true)
+                .withFrontendDependenciesScanner(
+                        getScanner(classFinder, featureFlags));
+        return new TaskUpdateImports(options);
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -439,9 +439,10 @@ public class FrontendUtilsTest {
                 packageJson.toJson(), StandardCharsets.UTF_8);
 
         Logger logger = Mockito.spy(LoggerFactory.getLogger(NodeUpdater.class));
-        Options options = new MockOptions(npmFolder).withBuildDirectory(TARGET);
-        NodeUpdater nodeUpdater = new NodeUpdater(
-                Mockito.mock(FrontendDependencies.class), options) {
+        Options options = new MockOptions(npmFolder).withBuildDirectory(TARGET)
+                .withFrontendDependenciesScanner(
+                        Mockito.mock(FrontendDependencies.class));
+        NodeUpdater nodeUpdater = new NodeUpdater(options) {
             @Override
             public void execute() {
                 // no need to execute logic for this test

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdatePackagesNpmVersionLockingTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdatePackagesNpmVersionLockingTest.java
@@ -12,15 +12,15 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- *
  */
-
 package com.vaadin.flow.server.frontend;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
@@ -40,6 +40,8 @@ import com.vaadin.flow.testutil.FrontendStubs;
 import com.vaadin.tests.util.MockOptions;
 
 import static com.vaadin.flow.server.Constants.TARGET;
+import static com.vaadin.flow.server.frontend.NodeUpdater.PNPM;
+import static com.vaadin.flow.server.frontend.NodeUpdater.VAADIN_DEP_KEY;
 
 @Category(SlowTests.class)
 public class NodeUpdatePackagesNpmVersionLockingTest
@@ -50,6 +52,7 @@ public class NodeUpdatePackagesNpmVersionLockingTest
     private static final String OVERRIDES = "overrides";
     private static final String PLATFORM_PINNED_DEPENDENCY_VERSION = "3.2.17";
     private static final String USER_PINNED_DEPENDENCY_VERSION = "1.0";
+    private static final String RELATIVE_DEPENDENCY_VERSION = "$@vaadin/vaadin-overlay";
 
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -131,6 +134,27 @@ public class NodeUpdatePackagesNpmVersionLockingTest
     }
 
     @Test
+    public void shouldUpdatesOverrides_whenNoVaadinOverrides_changingVersion()
+            throws IOException {
+        TaskUpdatePackages packageUpdater = createPackageUpdater(false,
+                JacksonUtils.createObjectNode().put(TEST_DEPENDENCY,
+                        PLATFORM_PINNED_DEPENDENCY_VERSION));
+        ObjectNode packageJson = packageUpdater.getPackageJson();
+        ObjectNode overridesSection = JacksonUtils.createObjectNode();
+        packageJson.set(OVERRIDES, overridesSection);
+
+        ((ObjectNode) packageJson.get(DEPENDENCIES)).put(TEST_DEPENDENCY,
+                USER_PINNED_DEPENDENCY_VERSION);
+        overridesSection.put(TEST_DEPENDENCY, USER_PINNED_DEPENDENCY_VERSION);
+
+        packageUpdater.generateVersionsJson(packageJson);
+        packageUpdater.lockVersionForNpm(packageJson);
+
+        Assert.assertEquals(PLATFORM_PINNED_DEPENDENCY_VERSION,
+                packageJson.get(OVERRIDES).get(TEST_DEPENDENCY).textValue());
+    }
+
+    @Test
     public void shouldRemoveUnusedLocking() throws IOException {
         // Test when there is no vaadin-version-core.json available
         Mockito.when(
@@ -156,13 +180,191 @@ public class NodeUpdatePackagesNpmVersionLockingTest
 
     }
 
-    private TaskUpdatePackages createPackageUpdater(boolean enablePnpm) {
+    @Test
+    public void shouldHandleNestedObjectOverrides_withoutError()
+            throws IOException {
+        final ObjectNode testOverrides = JacksonUtils.readTree("""
+                {
+                  "parent-package": {
+                    "nested-dep": "1.0.0"
+                  },
+                  "level1": {
+                    "level2": {
+                      "deep-dep": "2.0.0"
+                    }
+                  },
+                  "flat-dep": "3.0.0"
+                }
+                """);
+
+        TaskUpdatePackages packageUpdater = createPackageUpdater(false,
+                testOverrides);
+        ObjectNode packageJson = packageUpdater.getPackageJson();
+
+        // Add dependency
+        ((ObjectNode) packageJson.get(DEPENDENCIES)).put(TEST_DEPENDENCY,
+                PLATFORM_PINNED_DEPENDENCY_VERSION);
+
+        packageUpdater.generateVersionsJson(packageJson);
+
+        // Should not throw and should handle nested objects correctly
+        packageUpdater.lockVersionForNpm(packageJson);
+
+        // Verify flat override stays flat
+        JsonNode overrides = packageJson.get(OVERRIDES);
+        Assert.assertTrue("Flat override should remain unchanged",
+                overrides.has("flat-dep"));
+        Assert.assertEquals("3.0.0", overrides.get("flat-dep").textValue());
+
+        // Verify nested object override is preserved
+        Assert.assertTrue("Nested object override should be preserved",
+                overrides.has("parent-package"));
+        Assert.assertTrue("Nested override should remain an object",
+                overrides.get("parent-package").isObject());
+        Assert.assertEquals("Nested override value should be preserved",
+                "1.0.0",
+                overrides.get("parent-package").get("nested-dep").textValue());
+
+        // Verify vaadin.overrides tracks the nested structure correctly
+        Assert.assertTrue(packageJson.has(VAADIN_DEP_KEY));
+        JsonNode vaadinSection = packageJson.get(VAADIN_DEP_KEY);
+        Assert.assertTrue("vaadin.overrides should exist",
+                vaadinSection.has(OVERRIDES));
+        JsonNode vaadinOverrides = vaadinSection.get(OVERRIDES);
+        Assert.assertTrue("vaadin.overrides should track nested override",
+                vaadinOverrides.has("parent-package"));
+        Assert.assertTrue("vaadin.overrides should preserve nested structure",
+                vaadinOverrides.get("parent-package").isObject());
+        Assert.assertEquals("vaadin.overrides should track exact nested values",
+                "1.0.0", vaadinOverrides.get("parent-package").get("nested-dep")
+                        .textValue());
+
+        // Verify deep nesting is preserved
+        JsonNode level1Override = overrides.get("level1");
+        Assert.assertTrue(level1Override.isObject());
+        JsonNode level2Override = level1Override.get("level2");
+        Assert.assertTrue(level2Override.isObject());
+        Assert.assertEquals("2.0.0",
+                level2Override.get("deep-dep").textValue());
+    }
+
+    @Test
+    public void pnpmIsInUse_nestedOverrides_flattenedWithSeparator()
+            throws IOException {
+        final ObjectNode testOverrides = JacksonUtils.readTree("""
+                {
+                  "parent-package": {
+                    "nested-dep": "1.0.0"
+                  },
+                  "level1": {
+                    "level2": {
+                      "deep-dep": "2.0.0"
+                    }
+                  },
+                  "flat-dep": "3.0.0"
+                }
+                """);
+
+        TaskUpdatePackages packageUpdater = createPackageUpdater(true,
+                testOverrides);
+        ObjectNode packageJson = packageUpdater.getPackageJson();
+
+        // Add dependency
+        ((ObjectNode) packageJson.get(DEPENDENCIES)).put(TEST_DEPENDENCY,
+                PLATFORM_PINNED_DEPENDENCY_VERSION);
+
+        packageUpdater.generateVersionsJson(packageJson);
+
+        // Run version locking
+        packageUpdater.lockVersionForNpm(packageJson);
+
+        // Verify pnpm flattens overrides with > separator
+        JsonNode overrides = packageJson.get(PNPM).get(OVERRIDES);
+        Assert.assertTrue(
+                "Nested override should be flattened with > separator for pnpm",
+                overrides.has("parent-package>nested-dep"));
+        Assert.assertEquals("Flattened override should have correct value",
+                "1.0.0",
+                overrides.get("parent-package>nested-dep").textValue());
+
+        // Verify flat override stays flat
+        Assert.assertTrue("Flat override should remain unchanged",
+                overrides.has("flat-dep"));
+        Assert.assertEquals("3.0.0", overrides.get("flat-dep").textValue());
+
+        // Verify vaadin.overrides tracks the original nested structure
+        JsonNode vaadinOverrides = packageJson.get(VAADIN_DEP_KEY)
+                .get(OVERRIDES);
+        Assert.assertTrue("vaadin.overrides should track nested structure",
+                vaadinOverrides.has("parent-package"));
+        Assert.assertTrue("vaadin.overrides should preserve object format",
+                vaadinOverrides.get("parent-package").isObject());
+
+        // Verify deep nesting is fully flattened
+        Assert.assertTrue("Deeply nested override should be fully flattened",
+                overrides.has("level1>level2>deep-dep"));
+        Assert.assertEquals("2.0.0",
+                overrides.get("level1>level2>deep-dep").textValue());
+    }
+
+    @Test
+    public void pnpmIsInUse_userFlatOverride_preserved() throws IOException {
+        TaskUpdatePackages packageUpdater = createPackageUpdater(true);
+        ObjectNode packageJson = packageUpdater.getPackageJson();
+
+        // User adds a flat override in pnpm format
+        ObjectNode overridesSection = JacksonUtils.createObjectNode();
+        overridesSection.put("user-package>user-dep", "5.0.0");
+        JacksonUtils.setNestedKey(packageJson, List.of(PNPM, OVERRIDES),
+                overridesSection,
+                (nonObjectNode) -> JacksonUtils.createObjectNode());
+
+        packageUpdater.generateVersionsJson(packageJson);
+        packageUpdater.lockVersionForNpm(packageJson);
+
+        // Verify user's override is preserved
+        JsonNode overrides = JacksonUtils.getNestedKey(packageJson,
+                List.of(PNPM, OVERRIDES));
+        Assert.assertNotNull(overrides);
+        Assert.assertTrue("User's override should be preserved",
+                overrides.has("user-package>user-dep"));
+        Assert.assertEquals("5.0.0",
+                overrides.get("user-package>user-dep").textValue());
+
+        // Run again to ensure it remains stable
+        packageUpdater.lockVersionForNpm(packageJson);
+
+        overrides = JacksonUtils.getNestedKey(packageJson,
+                List.of(PNPM, OVERRIDES));
+        Assert.assertNotNull(overrides);
+        Assert.assertTrue(
+                "User's override should remain preserved on second run",
+                overrides.has("user-package>user-dep"));
+        Assert.assertEquals("5.0.0",
+                overrides.get("user-package>user-dep").textValue());
+    }
+
+    private TaskUpdatePackages createPackageUpdater(boolean enablePnpm,
+            ObjectNode testOverrides) {
         FrontendDependenciesScanner scanner = Mockito
                 .mock(FrontendDependenciesScanner.class);
         Options options = new MockOptions(baseDir).withEnablePnpm(enablePnpm)
-                .withBuildDirectory(TARGET).withProductionMode(true);
+                .withBuildDirectory(TARGET).withProductionMode(true)
+                .withFrontendDependenciesScanner(scanner);
 
-        return new TaskUpdatePackages(scanner, options);
+        return new TaskUpdatePackages(options) {
+            @Override
+            ObjectNode getDefaultOverrides() {
+                final ObjectNode overrides = super.getDefaultOverrides();
+                overrides.setAll(testOverrides);
+                return overrides;
+            }
+        };
+    }
+
+    private TaskUpdatePackages createPackageUpdater(boolean enablePnpm) {
+        return createPackageUpdater(enablePnpm,
+                JacksonUtils.createObjectNode());
     }
 
     private TaskUpdatePackages createPackageUpdater() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -71,10 +71,10 @@ public class NodeUpdaterTest {
         finder = Mockito.spy(new ClassFinder.DefaultClassFinder(
                 this.getClass().getClassLoader()));
         options = new MockOptions(finder, npmFolder).withBuildDirectory(TARGET)
-                .withFeatureFlags(featureFlags);
+                .withFeatureFlags(featureFlags).withFrontendDependenciesScanner(
+                        Mockito.mock(FrontendDependencies.class));
 
-        nodeUpdater = new NodeUpdater(Mockito.mock(FrontendDependencies.class),
-                options) {
+        nodeUpdater = new NodeUpdater(options) {
 
             @Override
             public void execute() {
@@ -165,7 +165,7 @@ public class NodeUpdaterTest {
         expectedDependencies.add("@rollup/pluginutils");
         expectedDependencies.add("rollup-plugin-visualizer");
         expectedDependencies.add("vite-plugin-checker");
-        expectedDependencies.add("workbox-build");
+        // Note: workbox is now only included when PWA offline is enabled
         expectedDependencies.add("transform-ast");
         expectedDependencies.add("strip-css-comments");
         expectedDependencies.add("@babel/preset-react");
@@ -182,8 +182,6 @@ public class NodeUpdaterTest {
     private Set<String> getCommonDevDeps() {
         Set<String> expectedDependencies = new HashSet<>();
         expectedDependencies.add("typescript");
-        expectedDependencies.add("workbox-core");
-        expectedDependencies.add("workbox-precaching");
         expectedDependencies.add("glob");
         return expectedDependencies;
     }
@@ -713,6 +711,156 @@ public class NodeUpdaterTest {
     }
 
     @Test
+    public void getDefaultDevDependencies_includesWorkbox_whenPwaOfflineEnabled() {
+        // Create a mock PwaConfiguration with PWA offline enabled
+        com.vaadin.flow.server.PwaConfiguration pwaConfig = Mockito
+                .mock(com.vaadin.flow.server.PwaConfiguration.class);
+        Mockito.when(pwaConfig.isOfflineEnabled()).thenReturn(true);
+        Mockito.when(
+                options.getFrontendDependenciesScanner().getPwaConfiguration())
+                .thenReturn(pwaConfig);
+
+        nodeUpdater = new NodeUpdater(options) {
+            @Override
+            public void execute() {
+                // NO-OP
+            }
+        };
+
+        Map<String, String> defaultDevDeps = nodeUpdater
+                .getDefaultDevDependencies();
+        Assert.assertTrue(
+                "workbox-core should be included when PWA offline is enabled",
+                defaultDevDeps.containsKey("workbox-core"));
+        Assert.assertTrue(
+                "workbox-precaching should be included when PWA offline is enabled",
+                defaultDevDeps.containsKey("workbox-precaching"));
+    }
+
+    @Test
+    public void getDefaultDevDependencies_excludesWorkbox_whenPwaOfflineDisabled() {
+        // Create a mock PwaConfiguration with PWA offline disabled
+        com.vaadin.flow.server.PwaConfiguration pwaConfig = Mockito
+                .mock(com.vaadin.flow.server.PwaConfiguration.class);
+        Mockito.when(pwaConfig.isOfflineEnabled()).thenReturn(false);
+        Mockito.when(
+                options.getFrontendDependenciesScanner().getPwaConfiguration())
+                .thenReturn(pwaConfig);
+
+        nodeUpdater = new NodeUpdater(options) {
+            @Override
+            public void execute() {
+                // NO-OP
+            }
+        };
+
+        Map<String, String> defaultDevDeps = nodeUpdater
+                .getDefaultDevDependencies();
+        Assert.assertFalse(
+                "workbox-core should not be included when PWA offline is disabled",
+                defaultDevDeps.containsKey("workbox-core"));
+        Assert.assertFalse(
+                "workbox-precaching should not be included when PWA offline is disabled",
+                defaultDevDeps.containsKey("workbox-precaching"));
+    }
+
+    @Test
+    public void getDefaultDevDependencies_excludesWorkbox_whenPwaNull() {
+        // No PWA configuration
+        Mockito.when(
+                options.getFrontendDependenciesScanner().getPwaConfiguration())
+                .thenReturn(null);
+
+        nodeUpdater = new NodeUpdater(options) {
+            @Override
+            public void execute() {
+                // NO-OP
+            }
+        };
+
+        Map<String, String> defaultDevDeps = nodeUpdater
+                .getDefaultDevDependencies();
+        Assert.assertFalse(
+                "React dev dependency added unexpectedly when Hilla isn't used",
+                defaultDevDeps.containsKey("react-dev-dependency"));
+        Assert.assertFalse(
+                "Lit dev dependency added unexpectedly when Hilla isn't used",
+                defaultDevDeps.containsKey("lit-dev-dependency"));
+    }
+
+    @Test
+    public void getDefaultOverrides_includesWorkboxOverrides_whenPwaOfflineEnabled() {
+        // Create a mock PwaConfiguration with PWA offline enabled
+        com.vaadin.flow.server.PwaConfiguration pwaConfig = Mockito
+                .mock(com.vaadin.flow.server.PwaConfiguration.class);
+        Mockito.when(pwaConfig.isOfflineEnabled()).thenReturn(true);
+        Mockito.when(
+                options.getFrontendDependenciesScanner().getPwaConfiguration())
+                .thenReturn(pwaConfig);
+
+        nodeUpdater = new NodeUpdater(options) {
+            @Override
+            public void execute() {
+                // NO-OP
+            }
+        };
+
+        ObjectNode overrides = nodeUpdater.getDefaultOverrides();
+        Assert.assertTrue(
+                "workbox-build override should be included when PWA offline is enabled",
+                overrides.has("workbox-build"));
+        // Verify nested structure
+        JsonNode workboxBuildOverride = overrides.get("workbox-build");
+        Assert.assertTrue("workbox-build override should be an object",
+                workboxBuildOverride.isObject());
+        Assert.assertTrue(
+                "workbox-build override should contain serialize-javascript",
+                workboxBuildOverride.has("serialize-javascript"));
+    }
+
+    @Test
+    public void getDefaultOverrides_returnsEmpty_whenPwaOfflineDisabled() {
+        // Create a mock PwaConfiguration with PWA offline enabled
+        com.vaadin.flow.server.PwaConfiguration pwaConfig = Mockito
+                .mock(com.vaadin.flow.server.PwaConfiguration.class);
+        Mockito.when(pwaConfig.isOfflineEnabled()).thenReturn(false);
+        Mockito.when(
+                options.getFrontendDependenciesScanner().getPwaConfiguration())
+                .thenReturn(pwaConfig);
+
+        nodeUpdater = new NodeUpdater(options) {
+            @Override
+            public void execute() {
+                // NO-OP
+            }
+        };
+
+        ObjectNode overrides = nodeUpdater.getDefaultOverrides();
+        Assert.assertTrue(
+                "overrides should be empty when PWA offline is disabled",
+                overrides.isEmpty());
+    }
+
+    @Test
+    public void getDefaultOverrides_returnsEmpty_whenPwaNull() {
+        // No PWA configuration
+        Mockito.when(
+                options.getFrontendDependenciesScanner().getPwaConfiguration())
+                .thenReturn(null);
+
+        nodeUpdater = new NodeUpdater(options) {
+            @Override
+            public void execute() {
+                // NO-OP
+            }
+        };
+
+        ObjectNode overrides = nodeUpdater.getDefaultOverrides();
+        Assert.assertTrue("overrides should be empty when PWA is null",
+                overrides.isEmpty());
+    }
+
+    @Test
     public void readPackageJson_nonExistingFile_doesNotThrow()
             throws IOException {
         nodeUpdater.readPackageJson("non-existing-folder");
@@ -736,8 +884,7 @@ public class NodeUpdaterTest {
     @Test
     public void readPackageJsonIfAvailable_nonExistingFile_noErrorLog() {
         Logger log = Mockito.mock(Logger.class);
-        nodeUpdater = new NodeUpdater(Mockito.mock(FrontendDependencies.class),
-                options) {
+        nodeUpdater = new NodeUpdater(options) {
 
             @Override
             public void execute() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrapTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrapTest.java
@@ -78,9 +78,10 @@ public class TaskGenerateBootstrapTest {
 
         frontendFolder = temporaryFolder.newFolder(FRONTEND);
         options = new MockOptions(finder, null)
-                .withFrontendDirectory(frontendFolder).withProductionMode(true);
+                .withFrontendDirectory(frontendFolder).withProductionMode(true)
+                .withFrontendDependenciesScanner(frontDeps);
 
-        taskGenerateBootstrap = new TaskGenerateBootstrap(frontDeps, options);
+        taskGenerateBootstrap = new TaskGenerateBootstrap(options);
     }
 
     @Test
@@ -103,7 +104,7 @@ public class TaskGenerateBootstrapTest {
     public void should_importDevTools_inDevMode()
             throws ExecutionFailedException {
         options.withProductionMode(false);
-        taskGenerateBootstrap = new TaskGenerateBootstrap(frontDeps, options);
+        taskGenerateBootstrap = new TaskGenerateBootstrap(options);
         taskGenerateBootstrap.execute();
         String content = taskGenerateBootstrap.getFileContent();
         Assert.assertTrue(content.contains(DEV_TOOLS_IMPORT));
@@ -150,10 +151,10 @@ public class TaskGenerateBootstrapTest {
     @Test
     public void should_load_AppTheme()
             throws MalformedURLException, ExecutionFailedException {
-        options.withFrontendDirectory(frontendFolder).withProductionMode(true);
+        options.withFrontendDirectory(frontendFolder).withProductionMode(true)
+                .withFrontendDependenciesScanner(getThemedDependency());
 
-        taskGenerateBootstrap = new TaskGenerateBootstrap(getThemedDependency(),
-                options);
+        taskGenerateBootstrap = new TaskGenerateBootstrap(options);
         taskGenerateBootstrap.execute();
         String content = taskGenerateBootstrap.getFileContent();
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskInstallFrontendBuildPluginsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskInstallFrontendBuildPluginsTest.java
@@ -37,7 +37,6 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.internal.JacksonUtils;
-import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
 import com.vaadin.tests.util.MockOptions;
 
 import static com.vaadin.flow.server.Constants.TARGET;
@@ -98,8 +97,7 @@ public class TaskInstallFrontendBuildPluginsTest {
     public void pluginsNotAddedToPackageJson() throws IOException {
         Options options = new MockOptions(rootFolder)
                 .withBuildDirectory(BUILD_DIRECTORY);
-        NodeUpdater nodeUpdater = new NodeUpdater(
-                Mockito.mock(FrontendDependencies.class), options) {
+        NodeUpdater nodeUpdater = new NodeUpdater(options) {
             @Override
             public void execute() {
             }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import net.jcip.annotations.NotThreadSafe;
@@ -49,7 +50,6 @@ import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.frontend.installer.NodeInstaller;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
-import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
 import com.vaadin.flow.testcategory.SlowTests;
 import com.vaadin.tests.util.MockOptions;
 
@@ -91,8 +91,7 @@ public class TaskRunNpmInstallTest {
         options = new MockOptions(npmFolder).withBuildDirectory(TARGET)
                 .withBundleBuild(true);
         finder = options.getClassFinder();
-        nodeUpdater = new NodeUpdater(Mockito.mock(FrontendDependencies.class),
-                options) {
+        nodeUpdater = new NodeUpdater(options) {
 
             @Override
             public void execute() {
@@ -505,7 +504,8 @@ public class TaskRunNpmInstallTest {
      * @param packageJson
      *            package.json json object
      */
-    public void updatePackageHash(ObjectNode packageJson) {
+    public void updatePackageHash(ObjectNode packageJson)
+            throws JsonProcessingException {
         final ObjectNode vaadinDep = (ObjectNode) packageJson
                 .get(VAADIN_DEP_KEY).get(DEPENDENCIES);
         ObjectNode dependencies = JacksonUtils.createObjectNode();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -42,7 +42,6 @@ import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.frontend.installer.NodeInstaller;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
-import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
 import com.vaadin.flow.testcategory.SlowTests;
 import com.vaadin.flow.testutil.FrontendStubs;
 
@@ -503,8 +502,7 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
     private NodeUpdater createNodeUpdater(String versionsContent) {
         options.withBuildDirectory(TARGET);
 
-        return new NodeUpdater(Mockito.mock(FrontendDependencies.class),
-                options) {
+        return new NodeUpdater(options) {
 
             @Override
             public void execute() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
@@ -42,8 +42,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.BaseJsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Before;
@@ -57,13 +57,13 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.PwaConfiguration;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
 import com.vaadin.tests.util.MockOptions;
 
 import elemental.json.Json;
 import elemental.json.JsonObject;
-import elemental.json.JsonValue;
 import net.jcip.annotations.NotThreadSafe;
 
 @NotThreadSafe
@@ -241,6 +241,11 @@ public class TaskUpdatePackagesNpmTest {
         ObjectNode packageJson = getOrCreatePackageJson();
         packageJson.set(OVERRIDES, JacksonUtils.createObjectNode());
         ((ObjectNode) packageJson.get(OVERRIDES)).put("@vaadin/aura", "1.0");
+        // Assuming Vaadin added the override, set Vaadin overrides accordingly
+        JacksonUtils.setNestedKey(packageJson,
+                List.of(VAADIN_DEP_KEY, OVERRIDES, "@vaadin/aura"),
+                TextNode.valueOf("1.0"),
+                (nonObjectNode) -> JacksonUtils.createObjectNode());
 
         FileUtils.writeStringToFile(new File(npmFolder, PACKAGE_JSON),
                 packageJson.toPrettyString(), StandardCharsets.UTF_8);
@@ -368,6 +373,10 @@ public class TaskUpdatePackagesNpmTest {
         ObjectNode packageJson = getOrCreatePackageJson();
         ((ObjectNode) packageJson.get(DEV_DEPENDENCIES))
                 .put(VAADIN_ELEMENT_MIXIN, PLATFORM_ELEMENT_MIXIN_VERSION);
+        // Remove VAADIN_ELEMENT_MIXIN override from Vaadin overrides
+        JacksonUtils.removeNestedKey(packageJson,
+                List.of(VAADIN_DEP_KEY, OVERRIDES, VAADIN_ELEMENT_MIXIN));
+        // Save modified package.json
         FileUtils.writeStringToFile(this.packageJson,
                 packageJson.toPrettyString(), StandardCharsets.UTF_8);
 
@@ -380,6 +389,46 @@ public class TaskUpdatePackagesNpmTest {
         Assert.assertTrue("Updates not picked", task.modified);
 
         verifyVersionLockingWithNpmOverrides(true, true, true);
+    }
+
+    @Test
+    public void npmIsInUse_emptyVaadinOverrides_obsoleteOverride_overrideRemoved()
+            throws IOException {
+        createVaadinVersionsJson(PLATFORM_DIALOG_VERSION,
+                PLATFORM_ELEMENT_MIXIN_VERSION, PLATFORM_OVERLAY_VERSION);
+
+        final Map<String, String> applicationDependencies = createApplicationDependencies();
+        applicationDependencies.put(VAADIN_ELEMENT_MIXIN,
+                PLATFORM_ELEMENT_MIXIN_VERSION);
+        applicationDependencies.put(VAADIN_OVERLAY, PLATFORM_OVERLAY_VERSION);
+        TaskUpdatePackages task = createTask(applicationDependencies);
+        task.execute();
+
+        // Remove platform lock for vaadin-element-mixin
+        final ObjectNode versions = JacksonUtils.readTree(FileUtils
+                .readFileToString(versionJsonFile, StandardCharsets.UTF_8));
+        ((ObjectNode) versions.get("core")).remove("vaadin-element-mixin");
+        FileUtils.writeStringToFile(versionJsonFile, versions.toString(),
+                StandardCharsets.UTF_8);
+
+        // Remove Vaadin overrides from package.json (simulate old style
+        // overrides not tracked using Vaadin overrides section introduced in
+        // PR #24008)
+        ObjectNode packageJson = getOrCreatePackageJson();
+        JacksonUtils.removeNestedKey(packageJson,
+                List.of(VAADIN_DEP_KEY, OVERRIDES));
+        FileUtils.writeStringToFile(this.packageJson,
+                packageJson.toPrettyString(), StandardCharsets.UTF_8);
+
+        // Remove VAADIN_ELEMENT_MIXIN from the application dependencies
+        applicationDependencies.remove(VAADIN_ELEMENT_MIXIN);
+        task = createTask(applicationDependencies);
+
+        task.execute();
+
+        Assert.assertTrue("Updates not picked", task.modified);
+
+        verifyVersionLockingWithNpmOverrides(true, false, true);
     }
 
     @Test
@@ -839,9 +888,9 @@ public class TaskUpdatePackagesNpmTest {
                 .thenReturn(createApplicationDependencies());
         Options options = new MockOptions(finder, npmFolder)
                 .withBuildDirectory(TARGET).withEnablePnpm(false)
-                .withBundleBuild(true).withReact(true);
-        final TaskUpdatePackages task = new TaskUpdatePackages(
-                frontendDependenciesScanner, options) {
+                .withBundleBuild(true).withReact(true)
+                .withFrontendDependenciesScanner(frontendDependenciesScanner);
+        final TaskUpdatePackages task = new TaskUpdatePackages(options) {
         };
         task.execute();
         final ObjectNode newPackageJson = getOrCreatePackageJson();
@@ -872,9 +921,9 @@ public class TaskUpdatePackagesNpmTest {
                 .thenReturn(createApplicationDependencies());
         Options options = new MockOptions(finder, npmFolder)
                 .withBuildDirectory(TARGET).withEnablePnpm(false)
-                .withBundleBuild(true).withReact(true);
-        final TaskUpdatePackages task = new TaskUpdatePackages(
-                frontendDependenciesScanner, options) {
+                .withBundleBuild(true).withReact(true)
+                .withFrontendDependenciesScanner(frontendDependenciesScanner);
+        final TaskUpdatePackages task = new TaskUpdatePackages(options) {
         };
         task.execute();
         final JsonNode newPackageJson = getOrCreatePackageJson();
@@ -904,9 +953,9 @@ public class TaskUpdatePackagesNpmTest {
                 .thenReturn(new HashMap<>());
         Options options = new MockOptions(finder, npmFolder)
                 .withBuildDirectory(TARGET).withEnablePnpm(false)
-                .withBundleBuild(true).withReact(true);
-        final TaskUpdatePackages task = new TaskUpdatePackages(
-                frontendDependenciesScanner, options) {
+                .withBundleBuild(true).withReact(true)
+                .withFrontendDependenciesScanner(frontendDependenciesScanner);
+        final TaskUpdatePackages task = new TaskUpdatePackages(options) {
         };
         task.execute();
         final JsonNode newPackageJson = getOrCreatePackageJson();
@@ -935,9 +984,9 @@ public class TaskUpdatePackagesNpmTest {
                 .thenReturn(createApplicationDependencies());
         Options options = new MockOptions(finder, npmFolder)
                 .withBuildDirectory(TARGET).withEnablePnpm(false)
-                .withBundleBuild(true).withReact(false);
-        final TaskUpdatePackages task = new TaskUpdatePackages(
-                frontendDependenciesScanner, options) {
+                .withBundleBuild(true).withReact(false)
+                .withFrontendDependenciesScanner(frontendDependenciesScanner);
+        final TaskUpdatePackages task = new TaskUpdatePackages(options) {
         };
         task.execute();
         final JsonNode newPackageJson = getOrCreatePackageJson();
@@ -1097,8 +1146,9 @@ public class TaskUpdatePackagesNpmTest {
                 .mock(FrontendDependencies.class);
         Mockito.when(frontendDependenciesScanner.getPackages())
                 .thenReturn(scannedApplicationDependencies);
-        final TaskUpdatePackages task = new TaskUpdatePackages(
-                frontendDependenciesScanner, options) {
+        options = options
+                .withFrontendDependenciesScanner(frontendDependenciesScanner);
+        final TaskUpdatePackages task = new TaskUpdatePackages(options) {
         };
         task.execute();
     }
@@ -1188,9 +1238,9 @@ public class TaskUpdatePackagesNpmTest {
                 .thenReturn(applicationDependencies);
         Options options = new MockOptions(finder, npmFolder)
                 .withBuildDirectory(TARGET).withEnablePnpm(enablePnpm)
-                .withBundleBuild(true).withReact(false);
-
-        return new TaskUpdatePackages(frontendDependenciesScanner, options) {
+                .withBundleBuild(true).withReact(false)
+                .withFrontendDependenciesScanner(frontendDependenciesScanner);
+        return new TaskUpdatePackages(options) {
         };
     }
 
@@ -1325,6 +1375,545 @@ public class TaskUpdatePackagesNpmTest {
         task.execute();
 
         verifyVersions(newVersion, newVersion, newVersion);
+    }
+
+    @Test
+    public void npmIsInUse_pwaOfflineEnabled_workboxOverridesAdded()
+            throws IOException {
+        createBasicVaadinVersionsJson();
+        final TaskUpdatePackages task = createTaskWithPwa(
+                createApplicationDependencies(), false, true);
+        task.execute();
+
+        ObjectNode pkgJson = getOrCreatePackageJson();
+        Assert.assertTrue("overrides section should exist",
+                pkgJson.has(OVERRIDES));
+        JsonNode overrides = pkgJson.get(OVERRIDES);
+
+        // Verify workbox-build nested object override is present
+        Assert.assertTrue(
+                "workbox-build override should be added when PWA offline is enabled",
+                overrides.has("workbox-build"));
+        JsonNode workboxBuildOverride = overrides.get("workbox-build");
+        Assert.assertTrue("workbox-build override should be a nested object",
+                workboxBuildOverride.isObject());
+        Assert.assertTrue(
+                "workbox-build override should contain serialize-javascript",
+                workboxBuildOverride.has("serialize-javascript"));
+    }
+
+    @Test
+    public void npmIsInUse_pwaOfflineDisabled_workboxOverridesNotAdded()
+            throws IOException {
+        createBasicVaadinVersionsJson();
+        final TaskUpdatePackages task = createTaskWithPwa(
+                createApplicationDependencies(), false, false);
+        task.execute();
+
+        ObjectNode pkgJson = getOrCreatePackageJson();
+        if (pkgJson.has(OVERRIDES)) {
+            JsonNode overrides = pkgJson.get(OVERRIDES);
+            Assert.assertFalse(
+                    "workbox-build override should not be added when PWA offline is disabled",
+                    overrides.has("workbox-build"));
+        }
+    }
+
+    @Test
+    public void npmIsInUse_pwaOfflineEnabled_overridesTrackedInVaadinSection()
+            throws IOException {
+        createBasicVaadinVersionsJson();
+        final TaskUpdatePackages task = createTaskWithPwa(
+                createApplicationDependencies(), false, true);
+        task.execute();
+
+        ObjectNode pkgJson = getOrCreatePackageJson();
+        Assert.assertTrue("vaadin section should exist",
+                pkgJson.has(VAADIN_DEP_KEY));
+        JsonNode vaadin = pkgJson.get(VAADIN_DEP_KEY);
+        Assert.assertTrue("vaadin.overrides section should exist",
+                vaadin.has(OVERRIDES));
+        JsonNode vaadinOverrides = vaadin.get(OVERRIDES);
+
+        // Verify workbox-build is tracked in vaadin.overrides
+        Assert.assertTrue("workbox-build should be tracked in vaadin.overrides",
+                vaadinOverrides.has("workbox-build"));
+    }
+
+    @Test
+    public void npmIsInUse_pwaOfflineDisabledAfterEnabled_workboxOverridesRemoved()
+            throws IOException {
+        createBasicVaadinVersionsJson();
+
+        // First run with PWA offline enabled
+        TaskUpdatePackages task = createTaskWithPwa(
+                createApplicationDependencies(), false, true);
+        task.execute();
+
+        // Verify workbox override was added
+        ObjectNode pkgJson = getOrCreatePackageJson();
+        Assert.assertTrue(pkgJson.has(OVERRIDES));
+        Assert.assertTrue(
+                "workbox-build override should be present after first run",
+                pkgJson.get(OVERRIDES).has("workbox-build"));
+        JsonNode workboxOverride = pkgJson.get(OVERRIDES).get("workbox-build");
+        Assert.assertTrue("workbox-build should be a nested object",
+                workboxOverride.isObject());
+
+        // Verify nested structure exists
+        Assert.assertTrue(
+                "workbox-build nested object should have at least one child",
+                !((ObjectNode) workboxOverride).isEmpty());
+
+        // Second run with PWA offline disabled
+        task = createTaskWithPwa(createApplicationDependencies(), false, false);
+        task.execute();
+
+        // Verify workbox override was removed
+        pkgJson = getOrCreatePackageJson();
+        if (pkgJson.has(OVERRIDES)) {
+            Assert.assertFalse(
+                    "workbox-build override should be removed when PWA offline is disabled",
+                    pkgJson.get(OVERRIDES).has("workbox-build"));
+            // Verify the entire nested object structure is gone, not just the
+            // key
+            ObjectNode overridesSection = (ObjectNode) pkgJson.get(OVERRIDES);
+            for (String key : JacksonUtils.getKeys(overridesSection)) {
+                Assert.assertFalse(
+                        "No workbox-build key should remain in any form",
+                        key.equals("workbox-build"));
+            }
+        }
+
+        // Verify vaadin.overrides was cleaned up properly
+        if (pkgJson.has(VAADIN_DEP_KEY)
+                && pkgJson.get(VAADIN_DEP_KEY).has(OVERRIDES)) {
+            Assert.assertFalse(
+                    "workbox-build should be removed from vaadin.overrides",
+                    pkgJson.get(VAADIN_DEP_KEY).get(OVERRIDES)
+                            .has("workbox-build"));
+            // Verify empty vaadin.overrides section is removed
+            JsonNode vaadinOverrides = pkgJson.get(VAADIN_DEP_KEY)
+                    .get(OVERRIDES);
+            if (vaadinOverrides != null && vaadinOverrides.size() == 0) {
+                Assert.assertFalse("Empty vaadin.overrides should be removed",
+                        pkgJson.get(VAADIN_DEP_KEY).has(OVERRIDES));
+            }
+        }
+
+        // Add user override and re-enable PWA to verify proper coexistence
+        pkgJson = getOrCreatePackageJson();
+        if (!pkgJson.has(OVERRIDES)) {
+            pkgJson.set(OVERRIDES, JacksonUtils.createObjectNode());
+        }
+        ((ObjectNode) pkgJson.get(OVERRIDES)).put("user-dep", "1.0.0");
+        FileUtils.writeStringToFile(packageJson, pkgJson.toPrettyString(),
+                StandardCharsets.UTF_8);
+
+        // Third run with PWA re-enabled
+        task = createTaskWithPwa(createApplicationDependencies(), false, true);
+        task.execute();
+
+        // Verify both user override and workbox override coexist
+        pkgJson = getOrCreatePackageJson();
+        Assert.assertTrue("User override should be preserved",
+                pkgJson.get(OVERRIDES).has("user-dep"));
+        Assert.assertEquals("1.0.0",
+                pkgJson.get(OVERRIDES).get("user-dep").asText());
+        Assert.assertTrue("workbox-build override should be re-added",
+                pkgJson.get(OVERRIDES).has("workbox-build"));
+    }
+
+    @Test
+    public void npmIsInUse_nestedObjectOverrides_handledCorrectlyInVersionLocking()
+            throws IOException {
+        createBasicVaadinVersionsJson();
+
+        // Create package.json with a nested object override (not a string)
+        ObjectNode pkgJson = getOrCreatePackageJson();
+        ObjectNode overrides = JacksonUtils.createObjectNode();
+        ObjectNode nestedOverride = JacksonUtils.createObjectNode();
+        nestedOverride.put("some-dep", "1.0.0");
+        overrides.set("parent-pkg", nestedOverride);
+        pkgJson.set(OVERRIDES, overrides);
+        FileUtils.writeStringToFile(packageJson, pkgJson.toPrettyString(),
+                StandardCharsets.UTF_8);
+
+        // Run the task - should not fail with nested object overrides
+        final TaskUpdatePackages task = createTask(
+                createApplicationDependencies());
+        task.execute();
+
+        // Verify the nested override is preserved (not treated as string)
+        pkgJson = getOrCreatePackageJson();
+        Assert.assertTrue(pkgJson.has(OVERRIDES));
+        JsonNode parentPkgOverride = pkgJson.get(OVERRIDES).get("parent-pkg");
+        if (parentPkgOverride != null) {
+            Assert.assertTrue("nested object override should be preserved",
+                    parentPkgOverride.isObject());
+        }
+    }
+
+    @Test
+    public void npmIsInUse_emptyVaadinOverrides_removedFromPackageJson()
+            throws IOException {
+        // Setup: Create package.json with vaadin.overrides that will be removed
+        FileUtils.write(versionJsonFile, "{}", StandardCharsets.UTF_8);
+
+        // First run to create a valid package.json with empty dependencies
+        TaskUpdatePackages task = createTask(Map.of());
+        task.execute();
+
+        // Now add a Vaadin-managed override (both in vaadin.overrides and main
+        // overrides). This simulates an override that was added by Vaadin but
+        // is no longer needed.
+        ObjectNode pkgJson = getOrCreatePackageJson();
+        pkgJson.set(VAADIN_DEP_KEY,
+                JacksonUtils.createObjectNode().set(OVERRIDES, JacksonUtils
+                        .createObjectNode().put("some-old-override", "value")));
+
+        // Also add to main overrides section (this makes it a "Vaadin-managed"
+        // override)
+        pkgJson.set(OVERRIDES, JacksonUtils.createObjectNode()
+                .put("some-old-override", "value"));
+
+        FileUtils.writeStringToFile(packageJson, pkgJson.toPrettyString(),
+                StandardCharsets.UTF_8);
+
+        // Execute task again
+        task.execute();
+
+        // Verify vaadin.overrides is removed when empty
+        ObjectNode resultJson = getOrCreatePackageJson();
+        ObjectNode resultVaadin = (ObjectNode) resultJson.get(VAADIN_DEP_KEY);
+        Assert.assertFalse(
+                "Empty vaadin.overrides should be removed from package.json",
+                resultVaadin.has(OVERRIDES));
+    }
+
+    @Test
+    public void pnpmIsInUse_pwaOfflineEnabled_workboxOverridesFlattened()
+            throws IOException {
+        createBasicVaadinVersionsJson();
+        final TaskUpdatePackages task = createTaskWithPwa(
+                createApplicationDependencies(), true, true);
+        task.execute();
+
+        ObjectNode pkgJson = getOrCreatePackageJson();
+
+        // Verify npm-style overrides are NOT at root level
+        Assert.assertFalse(
+                "npm overrides should not exist at root when pnpm is enabled",
+                pkgJson.has(OVERRIDES));
+
+        // Verify pnpm.overrides section exists
+        Assert.assertTrue("pnpm section should exist", pkgJson.has(PNPM));
+        JsonNode pnpm = pkgJson.get(PNPM);
+        Assert.assertTrue("pnpm.overrides should exist", pnpm.has(OVERRIDES));
+        JsonNode overrides = pnpm.get(OVERRIDES);
+
+        // Verify workbox-build nested overrides are flattened with > separator
+        Assert.assertTrue(
+                "Flattened workbox-build>serialize-javascript should be present",
+                overrides.has("workbox-build>serialize-javascript"));
+        Assert.assertTrue(
+                "Flattened workbox-build>@rollup/plugin-terser should be present",
+                overrides.has("workbox-build>@rollup/plugin-terser"));
+        Assert.assertTrue("Flattened workbox-build>glob should be present",
+                overrides.has("workbox-build>glob"));
+
+        // Verify the values are strings, not nested objects
+        Assert.assertTrue("Flattened override should be a string value",
+                overrides.get("workbox-build>serialize-javascript")
+                        .isTextual());
+
+        // Verify nested object form does NOT exist
+        Assert.assertFalse(
+                "Nested object workbox-build should not exist in pnpm overrides",
+                overrides.has("workbox-build"));
+    }
+
+    @Test
+    public void pnpmIsInUse_pwaOfflineDisabledAfterEnabled_flattenedOverridesRemoved()
+            throws IOException {
+        createBasicVaadinVersionsJson();
+
+        // First run with PWA offline enabled (creates flattened overrides)
+        TaskUpdatePackages task = createTaskWithPwa(
+                createApplicationDependencies(), true, true);
+        task.execute();
+
+        // Verify flattened overrides were added
+        ObjectNode pkgJson = getOrCreatePackageJson();
+        Assert.assertTrue(
+                pkgJson.has(PNPM) && pkgJson.get(PNPM).has(OVERRIDES));
+        Assert.assertTrue(
+                "Flattened override should be present after first run",
+                pkgJson.get(PNPM).get(OVERRIDES)
+                        .has("workbox-build>serialize-javascript"));
+
+        // Second run with PWA offline disabled
+        task = createTaskWithPwa(createApplicationDependencies(), true, false);
+        task.execute();
+
+        // Verify all flattened workbox overrides were removed
+        pkgJson = getOrCreatePackageJson();
+        if (pkgJson.has(PNPM) && pkgJson.get(PNPM).has(OVERRIDES)) {
+            JsonNode overrides = pkgJson.get(PNPM).get(OVERRIDES);
+            Assert.assertFalse(
+                    "Flattened workbox-build>serialize-javascript should be removed",
+                    overrides.has("workbox-build>serialize-javascript"));
+            Assert.assertFalse(
+                    "Flattened workbox-build>@rollup/plugin-terser should be removed",
+                    overrides.has("workbox-build>@rollup/plugin-terser"));
+            Assert.assertFalse("Flattened workbox-build>glob should be removed",
+                    overrides.has("workbox-build>glob"));
+        }
+
+        // Also verify vaadin.overrides was cleaned up
+        if (pkgJson.has(VAADIN_DEP_KEY)
+                && pkgJson.get(VAADIN_DEP_KEY).has(OVERRIDES)) {
+            Assert.assertFalse(
+                    "workbox-build should be removed from vaadin.overrides",
+                    pkgJson.get(VAADIN_DEP_KEY).get(OVERRIDES)
+                            .has("workbox-build"));
+        }
+    }
+
+    @Test
+    public void generatePackageJsonHash_pnpmOverrides_includedInHash()
+            throws IOException {
+        // Create package.json with pnpm overrides
+        ObjectNode pkgJson = getOrCreatePackageJson();
+        ObjectNode pnpmSection = JacksonUtils.createObjectNode();
+        ObjectNode pnpmOverrides = JacksonUtils.createObjectNode();
+        pnpmOverrides.put("some-package", "1.0.0");
+        pnpmSection.set(OVERRIDES, pnpmOverrides);
+        pkgJson.set(PNPM, pnpmSection);
+
+        String hashWithPnpmOverrides = TaskUpdatePackages
+                .generatePackageJsonHash(pkgJson);
+
+        // Modify pnpm overrides and verify hash changes
+        pnpmOverrides.put("some-package", "2.0.0");
+        String hashWithModifiedOverrides = TaskUpdatePackages
+                .generatePackageJsonHash(pkgJson);
+
+        Assert.assertNotEquals(
+                "Hash should change when pnpm overrides are modified",
+                hashWithPnpmOverrides, hashWithModifiedOverrides);
+    }
+
+    @Test
+    public void generatePackageJsonHash_pnpmOverridesAdded_hashChanges()
+            throws IOException {
+        // Create package.json without pnpm overrides
+        ObjectNode pkgJson = getOrCreatePackageJson();
+        String hashWithoutPnpmOverrides = TaskUpdatePackages
+                .generatePackageJsonHash(pkgJson);
+
+        // Add pnpm overrides
+        ObjectNode pnpmSection = JacksonUtils.createObjectNode();
+        ObjectNode pnpmOverrides = JacksonUtils.createObjectNode();
+        pnpmOverrides.put("workbox-build>serialize-javascript", "7.0.4");
+        pnpmSection.set(OVERRIDES, pnpmOverrides);
+        pkgJson.set(PNPM, pnpmSection);
+
+        String hashWithPnpmOverrides = TaskUpdatePackages
+                .generatePackageJsonHash(pkgJson);
+
+        Assert.assertNotEquals(
+                "Hash should change when pnpm overrides are added",
+                hashWithoutPnpmOverrides, hashWithPnpmOverrides);
+    }
+
+    @Test
+    public void pnpmIsInUse_pwaOfflineEnabled_hashIncludesWorkboxOverrides()
+            throws IOException {
+        createBasicVaadinVersionsJson();
+
+        // First run without PWA - record the hash
+        TaskUpdatePackages taskNoPwa = createTaskWithPwa(
+                createApplicationDependencies(), true, false);
+        taskNoPwa.execute();
+
+        ObjectNode pkgJsonNoPwa = getOrCreatePackageJson();
+        String hashWithoutWorkboxOverrides = pkgJsonNoPwa.get(VAADIN_DEP_KEY)
+                .get("hash").textValue();
+
+        // Reset package.json
+        FileUtils.writeStringToFile(packageJson, "{\"dependencies\": {}}",
+                StandardCharsets.UTF_8);
+
+        // Second run with PWA offline enabled - should have different hash
+        TaskUpdatePackages taskWithPwa = createTaskWithPwa(
+                createApplicationDependencies(), true, true);
+        taskWithPwa.execute();
+
+        ObjectNode pkgJsonWithPwa = getOrCreatePackageJson();
+        String hashWithWorkboxOverrides = pkgJsonWithPwa.get(VAADIN_DEP_KEY)
+                .get("hash").textValue();
+
+        Assert.assertNotEquals(
+                "Hash should be different when workbox overrides are added",
+                hashWithoutWorkboxOverrides, hashWithWorkboxOverrides);
+
+        // Verify flattened overrides exist
+        Assert.assertTrue(pkgJsonWithPwa.has(PNPM));
+        Assert.assertTrue(pkgJsonWithPwa.get(PNPM).has(OVERRIDES));
+        Assert.assertTrue("Flattened workbox override should be present",
+                pkgJsonWithPwa.get(PNPM).get(OVERRIDES)
+                        .has("workbox-build>serialize-javascript"));
+    }
+
+    @Test
+    public void pwaOfflineEnabled_npmToPnpmTransition_workboxOverridesFlattened()
+            throws IOException {
+        // Create initial package.json in npm mode
+        createBasicVaadinVersionsJson();
+        TaskUpdatePackages task = createTaskWithPwa(
+                createApplicationDependencies(), false, true);
+        task.execute();
+
+        // Add user nested override (npm format)
+        ObjectNode pkgJson = getOrCreatePackageJson();
+        ((ObjectNode) pkgJson.get(OVERRIDES)).set("user-nested", JacksonUtils
+                .createObjectNode().put(".", "1.0").put("dep", "2.0"));
+        FileUtils.writeStringToFile(packageJson, pkgJson.toPrettyString(),
+                StandardCharsets.UTF_8);
+
+        // Run update in pnpm mode
+        task = createTaskWithPwa(createApplicationDependencies(), true, true);
+        task.execute();
+
+        pkgJson = getOrCreatePackageJson();
+
+        // Verify npm-style overrides are NOT at root level
+        Assert.assertFalse(
+                "npm overrides should not exist at root when pnpm is enabled",
+                pkgJson.has(OVERRIDES));
+
+        // Verify pnpm.overrides section exists
+        Assert.assertTrue("pnpm section should exist", pkgJson.has(PNPM));
+        JsonNode pnpm = pkgJson.get(PNPM);
+        Assert.assertTrue("pnpm.overrides should exist", pnpm.has(OVERRIDES));
+        JsonNode overrides = pnpm.get(OVERRIDES);
+
+        // Verify workbox-build nested overrides are flattened with > separator
+        Assert.assertTrue(
+                "Flattened workbox-build>serialize-javascript should be present",
+                overrides.has("workbox-build>serialize-javascript"));
+        Assert.assertTrue(
+                "Flattened workbox-build>@rollup/plugin-terser should be present",
+                overrides.has("workbox-build>@rollup/plugin-terser"));
+        Assert.assertTrue("Flattened workbox-build>glob should be present",
+                overrides.has("workbox-build>glob"));
+
+        // Verify user overrides are converted to pnpm format
+        Assert.assertTrue("Flattened user-nested should be present",
+                overrides.has("user-nested"));
+        Assert.assertTrue("Flattened user-nested>dep should be present",
+                overrides.has("user-nested>dep"));
+
+        // Verify the values are strings, not nested objects
+        Assert.assertTrue("Flattened override should be a string value",
+                overrides.get("workbox-build>serialize-javascript")
+                        .isTextual());
+
+        // Verify nested object form does NOT exist
+        Assert.assertFalse(
+                "Nested object workbox-build should not exist in pnpm overrides",
+                overrides.has("workbox-build"));
+    }
+
+    @Test
+    public void pwaOfflineEnabled_pnpmToNpmTransition_workboxOverridesFlattened()
+            throws IOException {
+        // Create initial package.json in pnpm mode
+        createBasicVaadinVersionsJson();
+        TaskUpdatePackages task = createTaskWithPwa(
+                createApplicationDependencies(), true, true);
+        task.execute();
+
+        // Add user nested override (pnpm format)
+        ObjectNode pkgJson = getOrCreatePackageJson();
+        ((ObjectNode) pkgJson.get(PNPM).get(OVERRIDES))
+                .put("user-nested", "1.0").put("user-nested>dep", "2.0")
+                .put("user-nested-reverse>dep", "3.0")
+                .put("user-nested-reverse", "4.0");
+        FileUtils.writeStringToFile(packageJson, pkgJson.toPrettyString(),
+                StandardCharsets.UTF_8);
+
+        // Run update in npm mode
+        task = createTaskWithPwa(createApplicationDependencies(), false, true);
+        task.execute();
+
+        pkgJson = getOrCreatePackageJson();
+        Assert.assertTrue("overrides section should exist",
+                pkgJson.has(OVERRIDES));
+        JsonNode overrides = pkgJson.get(OVERRIDES);
+
+        // Verify workbox-build nested object override is present
+        Assert.assertTrue(
+                "workbox-build override should be added when PWA offline is enabled",
+                overrides.has("workbox-build"));
+        JsonNode workboxBuildOverride = overrides.get("workbox-build");
+        Assert.assertTrue("workbox-build override should be a nested object",
+                workboxBuildOverride.isObject());
+        Assert.assertTrue(
+                "workbox-build override should contain serialize-javascript",
+                workboxBuildOverride.has("serialize-javascript"));
+
+        // Verify user overrides are converted to npm format
+        JsonNode nestedOverride = overrides.get("user-nested");
+        Assert.assertNotNull("user-nested override should be present",
+                nestedOverride);
+        Assert.assertTrue("user-nested override should be an object",
+                nestedOverride.isObject());
+        Assert.assertTrue("user-nested override should have a version",
+                nestedOverride.has("."));
+        Assert.assertTrue("user-nested>dep override should have a version",
+                nestedOverride.has("dep"));
+        JsonNode nestedReverse = overrides.get("user-nested-reverse");
+        Assert.assertNotNull("user-nested-reverse override should be present",
+                nestedReverse);
+        Assert.assertTrue("user-nested-reverse override should be an object",
+                nestedReverse.isObject());
+        Assert.assertTrue("user-nested-reverse override should have a version",
+                nestedReverse.has("."));
+        Assert.assertTrue(
+                "user-nested-reverse>dep override should have a version",
+                nestedReverse.has("dep"));
+
+        // Verify pnpm.overrides was removed
+        Assert.assertFalse(pkgJson.has(PNPM));
+    }
+
+    private TaskUpdatePackages createTaskWithPwa(
+            Map<String, String> applicationDependencies, boolean enablePnpm,
+            boolean pwaOfflineEnabled) {
+        final FrontendDependencies frontendDependenciesScanner = Mockito
+                .mock(FrontendDependencies.class);
+        Mockito.when(frontendDependenciesScanner.getPackages())
+                .thenReturn(applicationDependencies);
+
+        PwaConfiguration pwaConfig = Mockito.mock(PwaConfiguration.class);
+        Mockito.when(pwaConfig.isOfflineEnabled())
+                .thenReturn(pwaOfflineEnabled);
+        Mockito.when(frontendDependenciesScanner.getPwaConfiguration())
+                .thenReturn(pwaConfig);
+
+        // Use a real ClassFinder to access workbox resources from flow-server
+        ClassFinder realFinder = new ClassFinder.DefaultClassFinder(
+                this.getClass().getClassLoader());
+
+        Options options = new MockOptions(realFinder, npmFolder)
+                .withBuildDirectory(TARGET).withEnablePnpm(enablePnpm)
+                .withBundleBuild(true).withReact(false)
+                .withFrontendDependenciesScanner(frontendDependenciesScanner);
+
+        return new TaskUpdatePackages(options) {
+        };
     }
 
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateViteTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateViteTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.flow.server.frontend;
 
 import java.io.File;
@@ -19,6 +34,7 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.server.PwaConfiguration;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
+import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 import com.vaadin.tests.util.MockOptions;
 
 import elemental.json.Json;
@@ -39,7 +55,8 @@ public class TaskUpdateViteTest {
         finder = Mockito.spy(new ClassFinder.DefaultClassFinder(
                 this.getClass().getClassLoader()));
         options = new MockOptions(finder, temporaryFolder.getRoot())
-                .withBuildDirectory("build");
+                .withBuildDirectory("build").withFrontendDependenciesScanner(
+                        Mockito.mock(FrontendDependenciesScanner.class));
     }
 
     @Test
@@ -219,5 +236,76 @@ public class TaskUpdateViteTest {
                 "Extra frontend extensions should be added to vite configuration, but was not.",
                 "'.js', '.js.map', '.ts', '.ts.map', '.tsx', '.tsx.map', '.css', '.css.map'",
                 matcher.group(1));
+    }
+
+    @Test
+    public void generatedTemplate_pwaOfflineEnabled_serviceWorkerPluginIncluded()
+            throws IOException {
+        PwaConfiguration pwaConfig = Mockito.mock(PwaConfiguration.class);
+        Mockito.when(pwaConfig.isOfflineEnabled()).thenReturn(true);
+        final FrontendDependenciesScanner frontendDeps = options
+                .getFrontendDependenciesScanner();
+        Mockito.when(frontendDeps.getPwaConfiguration()).thenReturn(pwaConfig);
+
+        TaskUpdateVite task = new TaskUpdateVite(options, null);
+        task.execute();
+
+        File configFile = new File(temporaryFolder.getRoot(),
+                FrontendUtils.VITE_GENERATED_CONFIG);
+        String template = IOUtils.toString(configFile.toURI(),
+                StandardCharsets.UTF_8);
+
+        Assert.assertTrue(
+                "serviceWorkerPlugin import should be included when PWA offline is enabled",
+                template.contains(
+                        "import serviceWorkerPlugin from './build/plugins/vite-plugin-service-worker'"));
+        Assert.assertTrue(
+                "serviceWorkerPlugin should be used when PWA offline is enabled",
+                template.contains(
+                        "serviceWorkerPlugin({ srcPath: settings.clientServiceWorkerSource }),"));
+    }
+
+    @Test
+    public void generatedTemplate_pwaOfflineDisabled_serviceWorkerPluginNotIncluded()
+            throws IOException {
+        PwaConfiguration pwaConfig = Mockito.mock(PwaConfiguration.class);
+        Mockito.when(pwaConfig.isOfflineEnabled()).thenReturn(false);
+        final FrontendDependenciesScanner frontendDeps = options
+                .getFrontendDependenciesScanner();
+        Mockito.when(frontendDeps.getPwaConfiguration()).thenReturn(pwaConfig);
+
+        TaskUpdateVite task = new TaskUpdateVite(options, null);
+        task.execute();
+
+        File configFile = new File(temporaryFolder.getRoot(),
+                FrontendUtils.VITE_GENERATED_CONFIG);
+        String template = IOUtils.toString(configFile.toURI(),
+                StandardCharsets.UTF_8);
+
+        Assert.assertFalse(
+                "serviceWorkerPlugin import should not be included when PWA offline is disabled",
+                template.contains("import serviceWorkerPlugin from"));
+        Assert.assertFalse(
+                "serviceWorkerPlugin should not be used when PWA offline is disabled",
+                template.contains("serviceWorkerPlugin("));
+    }
+
+    @Test
+    public void generatedTemplate_pwaNull_serviceWorkerPluginNotIncluded()
+            throws IOException {
+        TaskUpdateVite task = new TaskUpdateVite(options, null);
+        task.execute();
+
+        File configFile = new File(temporaryFolder.getRoot(),
+                FrontendUtils.VITE_GENERATED_CONFIG);
+        String template = IOUtils.toString(configFile.toURI(),
+                StandardCharsets.UTF_8);
+
+        Assert.assertFalse(
+                "serviceWorkerPlugin import should not be included when PWA is null",
+                template.contains("import serviceWorkerPlugin from"));
+        Assert.assertFalse(
+                "serviceWorkerPlugin should not be used when PWA is null",
+                template.contains("serviceWorkerPlugin("));
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/UpdateImportsWithByteCodeScannerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/UpdateImportsWithByteCodeScannerTest.java
@@ -134,7 +134,8 @@ public class UpdateImportsWithByteCodeScannerTest
 
         createExpectedLazyImports();
         ClassFinder classFinder = getClassFinder(testClasses);
-        updater = new UpdateImports(getScanner(classFinder), options);
+        updater = new UpdateImports(options
+                .withFrontendDependenciesScanner(getScanner(classFinder)));
         updater.run();
 
         Map<File, List<String>> output = updater.getOutput();
@@ -172,7 +173,8 @@ public class UpdateImportsWithByteCodeScannerTest
 
         createExpectedLazyImports();
         ClassFinder classFinder = getClassFinder(testClasses);
-        updater = new UpdateImports(getScanner(classFinder), options);
+        updater = new UpdateImports(options
+                .withFrontendDependenciesScanner(getScanner(classFinder)));
         updater.run();
 
         Map<File, List<String>> output = updater.getOutput();
@@ -231,7 +233,8 @@ public class UpdateImportsWithByteCodeScannerTest
                 LazyAppConf.class, UI.class };
 
         ClassFinder classFinder = getClassFinder(testClasses);
-        updater = new UpdateImports(getScanner(classFinder), options);
+        updater = new UpdateImports(options
+                .withFrontendDependenciesScanner(getScanner(classFinder)));
         updater.run();
 
         Map<File, List<String>> output = updater.getOutput();
@@ -264,7 +267,8 @@ public class UpdateImportsWithByteCodeScannerTest
                 LazyAppConf.class, UI.class };
 
         ClassFinder classFinder = getClassFinder(testClasses);
-        updater = new UpdateImports(getScanner(classFinder), options);
+        updater = new UpdateImports(options
+                .withFrontendDependenciesScanner(getScanner(classFinder)));
         updater.run();
 
         Map<File, List<String>> output = updater.getOutput();
@@ -297,7 +301,8 @@ public class UpdateImportsWithByteCodeScannerTest
     public void cssInLazyChunkWorks() throws Exception {
         Class<?>[] testClasses = { FooCssImport.class, UI.class };
         ClassFinder classFinder = getClassFinder(testClasses);
-        updater = new UpdateImports(getScanner(classFinder), options);
+        updater = new UpdateImports(options
+                .withFrontendDependenciesScanner(getScanner(classFinder)));
         updater.run();
 
         Map<File, List<String>> output = updater.getOutput();
@@ -379,7 +384,8 @@ public class UpdateImportsWithByteCodeScannerTest
                 OtherView.class, UI.class };
 
         ClassFinder classFinder = getClassFinder(testClasses);
-        updater = new UpdateImports(getScanner(classFinder), options);
+        updater = new UpdateImports(options
+                .withFrontendDependenciesScanner(getScanner(classFinder)));
         updater.run();
 
         Map<File, List<String>> output = updater.getOutput();
@@ -405,7 +411,8 @@ public class UpdateImportsWithByteCodeScannerTest
         Class<?>[] testClasses = { OtherView.class, CloneView.class };
 
         ClassFinder classFinder = getClassFinder(testClasses);
-        updater = new UpdateImports(getScanner(classFinder), options);
+        updater = new UpdateImports(options
+                .withFrontendDependenciesScanner(getScanner(classFinder)));
         updater.run();
 
         Map<File, List<String>> output = updater.getOutput();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/UpdateThemedImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/UpdateThemedImportsTest.java
@@ -144,8 +144,9 @@ public class UpdateThemedImportsTest extends NodeUpdateTestUtil {
         };
         Options options = new MockOptions(finder, tmpRoot)
                 .withFrontendDirectory(frontendDirectory)
-                .withBuildDirectory(TARGET).withProductionMode(true);
-        updater = new TaskUpdateImports(deps, options);
+                .withBuildDirectory(TARGET).withProductionMode(true)
+                .withFrontendDependenciesScanner(deps);
+        updater = new TaskUpdateImports(options);
     }
 
     @Test


### PR DESCRIPTION
- Add PwaConfiguration parameter to TaskUpdateVite constructor
- Remove service worker plugin and its imports from vite.generated.ts when offline build is not enabled
- Use FrontendDependenciesScanner in TaskGeneratePackageJson to generate correct dev dependencies
- Enhance TaskUpdatePackages for proper override handling
- Move all workbox dependencies to `workbox/package.json` and only add when offline sw build is needed
- Add overrides for workbox dependencies to package.json
- Add overrides support to NodeUpdater
- Remove empty vaadin.overrides from package.json

(cherry picked from commit 90eb19644b831fbed80c30919908150d418b7d3f)
