### PR TITLE
feat: expose application properties via `Options` for `TypeScriptBootstrapModifier` consumers (#24073) (CP: 24.10)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/Options.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/Options.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.flow.server.frontend;
 
 import java.io.File;
@@ -6,6 +21,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -18,6 +34,7 @@ import com.vaadin.flow.server.frontend.installer.NodeInstaller;
 import com.vaadin.flow.server.frontend.installer.Platform;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
+import com.vaadin.flow.server.startup.ApplicationConfiguration;
 
 /**
  * Build a <code>NodeExecutor</code> instance.
@@ -143,6 +160,8 @@ public class Options implements Serializable {
 
     private boolean commercialBannerEnabled = false;
 
+    private ApplicationConfiguration applicationConfiguration;
+
     /**
      * Creates a new instance.
      *
@@ -170,6 +189,21 @@ public class Options implements Serializable {
         this.lookup = lookup;
         this.classFinder = classFinder;
         this.npmFolder = npmFolder;
+    }
+
+    /**
+     * Sets the application configuration for the current options and returns
+     * the updated options instance.
+     *
+     * @param applicationConfiguration
+     *            the application configuration to be applied
+     * @return the updated {@code Options} instance with the specified
+     *         application configuration
+     */
+    public Options withApplicationConfiguration(
+            ApplicationConfiguration applicationConfiguration) {
+        this.applicationConfiguration = applicationConfiguration;
+        return this;
     }
 
     /**
@@ -1124,5 +1158,43 @@ public class Options implements Serializable {
             return true;
         }
         return copyAssets;
+    }
+
+    /**
+     * Retrieves the value of a string application property.
+     * <p>
+     * Returns an empty {@code Optional} if the application configuration is not
+     * available (e.g., at build time). When configuration is available, returns
+     * the property value or the given default.
+     *
+     * @param name
+     *            the name of the property to retrieve
+     * @param defaultValue
+     *            the value to return if the property is not set
+     * @return the property value, or empty if configuration is unavailable
+     */
+    public Optional<String> getApplicationStringProperty(String name,
+            String defaultValue) {
+        return Optional.ofNullable(applicationConfiguration)
+                .map(app -> app.getStringProperty(name, defaultValue));
+    }
+
+    /**
+     * Retrieves the value of a boolean application property.
+     * <p>
+     * Returns an empty {@code Optional} if the application configuration is not
+     * available (e.g., at build time). When configuration is available, returns
+     * the property value or the given default.
+     *
+     * @param name
+     *            the name of the property to retrieve
+     * @param defaultValue
+     *            the value to return if the property is not set
+     * @return the property value, or empty if configuration is unavailable
+     */
+    public Optional<Boolean> getApplicationBooleanProperty(String name,
+            boolean defaultValue) {
+        return Optional.ofNullable(applicationConfiguration)
+                .map(app -> app.getBooleanProperty(name, defaultValue));
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/OptionsApplicationPropertiesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/OptionsApplicationPropertiesTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.frontend;
+
+import java.io.File;
+import java.util.Optional;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.server.startup.ApplicationConfiguration;
+import com.vaadin.tests.util.MockOptions;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class OptionsApplicationPropertiesTest {
+
+    @Test
+    public void getApplicationBooleanProperty_configAvailable_returnsPropertyValue() {
+        ApplicationConfiguration config = Mockito
+                .mock(ApplicationConfiguration.class);
+        Mockito.when(config.getBooleanProperty("test.prop", false))
+                .thenReturn(true);
+
+        Options options = new MockOptions(new File("."))
+                .withApplicationConfiguration(config);
+
+        Optional<Boolean> result = options
+                .getApplicationBooleanProperty("test.prop", false);
+        assertEquals(Optional.of(true), result);
+    }
+
+    @Test
+    public void getApplicationBooleanProperty_noConfig_returnsEmpty() {
+        Options options = new MockOptions(new File("."));
+
+        Optional<Boolean> result = options
+                .getApplicationBooleanProperty("test.prop", true);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void getApplicationStringProperty_configAvailable_returnsPropertyValue() {
+        ApplicationConfiguration config = Mockito
+                .mock(ApplicationConfiguration.class);
+        Mockito.when(config.getStringProperty("test.prop", "default"))
+                .thenReturn("custom");
+
+        Options options = new MockOptions(new File("."))
+                .withApplicationConfiguration(config);
+
+        Optional<String> result = options
+                .getApplicationStringProperty("test.prop", "default");
+        assertEquals(Optional.of("custom"), result);
+    }
+
+    @Test
+    public void getApplicationStringProperty_noConfig_returnsEmpty() {
+        Options options = new MockOptions(new File("."));
+
+        Optional<String> result = options
+                .getApplicationStringProperty("test.prop", "default");
+        assertTrue(result.isEmpty());
+    }
+}

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
@@ -252,6 +252,7 @@ public class DevModeInitializer implements Serializable {
                 ClassFinder.class);
         Lookup lookup = Lookup.compose(lookupForClassFinder, lookupFromContext);
         Options options = new Options(lookup, baseDir)
+                .withApplicationConfiguration(config)
                 .withFrontendDirectory(frontendFolder)
                 .withFrontendGeneratedFolder(
                         new File(frontendFolder + GENERATED))


### PR DESCRIPTION
`TypeScriptBootstrapModifier` implementations (e.g., Copilot) need access
to application properties to conditionally modify bootstrap TypeScript. Currently, the Copilot script is injected in dev mode regardless of whether Copilot is enabled in the project configuration.

Add `withApplicationConfiguration` to `Options` and property accessor methods (`getApplicationStringProperty`,
`getApplicationBooleanProperty`)
that return `Optional.empty()` when configuration is unavailable (build time). Wire `ApplicationConfiguration` from `DevModeInitializer`.

Fixes #24055