### PR TITLE
fix: always commit array update on viewport flush

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -1403,10 +1403,10 @@ public class DataCommunicator<T> implements Serializable {
          * before our message about removal arrives at the client and is
          * applied.
          */
-        if (updated) {
-            int updateId = nextUpdateId++;
-            update.commit(updateId);
+        int updateId = nextUpdateId++;
+        update.commit(updateId);
 
+        if (updated) {
             // Finally clear any passivated items that have now been confirmed
             Set<String> passivatedKeys = getPassivatedKeys(oldActive);
             if (!passivatedKeys.isEmpty()) {

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
@@ -644,6 +644,8 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
         var previousViewportRange = viewportRange;
         viewportRange = computeViewportRange(start, length);
 
+        requestFlush();
+
         var partition = viewportRange.partitionWith(previousViewportRange);
         if (!partition[0].isEmpty()) {
             requestFlush().invalidateRange(partition[0]);

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
@@ -200,6 +200,25 @@ public class DataCommunicatorTest {
 
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
+    void setViewportRange_sameRange_commitCalled(
+            boolean dataProviderWithParallelStream) {
+        this.dataProviderWithParallelStream = dataProviderWithParallelStream;
+        dataCommunicator.setDataProvider(createDataProvider(), null);
+
+        dataCommunicator.setViewportRange(0, 50);
+        fakeClientCommunication();
+        int firstUpdateId = lastUpdateId;
+        assertTrue(firstUpdateId >= 0, "Expected commit on initial flush.");
+
+        dataCommunicator.setViewportRange(0, 50);
+        fakeClientCommunication();
+
+        assertTrue(lastUpdateId > firstUpdateId,
+                "Expected commit even when no data was sent.");
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
     void reattach_different_roundtrip_refresh_all(
             boolean dataProviderWithParallelStream) {
         this.dataProviderWithParallelStream = dataProviderWithParallelStream;

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorViewportTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicatorViewportTest.java
@@ -116,7 +116,13 @@ class HierarchicalDataCommunicatorViewportTest
         dataCommunicator.setViewportRange(3, 5);
         fakeClientCommunication();
 
-        Mockito.verifyNoInteractions(arrayUpdater, arrayUpdate);
+        assertArrayUpdateSize(100);
+        assertArrayUpdateRange(3, 5);
+        Mockito.verify(arrayUpdate, Mockito.never()).set(Mockito.anyInt(),
+                Mockito.anyList());
+        Mockito.verify(arrayUpdate).commit(Mockito.anyInt());
+
+        Mockito.clearInvocations(arrayUpdater, arrayUpdate);
 
         dataCommunicator.setViewportRange(0, 5);
         fakeClientCommunication();


### PR DESCRIPTION
This PR makes `DataCommunicator` and `HierarchicalDataCommunicator` always call `arrayUpdate.commit()` on viewport flush, even when no data diff is produced or the viewport range is unchanged.

Previously, `DataCommunicator` skipped `commit()` when a flush produced no data diff, even though `arrayUpdater.startUpdate()` had already been called. `HierarchicalDataCommunicator.setViewportRange` skipped `requestFlush()` entirely when the viewport range was unchanged, so no commit happened at all.

The reason is that connectors may still need to perform cleanup (for example, resolving pending callbacks) even if `setViewportRange` completed without sending data, and skipping `commit` makes this impossible since the connector has no other way of knowing that the request has completed.

Required for
- https://github.com/vaadin/flow-components/pull/9301

> [!WARNING]
> This can be considered behavior-altering change. Connectors will now receive `commit()` calls in cases where they previously did not.