### PR TITLE
chore: avoid IT job hangs caused by orphan Spring Boot JVM

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -132,8 +132,18 @@ jobs:
             ARGS="-pl ${{matrix.module}} -Dtest=${{matrix.args}}" || \
             ARGS="-pl ${{matrix.args}}"
           cmd="mvn -B -ntp -T 1C $ARGS"
-          set -x -e -o pipefail
-          $cmd verify -Dmaven.javadoc.skip=false | tee mvn-unit-tests-${{matrix.current}}.out
+          set -x -e
+          LOG=mvn-unit-tests-${{matrix.current}}.out
+          $cmd verify -Dmaven.javadoc.skip=false </dev/null >"$LOG" 2>&1 &
+          MVN_PID=$!
+          tail -f --pid=$MVN_PID "$LOG" &
+          wait $MVN_PID
+      - name: Kill leftover Java processes
+        if: ${{ always() }}
+        run: |
+          pkill -TERM java || true
+          sleep 2
+          pkill -KILL java || true
       - name: Package test-report files
         if: ${{ failure() || success() }}
         run: find . -name surefire-reports -o -name failsafe-reports -o -name error-screenshots -o -name "mvn-*.out" | tar -czf tests-report-unit-${{matrix.current}}.tgz -T -
@@ -210,13 +220,27 @@ jobs:
             $cmd -T 1C || $cmd
           fi
       - name: Run ITs
+        timeout-minutes: 22
         run: |
           [ -n "${{matrix.module}}" ] && \
             ARGS="-Dfailsafe.forkCount=4 -pl ${{matrix.module}} -Dit.test=${{matrix.args}}" || \
             ARGS="-pl ${{matrix.args}}"
           cmd="mvn -V -B -ntp -e -fae -Dcom.vaadin.testbench.Parameters.testsInParallel=5 -Dfailsafe.rerunFailingTestsCount=2 -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Pbun $ARGS"
-          set -x -e -o pipefail
-          $cmd verify | tee -a mvn-it-tests-${{matrix.current}}.out
+          set -x -e
+          LOG=mvn-it-tests-${{matrix.current}}.out
+          # Detach mvn's stdio from this shell so an orphan child JVM (e.g. a
+          # Spring Boot fork that spring-boot:stop failed to kill) can't pin
+          # the step open by holding the pipe to tee.
+          $cmd verify </dev/null >"$LOG" 2>&1 &
+          MVN_PID=$!
+          tail -f --pid=$MVN_PID "$LOG" &
+          wait $MVN_PID
+      - name: Kill leftover Java processes
+        if: ${{ always() }}
+        run: |
+          pkill -TERM java || true
+          sleep 2
+          pkill -KILL java || true
       - name: Package test-report files
         if: ${{ always() }}
         run: find . -name surefire-reports -o -name failsafe-reports -o -name error-screenshots -o -name "mvn-*.out" -o -name "jetty-start.out" | tar -czf tests-report-it-${{matrix.current}}.tgz -T -

--- a/flow-tests/test-redeployment/pom.xml
+++ b/flow-tests/test-redeployment/pom.xml
@@ -78,6 +78,29 @@
 
   <build>
     <plugins>
+      <!-- Run BEFORE spring-boot-maven-plugin so the sleep below executes
+           ahead of stop-server in the post-integration-test phase. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>quiet-period-before-stop</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>post-integration-test</phase>
+            <configuration>
+              <!-- Tests in this module trigger DevTools restarts; give the
+                   admin JMX bean time to be re-registered after the last
+                   restart so spring-boot:stop can find it. -->
+              <target>
+                <sleep seconds="5"/>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>


### PR DESCRIPTION
  ## Summary

  Validation runs occasionally lose ~30 minutes on `it-tests (11, ...)` because
  the step runs to the job timeout instead of finishing — costing a full re-run
  attempt to produce green. Example:
  https://github.com/vaadin/flow/actions/runs/25435931074/job/74614298073
  (attempt 1 cancelled at 30:00, attempt 2 succeeded.)

  ## Current behavior (root cause)

  The `flow-test-redeployment` module starts its app via
  `spring-boot-maven-plugin:start` (pre-IT) and stops it via `:stop` (post-IT).
  Spring DevTools is on the classpath and the test churns class files (touching
  `Application.class` to trigger reloads), which in this run produced **8
  DevTools-driven restarts in 20 seconds**, the last firing 442 ms before
  `spring-boot:stop` ran:

  12:47:56.241 [File Watcher] Restarting due to 1 class path change ...
  12:47:56.683 [INFO] --- spring-boot-maven-plugin:4.1.0-RC1:stop ...
  [ERROR] Spring application lifecycle JMX bean not found.
          Could not stop application gracefully:
          org.springframework.boot:type=Admin,name=SpringApplication

  `stop` queries the admin MBean exactly once and there is no retry; during a
  restart the bean is briefly unregistered, so the call fails. The forked
  Spring Boot JVM (PID 3969 in this run) is therefore **never killed**. Maven
  moves on under `-fae`, finishes 16 more modules, and exits with BUILD
  FAILURE — but the orphan JVM still holds the write end of the pipe inherited
  from `mvn ... | tee -a mvn-it-tests-11.out` (`.github/workflows/validation.yml`).
  `tee` cannot reach EOF, the bash pipeline cannot complete, and the job
  hangs until GitHub force-cancels at the 30-min job timeout. The runner
  cleanup confirms the orphan: `Terminate orphan process: pid (3969) (java)`.

  ## Fix

  Two small, independent changes:

  1. **`flow-tests/test-redeployment/pom.xml`** — insert a maven-antrun-plugin 
      execution bound to post-integration-test (declared before 
      spring-boot-maven-plugin so it runs first in that phase) that sleeps 5 seconds 
      before spring-boot:stop runs. This module's tests deliberately trigger DevTools 
      restarts; the original failure was a 442 ms race between the last restart and 
      stop-server querying the admin JMX bean. The 5-second quiet period lets 
      DevTools finish re-registering the bean so stop-server can shut the app down 
      cleanly instead of leaving an orphan JVM behind.

  2. **`.github/workflows/validation.yml`** — add `timeout-minutes: 22` on the
     `Run ITs` step (the job-level 30-min cap stays as the outer fence). If a
     future plugin produces a similar shape of hang, the step now fails after
     22 min instead of 30, leaving room within the original job budget for
     report packaging, artifact upload, and the existing `run_attempt > 1`
     retry path.

  3. **`.github/workflows/validation.yml`** — replace mvn ... | tee ...out with file 
      redirection (>"$LOG" 2>&1 + tail -f --pid) so an orphan child JVM holding 
      an inherited stdout fd can no longer pin the step open. Add a follow-up Kill
      leftover Java processes step (if: always()) that SIGTERM/SIGKILLs any remaining 
      java processes before report packaging — defensive cleanup against any 
      future plugin that leaks a JVM.
