### PR TITLE
feat: Only install npm packages that have been available more than a day

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/Options.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/Options.java
@@ -168,11 +168,11 @@ public class Options implements Serializable {
 
     /**
      * Minimum age, in days, that an npm/pnpm/bun frontend package version must
-     * have before it is allowed to be installed. Defaults to {@code 0}
-     * (disabled); set to a positive value to enable as a mitigation against
-     * malicious packages published to the registry.
+     * have before it is allowed to be installed. Defaults to {@code 1} day as a
+     * mitigation against malicious packages published to the registry; set to
+     * {@code 0} to disable.
      */
-    private int minimumFrontendPackageAgeDays = 0;
+    private int minimumFrontendPackageAgeDays = 1;
 
     private ApplicationConfiguration applicationConfiguration;
 

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -765,17 +765,29 @@ class TaskRunNpmInstallTest {
     }
 
     @Test
-    void minimumFrontendPackageAge_defaultIsDisabled_returnsEmpty() {
-        // Default is 0 (disabled) — no flag must be added
+    void minimumFrontendPackageAge_defaultIsOneDay_addsArgument() {
+        // Default is 1 day → 1440 minutes for pnpm, 86400 seconds for bun,
+        // and a --before=<iso-instant> argument for npm
+        assertTrue(TaskRunNpmInstall
+                .getMinimumFrontendPackageAgeArgument(
+                        new MockOptions(npmFolder))
+                .orElseThrow().startsWith("--before="));
+        assertEquals("--config.minimum-release-age=1440",
+                TaskRunNpmInstall
+                        .getMinimumFrontendPackageAgeArgument(
+                                new MockOptions(npmFolder).withEnablePnpm(true))
+                        .orElseThrow());
+        assertEquals("--minimum-release-age=86400",
+                TaskRunNpmInstall
+                        .getMinimumFrontendPackageAgeArgument(
+                                new MockOptions(npmFolder).withEnableBun(true))
+                        .orElseThrow());
+    }
+
+    @Test
+    void minimumFrontendPackageAge_zeroDisablesCheck_returnsEmpty() {
         assertFalse(TaskRunNpmInstall.getMinimumFrontendPackageAgeArgument(
-                new MockOptions(npmFolder)).isPresent());
-        assertFalse(TaskRunNpmInstall
-                .getMinimumFrontendPackageAgeArgument(
-                        new MockOptions(npmFolder).withEnablePnpm(true))
-                .isPresent());
-        assertFalse(TaskRunNpmInstall
-                .getMinimumFrontendPackageAgeArgument(
-                        new MockOptions(npmFolder).withEnableBun(true))
+                new MockOptions(npmFolder).withMinimumFrontendPackageAgeDays(0))
                 .isPresent());
     }
 

--- a/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
+++ b/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
@@ -206,11 +206,11 @@ public class BuildDevBundleMojo extends AbstractMojo
      * Minimum age (in days) a frontend (npm) package version must have before
      * npm, pnpm or bun is allowed to install it. Mitigates supply-chain attacks
      * where a compromised version is briefly available on the registry.
-     * Defaults to {@code 0} (disabled); set to a positive value to enable.
-     * Requires pnpm &ge; 10.16.0 or bun &ge; 1.3.0 when those tools are used.
+     * Defaults to {@code 1} day; set to {@code 0} to disable. Requires pnpm
+     * &ge; 10.16.0 or bun &ge; 1.3.0 when those tools are used.
      */
     @Parameter(property = "vaadin."
-            + InitParameters.MINIMUM_FRONTEND_PACKAGE_AGE_DAYS, defaultValue = "0")
+            + InitParameters.MINIMUM_FRONTEND_PACKAGE_AGE_DAYS, defaultValue = "1")
     private int minimumFrontendPackageAgeDays;
 
     /**

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
@@ -347,9 +347,8 @@ public abstract class VaadinFlowPluginExtension @Inject constructor(private val 
      * Minimum age (in days) a frontend (npm) package version must have before
      * npm, pnpm or bun is allowed to install it. Mitigates supply-chain
      * attacks where a compromised version is briefly available on the
-     * registry. Defaults to {@code 0} (disabled); set to a positive value to
-     * enable. Requires pnpm >= 10.16.0 or bun >= 1.3.0 when those tools are
-     * used.
+     * registry. Defaults to {@code 1} day; set to {@code 0} to disable.
+     * Requires pnpm >= 10.16.0 or bun >= 1.3.0 when those tools are used.
      */
     public abstract val minimumFrontendPackageAgeDays: Property<Int>
 
@@ -659,7 +658,7 @@ public class PluginEffectiveConfiguration(
         project.getStringProperty(
             "vaadin.${InitParameters.MINIMUM_FRONTEND_PACKAGE_AGE_DAYS}"
         ).map(String::toInt)
-            .orElse(extension.minimumFrontendPackageAgeDays.convention(0))
+            .orElse(extension.minimumFrontendPackageAgeDays.convention(1))
 
     public val npmExcludeWebComponents: Provider<Boolean> = extension
         .npmExcludeWebComponents.convention(false)

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -149,11 +149,11 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo
      * Minimum age (in days) a frontend (npm) package version must have before
      * npm, pnpm or bun is allowed to install it. Mitigates supply-chain attacks
      * where a compromised version is briefly available on the registry.
-     * Defaults to {@code 0} (disabled); set to a positive value to enable.
-     * Requires pnpm &ge; 10.16.0 or bun &ge; 1.3.0 when those tools are used.
+     * Defaults to {@code 1} day; set to {@code 0} to disable. Requires pnpm
+     * &ge; 10.16.0 or bun &ge; 1.3.0 when those tools are used.
      */
     @Parameter(property = "vaadin."
-            + InitParameters.MINIMUM_FRONTEND_PACKAGE_AGE_DAYS, defaultValue = "0")
+            + InitParameters.MINIMUM_FRONTEND_PACKAGE_AGE_DAYS, defaultValue = "1")
     private int minimumFrontendPackageAgeDays;
 
     @Override

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBuild.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBuild.java
@@ -129,13 +129,13 @@ public interface PluginAdapterBuild extends PluginAdapterBase {
 
     /**
      * Minimum age (in days) a frontend package version must have before npm,
-     * pnpm or bun is allowed to install it. Defaults to {@code 0} (disabled);
-     * set to a positive value to enable as a mitigation against malicious
-     * packages briefly published to the registry.
+     * pnpm or bun is allowed to install it. Defaults to {@code 1} day as a
+     * mitigation against malicious packages briefly published to the registry;
+     * set to {@code 0} to disable.
      *
      * @return the minimum allowed age in days, or {@code 0} when disabled
      */
     default int minimumFrontendPackageAgeDays() {
-        return 0;
+        return 1;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -304,7 +304,7 @@ public class InitParameters implements Serializable {
     /**
      * Configuration name for the minimum age (in days) a frontend (npm) package
      * version must have before npm, pnpm or bun is allowed to install it.
-     * Defaults to {@code 0} (disabled); set to a positive value to enable.
+     * Defaults to {@code 1} day; set to {@code 0} to disable.
      */
     public static final String MINIMUM_FRONTEND_PACKAGE_AGE_DAYS = "npm.minimumFrontendPackageAgeDays";
 


### PR DESCRIPTION
Bumps the default from 0 to 1 to enable the supply-chain delay by default while keeping the window short enough that the same-day Vaadin upgrade pain is at least bounded. Users can still opt out by setting the option to 0.
