### PR TITLE
test: wait for DevTools restart in redeployment ITs

### DIFF
--- a/flow-tests/test-redeployment/src/test/java/com/vaadin/flow/uitest/ui/AbstractReloadIT.java
+++ b/flow-tests/test-redeployment/src/test/java/com/vaadin/flow/uitest/ui/AbstractReloadIT.java
@@ -15,11 +15,29 @@
  */
 package com.vaadin.flow.uitest.ui;
 
+import org.junit.Before;
 import org.openqa.selenium.StaleElementReferenceException;
 
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
 public abstract class AbstractReloadIT extends ChromeBrowserTest {
+
+    // Tests in this module routinely recompile classes, which causes Spring
+    // Boot DevTools to restart Tomcat. A previous test's restart can still be
+    // in progress when the next test starts, so wait until the server is
+    // reachable instead of failing on the first refused connection.
+    @Before
+    @Override
+    public void checkIfServerAvailable() {
+        waitUntil(driver -> {
+            try {
+                super.checkIfServerAvailable();
+                return true;
+            } catch (Exception e) {
+                return false;
+            }
+        });
+    }
 
     protected void reloadAndWait() {
         String viewId = getViewId();

--- a/flow-tests/test-redeployment/src/test/java/com/vaadin/flow/uitest/ui/ThemeSwitchLiveReloadIT.java
+++ b/flow-tests/test-redeployment/src/test/java/com/vaadin/flow/uitest/ui/ThemeSwitchLiveReloadIT.java
@@ -27,7 +27,6 @@ import net.jcip.annotations.NotThreadSafe;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.StaleElementReferenceException;
@@ -35,10 +34,9 @@ import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.function.SerializableSupplier;
-import com.vaadin.flow.testutil.ChromeBrowserTest;
 
 @NotThreadSafe
-public class ThemeSwitchLiveReloadIT extends ChromeBrowserTest {
+public class ThemeSwitchLiveReloadIT extends AbstractReloadIT {
 
     private static final String BLUE_COLOR = "rgba(0, 0, 255, 1)";
     private static final String ERROR_MESSAGE = "Expected theme swap from '%s' to '%s' has not been done after '%d' attempts";
@@ -51,21 +49,6 @@ public class ThemeSwitchLiveReloadIT extends ChromeBrowserTest {
     @Override
     protected String getTestPath() {
         return super.getTestPath().replace("/view", "");
-    }
-
-    @Before
-    @Override
-    public void checkIfServerAvailable() {
-        // Make sure the server is not still restarting
-        waitUntil(driver -> {
-            String rootUrl = getRootURL();
-            try {
-                super.checkIfServerAvailable();
-                return true;
-            } catch (Exception e) {
-                return false;
-            }
-        });
     }
 
     @After


### PR DESCRIPTION
Hoist ThemeSwitchLiveReloadIT's checkIfServerAvailable wait into AbstractReloadIT so SessionValueIT and DevModeClassCacheIT also tolerate a Spring Boot DevTools restart triggered by a neighbouring test.
