### PR TITLE
fix: install pnpm deps in hoisted mode + declare @babel/types (#24288) (CP:23.7)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -608,7 +608,13 @@ public class FrontendTools {
         List<String> pnpmCommand = getSuitablePnpm();
         assert !pnpmCommand.isEmpty();
         pnpmCommand = new ArrayList<>(pnpmCommand);
-        pnpmCommand.add("--shamefully-hoist=true");
+        // Force hoisted (flat npm-style) layout. CLI takes precedence over
+        // .npmrc, so this is unambiguous even if the project lacks the
+        // generated .npmrc. Replaces the previous --shamefully-hoist=true,
+        // which only controls the partial-hoist heuristic on top of the
+        // default isolated layout and did not consistently expose every
+        // transitive at the project root.
+        pnpmCommand.add("--config.node-linker=hoisted");
         return pnpmCommand;
     }
 

--- a/flow-server/src/main/resources/npmrc
+++ b/flow-server/src/main/resources/npmrc
@@ -3,5 +3,11 @@
 #
 # This file sets the default parameters for manual `pnpm install`.
 #
+# node-linker=hoisted produces a flat node_modules layout (like npm),
+# so every transitive dependency lives at the project root. Flow's
+# frontend tooling and bundled Vite plugins (e.g. the React function
+# location plugin) import transitive deps that pnpm's symlink-based
+# layout did not consistently hoist, even with shamefully-hoist=true.
+node-linker=hoisted
 shamefully-hoist=true
 strict-peer-dependencies=false

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -432,8 +432,9 @@ public class FrontendToolsTest {
     @Test
     public void getPnpmExecutable_executableIsAvailable() {
         List<String> executable = tools.getPnpmExecutable();
-        // command line should contain --shamefully-hoist=true option
-        Assert.assertTrue(executable.contains("--shamefully-hoist=true"));
+        // command line should force hoisted node-linker so transitive
+        // deps are always installed at the project root
+        Assert.assertTrue(executable.contains("--config.node-linker=hoisted"));
         Assert.assertTrue(
                 executable.stream().anyMatch(cmd -> cmd.contains("pnpm")));
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -432,6 +432,7 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         String content = FileUtils.readFileToString(npmRcFile,
                 StandardCharsets.UTF_8);
         Assert.assertTrue(content.contains("shamefully-hoist"));
+        Assert.assertTrue(content.contains("node-linker=hoisted"));
     }
 
     @Test

--- a/flow-tests/test-frontend/test-pnpm/src/test/java/com/vaadin/flow/mixedtest/ui/PnpmUsedIT.java
+++ b/flow-tests/test-frontend/test-pnpm/src/test/java/com/vaadin/flow/mixedtest/ui/PnpmUsedIT.java
@@ -18,12 +18,14 @@ public class PnpmUsedIT {
 
     @Test
     public void pnpmIsUsed() {
-        File testPackage = new File("node_modules/lit");
+        // The previous check asserted that node_modules/lit is a symlink
+        // (pnpm isolated-mode signature). Since FrontendTools now forces
+        // --config.node-linker=hoisted to make transitive deps reachable
+        // at the project root, pnpm produces a flat layout and that
+        // symlink no longer exists. Presence of pnpm-lock.yaml is the
+        // remaining reliable signal that pnpm (not npm) ran the install.
+        File testPackage = new File("pnpm-lock.yaml");
         FileTestUtil.waitForFile(testPackage);
-        FileTestUtil.assertSymlink(testPackage,
-                "pnpm should have been used to install frontend dependencies but "
-                        + testPackage.getAbsolutePath()
-                        + " is a not a symlink like it should be");
     }
 
 }


### PR DESCRIPTION
…) (CP: 23.7)

## Summary

The Vite dev server intermittently fails (or hangs) on `vite-basics` and other Vite-using IT modules because transitive npm dependencies are not consistently reachable from the project's root `node_modules`. Selenium tests then wait for pages that never render, and the matrix shard times out at the 30-minute job cap.

Two distinct symptoms observed:

1. **`Cannot find package '@babel/types'`** — the bundled Vite plugin `react-function-location-plugin.js` does `import * as t from '@babel/types';`, but `@babel/types` was only present transitively via `@babel/core` and pnpm did not always hoist it to the root.

2. **`Failed to resolve import "@lit/reactive-element/..."`, `"cookie"`, `"set-cookie-parser"`, `"@preact/signals-react/runtime"`** — all transitives of declared deps (`lit`, `react-router`, `@preact/signals-react-transform`) — also not consistently hoisted.

Both are the same underlying problem: pnpm with `shamefully-hoist=true` does not deterministically expose every transitive at the project root. On 23.7 the same root cause surfaces as `Cannot find module 'rollup'` when Vite 3.2.11 tries to load `vite.generated.js`.

## Fix

### 1. Switch the bundled `.npmrc` template to `node-linker=hoisted`

Adds `node-linker=hoisted` to `flow-server/src/main/resources/npmrc`, the template `TaskRunNpmInstall` writes to the project. This tells pnpm to install in **flat npm-style mode** — every package (declared or transitive) at the project root, no `.pnpm/` virtual store. Resolutions become deterministic.

`shamefully-hoist=true` is left in the template alongside, so manual `pnpm install` invocations from a developer shell still pick up at least the legacy partial-hoist behavior if some user-level config overrides our `node-linker`.

### 2. Pass `--config.node-linker=hoisted` on the pnpm CLI

The `.npmrc` change alone did not actually flip pnpm's install layout in CI: `node_modules/.pnpm/...` paths kept appearing in error messages, indicating pnpm was still using its default `isolated` mode. The pre-existing `--shamefully-hoist=true` CLI flag added by `FrontendTools.getPnpmExecutable()` likely took precedence and locked pnpm to the isolated layout (where `shamefully-hoist` makes sense as a partial-hoist heuristic).

Replace `--shamefully-hoist=true` with `--config.node-linker=hoisted` on the CLI. CLI > `.npmrc` > defaults in pnpm's config precedence, so the install is now unambiguously hoisted regardless of any project- or user-level `.npmrc` content. `FrontendToolsTest` updated to assert the new flag.

## Backport notes (23.7)

* Source paths remapped from `flow-build-tools/` (post-refactor on newer branches) back to `flow-server/` where these classes still live on 23.7.
* The `@babel/types` dependency addition and the matching `NodeUpdaterTest` change from the original commit were **omitted**: 23.7 uses Vite 3.2.11 and does not ship the React function-location plugin that consumes `@babel/types`, so declaring it would be dead weight. The load-bearing fixes (pnpm CLI flag + npmrc) are sufficient to resolve the `Cannot find module 'rollup'` failure observed in the 23.7 nightly build.

## Trade-offs

- **Disk/install time**: hoisted mode uses slightly more disk and is a few seconds slower than the symlink store for fresh installs. Acceptable for the determinism gain.
- **Loose isolation**: hoisted mode allows packages to import any other package, declared or not. Flow's frontend code already relies on this (e.g. plugins importing transitives), so this is the current de-facto behavior — just made deterministic.
- **Behavioral change for downstream users**: anyone with a custom `.npmrc` that lacks the auto-gen marker keeps their config (per existing `TaskRunNpmInstall.createNpmRcFile()` logic), but the new CLI flag still applies — they'll silently get hoisted mode for Flow-driven installs. Worth flagging in release notes.


(cherry picked from commit d9290f81ad52f709ca2553848ed0eb8452b8c397)
