### PR TITLE
feat: add support for accepting hidden fields in Binder (#24139)(CP: 25.0)

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -1841,9 +1841,13 @@ public class Binder<BEAN> implements Serializable {
         }
 
         public SerializablePredicate<Binding<BEAN, TARGET>> getIsAppliedPredicate() {
-            return isAppliedPredicate == null
-                    ? Binding.super.getIsAppliedPredicate()
-                    : isAppliedPredicate;
+            if (isAppliedPredicate != null) {
+                return isAppliedPredicate;
+            }
+            if (getBinder().isApplyBindingsToHiddenFields()) {
+                return binding -> true;
+            }
+            return Binding.super.getIsAppliedPredicate();
         }
 
         @Override
@@ -1975,6 +1979,8 @@ public class Binder<BEAN> implements Serializable {
     private boolean defaultValidatorsEnabled = true;
 
     private boolean changeDetectionEnabled = false;
+
+    private boolean applyBindingsToHiddenFields = false;
 
     /**
      * Creates a binder using a custom {@link PropertySet} implementation for
@@ -4119,6 +4125,40 @@ public class Binder<BEAN> implements Serializable {
      */
     public boolean isValidatorsDisabled() {
         return validatorsDisabled;
+    }
+
+    /**
+     * Sets whether all bindings of this Binder should be applied to fields that
+     * are not currently visible. By default, bindings whose field is a
+     * {@link Component} with {@link Component#isVisible()} returning
+     * {@literal false} are skipped during validation and when writing values to
+     * the bean. Enabling this setting restores the pre-Vaadin 25 behavior where
+     * hidden fields are validated and written just like visible ones.
+     * <p>
+     * This is a Binder-level fallback: any binding that has its own predicate
+     * set via {@link Binding#setIsAppliedPredicate(SerializablePredicate)}
+     * continues to use that predicate and is not affected by this flag.
+     * <p>
+     * Defaults to {@literal false}.
+     *
+     * @param applyBindingsToHiddenFields
+     *            {@literal true} to make all bindings apply to hidden fields,
+     *            {@literal false} to skip hidden fields (the default)
+     */
+    public void setApplyBindingsToHiddenFields(
+            boolean applyBindingsToHiddenFields) {
+        this.applyBindingsToHiddenFields = applyBindingsToHiddenFields;
+    }
+
+    /**
+     * Returns whether all bindings of this Binder apply to fields that are not
+     * currently visible.
+     *
+     * @return {@literal true} if bindings are applied to hidden fields,
+     *         {@literal false} if hidden fields are skipped (the default)
+     */
+    public boolean isApplyBindingsToHiddenFields() {
+        return applyBindingsToHiddenFields;
     }
 
     /**

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -973,6 +973,71 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
     }
 
     @Test
+    public void setApplyBindingsToHiddenFields_defaultsToFalse_appliesToHiddenFieldsWhenEnabled() {
+        Binding<Person, String> nameBinding = binder.forField(nameField)
+                .withValidator(name -> false, "")
+                .bind(Person::getFirstName, Person::setFirstName);
+        binder.setBean(item);
+
+        assertFalse(binder.isApplyBindingsToHiddenFields());
+
+        ((Component) nameBinding.getField()).setVisible(false);
+        assertTrue("Hidden field should be skipped by default",
+                binder.isValid());
+
+        binder.setApplyBindingsToHiddenFields(true);
+        assertFalse(
+                "Hidden field should be validated when applyBindingsToHiddenFields is true",
+                binder.isValid());
+
+        nameBinding.setIsAppliedPredicate(p -> false);
+        assertTrue(
+                "Per-binding predicate should override Binder-level applyBindingsToHiddenFields",
+                binder.isValid());
+    }
+
+    @Test
+    public void writeBean_applyBindingsToHiddenFields_writesHiddenFieldsWhenEnabled()
+            throws ValidationException {
+        Binding<Person, String> nameBinding = binder.forField(nameField)
+                .bind(Person::getFirstName, Person::setFirstName);
+        binder.readBean(item);
+
+        nameField.setValue("NewName");
+        ((Component) nameBinding.getField()).setVisible(false);
+
+        binder.writeBean(item);
+        assertEquals("Hidden field should not be written by default",
+                "Johannes", item.getFirstName());
+
+        binder.setApplyBindingsToHiddenFields(true);
+        binder.writeBean(item);
+        assertEquals(
+                "Hidden field should be written when applyBindingsToHiddenFields is true",
+                "NewName", item.getFirstName());
+    }
+
+    @Test
+    public void writeBeanIfValid_applyBindingsToHiddenFields_writesHiddenFieldsWhenEnabled() {
+        Binding<Person, String> nameBinding = binder.forField(nameField)
+                .bind(Person::getFirstName, Person::setFirstName);
+        binder.readBean(item);
+
+        nameField.setValue("NewName");
+        ((Component) nameBinding.getField()).setVisible(false);
+
+        assertTrue(binder.writeBeanIfValid(item));
+        assertEquals("Hidden field should not be written by default",
+                "Johannes", item.getFirstName());
+
+        binder.setApplyBindingsToHiddenFields(true);
+        assertTrue(binder.writeBeanIfValid(item));
+        assertEquals(
+                "Hidden field should be written when applyBindingsToHiddenFields is true",
+                "NewName", item.getFirstName());
+    }
+
+    @Test
     public void writeBean_isAppliedIsEvaluated() {
         AtomicInteger invokes = new AtomicInteger();
 


### PR DESCRIPTION
Adds setAcceptHiddenFields(boolean) to Binder.
setAcceptHiddenFields(true) makes Binder apply bindings for hidden fields by default in same way as with pre-Vaadin 25.

PartOf: #24109
