### PR TITLE
feat: support delaying installation of recently published npm packages

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -118,13 +118,18 @@ public class FrontendTools {
     private static final FrontendVersion SUPPORTED_NPM_VERSION = new FrontendVersion(
             SUPPORTED_NPM_MAJOR_VERSION, SUPPORTED_NPM_MINOR_VERSION);
 
-    private static final int SUPPORTED_PNPM_MAJOR_VERSION = 7;
-    private static final int SUPPORTED_PNPM_MINOR_VERSION = 0;
+    // pnpm 10.16.0 is the first version that supports the
+    // minimumReleaseAge setting used to delay installation of newly
+    // published packages as a supply-chain mitigation.
+    private static final int SUPPORTED_PNPM_MAJOR_VERSION = 10;
+    private static final int SUPPORTED_PNPM_MINOR_VERSION = 16;
 
     private static final FrontendVersion SUPPORTED_PNPM_VERSION = new FrontendVersion(
             SUPPORTED_PNPM_MAJOR_VERSION, SUPPORTED_PNPM_MINOR_VERSION);
+    // Bun 1.3.0 is the first version that supports --minimum-release-age
+    // for the same supply-chain mitigation.
     private static final FrontendVersion SUPPORTED_BUN_VERSION = new FrontendVersion(
-            1, 0, 6); // Bun 1.0.6 is the first version with "overrides" support
+            1, 3, 0);
 
     private enum BuildTool {
         NPM("npm", "npm-cli.js"),

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/Options.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/Options.java
@@ -1117,6 +1117,8 @@ public class Options implements Serializable {
      * @param minimumFrontendPackageAgeDays
      *            minimum allowed age in days, or {@code 0} to disable the check
      * @return this builder
+     * @throws IllegalArgumentException
+     *             if {@code minimumFrontendPackageAgeDays} is negative
      */
     public Options withMinimumFrontendPackageAgeDays(
             int minimumFrontendPackageAgeDays) {

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/Options.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/Options.java
@@ -167,12 +167,12 @@ public class Options implements Serializable {
     private boolean commercialBannerEnabled = false;
 
     /**
-     * Minimum age, in days, that an npm/pnpm/bun package version must have
-     * before it is allowed to be installed. Defaults to {@code 0} (disabled);
-     * set to a positive value to enable as a mitigation against malicious
-     * packages published to the registry.
+     * Minimum age, in days, that an npm/pnpm/bun frontend package version must
+     * have before it is allowed to be installed. Defaults to {@code 0}
+     * (disabled); set to a positive value to enable as a mitigation against
+     * malicious packages published to the registry.
      */
-    private int minimumPackageAgeDays = 0;
+    private int minimumFrontendPackageAgeDays = 0;
 
     private ApplicationConfiguration applicationConfiguration;
 
@@ -1104,36 +1104,39 @@ public class Options implements Serializable {
     }
 
     /**
-     * Sets the minimum age (in days) a package version must have before it is
-     * allowed to be installed by npm or pnpm. The intent is to avoid pulling in
-     * brand-new versions that may have been compromised by a supply-chain
-     * attack but not yet detected and removed from the registry.
+     * Sets the minimum age (in days) a frontend package version must have
+     * before it is allowed to be installed by npm, pnpm or bun. The intent is
+     * to avoid pulling in brand-new versions that may have been compromised by
+     * a supply-chain attack but not yet detected and removed from the registry.
      * <p>
      * For npm this is translated to a {@code --before=<date>} argument; for
-     * pnpm it becomes {@code --config.minimum-release-age=<minutes>}; for bun
-     * it becomes {@code --minimum-release-age=<seconds>}.
+     * pnpm it becomes {@code --config.minimum-release-age=<minutes>} (requires
+     * pnpm &ge; 10.16.0); for bun it becomes
+     * {@code --minimum-release-age=<seconds>} (requires bun &ge; 1.3.0).
      *
-     * @param minimumPackageAgeDays
+     * @param minimumFrontendPackageAgeDays
      *            minimum allowed age in days, or {@code 0} to disable the check
      * @return this builder
      */
-    public Options withMinimumPackageAgeDays(int minimumPackageAgeDays) {
-        if (minimumPackageAgeDays < 0) {
+    public Options withMinimumFrontendPackageAgeDays(
+            int minimumFrontendPackageAgeDays) {
+        if (minimumFrontendPackageAgeDays < 0) {
             throw new IllegalArgumentException(
-                    "minimumPackageAgeDays must be >= 0");
+                    "minimumFrontendPackageAgeDays must be >= 0");
         }
-        this.minimumPackageAgeDays = minimumPackageAgeDays;
+        this.minimumFrontendPackageAgeDays = minimumFrontendPackageAgeDays;
         return this;
     }
 
     /**
-     * Gets the minimum age (in days) a package version must have before npm or
-     * pnpm is allowed to install it. {@code 0} means the check is disabled.
+     * Gets the minimum age (in days) a frontend package version must have
+     * before npm, pnpm or bun is allowed to install it. {@code 0} means the
+     * check is disabled.
      *
      * @return the minimum allowed age in days
      */
-    public int getMinimumPackageAgeDays() {
-        return minimumPackageAgeDays;
+    public int getMinimumFrontendPackageAgeDays() {
+        return minimumFrontendPackageAgeDays;
     }
 
     /**

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/Options.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/Options.java
@@ -1109,8 +1109,8 @@ public class Options implements Serializable {
      * attack but not yet detected and removed from the registry.
      * <p>
      * For npm this is translated to a {@code --before=<date>} argument; for
-     * pnpm it becomes {@code --minimum-release-age=<minutes>}; for bun it
-     * becomes {@code --minimum-release-age=<seconds>}.
+     * pnpm it becomes {@code --config.minimum-release-age=<minutes>}; for bun
+     * it becomes {@code --minimum-release-age=<seconds>}.
      *
      * @param minimumPackageAgeDays
      *            minimum allowed age in days, or {@code 0} to disable the check

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/Options.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/Options.java
@@ -167,11 +167,12 @@ public class Options implements Serializable {
     private boolean commercialBannerEnabled = false;
 
     /**
-     * Minimum age, in days, that an npm/pnpm package version must have before
-     * it is allowed to be installed. Defaults to 2 days as a mitigation against
-     * malicious packages published to the registry. Set to 0 to disable.
+     * Minimum age, in days, that an npm/pnpm/bun package version must have
+     * before it is allowed to be installed. Defaults to {@code 0} (disabled);
+     * set to a positive value to enable as a mitigation against malicious
+     * packages published to the registry.
      */
-    private int minimumPackageAgeDays = 2;
+    private int minimumPackageAgeDays = 0;
 
     private ApplicationConfiguration applicationConfiguration;
 

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/Options.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/Options.java
@@ -166,6 +166,13 @@ public class Options implements Serializable {
 
     private boolean commercialBannerEnabled = false;
 
+    /**
+     * Minimum age, in days, that an npm/pnpm package version must have before
+     * it is allowed to be installed. Defaults to 2 days as a mitigation against
+     * malicious packages published to the registry. Set to 0 to disable.
+     */
+    private int minimumPackageAgeDays = 2;
+
     private ApplicationConfiguration applicationConfiguration;
 
     /**
@@ -1093,6 +1100,39 @@ public class Options implements Serializable {
     public Options withCommercialBanner(boolean enableCommercialBanner) {
         this.commercialBannerEnabled = enableCommercialBanner;
         return this;
+    }
+
+    /**
+     * Sets the minimum age (in days) a package version must have before it is
+     * allowed to be installed by npm or pnpm. The intent is to avoid pulling in
+     * brand-new versions that may have been compromised by a supply-chain
+     * attack but not yet detected and removed from the registry.
+     * <p>
+     * For npm this is translated to a {@code --before=<date>} argument; for
+     * pnpm it becomes {@code --minimum-release-age=<minutes>}; for bun it
+     * becomes {@code --minimum-release-age=<seconds>}.
+     *
+     * @param minimumPackageAgeDays
+     *            minimum allowed age in days, or {@code 0} to disable the check
+     * @return this builder
+     */
+    public Options withMinimumPackageAgeDays(int minimumPackageAgeDays) {
+        if (minimumPackageAgeDays < 0) {
+            throw new IllegalArgumentException(
+                    "minimumPackageAgeDays must be >= 0");
+        }
+        this.minimumPackageAgeDays = minimumPackageAgeDays;
+        return this;
+    }
+
+    /**
+     * Gets the minimum age (in days) a package version must have before npm or
+     * pnpm is allowed to install it. {@code 0} means the check is disabled.
+     *
+     * @return the minimum allowed age in days
+     */
+    public int getMinimumPackageAgeDays() {
+        return minimumPackageAgeDays;
     }
 
     /**

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -24,11 +24,14 @@ import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
@@ -289,6 +292,8 @@ public class TaskRunNpmInstall implements FallibleCommand {
             }
         }
 
+        getMinimumPackageAgeArgument(options).ifPresent(npmInstallCommand::add);
+
         postinstallCommand.add("run");
         postinstallCommand.add("postinstall");
 
@@ -423,6 +428,32 @@ public class TaskRunNpmInstall implements FallibleCommand {
         } else {
             return "npm";
         }
+    }
+
+    /**
+     * Builds the install argument that prevents npm or pnpm from installing
+     * package versions newer than {@link Options#getMinimumPackageAgeDays()}
+     * days. Returns an empty optional when the check is disabled or when the
+     * active tool (bun) does not support it.
+     */
+    static Optional<String> getMinimumPackageAgeArgument(Options options) {
+        int days = options.getMinimumPackageAgeDays();
+        if (days <= 0) {
+            return Optional.empty();
+        }
+        if (options.isEnableBun()) {
+            // bun: --minimum-release-age takes a value in seconds
+            long seconds = (long) days * 24 * 60 * 60;
+            return Optional.of("--minimum-release-age=" + seconds);
+        }
+        if (options.isEnablePnpm()) {
+            // pnpm: --minimum-release-age takes a value in minutes
+            long minutes = (long) days * 24 * 60;
+            return Optional.of("--minimum-release-age=" + minutes);
+        }
+        // npm: --before takes any Date.parse-able string
+        String before = Instant.now().minus(days, ChronoUnit.DAYS).toString();
+        return Optional.of("--before=" + before);
     }
 
     private void consumeProcessOutput(Process process,

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -447,9 +447,11 @@ public class TaskRunNpmInstall implements FallibleCommand {
             return Optional.of("--minimum-release-age=" + seconds);
         }
         if (options.isEnablePnpm()) {
-            // pnpm: --minimum-release-age takes a value in minutes
+            // pnpm: minimumReleaseAge is a setting (in minutes), so it has
+            // to be passed via the --config.<name> CLI form, not as a
+            // top-level option
             long minutes = (long) days * 24 * 60;
-            return Optional.of("--minimum-release-age=" + minutes);
+            return Optional.of("--config.minimum-release-age=" + minutes);
         }
         // npm: --before takes any Date.parse-able string
         String before = Instant.now().minus(days, ChronoUnit.DAYS).toString();

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -292,7 +292,8 @@ public class TaskRunNpmInstall implements FallibleCommand {
             }
         }
 
-        getMinimumPackageAgeArgument(options).ifPresent(npmInstallCommand::add);
+        getMinimumFrontendPackageAgeArgument(options)
+                .ifPresent(npmInstallCommand::add);
 
         postinstallCommand.add("run");
         postinstallCommand.add("postinstall");
@@ -431,13 +432,14 @@ public class TaskRunNpmInstall implements FallibleCommand {
     }
 
     /**
-     * Builds the install argument that prevents npm or pnpm from installing
-     * package versions newer than {@link Options#getMinimumPackageAgeDays()}
-     * days. Returns an empty optional when the check is disabled or when the
-     * active tool (bun) does not support it.
+     * Builds the install argument that prevents npm, pnpm or bun from
+     * installing frontend package versions newer than
+     * {@link Options#getMinimumFrontendPackageAgeDays()} days. Returns an empty
+     * optional when the check is disabled.
      */
-    static Optional<String> getMinimumPackageAgeArgument(Options options) {
-        int days = options.getMinimumPackageAgeDays();
+    static Optional<String> getMinimumFrontendPackageAgeArgument(
+            Options options) {
+        int days = options.getMinimumFrontendPackageAgeDays();
         if (days <= 0) {
             return Optional.empty();
         }

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -81,7 +81,7 @@ class FrontendToolsTest {
 
     private static final String OLD_PNPM_VERSION = "4.5.0";
 
-    private static final String SUPPORTED_PNPM_VERSION = "7.0.0";
+    private static final String SUPPORTED_PNPM_VERSION = "10.16.0";
 
     private String baseDir;
 

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -765,58 +765,50 @@ class TaskRunNpmInstallTest {
     }
 
     @Test
-    void minimumPackageAge_defaultIsDisabled_returnsEmpty() {
+    void minimumFrontendPackageAge_defaultIsDisabled_returnsEmpty() {
         // Default is 0 (disabled) — no flag must be added
+        assertFalse(TaskRunNpmInstall.getMinimumFrontendPackageAgeArgument(
+                new MockOptions(npmFolder)).isPresent());
         assertFalse(TaskRunNpmInstall
-                .getMinimumPackageAgeArgument(new MockOptions(npmFolder))
-                .isPresent());
-        assertFalse(TaskRunNpmInstall
-                .getMinimumPackageAgeArgument(
+                .getMinimumFrontendPackageAgeArgument(
                         new MockOptions(npmFolder).withEnablePnpm(true))
                 .isPresent());
         assertFalse(TaskRunNpmInstall
-                .getMinimumPackageAgeArgument(
+                .getMinimumFrontendPackageAgeArgument(
                         new MockOptions(npmFolder).withEnableBun(true))
                 .isPresent());
     }
 
     @Test
-    void minimumPackageAge_npm_addsBeforeArgument() {
+    void minimumFrontendPackageAge_npm_addsBeforeArgument() {
         Options npmOptions = new MockOptions(npmFolder)
-                .withMinimumPackageAgeDays(2);
+                .withMinimumFrontendPackageAgeDays(2);
         Optional<String> arg = TaskRunNpmInstall
-                .getMinimumPackageAgeArgument(npmOptions);
+                .getMinimumFrontendPackageAgeArgument(npmOptions);
         assertTrue(arg.isPresent());
         assertTrue(arg.get().startsWith("--before="),
                 "npm should use --before, was: " + arg.get());
     }
 
     @Test
-    void minimumPackageAge_pnpm_addsMinimumReleaseAgeArgument() {
+    void minimumFrontendPackageAge_pnpm_addsMinimumReleaseAgeArgument() {
         Options pnpmOptions = new MockOptions(npmFolder).withEnablePnpm(true)
-                .withMinimumPackageAgeDays(2);
+                .withMinimumFrontendPackageAgeDays(2);
         Optional<String> arg = TaskRunNpmInstall
-                .getMinimumPackageAgeArgument(pnpmOptions);
+                .getMinimumFrontendPackageAgeArgument(pnpmOptions);
         // 2 days = 2880 minutes; pnpm setting form
         assertEquals("--config.minimum-release-age=2880", arg.orElseThrow());
     }
 
     @Test
-    void minimumPackageAge_bun_addsMinimumReleaseAgeInSeconds() {
+    void minimumFrontendPackageAge_bun_addsMinimumReleaseAgeInSeconds() {
         Options bunOptions = new MockOptions(npmFolder).withEnableBun(true)
-                .withMinimumPackageAgeDays(2);
+                .withMinimumFrontendPackageAgeDays(2);
         // 2 days = 172800 seconds
-        assertEquals("--minimum-release-age=172800", TaskRunNpmInstall
-                .getMinimumPackageAgeArgument(bunOptions).orElseThrow());
-    }
-
-    @Test
-    void minimumPackageAge_overrideValue_pnpmReflectsCustomDays() {
-        Options pnpmOptions = new MockOptions(npmFolder).withEnablePnpm(true)
-                .withMinimumPackageAgeDays(7);
-        // 7 days = 10080 minutes
-        assertEquals("--config.minimum-release-age=10080", TaskRunNpmInstall
-                .getMinimumPackageAgeArgument(pnpmOptions).orElseThrow());
+        assertEquals("--minimum-release-age=172800",
+                TaskRunNpmInstall
+                        .getMinimumFrontendPackageAgeArgument(bunOptions)
+                        .orElseThrow());
     }
 
 }

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -779,8 +779,8 @@ class TaskRunNpmInstallTest {
         Options pnpmOptions = new MockOptions(npmFolder).withEnablePnpm(true);
         Optional<String> arg = TaskRunNpmInstall
                 .getMinimumPackageAgeArgument(pnpmOptions);
-        // Default is 2 days = 2880 minutes
-        assertEquals("--minimum-release-age=2880", arg.orElseThrow());
+        // Default is 2 days = 2880 minutes; pnpm setting form
+        assertEquals("--config.minimum-release-age=2880", arg.orElseThrow());
     }
 
     @Test
@@ -804,7 +804,7 @@ class TaskRunNpmInstallTest {
         Options pnpmOptions = new MockOptions(npmFolder).withEnablePnpm(true)
                 .withMinimumPackageAgeDays(7);
         // 7 days = 10080 minutes
-        assertEquals("--minimum-release-age=10080", TaskRunNpmInstall
+        assertEquals("--config.minimum-release-age=10080", TaskRunNpmInstall
                 .getMinimumPackageAgeArgument(pnpmOptions).orElseThrow());
     }
 

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -765,8 +765,25 @@ class TaskRunNpmInstallTest {
     }
 
     @Test
-    void minimumPackageAge_npmDefaults_addsBeforeArgument() {
-        Options npmOptions = new MockOptions(npmFolder);
+    void minimumPackageAge_defaultIsDisabled_returnsEmpty() {
+        // Default is 0 (disabled) — no flag must be added
+        assertFalse(TaskRunNpmInstall
+                .getMinimumPackageAgeArgument(new MockOptions(npmFolder))
+                .isPresent());
+        assertFalse(TaskRunNpmInstall
+                .getMinimumPackageAgeArgument(
+                        new MockOptions(npmFolder).withEnablePnpm(true))
+                .isPresent());
+        assertFalse(TaskRunNpmInstall
+                .getMinimumPackageAgeArgument(
+                        new MockOptions(npmFolder).withEnableBun(true))
+                .isPresent());
+    }
+
+    @Test
+    void minimumPackageAge_npm_addsBeforeArgument() {
+        Options npmOptions = new MockOptions(npmFolder)
+                .withMinimumPackageAgeDays(2);
         Optional<String> arg = TaskRunNpmInstall
                 .getMinimumPackageAgeArgument(npmOptions);
         assertTrue(arg.isPresent());
@@ -775,28 +792,22 @@ class TaskRunNpmInstallTest {
     }
 
     @Test
-    void minimumPackageAge_pnpmDefaults_addsMinimumReleaseAgeArgument() {
-        Options pnpmOptions = new MockOptions(npmFolder).withEnablePnpm(true);
+    void minimumPackageAge_pnpm_addsMinimumReleaseAgeArgument() {
+        Options pnpmOptions = new MockOptions(npmFolder).withEnablePnpm(true)
+                .withMinimumPackageAgeDays(2);
         Optional<String> arg = TaskRunNpmInstall
                 .getMinimumPackageAgeArgument(pnpmOptions);
-        // Default is 2 days = 2880 minutes; pnpm setting form
+        // 2 days = 2880 minutes; pnpm setting form
         assertEquals("--config.minimum-release-age=2880", arg.orElseThrow());
     }
 
     @Test
-    void minimumPackageAge_bunDefaults_addsMinimumReleaseAgeInSeconds() {
-        Options bunOptions = new MockOptions(npmFolder).withEnableBun(true);
-        // Default is 2 days = 172800 seconds
+    void minimumPackageAge_bun_addsMinimumReleaseAgeInSeconds() {
+        Options bunOptions = new MockOptions(npmFolder).withEnableBun(true)
+                .withMinimumPackageAgeDays(2);
+        // 2 days = 172800 seconds
         assertEquals("--minimum-release-age=172800", TaskRunNpmInstall
                 .getMinimumPackageAgeArgument(bunOptions).orElseThrow());
-    }
-
-    @Test
-    void minimumPackageAge_disabledByZero_returnsEmpty() {
-        Options npmOptions = new MockOptions(npmFolder)
-                .withMinimumPackageAgeDays(0);
-        assertFalse(TaskRunNpmInstall.getMinimumPackageAgeArgument(npmOptions)
-                .isPresent());
     }
 
     @Test

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 import net.jcip.annotations.NotThreadSafe;
 import org.junit.jupiter.api.BeforeEach;
@@ -761,6 +762,50 @@ class TaskRunNpmInstallTest {
 
     private void assumeNPMIsInUse() {
         assumeTrue(getClass().equals(TaskRunNpmInstallTest.class));
+    }
+
+    @Test
+    void minimumPackageAge_npmDefaults_addsBeforeArgument() {
+        Options npmOptions = new MockOptions(npmFolder);
+        Optional<String> arg = TaskRunNpmInstall
+                .getMinimumPackageAgeArgument(npmOptions);
+        assertTrue(arg.isPresent());
+        assertTrue(arg.get().startsWith("--before="),
+                "npm should use --before, was: " + arg.get());
+    }
+
+    @Test
+    void minimumPackageAge_pnpmDefaults_addsMinimumReleaseAgeArgument() {
+        Options pnpmOptions = new MockOptions(npmFolder).withEnablePnpm(true);
+        Optional<String> arg = TaskRunNpmInstall
+                .getMinimumPackageAgeArgument(pnpmOptions);
+        // Default is 2 days = 2880 minutes
+        assertEquals("--minimum-release-age=2880", arg.orElseThrow());
+    }
+
+    @Test
+    void minimumPackageAge_bunDefaults_addsMinimumReleaseAgeInSeconds() {
+        Options bunOptions = new MockOptions(npmFolder).withEnableBun(true);
+        // Default is 2 days = 172800 seconds
+        assertEquals("--minimum-release-age=172800", TaskRunNpmInstall
+                .getMinimumPackageAgeArgument(bunOptions).orElseThrow());
+    }
+
+    @Test
+    void minimumPackageAge_disabledByZero_returnsEmpty() {
+        Options npmOptions = new MockOptions(npmFolder)
+                .withMinimumPackageAgeDays(0);
+        assertFalse(TaskRunNpmInstall.getMinimumPackageAgeArgument(npmOptions)
+                .isPresent());
+    }
+
+    @Test
+    void minimumPackageAge_overrideValue_pnpmReflectsCustomDays() {
+        Options pnpmOptions = new MockOptions(npmFolder).withEnablePnpm(true)
+                .withMinimumPackageAgeDays(7);
+        // 7 days = 10080 minutes
+        assertEquals("--minimum-release-age=10080", TaskRunNpmInstall
+                .getMinimumPackageAgeArgument(pnpmOptions).orElseThrow());
     }
 
 }

--- a/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
+++ b/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
@@ -205,11 +205,11 @@ public class BuildDevBundleMojo extends AbstractMojo
     /**
      * Minimum age (in days) a package version must have before npm, pnpm or bun
      * is allowed to install it. Mitigates supply-chain attacks where a
-     * compromised version is briefly available on the registry. Set to
-     * {@code 0} to disable.
+     * compromised version is briefly available on the registry. Defaults to
+     * {@code 0} (disabled); set to a positive value to enable.
      */
     @Parameter(property = "vaadin."
-            + InitParameters.MINIMUM_PACKAGE_AGE_DAYS, defaultValue = "2")
+            + InitParameters.MINIMUM_PACKAGE_AGE_DAYS, defaultValue = "0")
     private int minimumPackageAgeDays;
 
     /**

--- a/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
+++ b/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
@@ -203,6 +203,16 @@ public class BuildDevBundleMojo extends AbstractMojo
     private boolean frontendIgnoreVersionChecks;
 
     /**
+     * Minimum age (in days) a package version must have before npm, pnpm or bun
+     * is allowed to install it. Mitigates supply-chain attacks where a
+     * compromised version is briefly available on the registry. Set to
+     * {@code 0} to disable.
+     */
+    @Parameter(property = "vaadin."
+            + InitParameters.MINIMUM_PACKAGE_AGE_DAYS, defaultValue = "2")
+    private int minimumPackageAgeDays;
+
+    /**
      * The folder where the META-INF/resources files are copied. Used for
      * finding the StyleSheet referenced css files.
      */
@@ -550,6 +560,11 @@ public class BuildDevBundleMojo extends AbstractMojo
     @Override
     public boolean isFrontendIgnoreVersionChecks() {
         return frontendIgnoreVersionChecks;
+    }
+
+    @Override
+    public int minimumPackageAgeDays() {
+        return minimumPackageAgeDays;
     }
 
     @Override

--- a/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
+++ b/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
@@ -203,14 +203,15 @@ public class BuildDevBundleMojo extends AbstractMojo
     private boolean frontendIgnoreVersionChecks;
 
     /**
-     * Minimum age (in days) a package version must have before npm, pnpm or bun
-     * is allowed to install it. Mitigates supply-chain attacks where a
-     * compromised version is briefly available on the registry. Defaults to
-     * {@code 0} (disabled); set to a positive value to enable.
+     * Minimum age (in days) a frontend (npm) package version must have before
+     * npm, pnpm or bun is allowed to install it. Mitigates supply-chain attacks
+     * where a compromised version is briefly available on the registry.
+     * Defaults to {@code 0} (disabled); set to a positive value to enable.
+     * Requires pnpm &ge; 10.16.0 or bun &ge; 1.3.0 when those tools are used.
      */
     @Parameter(property = "vaadin."
-            + InitParameters.MINIMUM_PACKAGE_AGE_DAYS, defaultValue = "0")
-    private int minimumPackageAgeDays;
+            + InitParameters.MINIMUM_FRONTEND_PACKAGE_AGE_DAYS, defaultValue = "0")
+    private int minimumFrontendPackageAgeDays;
 
     /**
      * The folder where the META-INF/resources files are copied. Used for
@@ -563,8 +564,8 @@ public class BuildDevBundleMojo extends AbstractMojo
     }
 
     @Override
-    public int minimumPackageAgeDays() {
-        return minimumPackageAgeDays;
+    public int minimumFrontendPackageAgeDays() {
+        return minimumFrontendPackageAgeDays;
     }
 
     @Override

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
@@ -336,4 +336,7 @@ internal class GradlePluginAdapter private constructor(
         return config.commercialWithBanner.get()
     }
 
+    override fun minimumPackageAgeDays(): Int =
+        config.minimumPackageAgeDays.get()
+
 }

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
@@ -336,7 +336,7 @@ internal class GradlePluginAdapter private constructor(
         return config.commercialWithBanner.get()
     }
 
-    override fun minimumPackageAgeDays(): Int =
-        config.minimumPackageAgeDays.get()
+    override fun minimumFrontendPackageAgeDays(): Int =
+        config.minimumFrontendPackageAgeDays.get()
 
 }

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
@@ -344,6 +344,14 @@ public abstract class VaadinFlowPluginExtension @Inject constructor(private val 
     public abstract val frontendIgnoreVersionChecks: Property<Boolean>
 
     /**
+     * Minimum age (in days) a package version must have before npm, pnpm or
+     * bun is allowed to install it. Mitigates supply-chain attacks where a
+     * compromised version is briefly available on the registry. Defaults to
+     * {@code 1} day; set to {@code 0} to disable.
+     */
+    public abstract val minimumPackageAgeDays: Property<Int>
+
+    /**
      * Allows building a version of the application with a commercial banner
      * when commercial components are used without a license key.
      */
@@ -644,6 +652,12 @@ public class PluginEffectiveConfiguration(
             project,
             FrontendUtils.PARAM_IGNORE_VERSION_CHECKS
         )
+
+    public val minimumPackageAgeDays: Provider<Int> =
+        project.getStringProperty(
+            "vaadin.${InitParameters.MINIMUM_PACKAGE_AGE_DAYS}"
+        ).map(String::toInt)
+            .orElse(extension.minimumPackageAgeDays.convention(1))
 
     public val npmExcludeWebComponents: Provider<Boolean> = extension
         .npmExcludeWebComponents.convention(false)

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
@@ -344,12 +344,14 @@ public abstract class VaadinFlowPluginExtension @Inject constructor(private val 
     public abstract val frontendIgnoreVersionChecks: Property<Boolean>
 
     /**
-     * Minimum age (in days) a package version must have before npm, pnpm or
-     * bun is allowed to install it. Mitigates supply-chain attacks where a
-     * compromised version is briefly available on the registry. Defaults to
-     * {@code 1} day; set to {@code 0} to disable.
+     * Minimum age (in days) a frontend (npm) package version must have before
+     * npm, pnpm or bun is allowed to install it. Mitigates supply-chain
+     * attacks where a compromised version is briefly available on the
+     * registry. Defaults to {@code 0} (disabled); set to a positive value to
+     * enable. Requires pnpm >= 10.16.0 or bun >= 1.3.0 when those tools are
+     * used.
      */
-    public abstract val minimumPackageAgeDays: Property<Int>
+    public abstract val minimumFrontendPackageAgeDays: Property<Int>
 
     /**
      * Allows building a version of the application with a commercial banner
@@ -653,11 +655,11 @@ public class PluginEffectiveConfiguration(
             FrontendUtils.PARAM_IGNORE_VERSION_CHECKS
         )
 
-    public val minimumPackageAgeDays: Provider<Int> =
+    public val minimumFrontendPackageAgeDays: Provider<Int> =
         project.getStringProperty(
-            "vaadin.${InitParameters.MINIMUM_PACKAGE_AGE_DAYS}"
+            "vaadin.${InitParameters.MINIMUM_FRONTEND_PACKAGE_AGE_DAYS}"
         ).map(String::toInt)
-            .orElse(extension.minimumPackageAgeDays.convention(1))
+            .orElse(extension.minimumFrontendPackageAgeDays.convention(0))
 
     public val npmExcludeWebComponents: Provider<Boolean> = extension
         .npmExcludeWebComponents.convention(false)

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -145,6 +145,17 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo
             + "resources/")
     private File resourcesOutputDirectory;
 
+    /**
+     * Minimum age (in days) a frontend (npm) package version must have before
+     * npm, pnpm or bun is allowed to install it. Mitigates supply-chain attacks
+     * where a compromised version is briefly available on the registry.
+     * Defaults to {@code 0} (disabled); set to a positive value to enable.
+     * Requires pnpm &ge; 10.16.0 or bun &ge; 1.3.0 when those tools are used.
+     */
+    @Parameter(property = "vaadin."
+            + InitParameters.MINIMUM_FRONTEND_PACKAGE_AGE_DAYS, defaultValue = "0")
+    private int minimumFrontendPackageAgeDays;
+
     @Override
     protected void executeInternal()
             throws MojoExecutionException, MojoFailureException {
@@ -301,6 +312,11 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo
     @Override
     public File resourcesOutputDirectory() {
         return resourcesOutputDirectory;
+    }
+
+    @Override
+    public int minimumFrontendPackageAgeDays() {
+        return minimumFrontendPackageAgeDays;
     }
 
     @Override

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/DeprecatedPropertyResolver.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/DeprecatedPropertyResolver.java
@@ -56,7 +56,8 @@ final class DeprecatedPropertyResolver {
             "vaadin.commercialWithBanner", "vaadin.ci.build",
             "vaadin.force.production.build",
             "vaadin.clean.build.frontend.files", "vaadin.path",
-            "vaadin.useLit1", "vaadin.disableOptionalChaining");
+            "vaadin.useLit1", "vaadin.disableOptionalChaining",
+            "vaadin.npm.minimumFrontendPackageAgeDays");
 
     private DeprecatedPropertyResolver() {
     }

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -313,16 +313,6 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
     private boolean frontendIgnoreVersionChecks;
 
     /**
-     * Minimum age (in days) a package version must have before npm, pnpm or bun
-     * is allowed to install it. Mitigates supply-chain attacks where a
-     * compromised version is briefly available on the registry. Defaults to
-     * {@code 0} (disabled); set to a positive value to enable.
-     */
-    @Parameter(property = "vaadin."
-            + InitParameters.MINIMUM_PACKAGE_AGE_DAYS, defaultValue = "0")
-    private int minimumPackageAgeDays;
-
-    /**
      * Allows to fine tune frontend resources detection by defining which
      * artifacts should be included or excluded during the class scanning
      * process.
@@ -775,10 +765,6 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
     @Override
     public boolean isFrontendIgnoreVersionChecks() {
         return frontendIgnoreVersionChecks;
-    }
-
-    public int minimumPackageAgeDays() {
-        return minimumPackageAgeDays;
     }
 
     @Override

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -315,11 +315,11 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
     /**
      * Minimum age (in days) a package version must have before npm, pnpm or bun
      * is allowed to install it. Mitigates supply-chain attacks where a
-     * compromised version is briefly available on the registry. Set to
-     * {@code 0} to disable.
+     * compromised version is briefly available on the registry. Defaults to
+     * {@code 0} (disabled); set to a positive value to enable.
      */
     @Parameter(property = "vaadin."
-            + InitParameters.MINIMUM_PACKAGE_AGE_DAYS, defaultValue = "2")
+            + InitParameters.MINIMUM_PACKAGE_AGE_DAYS, defaultValue = "0")
     private int minimumPackageAgeDays;
 
     /**

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -313,6 +313,16 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
     private boolean frontendIgnoreVersionChecks;
 
     /**
+     * Minimum age (in days) a package version must have before npm, pnpm or bun
+     * is allowed to install it. Mitigates supply-chain attacks where a
+     * compromised version is briefly available on the registry. Set to
+     * {@code 0} to disable.
+     */
+    @Parameter(property = "vaadin."
+            + InitParameters.MINIMUM_PACKAGE_AGE_DAYS, defaultValue = "2")
+    private int minimumPackageAgeDays;
+
+    /**
      * Allows to fine tune frontend resources detection by defining which
      * artifacts should be included or excluded during the class scanning
      * process.
@@ -765,6 +775,10 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
     @Override
     public boolean isFrontendIgnoreVersionChecks() {
         return frontendIgnoreVersionChecks;
+    }
+
+    public int minimumPackageAgeDays() {
+        return minimumPackageAgeDays;
     }
 
     @Override

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -375,7 +375,8 @@ public class BuildFrontendUtil {
                     .withFrontendDependenciesScanner(frontendDependencies)
                     .withCommercialBanner(adapter.isCommercialBannerEnabled())
                     .withMetaInfResourcesDirectory(
-                            adapter.resourcesOutputDirectory());
+                            adapter.resourcesOutputDirectory())
+                    .withMinimumPackageAgeDays(adapter.minimumPackageAgeDays());
             new NodeTasks(options).execute();
         } catch (ExecutionFailedException exception) {
             throw exception;
@@ -447,7 +448,8 @@ public class BuildFrontendUtil {
                     .withNpmExcludeWebComponents(
                             adapter.isNpmExcludeWebComponents())
                     .withFrontendIgnoreVersionChecks(
-                            adapter.isFrontendIgnoreVersionChecks());
+                            adapter.isFrontendIgnoreVersionChecks())
+                    .withMinimumPackageAgeDays(adapter.minimumPackageAgeDays());
             new NodeTasks(options).execute();
         } catch (ExecutionFailedException exception) {
             throw exception;

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -376,7 +376,8 @@ public class BuildFrontendUtil {
                     .withCommercialBanner(adapter.isCommercialBannerEnabled())
                     .withMetaInfResourcesDirectory(
                             adapter.resourcesOutputDirectory())
-                    .withMinimumPackageAgeDays(adapter.minimumPackageAgeDays());
+                    .withMinimumFrontendPackageAgeDays(
+                            adapter.minimumFrontendPackageAgeDays());
             new NodeTasks(options).execute();
         } catch (ExecutionFailedException exception) {
             throw exception;
@@ -449,7 +450,8 @@ public class BuildFrontendUtil {
                             adapter.isNpmExcludeWebComponents())
                     .withFrontendIgnoreVersionChecks(
                             adapter.isFrontendIgnoreVersionChecks())
-                    .withMinimumPackageAgeDays(adapter.minimumPackageAgeDays());
+                    .withMinimumFrontendPackageAgeDays(
+                            adapter.minimumFrontendPackageAgeDays());
             new NodeTasks(options).execute();
         } catch (ExecutionFailedException exception) {
             throw exception;

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBuild.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBuild.java
@@ -128,14 +128,14 @@ public interface PluginAdapterBuild extends PluginAdapterBase {
     File resourcesOutputDirectory();
 
     /**
-     * Minimum age (in days) a package version must have before npm, pnpm or bun
-     * is allowed to install it. Defaults to {@code 0} (disabled); set to a
-     * positive value to enable as a mitigation against malicious packages
-     * briefly published to the registry.
+     * Minimum age (in days) a frontend package version must have before npm,
+     * pnpm or bun is allowed to install it. Defaults to {@code 0} (disabled);
+     * set to a positive value to enable as a mitigation against malicious
+     * packages briefly published to the registry.
      *
      * @return the minimum allowed age in days, or {@code 0} when disabled
      */
-    default int minimumPackageAgeDays() {
+    default int minimumFrontendPackageAgeDays() {
         return 0;
     }
 }

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBuild.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBuild.java
@@ -126,4 +126,16 @@ public interface PluginAdapterBuild extends PluginAdapterBase {
      *         {output}/classes/META-INF/resources
      */
     File resourcesOutputDirectory();
+
+    /**
+     * Minimum age (in days) a package version must have before npm, pnpm or bun
+     * is allowed to install it. Defaults to {@code 2} days as a mitigation
+     * against malicious packages briefly published to the registry. Set to
+     * {@code 0} to disable.
+     *
+     * @return the minimum allowed age in days
+     */
+    default int minimumPackageAgeDays() {
+        return 2;
+    }
 }

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBuild.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBuild.java
@@ -129,13 +129,13 @@ public interface PluginAdapterBuild extends PluginAdapterBase {
 
     /**
      * Minimum age (in days) a package version must have before npm, pnpm or bun
-     * is allowed to install it. Defaults to {@code 2} days as a mitigation
-     * against malicious packages briefly published to the registry. Set to
-     * {@code 0} to disable.
+     * is allowed to install it. Defaults to {@code 0} (disabled); set to a
+     * positive value to enable as a mitigation against malicious packages
+     * briefly published to the registry.
      *
-     * @return the minimum allowed age in days
+     * @return the minimum allowed age in days, or {@code 0} when disabled
      */
     default int minimumPackageAgeDays() {
-        return 2;
+        return 0;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -302,10 +302,10 @@ public class InitParameters implements Serializable {
     public static final String BROWSERLESS = "browserless";
 
     /**
-     * Configuration name for the minimum age (in days) a package version must
-     * have before npm, pnpm or bun is allowed to install it. Defaults to
-     * {@code 0} (disabled); set to a positive value to enable.
+     * Configuration name for the minimum age (in days) a frontend (npm) package
+     * version must have before npm, pnpm or bun is allowed to install it.
+     * Defaults to {@code 0} (disabled); set to a positive value to enable.
      */
-    public static final String MINIMUM_PACKAGE_AGE_DAYS = "npm.minimumPackageAgeDays";
+    public static final String MINIMUM_FRONTEND_PACKAGE_AGE_DAYS = "npm.minimumFrontendPackageAgeDays";
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -303,8 +303,8 @@ public class InitParameters implements Serializable {
 
     /**
      * Configuration name for the minimum age (in days) a package version must
-     * have before npm, pnpm or bun is allowed to install it. Defaults to 2
-     * days; set to 0 to disable.
+     * have before npm, pnpm or bun is allowed to install it. Defaults to
+     * {@code 0} (disabled); set to a positive value to enable.
      */
     public static final String MINIMUM_PACKAGE_AGE_DAYS = "npm.minimumPackageAgeDays";
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -301,4 +301,11 @@ public class InitParameters implements Serializable {
      */
     public static final String BROWSERLESS = "browserless";
 
+    /**
+     * Configuration name for the minimum age (in days) a package version must
+     * have before npm, pnpm or bun is allowed to install it. Defaults to 2
+     * days; set to 0 to disable.
+     */
+    public static final String MINIMUM_PACKAGE_AGE_DAYS = "npm.minimumPackageAgeDays";
+
 }


### PR DESCRIPTION
Adds a minimum package age check (default disabled) so that npm, pnpm and bun are instructed not to install package versions newer than the configured threshold. This mitigates supply-chain attacks where a compromised version is briefly published to the registry.

The threshold is exposed via Options#withMinimumPackageAgeDays(int); setting it to 0 disables the check.
