### PR TITLE
test: drop vaadin-upload-flow dep from test-spring-common

### DIFF
--- a/flow-tests/vaadin-spring-tests/test-spring-common/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/pom.xml
@@ -50,18 +50,6 @@
       <version>${project.version}</version>
     </dependency>
 
-    <!-- Test components -->
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>vaadin-upload-flow</artifactId>
-      <version>${component.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.vaadin</groupId>
-      <artifactId>vaadin-upload-testbench</artifactId>
-      <version>${component.version}</version>
-    </dependency>
-
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>

--- a/flow-tests/vaadin-spring-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/test/UploadView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/test/UploadView.java
@@ -70,16 +70,26 @@ public class UploadView extends Div {
         Input upload = new Input();
         upload.setType("file");
         upload.setId("upl");
-        upload.getElement().executeJs("""
-                this.addEventListener('change', () => {
-                    const file = this.files[0];
-                    if (!file) return;
-                    const formData = new FormData();
-                    formData.append('file', file);
-                    fetch($0, { method: 'POST', body: formData })
-                        .then(() => $1.click());
-                });
-                """, uploadUrl, sync.getElement());
+        // Send the file as a raw XHR body with X-Filename rather than as
+        // multipart/form-data, since the test-spring servlet is not
+        // @MultipartConfig-annotated and Vaadin's UploadHandler accepts
+        // both forms (raw body is the default in 25.0+).
+        upload.getElement().executeJs(
+                """
+                        this.addEventListener('change', () => {
+                            const file = this.files[0];
+                            if (!file) return;
+                            fetch($0, {
+                                method: 'POST',
+                                headers: {
+                                    'Content-Type': file.type || 'application/octet-stream',
+                                    'X-Filename': encodeURIComponent(file.name)
+                                },
+                                body: file
+                            }).then(() => $1.click());
+                        });
+                        """,
+                uploadUrl, sync.getElement());
         add(upload, sync);
     }
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/test/UploadView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/test/UploadView.java
@@ -19,8 +19,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
-import org.apache.commons.io.IOUtils;
-
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Input;
 import com.vaadin.flow.component.html.NativeButton;
@@ -41,7 +39,8 @@ public class UploadView extends Div {
             }
             String content;
             try (InputStream stream = event.getInputStream()) {
-                content = IOUtils.toString(stream, StandardCharsets.UTF_8);
+                content = new String(stream.readAllBytes(),
+                        StandardCharsets.UTF_8);
             } catch (IOException e) {
                 content = "exception reading stream";
             }

--- a/flow-tests/vaadin-spring-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/test/UploadView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/test/UploadView.java
@@ -31,6 +31,8 @@ import com.vaadin.flow.server.streams.UploadHandler;
 @Route("multipart-upload")
 public class UploadView extends Div {
 
+    public static final String UPLOAD_ID = "upl";
+
     public UploadView() {
         UploadHandler handler = event -> {
             if (!event.getContentType().startsWith("text")) {
@@ -69,7 +71,7 @@ public class UploadView extends Div {
 
         Input upload = new Input();
         upload.setType("file");
-        upload.setId("upl");
+        upload.setId(UPLOAD_ID);
         // Send the file as a raw XHR body with X-Filename rather than as
         // multipart/form-data, since the test-spring servlet is not
         // @MultipartConfig-annotated and Vaadin's UploadHandler accepts

--- a/flow-tests/vaadin-spring-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/test/UploadView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/test/UploadView.java
@@ -21,44 +21,57 @@ import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 
-import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.upload.Upload;
-import com.vaadin.flow.component.upload.receivers.MultiFileMemoryBuffer;
+import com.vaadin.flow.component.html.Input;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.StreamRegistration;
+import com.vaadin.flow.server.StreamResourceRegistry;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.server.streams.UploadHandler;
 
 @Route("multipart-upload")
 public class UploadView extends Div {
 
     public UploadView() {
-        MultiFileMemoryBuffer buffer = new MultiFileMemoryBuffer();
-        Upload upload = new Upload(buffer);
+        UploadHandler handler = event -> {
+            if (!event.getContentType().startsWith("text")) {
+                event.reject("Only text uploads are supported");
+                return;
+            }
+            String content;
+            try (InputStream stream = event.getInputStream()) {
+                content = IOUtils.toString(stream, StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                content = "exception reading stream";
+            }
+            String text = content;
+            event.getUI().access(() -> {
+                Div div = new Div();
+                div.setText(text);
+                div.addClassName("uploaded-text");
+                add(div);
+            });
+        };
+
+        StreamResourceRegistry resourceRegistry = VaadinSession.getCurrent()
+                .getResourceRegistry();
+        StreamRegistration registration = resourceRegistry
+                .registerResource(handler);
+        String uploadUrl = resourceRegistry
+                .getTargetURI(registration.getResource()).toString();
+
+        Input upload = new Input();
+        upload.setType("file");
         upload.setId("upl");
-
-        upload.addSucceededListener(event -> {
-            Component component = createComponent(event.getMIMEType(),
-                    event.getFileName(),
-                    buffer.getInputStream(event.getFileName()));
-            add(component);
-        });
-
+        upload.getElement().executeJs("""
+                this.addEventListener('change', () => {
+                    const file = this.files[0];
+                    if (!file) return;
+                    const formData = new FormData();
+                    formData.append('file', file);
+                    fetch($0, { method: 'POST', body: formData });
+                });
+                """, uploadUrl);
         add(upload);
-    }
-
-    private Component createComponent(String mimeType, String fileName,
-            InputStream stream) {
-        if (!mimeType.startsWith("text")) {
-            throw new IllegalStateException();
-        }
-        String text = "";
-        try {
-            text = IOUtils.toString(stream, StandardCharsets.UTF_8);
-        } catch (IOException e) {
-            text = "exception reading stream";
-        }
-        Div div = new Div();
-        div.setText(text);
-        div.addClassName("uploaded-text");
-        return div;
     }
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/test/UploadView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/test/UploadView.java
@@ -23,6 +23,7 @@ import org.apache.commons.io.IOUtils;
 
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Input;
+import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.StreamRegistration;
 import com.vaadin.flow.server.StreamResourceRegistry;
@@ -60,6 +61,13 @@ public class UploadView extends Div {
         String uploadUrl = resourceRegistry
                 .getTargetURI(registration.getResource()).toString();
 
+        // The upload posts via fetch(), which does not piggyback Flow's
+        // UIDL sync. Click a hidden button after the response to force a
+        // server roundtrip that pulls down the queued DOM updates.
+        NativeButton sync = new NativeButton("", event -> {
+        });
+        sync.getStyle().set("display", "none");
+
         Input upload = new Input();
         upload.setType("file");
         upload.setId("upl");
@@ -69,9 +77,10 @@ public class UploadView extends Div {
                     if (!file) return;
                     const formData = new FormData();
                     formData.append('file', file);
-                    fetch($0, { method: 'POST', body: formData });
+                    fetch($0, { method: 'POST', body: formData })
+                        .then(() => $1.click());
                 });
-                """, uploadUrl);
-        add(upload);
+                """, uploadUrl, sync.getElement());
+        add(upload, sync);
     }
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/UploadIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/UploadIT.java
@@ -19,10 +19,8 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.List;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -37,7 +35,6 @@ public class UploadIT extends AbstractSpringTest {
     private static final String UPLOAD_ID = "upl";
 
     @Test
-    @Ignore
     public void multiFileUpload() throws Exception {
         open();
 
@@ -49,8 +46,7 @@ public class UploadIT extends AbstractSpringTest {
 
         File tempFile = createTempFile("foo");
 
-        TestBenchElement input = $(TestBenchElement.class).id(UPLOAD_ID)
-                .$(TestBenchElement.class).id("fileInput");
+        TestBenchElement input = $(TestBenchElement.class).id(UPLOAD_ID);
         setLocalFileDetector(input);
         input.sendKeys(tempFile.getPath());
 
@@ -66,12 +62,9 @@ public class UploadIT extends AbstractSpringTest {
         waitUntil(driver -> isElementPresent(By.id(UPLOAD_ID))
                 && findElement(By.id(UPLOAD_ID)).isDisplayed());
 
-        List<TestBenchElement> inputs = $(TestBenchElement.class).id(UPLOAD_ID)
-                .$("input").all();
-        Assert.assertFalse(
-                "Upload element is not initialized: it doesn't contain "
-                        + "any child element (so it has no element in the shadow root)",
-                inputs.isEmpty());
+        Assert.assertEquals("Expected the upload element to be an <input>",
+                "input",
+                findElement(By.id(UPLOAD_ID)).getTagName().toLowerCase());
     }
 
     @Override

--- a/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/UploadIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/UploadIT.java
@@ -30,9 +30,9 @@ import org.openqa.selenium.remote.RemoteWebElement;
 
 import com.vaadin.testbench.TestBenchElement;
 
-public class UploadIT extends AbstractSpringTest {
+import static com.vaadin.flow.spring.test.UploadView.UPLOAD_ID;
 
-    private static final String UPLOAD_ID = "upl";
+public class UploadIT extends AbstractSpringTest {
 
     @Test
     public void multiFileUpload() throws Exception {


### PR DESCRIPTION
Rewrite UploadView to use flow-server's UploadHandler registered via VaadinSession.getResourceRegistry() with a plain <input type="file"> and a tiny change-listener that fetch-POSTs the selected file. Drop the vaadin-upload-flow and vaadin-upload-testbench dependencies as part of breaking the Flow <-> flow-components build cycle.

UploadIT now sends keys directly to the native input instead of digging into the vaadin-upload shadow DOM for #fileInput, and multiFileUpload is un-@Ignore'd since the rewritten view no longer depends on vaadin-upload's internals.
