### PR TITLE
chore(spring): set proxyBeanMethods=false on Vaadin Spring config classes

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringBootAutoConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringBootAutoConfiguration.java
@@ -48,7 +48,7 @@ import jakarta.servlet.MultipartConfigElement;
  * @author Vaadin Ltd
  *
  */
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @AutoConfigureBefore(WebMvcAutoConfiguration.class)
 @ConditionalOnClass(ServletContextInitializer.class)
 @EnableConfigurationProperties(VaadinConfigurationProperties.class)

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinApplicationConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinApplicationConfiguration.java
@@ -43,7 +43,7 @@ import com.vaadin.flow.spring.security.SpringMenuAccessControl;
  * @since
  *
  */
-@Configuration
+@Configuration(proxyBeanMethods = false)
 public class VaadinApplicationConfiguration {
 
     /**


### PR DESCRIPTION
## Summary

`VaadinApplicationConfiguration` and `SpringBootAutoConfiguration`
declare `@Configuration` without an explicit `proxyBeanMethods`
setting, which defaults to `true`. Neither class self-cross-references
its own `@Bean` methods, and neither uses `@Transactional`,
`@Async` or other AOP that requires the configuration self-proxy —
so the CGLIB-enhancement step that the default brings is dead weight.

Setting `proxyBeanMethods = false` on both classes drops that
enhancement step. Per Spring's own
[`@Configuration` Javadoc](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/annotation/Configuration.html#proxyBeanMethods),
this is the recommended setting whenever `@Bean` cross-references
are not in use.

## Diff

```diff
-@Configuration
+@Configuration(proxyBeanMethods = false)
 public class VaadinApplicationConfiguration {

-@Configuration
+@Configuration(proxyBeanMethods = false)
 public class SpringBootAutoConfiguration {
```

## Why this matters in practice

In a Jakarta EE FAT-EAR with multiple Vaadin-bearing WARs deployed
in parallel on WildFly / JBoss EAP, each WAR drives its own Spring
`ApplicationContext` through these two classes concurrently. Their
CGLIB-enhancement stage races on the JBoss-Modules class-loader
lock and produces a deployment hang. Removing the proxy (which is
unused) removes the contention.

## Intentionally not changed

`VaadinServletConfiguration` (imported via `@Import` from
`SpringBootAutoConfiguration`) really does have a self
cross-reference: `vaadinRootMapping` directly invokes
`vaadinForwardingController()`. That class needs the `@Bean`
self proxy and is left untouched.

## Risk

Minimal. The change is local to two configuration classes that
do not exercise the proxy semantics. Subclasses with custom
`@Bean` self-cross-references would need their own
`proxyBeanMethods = true` — none such exist upstream.