### PR TITLE
test: set login form values via DOM property in security ITs

### DIFF
--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-methodsecurity/src/test/java/com/vaadin/flow/spring/flowsecurity/AbstractIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-methodsecurity/src/test/java/com/vaadin/flow/spring/flowsecurity/AbstractIT.java
@@ -107,8 +107,8 @@ public abstract class AbstractIT extends AbstractSpringTest {
                 .id(LOGIN_USERNAME_ID);
         TestBenchElement passwordField = context.$("input")
                 .id(LOGIN_PASSWORD_ID);
-        usernameField.sendKeys(username);
-        passwordField.sendKeys(password);
+        usernameField.setProperty("value", username);
+        passwordField.setProperty("value", password);
         context.$("button").id(LOGIN_SUBMIT_ID).click();
     }
 

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/test/java/com/vaadin/flow/spring/flowsecurity/AbstractIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker/src/test/java/com/vaadin/flow/spring/flowsecurity/AbstractIT.java
@@ -112,8 +112,8 @@ public abstract class AbstractIT extends AbstractSpringTest {
                 .id(LOGIN_USERNAME_ID);
         TestBenchElement passwordField = context.$("input")
                 .id(LOGIN_PASSWORD_ID);
-        usernameField.sendKeys(username);
-        passwordField.sendKeys(password);
+        usernameField.setProperty("value", username);
+        passwordField.setProperty("value", password);
         context.$("button").id(LOGIN_SUBMIT_ID).click();
     }
 

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow-standalone-routepathaccesschecker/src/test/java/com/vaadin/flow/spring/flowsecurity/AbstractIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow-standalone-routepathaccesschecker/src/test/java/com/vaadin/flow/spring/flowsecurity/AbstractIT.java
@@ -112,8 +112,8 @@ public abstract class AbstractIT extends AbstractSpringTest {
                 .id(LOGIN_USERNAME_ID);
         TestBenchElement passwordField = context.$("input")
                 .id(LOGIN_PASSWORD_ID);
-        usernameField.sendKeys(username);
-        passwordField.sendKeys(password);
+        usernameField.setProperty("value", username);
+        passwordField.setProperty("value", password);
         context.$("button").id(LOGIN_SUBMIT_ID).click();
     }
 

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AbstractIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/test/java/com/vaadin/flow/spring/flowsecurity/AbstractIT.java
@@ -121,8 +121,8 @@ public abstract class AbstractIT extends AbstractSpringTest {
                 .id(LOGIN_USERNAME_ID);
         TestBenchElement passwordField = context.$("input")
                 .id(LOGIN_PASSWORD_ID);
-        usernameField.sendKeys(username);
-        passwordField.sendKeys(password);
+        usernameField.setProperty("value", username);
+        passwordField.setProperty("value", password);
         context.$("button").id(LOGIN_SUBMIT_ID).click();
     }
 


### PR DESCRIPTION
`sendKeys` on the plain `<input>` fields introduced by the flow-components rework intermittently failed to populate the value on the second login in a test (after a prior login + logout), causing the form to POST empty credentials and Spring to 302 back to `/my/login/page?error`. Setting `value` directly via the DOM property bypasses the keystroke/focus/autofill path; the form still submits the new value since the browser reads the DOM property at submit time.
