### PR TITLE
fix(geolocation): always invoke callback / signal on JS-bridge failure

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/geolocation/BrowserGeolocationClient.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/geolocation/BrowserGeolocationClient.java
@@ -171,8 +171,13 @@ final class BrowserGeolocationClient implements GeolocationClient {
                     .addEventDetail().allowInert();
             el.executeJs("window.Vaadin.Flow.geolocation.watch(this, $0, $1)",
                     options, watchKey).then(ignored -> {
-                    }, err -> LOGGER.debug(
-                            "Client-side geolocation.watch failed: {}", err));
+                    }, err -> {
+                        LOGGER.debug("Client-side geolocation.watch failed: {}",
+                                err);
+                        onUpdate.accept(new GeolocationError(
+                                GeolocationErrorCode.UNKNOWN.code(),
+                                "Client-side geolocation bridge failure"));
+                    });
         }
 
         @Override

--- a/flow-server/src/main/java/com/vaadin/flow/component/geolocation/Geolocation.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/geolocation/Geolocation.java
@@ -179,6 +179,9 @@ public class Geolocation implements Serializable {
         client.get(options).whenComplete((outcome, error) -> {
             if (error != null) {
                 LOGGER.debug("Geolocation get() failed", error);
+                callback.accept(new GeolocationError(
+                        GeolocationErrorCode.UNKNOWN.code(),
+                        "Client-side geolocation bridge failure"));
             } else {
                 callback.accept(outcome);
             }

--- a/flow-server/src/test/java/com/vaadin/flow/component/geolocation/GeolocationClientSeamTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/geolocation/GeolocationClientSeamTest.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.geolocation;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,6 +31,8 @@ import com.vaadin.flow.shared.Registration;
 import com.vaadin.tests.util.MockUI;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -105,6 +108,29 @@ class GeolocationClientSeamTest {
                 "handle() should return null after stop()");
     }
 
+    @Test
+    void get_callbackReceivesUnknownErrorWhenClientFutureFailsExceptionally() {
+        FakeClient fake = new FakeClient();
+        fake.nextGetResult = CompletableFuture
+                .failedFuture(new RuntimeException(
+                        "Client-side geolocation.get failed: boom"));
+        ui.getGeolocation().setClient(fake);
+
+        AtomicReference<@Nullable GeolocationOutcome> received = new AtomicReference<>();
+        ui.getGeolocation().get(received::set);
+
+        GeolocationOutcome outcome = received.get();
+        assertNotNull(outcome,
+                "callback must fire even when the JS bridge fails");
+        GeolocationError err = assertInstanceOf(GeolocationError.class, outcome,
+                "infra failure should surface as a GeolocationError");
+        assertEquals(GeolocationErrorCode.UNKNOWN, err.errorCode(),
+                "error code should be UNKNOWN for client-bridge failures");
+        assertFalse(err.message().contains("boom"),
+                "synthesized message must not leak the wrapped exception text;"
+                        + " the cause is logged at DEBUG instead");
+    }
+
     /**
      * Minimal in-test fake. Records get() calls and serves a sentinel
      * WatchHandle from startWatch.
@@ -113,12 +139,15 @@ class GeolocationClientSeamTest {
         final List<@Nullable GeolocationOptions> getCalls = new ArrayList<>();
         boolean closed;
         GeolocationClient.@Nullable WatchHandle lastWatchHandle;
+        @Nullable
+        CompletableFuture<GeolocationOutcome> nextGetResult;
 
         @Override
         public CompletableFuture<GeolocationOutcome> get(
                 @Nullable GeolocationOptions options) {
             getCalls.add(options);
-            return new CompletableFuture<>();
+            CompletableFuture<GeolocationOutcome> result = nextGetResult;
+            return result != null ? result : new CompletableFuture<>();
         }
 
         @Override

--- a/flow-server/src/test/java/com/vaadin/flow/component/geolocation/GeolocationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/geolocation/GeolocationTest.java
@@ -231,6 +231,34 @@ class GeolocationTest {
     }
 
     @Test
+    void track_signalSurfacesUnknownErrorWhenWatchExecuteJsFails() {
+        TestComponent component = new TestComponent();
+        ui.add(component);
+
+        GeolocationTracker tracker = ui.getGeolocation().track(component);
+
+        PendingJavaScriptInvocation watchInvocation = ui
+                .dumpPendingJsInvocations().stream()
+                .filter(inv -> inv.getInvocation().getExpression()
+                        .contains("geolocation.watch"))
+                .reduce((a, b) -> b).orElseThrow();
+        watchInvocation.completeExceptionally(
+                JacksonUtils.createNode("module not loaded"));
+
+        GeolocationResult value = tracker.valueSignal().peek();
+        GeolocationError err = assertInstanceOf(GeolocationError.class, value,
+                "watch executeJs failure must surface as a GeolocationError"
+                        + " on the tracker's valueSignal");
+        assertEquals(GeolocationErrorCode.UNKNOWN, err.errorCode());
+        assertFalse(err.message().contains("module not loaded"),
+                "synthesized message must not leak the wrapped client text;"
+                        + " the cause is logged at DEBUG instead");
+        assertTrue(tracker.activeSignal().peek(),
+                "activeSignal stays true on infra failure — its contract"
+                        + " is tied to resume()/stop(), not data flow");
+    }
+
+    @Test
     void track_signalUpdatesOnPositionEvent() {
         TestComponent component = new TestComponent();
         ui.add(component);


### PR DESCRIPTION
Geolocation.get() and the watch path silently dropped the request when the JS bridge rejected (module not loaded, executeJs error, serialization mismatch). The application saw nothing — only a DEBUG log line. Now both paths surface the failure as a GeolocationError carrying the UNKNOWN error code, so apps see a consistent outcome via their existing callback or valueSignal.
