### PR TITLE
test: drop flow-components usage from test-spring-white-list

### DIFF
--- a/flow-tests/vaadin-spring-tests/test-spring-white-list/src/main/frontend/simple-view.js
+++ b/flow-tests/vaadin-spring-tests/test-spring-white-list/src/main/frontend/simple-view.js
@@ -1,13 +1,11 @@
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
-import '@vaadin/text-field/src/vaadin-text-field.js';
-import '@vaadin/button/src/vaadin-button.js';
 
 class SimpleViewElement extends PolymerElement {
   static get template() {
     return html`
-      <vaadin-button id="button">Click</vaadin-button>
-      <vaadin-text-field id="log"></vaadin-text-field>
+      <button id="button">Click</button>
+      <input id="log" />
     `;
   }
 

--- a/flow-tests/vaadin-spring-tests/test-spring-white-list/src/main/java/com/vaadin/flow/spring/test/whitelist/SimpleView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-white-list/src/main/java/com/vaadin/flow/spring/test/whitelist/SimpleView.java
@@ -16,11 +16,11 @@
 package com.vaadin.flow.spring.test.whitelist;
 
 import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.html.Input;
+import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.polymertemplate.Id;
 import com.vaadin.flow.component.polymertemplate.PolymerTemplate;
-import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.templatemodel.TemplateModel;
 
@@ -35,10 +35,10 @@ public class SimpleView extends PolymerTemplate<SimpleView.SimpleModel> {
     public static final String CLICKED_MESSAGE = "Button clicked";
 
     @Id("button")
-    Button button;
+    NativeButton button;
 
     @Id("log")
-    TextField log;
+    Input log;
 
     public SimpleView() {
         button.addClickListener(event -> log.setValue(CLICKED_MESSAGE));

--- a/flow-tests/vaadin-spring-tests/test-spring-white-list/src/test/java/com/vaadin/flow/spring/test/whitelist/SimpleIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-white-list/src/test/java/com/vaadin/flow/spring/test/whitelist/SimpleIT.java
@@ -19,8 +19,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.vaadin.flow.component.button.testbench.ButtonElement;
-import com.vaadin.flow.component.textfield.testbench.TextFieldElement;
+import com.vaadin.flow.component.html.testbench.InputTextElement;
+import com.vaadin.flow.component.html.testbench.NativeButtonElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
@@ -33,11 +33,12 @@ public class SimpleIT extends ChromeBrowserTest {
     @Test
     public void simplePage_withWhiteList_works() {
         TestBenchElement viewElement = $("simple-view").first();
-        ButtonElement button = viewElement.$(ButtonElement.class).id("button");
+        NativeButtonElement button = viewElement.$(NativeButtonElement.class)
+                .id("button");
 
         button.click();
 
-        TextFieldElement log = viewElement.$(TextFieldElement.class).id("log");
+        InputTextElement log = viewElement.$(InputTextElement.class).id("log");
         Assert.assertEquals(SimpleView.CLICKED_MESSAGE, log.getValue());
     }
 


### PR DESCRIPTION
Switch SimpleView's Polymer template to native <button>/<input> elements backed by NativeButton + Input @Id fields, and update SimpleIT to look them up via flow-html-components-testbench (NativeButtonElement, InputTextElement). Drop the @vaadin/button and @vaadin/text-field imports from simple-view.js. The allowed-packages whitelist test exercises the same scanning/registration logic as before; the components on the page are only scaffolding.

This module had no direct flow-components Maven dep — Button/TextField arrived transitively from test-spring-common, which was cleaned in the preceding commit. Part of breaking the Flow <-> flow-components build cycle.
