### PR TITLE
feat: support delaying installation of recently published npm packages (#24334) (CP: 25.1)

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -118,13 +118,18 @@ public class FrontendTools {
     private static final FrontendVersion SUPPORTED_NPM_VERSION = new FrontendVersion(
             SUPPORTED_NPM_MAJOR_VERSION, SUPPORTED_NPM_MINOR_VERSION);
 
-    private static final int SUPPORTED_PNPM_MAJOR_VERSION = 7;
-    private static final int SUPPORTED_PNPM_MINOR_VERSION = 0;
+    // pnpm 10.16.0 is the first version that supports the
+    // minimumReleaseAge setting used to delay installation of newly
+    // published packages as a supply-chain mitigation.
+    private static final int SUPPORTED_PNPM_MAJOR_VERSION = 10;
+    private static final int SUPPORTED_PNPM_MINOR_VERSION = 16;
 
     private static final FrontendVersion SUPPORTED_PNPM_VERSION = new FrontendVersion(
             SUPPORTED_PNPM_MAJOR_VERSION, SUPPORTED_PNPM_MINOR_VERSION);
+    // Bun 1.3.0 is the first version that supports --minimum-release-age
+    // for the same supply-chain mitigation.
     private static final FrontendVersion SUPPORTED_BUN_VERSION = new FrontendVersion(
-            1, 0, 6); // Bun 1.0.6 is the first version with "overrides" support
+            1, 3, 0);
 
     private enum BuildTool {
         NPM("npm", "npm-cli.js"),

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -118,17 +118,22 @@ public class FrontendTools {
     private static final FrontendVersion SUPPORTED_NPM_VERSION = new FrontendVersion(
             SUPPORTED_NPM_MAJOR_VERSION, SUPPORTED_NPM_MINOR_VERSION);
 
-    // pnpm 10.16.0 is the first version that supports the
-    // minimumReleaseAge setting used to delay installation of newly
-    // published packages as a supply-chain mitigation.
-    private static final int SUPPORTED_PNPM_MAJOR_VERSION = 10;
-    private static final int SUPPORTED_PNPM_MINOR_VERSION = 16;
+    private static final int SUPPORTED_PNPM_MAJOR_VERSION = 7;
+    private static final int SUPPORTED_PNPM_MINOR_VERSION = 0;
 
     private static final FrontendVersion SUPPORTED_PNPM_VERSION = new FrontendVersion(
             SUPPORTED_PNPM_MAJOR_VERSION, SUPPORTED_PNPM_MINOR_VERSION);
+    private static final FrontendVersion SUPPORTED_BUN_VERSION = new FrontendVersion(
+            1, 0, 6); // Bun 1.0.6 is the first version with "overrides" support
+
+    // pnpm 10.16.0 is the first version that supports the
+    // minimumReleaseAge setting used to delay installation of newly
+    // published packages as a supply-chain mitigation.
+    static final FrontendVersion MIN_PNPM_VERSION_FOR_RELEASE_AGE = new FrontendVersion(
+            10, 16, 0);
     // Bun 1.3.0 is the first version that supports --minimum-release-age
     // for the same supply-chain mitigation.
-    private static final FrontendVersion SUPPORTED_BUN_VERSION = new FrontendVersion(
+    static final FrontendVersion MIN_BUN_VERSION_FOR_RELEASE_AGE = new FrontendVersion(
             1, 3, 0);
 
     private enum BuildTool {
@@ -520,6 +525,55 @@ public class FrontendTools {
                 getNpmExecutable(false));
         npmVersionCommand.add("--version"); // NOSONAR
         return FrontendUtils.getVersion("npm", npmVersionCommand);
+    }
+
+    /**
+     * Verifies that the given pnpm or bun command is recent enough to support
+     * the {@code --minimum-release-age} (bun) or {@code minimumReleaseAge}
+     * (pnpm) install flag used by
+     * {@link Options#withMinimumFrontendPackageAgeDays(int)}.
+     * <p>
+     * Throws {@link IllegalStateException} if the installed tool is older than
+     * {@link #MIN_PNPM_VERSION_FOR_RELEASE_AGE} or
+     * {@link #MIN_BUN_VERSION_FOR_RELEASE_AGE}, or if the version cannot be
+     * resolved. The check is not bypassed by
+     * {@link FrontendToolsSettings#isIgnoreVersionChecks()} since passing the
+     * install flag to an unsupported tool would either be ignored silently or
+     * fail the install.
+     *
+     * @param toolCommand
+     *            the pnpm or bun command to invoke for {@code --version}
+     * @param isBun
+     *            {@code true} when {@code toolCommand} refers to bun,
+     *            {@code false} for pnpm
+     */
+    public void assertSupportsMinimumPackageReleaseAge(List<String> toolCommand,
+            boolean isBun) {
+        String toolName = isBun ? "bun" : "pnpm";
+        FrontendVersion required = isBun ? MIN_BUN_VERSION_FOR_RELEASE_AGE
+                : MIN_PNPM_VERSION_FOR_RELEASE_AGE;
+        List<String> versionCmd = new ArrayList<>(toolCommand);
+        versionCmd.add("--version"); // NOSONAR
+        FrontendVersion actual;
+        try {
+            actual = FrontendUtils.getVersion(toolName, versionCmd);
+        } catch (UnknownVersionException e) {
+            throw new IllegalStateException(String.format(
+                    "Could not determine %s version to verify support for the minimum frontend package age check",
+                    toolName), e);
+        }
+        assertVersionSupportsMinimumPackageReleaseAge(toolName, actual,
+                required);
+    }
+
+    static void assertVersionSupportsMinimumPackageReleaseAge(String toolName,
+            FrontendVersion actual, FrontendVersion required) {
+        if (!actual.isEqualOrNewer(required)) {
+            throw new IllegalStateException(String.format(
+                    "The minimum frontend package age check is enabled but the installed %s version %s is too old. Please upgrade %s to %s or newer, or disable the check by setting minimumFrontendPackageAgeDays to 0.",
+                    toolName, actual.getFullVersion(), toolName,
+                    required.getFullVersion()));
+        }
     }
 
     /**

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/Options.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/Options.java
@@ -166,6 +166,14 @@ public class Options implements Serializable {
 
     private boolean commercialBannerEnabled = false;
 
+    /**
+     * Minimum age, in days, that an npm/pnpm/bun frontend package version must
+     * have before it is allowed to be installed. Defaults to {@code 0}
+     * (disabled); set to a positive value to enable as a mitigation against
+     * malicious packages published to the registry.
+     */
+    private int minimumFrontendPackageAgeDays = 0;
+
     private ApplicationConfiguration applicationConfiguration;
 
     /**
@@ -1093,6 +1101,44 @@ public class Options implements Serializable {
     public Options withCommercialBanner(boolean enableCommercialBanner) {
         this.commercialBannerEnabled = enableCommercialBanner;
         return this;
+    }
+
+    /**
+     * Sets the minimum age (in days) a frontend package version must have
+     * before it is allowed to be installed by npm, pnpm or bun. The intent is
+     * to avoid pulling in brand-new versions that may have been compromised by
+     * a supply-chain attack but not yet detected and removed from the registry.
+     * <p>
+     * For npm this is translated to a {@code --before=<date>} argument; for
+     * pnpm it becomes {@code --config.minimum-release-age=<minutes>} (requires
+     * pnpm &ge; 10.16.0); for bun it becomes
+     * {@code --minimum-release-age=<seconds>} (requires bun &ge; 1.3.0).
+     *
+     * @param minimumFrontendPackageAgeDays
+     *            minimum allowed age in days, or {@code 0} to disable the check
+     * @return this builder
+     * @throws IllegalArgumentException
+     *             if {@code minimumFrontendPackageAgeDays} is negative
+     */
+    public Options withMinimumFrontendPackageAgeDays(
+            int minimumFrontendPackageAgeDays) {
+        if (minimumFrontendPackageAgeDays < 0) {
+            throw new IllegalArgumentException(
+                    "minimumFrontendPackageAgeDays must be >= 0");
+        }
+        this.minimumFrontendPackageAgeDays = minimumFrontendPackageAgeDays;
+        return this;
+    }
+
+    /**
+     * Gets the minimum age (in days) a frontend package version must have
+     * before npm, pnpm or bun is allowed to install it. {@code 0} means the
+     * check is disabled.
+     *
+     * @return the minimum allowed age in days
+     */
+    public int getMinimumFrontendPackageAgeDays() {
+        return minimumFrontendPackageAgeDays;
     }
 
     /**

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -266,6 +266,11 @@ public class TaskRunNpmInstall implements FallibleCommand {
             } else {
                 npmExecutable = tools.getNpmExecutable();
             }
+            if (options.getMinimumFrontendPackageAgeDays() > 0
+                    && (options.isEnableBun() || options.isEnablePnpm())) {
+                tools.assertSupportsMinimumPackageReleaseAge(npmExecutable,
+                        options.isEnableBun());
+            }
             npmInstallCommand = new ArrayList<>(npmExecutable);
             postinstallCommand = new ArrayList<>(npmExecutable);
             // This only works together with "install"

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -24,11 +24,14 @@ import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
@@ -289,6 +292,9 @@ public class TaskRunNpmInstall implements FallibleCommand {
             }
         }
 
+        getMinimumFrontendPackageAgeArgument(options)
+                .ifPresent(npmInstallCommand::add);
+
         postinstallCommand.add("run");
         postinstallCommand.add("postinstall");
 
@@ -423,6 +429,35 @@ public class TaskRunNpmInstall implements FallibleCommand {
         } else {
             return "npm";
         }
+    }
+
+    /**
+     * Builds the install argument that prevents npm, pnpm or bun from
+     * installing frontend package versions newer than
+     * {@link Options#getMinimumFrontendPackageAgeDays()} days. Returns an empty
+     * optional when the check is disabled.
+     */
+    static Optional<String> getMinimumFrontendPackageAgeArgument(
+            Options options) {
+        int days = options.getMinimumFrontendPackageAgeDays();
+        if (days <= 0) {
+            return Optional.empty();
+        }
+        if (options.isEnableBun()) {
+            // bun: --minimum-release-age takes a value in seconds
+            long seconds = (long) days * 24 * 60 * 60;
+            return Optional.of("--minimum-release-age=" + seconds);
+        }
+        if (options.isEnablePnpm()) {
+            // pnpm: minimumReleaseAge is a setting (in minutes), so it has
+            // to be passed via the --config.<name> CLI form, not as a
+            // top-level option
+            long minutes = (long) days * 24 * 60;
+            return Optional.of("--config.minimum-release-age=" + minutes);
+        }
+        // npm: --before takes any Date.parse-able string
+        String before = Instant.now().minus(days, ChronoUnit.DAYS).toString();
+        return Optional.of("--before=" + before);
     }
 
     private void consumeProcessOutput(Process process,

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -81,7 +81,7 @@ class FrontendToolsTest {
 
     private static final String OLD_PNPM_VERSION = "4.5.0";
 
-    private static final String SUPPORTED_PNPM_VERSION = "7.0.0";
+    private static final String SUPPORTED_PNPM_VERSION = "10.16.0";
 
     private String baseDir;
 

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -81,7 +81,7 @@ class FrontendToolsTest {
 
     private static final String OLD_PNPM_VERSION = "4.5.0";
 
-    private static final String SUPPORTED_PNPM_VERSION = "10.16.0";
+    private static final String SUPPORTED_PNPM_VERSION = "7.0.0";
 
     private String baseDir;
 
@@ -687,6 +687,42 @@ class FrontendToolsTest {
                         + "on your system."),
                 "Unexpected exception message content '"
                         + exception.getMessage() + "'");
+    }
+
+    @Test
+    void assertVersionSupportsMinimumPackageReleaseAge_pnpmTooOld_throws() {
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> FrontendTools
+                        .assertVersionSupportsMinimumPackageReleaseAge("pnpm",
+                                new FrontendVersion(7, 0, 0),
+                                FrontendTools.MIN_PNPM_VERSION_FOR_RELEASE_AGE));
+        assertThat(exception.getMessage(), containsString("pnpm"));
+        assertThat(exception.getMessage(), containsString("7.0.0"));
+        assertThat(exception.getMessage(), containsString("10.16.0"));
+    }
+
+    @Test
+    void assertVersionSupportsMinimumPackageReleaseAge_bunTooOld_throws() {
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> FrontendTools
+                        .assertVersionSupportsMinimumPackageReleaseAge("bun",
+                                new FrontendVersion(1, 0, 6),
+                                FrontendTools.MIN_BUN_VERSION_FOR_RELEASE_AGE));
+        assertThat(exception.getMessage(), containsString("bun"));
+        assertThat(exception.getMessage(), containsString("1.0.6"));
+        assertThat(exception.getMessage(), containsString("1.3.0"));
+    }
+
+    @Test
+    void assertVersionSupportsMinimumPackageReleaseAge_versionNewEnough_doesNotThrow() {
+        FrontendTools.assertVersionSupportsMinimumPackageReleaseAge("pnpm",
+                new FrontendVersion(10, 16, 0),
+                FrontendTools.MIN_PNPM_VERSION_FOR_RELEASE_AGE);
+        FrontendTools.assertVersionSupportsMinimumPackageReleaseAge("bun",
+                new FrontendVersion(1, 3, 0),
+                FrontendTools.MIN_BUN_VERSION_FOR_RELEASE_AGE);
     }
 
     @Test

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 import net.jcip.annotations.NotThreadSafe;
 import org.apache.commons.io.FileUtils;
@@ -755,6 +756,53 @@ class TaskRunNpmInstallTest {
 
     private void assumeNPMIsInUse() {
         assumeTrue(getClass().equals(TaskRunNpmInstallTest.class));
+    }
+
+    @Test
+    void minimumFrontendPackageAge_defaultIsDisabled_returnsEmpty() {
+        // Default is 0 (disabled) — no flag must be added
+        assertFalse(TaskRunNpmInstall.getMinimumFrontendPackageAgeArgument(
+                new MockOptions(npmFolder)).isPresent());
+        assertFalse(TaskRunNpmInstall
+                .getMinimumFrontendPackageAgeArgument(
+                        new MockOptions(npmFolder).withEnablePnpm(true))
+                .isPresent());
+        assertFalse(TaskRunNpmInstall
+                .getMinimumFrontendPackageAgeArgument(
+                        new MockOptions(npmFolder).withEnableBun(true))
+                .isPresent());
+    }
+
+    @Test
+    void minimumFrontendPackageAge_npm_addsBeforeArgument() {
+        Options npmOptions = new MockOptions(npmFolder)
+                .withMinimumFrontendPackageAgeDays(2);
+        Optional<String> arg = TaskRunNpmInstall
+                .getMinimumFrontendPackageAgeArgument(npmOptions);
+        assertTrue(arg.isPresent());
+        assertTrue(arg.get().startsWith("--before="),
+                "npm should use --before, was: " + arg.get());
+    }
+
+    @Test
+    void minimumFrontendPackageAge_pnpm_addsMinimumReleaseAgeArgument() {
+        Options pnpmOptions = new MockOptions(npmFolder).withEnablePnpm(true)
+                .withMinimumFrontendPackageAgeDays(2);
+        Optional<String> arg = TaskRunNpmInstall
+                .getMinimumFrontendPackageAgeArgument(pnpmOptions);
+        // 2 days = 2880 minutes; pnpm setting form
+        assertEquals("--config.minimum-release-age=2880", arg.orElseThrow());
+    }
+
+    @Test
+    void minimumFrontendPackageAge_bun_addsMinimumReleaseAgeInSeconds() {
+        Options bunOptions = new MockOptions(npmFolder).withEnableBun(true)
+                .withMinimumFrontendPackageAgeDays(2);
+        // 2 days = 172800 seconds
+        assertEquals("--minimum-release-age=172800",
+                TaskRunNpmInstall
+                        .getMinimumFrontendPackageAgeArgument(bunOptions)
+                        .orElseThrow());
     }
 
 }

--- a/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
+++ b/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
@@ -203,6 +203,17 @@ public class BuildDevBundleMojo extends AbstractMojo
     private boolean frontendIgnoreVersionChecks;
 
     /**
+     * Minimum age (in days) a frontend (npm) package version must have before
+     * npm, pnpm or bun is allowed to install it. Mitigates supply-chain attacks
+     * where a compromised version is briefly available on the registry.
+     * Defaults to {@code 0} (disabled); set to a positive value to enable.
+     * Requires pnpm &ge; 10.16.0 or bun &ge; 1.3.0 when those tools are used.
+     */
+    @Parameter(property = "vaadin."
+            + InitParameters.MINIMUM_FRONTEND_PACKAGE_AGE_DAYS, defaultValue = "0")
+    private int minimumFrontendPackageAgeDays;
+
+    /**
      * The folder where the META-INF/resources files are copied. Used for
      * finding the StyleSheet referenced css files.
      */
@@ -550,6 +561,11 @@ public class BuildDevBundleMojo extends AbstractMojo
     @Override
     public boolean isFrontendIgnoreVersionChecks() {
         return frontendIgnoreVersionChecks;
+    }
+
+    @Override
+    public int minimumFrontendPackageAgeDays() {
+        return minimumFrontendPackageAgeDays;
     }
 
     @Override

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
@@ -336,4 +336,7 @@ internal class GradlePluginAdapter private constructor(
         return config.commercialWithBanner.get()
     }
 
+    override fun minimumFrontendPackageAgeDays(): Int =
+        config.minimumFrontendPackageAgeDays.get()
+
 }

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
@@ -331,6 +331,16 @@ public abstract class VaadinFlowPluginExtension @Inject constructor(private val 
     public abstract val frontendIgnoreVersionChecks: Property<Boolean>
 
     /**
+     * Minimum age (in days) a frontend (npm) package version must have before
+     * npm, pnpm or bun is allowed to install it. Mitigates supply-chain
+     * attacks where a compromised version is briefly available on the
+     * registry. Defaults to {@code 0} (disabled); set to a positive value to
+     * enable. Requires pnpm >= 10.16.0 or bun >= 1.3.0 when those tools are
+     * used.
+     */
+    public abstract val minimumFrontendPackageAgeDays: Property<Int>
+
+    /**
      * Allows building a version of the application with a commercial banner
      * when commercial components are used without a license key.
      */
@@ -627,6 +637,12 @@ public class PluginEffectiveConfiguration(
             project,
             FrontendUtils.PARAM_IGNORE_VERSION_CHECKS
         )
+
+    public val minimumFrontendPackageAgeDays: Provider<Int> =
+        project.getStringProperty(
+            "vaadin.${InitParameters.MINIMUM_FRONTEND_PACKAGE_AGE_DAYS}"
+        ).map(String::toInt)
+            .orElse(extension.minimumFrontendPackageAgeDays.convention(0))
 
     public val npmExcludeWebComponents: Provider<Boolean> = extension
         .npmExcludeWebComponents.convention(false)

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -145,6 +145,17 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo
             + "resources/")
     private File resourcesOutputDirectory;
 
+    /**
+     * Minimum age (in days) a frontend (npm) package version must have before
+     * npm, pnpm or bun is allowed to install it. Mitigates supply-chain attacks
+     * where a compromised version is briefly available on the registry.
+     * Defaults to {@code 0} (disabled); set to a positive value to enable.
+     * Requires pnpm &ge; 10.16.0 or bun &ge; 1.3.0 when those tools are used.
+     */
+    @Parameter(property = "vaadin."
+            + InitParameters.MINIMUM_FRONTEND_PACKAGE_AGE_DAYS, defaultValue = "0")
+    private int minimumFrontendPackageAgeDays;
+
     @Override
     protected void executeInternal()
             throws MojoExecutionException, MojoFailureException {
@@ -287,6 +298,11 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo
     @Override
     public File resourcesOutputDirectory() {
         return resourcesOutputDirectory;
+    }
+
+    @Override
+    public int minimumFrontendPackageAgeDays() {
+        return minimumFrontendPackageAgeDays;
     }
 
     @Override

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -375,7 +375,9 @@ public class BuildFrontendUtil {
                     .withFrontendDependenciesScanner(frontendDependencies)
                     .withCommercialBanner(adapter.isCommercialBannerEnabled())
                     .withMetaInfResourcesDirectory(
-                            adapter.resourcesOutputDirectory());
+                            adapter.resourcesOutputDirectory())
+                    .withMinimumFrontendPackageAgeDays(
+                            adapter.minimumFrontendPackageAgeDays());
             new NodeTasks(options).execute();
         } catch (ExecutionFailedException exception) {
             throw exception;
@@ -447,7 +449,9 @@ public class BuildFrontendUtil {
                     .withNpmExcludeWebComponents(
                             adapter.isNpmExcludeWebComponents())
                     .withFrontendIgnoreVersionChecks(
-                            adapter.isFrontendIgnoreVersionChecks());
+                            adapter.isFrontendIgnoreVersionChecks())
+                    .withMinimumFrontendPackageAgeDays(
+                            adapter.minimumFrontendPackageAgeDays());
             new NodeTasks(options).execute();
         } catch (ExecutionFailedException exception) {
             throw exception;

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBuild.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBuild.java
@@ -126,4 +126,16 @@ public interface PluginAdapterBuild extends PluginAdapterBase {
      *         {output}/classes/META-INF/resources
      */
     File resourcesOutputDirectory();
+
+    /**
+     * Minimum age (in days) a frontend package version must have before npm,
+     * pnpm or bun is allowed to install it. Defaults to {@code 0} (disabled);
+     * set to a positive value to enable as a mitigation against malicious
+     * packages briefly published to the registry.
+     *
+     * @return the minimum allowed age in days, or {@code 0} when disabled
+     */
+    default int minimumFrontendPackageAgeDays() {
+        return 0;
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -301,4 +301,11 @@ public class InitParameters implements Serializable {
      */
     public static final String BROWSERLESS = "browserless";
 
+    /**
+     * Configuration name for the minimum age (in days) a frontend (npm) package
+     * version must have before npm, pnpm or bun is allowed to install it.
+     * Defaults to {@code 0} (disabled); set to a positive value to enable.
+     */
+    public static final String MINIMUM_FRONTEND_PACKAGE_AGE_DAYS = "npm.minimumFrontendPackageAgeDays";
+
 }


### PR DESCRIPTION
Adds a minimum package age check (default disabled) so that npm, pnpm and bun are instructed not to install package versions newer than the configured threshold. This mitigates supply-chain attacks where a compromised version is briefly published to the registry.

The threshold is exposed via Options#withMinimumPackageAgeDays(int); setting it to 0 disables the check.
