### PR TITLE
fix: install pnpm deps in hoisted mode + declare @babel/types

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -364,7 +364,13 @@ public class FrontendTools {
         List<String> pnpmCommand = getSuitablePnpm();
         assert !pnpmCommand.isEmpty();
         pnpmCommand = new ArrayList<>(pnpmCommand);
-        pnpmCommand.add("--shamefully-hoist=true");
+        // Force hoisted (flat npm-style) layout. CLI takes precedence over
+        // .npmrc, so this is unambiguous even if the project lacks the
+        // generated .npmrc. Replaces the previous --shamefully-hoist=true,
+        // which only controls the partial-hoist heuristic on top of the
+        // default isolated layout and did not consistently expose every
+        // transitive at the project root.
+        pnpmCommand.add("--config.node-linker=hoisted");
         return pnpmCommand;
     }
 

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -379,8 +379,9 @@ class FrontendToolsTest {
     @Test
     void getPnpmExecutable_executableIsAvailable() {
         List<String> executable = tools.getPnpmExecutable();
-        // command line should contain --shamefully-hoist=true option
-        assertTrue(executable.contains("--shamefully-hoist=true"));
+        // command line should force hoisted node-linker so transitive
+        // deps are always installed at the project root
+        assertTrue(executable.contains("--config.node-linker=hoisted"));
         assertTrue(executable.stream().anyMatch(cmd -> cmd.contains("pnpm")));
     }
 

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -169,6 +169,7 @@ class NodeUpdaterTest {
         expectedDependencies.add("transform-ast");
         expectedDependencies.add("strip-css-comments");
         expectedDependencies.add("@babel/core");
+        expectedDependencies.add("@babel/types");
         expectedDependencies
                 .add("@babel/plugin-transform-react-jsx-development");
         expectedDependencies.add("@babel/preset-react");

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -223,6 +223,7 @@ class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         assertTrue(npmRcFile.exists());
         String content = Files.readString(npmRcFile.toPath());
         assertTrue(content.contains("shamefully-hoist"));
+        assertTrue(content.contains("node-linker=hoisted"));
     }
 
     @Test

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
@@ -15,6 +15,7 @@
     "@rollup/plugin-replace": "6.0.3",
     "@rollup/pluginutils": "5.3.0",
     "@babel/core": "7.29.0",
+    "@babel/types": "7.29.0",
     "@babel/plugin-transform-react-jsx-development": "7.27.1",
     "@babel/preset-react": "7.28.5",
     "@rolldown/plugin-babel": "0.2.3",

--- a/flow-server/src/main/resources/npmrc
+++ b/flow-server/src/main/resources/npmrc
@@ -3,5 +3,11 @@
 #
 # This file sets the default parameters for manual `pnpm install`.
 #
+# node-linker=hoisted produces a flat node_modules layout (like npm),
+# so every transitive dependency lives at the project root. Flow's
+# frontend tooling and bundled Vite plugins (e.g. the React function
+# location plugin) import transitive deps that pnpm's symlink-based
+# layout did not consistently hoist, even with shamefully-hoist=true.
+node-linker=hoisted
 shamefully-hoist=true
 strict-peer-dependencies=false


### PR DESCRIPTION
## Summary

  The Vite dev server intermittently fails (or hangs) on `vite-basics` and
  other Vite-using IT modules because transitive npm dependencies are not
  consistently reachable from the project's root `node_modules`. Selenium
  tests then wait for pages that never render, and the matrix shard times
  out at the 30-minute job cap.

  Two distinct symptoms observed:

  1. **`Cannot find package '@babel/types'`** — the bundled Vite plugin
     `react-function-location-plugin.js` does
     `import * as t from '@babel/types';`, but `@babel/types` was only
     present transitively via `@babel/core` and pnpm did not always hoist
     it to the root.

  2. **`Failed to resolve import "@lit/reactive-element/..."`,
     `"cookie"`, `"set-cookie-parser"`, `"@preact/signals-react/runtime"`** —
     all transitives of declared deps (`lit`, `react-router`,
     `@preact/signals-react-transform`) — also not consistently hoisted.

  Both are the same underlying problem: pnpm with `shamefully-hoist=true`
  does not deterministically expose every transitive at the project root.

  ## Fix

  Three commits, layered:

  ### 1. Declare `@babel/types` directly

  Adds `"@babel/types": "7.29.0"` (matching `@babel/core`) to the bundled
  `devDependencies` in
  `flow-server/.../dependencies/vite/package.json`. Correct on its own
  merits — the plugin imports the package, so the package should be a
  real dependency. Updates `NodeUpdaterTest`'s expected-set accordingly.

  ### 2. Switch the bundled `.npmrc` template to `node-linker=hoisted`

  Adds `node-linker=hoisted` to `flow-server/src/main/resources/npmrc`,
  the template `TaskRunNpmInstall` writes to the project. This tells
  pnpm to install in **flat npm-style mode** — every package (declared
  or transitive) at the project root, no `.pnpm/` virtual store.
  Resolutions become deterministic.

  `shamefully-hoist=true` is left in the template alongside, so manual
  `pnpm install` invocations from a developer shell still pick up at
  least the legacy partial-hoist behavior if some user-level config
  overrides our `node-linker`.

  ### 3. Pass `--config.node-linker=hoisted` on the pnpm CLI

  The `.npmrc` change alone did not actually flip pnpm's install layout
  in CI: `node_modules/.pnpm/...` paths kept appearing in error
  messages, indicating pnpm was still using its default `isolated`
  mode. The pre-existing `--shamefully-hoist=true` CLI flag added by
  `FrontendTools.getPnpmExecutable()` likely took precedence and locked
  pnpm to the isolated layout (where `shamefully-hoist` makes sense as
  a partial-hoist heuristic).

  Replace `--shamefully-hoist=true` with `--config.node-linker=hoisted`
  on the CLI. CLI > `.npmrc` > defaults in pnpm's config precedence, so
  the install is now unambiguously hoisted regardless of any project-
  or user-level `.npmrc` content. `FrontendToolsTest` updated to assert
  the new flag.

  ## Trade-offs

  - **Disk/install time**: hoisted mode uses slightly more disk and is
    a few seconds slower than the symlink store for fresh installs.
    Acceptable for the determinism gain.
  - **Loose isolation**: hoisted mode allows packages to import any
    other package, declared or not. Flow's frontend code already relies
    on this (e.g. plugins importing transitives), so this is the
    current de-facto behavior — just made deterministic.
  - **Behavioral change for downstream users**: anyone with a custom
    `.npmrc` that lacks the auto-gen marker keeps their config (per
    existing `TaskRunNpmInstall.createNpmRcFile()` logic), but the new
    CLI flag still applies — they'll silently get hoisted mode for
    Flow-driven installs. Worth flagging in release notes.
