### PR TITLE
Drop button, text-field, and notification flow-components deps from test-spring-common

### DIFF
--- a/flow-tests/vaadin-spring-tests/test-spring-common/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/pom.xml
@@ -44,6 +44,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.vaadin</groupId>
+      <artifactId>flow-html-components-testbench</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
     <!-- Test components -->
     <dependency>
       <groupId>com.vaadin</groupId>
@@ -54,41 +60,6 @@
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-upload-testbench</artifactId>
       <version>${component.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>vaadin-notification-flow</artifactId>
-      <version>${component.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>vaadin-notification-testbench</artifactId>
-      <version>${component.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>vaadin-button-flow</artifactId>
-      <version>${component.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>vaadin-button-testbench</artifactId>
-      <version>${component.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>vaadin-text-field-flow</artifactId>
-      <version>${component.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>vaadin-text-field-testbench</artifactId>
-      <version>${component.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>flow-html-components-testbench</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/flow-tests/vaadin-spring-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/test/ComponentTestView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/test/ComponentTestView.java
@@ -15,18 +15,23 @@
  */
 package com.vaadin.flow.spring.test;
 
-import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.notification.Notification;
+import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.Route;
 
 @Route("component-test")
 public class ComponentTestView extends Div {
 
     public ComponentTestView() {
-        Button button = new Button("Click me",
-                event -> Notification.show("Clicked!"));
+        Div notification = new Div();
+        notification.setId("notification");
+        notification.setVisible(false);
 
-        add(button);
+        NativeButton button = new NativeButton("Click me", event -> {
+            notification.setText("Clicked!");
+            notification.setVisible(true);
+        });
+
+        add(button, notification);
     }
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/ComponentTestIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/ComponentTestIT.java
@@ -18,8 +18,8 @@ package com.vaadin.flow.spring.test;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.vaadin.flow.component.button.testbench.ButtonElement;
-import com.vaadin.flow.component.notification.testbench.NotificationElement;
+import com.vaadin.flow.component.html.testbench.DivElement;
+import com.vaadin.flow.component.html.testbench.NativeButtonElement;
 
 public class ComponentTestIT extends AbstractSpringTest {
 
@@ -27,13 +27,12 @@ public class ComponentTestIT extends AbstractSpringTest {
     public void componentsAreFoundAndLoaded() throws Exception {
         open();
 
-        $(ButtonElement.class).waitForFirst();
+        $(NativeButtonElement.class).waitForFirst();
 
-        $(ButtonElement.class).first().click();
+        $(NativeButtonElement.class).first().click();
 
-        Assert.assertTrue(
-                "Clicking button should have opened a notification successfully.",
-                $(NotificationElement.class).exists());
+        Assert.assertTrue("Clicking button should have shown the notification.",
+                $(DivElement.class).id("notification").isDisplayed());
     }
 
     @Override

--- a/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/SmokeTestIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/SmokeTestIT.java
@@ -23,8 +23,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.vaadin.flow.component.button.testbench.ButtonElement;
-import com.vaadin.flow.component.notification.testbench.NotificationElement;
+import com.vaadin.flow.component.html.testbench.DivElement;
+import com.vaadin.flow.component.html.testbench.NativeButtonElement;
 
 /**
  * Test that application is deployed and can be opened in the browser. Works
@@ -48,13 +48,12 @@ public class SmokeTestIT extends AbstractSpringTest {
     public void componentsAreFoundAndLoaded() throws Exception {
         open();
 
-        $(ButtonElement.class).waitForFirst();
+        $(NativeButtonElement.class).waitForFirst();
 
-        $(ButtonElement.class).first().click();
+        $(NativeButtonElement.class).first().click();
 
-        Assert.assertTrue(
-                "Clicking button should have opened a notification successfully.",
-                $(NotificationElement.class).exists());
+        Assert.assertTrue("Clicking button should have shown the notification.",
+                $(DivElement.class).id("notification").isDisplayed());
     }
 
     @Override


### PR DESCRIPTION
Part of breaking the Flow <-> flow-components build cycle. ComponentTestView
now uses NativeButton + a hidden Div that becomes visible on click, and the
ComponentTestIT / SmokeTestIT integration tests query those native elements
via flow-html-components-testbench (NativeButtonElement, DivElement).
vaadin-upload-flow / -testbench and the Upload-based UploadView/UploadIT are
left intact for now since a plain <input type="file"> loses the multipart
receiver behavior the upload tests exercise.
