### PR TITLE
feat: add window.Vaadin.Flow.ready() and whenReady(callback)

### DIFF
--- a/flow-client/src/test/frontend/FlowTests.ts
+++ b/flow-client/src/test/frontend/FlowTests.ts
@@ -14,6 +14,21 @@ import sinon from 'sinon';
 const $wnd = window as any;
 const flowRoot = window.document.body as any;
 
+/**
+ * Stubs window.Vaadin.Flow.ready and whenReady with sentinel values so the
+ * preservation test can verify that constructing a Flow instance does not
+ * overwrite definitions from the inline bootstrap script. The real
+ * implementations live in flow-server's whenReady.js and are not tested here.
+ */
+const READY_SENTINEL = () => {};
+const WHEN_READY_SENTINEL = () => {};
+function stubWhenReady() {
+  $wnd.Vaadin = $wnd.Vaadin || {};
+  $wnd.Vaadin.Flow = $wnd.Vaadin.Flow || {};
+  $wnd.Vaadin.Flow.ready = READY_SENTINEL;
+  $wnd.Vaadin.Flow.whenReady = WHEN_READY_SENTINEL;
+}
+
 const stubVaadinPushSrc = '/src/test/frontend/stubVaadinPush.js';
 let server: MockXhrServer;
 // A `changes` array that adds a div with 'Foo' text to body
@@ -655,6 +670,13 @@ describe('Flow', () => {
     expect($wnd.Vaadin.connectionState.state).to.equal(ConnectionState.CONNECTION_LOST);
     $wnd.dispatchEvent(new Event('online')); // caught by DefaultConnectionStateHandler
     expect($wnd.Vaadin.connectionState.state).to.equal(ConnectionState.RECONNECTING);
+  });
+
+  it('should preserve ready and whenReady defined by inline script after construction', () => {
+    stubWhenReady();
+    new Flow({ imports: () => {} });
+    expect($wnd.Vaadin.Flow.ready).to.equal(READY_SENTINEL);
+    expect($wnd.Vaadin.Flow.whenReady).to.equal(WHEN_READY_SENTINEL);
   });
 
   it('should pre-attach container element on every navigation', async () => {

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -133,6 +133,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             + "/client.nocache.js";
     private static final String BOOTSTRAP_JS = readResource(
             "BootstrapHandler.js");
+    public static final String WHEN_READY_JS = readResource("whenReady.js");
     private static final String CSS_TYPE_ATTRIBUTE_VALUE = "text/css";
 
     private static final String CAPTION = "caption";
@@ -1194,6 +1195,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                 result = result.replace("{{GWT_STAT_EVENTS}}", "");
             }
 
+            result = result.replace("{{WHEN_READY}}", WHEN_READY_JS);
             result = result.replace("{{APP_ID}}", context.getAppId());
             result = result.replace("{{CONFIG_JSON}}", appConfigString);
             // {{INITIAL_UIDL}} should be the last replaced so that it may have

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -133,6 +133,11 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             + "/client.nocache.js";
     private static final String BOOTSTRAP_JS = readResource(
             "BootstrapHandler.js");
+    /**
+     * Inlined into the bootstrap {@code <script>}. Must not contain {@code //}
+     * comments — they would swallow the rest of the line if the inline script
+     * is collapsed to one line by HTML processing.
+     */
     public static final String WHEN_READY_JS = readResource("whenReady.js");
     private static final String CSS_TYPE_ATTRIBUTE_VALUE = "text/css";
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
@@ -583,8 +583,10 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
                 indexDocument.head(), request);
         Element elm = new Element(SCRIPT);
         elm.attr(SCRIPT_INITIAL, "");
-        elm.appendChild(new DataNode("window.Vaadin = window.Vaadin || {};" + //
-                "window.Vaadin.TypeScript= " + initialJson.toString() + ";"));
+        elm.appendChild(new DataNode("window.Vaadin = window.Vaadin || {};"
+                + "window.Vaadin.Flow = window.Vaadin.Flow || {};"
+                + BootstrapHandler.WHEN_READY_JS + "window.Vaadin.TypeScript= "
+                + initialJson.toString() + ";"));
         indexDocument.head().insertChildren(0, elm);
     }
 

--- a/flow-server/src/main/resources/com/vaadin/flow/server/BootstrapHandler.js
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/BootstrapHandler.js
@@ -42,6 +42,10 @@
   window.Vaadin = window.Vaadin || {};
   window.Vaadin.Flow = window.Vaadin.Flow || {};
 
+  if (!window.Vaadin.Flow.whenReady) {
+    {{WHEN_READY}}
+  }
+
   /**
    * Triggers a CSS animation on an element by adding a class, then
    * removes the class when the animation ends.

--- a/flow-server/src/main/resources/com/vaadin/flow/server/whenReady.js
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/whenReady.js
@@ -1,4 +1,3 @@
-/* No // comments: this file is concatenated into an inline <script> that may collapse to one line. */
 window.Vaadin.Flow.ready = async function ({ timeout = 30000 } = {}) {
   const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
   const deadline = Date.now() + timeout;

--- a/flow-server/src/main/resources/com/vaadin/flow/server/whenReady.js
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/whenReady.js
@@ -1,3 +1,4 @@
+/* No // comments: this file is concatenated into an inline <script> that may collapse to one line. */
 window.Vaadin.Flow.ready = async function ({ timeout = 30000 } = {}) {
   const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
   const deadline = Date.now() + timeout;
@@ -7,7 +8,6 @@ window.Vaadin.Flow.ready = async function ({ timeout = 30000 } = {}) {
     if (window.Vaadin.Flow.devServerIsNotLoaded) return false;
     const clients = window.Vaadin.Flow.clients;
     if (!clients) return false;
-    // Flow has not bootstrapped until at least one client with isActive is registered
     const probes = Object.values(clients).filter((c) => typeof c.isActive === 'function');
     if (probes.length === 0) return false;
     return probes.every((c) => !c.isActive());

--- a/flow-server/src/main/resources/com/vaadin/flow/server/whenReady.js
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/whenReady.js
@@ -1,0 +1,28 @@
+window.Vaadin.Flow.ready = async function ({ timeout = 30000 } = {}) {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  const deadline = Date.now() + timeout;
+
+  const isIdle = () => {
+    if (document.readyState !== 'complete') return false;
+    if (window.Vaadin.Flow.devServerIsNotLoaded) return false;
+    const clients = window.Vaadin.Flow.clients;
+    if (!clients) return false;
+    // Flow has not bootstrapped until at least one client with isActive is registered
+    const probes = Object.values(clients).filter((c) => typeof c.isActive === 'function');
+    if (probes.length === 0) return false;
+    return probes.every((c) => !c.isActive());
+  };
+
+  while (!isIdle()) {
+    if (Date.now() >= deadline) {
+      throw new Error('Vaadin.Flow.ready timed out after ' + timeout + 'ms');
+    }
+    await sleep(50);
+  }
+};
+
+window.Vaadin.Flow.whenReady = function (callback) {
+  window.Vaadin.Flow.ready()
+    .catch((e) => console.warn(e.message))
+    .then(callback);
+};

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
@@ -397,9 +397,13 @@ public class IndexHtmlRequestHandlerTest {
         Element initialUidlScript = findScript(scripts,
                 INITIAL_UIDL_SEARCH_STRING);
 
-        assertEquals(
-                "window.Vaadin = window.Vaadin || {};window.Vaadin.TypeScript= {};",
-                initialUidlScript.childNode(0).toString());
+        String scriptContent = initialUidlScript.childNode(0).toString();
+        assertTrue(
+                scriptContent.startsWith("window.Vaadin = window.Vaadin || {};"
+                        + "window.Vaadin.Flow = window.Vaadin.Flow || {};"
+                        + "window.Vaadin.Flow.ready = "));
+        assertTrue(scriptContent.contains("window.Vaadin.Flow.whenReady = "));
+        assertTrue(scriptContent.endsWith("window.Vaadin.TypeScript= {};"));
         assertEquals("", initialUidlScript.attr("initial"));
     }
 
@@ -448,9 +452,13 @@ public class IndexHtmlRequestHandlerTest {
         Elements scripts = document.head().getElementsByTag("script");
         Element initialUidlScript = findScript(scripts,
                 INITIAL_UIDL_SEARCH_STRING);
-        assertEquals(
-                "window.Vaadin = window.Vaadin || {};window.Vaadin.TypeScript= {};",
-                initialUidlScript.childNode(0).toString());
+        String scriptContent = initialUidlScript.childNode(0).toString();
+        assertTrue(
+                scriptContent.startsWith("window.Vaadin = window.Vaadin || {};"
+                        + "window.Vaadin.Flow = window.Vaadin.Flow || {};"
+                        + "window.Vaadin.Flow.ready = "));
+        assertTrue(scriptContent.contains("window.Vaadin.Flow.whenReady = "));
+        assertTrue(scriptContent.endsWith("window.Vaadin.TypeScript= {};"));
         assertEquals("", initialUidlScript.attr("initial"));
         assertNull(UI.getCurrent());
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
@@ -399,11 +399,12 @@ public class IndexHtmlRequestHandlerTest {
 
         String scriptContent = initialUidlScript.childNode(0).toString();
         assertTrue(
-                scriptContent.startsWith("window.Vaadin = window.Vaadin || {};"
-                        + "window.Vaadin.Flow = window.Vaadin.Flow || {};"
-                        + "window.Vaadin.Flow.ready = "));
+                scriptContent.contains("window.Vaadin = window.Vaadin || {};"));
+        assertTrue(scriptContent
+                .contains("window.Vaadin.Flow = window.Vaadin.Flow || {};"));
+        assertTrue(scriptContent.contains("window.Vaadin.Flow.ready = "));
         assertTrue(scriptContent.contains("window.Vaadin.Flow.whenReady = "));
-        assertTrue(scriptContent.endsWith("window.Vaadin.TypeScript= {};"));
+        assertTrue(scriptContent.contains("window.Vaadin.TypeScript= {};"));
         assertEquals("", initialUidlScript.attr("initial"));
     }
 
@@ -454,11 +455,12 @@ public class IndexHtmlRequestHandlerTest {
                 INITIAL_UIDL_SEARCH_STRING);
         String scriptContent = initialUidlScript.childNode(0).toString();
         assertTrue(
-                scriptContent.startsWith("window.Vaadin = window.Vaadin || {};"
-                        + "window.Vaadin.Flow = window.Vaadin.Flow || {};"
-                        + "window.Vaadin.Flow.ready = "));
+                scriptContent.contains("window.Vaadin = window.Vaadin || {};"));
+        assertTrue(scriptContent
+                .contains("window.Vaadin.Flow = window.Vaadin.Flow || {};"));
+        assertTrue(scriptContent.contains("window.Vaadin.Flow.ready = "));
         assertTrue(scriptContent.contains("window.Vaadin.Flow.whenReady = "));
-        assertTrue(scriptContent.endsWith("window.Vaadin.TypeScript= {};"));
+        assertTrue(scriptContent.contains("window.Vaadin.TypeScript= {};"));
         assertEquals("", initialUidlScript.attr("initial"));
         assertNull(UI.getCurrent());
     }

--- a/vaadin-dev-server/src/main/resources/com/vaadin/base/devserver/dev-mode-not-ready.html
+++ b/vaadin-dev-server/src/main/resources/com/vaadin/base/devserver/dev-mode-not-ready.html
@@ -49,7 +49,7 @@
     <script type="text/javascript">
       // Set specific flag for TB and make sure that there are no any clients.
       // It allows to work correct waitForVaadin in TB
-      window.Vaadin = { Flow: { devServerIsNotLoaded: true } };
+      window.Vaadin = { Flow: { devServerIsNotLoaded: true, ready: false, whenReady: false } };
 
       const delay = 200;
       const poll = async () => {


### PR DESCRIPTION
Define ready() as the canonical Promise-based "wait until Flow is idle" API and whenReady(callback) as a thin callback adapter for TestBench-style usage. Both are inlined into the bootstrap HTML so they are available on every Flow page in dev and production mode.

ready() resolves once document.readyState is complete, window.Vaadin.Flow.devServerIsNotLoaded is falsy, at least one client with isActive() has been registered, and all such clients report inactive. The "at least one client" requirement avoids a false positive before Flow has bootstrapped. ready() takes an optional { timeout } (default 30s) and rejects on timeout instead of polling forever. whenReady(callback) invokes the callback either when ready() resolves or after logging the rejection on timeout, so the callback contract holds either way.

The dev-mode-not-ready page sets ready and whenReady to false as not-ready sentinels for TestBench.
