### PR TITLE
feat: add GeolocationClient port for external test drivers

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/geolocation/BrowserGeolocationClient.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/geolocation/BrowserGeolocationClient.java
@@ -61,17 +61,12 @@ final class BrowserGeolocationClient implements GeolocationClient {
     private final UI ui;
     private final List<SerializableConsumer<GeolocationAvailability>> availabilityListeners = new ArrayList<>();
     private final DomListenerRegistration availabilityChangeRegistration;
-    private GeolocationAvailability currentAvailability = GeolocationAvailability.UNKNOWN;
+    private GeolocationAvailability currentAvailability;
     private boolean closed;
 
-    BrowserGeolocationClient(UI ui) {
+    BrowserGeolocationClient(UI ui, GeolocationAvailability seed) {
         this.ui = ui;
-        // Seed availability from bootstrap if it has been populated.
-        GeolocationAvailability seeded = ui.getInternals()
-                .getGeolocationAvailabilitySignal().peek();
-        if (seeded != null) {
-            currentAvailability = seeded;
-        }
+        this.currentAvailability = seed;
         availabilityChangeRegistration = ui.getElement()
                 .addEventListener("vaadin-geolocation-availability-change",
                         e -> updateAvailability(

--- a/flow-server/src/main/java/com/vaadin/flow/component/geolocation/BrowserGeolocationClient.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/geolocation/BrowserGeolocationClient.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.geolocation;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.dom.DomListenerRegistration;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.shared.Registration;
+
+/**
+ * {@link GeolocationClient} implementation backed by the real browser
+ * Geolocation API via {@code window.Vaadin.Flow.geolocation} and DOM events.
+ * This is the default implementation injected at facade construction time;
+ * external browserless test drivers replace it via
+ * {@link Geolocation#setClient(GeolocationClient)}.
+ * <p>
+ * <b>Framework internal.</b> Application code does not reference this class
+ * directly.
+ */
+@NullMarked
+final class BrowserGeolocationClient implements GeolocationClient {
+
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(BrowserGeolocationClient.class);
+
+    private record GetResult(@Nullable GeolocationPosition position,
+            @Nullable GeolocationError error,
+            @Nullable String availability) implements Serializable {
+    }
+
+    private record AvailabilityDetail(
+            @Nullable String availability) implements Serializable {
+    }
+
+    private final UI ui;
+    private final List<SerializableConsumer<GeolocationAvailability>> availabilityListeners = new ArrayList<>();
+    private final DomListenerRegistration availabilityChangeRegistration;
+    private GeolocationAvailability currentAvailability = GeolocationAvailability.UNKNOWN;
+    private boolean closed;
+
+    BrowserGeolocationClient(UI ui) {
+        this.ui = ui;
+        // Seed availability from bootstrap if it has been populated.
+        GeolocationAvailability seeded = ui.getInternals()
+                .getGeolocationAvailabilitySignal().peek();
+        if (seeded != null) {
+            currentAvailability = seeded;
+        }
+        availabilityChangeRegistration = ui.getElement()
+                .addEventListener("vaadin-geolocation-availability-change",
+                        e -> updateAvailability(
+                                e.getEventDetail(AvailabilityDetail.class)
+                                        .availability()))
+                .addEventDetail().allowInert();
+    }
+
+    @Override
+    public CompletableFuture<GeolocationOutcome> get(
+            @Nullable GeolocationOptions options) {
+        CompletableFuture<GeolocationOutcome> future = new CompletableFuture<>();
+        ui.getElement()
+                .executeJs("return window.Vaadin.Flow.geolocation.get($0)",
+                        options)
+                .then(GetResult.class, result -> {
+                    updateAvailability(result.availability());
+                    if (result.position() != null) {
+                        future.complete(result.position());
+                    } else if (result.error() != null) {
+                        future.complete(result.error());
+                    } else {
+                        LOGGER.debug(
+                                "Geolocation get() returned neither position nor error");
+                    }
+                }, err -> LOGGER.debug("Client-side geolocation.get failed: {}",
+                        err));
+        return future;
+    }
+
+    @Override
+    public WatchHandle startWatch(Component owner,
+            @Nullable GeolocationOptions options,
+            SerializableConsumer<GeolocationResult> onUpdate) {
+        return new BrowserWatchHandle(owner, options, onUpdate);
+    }
+
+    @Override
+    public Registration subscribeAvailability(
+            SerializableConsumer<GeolocationAvailability> onChange) {
+        availabilityListeners.add(onChange);
+        return () -> availabilityListeners.remove(onChange);
+    }
+
+    @Override
+    public GeolocationAvailability currentAvailability() {
+        return currentAvailability;
+    }
+
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        availabilityChangeRegistration.remove();
+        availabilityListeners.clear();
+    }
+
+    private void updateAvailability(@Nullable String value) {
+        if (value == null) {
+            return;
+        }
+        GeolocationAvailability next;
+        try {
+            next = GeolocationAvailability.valueOf(value);
+        } catch (IllegalArgumentException ignored) {
+            return;
+        }
+        if (next == currentAvailability) {
+            return;
+        }
+        currentAvailability = next;
+        for (SerializableConsumer<GeolocationAvailability> listener : new ArrayList<>(
+                availabilityListeners)) {
+            listener.accept(next);
+        }
+    }
+
+    private final class BrowserWatchHandle implements WatchHandle {
+
+        private final String watchKey = UUID.randomUUID().toString();
+        private final Component owner;
+        private @Nullable DomListenerRegistration positionListener;
+        private @Nullable DomListenerRegistration errorListener;
+        private boolean active = true;
+
+        BrowserWatchHandle(Component owner,
+                @Nullable GeolocationOptions options,
+                SerializableConsumer<GeolocationResult> onUpdate) {
+            this.owner = owner;
+            Element el = owner.getElement();
+            positionListener = el
+                    .addEventListener("vaadin-geolocation-position",
+                            e -> onUpdate.accept(e
+                                    .getEventDetail(GeolocationPosition.class)))
+                    .addEventDetail().allowInert();
+            errorListener = el
+                    .addEventListener("vaadin-geolocation-error",
+                            e -> onUpdate.accept(
+                                    e.getEventDetail(GeolocationError.class)))
+                    .addEventDetail().allowInert();
+            el.executeJs("window.Vaadin.Flow.geolocation.watch(this, $0, $1)",
+                    options, watchKey).then(ignored -> {
+                    }, err -> LOGGER.debug(
+                            "Client-side geolocation.watch failed: {}", err));
+        }
+
+        @Override
+        public void stop() {
+            if (!active) {
+                return;
+            }
+            active = false;
+            if (positionListener != null) {
+                positionListener.remove();
+                positionListener = null;
+            }
+            if (errorListener != null) {
+                errorListener.remove();
+                errorListener = null;
+            }
+            ui.getPage()
+                    .executeJs("window.Vaadin.Flow.geolocation.clearWatch($0)",
+                            watchKey)
+                    .then(ignored -> {
+                    }, err -> LOGGER.debug(
+                            "Client-side geolocation.clearWatch failed: {}",
+                            err));
+        }
+
+        @Override
+        public boolean isActive() {
+            return active;
+        }
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/geolocation/BrowserGeolocationClient.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/geolocation/BrowserGeolocationClient.java
@@ -89,11 +89,11 @@ final class BrowserGeolocationClient implements GeolocationClient {
                     } else if (result.error() != null) {
                         future.complete(result.error());
                     } else {
-                        LOGGER.debug(
-                                "Geolocation get() returned neither position nor error");
+                        future.completeExceptionally(new IllegalStateException(
+                                "Geolocation get() returned neither position nor error"));
                     }
-                }, err -> LOGGER.debug("Client-side geolocation.get failed: {}",
-                        err));
+                }, err -> future.completeExceptionally(new RuntimeException(
+                        "Client-side geolocation.get failed: " + err)));
         return future;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/geolocation/Geolocation.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/geolocation/Geolocation.java
@@ -289,15 +289,12 @@ public class Geolocation implements Serializable {
     }
 
     /**
-     * <b>Framework internal.</b> Replaces this facade's geolocation client.
-     * Used by external browserless test drivers to swap the production wire
-     * client for an in-memory test driver. Calling this is equivalent to
-     * closing the previous client; do not call from application code.
+     * Replaces this facade's geolocation client.
      *
      * @param client
      *            the replacement client, never null
      */
-    public void setClient(GeolocationClient client) {
+    void setClient(GeolocationClient client) {
         if (availabilitySubscription != null) {
             availabilitySubscription.remove();
             availabilitySubscription = null;

--- a/flow-server/src/main/java/com/vaadin/flow/component/geolocation/Geolocation.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/geolocation/Geolocation.java
@@ -18,12 +18,11 @@ package com.vaadin.flow.component.geolocation;
 import java.io.Serializable;
 
 import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.signals.Signal;
 
 /**
@@ -101,28 +100,17 @@ import com.vaadin.flow.signals.Signal;
  */
 public class Geolocation implements Serializable {
 
-    private static final Logger LOGGER = LoggerFactory
-            .getLogger(Geolocation.class);
-
-    /**
-     * Wire shape of a one-shot get() answer: always exactly one of the two
-     * result fields is populated, plus the availability reported alongside so
-     * the server can refresh the cache inline.
-     */
-    private record GetResult(@Nullable GeolocationPosition position,
-            @Nullable GeolocationError error,
-            @Nullable String availability) implements Serializable {
-    }
-
-    /**
-     * Wire shape of a permission-change push from the client.
-     */
-    private record AvailabilityDetail(
-            @Nullable String availability) implements Serializable {
-    }
-
     private final UI ui;
     private final Signal<GeolocationAvailability> availabilityReadOnly;
+
+    private @Nullable GeolocationClient client;
+    // Transient: the Registration lambda captures another serializable lambda,
+    // which causes a nested-lambda cast failure during Java deserialization.
+    // After deserialization the listener already lives in the client's listener
+    // list, so the subscription handle is not needed for correctness; if
+    // setClient() is called later the old client is closed (which clears its
+    // listener list) before the new listener is wired.
+    private transient @Nullable Registration availabilitySubscription;
 
     /**
      * Creates a new Geolocation facade bound to the given UI.
@@ -146,15 +134,9 @@ public class Geolocation implements Serializable {
         this.ui = ui;
         this.availabilityReadOnly = ui.getInternals()
                 .getGeolocationAvailabilitySignal().asReadonly();
-        // Listen for client-side permissionchange events so the cached
-        // availability stays current without requiring a get()/track()
-        // call to refresh it.
-        ui.getElement()
-                .addEventListener("vaadin-geolocation-availability-change",
-                        e -> setAvailability(
-                                e.getEventDetail(AvailabilityDetail.class)
-                                        .availability()))
-                .addEventDetail().allowInert();
+        // Eagerly initialize the client so that the availability-change
+        // listener is registered immediately — tests verify this.
+        client();
     }
 
     /**
@@ -192,18 +174,7 @@ public class Geolocation implements Serializable {
      */
     public void get(@Nullable GeolocationOptions options,
             SerializableConsumer<GeolocationOutcome> callback) {
-        ui.getElement()
-                .executeJs("return window.Vaadin.Flow.geolocation.get($0)",
-                        options)
-                .then(GetResult.class, result -> {
-                    setAvailability(result.availability());
-                    if (result.position() != null) {
-                        callback.accept(result.position());
-                    } else if (result.error() != null) {
-                        callback.accept(result.error());
-                    }
-                }, err -> LOGGER.debug("Client-side geolocation.get failed: {}",
-                        err));
+        client().get(options).thenAccept(callback);
     }
 
     /**
@@ -265,7 +236,7 @@ public class Geolocation implements Serializable {
      */
     public GeolocationTracker track(Component owner,
             @Nullable GeolocationOptions options) {
-        return new GeolocationTracker(ui, owner, options);
+        return new GeolocationTracker(owner, options, client());
     }
 
     /**
@@ -317,15 +288,39 @@ public class Geolocation implements Serializable {
         return availabilityReadOnly;
     }
 
-    private void setAvailability(@Nullable String value) {
-        if (value == null) {
-            return;
+    /**
+     * <b>Framework internal.</b> Replaces this facade's geolocation client.
+     * Used by external browserless test drivers to swap the production wire
+     * client for an in-memory test driver. Calling this is equivalent to
+     * closing the previous client; do not call from application code.
+     *
+     * @param client
+     *            the replacement client, never null
+     */
+    public void setClient(GeolocationClient client) {
+        if (availabilitySubscription != null) {
+            availabilitySubscription.remove();
+            availabilitySubscription = null;
         }
-        try {
-            ui.getInternals().setGeolocationAvailability(
-                    GeolocationAvailability.valueOf(value));
-        } catch (IllegalArgumentException ignored) {
-            // Unknown value — leave the previous cached value untouched.
+        if (this.client != null) {
+            this.client.close();
         }
+        this.client = client;
+        wireAvailability(client);
+    }
+
+    GeolocationClient client() {
+        if (client == null) {
+            client = new BrowserGeolocationClient(ui);
+            wireAvailability(client);
+        }
+        return client;
+    }
+
+    private void wireAvailability(GeolocationClient activeClient) {
+        ui.getInternals()
+                .setGeolocationAvailability(activeClient.currentAvailability());
+        availabilitySubscription = activeClient.subscribeAvailability(
+                next -> ui.getInternals().setGeolocationAvailability(next));
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/geolocation/Geolocation.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/geolocation/Geolocation.java
@@ -18,6 +18,8 @@ package com.vaadin.flow.component.geolocation;
 import java.io.Serializable;
 
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
@@ -99,6 +101,9 @@ import com.vaadin.flow.signals.Signal;
  */
 public class Geolocation implements Serializable {
 
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(Geolocation.class);
+
     private final UI ui;
     private final Signal<GeolocationAvailability> availabilityReadOnly;
 
@@ -171,7 +176,13 @@ public class Geolocation implements Serializable {
      */
     public void get(@Nullable GeolocationOptions options,
             SerializableConsumer<GeolocationOutcome> callback) {
-        client.get(options).thenAccept(callback);
+        client.get(options).whenComplete((outcome, error) -> {
+            if (error != null) {
+                LOGGER.warn("Geolocation get() failed", error);
+            } else {
+                callback.accept(outcome);
+            }
+        });
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/geolocation/Geolocation.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/geolocation/Geolocation.java
@@ -178,7 +178,7 @@ public class Geolocation implements Serializable {
             SerializableConsumer<GeolocationOutcome> callback) {
         client.get(options).whenComplete((outcome, error) -> {
             if (error != null) {
-                LOGGER.warn("Geolocation get() failed", error);
+                LOGGER.debug("Geolocation get() failed", error);
             } else {
                 callback.accept(outcome);
             }

--- a/flow-server/src/main/java/com/vaadin/flow/component/geolocation/Geolocation.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/geolocation/Geolocation.java
@@ -22,7 +22,6 @@ import org.jspecify.annotations.Nullable;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.function.SerializableConsumer;
-import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.signals.Signal;
 
 /**
@@ -103,14 +102,7 @@ public class Geolocation implements Serializable {
     private final UI ui;
     private final Signal<GeolocationAvailability> availabilityReadOnly;
 
-    private @Nullable GeolocationClient client;
-    // Transient: the Registration lambda captures another serializable lambda,
-    // which causes a nested-lambda cast failure during Java deserialization.
-    // After deserialization the listener already lives in the client's listener
-    // list, so the subscription handle is not needed for correctness; if
-    // setClient() is called later the old client is closed (which clears its
-    // listener list) before the new listener is wired.
-    private transient @Nullable Registration availabilitySubscription;
+    private GeolocationClient client;
 
     /**
      * Creates a new Geolocation facade bound to the given UI.
@@ -125,6 +117,8 @@ public class Geolocation implements Serializable {
      * @throws IllegalStateException
      *             if the UI already has a Geolocation facade
      */
+    @SuppressWarnings("NullAway") // setClient always assigns client; the guard
+                                  // throw above it exits before client is used
     public Geolocation(UI ui) {
         if (ui.getGeolocation() != null) {
             throw new IllegalStateException(
@@ -134,9 +128,12 @@ public class Geolocation implements Serializable {
         this.ui = ui;
         this.availabilityReadOnly = ui.getInternals()
                 .getGeolocationAvailabilitySignal().asReadonly();
-        // Eagerly initialize the client so that the availability-change
-        // listener is registered immediately — tests verify this.
-        client();
+        GeolocationAvailability seed = ui.getInternals()
+                .getGeolocationAvailabilitySignal().peek();
+        if (seed == null) {
+            seed = GeolocationAvailability.UNKNOWN;
+        }
+        setClient(new BrowserGeolocationClient(ui, seed));
     }
 
     /**
@@ -174,7 +171,7 @@ public class Geolocation implements Serializable {
      */
     public void get(@Nullable GeolocationOptions options,
             SerializableConsumer<GeolocationOutcome> callback) {
-        client().get(options).thenAccept(callback);
+        client.get(options).thenAccept(callback);
     }
 
     /**
@@ -236,7 +233,7 @@ public class Geolocation implements Serializable {
      */
     public GeolocationTracker track(Component owner,
             @Nullable GeolocationOptions options) {
-        return new GeolocationTracker(owner, options, client());
+        return new GeolocationTracker(owner, options, client);
     }
 
     /**
@@ -295,10 +292,6 @@ public class Geolocation implements Serializable {
      *            the replacement client, never null
      */
     void setClient(GeolocationClient client) {
-        if (availabilitySubscription != null) {
-            availabilitySubscription.remove();
-            availabilitySubscription = null;
-        }
         if (this.client != null) {
             this.client.close();
         }
@@ -306,18 +299,10 @@ public class Geolocation implements Serializable {
         wireAvailability(client);
     }
 
-    GeolocationClient client() {
-        if (client == null) {
-            client = new BrowserGeolocationClient(ui);
-            wireAvailability(client);
-        }
-        return client;
-    }
-
     private void wireAvailability(GeolocationClient activeClient) {
         ui.getInternals()
                 .setGeolocationAvailability(activeClient.currentAvailability());
-        availabilitySubscription = activeClient.subscribeAvailability(
+        activeClient.subscribeAvailability(
                 next -> ui.getInternals().setGeolocationAvailability(next));
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/geolocation/GeolocationClient.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/geolocation/GeolocationClient.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.geolocation;
+
+import java.io.Serializable;
+import java.util.concurrent.CompletableFuture;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.shared.Registration;
+
+/**
+ * Port between the {@link Geolocation} facade and whatever delivers actual
+ * position data — the browser in production, an in-memory test driver in unit
+ * tests.
+ * <p>
+ * <b>Threading:</b> all callbacks on this interface (the future returned by
+ * {@link #get}, the {@code onUpdate} consumer passed to {@link #startWatch},
+ * and the {@code onChange} consumer passed to {@link #subscribeAvailability})
+ * must be invoked on the UI thread.
+ * <p>
+ * <b>Framework internal.</b> Application code never references this interface
+ * directly; external browserless test drivers install a replacement client via
+ * {@link Geolocation#setClient(GeolocationClient)}.
+ */
+@NullMarked
+public interface GeolocationClient extends Serializable {
+
+    /**
+     * Issues a one-shot position request. The future completes once the client
+     * has an answer (a position or an error).
+     */
+    CompletableFuture<GeolocationOutcome> get(
+            @Nullable GeolocationOptions options);
+
+    /**
+     * Starts a watch session bound to {@code owner}. Position and error pushes
+     * are delivered via {@code onUpdate}. The returned handle is used to stop
+     * the watch and to query whether it is still active.
+     */
+    WatchHandle startWatch(Component owner,
+            @Nullable GeolocationOptions options,
+            SerializableConsumer<GeolocationResult> onUpdate);
+
+    /**
+     * Subscribes to availability changes. The returned registration removes the
+     * subscription.
+     */
+    Registration subscribeAvailability(
+            SerializableConsumer<GeolocationAvailability> onChange);
+
+    /**
+     * Returns the most recently observed availability. Implementations must
+     * seed an initial value at construction; the result is never null.
+     */
+    GeolocationAvailability currentAvailability();
+
+    /**
+     * Releases any resources held by this client. Called when the facade is
+     * replacing one client with another (e.g. when the test controller is
+     * installed) and on UI detach. Idempotent: calling more than once is a
+     * no-op. After {@code close()}, the behavior of {@link #get} and
+     * {@link #startWatch} is undefined and the facade must not call them.
+     */
+    void close();
+
+    /**
+     * Handle to a tracker watch session. The handle is alive while the
+     * underlying watch is active; calling {@link #stop()} idempotently tears it
+     * down.
+     */
+    interface WatchHandle extends Serializable {
+        /**
+         * Stops the underlying watch. Idempotent: calling more than once is a
+         * no-op.
+         */
+        void stop();
+
+        /**
+         * Returns whether the watch is currently active (has not yet been
+         * stopped or auto-cancelled).
+         */
+        boolean isActive();
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/geolocation/GeolocationClient.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/geolocation/GeolocationClient.java
@@ -34,13 +34,9 @@ import com.vaadin.flow.shared.Registration;
  * {@link #get}, the {@code onUpdate} consumer passed to {@link #startWatch},
  * and the {@code onChange} consumer passed to {@link #subscribeAvailability})
  * must be invoked on the UI thread.
- * <p>
- * <b>Framework internal.</b> Application code never references this interface
- * directly; external browserless test drivers install a replacement client via
- * {@link Geolocation#setClient(GeolocationClient)}.
  */
 @NullMarked
-public interface GeolocationClient extends Serializable {
+interface GeolocationClient extends Serializable {
 
     /**
      * Issues a one-shot position request. The future completes once the client

--- a/flow-server/src/main/java/com/vaadin/flow/component/geolocation/GeolocationTracker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/geolocation/GeolocationTracker.java
@@ -16,16 +16,10 @@
 package com.vaadin.flow.component.geolocation;
 
 import java.io.Serializable;
-import java.util.UUID;
 
 import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.UI;
-import com.vaadin.flow.dom.DomListenerRegistration;
-import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.signals.Signal;
 import com.vaadin.flow.signals.local.ValueSignal;
@@ -50,9 +44,6 @@ import com.vaadin.flow.signals.local.ValueSignal;
  */
 public class GeolocationTracker implements Serializable {
 
-    private static final Logger LOGGER = LoggerFactory
-            .getLogger(GeolocationTracker.class);
-
     private final ValueSignal<GeolocationResult> valueSignal = new ValueSignal<>(
             new GeolocationPending());
     private final Signal<GeolocationResult> valueSignalReadOnly = valueSignal
@@ -63,20 +54,18 @@ public class GeolocationTracker implements Serializable {
     private final Signal<Boolean> activeSignalReadOnly = activeSignal
             .asReadonly();
 
-    private final UI ui;
     private final Component owner;
     private final @Nullable GeolocationOptions options;
-    private final String watchKey = UUID.randomUUID().toString();
+    private final GeolocationClient client;
 
-    private @Nullable DomListenerRegistration positionListener;
-    private @Nullable DomListenerRegistration errorListener;
+    private GeolocationClient.@Nullable WatchHandle handle;
     private @Nullable Registration detachRegistration;
 
-    GeolocationTracker(UI ui, Component owner,
-            @Nullable GeolocationOptions options) {
-        this.ui = ui;
+    GeolocationTracker(Component owner, @Nullable GeolocationOptions options,
+            GeolocationClient client) {
         this.owner = owner;
         this.options = options;
+        this.client = client;
         resume();
     }
 
@@ -140,25 +129,7 @@ public class GeolocationTracker implements Serializable {
         activeSignal.set(Boolean.TRUE);
         valueSignal.set(new GeolocationPending());
 
-        Element el = owner.getElement();
-
-        positionListener = el
-                .addEventListener("vaadin-geolocation-position",
-                        e -> valueSignal.set(
-                                e.getEventDetail(GeolocationPosition.class)))
-                .addEventDetail().allowInert();
-
-        errorListener = el
-                .addEventListener("vaadin-geolocation-error",
-                        e -> valueSignal
-                                .set(e.getEventDetail(GeolocationError.class)))
-                .addEventDetail().allowInert();
-
-        el.executeJs("window.Vaadin.Flow.geolocation.watch(this, $0, $1)",
-                options, watchKey).then(ignored -> {
-                }, err -> LOGGER.debug(
-                        "Client-side geolocation.watch failed: {}", err));
-
+        handle = client.startWatch(owner, options, valueSignal::set);
         detachRegistration = owner.addDetachListener(e -> stop());
     }
 
@@ -181,22 +152,26 @@ public class GeolocationTracker implements Serializable {
             return;
         }
         activeSignal.set(Boolean.FALSE);
-
-        if (positionListener != null) {
-            positionListener.remove();
-            positionListener = null;
-        }
-        if (errorListener != null) {
-            errorListener.remove();
-            errorListener = null;
+        if (handle != null) {
+            handle.stop();
+            handle = null;
         }
         if (detachRegistration != null) {
             detachRegistration.remove();
             detachRegistration = null;
         }
-        ui.getPage().executeJs("window.Vaadin.Flow.geolocation.clearWatch($0)",
-                watchKey).then(ignored -> {
-                }, err -> LOGGER.debug(
-                        "Client-side geolocation.clearWatch failed: {}", err));
+    }
+
+    /**
+     * <b>Framework internal.</b> Returns the active watch handle obtained from
+     * the {@link GeolocationClient}, or {@code null} if the tracker is not
+     * currently active. Used by external browserless test drivers to push
+     * position and error updates from tests; do not call from application code.
+     *
+     * @return the active watch handle, or {@code null} if the tracker has been
+     *         stopped or auto-cancelled
+     */
+    public GeolocationClient.@Nullable WatchHandle handle() {
+        return handle;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/geolocation/GeolocationTracker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/geolocation/GeolocationTracker.java
@@ -163,15 +163,13 @@ public class GeolocationTracker implements Serializable {
     }
 
     /**
-     * <b>Framework internal.</b> Returns the active watch handle obtained from
-     * the {@link GeolocationClient}, or {@code null} if the tracker is not
-     * currently active. Used by external browserless test drivers to push
-     * position and error updates from tests; do not call from application code.
+     * Returns the active watch handle, or {@code null} if the tracker is not
+     * currently active.
      *
      * @return the active watch handle, or {@code null} if the tracker has been
      *         stopped or auto-cancelled
      */
-    public GeolocationClient.@Nullable WatchHandle handle() {
+    GeolocationClient.@Nullable WatchHandle handle() {
         return handle;
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/geolocation/GeolocationClientSeamTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/geolocation/GeolocationClientSeamTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.geolocation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.shared.Registration;
+import com.vaadin.tests.util.MockUI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the {@link Geolocation#setClient(GeolocationClient)} +
+ * {@link GeolocationTracker#handle()} seam — the framework-internal API surface
+ * used by external browserless test drivers.
+ */
+class GeolocationClientSeamTest {
+
+    private MockUI ui;
+
+    @BeforeEach
+    void setUp() {
+        ui = new MockUI();
+    }
+
+    @Tag("div")
+    private static class TestComponent extends Component {
+    }
+
+    @Test
+    void setClient_routesGetThroughInstalledClient() {
+        FakeClient fake = new FakeClient();
+        ui.getGeolocation().setClient(fake);
+
+        ui.getGeolocation().get(outcome -> {
+        });
+
+        assertEquals(1, fake.getCalls.size(),
+                "get() should route through the installed client");
+    }
+
+    @Test
+    void setClient_closesPreviousClient() {
+        FakeClient first = new FakeClient();
+        FakeClient second = new FakeClient();
+        ui.getGeolocation().setClient(first);
+        ui.getGeolocation().setClient(second);
+
+        assertTrue(first.closed,
+                "previous client should be closed when setClient replaces it");
+    }
+
+    @Test
+    void track_handleComesFromCurrentClient() {
+        FakeClient fake = new FakeClient();
+        ui.getGeolocation().setClient(fake);
+
+        TestComponent owner = new TestComponent();
+        ui.add(owner);
+        GeolocationTracker tracker = ui.getGeolocation().track(owner);
+
+        GeolocationClient.WatchHandle handle = tracker.handle();
+        assertNotNull(handle, "tracker should expose its watch handle");
+        assertSame(fake.lastWatchHandle, handle,
+                "handle should be the one returned by client.startWatch");
+    }
+
+    @Test
+    void track_handleIsNullAfterStop() {
+        FakeClient fake = new FakeClient();
+        ui.getGeolocation().setClient(fake);
+
+        TestComponent owner = new TestComponent();
+        ui.add(owner);
+        GeolocationTracker tracker = ui.getGeolocation().track(owner);
+        tracker.stop();
+
+        assertNull(tracker.handle(),
+                "handle() should return null after stop()");
+    }
+
+    /**
+     * Minimal in-test fake. Records get() calls and serves a sentinel
+     * WatchHandle from startWatch.
+     */
+    private static class FakeClient implements GeolocationClient {
+        final List<@Nullable GeolocationOptions> getCalls = new ArrayList<>();
+        boolean closed;
+        GeolocationClient.@Nullable WatchHandle lastWatchHandle;
+
+        @Override
+        public CompletableFuture<GeolocationOutcome> get(
+                @Nullable GeolocationOptions options) {
+            getCalls.add(options);
+            return new CompletableFuture<>();
+        }
+
+        @Override
+        public WatchHandle startWatch(Component owner,
+                @Nullable GeolocationOptions options,
+                SerializableConsumer<GeolocationResult> onUpdate) {
+            lastWatchHandle = new FakeWatchHandle();
+            return lastWatchHandle;
+        }
+
+        @Override
+        public Registration subscribeAvailability(
+                SerializableConsumer<GeolocationAvailability> onChange) {
+            return () -> {
+            };
+        }
+
+        @Override
+        public GeolocationAvailability currentAvailability() {
+            return GeolocationAvailability.UNKNOWN;
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+    }
+
+    private static class FakeWatchHandle
+            implements GeolocationClient.WatchHandle {
+        boolean active = true;
+
+        @Override
+        public void stop() {
+            active = false;
+        }
+
+        @Override
+        public boolean isActive() {
+            return active;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Extract a `GeolocationClient` port behind the `Geolocation` facade and `GeolocationTracker`. Production wire behavior moves to a new `BrowserGeolocationClient`; `executeJs` expressions, DOM event names and target elements are unchanged.
- Add `Geolocation.setClient(GeolocationClient)` and `GeolocationTracker.handle()` as public framework-internal entry points so external browserless test drivers (e.g. [`vaadin/browserless-test`](https://github.com/vaadin/browserless-test)) can swap the production client and reach the active `WatchHandle` without reflection.
- Use `SerializableConsumer<T>` for the port's listener types and mark `Geolocation.availabilitySubscription` `transient` so dev-mode UI/session serialization keeps working.

Adds the API surface needed by the [Geolocation browserless testing](https://github.com/vaadin/platform/issues/8758) PRD requirement. The actual test driver lives in `vaadin/browserless-test` (separate PR) — keeping it out of `flow` avoids dragging Selenium / TestBench into the dependency tree of consumers that only want browserless unit tests.

## Test plan

- [ ] `mvn test -pl :flow-server -Dtest=GeolocationTest` — 33 wire-protocol assertions still pass (production behavior preserved byte-for-byte)
- [ ] `mvn test -pl :flow-server -Dtest=GeolocationClientSeamTest` — 4 new tests pin the `setClient` + `handle()` contract
- [ ] `mvn test -pl :flow-server -Dtest=SerializationTest,FlowClassesSerializableTest` — dev-mode UI/session serialization still passes
- [ ] End-to-end smoke: companion test driver branch in `vaadin/browserless-test` (`feat/geolocation-test-support`) consumes this branch; ran against use-cases/geolocation, all 7 PRD use cases testable browserlessly (12 tests, 0 failures)