### PR TITLE
chore: remove `zt-exec` dependency (#24219) (CP: 24.10)

### DIFF
--- a/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/Reflector.java
+++ b/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/Reflector.java
@@ -58,9 +58,8 @@ public final class Reflector implements Closeable {
             "org.apache.maven", "org.codehaus.plexus", "org.slf4j",
             "org.eclipse.sisu");
     // Dependency required by the plugin but not provided by Flow at runtime
-    private static final Set<String> REQUIRED_PLUGIN_DEPENDENCIES = Set.of(
-            "org.reflections:reflections:jar",
-            "org.zeroturnaround:zt-exec:jar");
+    private static final Set<String> REQUIRED_PLUGIN_DEPENDENCIES = Set
+            .of("org.reflections:reflections:jar");
     private static final ScopeArtifactFilter PRODUCTION_SCOPE_FILTER = new ScopeArtifactFilter(
             Artifact.SCOPE_COMPILE_PLUS_RUNTIME);
     private static final Cleaner CLEANER = Cleaner.create();

--- a/flow-plugins/flow-maven-plugin/src/it/plugin-pinned-deps-project/pom.xml
+++ b/flow-plugins/flow-maven-plugin/src/it/plugin-pinned-deps-project/pom.xml
@@ -39,11 +39,6 @@
             <artifactId>reflections</artifactId>
             <version>0.9.10</version>
         </dependency>
-        <dependency>
-            <groupId>org.zeroturnaround</groupId>
-            <artifactId>zt-exec</artifactId>
-            <version>1.4</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -19,7 +19,6 @@ import java.io.File;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
 import org.apache.maven.artifact.Artifact;
@@ -173,8 +172,7 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo
                 if (cleanFrontendFiles()) {
                     cleanTask.execute();
                 }
-            } catch (URISyntaxException | TimeoutException
-                    | ExecutionFailedException exception) {
+            } catch (URISyntaxException | ExecutionFailedException exception) {
                 throw new MojoExecutionException(exception.getMessage(),
                         exception);
             }

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/Reflector.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/Reflector.java
@@ -71,9 +71,8 @@ public final class Reflector implements Closeable {
             "org.apache.maven", "org.codehaus.plexus", "org.slf4j",
             "org.eclipse.sisu");
     // Dependency required by the plugin but not provided by Flow at runtime
-    private static final Set<String> REQUIRED_PLUGIN_DEPENDENCIES = Set.of(
-            "org.reflections:reflections:jar",
-            "org.zeroturnaround:zt-exec:jar");
+    private static final Set<String> REQUIRED_PLUGIN_DEPENDENCIES = Set
+            .of("org.reflections:reflections:jar");
     private static final ScopeArtifactFilter PRODUCTION_SCOPE_FILTER = new ScopeArtifactFilter(
             Artifact.SCOPE_COMPILE_PLUS_RUNTIME);
     private static final Cleaner CLEANER = Cleaner.create();

--- a/flow-plugins/flow-plugin-base/pom.xml
+++ b/flow-plugins/flow-plugin-base/pom.xml
@@ -47,11 +47,6 @@
             <version>${javassist.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.zeroturnaround</groupId>
-            <artifactId>zt-exec</artifactId>
-            <version>1.12</version>
-        </dependency>
-        <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.plugin.base;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -30,7 +31,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeoutException;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
@@ -42,8 +42,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.zeroturnaround.exec.InvalidExitValueException;
-import org.zeroturnaround.exec.ProcessExecutor;
 
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.internal.JacksonUtils;
@@ -496,13 +494,11 @@ public class BuildFrontendUtil {
      *
      * @param adapter
      *            - the PluginAdapterBase.
-     * @throws TimeoutException
-     *             - while running build system
      * @throws URISyntaxException
      *             - while parsing nodeDownloadRoot()) to URI
      */
     public static void runFrontendBuild(PluginAdapterBase adapter)
-            throws TimeoutException, URISyntaxException {
+            throws URISyntaxException {
         LicenseChecker.setStrictOffline(true);
 
         FrontendToolsSettings settings = getFrontendToolsSettings(adapter);
@@ -538,11 +534,9 @@ public class BuildFrontendUtil {
      *            - the PluginAdapterBase.
      * @param frontendTools
      *            - frontend tools access object
-     * @throws TimeoutException
-     *             - while running vite
      */
     public static void runVite(PluginAdapterBase adapter,
-            FrontendTools frontendTools) throws TimeoutException {
+            FrontendTools frontendTools) {
         runFrontendBuildTool(adapter, frontendTools, "Vite", "vite", "vite",
                 Collections.emptyMap(), "build");
     }
@@ -550,7 +544,7 @@ public class BuildFrontendUtil {
     private static void runFrontendBuildTool(PluginAdapterBase adapter,
             FrontendTools frontendTools, String toolName, String packageName,
             String binaryName, Map<String, String> environment,
-            String... params) throws TimeoutException {
+            String... params) {
 
         File buildExecutable;
         try {
@@ -583,28 +577,70 @@ public class BuildFrontendUtil {
         command.addAll(Arrays.asList(params));
 
         ProcessBuilder builder = FrontendUtils.createProcessBuilder(command);
-
-        ProcessExecutor processExecutor = new ProcessExecutor()
-                .command(builder.command()).environment(builder.environment())
-                .environment(environment)
-                .directory(adapter.projectBaseDirectory().toFile());
+        if (!environment.isEmpty()) {
+            builder.environment().putAll(environment);
+        }
+        builder.directory(adapter.projectBaseDirectory().toFile());
+        builder.redirectErrorStream(true);
 
         adapter.logInfo("Running " + toolName + " ...");
         if (adapter.isDebugEnabled()) {
             adapter.logDebug(FrontendUtils.commandToString(
                     adapter.npmFolder().getAbsolutePath(), command));
         }
+
+        Process process = null;
+        // Per-invocation hook: registered before start, removed in finally.
+        // The unconditional add+forget pattern leaks Thread refs in the Gradle
+        // daemon JVM, where the hook list never drains until JVM shutdown.
+        Thread shutdownHook = null;
         try {
-            processExecutor.exitValueNormal().readOutput(true).destroyOnExit()
-                    .execute();
-        } catch (InvalidExitValueException e) {
-            throw new IllegalStateException(String.format(
-                    "%s process exited with non-zero exit code.%nStderr: '%s'",
-                    toolName, e.getResult().outputUTF8()), e);
-        } catch (IOException | InterruptedException e) {
+            process = builder.start();
+            final Process startedProcess = process;
+            shutdownHook = new Thread(() -> {
+                if (startedProcess.isAlive()) {
+                    startedProcess.destroyForcibly();
+                }
+            }, toolName + "-shutdown-hook");
+            Runtime.getRuntime().addShutdownHook(shutdownHook);
+
+            StringBuilder toolOutput = new StringBuilder();
+            try (BufferedReader reader = process
+                    .inputReader(StandardCharsets.UTF_8)) {
+                reader.lines().forEach(line -> {
+                    if (adapter.isDebugEnabled()) {
+                        adapter.logDebug(line);
+                    }
+                    toolOutput.append(line).append(System.lineSeparator());
+                });
+            }
+
+            int exitCode = process.waitFor();
+            if (exitCode != 0) {
+                throw new IllegalStateException(String.format(
+                        "%s process exited with non-zero exit code %d.%nOutput: '%s'",
+                        toolName, exitCode, toolOutput.toString().trim()));
+            }
+        } catch (IOException e) {
             throw new IllegalStateException(
                     String.format("Failed to run %s due to an error", toolName),
                     e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(
+                    String.format("Failed to run %s due to an error", toolName),
+                    e);
+        } finally {
+            if (process != null && process.isAlive()) {
+                process.destroyForcibly();
+            }
+            if (shutdownHook != null) {
+                try {
+                    Runtime.getRuntime().removeShutdownHook(shutdownHook);
+                } catch (IllegalStateException ignore) {
+                    // JVM is already shutting down; the hook will run.
+                }
+            }
         }
     }
 

--- a/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
+++ b/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -785,6 +786,44 @@ public class BuildFrontendUtilTest {
 
         FileIOUtils.writeIfChanged(tokenFile,
                 buildInfo.toPrettyString() + "\n");
+    }
+
+    @Test
+    public void runVite_nonZeroExit_doesNotLeakEnvironment() throws Exception {
+        Assume.assumeFalse("Skipping test on windows.",
+                FrontendUtils.isWindows());
+        File fakeNode = new File(baseDir, "fake-node.sh");
+        Files.writeString(fakeNode.toPath(), """
+                #!/bin/sh
+                echo TEST_OUTPUT_LINE
+                exit 7
+                """);
+        Assert.assertTrue(fakeNode.setExecutable(true));
+
+        File viteJs = new File(baseDir, "node_modules/vite/bin/vite.js");
+
+        FrontendTools frontendTools = Mockito.mock(FrontendTools.class);
+        Mockito.when(frontendTools.getNodeExecutable())
+                .thenReturn(fakeNode.getAbsolutePath());
+        Mockito.when(
+                frontendTools.getNpmPackageExecutable("vite", "vite", baseDir))
+                .thenReturn(viteJs.toPath());
+
+        IllegalStateException ex = Assert.assertThrows(
+                IllegalStateException.class,
+                () -> BuildFrontendUtil.runVite(adapter, frontendTools));
+
+        String message = ex.getMessage();
+        Assert.assertTrue("missing exit code in: " + message,
+                message.contains("exited with non-zero exit code 7"));
+        Assert.assertTrue("missing process output in: " + message,
+                message.contains("TEST_OUTPUT_LINE"));
+        // zt-exec exception messages started with "with environment {…}" —
+        // proving its absence proves we are off the leak path.
+        Assert.assertFalse("leaked env marker in: " + message,
+                message.contains("with environment"));
+        // No zt-exec exception should be chained as cause.
+        Assert.assertNull(ex.getCause());
     }
 
     private static String statsJsonWithCommercialComponents() {


### PR DESCRIPTION
The Maven plugin used `org.zeroturnaround:zt-exec` to launch the Vite build process, adding an external dependency that had to be pinned on the plugin classpath.

Replace it with `java.lang.ProcessBuilder`, following the approach already used elsewhere in Flow for running external processes.