### PR TITLE
chore: log existing Node installation message at debug level

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/NodeResolver.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/NodeResolver.java
@@ -291,7 +291,7 @@ class NodeResolver implements java.io.Serializable {
                 String normalizedRequested = normalizeVersion(nodeVersion);
 
                 if (normalizedInstalled.equals(normalizedRequested)) {
-                    getLogger().info("Node {} is already installed in {}",
+                    getLogger().debug("Node {} is already installed in {}",
                             nodeVersion, alternativeDir);
                     return createActiveInstallation(nodeExecutable,
                             versionToUse, alternativeDirFile);


### PR DESCRIPTION
The "Node X is already installed in Y" message is expected output and should not appear at info level.
