### PR TITLE
fix: wrong existence check in getStaticResource

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
@@ -19,12 +19,10 @@ import jakarta.servlet.GenericServlet;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
-import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -338,13 +336,15 @@ public class VaadinServletService extends VaadinService {
         URL url = servletContext.getResource(path);
         if (url != null && Optional.ofNullable(servletContext.getServerInfo())
                 .orElse("").contains("jetty/12.")) {
-            // Making sure that resource exists before returning it. Jetty
-            // 12 may return URL for non-existing resource.
-            try {
-                if (!Files.exists(Path.of(url.toURI()))) {
-                    url = null;
-                }
-            } catch (URISyntaxException e) {
+            // Jetty 12 may return URLs for non-existing resources. Probe the
+            // URL by opening a stream: this works uniformly for file: URLs
+            // and for jar:file:...!/entry URLs without requiring a NIO
+            // FileSystem to be mounted for the JAR (which Path.of(jarUri)
+            // would need, breaking on Jetty 12.1.9 where classpath JARs are
+            // no longer kept mounted in the JVM-wide cache).
+            try (InputStream probe = url.openStream()) {
+                // resource exists
+            } catch (IOException e) {
                 url = null;
             }
         }

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletServiceTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletServiceTest.java
@@ -21,16 +21,24 @@ import jakarta.servlet.http.HttpSession;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.di.Instantiator;
@@ -329,6 +337,44 @@ class VaadinServletServiceTest {
                 "Filter was called on exception handling");
         assertEquals("true", request.getAttribute("ended"),
                 "Filter was called in the finally block");
+    }
+
+    @Test
+    void getStaticResource_jarUrlOnJetty12_returnsUrlInsteadOfThrowing(
+            @TempDir Path tempDir) throws Exception {
+        // Reproduces the regression caused by Jetty 12.1.9 where
+        // ServletContext.getResource() returns a jar:file:... URL for
+        // resources packaged inside a JAR (e.g. vaadinPush.js in flow-push).
+        // Path.of(jar:URI) throws FileSystemNotFoundException because no
+        // FileSystem has been opened for the JAR, and the existence check in
+        // VaadinServletService.getStaticResource catches only
+        // URISyntaxException, so the unchecked exception escapes and the
+        // request fails with HTTP 500.
+        String resourcePath = "META-INF/resources/VAADIN/static/push/vaadinPush.js";
+        Path jarFile = tempDir
+                .resolve("flow-push-" + UUID.randomUUID() + ".jar");
+        try (JarOutputStream jar = new JarOutputStream(
+                Files.newOutputStream(jarFile))) {
+            jar.putNextEntry(new JarEntry(resourcePath));
+            jar.write("// push".getBytes(StandardCharsets.UTF_8));
+            jar.closeEntry();
+        }
+
+        URL jarResourceUrl = URI
+                .create("jar:" + jarFile.toUri() + "!/" + resourcePath).toURL();
+
+        ServletContext servletContext = Mockito.mock(ServletContext.class);
+        when(servletContext.getServerInfo()).thenReturn("jetty/12.1.9");
+        when(servletContext.getResource("/VAADIN/static/push/vaadinPush.js"))
+                .thenReturn(jarResourceUrl);
+
+        URL resolved = VaadinServletService.getStaticResource(servletContext,
+                "/VAADIN/static/push/vaadinPush.js");
+
+        assertNotNull(resolved,
+                "An existing resource served from a JAR by Jetty 12 must be returned, "
+                        + "not lost to FileSystemNotFoundException");
+        assertEquals(jarResourceUrl, resolved);
     }
 
     static class ExceptionThrowingRequestHandler implements RequestHandler {


### PR DESCRIPTION
On Jetty 12.1.9, requests for static resources packaged inside a JAR (e.g. `vaadinPush.js` from `flow-push`) fail with
`FileSystemNotFoundException`. `VaadinServletService.getStaticResource` verifies the URL returned by `ServletContext.getResource` via `Path.of(url.toURI())`, which for a `jar:file:...!/entry` URI requires the JAR's NIO `FileSystem` to already be mounted in the JVM-wide cache. Jetty 12.1.8 incidentally kept those filesystems mounted during resource resolution; 12.1.9 no longer does, so `getFileSystem` throws and the existing `catch (URISyntaxException)` lets the unchecked exception escape, producing HTTP 500.

Probe the URL with `URL.openStream()` instead. `JarURLConnection` and `FileURLConnection` use `java.util.jar.JarFile` / `java.io.File` directly and are independent of the NIO `FileSystems` cache, so the check works uniformly for `file:` and `jar:file:` URLs and on every Jetty 12 build. The catch is broadened to `IOException`, covering both missing files (the original Jetty 12 workaround) and missing JAR entries.
