### PR TITLE
chore: upgrade license-maven-plugin to 2.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -528,7 +528,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>license-maven-plugin</artifactId>
-          <version>2.7.0</version>
+          <version>2.7.1</version>
           <configuration>
             <!-- Default is system -->
             <excludedScopes>system,test</excludedScopes>


### PR DESCRIPTION
this has been done in main and 25.1 branches. 
