### PR TITLE
fix(spring): handle Unicode classpath resource paths

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -976,8 +977,7 @@ public class VaadinServletContextInitializer
      * For npm we scan all packages. For performance reasons and due to problems
      * with atmosphere we skip known packaged from our resources collection.
      */
-    private static class CustomResourceLoader
-            extends FilterableResourceResolver {
+    static class CustomResourceLoader extends FilterableResourceResolver {
 
         private final PrefixTree scanNever = new PrefixTree(DEFAULT_SCAN_NEVER);
 
@@ -1048,15 +1048,8 @@ public class VaadinServletContextInitializer
 
             for (Resource resource : super.getResources(locationPattern)) {
                 String originalPath = resource.getURL().getPath();
-                String path;
-                if (originalPath.startsWith("file:///resources!")) {
-                    // It's a resource from a native build, remove the
-                    // prefix from URL path
-                    path = originalPath
-                            .substring("file:///resources!".length());
-                } else {
-                    path = originalPath;
-                }
+                final String path = getComparableResourcePath(resource,
+                        originalPath);
 
                 if (isDevModeCacheUsed() && skipped.contains(originalPath)) {
                     continue;
@@ -1066,8 +1059,8 @@ public class VaadinServletContextInitializer
                     resources.add(resource);
                     // Restore root paths to ensure new resources are correctly
                     // validate and cached after a reload
-                    if (originalPath.endsWith("/")) {
-                        rootPaths.add(originalPath);
+                    if (path.endsWith("/")) {
+                        rootPaths.add(path);
                     }
                 } else {
                     if (path.endsWith(".jar!/")) {
@@ -1122,6 +1115,26 @@ public class VaadinServletContextInitializer
             }
 
             return resources.toArray(new Resource[0]);
+        }
+
+        private String getComparableResourcePath(Resource resource,
+                String fallbackPath) throws IOException {
+            try {
+                String path = resource.getURL().toURI().getPath();
+                return stripNativeImageResourcePrefix(
+                        path == null ? fallbackPath : path);
+            } catch (IllegalArgumentException | URISyntaxException exception) {
+                return stripNativeImageResourcePrefix(fallbackPath);
+            }
+        }
+
+        private String stripNativeImageResourcePrefix(String path) {
+            if (path.startsWith("file:///resources!")) {
+                // It's a resource from a native build, remove the prefix from
+                // URL path.
+                return path.substring("file:///resources!".length());
+            }
+            return path;
         }
 
         private boolean isDevModeCacheUsed() {

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/VaadinServletContextInitializerTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/VaadinServletContextInitializerTest.java
@@ -19,6 +19,12 @@ import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletContextEvent;
 import jakarta.servlet.ServletContextListener;
 
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,6 +35,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -36,6 +43,8 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.env.Environment;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.Resource;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.di.Lookup;
@@ -53,6 +62,7 @@ import com.vaadin.flow.server.startup.ApplicationConfiguration;
 import com.vaadin.flow.server.startup.ApplicationRouteRegistry;
 import com.vaadin.flow.server.startup.ServletDeployer;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class VaadinServletContextInitializerTest {
@@ -214,6 +224,36 @@ class VaadinServletContextInitializerTest {
                 .getErrorNavigationTarget(new NotFoundException()).get()
                 .getNavigationTarget();
         assertEquals(TestErrorView.class, navigationTarget);
+    }
+
+    @Test
+    void customResourceLoader_classpathRootContainsUnicodeCombiningCharacter_resourcesAreMatched(
+            @TempDir Path tempDir) throws Exception {
+        Path classesRoot = tempDir.resolve("François")
+                .resolve("vaadin-c\u0327-repro").resolve("target/classes");
+        Path applicationClass = classesRoot
+                .resolve("com/example/application/Application.class");
+        Files.createDirectories(applicationClass.getParent());
+        Files.write(applicationClass, new byte[] { 0 });
+
+        try (URLClassLoader classLoader = new URLClassLoader(
+                new URL[] { classesRoot.toUri().toURL() }, null)) {
+            Resource[] resources = new VaadinServletContextInitializer.CustomResourceLoader(
+                    new DefaultResourceLoader(classLoader)).getResources(
+                            "classpath*:com/example/application/**/*.class");
+
+            assertThat(resources).as(Arrays.toString(resources)).anySatisfy(
+                    resource -> assertThat(getResourcePath(resource)).endsWith(
+                            "/com/example/application/Application.class"));
+        }
+    }
+
+    private static String getResourcePath(Resource resource) {
+        try {
+            return resource.getURI().getPath();
+        } catch (IOException exception) {
+            throw new IllegalStateException(exception);
+        }
     }
 
     private Runnable initRouteNotFoundMocksAndGetContextInitializedMockCall(


### PR DESCRIPTION
## Summary

Fix Spring classpath resource matching when an application is located under a directory whose path contains encoded Unicode or decomposed Unicode characters.

`CustomResourceLoader` previously compared resource paths from `URL#getPath()`, which can leave parts of the classpath root percent-encoded. When Spring later returned class resources using a decoded path, the resource no longer matched its parent root and startup could fail with `Parent resource ... not found in the resources!`.

This can happen even when both paths refer to the same filesystem location. The issue is that the compared strings are not in the same representation:

- `URL#getPath()` can return a path where non-ASCII characters are still percent-encoded, for example `%C3%A7` or `%CC%A7`.
- Spring resource resolution can later return the corresponding class resource using a decoded filesystem path.
- A raw string comparison then fails, even though both paths point to the same location.

This is especially easy to reproduce with decomposed Unicode characters. A decomposed character is represented as a base character plus one or more combining marks instead of a single precomposed code point. For example, `ç` can be represented either as the single code point `U+00E7`, or as `c` plus the combining cedilla `U+0327`.

Visually the path can look correct, but the encoded URL path and the decoded filesystem path are different strings. The culprit was therefore not Unicode normalization itself, but comparing URL-encoded paths with decoded paths during parent/child classpath resource matching.

This change normalizes resource paths through `URL#toURI().getPath()` for comparisons, while keeping the original URL path for dev-mode cache keys. It also keeps the existing native-image `file:///resources!` handling and falls back to the original URL path if URI conversion is not possible.

The key piece needed to make the fix work is using the decoded URI path for comparable resource paths:

```java
resource.getURL().toURI().getPath()
```

instead of relying on the raw URL path for matching:

```java
resource.getURL().getPath()
```

This follows the JDK recommendation for URL escaping handling. `URL` does not itself encode or decode URL components, and the recommended way to manage URL encoding and decoding is to use `URI` and convert between `URL` and `URI`.

Recommended reference:
https://docs.oracle.com/javase/8/docs/api/java/net/URL.html

Closes #11871

## Implementation note

The regression test needs to exercise `CustomResourceLoader` directly. I found existing Flow tests using both patterns: some use reflection to reach private implementation details, and others keep implementation types package-private so same-package tests can instantiate them directly.

I chose to make `CustomResourceLoader` package-private instead of using reflection, because it keeps the test simpler while still avoiding public API exposure. If the maintainers prefer preserving the private nested class, I can switch the test back to reflection and make `CustomResourceLoader` private again.

The important behavioral change is limited to the comparable path used for parent/child resource matching. The original URL path is still preserved where the previous encoded form is required, such as dev-mode cache lookup keys.

## Testing

- Reproduced the issue with a minimal Spring Boot/Vaadin application in a project path containing `François` and a decomposed Unicode segment. Before the fix, the app failed during test startup with `Parent resource ... not found in the resources!`.
- Verified the same minimal application starts/tests successfully after installing the fixed local Flow artifacts.
- Added regression coverage in `VaadinServletContextInitializerTest` for a classpath root containing Unicode and decomposed Unicode characters.
- Verified the regression test is meaningful: with only the production fix temporarily reverted, the new test fails with `Parent resource ... not found in the resources!`; with the fix restored, the same test passes.

Local checks run:

```bash
mvn -q -P!install-git-hooks -pl vaadin-spring spotless:check
mvn -q -P!install-git-hooks -pl vaadin-spring -Dtest=VaadinServletContextInitializerTest test
mvn -q -P!install-git-hooks -pl vaadin-spring -Dtest=VaadinServletContextInitializerTest#customResourceLoader_classpathRootContainsUnicodeCombiningCharacter_resourcesAreMatched test
mvn -q -P!install-git-hooks -pl vaadin-spring -am -DskipTests -Dexec.skip=true install
```

## AI Disclosure

Code drafted with OpenClaw/Codex for contributor review. Tests were added and run locally by the assistant. I reviewed the code and this description before opening the PR.