### PR TITLE
refactor: remove `FrontendDependenciesScanner` parameter from `TypeScriptBootstrapModifier` (#24069) (CP: 25.1)

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrap.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrap.java
@@ -80,8 +80,7 @@ public class TaskGenerateBootstrap extends AbstractTaskClientGenerator {
         lines.addAll(getThemeLines());
 
         for (TypeScriptBootstrapModifier modifier : modifiers) {
-            modifier.modify(lines, options,
-                    options.getFrontendDependenciesScanner());
+            modifier.modify(lines, options);
         }
         lines.add(0,
                 String.format("import './%s';%n", FEATURE_FLAGS_FILE_NAME));

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TypeScriptBootstrapModifier.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TypeScriptBootstrapModifier.java
@@ -34,9 +34,6 @@ public interface TypeScriptBootstrapModifier extends Serializable {
      *            options used by the build
      * @param frontendDependenciesScanner
      *            the frontend dependencies scanner
-     * @deprecated {@code frontendDependenciesScanner} can be obtained calling
-     *             {@link Options#getFrontendDependenciesScanner()}. Use
-     *             {@link #modify(List, Options)} instead
      */
     default void modify(List<String> bootstrapTypeScript, Options options,
             FrontendDependenciesScanner frontendDependenciesScanner) {

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TypeScriptBootstrapModifier.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TypeScriptBootstrapModifier.java
@@ -34,9 +34,25 @@ public interface TypeScriptBootstrapModifier extends Serializable {
      *            options used by the build
      * @param frontendDependenciesScanner
      *            the frontend dependencies scanner
+     * @deprecated {@code frontendDependenciesScanner} can be obtained calling
+     *             {@link Options#getFrontendDependenciesScanner()}. Use
+     *             {@link #modify(List, Options)} instead
      */
     default void modify(List<String> bootstrapTypeScript, Options options,
             FrontendDependenciesScanner frontendDependenciesScanner) {
+    }
+
+    /**
+     * Modifies the bootstrap typescript by mutating the parameter.
+     *
+     * @param bootstrapTypeScript
+     *            the input typescript split into lines
+     * @param options
+     *            options used by the build
+     */
+    default void modify(List<String> bootstrapTypeScript, Options options) {
+        modify(bootstrapTypeScript, options,
+                options.getFrontendDependenciesScanner());
     }
 
 }

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrapTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrapTest.java
@@ -63,8 +63,7 @@ class TaskGenerateBootstrapTest {
 
     public static class CustomModifier implements TypeScriptBootstrapModifier {
         @Override
-        public void modify(List<String> lines, Options options,
-                FrontendDependenciesScanner scanner) {
+        public void modify(List<String> lines, Options options) {
             lines.add(0, CUSTOM_MODIFIER_CONTENT);
         }
     }

--- a/flow-tests/test-frontend/vite-basics/src/main/java/com/vaadin/viteapp/BootstrapModifier.java
+++ b/flow-tests/test-frontend/vite-basics/src/main/java/com/vaadin/viteapp/BootstrapModifier.java
@@ -19,12 +19,10 @@ import java.util.List;
 
 import com.vaadin.flow.server.frontend.Options;
 import com.vaadin.flow.server.frontend.TypeScriptBootstrapModifier;
-import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 
 public class BootstrapModifier implements TypeScriptBootstrapModifier {
 
-    public void modify(List<String> bootstrapTypeScript, Options options,
-            FrontendDependenciesScanner frontendDependenciesScanner) {
+    public void modify(List<String> bootstrapTypeScript, Options options) {
         bootstrapTypeScript.add("(window as any).bootstrapMod=1;");
     }
 


### PR DESCRIPTION
The `FrontendDependenciesScanner` parameter in
`TypeScriptBootstrapModifier.modify()` is redundant since it can be obtained from `Options.getFrontendDependenciesScanner()`.

Deprecate the old three-parameter `modify()` method and introduce a new two-parameter overload. Callers and implementations are updated to use the simplified signature.
