### PR TITLE
fix(spring): handle Unicode classpath resource paths (#24220)(CP:25.0)

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -975,8 +976,7 @@ public class VaadinServletContextInitializer
      * For npm we scan all packages. For performance reasons and due to problems
      * with atmosphere we skip known packaged from our resources collection.
      */
-    private static class CustomResourceLoader
-            extends FilterableResourceResolver {
+    static class CustomResourceLoader extends FilterableResourceResolver {
 
         private final PrefixTree scanNever = new PrefixTree(DEFAULT_SCAN_NEVER);
 
@@ -1047,15 +1047,8 @@ public class VaadinServletContextInitializer
 
             for (Resource resource : super.getResources(locationPattern)) {
                 String originalPath = resource.getURL().getPath();
-                String path;
-                if (originalPath.startsWith("file:///resources!")) {
-                    // It's a resource from a native build, remove the
-                    // prefix from URL path
-                    path = originalPath
-                            .substring("file:///resources!".length());
-                } else {
-                    path = originalPath;
-                }
+                final String path = getComparableResourcePath(resource,
+                        originalPath);
 
                 if (isDevModeCacheUsed() && skipped.contains(originalPath)) {
                     continue;
@@ -1065,8 +1058,8 @@ public class VaadinServletContextInitializer
                     resources.add(resource);
                     // Restore root paths to ensure new resources are correctly
                     // validate and cached after a reload
-                    if (originalPath.endsWith("/")) {
-                        rootPaths.add(originalPath);
+                    if (path.endsWith("/")) {
+                        rootPaths.add(path);
                     }
                 } else {
                     if (path.endsWith(".jar!/")) {
@@ -1121,6 +1114,26 @@ public class VaadinServletContextInitializer
             }
 
             return resources.toArray(new Resource[0]);
+        }
+
+        private String getComparableResourcePath(Resource resource,
+                String fallbackPath) throws IOException {
+            try {
+                String path = resource.getURL().toURI().getPath();
+                return stripNativeImageResourcePrefix(
+                        path == null ? fallbackPath : path);
+            } catch (IllegalArgumentException | URISyntaxException exception) {
+                return stripNativeImageResourcePrefix(fallbackPath);
+            }
+        }
+
+        private String stripNativeImageResourcePrefix(String path) {
+            if (path.startsWith("file:///resources!")) {
+                // It's a resource from a native build, remove the prefix from
+                // URL path.
+                return path.substring("file:///resources!".length());
+            }
+            return path;
         }
 
         private boolean isDevModeCacheUsed() {

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/VaadinServletContextInitializerTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/VaadinServletContextInitializerTest.java
@@ -19,6 +19,12 @@ import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletContextEvent;
 import jakarta.servlet.ServletContextListener;
 
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,7 +35,9 @@ import java.util.stream.Stream;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -37,6 +45,8 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.env.Environment;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.Resource;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.di.Lookup;
@@ -54,7 +64,12 @@ import com.vaadin.flow.server.startup.ApplicationConfiguration;
 import com.vaadin.flow.server.startup.ApplicationRouteRegistry;
 import com.vaadin.flow.server.startup.ServletDeployer;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class VaadinServletContextInitializerTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Mock
     private ApplicationContext applicationContext;
@@ -214,6 +229,37 @@ public class VaadinServletContextInitializerTest {
                 .getErrorNavigationTarget(new NotFoundException()).get()
                 .getNavigationTarget();
         Assert.assertEquals(TestErrorView.class, navigationTarget);
+    }
+
+    @Test
+    public void customResourceLoader_classpathRootContainsUnicodeCombiningCharacter_resourcesAreMatched()
+            throws Exception {
+        Path tempDir = temporaryFolder.getRoot().toPath();
+        Path classesRoot = tempDir.resolve("François")
+                .resolve("vaadin-c\u0327-repro").resolve("target/classes");
+        Path applicationClass = classesRoot
+                .resolve("com/example/application/Application.class");
+        Files.createDirectories(applicationClass.getParent());
+        Files.write(applicationClass, new byte[] { 0 });
+
+        try (URLClassLoader classLoader = new URLClassLoader(
+                new URL[] { classesRoot.toUri().toURL() }, null)) {
+            Resource[] resources = new VaadinServletContextInitializer.CustomResourceLoader(
+                    new DefaultResourceLoader(classLoader)).getResources(
+                            "classpath*:com/example/application/**/*.class");
+
+            assertThat(resources).as(Arrays.toString(resources)).anySatisfy(
+                    resource -> assertThat(getResourcePath(resource)).endsWith(
+                            "/com/example/application/Application.class"));
+        }
+    }
+
+    private static String getResourcePath(Resource resource) {
+        try {
+            return resource.getURI().getPath();
+        } catch (IOException exception) {
+            throw new IllegalStateException(exception);
+        }
     }
 
     private Runnable initRouteNotFoundMocksAndGetContextInitializedMockCall(


### PR DESCRIPTION
Cherry pick of https://github.com/vaadin/flow/pull/24220 to 25.0