### PR TITLE
docs: Split design guidance out of CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ React support).
 **Core Server Framework (`flow-server/`)**:
 - Component system with server-side state management (`StateNode`, `StateTree`)
 - DOM abstraction layer (`Element`, `Node`) that syncs with client-side
-- JavaScript execution bridge (`JacksonCodec`, `JsonCodec`) for seamless
+- JavaScript execution bridge (`JacksonCodec`) for seamless
   client-server communication
 - Routing system (`Router`, `RouteConfiguration`) with navigation lifecycle
 - Dependency injection and instantiation (`Instantiator`, `Lookup`)
@@ -126,8 +126,8 @@ cd flow-client && npm install && npm run build
 
 ### JavaScript Execution and JSON Codec
 
-The `JacksonCodec` and `JsonCodec` classes handle serialization between
-Java and JavaScript:
+The `JacksonCodec` class handles serialization between Java and
+JavaScript:
 
 - Parameters: Java objects → JSON → JavaScript variables (`$0`, `$1`, etc.)
 - Return values: JavaScript objects → JSON → Java beans

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,26 +1,41 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code (claude.ai/code) when working with
+code in this repository.
+
+For guidance on **designing a new feature** (API shape, browser-API wrapping,
+signals, lifecycle, nullability, DOM events, bootstrap flow, Javadoc
+expectations), see [DESIGN_GUIDELINES.md](DESIGN_GUIDELINES.md). This file
+covers the operational side: repo structure, build commands, test workflow,
+coding conventions, and general coding rules that apply to all changes.
 
 ## Repository Overview
 
-Vaadin Flow is the Java framework of Vaadin Platform for building modern web applications. This is a large, multi-module Maven project that combines server-side Java components with modern frontend tooling (Vite, TypeScript, React support).
+Vaadin Flow is the Java framework of Vaadin Platform for building modern
+web applications. This is a large, multi-module Maven project that combines
+server-side Java components with modern frontend tooling (Vite, TypeScript,
+React support).
 
 ### Key Architecture Components
 
 **Core Server Framework (`flow-server/`)**:
 - Component system with server-side state management (`StateNode`, `StateTree`)
 - DOM abstraction layer (`Element`, `Node`) that syncs with client-side
-- JavaScript execution bridge (`JacksonCodec`, `JsonCodec`) for seamless client-server communication
+- JavaScript execution bridge (`JacksonCodec`, `JsonCodec`) for seamless
+  client-server communication
 - Routing system (`Router`, `RouteConfiguration`) with navigation lifecycle
 - Dependency injection and instantiation (`Instantiator`, `Lookup`)
 - Frontend asset management and bundling
 
 **Client-Server Communication**:
-- Uses Jackson for JSON serialization/deserialization between Java objects and JavaScript
-- `executeJs()` methods allow calling JavaScript from server with automatic parameter serialization
-- Return values from JavaScript can be automatically deserialized into Java beans
-- WebSocket-based push communication (`PushConnection`, `AtmospherePushConnection`)
+- Uses Jackson for JSON serialization/deserialization between Java objects
+  and JavaScript
+- `executeJs()` methods allow calling JavaScript from server with automatic
+  parameter serialization
+- Return values from JavaScript can be automatically deserialized into
+  Java beans
+- WebSocket-based push communication (`PushConnection`,
+  `AtmospherePushConnection`)
 
 **Frontend Build System**:
 - Vite-based development mode with hot reload
@@ -86,13 +101,6 @@ mvn spotless:check
 mvn checkstyle:check
 ```
 
-### Coding Conventions
-
-- Use triple quotes (`"""`) for multi-line string blocks in Java text blocks
-- **When tests fail, code doesn't compile, or similar issues occur: Always analyze why first, do not start rewriting code**
-- **When writing code, names and comments should describe how the code works and why, not what has changed from previous versions. Commit messages capture change information, not the code itself.**
-- **Always create proper tests for what should work first. If the tests expose problems in the implementation, fix the implementation after the tests have been created.**
-
 ### Frontend Development
 
 ```bash
@@ -102,16 +110,33 @@ mvn checkstyle:check
 cd flow-client && npm install && npm run build
 ```
 
+## Coding Conventions
+
+- Use triple quotes (`"""`) for multi-line string blocks in Java text blocks.
+- **When tests fail, code doesn't compile, or similar issues occur: Always
+  analyze why first. Do not start rewriting code.**
+- **When writing code, names and comments should describe how the code works
+  and why, not what has changed from previous versions. Commit messages
+  capture change information, not the code itself.**
+- **Always create proper tests for what should work first. If the tests
+  expose problems in the implementation, fix the implementation after the
+  tests have been created.**
+
 ## Working with Key Components
 
 ### JavaScript Execution and JSON Codec
 
-The `JacksonCodec` and `JsonCodec` classes handle serialization between Java and JavaScript:
+The `JacksonCodec` and `JsonCodec` classes handle serialization between
+Java and JavaScript:
 
 - Parameters: Java objects → JSON → JavaScript variables (`$0`, `$1`, etc.)
 - Return values: JavaScript objects → JSON → Java beans
 - Special handling for `Element` instances (sent as DOM references)
 - Support for arbitrary objects via Jackson serialization
+
+When calling `executeJs()`, always pass values as parameters (`$0`, `$1`,
+...) — never concatenate them into the expression string. See
+[DESIGN_GUIDELINES.md](DESIGN_GUIDELINES.md) for the full rules.
 
 ### State Management
 
@@ -133,16 +158,17 @@ Components extend `Component` and use:
 
 **Unit Tests**: Located in `src/test/java/` in each module
 - Use JUnit 4/5
-- Mock heavy use of Mockito
+- Heavy use of Mockito for mocks
 - Focus on individual class behavior
 
 **Integration Tests**: Located in `flow-tests/`
 - Use TestBench for browser automation
 - Test full client-server interaction
 - Require running application server
-- **When an IT fails: Use Playwright to debug the browser behavior and understand what's actually happening in the UI**
+- **When an IT fails: Use Playwright to debug the browser behavior and
+  understand what's actually happening in the UI.**
 
-### Common Patterns
+## Common Patterns
 
 **Test Improvements**: When improving tests, focus on:
 - Verifying actual behavior rather than just "not null"
@@ -166,19 +192,15 @@ Components extend `Component` and use:
 - Spring Boot 4 integration available
 - Hot reload available in development mode
 - Extensive CI/CD pipeline with multiple test configurations
-- When sending data to executeJS, always pass it as parameters and use $1,$2 etc and never concatenate strings
-- When creating a commit that will resolve an issue in the same repository, add "Fixes #issuenumber" to the commit message
-- When creating a PR, mark it as a draft on GitHub and remind the user about reviewing the code themselves and marking the PR ready
-- Don't add @since to javadocs
+- When creating a commit that will resolve an issue in the same repository,
+  add "Fixes #issuenumber" to the commit message
+- When creating a PR, mark it as a draft on GitHub and remind the user
+  about reviewing the code themselves and marking the PR ready
+- Don't add `@since` to javadocs
 - When adding unit tests, add only the essential ones and not more than that
-- Use test: instead of fix: when fixing only tests
-- Prefix custom DOM events with `vaadin-` (e.g. `vaadin-component-resize` instead of `component-resize`)
-- Always write even slightly complex JavaScript into a separate `.js` file rather than inlining it in Java strings. Use `@JsModule` on `UI.java` to load the file from `META-INF/frontend/`
-- Store global JavaScript state and functions on `window.Vaadin.Flow` (e.g. `window.Vaadin.Flow.componentSizeObserver`). Use annotations on the UI class for global scripts
-- Supported browsers — only write client code targeting these, and do not add fallbacks or polyfills for anything else:
-  - Chrome (evergreen)
-  - Firefox (evergreen)
-  - Firefox Extended Support Release (ESR)
-  - Safari 17 or newer (latest minor version in each major series)
-  - Edge (Chromium, evergreen)
-- Javadoc for any Java API that wraps a browser/JS API must be written for Java developers who do not know the underlying JS API. Explain what the method does in Java terms, when to call it, what the parameters and return value mean, threading/lifecycle expectations, and any browser-specific caveats (e.g. "Safari always returns UNKNOWN"). Do not assume the reader will read the W3C spec or the `.ts` source.
+- Use `test:` instead of `fix:` when fixing only tests
+
+See [DESIGN_GUIDELINES.md](DESIGN_GUIDELINES.md) for design-level guidance
+(API shape, signals, sealed types, DOM event naming, browser-wrapping
+conventions, supported browsers, bootstrap data flow, Javadoc for wrapped
+browser APIs).

--- a/DESIGN_GUIDELINES.md
+++ b/DESIGN_GUIDELINES.md
@@ -31,6 +31,35 @@ holds `private final UI ui`, and all `executeJs` calls go through
 `ui.getElement()` or `ui.getPage()`. Follow the `Page` / `History`
 pattern. Enforce single-instance creation in the constructor if needed.
 
+If the facade hands out a stateful handle (e.g. `Geolocation.track()`
+returning a `GeolocationTracker`), make the handle's constructor
+**package-private** so application code cannot bypass the facade.
+
+### Keep internal mutators off user-facing classes
+
+When the framework needs to write a value that the application is meant
+to read, don't hang the setter on the class users already use for reads
+— even if it's annotated "for framework use only". Put the read surface
+on the user-facing class or facade and the write surface on
+`UIInternals` (or equivalent internal-only class). Review feedback on
+this PR explicitly flagged the opposite shape as a DX hazard, and we
+moved `setGeolocationAvailability` from `ExtendedClientDetails` to
+`UIInternals` as a result.
+
+### Options records
+
+For tunable knobs (accuracy, timeout, cache age), prefer an immutable
+Java record over a long parameter list:
+
+- Public canonical constructor with `@Nullable` params and validation
+  (reject negative durations, etc.) — NullAway needs the canonical ctor
+  spelled out explicitly rather than the record-derived one.
+- Builder for ergonomics. Offer both `Duration` and `int`-ms overloads
+  on time-related setters where the wire format is ms; applications get
+  a fluent `Duration` API and the record stores the int.
+- Record stays serialisable — implement `Serializable` on the Builder
+  too if it's meant to be held in session state.
+
 ### Signals for reactive state
 
 Expose observable state as a `Signal<T>` rather than a listener API. Name
@@ -95,6 +124,12 @@ client-side subscriptions — must be tied to a component's lifecycle:
   detach-after-stop and double-stop are safe no-ops.
 - If the API supports resuming, reset observable state on resume so
   subscribers re-render with the correct initial value.
+- DOM listeners that must keep flowing while the UI is inert (e.g. a
+  modal is open over the view but position updates should still
+  accumulate) are registered with
+  `addEventListener(...).addEventDetail().allowInert()`. Use sparingly
+  — inert exists to prevent user actions while something else has
+  focus; only bypass it for passive streams.
 
 ## Browser / JavaScript integration
 
@@ -141,6 +176,10 @@ anything else:
   plan for that on both sides.
 - Return values from JS can be deserialised to Java records automatically;
   use a private record for the wire shape.
+- **Log `executeJs` client-side errors at `DEBUG`, not WARN/ERROR.** A
+  failed JS call usually means the feature is unavailable (user denied
+  permission, API missing, insecure context) — not a server bug. The
+  pattern is `.then(ok -> {}, err -> LOGGER.debug("X failed: {}", err))`.
 
 ### DOM event naming
 
@@ -150,6 +189,33 @@ anything else:
 - Event payloads travel as Jackson-annotated records. Keep the wire shape
   faithful to what the browser produces (e.g. `long timestamp` not
   `Instant`) and provide convenience accessors on the public type.
+
+### Server ↔ client signalling patterns
+
+For streaming and state-change wiring, keep DOM events as **transport**
+and `Signal` as **state**. Applications should subscribe to the signal;
+the DOM events are an implementation detail of the facade.
+
+- **Event-to-Signal bridging.** The client dispatches a
+  `vaadin-xxx-position` / `vaadin-xxx-error` CustomEvent per update; the
+  server-side facade has a DOM listener that pulls the detail record
+  and writes it to the private `ValueSignal`. Applications subscribe to
+  the signal.
+- **Client-initiated state-change bridge-back.** For state that changes
+  without a server-initiated request (permission change, network
+  online/offline, window resize), the client dispatches a
+  `vaadin-xxx-change` event on `document.body` (which is the UI's root
+  element on the server). The facade constructor registers a listener
+  on `ui.getElement()` and forwards the detail into the same
+  `UIInternals` signal the bootstrap path seeds. No polling required.
+- **Stable client-side keys for async browser handles.** When the
+  browser API returns an opaque id asynchronously (e.g.
+  `watchPosition()`), don't try to round-trip it back to the server to
+  later cancel. Pre-generate a UUID on the server, pass it as an
+  `executeJs` parameter, and have the client's wrapper store its own
+  `Map<key, browserId>`. Both sides then use the same key for
+  subsequent operations (`clearWatch(key)` on the client looks up the
+  browser-assigned id).
 
 ### Bootstrap-time data
 
@@ -164,6 +230,26 @@ round-trip:
   appropriate `UIInternals` field / signal.
 - The public Java signal picks up the value on UI attach — no
   additional round-trip required.
+
+### Feature-capability detection
+
+Probe for feature availability **without calling the feature itself**
+— calling it usually triggers a permission prompt, which defeats the
+point of probing. Useful primitives:
+
+- `window.isSecureContext` — HTTPS or `localhost`. Most sensitive
+  browser APIs require this.
+- `document.featurePolicy?.allowsFeature("xxx")` — Chromium-only;
+  Firefox and Safari don't expose a feature-policy introspection API.
+  Absence of the API should be treated as "allowed", not "unsupported".
+- `navigator.permissions.query({ name: "xxx" })` — returns a
+  `PermissionStatus` whose `.state` is `"granted" | "denied" |
+  "prompt"` and which also emits a `change` event. Safari may reject
+  with a TypeError for specific permission names; catch and fall back
+  to an `UNKNOWN` sentinel.
+- Expose the result to the server via the bootstrap param pattern
+  above, plus a `vaadin-xxx-availability-change` event for subsequent
+  changes.
 
 ## Documentation
 

--- a/DESIGN_GUIDELINES.md
+++ b/DESIGN_GUIDELINES.md
@@ -41,10 +41,9 @@ When the framework needs to write a value that the application is meant
 to read, don't hang the setter on the class users already use for reads
 — even if it's annotated "for framework use only". Put the read surface
 on the user-facing class or facade and the write surface on
-`UIInternals` (or equivalent internal-only class). Review feedback on
-this PR explicitly flagged the opposite shape as a DX hazard, and we
-moved `setGeolocationAvailability` from `ExtendedClientDetails` to
-`UIInternals` as a result.
+`UIInternals` (or equivalent internal-only class). The opposite shape
+is a DX hazard: for example, `setGeolocationAvailability` lives on
+`UIInternals`, not on the user-facing `ExtendedClientDetails`.
 
 ### Options records
 
@@ -295,11 +294,13 @@ point of probing. Useful primitives:
 - Keep the unit test count minimal — only the essential cases. More tests
   are not better; focused tests are.
 - For browser-facing features, add an IT view under
-  `flow-tests/test-root-context/` that mocks `navigator.geolocation` (or
-  the relevant browser API) and exercises both happy-path and error
-  branches. Use an option value to trigger errors deterministically
-  (e.g. `maximumAge === -1`). Use `setInterval` to simulate a stream of
-  updates, and verify that `clearWatch` actually stops them.
+  `flow-tests/test-root-context/` that mocks the relevant browser API
+  and exercises both happy-path and error branches. Use an option
+  value to trigger errors deterministically (for geolocation,
+  `maximumAge === -1` works). If the API streams updates (e.g.
+  `watchPosition`), use `setInterval` to simulate them and verify
+  that the matching cancel call (e.g. `clearWatch`) actually stops
+  them.
 - ITs assert concrete outputs, not just "not null". If floating-point
   arithmetic would make assertions brittle, simplify the mock to emit
   stable values (different timestamps suffice for uniqueness).
@@ -314,6 +315,6 @@ point of probing. Useful primitives:
 - When a commit resolves an issue in this repo, add `Fixes #issuenumber`
   to the message.
 - Use `test:` prefix for commits that only touch tests; `fix:` is for
-  production-code fixes.
+  production-code fixes; `feat:` is for new features.
 - When opening a PR, mark it as draft. Remind the author to self-review
   before marking it ready.

--- a/DESIGN_GUIDELINES.md
+++ b/DESIGN_GUIDELINES.md
@@ -155,14 +155,30 @@ anything else:
 
 ### JavaScript location and globals
 
-- **Non-trivial JS goes in its own `.js` or `.ts` file** under
-  `META-INF/frontend/` (Java side) or `flow-client/src/main/frontend/`
-  (client module), loaded via `@JsModule` on `UI.java`. Don't inline
-  anything beyond a one-liner in a Java string.
+- **Non-trivial JS goes in its own file**, never inlined beyond a
+  one-liner in a Java string. Two valid homes:
+  - `flow-client/src/main/frontend/Xxx.ts` imported from `Flow.ts`
+    (`import './Xxx';`). Use this for platform-level features that
+    need to be available before the bootstrap handshake (anything
+    referenced from `collectBrowserDetails`, anything that must attach
+    `document` / `window` listeners before the first user interaction).
+    Precedents: `Geolocation.ts`, `PageVisibility.ts`. Prefer TypeScript
+    here — new files should not be `.js`.
+  - `META-INF/frontend/xxx.js` loaded via `@JsModule("./xxx.js")` on
+    `UI.java` or a component. Use this when the script is tied to a
+    specific Java API surface and does not need to run at bootstrap
+    time.
 - **Global state and helper functions live under `window.Vaadin.Flow`**
   (e.g. `window.Vaadin.Flow.geolocation`,
+  `window.Vaadin.Flow.pageVisibility`,
   `window.Vaadin.Flow.componentSizeObserver`). Use annotations on
   `UI.java` for scripts that need to run globally.
+- **`init(element)` installers must be idempotent.** A facade may call
+  `window.Vaadin.Flow.xxx.init(this)` more than once per UI element
+  (lazy (re)arming from a signal accessor, navigation to a view that
+  re-subscribes, etc.). Track installations per element (WeakMap) and
+  dispose the previous set of listeners before attaching new ones so
+  the element never carries duplicates.
 
 ### `executeJs` parameter passing
 
@@ -225,11 +241,17 @@ round-trip:
 
 - Client collects the value in `collectBrowserDetails` (make that
   function async if needed) and appends it to the init request as a
-  `v-xxx` parameter.
+  `v-xxx` parameter. The TS that produces the value must be imported
+  from `Flow.ts` so it is loaded when `collectBrowserDetails` runs —
+  `@JsModule` on `UI.java` loads too late for this path.
 - Server reads it in `ExtendedClientDetails.fromJson` and seeds the
   appropriate `UIInternals` field / signal.
 - The public Java signal picks up the value on UI attach — no
   additional round-trip required.
+- Seed the server-side signal with a sentinel (`UNKNOWN`, `Pending`, …)
+  so the brief window between attach and handshake completion is
+  distinguishable from a genuine reading. Precedents:
+  `GeolocationAvailability.UNKNOWN`.
 
 ### Feature-capability detection
 

--- a/DESIGN_GUIDELINES.md
+++ b/DESIGN_GUIDELINES.md
@@ -1,0 +1,211 @@
+# DESIGN_GUIDELINES.md
+
+Guidance for designing new features in Vaadin Flow. Consult this before
+starting any non-trivial new API — especially anything that wraps a browser
+or JavaScript API, exposes observable state, or manages a resource with a
+lifecycle.
+
+For day-to-day commands, repo structure, and testing workflow, see
+[CLAUDE.md](CLAUDE.md).
+
+## Before you start
+
+- **Find the precedent.** Flow already has patterns for per-UI facades,
+  reactive signals, sealed result hierarchies, Jackson wire records, and
+  browser-API wrappers. Look at `Page`, `History`, `ExtendedClientDetails`,
+  `VaadinSession.localeSignal`, `window.Vaadin.Flow.*` helpers, etc. — match
+  the existing shape rather than inventing a new one.
+- **Understand the blast radius.** Changes to `StateNode`, `Element`, or the
+  codec layer ripple across the codebase. If your design needs to touch
+  them, plan for full test runs and a longer review cycle.
+- **Frontend ↔ server is a contract.** Any protocol or DOM-event change
+  needs both sides updated in the same PR.
+
+## API shape
+
+### Per-UI facades
+
+If a feature is UI-scoped (not session-scoped), expose it via
+`UI.getXxx()` returning a single instance created once per UI. The facade
+holds `private final UI ui`, and all `executeJs` calls go through
+`ui.getElement()` or `ui.getPage()`. Follow the `Page` / `History`
+pattern. Enforce single-instance creation in the constructor if needed.
+
+### Signals for reactive state
+
+Expose observable state as a `Signal<T>` rather than a listener API. Name
+accessors with a `Signal` suffix — `localeSignal()`, `availabilitySignal()`,
+`valueSignal()`, `activeSignal()` — so callers see the shape at the call
+site. Other precedents: `windowSizeSignal`, `validationStatusSignal`.
+
+- Back the signal with a private `ValueSignal<T>`; expose it as read-only
+  via `valueSignal.asReadonly()`.
+- Cache the read-only wrapper in a field so every call returns the same
+  instance. `asReadonly()` allocates a fresh lambda per call — identity is
+  unstable and allocations add up.
+- Seed the signal with a meaningful default, not `null`. If the initial
+  state is "no data yet", use a sentinel enum value (e.g. `UNKNOWN`) or a
+  dedicated record (e.g. `Pending`) that callers can handle in a normal
+  pattern match without a `case null` arm.
+- Inside a reactive context, callers use `.get()` (subscribes); outside,
+  they use `.peek()` (snapshot). Document this in the accessor's Javadoc.
+
+### Result types: sealed interfaces + pattern matching
+
+For values that are "one of N things" (position-or-error,
+pending-or-position-or-error), use a sealed hierarchy:
+
+```java
+public sealed interface Foo permits FooA, FooB, FooC {}
+```
+
+- Record subtypes are preferred over classes.
+- If the same values appear in two contexts with different permitted sets,
+  split into two sealed interfaces and let the narrower one `extends` and
+  `permits` a subset (see `GeolocationResult` vs `GeolocationOutcome`).
+  This lets a one-shot callback omit the "pending" arm that would be dead
+  there.
+- Exhaustive `switch` expressions over the sealed set are guaranteed
+  complete at compile time; design for that, don't add `default:` arms.
+
+### Nullability discipline
+
+- Apply `@NullMarked` at the package level (JSpecify). Only `@Nullable`
+  what genuinely may be null.
+- Prefer sentinel values over nullable returns in the public API
+  (`UNKNOWN` enum constant, `Pending` record).
+- Jackson wire records (the record used to decode `executeJs` return
+  values or DOM event payloads) are the legitimate exception — their
+  fields may be `@Nullable` because the wire format permits omissions.
+  Keep the wire record private and translate to a non-null public shape
+  at the boundary.
+- NullAway requires `@Nullable` on constructor type arguments for
+  nullable-parameterised signals:
+  `new ValueSignal<@Nullable X>(null)`.
+
+### Lifecycle and cleanup
+
+Resources that outlive a single request — watches, DOM listeners, timers,
+client-side subscriptions — must be tied to a component's lifecycle:
+
+- Accept a `Component owner` at construction.
+- Register a `DetachListener` that performs the cleanup.
+- Also expose an explicit `stop()` (or similar) for mid-view cancellation.
+- Make `stop()` idempotent — guard with an `active` flag or signal so
+  detach-after-stop and double-stop are safe no-ops.
+- If the API supports resuming, reset observable state on resume so
+  subscribers re-render with the correct initial value.
+
+## Browser / JavaScript integration
+
+### Wrap thin; document thick
+
+Java API wrapping a browser/JS API must be written for Java developers who
+do not know the underlying JS API. Explain: what the method does in Java
+terms; when to call it; what the parameters and return value mean;
+threading and lifecycle expectations; any browser-specific caveats
+(e.g. "Safari always returns UNKNOWN"). Do not assume the reader will
+read the W3C spec or the `.ts` source.
+
+### Supported browsers
+
+Only write client code targeting these. **No fallbacks, no polyfills** for
+anything else:
+
+- Chrome (evergreen)
+- Firefox (evergreen)
+- Firefox Extended Support Release (ESR)
+- Safari 17 or newer (latest minor version in each major series)
+- Edge (Chromium, evergreen)
+
+### JavaScript location and globals
+
+- **Non-trivial JS goes in its own `.js` or `.ts` file** under
+  `META-INF/frontend/` (Java side) or `flow-client/src/main/frontend/`
+  (client module), loaded via `@JsModule` on `UI.java`. Don't inline
+  anything beyond a one-liner in a Java string.
+- **Global state and helper functions live under `window.Vaadin.Flow`**
+  (e.g. `window.Vaadin.Flow.geolocation`,
+  `window.Vaadin.Flow.componentSizeObserver`). Use annotations on
+  `UI.java` for scripts that need to run globally.
+
+### `executeJs` parameter passing
+
+- **Never** concatenate values into the expression string. Always pass
+  them as parameters and reference them positionally (`$0`, `$1`, ...).
+  String concatenation is a prompt for injection bugs and quoting
+  nightmares.
+- **Never build JSON manually by string concatenation.** Use Jackson 3 for
+  construction.
+- Element parameters arrive on the client as DOM references (or `null`);
+  plan for that on both sides.
+- Return values from JS can be deserialised to Java records automatically;
+  use a private record for the wire shape.
+
+### DOM event naming
+
+- **Prefix custom DOM events with `vaadin-`** — e.g.
+  `vaadin-geolocation-position`, not `geolocation-position`. This keeps
+  the event namespace distinct and grepable.
+- Event payloads travel as Jackson-annotated records. Keep the wire shape
+  faithful to what the browser produces (e.g. `long timestamp` not
+  `Instant`) and provide convenience accessors on the public type.
+
+### Bootstrap-time data
+
+If a feature needs an initial value before the first user interaction,
+thread it through the bootstrap handshake rather than waiting for a
+round-trip:
+
+- Client collects the value in `collectBrowserDetails` (make that
+  function async if needed) and appends it to the init request as a
+  `v-xxx` parameter.
+- Server reads it in `ExtendedClientDetails.fromJson` and seeds the
+  appropriate `UIInternals` field / signal.
+- The public Java signal picks up the value on UI attach — no
+  additional round-trip required.
+
+## Documentation
+
+- Javadoc for public API explains the *why* and the caveats, not just the
+  type signature.
+- Call out reliability concerns prominently — if a value is best-effort,
+  say so, and enumerate the browsers where it degrades.
+- Prefer short, runnable examples in the class-level Javadoc. Keep
+  examples consistent with the real platform APIs (e.g. if you show
+  `map.setCenter(...)`, use the real Vaadin Map `Coordinate(longitude,
+  latitude)` shape).
+- **Do not add `@since` tags.**
+- Javadoc describes the code today, not what changed. Change history
+  belongs in commit messages.
+
+## Testing new features
+
+- **Write the tests that should pass first.** If they expose problems in
+  the implementation, fix the implementation afterwards — don't rewrite
+  the tests to match a broken implementation.
+- Keep the unit test count minimal — only the essential cases. More tests
+  are not better; focused tests are.
+- For browser-facing features, add an IT view under
+  `flow-tests/test-root-context/` that mocks `navigator.geolocation` (or
+  the relevant browser API) and exercises both happy-path and error
+  branches. Use an option value to trigger errors deterministically
+  (e.g. `maximumAge === -1`). Use `setInterval` to simulate a stream of
+  updates, and verify that `clearWatch` actually stops them.
+- ITs assert concrete outputs, not just "not null". If floating-point
+  arithmetic would make assertions brittle, simplify the mock to emit
+  stable values (different timestamps suffice for uniqueness).
+- Add a short settle pause before snapshotting counts after a
+  stop-like action — an in-flight event can still land right after the
+  stop marker appears in the DOM.
+- When an IT fails, debug with Playwright before guessing — see what the
+  browser is actually doing.
+
+## Commit / PR hygiene
+
+- When a commit resolves an issue in this repo, add `Fixes #issuenumber`
+  to the message.
+- Use `test:` prefix for commits that only touch tests; `fix:` is for
+  production-code fixes.
+- When opening a PR, mark it as draft. Remind the author to self-review
+  before marking it ready.


### PR DESCRIPTION
CLAUDE.md was mixing operational guidance (how to build/test, repo
structure, commit hygiene) with design rules (how to shape an API,
wrap a browser API, expose signals, model result types). The latter
grew out of the geolocation PR review cycle and is now long enough to
live on its own.

CLAUDE.md keeps build commands, coding conventions and component notes.
DESIGN_GUIDELINES.md collects the API-shape and browser-wrapping rules
plus patterns pulled from existing platform APIs (per-UI facades,
asReadonly signals, sealed hierarchies, bootstrap v-xxx params).
Each file links to the other at the top.


Cross-checked DESIGN_GUIDELINES.md against the Geolocation implementation
and review history. Added the decisions that were implicit before:

- Package-private constructor on facade-handed-out handles
  (GeolocationTracker).
- Keep framework-internal mutators on UIInternals, not on user-facing
  classes — documents why setGeolocationAvailability moved off
  ExtendedClientDetails.
- Options records pattern: canonical constructor with validation +
  Builder with Duration / int-ms overloads + Serializable.
- addEventDetail().allowInert() for DOM listeners that must keep
  streaming through inert states.
- Client-side executeJs errors log at DEBUG, not WARN — they usually
  mean the feature is unavailable, not a server bug.
- Server ↔ client signalling section covering event-to-Signal
  bridging, client-initiated bridge-back via vaadin-xxx-change on
  document.body, and stable server-generated UUID keys for async
  browser handles like watchPosition.
- Feature-capability detection without triggering prompts via
  isSecureContext / featurePolicy / navigator.permissions.query.
