### PR TITLE
refactor: remove FrontendDependenciesScanner parameter from TypeScriptBootstrapModifier (CP: 24.10)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrap.java
@@ -80,8 +80,7 @@ public class TaskGenerateBootstrap extends AbstractTaskClientGenerator {
         lines.addAll(getThemeLines());
 
         for (TypeScriptBootstrapModifier modifier : modifiers) {
-            modifier.modify(lines, options,
-                    options.getFrontendDependenciesScanner());
+            modifier.modify(lines, options);
         }
         lines.add(0,
                 String.format("import './%s';%n", FEATURE_FLAGS_FILE_NAME));

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TypeScriptBootstrapModifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TypeScriptBootstrapModifier.java
@@ -51,9 +51,6 @@ public interface TypeScriptBootstrapModifier extends Serializable {
      *            options used by the build
      * @param frontendDependenciesScanner
      *            the frontend dependencies scanner
-     * @deprecated {@code frontendDependenciesScanner} can be obtained calling
-     *             {@link Options#getFrontendDependenciesScanner()}. Use
-     *             {@link #modify(List, Options)} instead
      */
     default void modify(List<String> bootstrapTypeScript, Options options,
             FrontendDependenciesScanner frontendDependenciesScanner) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TypeScriptBootstrapModifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TypeScriptBootstrapModifier.java
@@ -51,6 +51,9 @@ public interface TypeScriptBootstrapModifier extends Serializable {
      *            options used by the build
      * @param frontendDependenciesScanner
      *            the frontend dependencies scanner
+     * @deprecated {@code frontendDependenciesScanner} can be obtained calling
+     *             {@link Options#getFrontendDependenciesScanner()}. Use
+     *             {@link #modify(List, Options)} instead
      */
     default void modify(List<String> bootstrapTypeScript, Options options,
             FrontendDependenciesScanner frontendDependenciesScanner) {
@@ -58,4 +61,16 @@ public interface TypeScriptBootstrapModifier extends Serializable {
                 frontendDependenciesScanner.getThemeDefinition());
     }
 
+    /**
+     * Modifies the bootstrap typescript by mutating the parameter.
+     *
+     * @param bootstrapTypeScript
+     *            the input typescript split into lines
+     * @param options
+     *            options used by the build
+     */
+    default void modify(List<String> bootstrapTypeScript, Options options) {
+        modify(bootstrapTypeScript, options,
+                options.getFrontendDependenciesScanner());
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrapTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrapTest.java
@@ -63,8 +63,7 @@ public class TaskGenerateBootstrapTest {
 
     public static class CustomModifier implements TypeScriptBootstrapModifier {
         @Override
-        public void modify(List<String> lines, Options options,
-                FrontendDependenciesScanner scanner) {
+        public void modify(List<String> lines, Options options) {
             lines.add(0, CUSTOM_MODIFIER_CONTENT);
         }
     }

--- a/flow-tests/test-frontend/vite-basics/src/main/java/com/vaadin/viteapp/BootstrapModifier.java
+++ b/flow-tests/test-frontend/vite-basics/src/main/java/com/vaadin/viteapp/BootstrapModifier.java
@@ -2,13 +2,13 @@ package com.vaadin.viteapp;
 
 import java.util.List;
 
+import com.vaadin.flow.server.frontend.Options;
 import com.vaadin.flow.server.frontend.TypeScriptBootstrapModifier;
 
 public class BootstrapModifier implements TypeScriptBootstrapModifier {
 
     @Override
-    public void modify(List<String> bootstrapTypeScript,
-            boolean productionMode) {
+    public void modify(List<String> bootstrapTypeScript, Options options) {
         bootstrapTypeScript.add("(window as any).bootstrapMod=1;");
     }
 


### PR DESCRIPTION
The `FrontendDependenciesScanner` parameter in
`TypeScriptBootstrapModifier.modify()` is redundant since it can be obtained from `Options.getFrontendDependenciesScanner()`.

Deprecate the old three-parameter `modify()` method and introduce a new two-parameter overload. Callers and implementations are updated to use the simplified signature.
