### PR TITLE
chore: remove `zt-exec` dependency (#24219) (CP: 23.7)

### DIFF
--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -10,7 +10,6 @@ package com.vaadin.flow.plugin.maven;
 
 import java.io.File;
 import java.net.URISyntaxException;
-import java.util.concurrent.TimeoutException;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -113,7 +112,7 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo
         if (generateBundle()) {
             try {
                 BuildFrontendUtil.runFrontendBuild(this);
-            } catch (URISyntaxException | TimeoutException exception) {
+            } catch (URISyntaxException exception) {
                 throw new MojoExecutionException(exception.getMessage(),
                         exception);
             }

--- a/flow-plugins/flow-plugin-base/pom.xml
+++ b/flow-plugins/flow-plugin-base/pom.xml
@@ -38,11 +38,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.zeroturnaround</groupId>
-            <artifactId>zt-exec</artifactId>
-            <version>1.12</version>
-        </dependency>
-        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
         </dependency>

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -8,10 +8,12 @@
  */
 package com.vaadin.flow.plugin.base;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -23,10 +25,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeoutException;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.di.Lookup;
@@ -46,16 +52,11 @@ import com.vaadin.flow.utils.FlowFileUtils;
 import com.vaadin.pro.licensechecker.BuildType;
 import com.vaadin.pro.licensechecker.LicenseChecker;
 import com.vaadin.pro.licensechecker.Product;
+
 import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 import elemental.json.impl.JsonUtil;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.zeroturnaround.exec.InvalidExitValueException;
-import org.zeroturnaround.exec.ProcessExecutor;
 
 import static com.vaadin.flow.server.Constants.CONNECT_APPLICATION_PROPERTIES_TOKEN;
 import static com.vaadin.flow.server.Constants.CONNECT_JAVA_SOURCE_FOLDER_TOKEN;
@@ -349,13 +350,11 @@ public class BuildFrontendUtil {
      *
      * @param adapter
      *            - the PluginAdapterBase.
-     * @throws TimeoutException
-     *             - while running build system
      * @throws URISyntaxException
      *             - while parsing nodeDownloadRoot()) to URI
      */
     public static void runFrontendBuild(PluginAdapterBase adapter)
-            throws TimeoutException, URISyntaxException {
+            throws URISyntaxException {
         FeatureFlags featureFlags = getFeatureFlags(adapter);
 
         LicenseChecker.setStrictOffline(
@@ -378,14 +377,11 @@ public class BuildFrontendUtil {
      *            - the PluginAdapterBase.
      * @param frontendTools
      *            - frontend tools access object
-     * @throws TimeoutException
-     *             - while run webpack
      * @throws URISyntaxException
      *             - while parsing nodeDownloadRoot()) to URI
      */
     public static void runWebpack(PluginAdapterBase adapter,
-            FrontendTools frontendTools)
-            throws TimeoutException, URISyntaxException {
+            FrontendTools frontendTools) throws URISyntaxException {
         runFrontendBuildTool(adapter, frontendTools, "Webpack",
                 "webpack/bin/webpack.js",
                 frontendTools.getWebpackNodeEnvironment());
@@ -398,14 +394,11 @@ public class BuildFrontendUtil {
      *            - the PluginAdapterBase.
      * @param frontendTools
      *            - frontend tools access object
-     * @throws TimeoutException
-     *             - while running vite
      * @throws URISyntaxException
      *             - while parsing nodeDownloadRoot()) to URI
      */
     public static void runVite(PluginAdapterBase adapter,
-            FrontendTools frontendTools)
-            throws TimeoutException, URISyntaxException {
+            FrontendTools frontendTools) throws URISyntaxException {
         runFrontendBuildTool(adapter, frontendTools, "Vite", "vite/bin/vite.js",
                 Collections.emptyMap(), "build");
     }
@@ -413,7 +406,7 @@ public class BuildFrontendUtil {
     private static void runFrontendBuildTool(PluginAdapterBase adapter,
             FrontendTools frontendTools, String toolName, String executable,
             Map<String, String> environment, String... params)
-            throws TimeoutException, URISyntaxException {
+            throws URISyntaxException {
 
         validateLicense();
 
@@ -439,28 +432,71 @@ public class BuildFrontendUtil {
         command.addAll(Arrays.asList(params));
 
         ProcessBuilder builder = FrontendUtils.createProcessBuilder(command);
-
-        ProcessExecutor processExecutor = new ProcessExecutor()
-                .command(builder.command()).environment(builder.environment())
-                .environment(environment)
-                .directory(adapter.projectBaseDirectory().toFile());
+        if (!environment.isEmpty()) {
+            builder.environment().putAll(environment);
+        }
+        builder.directory(adapter.projectBaseDirectory().toFile());
+        builder.redirectErrorStream(true);
 
         adapter.logInfo("Running " + toolName + " ...");
         if (adapter.isDebugEnabled()) {
             adapter.logDebug(FrontendUtils.commandToString(
                     adapter.npmFolder().getAbsolutePath(), command));
         }
+
+        Process process = null;
+        // Per-invocation hook: registered before start, removed in finally.
+        // The unconditional add+forget pattern leaks Thread refs in the Gradle
+        // daemon JVM, where the hook list never drains until JVM shutdown.
+        Thread shutdownHook = null;
         try {
-            processExecutor.exitValueNormal().readOutput(true).destroyOnExit()
-                    .execute();
-        } catch (InvalidExitValueException e) {
-            throw new IllegalStateException(String.format(
-                    "%s process exited with non-zero exit code.%nStderr: '%s'",
-                    toolName, e.getResult().outputUTF8()), e);
-        } catch (IOException | InterruptedException e) {
+            process = builder.start();
+            final Process startedProcess = process;
+            shutdownHook = new Thread(() -> {
+                if (startedProcess.isAlive()) {
+                    startedProcess.destroyForcibly();
+                }
+            }, toolName + "-shutdown-hook");
+            Runtime.getRuntime().addShutdownHook(shutdownHook);
+
+            StringBuilder toolOutput = new StringBuilder();
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(process.getInputStream(),
+                            StandardCharsets.UTF_8))) {
+                reader.lines().forEach(line -> {
+                    if (adapter.isDebugEnabled()) {
+                        adapter.logDebug(line);
+                    }
+                    toolOutput.append(line).append(System.lineSeparator());
+                });
+            }
+
+            int exitCode = process.waitFor();
+            if (exitCode != 0) {
+                throw new IllegalStateException(String.format(
+                        "%s process exited with non-zero exit code %d.%nOutput: '%s'",
+                        toolName, exitCode, toolOutput.toString().trim()));
+            }
+        } catch (IOException e) {
             throw new IllegalStateException(
                     String.format("Failed to run %s due to an error", toolName),
                     e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(
+                    String.format("Failed to run %s due to an error", toolName),
+                    e);
+        } finally {
+            if (process != null && process.isAlive()) {
+                process.destroyForcibly();
+            }
+            if (shutdownHook != null) {
+                try {
+                    Runtime.getRuntime().removeShutdownHook(shutdownHook);
+                } catch (IllegalStateException ignore) {
+                    // JVM is already shutting down; the hook will run.
+                }
+            }
         }
 
         // Check License

--- a/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
+++ b/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
@@ -15,9 +15,23 @@ import java.io.PrintWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.InOrder;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.di.Lookup;
@@ -34,18 +48,6 @@ import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.utils.LookupImpl;
 import com.vaadin.pro.licensechecker.BuildType;
 import com.vaadin.pro.licensechecker.LicenseChecker;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.mockito.InOrder;
-import org.mockito.MockedConstruction;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 public class BuildFrontendUtilTest {
 
@@ -229,4 +231,35 @@ public class BuildFrontendUtilTest {
                         this.getClass().getClassLoader()));
         Mockito.when(adapter.runNpmInstall()).thenReturn(true);
     }
+
+    @Test
+    public void runVite_nonZeroExit_doesNotLeakEnvironment() throws Exception {
+        Assume.assumeFalse("Skipping test on windows.",
+                FrontendUtils.isWindows());
+        File fakeNode = new File(baseDir, "fake-node.sh");
+        Files.writeString(fakeNode.toPath(),
+                "#!/bin/sh\necho TEST_OUTPUT_LINE\nexit 7\n");
+        Assert.assertTrue(fakeNode.setExecutable(true));
+
+        FrontendTools frontendTools = Mockito.mock(FrontendTools.class);
+        Mockito.when(frontendTools.getNodeExecutable())
+                .thenReturn(fakeNode.getAbsolutePath());
+
+        IllegalStateException ex = Assert.assertThrows(
+                IllegalStateException.class,
+                () -> BuildFrontendUtil.runVite(adapter, frontendTools));
+
+        String message = ex.getMessage();
+        Assert.assertTrue("missing exit code in: " + message,
+                message.contains("exited with non-zero exit code 7"));
+        Assert.assertTrue("missing process output in: " + message,
+                message.contains("TEST_OUTPUT_LINE"));
+        // zt-exec exception messages started with "with environment {…}" —
+        // proving its absence proves we are off the leak path.
+        Assert.assertFalse("leaked env marker in: " + message,
+                message.contains("with environment"));
+        // No zt-exec exception should be chained as cause.
+        Assert.assertNull(ex.getCause());
+    }
+
 }


### PR DESCRIPTION
The Maven plugin used `org.zeroturnaround:zt-exec` to launch the Vite build process, adding an external dependency that had to be pinned on the plugin classpath.

Replace it with `java.lang.ProcessBuilder`, following the approach already used elsewhere in Flow for running external processes.