### PR TITLE
fix: avoid possible ABBA deadlock in Effect

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/signals/impl/Effect.java
+++ b/flow-server/src/main/java/com/vaadin/flow/signals/impl/Effect.java
@@ -161,33 +161,34 @@ public class Effect implements Serializable {
         assert dispatcher != null;
         this.dispatcher = dispatcher;
 
-        dispatcher.execute(() -> {
-            synchronized (this) {
-                revalidate();
-            }
-        });
+        dispatcher.execute(this::revalidate);
     }
 
     private void revalidate() {
-        assert registrations.isEmpty();
-
-        if (action == null || passivated) {
-            // closed or passivated
-            return;
+        SerializableRunnable currentAction;
+        synchronized (this) {
+            if (action == null || passivated) {
+                // closed or passivated
+                return;
+            }
+            assert registrations.isEmpty();
+            usages.clear();
+            currentAction = action;
         }
 
-        usages.clear();
+        List<UsageTracker.Usage> newUsages = new ArrayList<>();
+        List<Registration> newRegistrations = new ArrayList<>();
+        boolean[] hasSignalUsage = { false };
+        // Ensure effect runs only once per change event, even if the same
+        // signal is read multiple times (each read registers a listener)
+        boolean[] changeHandled = { false };
 
         activeEffects.get().add(this);
         try {
-            boolean[] hasSignalUsage = { false };
-            // Ensure effect runs only once per change event, even if the same
-            // signal is read multiple times (each read registers a listener)
-            boolean[] changeHandled = { false };
-            UsageTracker.track(action, usage -> {
+            UsageTracker.track(currentAction, usage -> {
                 hasSignalUsage[0] = true;
-                usages.add(usage);
-                registrations.add(usage
+                newUsages.add(usage);
+                newRegistrations.add(usage
                         .onNextChange(createChangeListener(changeHandled)));
             });
             if (!hasSignalUsage[0]) {
@@ -197,6 +198,18 @@ public class Effect implements Serializable {
         } finally {
             Effect removed = activeEffects.get().removeLast();
             assert removed == this;
+        }
+
+        synchronized (this) {
+            if (action == null || passivated) {
+                // dispose or passivate ran concurrently with the action;
+                // remove the observers we just registered so we don't leak
+                // listeners on the signal trees.
+                newRegistrations.forEach(Registration::remove);
+                return;
+            }
+            usages.addAll(newUsages);
+            registrations.addAll(newRegistrations);
         }
     }
 
@@ -252,10 +265,21 @@ public class Effect implements Serializable {
         }
     }
 
-    private synchronized void invalidate() {
+    private void invalidate() {
         invalidateScheduled.set(false);
 
-        clearRegistrations();
+        // Remove registrations outside the synchronized block to avoid ABBA
+        // deadlock.
+        List<Registration> toRemove;
+        synchronized (this) {
+            if (registrations.isEmpty()) {
+                toRemove = List.of();
+            } else {
+                toRemove = new ArrayList<>(registrations);
+                registrations.clear();
+            }
+        }
+        toRemove.forEach(Registration::remove);
 
         revalidate();
     }

--- a/flow-server/src/main/java/com/vaadin/flow/signals/impl/Effect.java
+++ b/flow-server/src/main/java/com/vaadin/flow/signals/impl/Effect.java
@@ -166,15 +166,23 @@ public class Effect implements Serializable {
 
     private void revalidate() {
         SerializableRunnable currentAction;
+        List<Registration> staleRegistrations;
         synchronized (this) {
             if (action == null || passivated) {
                 // closed or passivated
                 return;
             }
-            assert registrations.isEmpty();
+            // Drain any leftover registrations. They are usually absent
+            // (invalidate drains before calling here), but a concurrent
+            // revalidate triggered by a signal write can squeeze its
+            // second sync block in between invalidate's drain and this
+            // sync block. Removing them here keeps the observer set
+            // consistent and avoids a stale-observer leak.
+            staleRegistrations = drainRegistrations();
             usages.clear();
             currentAction = action;
         }
+        staleRegistrations.forEach(Registration::remove);
 
         List<UsageTracker.Usage> newUsages = new ArrayList<>();
         List<Registration> newRegistrations = new ArrayList<>();
@@ -284,9 +292,14 @@ public class Effect implements Serializable {
         revalidate();
     }
 
-    private void clearRegistrations() {
-        registrations.forEach(Registration::remove);
+    private List<Registration> drainRegistrations() {
+        assert Thread.holdsLock(this);
+        if (registrations.isEmpty()) {
+            return List.of();
+        }
+        List<Registration> drained = new ArrayList<>(registrations);
         registrations.clear();
+        return drained;
     }
 
     /**
@@ -323,9 +336,17 @@ public class Effect implements Serializable {
      * {@link #activate()}, which will check if any tracked values have changed
      * and only re-run the callback if needed.
      */
-    public synchronized void passivate() {
-        clearRegistrations();
-        passivated = true;
+    public void passivate() {
+        // Drain registrations under the monitor but call Registration::remove
+        // outside it: removal acquires the SignalTree lock and a concurrent
+        // signal writer holding that lock can drive Effect.invalidate, which
+        // needs the Effect monitor (ABBA deadlock otherwise).
+        List<Registration> toRemove;
+        synchronized (this) {
+            passivated = true;
+            toRemove = drainRegistrations();
+        }
+        toRemove.forEach(Registration::remove);
     }
 
     /**
@@ -335,38 +356,67 @@ public class Effect implements Serializable {
      * has changed, the effect simply re-registers its dependency listeners
      * without running the callback.
      */
-    public synchronized void activate() {
-        if (action == null || !passivated) {
+    public void activate() {
+        List<UsageTracker.Usage> snapshot;
+        synchronized (this) {
+            if (action == null || !passivated) {
+                return;
+            }
+            passivated = false;
+            firstRun = true;
+            snapshot = new ArrayList<>(usages);
+        }
+
+        // hasChanges() reads signal state but does not acquire the
+        // SignalTree lock, so it is safe to call without the monitor held.
+        boolean needsRevalidation = snapshot.isEmpty()
+                || snapshot.stream().anyMatch(UsageTracker.Usage::hasChanges);
+
+        if (needsRevalidation) {
+            // Full revalidation re-runs the action. revalidate's first
+            // sync block drains any stale registrations a concurrent
+            // invalidate may have installed between this call and
+            // entering the sync block, so we don't need to drain here.
+            revalidate();
             return;
         }
-        passivated = false;
-        firstRun = true;
 
-        if (usages.isEmpty()
-                || usages.stream().anyMatch(UsageTracker.Usage::hasChanges)) {
-            // Something changed while passivated, do a full revalidation
-            usages.clear();
-            revalidate();
-        } else {
-            // Nothing changed, just re-register listeners. A change
-            // listener may still fire immediately if a change sneaks in
-            // between the hasChanges check and the onNextChange call,
-            // in which case firstRun is already set to true above.
-            // Ensure effect runs only once even if the same signal is
-            // registered multiple times
-            boolean[] changeHandled = { false };
-            for (UsageTracker.Usage usage : usages) {
-                registrations.add(usage
-                        .onNextChange(createChangeListener(changeHandled)));
+        // Fast-path: re-register listeners on the existing usages without
+        // running the action. onNextChange acquires the SignalTree lock,
+        // so it must run without the Effect monitor held to avoid ABBA
+        // deadlock with a concurrent signal writer driving invalidate.
+        // A listener may fire immediately if a change sneaks in between
+        // the hasChanges check and the onNextChange call; firstRun stays
+        // true so the eventual revalidation behaves as an initial run.
+        boolean[] changeHandled = { false };
+        List<Registration> newRegistrations = new ArrayList<>();
+        for (UsageTracker.Usage usage : snapshot) {
+            newRegistrations.add(
+                    usage.onNextChange(createChangeListener(changeHandled)));
+        }
+
+        boolean discardNewRegistrations = false;
+        synchronized (this) {
+            if (action == null || passivated || !registrations.isEmpty()) {
+                // Either disposed/passivated concurrently, or an invalidate
+                // already ran on another thread and installed fresh
+                // registrations. Drop the ones we just installed to avoid
+                // duplicate observers on the signal tree.
+                discardNewRegistrations = true;
+            } else {
+                registrations.addAll(newRegistrations);
+                if (!invalidateScheduled.get()) {
+                    // No invalidation was scheduled, so no change was
+                    // detected during re-registration. Reset firstRun
+                    // for normal tracking. If an invalidation was
+                    // scheduled, firstRun stays true and will be reset
+                    // by the eventual revalidation.
+                    firstRun = false;
+                }
             }
-            if (!invalidateScheduled.get()) {
-                // No invalidation was scheduled, so no change was
-                // detected during re-registration. Reset firstRun for
-                // normal tracking. If an invalidation was scheduled,
-                // firstRun stays true and will be reset by the
-                // eventual revalidation.
-                firstRun = false;
-            }
+        }
+        if (discardNewRegistrations) {
+            newRegistrations.forEach(Registration::remove);
         }
     }
 
@@ -374,10 +424,17 @@ public class Effect implements Serializable {
      * Disposes this effect by unregistering all current dependencies and
      * preventing the action from running again.
      */
-    public synchronized void dispose() {
-        clearRegistrations();
-        usages.clear();
-        action = null;
+    public void dispose() {
+        // Same ABBA-avoidance as passivate(): drain under the monitor,
+        // remove outside it. Concurrent invalidate runs that observe
+        // action == null will short-circuit in revalidate.
+        List<Registration> toRemove;
+        synchronized (this) {
+            action = null;
+            usages.clear();
+            toRemove = drainRegistrations();
+        }
+        toRemove.forEach(Registration::remove);
     }
 
 }

--- a/flow-server/src/test/java/com/vaadin/flow/signals/impl/EffectTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/impl/EffectTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -1087,5 +1088,137 @@ class EffectTest extends SignalTestBase {
         }
         assertTrue(effectCreated.get(),
                 "Effect should have been created without deadlock");
+    }
+
+    @Test
+    void dispose_concurrentSignalWrite_doesNotDeadlock() throws Exception {
+        // ABBA deadlock probe for dispose(). dispose() is synchronized
+        // on the Effect monitor and calls clearRegistrations(), whose
+        // Registration::remove acquires the SignalTree lock. Concurrently,
+        // a signal write holds the SignalTree lock while notifyObservers
+        // invokes the listener that schedules invalidate(), which now
+        // takes the Effect monitor briefly. Opposite acquire orders form
+        // a deadlock.
+        runEffectVsSignalWriteDeadlockProbe("dispose", false, Effect::dispose);
+    }
+
+    @Test
+    void passivate_concurrentSignalWrite_doesNotDeadlock() throws Exception {
+        // Same ABBA shape as dispose(): passivate() is synchronized and
+        // calls clearRegistrations() (Registration::remove acquires the
+        // SignalTree lock) while a concurrent signal writer holds the
+        // SignalTree lock and reaches Effect.invalidate, which needs the
+        // Effect monitor.
+        runEffectVsSignalWriteDeadlockProbe("passivate", false,
+                Effect::passivate);
+    }
+
+    @Test
+    void activate_concurrentSignalWrite_doesNotDeadlock() throws Exception {
+        // activate()'s fast-path re-registers observers via
+        // usage.onNextChange() under the Effect monitor. onNextChange
+        // acquires the SignalTree lock, while a concurrent writer holding
+        // that lock invokes the just-registered observer, drives
+        // scheduleInvalidate, and Effect.invalidate then needs the Effect
+        // monitor. Opposite acquire orders form a deadlock.
+        runEffectVsSignalWriteDeadlockProbe("activate", true, effect -> {
+            effect.passivate();
+            effect.activate();
+        });
+    }
+
+    private static void runEffectVsSignalWriteDeadlockProbe(String name,
+            boolean delayWriter, Consumer<Effect> lifecycleAction)
+            throws Exception {
+        // The race is timing-sensitive, so try many iterations. The first
+        // deadlock trips the ThreadMXBean check and fails the test.
+        int iterations = 200;
+        long perIterationTimeoutMs = 2000;
+
+        for (int i = 0; i < iterations; i++) {
+            SharedValueSignal<String> signal = new SharedValueSignal<>("v" + i);
+
+            // Read the signal multiple times so the action registers
+            // multiple usages on the same signal. That widens the window
+            // for the lifecycle action's per-registration lock acquisitions
+            // to race the writer.
+            Effect effect = new Effect(() -> {
+                for (int k = 0; k < 8; k++) {
+                    signal.get();
+                }
+            }, Runnable::run);
+
+            CountDownLatch ready = new CountDownLatch(1);
+            AtomicReference<Throwable> writerFailure = new AtomicReference<>();
+            AtomicReference<Throwable> callerFailure = new AtomicReference<>();
+
+            Thread writer = new Thread(() -> {
+                try {
+                    ready.await();
+                    signal.set("update-" + System.nanoTime());
+                } catch (Throwable t) {
+                    writerFailure.set(t);
+                }
+            }, name + "-writer-" + i);
+            writer.setDaemon(true);
+
+            Thread caller = new Thread(() -> {
+                try {
+                    ready.await();
+                    lifecycleAction.accept(effect);
+                } catch (Throwable t) {
+                    callerFailure.set(t);
+                }
+            }, name + "-caller-" + i);
+            caller.setDaemon(true);
+
+            writer.start();
+            caller.start();
+            // For lifecycle actions that need to be entered before the
+            // writer drives notifyObservers (activate's fast-path needs
+            // the observers to be installed mid-loop), nudge the caller
+            // ahead with a small head start.
+            if (delayWriter) {
+                Thread.yield();
+            }
+            ready.countDown();
+
+            writer.join(perIterationTimeoutMs);
+            caller.join(perIterationTimeoutMs);
+
+            if (writer.isAlive() || caller.isAlive()) {
+                ThreadMXBean tmx = ManagementFactory.getThreadMXBean();
+                long[] deadlocked = tmx.findDeadlockedThreads();
+                StringBuilder sb = new StringBuilder(name)
+                        .append(" deadlocked on iteration ").append(i)
+                        .append(". writer alive=").append(writer.isAlive())
+                        .append(", caller alive=").append(caller.isAlive());
+                if (deadlocked != null) {
+                    sb.append(", deadlocked thread IDs=")
+                            .append(Arrays.toString(deadlocked));
+                    for (var info : tmx.getThreadInfo(deadlocked, true, true)) {
+                        sb.append("\n  ").append(info.getThreadName())
+                                .append(" waiting on ")
+                                .append(info.getLockName()).append(" owned by ")
+                                .append(info.getLockOwnerName());
+                        for (var frame : info.getStackTrace()) {
+                            sb.append("\n    at ").append(frame);
+                        }
+                    }
+                }
+                fail(sb.toString());
+            }
+
+            if (writerFailure.get() != null) {
+                throw new AssertionError(
+                        name + " writer failed on iteration " + i,
+                        writerFailure.get());
+            }
+            if (callerFailure.get() != null) {
+                throw new AssertionError(
+                        name + " caller failed on iteration " + i,
+                        callerFailure.get());
+            }
+        }
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/signals/impl/EffectTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/signals/impl/EffectTest.java
@@ -15,11 +15,15 @@
  */
 package com.vaadin.flow.signals.impl;
 
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -43,6 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class EffectTest extends SignalTestBase {
 
@@ -983,5 +988,104 @@ class EffectTest extends SignalTestBase {
         assertEquals(5, effectRunCount.get(),
                 "Effect should run exactly once when signal2 changes again");
         assertEquals(List.of("a:1", "b:1", "b:2", "c:2", "c:3"), invocations);
+    }
+
+    @Test
+    void initialRun_concurrentSignalWrite_doesNotDeadlock() throws Exception {
+        // ABBA deadlock regression. Effect.<init> runs revalidate()
+        // (which calls the action that reads signals, acquiring the
+        // SignalTree lock). It shouldn't run inside a synchronized(this) block
+        // because a concurrent
+        // signal write on another thread acquires the SignalTree lock first
+        // and then needs the same Effect monitor (because scheduleInvalidate
+        // dispatches inline when the writer thread has no environment
+        // dispatcher). The opposite acquire orders form a deadlock.
+        SharedValueSignal<String> signal = new SharedValueSignal<>("initial");
+
+        CountDownLatch firstReadDone = new CountDownLatch(1);
+        AtomicReference<Throwable> threadBFailure = new AtomicReference<>();
+
+        Thread writer = new Thread(() -> {
+            try {
+                firstReadDone.await();
+                signal.set("update");
+            } catch (Throwable t) {
+                threadBFailure.set(t);
+            }
+        }, "deadlock-test-writer");
+        writer.setDaemon(true);
+
+        AtomicReference<Throwable> threadAFailure = new AtomicReference<>();
+        AtomicBoolean effectCreated = new AtomicBoolean();
+        // Once the deadlock is fixed, the writer's notifyObservers fires
+        // the just-installed observer synchronously and the effect action
+        // re-runs on the writer thread. Guard side effects so re-entry is
+        // safe.
+        AtomicBoolean racePrimed = new AtomicBoolean();
+
+        Thread reader = new Thread(() -> {
+            try {
+                new Effect(() -> {
+                    // First read registers an observer on the signal.
+                    signal.get();
+                    if (racePrimed.compareAndSet(false, true)) {
+                        // Let the writer start its set() call.
+                        firstReadDone.countDown();
+                        writer.start();
+                        // Wait until the writer is BLOCKED entering
+                        // Effect.invalidate (deadlock scenario) or has
+                        // already finished (fixed scenario). Either way
+                        // the next read happens after the writer has had
+                        // a chance to drive its side of the race.
+                        long deadline = System.currentTimeMillis() + 2000;
+                        while (System.currentTimeMillis() < deadline) {
+                            Thread.State state = writer.getState();
+                            if (state == Thread.State.BLOCKED
+                                    || state == Thread.State.TERMINATED) {
+                                break;
+                            }
+                            try {
+                                Thread.sleep(10);
+                            } catch (InterruptedException ie) {
+                                Thread.currentThread().interrupt();
+                                break;
+                            }
+                        }
+                    }
+                    signal.get();
+                }, Runnable::run);
+                effectCreated.set(true);
+            } catch (Throwable t) {
+                threadAFailure.set(t);
+            }
+        }, "deadlock-test-reader");
+        reader.setDaemon(true);
+
+        reader.start();
+        reader.join(5000);
+        writer.join(1000);
+
+        if (reader.isAlive() || writer.isAlive()) {
+            ThreadMXBean tmx = ManagementFactory.getThreadMXBean();
+            long[] deadlocked = tmx.findDeadlockedThreads();
+            fail("Effect creation deadlocked with a concurrent signal write."
+                    + " reader alive=" + reader.isAlive() + ", writer alive="
+                    + writer.isAlive()
+                    + (deadlocked != null
+                            ? ", deadlocked thread IDs="
+                                    + Arrays.toString(deadlocked)
+                            : ""));
+        }
+
+        if (threadAFailure.get() != null) {
+            throw new AssertionError("Reader thread failed",
+                    threadAFailure.get());
+        }
+        if (threadBFailure.get() != null) {
+            throw new AssertionError("Writer thread failed",
+                    threadBFailure.get());
+        }
+        assertTrue(effectCreated.get(),
+                "Effect should have been created without deadlock");
     }
 }


### PR DESCRIPTION
The Effect monitor was held across the user action both in the constructor's initial run and in invalidate(). The action reads signals and acquires the SignalTree lock, while a concurrent writer holding the tree lock reaches back into Effect.invalidate via its observer notifications and needs the same monitor, the opposite acquire orders deadlock.

revalidate() now acquires the Effect monitor only for short state-transition sections (prep and install) and runs the action with no monitor held. invalidate() drains registrations under a brief monitor section and calls Registration::remove outside it, so the tree lock is never acquired with the Effect monitor held.