### PR TITLE
test: drop flow-components deps from test-spring-boot-reload-time

### DIFF
--- a/flow-tests/vaadin-spring-tests/test-spring-boot-reload-time/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-reload-time/pom.xml
@@ -54,21 +54,6 @@
       <artifactId>spring-boot-devtools</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>vaadin-ordered-layout-flow</artifactId>
-      <version>${component.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>vaadin-button-flow</artifactId>
-      <version>${component.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>vaadin-text-field-flow</artifactId>
-      <version>${component.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-reload-time/src/main/java/com/vaadin/flow/spring/test/SpringDevToolsHorizontalLayoutReloadView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-reload-time/src/main/java/com/vaadin/flow/spring/test/SpringDevToolsHorizontalLayoutReloadView.java
@@ -17,13 +17,11 @@ package com.vaadin.flow.spring.test;
 
 import com.vaadin.flow.component.Html;
 import com.vaadin.flow.component.UI;
-import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Input;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Span;
-import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
-import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.router.Route;
 
 @Route("reload-layout-test")
@@ -38,8 +36,8 @@ public class SpringDevToolsHorizontalLayoutReloadView extends Div {
         NativeButton startTriggerButton = SpringDevToolsReloadUtils
                 .createReloadTriggerButton();
 
-        HorizontalLayout layout = new HorizontalLayout(
-                new Button("Vaadin Button"), new TextField());
+        Div layout = new Div(new NativeButton("Button"), new Input());
+        layout.getStyle().set("display", "flex").set("flex-direction", "row");
         add(startTriggerButton, result);
         add(new Html("<br/>"));
         add(layout);


### PR DESCRIPTION
Replace HorizontalLayout / Button / TextField in SpringDevToolsHorizontalLayoutReloadView with Div / NativeButton / Input from flow-html-components so the module no longer depends on vaadin-ordered-layout-flow, vaadin-button-flow, or vaadin-text-field-flow. This is part of breaking the Flow <-> flow-components build cycle.
