### PR TITLE
fix: load Image/IFrame sources when disabled

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
@@ -189,6 +189,12 @@ public class IFrame extends HtmlComponent implements HasAriaLabel {
      * {@link DownloadHandler}, as well as for other
      * {@link AbstractDownloadHandler} implementations.
      *
+     * The handler is wrapped with {@link DownloadHandler#allowDisabled()} so
+     * that the iframe content is still served when the component, or one of its
+     * ancestors, is disabled. The browser fetches the content as part of
+     * rendering rather than as a user action, so blocking the request on the
+     * disabled state would leave the iframe empty.
+     *
      * @see #setSrc(String)
      *
      * @param downloadHandler
@@ -200,7 +206,7 @@ public class IFrame extends HtmlComponent implements HasAriaLabel {
             // where it is 'attachment' by default
             handler.inline();
         }
-        getElement().setAttribute("src", downloadHandler);
+        getElement().setAttribute("src", downloadHandler.allowDisabled());
     }
 
     /**

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
@@ -225,6 +225,12 @@ public class Image extends HtmlContainer
      * {@link DownloadHandler}, as well as for other
      * {@link AbstractDownloadHandler} implementations.
      *
+     * The handler is wrapped with {@link DownloadHandler#allowDisabled()} so
+     * that the image is still served when the component, or one of its
+     * ancestors, is disabled. The browser fetches the image as part of
+     * rendering rather than as a user action, so blocking the request on the
+     * disabled state would leave the icon broken.
+     *
      * @param downloadHandler
      *            the download handler resource, not null
      */
@@ -234,7 +240,7 @@ public class Image extends HtmlContainer
             // where it is 'attachment' by default
             handler.inline();
         }
-        getElement().setAttribute("src", downloadHandler);
+        getElement().setAttribute("src", downloadHandler.allowDisabled());
     }
 
     /**

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/IFrameTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/IFrameTest.java
@@ -18,14 +18,17 @@ package com.vaadin.flow.component.html;
 import java.lang.reflect.Field;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.dom.DisabledUpdateMode;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.server.streams.DownloadHandler;
 import com.vaadin.flow.server.streams.DownloadResponse;
 import com.vaadin.flow.server.streams.InputStreamDownloadHandler;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -68,6 +71,29 @@ class IFrameTest extends ComponentTest {
     @Override
     protected void testHasAriaLabelIsImplemented() {
         super.testHasAriaLabelIsImplemented();
+    }
+
+    @Test
+    void setSrc_downloadHandler_disabledUpdateModeIsAlways() {
+        Element element = Mockito.mock(Element.class);
+        class TestIFrame extends IFrame {
+            @Override
+            public Element getElement() {
+                return element;
+            }
+        }
+        // Plain lambda DownloadHandler, not an AbstractDownloadHandler subclass
+        DownloadHandler lambda = event -> {
+        };
+
+        new TestIFrame().setSrc(lambda);
+
+        ArgumentCaptor<DownloadHandler> captor = ArgumentCaptor
+                .forClass(DownloadHandler.class);
+        Mockito.verify(element).setAttribute(Mockito.eq("src"),
+                captor.capture());
+        assertEquals(DisabledUpdateMode.ALWAYS,
+                captor.getValue().getDisabledUpdateMode());
     }
 
     @Test

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/ImageTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/ImageTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
+import com.vaadin.flow.dom.DisabledUpdateMode;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
@@ -63,6 +64,29 @@ class ImageTest extends ComponentTest {
     }
 
     @Test
+    void setSrc_downloadHandler_disabledUpdateModeIsAlways() {
+        Element element = Mockito.mock(Element.class);
+        class TestImage extends Image {
+            @Override
+            public Element getElement() {
+                return element;
+            }
+        }
+        // Plain lambda DownloadHandler, not an AbstractDownloadHandler subclass
+        DownloadHandler lambda = event -> {
+        };
+
+        new TestImage().setSrc(lambda);
+
+        ArgumentCaptor<DownloadHandler> captor = ArgumentCaptor
+                .forClass(DownloadHandler.class);
+        Mockito.verify(element).setAttribute(Mockito.eq("src"),
+                captor.capture());
+        assertEquals(DisabledUpdateMode.ALWAYS,
+                captor.getValue().getDisabledUpdateMode());
+    }
+
+    @Test
     void downloadHandler_isSetToInline() {
         Element element = Mockito.mock(Element.class);
         class TestImage extends Image {
@@ -95,8 +119,8 @@ class ImageTest extends ComponentTest {
                 handlerCaptor.capture());
 
         DownloadHandler handler = handlerCaptor.getValue();
-        assertTrue(handler instanceof InputStreamDownloadHandler,
-                "Handler should be InputStreamDownloadHandler");
+        assertEquals(DisabledUpdateMode.ALWAYS, handler.getDisabledUpdateMode(),
+                "Handler set on the image must allow disabled, so the browser can still load the image when the component is disabled");
 
         // Create mock event and response to capture content type
         VaadinRequest request = Mockito.mock(VaadinRequest.class);

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadHandler.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.server.streams;
 import java.io.File;
 import java.io.IOException;
 
+import com.vaadin.flow.dom.DisabledUpdateMode;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
@@ -100,6 +101,59 @@ public interface DownloadHandler extends ElementRequestHandler {
                 session, owner);
 
         handleDownloadRequest(downloadEvent);
+    }
+
+    /**
+     * Returns a view of this handler that is served even when the owning
+     * component is disabled.
+     * <p>
+     * By default a {@link DownloadHandler} inherits
+     * {@link DisabledUpdateMode#ONLY_WHEN_ENABLED} from
+     * {@link ElementRequestHandler}, which causes the framework to respond with
+     * HTTP 403 when the owning element is disabled. That is appropriate for
+     * action-style downloads such as a "save file" link on an
+     * {@code com.vaadin.flow.component.html.Anchor}, but not for resources that
+     * the browser fetches passively as part of rendering, such as the
+     * {@code src} of an icon or image inside a disabled container.
+     * <p>
+     * This method returns a wrapper that delegates
+     * {@link #handleDownloadRequest}, {@link #getUrlPostfix()} and
+     * {@link #isAllowInert()} to this handler and overrides
+     * {@link #getDisabledUpdateMode()} to return
+     * {@link DisabledUpdateMode#ALWAYS}. If this handler already reports
+     * {@code ALWAYS}, the same instance is returned.
+     *
+     * @return a {@link DownloadHandler} that is served regardless of the
+     *         owner's enabled state, or {@code this} if the disabled mode is
+     *         already {@link DisabledUpdateMode#ALWAYS}
+     */
+    default DownloadHandler allowDisabled() {
+        if (getDisabledUpdateMode() == DisabledUpdateMode.ALWAYS) {
+            return this;
+        }
+        DownloadHandler delegate = this;
+        return new DownloadHandler() {
+            @Override
+            public void handleDownloadRequest(DownloadEvent event)
+                    throws IOException {
+                delegate.handleDownloadRequest(event);
+            }
+
+            @Override
+            public String getUrlPostfix() {
+                return delegate.getUrlPostfix();
+            }
+
+            @Override
+            public boolean isAllowInert() {
+                return delegate.isAllowInert();
+            }
+
+            @Override
+            public DisabledUpdateMode getDisabledUpdateMode() {
+                return DisabledUpdateMode.ALWAYS;
+            }
+        };
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/server/streams/DownloadHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/streams/DownloadHandlerTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.streams;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.dom.DisabledUpdateMode;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinResponse;
+import com.vaadin.flow.server.VaadinSession;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DownloadHandlerTest {
+
+    @Test
+    void allowDisabled_lambda_disabledUpdateModeIsAlways() {
+        DownloadHandler delegate = event -> {
+        };
+
+        DownloadHandler wrapped = delegate.allowDisabled();
+
+        assertEquals(DisabledUpdateMode.ALWAYS,
+                wrapped.getDisabledUpdateMode());
+    }
+
+    @Test
+    void allowDisabled_lambda_forwardsHandleDownloadRequest() throws Exception {
+        AtomicReference<DownloadEvent> received = new AtomicReference<>();
+        DownloadHandler delegate = received::set;
+
+        DownloadEvent event = new DownloadEvent(
+                Mockito.mock(VaadinRequest.class),
+                Mockito.mock(VaadinResponse.class),
+                Mockito.mock(VaadinSession.class), Mockito.mock(Element.class));
+
+        delegate.allowDisabled().handleDownloadRequest(event);
+
+        assertSame(event, received.get(),
+                "Wrapped handler must forward the event to the delegate");
+    }
+
+    @Test
+    void allowDisabled_forwardsUrlPostfixAndAllowInert() {
+        DownloadHandler delegate = new DownloadHandler() {
+            @Override
+            public void handleDownloadRequest(DownloadEvent event) {
+            }
+
+            @Override
+            public String getUrlPostfix() {
+                return "icon.svg";
+            }
+
+            @Override
+            public boolean isAllowInert() {
+                return true;
+            }
+        };
+
+        DownloadHandler wrapped = delegate.allowDisabled();
+
+        assertEquals("icon.svg", wrapped.getUrlPostfix());
+        assertTrue(wrapped.isAllowInert());
+    }
+
+    @Test
+    void allowDisabled_abstractDownloadHandlerWrapped_modeIsAlways_inlinePreserved() {
+        InputStreamDownloadHandler handler = DownloadHandler
+                .fromInputStream(event -> DownloadResponse.error(500));
+        handler.inline();
+
+        DownloadHandler wrapped = handler.allowDisabled();
+
+        assertEquals(DisabledUpdateMode.ALWAYS,
+                wrapped.getDisabledUpdateMode());
+        // The wrap does not interfere with the original handler's inline state
+        assertTrue(handler.isInline());
+    }
+
+    @Test
+    void allowDisabled_isIdempotent_returnsSameInstance() {
+        DownloadHandler alwaysAllowed = new DownloadHandler() {
+            @Override
+            public void handleDownloadRequest(DownloadEvent event) {
+            }
+
+            @Override
+            public DisabledUpdateMode getDisabledUpdateMode() {
+                return DisabledUpdateMode.ALWAYS;
+            }
+        };
+
+        assertSame(alwaysAllowed, alwaysAllowed.allowDisabled(),
+                "allowDisabled() on a handler that is already ALWAYS must be a no-op");
+    }
+
+    @Test
+    void allowDisabled_doubleWrap_returnsFirstWrapper() {
+        DownloadHandler delegate = event -> {
+        };
+        DownloadHandler wrappedOnce = delegate.allowDisabled();
+        DownloadHandler wrappedTwice = wrappedOnce.allowDisabled();
+
+        assertSame(wrappedOnce, wrappedTwice,
+                "Wrapping a handler that is already ALWAYS must be a no-op");
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DisabledImageDownloadHandlerView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DisabledImageDownloadHandlerView.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.IFrame;
+import com.vaadin.flow.component.html.Image;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.streams.DownloadHandler;
+import com.vaadin.flow.server.streams.DownloadResponse;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+@Route(value = "com.vaadin.flow.uitest.ui.DisabledImageDownloadHandlerView", layout = ViewTestLayout.class)
+public class DisabledImageDownloadHandlerView extends Div {
+
+    static final String IMAGE_PAYLOAD = """
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">\
+            <circle cx="8" cy="8" r="7" fill="#1676f3"/></svg>""";
+    static final String IFRAME_PAYLOAD = """
+            <!DOCTYPE html><html><body><p>Hello from iframe</p></body></html>""";
+
+    public DisabledImageDownloadHandlerView() {
+        Image image = new Image(DownloadHandler.fromInputStream(event -> {
+            byte[] bytes = IMAGE_PAYLOAD.getBytes(StandardCharsets.UTF_8);
+            return new DownloadResponse(new ByteArrayInputStream(bytes),
+                    "icon.svg", "image/svg+xml", bytes.length);
+        }), "icon");
+        image.setId("disabled-image");
+        image.setWidth("100px");
+        image.setHeight("100px");
+
+        IFrame iframe = new IFrame(DownloadHandler.fromInputStream(event -> {
+            byte[] bytes = IFRAME_PAYLOAD.getBytes(StandardCharsets.UTF_8);
+            return new DownloadResponse(new ByteArrayInputStream(bytes),
+                    "frame.html", "text/html", bytes.length);
+        }));
+        iframe.setId("disabled-iframe");
+        iframe.setWidth("200px");
+        iframe.setHeight("100px");
+
+        Div disabledContainer = new Div(image, iframe);
+        disabledContainer.setId("disabled-container");
+        disabledContainer.setEnabled(false);
+
+        add(disabledContainer);
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DisabledImageDownloadHandlerIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DisabledImageDownloadHandlerIT.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import static com.vaadin.flow.uitest.ui.DisabledImageDownloadHandlerView.IFRAME_PAYLOAD;
+import static com.vaadin.flow.uitest.ui.DisabledImageDownloadHandlerView.IMAGE_PAYLOAD;
+
+/**
+ * Regression test for issue #22772: an
+ * {@link com.vaadin.flow.component.html.Image} or
+ * {@link com.vaadin.flow.component.html.IFrame} backed by a
+ * {@link com.vaadin.flow.server.streams.DownloadHandler} must still serve its
+ * content when the owning component is disabled.
+ */
+public class DisabledImageDownloadHandlerIT extends AbstractStreamResourceIT {
+
+    @Test
+    public void disabledImage_downloadHandlerStillServesContent()
+            throws IOException {
+        open();
+
+        WebElement image = findElement(By.id("disabled-image"));
+        String url = image.getAttribute("src");
+        Assert.assertNotNull("Image must have an src attribute", url);
+        Assert.assertFalse(
+                "Image src must not be empty when the owner is disabled",
+                url.isEmpty());
+
+        try (InputStream stream = download(url)) {
+            String content = IOUtils.toString(stream, StandardCharsets.UTF_8);
+            Assert.assertEquals(IMAGE_PAYLOAD, content);
+        }
+    }
+
+    @Test
+    public void disabledIFrame_downloadHandlerStillServesContent()
+            throws IOException {
+        open();
+
+        WebElement iframe = findElement(By.id("disabled-iframe"));
+        String url = iframe.getAttribute("src");
+        Assert.assertNotNull("IFrame must have an src attribute", url);
+        Assert.assertFalse(
+                "IFrame src must not be empty when the owner is disabled",
+                url.isEmpty());
+
+        try (InputStream stream = download(url)) {
+            String content = IOUtils.toString(stream, StandardCharsets.UTF_8);
+            Assert.assertEquals(IFRAME_PAYLOAD, content);
+        }
+    }
+}


### PR DESCRIPTION
When an `Image` or `IFrame` backed by a `DownloadHandler` lives inside a disabled component, the browser receives a 403 and the resource never loads.

`Image.setSrc(DownloadHandler)` and `IFrame.setSrc(DownloadHandler)` now allow the resource to be served regardless of the owner's enabled state, since these sources are fetched passively as part of rendering rather than as a user action.

Fixes #22772