### PR TITLE
fix: show validation error when null is bound to primitive bean property

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -1252,6 +1252,17 @@ public class Binder<BEAN> implements Serializable {
                     });
         }
 
+        @SuppressWarnings("unchecked")
+        private Converter<TARGET, Object> createConverterForPrimitive(
+                Class<?> boxedType) {
+            return Converter.from(value -> value == null ? Result.error(
+                    "Null value cannot be assigned to a primitive bean property. "
+                            + "Use asRequired() to prevent null values.")
+                    : Result.of(() -> boxedType.cast(value), exception -> {
+                        throw new RuntimeException(exception);
+                    }), propertyValue -> (TARGET) propertyValue);
+        }
+
         @SuppressWarnings({ "unchecked", "rawtypes" })
         private Binding<BEAN, TARGET> bind(String propertyName,
                 boolean readOnly) {
@@ -1273,8 +1284,11 @@ public class Binder<BEAN> implements Serializable {
                         propertyName + " does not have an accessible setter");
             }
 
-            BindingBuilder<BEAN, ?> finalBinding = withConverter(
-                    createConverter(definition.getType()), false);
+            boolean isPrimitive = definition instanceof AbstractBeanPropertyDefinition<?, ?> abpd
+                    && abpd.getDescriptor().getPropertyType().isPrimitive();
+            BindingBuilder<BEAN, ?> finalBinding = withConverter(isPrimitive
+                    ? createConverterForPrimitive(definition.getType())
+                    : createConverter(definition.getType()), false);
 
             finalBinding = getBinder().configureBinding(finalBinding,
                     definition);

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -1257,7 +1257,7 @@ public class Binder<BEAN> implements Serializable {
                 Class<?> boxedType) {
             return Converter.from(value -> value == null ? Result.error(
                     "Null value cannot be assigned to a primitive bean property. "
-                            + "Use asRequired() to prevent null values.")
+                            + "Use asRequired() before any converter to prevent null values.")
                     : Result.of(() -> boxedType.cast(value), exception -> {
                         throw new RuntimeException(exception);
                     }), propertyValue -> (TARGET) propertyValue);

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -43,12 +43,10 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.data.binder.Binder.Binding;
 import com.vaadin.flow.data.binder.Binder.BindingBuilder;
 import com.vaadin.flow.data.binder.testcomponents.TestTextField;
-import com.vaadin.flow.data.converter.BigDecimalToDoubleConverter;
 import com.vaadin.flow.data.converter.Converter;
 import com.vaadin.flow.data.converter.StringToBigDecimalConverter;
 import com.vaadin.flow.data.converter.StringToDoubleConverter;
 import com.vaadin.flow.data.converter.StringToIntegerConverter;
-import com.vaadin.flow.data.validator.DoubleRangeValidator;
 import com.vaadin.flow.data.validator.IntegerRangeValidator;
 import com.vaadin.flow.data.validator.NotEmptyValidator;
 import com.vaadin.flow.data.validator.StringLengthValidator;
@@ -1529,15 +1527,11 @@ class BinderTest extends BinderTestBase<Binder<Person>, Person> {
     }
 
     @Test
-    void nullBigDecimalForPrimitiveDoubleField_showsValidationError() {
+    void nullValueForPrimitiveDoubleField_showsValidationError() {
         Binder<ExampleDouble> binder = new Binder<>(ExampleDouble.class);
         TestTextField field = new TestTextField();
         Binder.Binding<ExampleDouble, ?> binding = binder.forField(field)
-                .withConverter(new StringToBigDecimalConverter(""))
-                .withConverter(new BigDecimalToDoubleConverter())
-                .withValidator(new DoubleRangeValidator(
-                        "Value must be between 0 and 99.999", 0d, 99.999))
-                .bind("value");
+                .withConverter(new StringToDoubleConverter("")).bind("value");
         binder.setBean(new ExampleDouble());
 
         field.setValue("");
@@ -1546,7 +1540,7 @@ class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         assertTrue(status.isError());
         assertEquals(
                 "Null value cannot be assigned to a primitive bean property. "
-                        + "Use asRequired() to prevent null values.",
+                        + "Use asRequired() before any converter to prevent null values.",
                 status.getMessage().get());
     }
 

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -43,10 +43,12 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.data.binder.Binder.Binding;
 import com.vaadin.flow.data.binder.Binder.BindingBuilder;
 import com.vaadin.flow.data.binder.testcomponents.TestTextField;
+import com.vaadin.flow.data.converter.BigDecimalToDoubleConverter;
 import com.vaadin.flow.data.converter.Converter;
 import com.vaadin.flow.data.converter.StringToBigDecimalConverter;
 import com.vaadin.flow.data.converter.StringToDoubleConverter;
 import com.vaadin.flow.data.converter.StringToIntegerConverter;
+import com.vaadin.flow.data.validator.DoubleRangeValidator;
 import com.vaadin.flow.data.validator.IntegerRangeValidator;
 import com.vaadin.flow.data.validator.NotEmptyValidator;
 import com.vaadin.flow.data.validator.StringLengthValidator;
@@ -1524,6 +1526,28 @@ class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         validation = bind.validate();
         assertFalse(validation.isError());
         assertEquals(30, item.getAge());
+    }
+
+    @Test
+    void nullBigDecimalForPrimitiveDoubleField_showsValidationError() {
+        Binder<ExampleDouble> binder = new Binder<>(ExampleDouble.class);
+        TestTextField field = new TestTextField();
+        Binder.Binding<ExampleDouble, ?> binding = binder.forField(field)
+                .withConverter(new StringToBigDecimalConverter(""))
+                .withConverter(new BigDecimalToDoubleConverter())
+                .withValidator(new DoubleRangeValidator(
+                        "Value must be between 0 and 99.999", 0d, 99.999))
+                .bind("value");
+        binder.setBean(new ExampleDouble());
+
+        field.setValue("");
+
+        BindingValidationStatus<?> status = binding.validate();
+        assertTrue(status.isError());
+        assertEquals(
+                "Null value cannot be assigned to a primitive bean property. "
+                        + "Use asRequired() to prevent null values.",
+                status.getMessage().get());
     }
 
     @Test
@@ -3028,6 +3052,18 @@ class BinderTest extends BinderTestBase<Binder<Person>, Person> {
                 ((DecimalFormat) format).setMinimumFractionDigits(2);
             }
             return format;
+        }
+    }
+
+    private static class ExampleDouble {
+        private double value;
+
+        public double getValue() {
+            return value;
+        }
+
+        public void setValue(double value) {
+            this.value = value;
         }
     }
 


### PR DESCRIPTION
When a field bound to a primitive property (e.g. double) produces a null value through converters, the Binder now returns a descriptive validation error instead of throwing a NullPointerException.

Fixes #24253

## Description

When a `Binder` field is bound to a primitive bean property (e.g. `double`) via `bind("propertyName")`, and the field value becomes `null` through
   a converter chain (for example `StringToBigDecimalConverter` → `BigDecimalToDoubleConverter` producing `null`), the Binder was throwing a        
  `NullPointerException` instead of showing a user-facing validation error.                                                                         
                                                                                                                                                    
  This fix detects primitive-typed properties in `bind(String propertyName)` and adds a converter that returns a descriptive `Result.error(...)`
  when the value is `null`, preventing the NPE and surfacing a meaningful message.

Fixes #24253 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.