### PR TITLE
test: drop flow-components deps from test-spring-boot-multimodule-reload-time UI

### DIFF
--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/pom.xml
@@ -35,26 +35,6 @@
       <artifactId>spring-boot-devtools</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>vaadin-ordered-layout-flow</artifactId>
-      <version>${component.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>vaadin-button-flow</artifactId>
-      <version>${component.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>vaadin-text-field-flow</artifactId>
-      <version>${component.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>vaadin-app-layout-flow</artifactId>
-      <version>${component.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/main/java/com/vaadin/flow/spring/test/MainLayout.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/main/java/com/vaadin/flow/spring/test/MainLayout.java
@@ -15,70 +15,61 @@
  */
 package com.vaadin.flow.spring.test;
 
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.UI;
-import com.vaadin.flow.component.applayout.AppLayout;
-import com.vaadin.flow.component.applayout.DrawerToggle;
+import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Footer;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.Header;
-import com.vaadin.flow.component.orderedlayout.Scroller;
-import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.AfterNavigationEvent;
 import com.vaadin.flow.router.AfterNavigationObserver;
 import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.router.RouterLink;
-import com.vaadin.flow.theme.lumo.LumoUtility;
 
-/**
- * The main view is a top-level placeholder for other views.
- */
-public class MainLayout extends AppLayout implements AfterNavigationObserver {
+public class MainLayout extends Div
+        implements RouterLayout, AfterNavigationObserver {
 
-    private H2 viewTitle;
+    private final H2 viewTitle = new H2();
+    private final Div drawer = new Div();
+    private final Div content = new Div();
 
     public MainLayout() {
-        setPrimarySection(Section.DRAWER);
-        addDrawerContent();
-        addHeaderContent();
-    }
+        getStyle().set("display", "flex").set("flex-direction", "column");
 
-    private void addHeaderContent() {
-        DrawerToggle toggle = new DrawerToggle();
+        NativeButton toggle = new NativeButton("☰",
+                e -> drawer.setVisible(!drawer.isVisible()));
 
-        viewTitle = new H2();
-        viewTitle.addClassNames(LumoUtility.FontSize.LARGE,
-                LumoUtility.Margin.NONE);
+        Header navbar = new Header(toggle, viewTitle);
+        navbar.getStyle().set("display", "flex").set("gap", "0.5rem");
 
-        addToNavbar(true, toggle, viewTitle);
-    }
-
-    private void addDrawerContent() {
         H1 appName = new H1("My Spring App");
-        appName.addClassNames(LumoUtility.FontSize.LARGE,
-                LumoUtility.Margin.NONE);
-        Header header = new Header(appName);
-
-        Scroller scroller = new Scroller(createNavigation());
-
-        addToDrawer(header, scroller, createFooter());
-    }
-
-    private VerticalLayout createNavigation() {
-        VerticalLayout layout = new VerticalLayout();
+        Div nav = new Div();
+        nav.getStyle().set("display", "flex").set("flex-direction", "column");
         UI.getCurrent().getInternals().getRouter().getRegistry()
-                .getRegisteredRoutes().forEach(route -> {
-                    layout.add(new RouterLink(route.getTemplate(),
-                            route.getNavigationTarget()));
-                });
+                .getRegisteredRoutes()
+                .forEach(route -> nav.add(new RouterLink(route.getTemplate(),
+                        route.getNavigationTarget())));
 
-        return layout;
+        drawer.add(new Header(appName), nav, new Footer());
+        drawer.getStyle().set("display", "flex").set("flex-direction",
+                "column");
+
+        Div body = new Div(drawer, content);
+        body.getStyle().set("display", "flex").set("flex", "1");
+
+        add(navbar, body);
     }
 
-    private Footer createFooter() {
-        Footer layout = new Footer();
-
-        return layout;
+    @Override
+    public void showRouterLayoutContent(HasElement contentElement) {
+        content.removeAll();
+        if (contentElement != null) {
+            content.getElement().appendChild(contentElement.getElement());
+        }
     }
 
     @Override
@@ -87,8 +78,15 @@ public class MainLayout extends AppLayout implements AfterNavigationObserver {
     }
 
     private String getCurrentPageTitle() {
-        PageTitle title = getContent().getClass()
-                .getAnnotation(PageTitle.class);
+        Component current = currentContent();
+        if (current == null) {
+            return "";
+        }
+        PageTitle title = current.getClass().getAnnotation(PageTitle.class);
         return title == null ? "" : title.value();
+    }
+
+    private Component currentContent() {
+        return content.getChildren().findFirst().orElse(null);
     }
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/main/java/com/vaadin/flow/spring/test/store/CatalogLayout.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/main/java/com/vaadin/flow/spring/test/store/CatalogLayout.java
@@ -16,9 +16,8 @@
 package com.vaadin.flow.spring.test.store;
 
 import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H1;
-import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
-import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.ParentLayout;
 import com.vaadin.flow.router.RoutePrefix;
 import com.vaadin.flow.router.RouterLayout;
@@ -27,19 +26,23 @@ import com.vaadin.flow.spring.test.MainLayout;
 
 @RoutePrefix("catalog")
 @ParentLayout(MainLayout.class)
-public class CatalogLayout extends VerticalLayout implements RouterLayout {
+public class CatalogLayout extends Div implements RouterLayout {
 
-    private VerticalLayout rightSideLayout;
+    private final Div rightSideLayout = new Div();
 
     public CatalogLayout() {
-        rightSideLayout = new VerticalLayout();
+        getStyle().set("display", "flex").set("flex-direction", "column");
 
         add(new H1("Product Catalog"));
 
-        var leftSideLayout = new VerticalLayout();
-        var layout = new HorizontalLayout();
-        layout.setWidthFull();
-        layout.addAndExpand(leftSideLayout, rightSideLayout);
+        Div leftSideLayout = new Div();
+        leftSideLayout.getStyle().set("display", "flex").set("flex-direction",
+                "column");
+
+        rightSideLayout.getStyle().set("flex", "1");
+
+        Div layout = new Div(leftSideLayout, rightSideLayout);
+        layout.getStyle().set("display", "flex").set("width", "100%");
 
         for (int index = 0; index < 10; index++) {
             leftSideLayout.add(new RouterLink("Product " + index,

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/main/java/com/vaadin/flow/spring/test/store/ProductView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-multimodule-reload-time/ui/src/main/java/com/vaadin/flow/spring/test/store/ProductView.java
@@ -21,7 +21,6 @@ import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.Hr;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Span;
-import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.BeforeEvent;
 import com.vaadin.flow.router.HasUrlParameter;
 import com.vaadin.flow.router.OptionalParameter;
@@ -31,14 +30,14 @@ import com.vaadin.flow.spring.test.SpringDevToolsReloadUtils;
 
 @Route(value = "product", layout = CatalogLayout.class, registerAtStartup = false)
 @RouteAlias(value = "prod", layout = CatalogLayout.class)
-public class ProductView extends VerticalLayout
-        implements HasUrlParameter<Integer> {
+public class ProductView extends Div implements HasUrlParameter<Integer> {
 
-    private Div productDetails;
+    private final Div productDetails;
 
     public ProductView() {
+        getStyle().set("display", "flex").set("flex-direction", "column");
         productDetails = new Div();
-        productDetails.setWidthFull();
+        productDetails.getStyle().set("width", "100%");
         add(new H2("Product Details"));
         add(productDetails);
     }


### PR DESCRIPTION
Replace AppLayout/DrawerToggle/Scroller in MainLayout with a Div-based shell that implements RouterLayout directly, swap HorizontalLayout / VerticalLayout for styled Divs in CatalogLayout/ProductView, and drop the LumoUtility CSS-class helpers. Removes the vaadin-ordered-layout-flow, vaadin-button-flow, vaadin-text-field-flow, and vaadin-app-layout-flow dependencies from this module as part of breaking the Flow <-> flow-components build cycle.

The benchmark-directory-addons profile still references third-party addon artifacts that transitively pull in flow components; that profile is opt-in and outside the scope of breaking the default-build cycle.
