### PR TITLE
chore: revert dependency version bump in plugin test

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    exclude-paths:
+      - "flow-plugins/flow-maven-plugin/src/it"

--- a/flow-plugins/flow-maven-plugin/src/it/plugin-pinned-deps-project/pom.xml
+++ b/flow-plugins/flow-maven-plugin/src/it/plugin-pinned-deps-project/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>io.github.classgraph</groupId>
             <artifactId>classgraph</artifactId>
-            <version>4.8.112</version>
+            <version>4.0.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
The classgraph plugin is intentionally pinned to an old version to ensure project dependecies does not leak into the plugin classpaht.

This change reverts the change and exclude flow maven plugin integration tests POM files from dependabot updates
