### PR TITLE
chore: create formatter report comment when missing

### DIFF
--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -81,7 +81,7 @@ jobs:
           body-includes: '<!-- tc-formatter -->'
 
       - name: Create or update comment
-        if: steps.find-comment.outputs.comment-id != '' && steps.formatter.outputs.modified != '0'
+        if: github.event_name == 'pull_request_target' && steps.formatter.outputs.modified != '0'
         uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}


### PR DESCRIPTION
The Formatter workflow only updated or deleted an existing report comment but never created a new one when formatting issues were detected on a PR without a prior comment.

Adjust the condition so the comment is created when missing and updated when already present.
