### PR TITLE
feat: add JsFunction value type for composable executeJs

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/flow/util/ClientJsonCodec.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/util/ClientJsonCodec.java
@@ -210,17 +210,30 @@ public class ClientJsonCodec {
         }
         paramsAndCode[captureCount + argCount] = body;
         NativeFunction fn = new NativeFunction(paramsAndCode);
-        return bindCaptures(fn, captures);
+        return applyCaptures(fn, captures);
     }
 
-    private static native Object bindCaptures(NativeFunction fn,
+    /**
+     * Wraps {@code fn} in a function that prepends {@code captures} to the
+     * runtime arguments before delegating, while leaving {@code this}
+     * controlled by the caller. {@code Function.prototype.bind} would also
+     * pre-bind {@code this} to {@code undefined}, which prevents callers from
+     * setting {@code this} via {@code .call()} or {@code .apply()} on the
+     * resulting function.
+     */
+    private static native Object applyCaptures(NativeFunction fn,
             JsArray<Object> captures)
     /*-{
-        var args = [undefined];
-        for (var i = 0; i < captures.length; i++) {
-            args.push(captures[i]);
-        }
-        return Function.prototype.bind.apply(fn, args);
+        return function() {
+            var args = new Array(captures.length + arguments.length);
+            for (var i = 0; i < captures.length; i++) {
+                args[i] = captures[i];
+            }
+            for (var j = 0; j < arguments.length; j++) {
+                args[captures.length + j] = arguments[j];
+            }
+            return fn.apply(this, args);
+        };
     }-*/;
 
     /**

--- a/flow-client/src/main/java/com/vaadin/client/flow/util/ClientJsonCodec.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/util/ClientJsonCodec.java
@@ -129,6 +129,19 @@ public class ClientJsonCodec {
                         tree.getRegistry().getServerConnector());
             }
 
+            // Check for @v-fn format
+            JsonValue fnValue = jsonObject.get("@v-fn");
+            if (fnValue != null) {
+                if (fnValue.getType() != JsonType.OBJECT) {
+                    throw new IllegalArgumentException(
+                            "@v-fn value must be an object, got "
+                                    + fnValue.getType() + " in "
+                                    + json.toJson());
+                }
+                return decodeJsFunction(tree, (JsonObject) fnValue,
+                        json.toJson());
+            }
+
             // Check for unknown @v- types
             for (String key : jsonObject.keys()) {
                 if (key.startsWith("@v-")) {
@@ -152,6 +165,45 @@ public class ClientJsonCodec {
           var args = Array.prototype.slice.call(arguments);
           serverConnector.@ServerConnector::sendReturnChannelMessage(*)(nodeId, channelId, args);
         });
+    }-*/;
+
+    private static Object decodeJsFunction(StateTree tree, JsonObject fnObject,
+            String originalJson) {
+        JsonValue bodyValue = fnObject.get("body");
+        if (bodyValue == null || bodyValue.getType() != JsonType.STRING) {
+            throw new IllegalArgumentException(
+                    "@v-fn 'body' must be a string in " + originalJson);
+        }
+        JsonValue capturesValue = fnObject.get("captures");
+        if (capturesValue == null
+                || capturesValue.getType() != JsonType.ARRAY) {
+            throw new IllegalArgumentException(
+                    "@v-fn 'captures' must be an array in " + originalJson);
+        }
+        String body = bodyValue.asString();
+        JsonArray capturesJson = (JsonArray) capturesValue;
+        int captureCount = capturesJson.length();
+        JsArray<Object> captures = JsCollections.array();
+        for (int i = 0; i < captureCount; i++) {
+            captures.push(decodeWithTypeInfo(tree, capturesJson.get(i)));
+        }
+        String[] paramsAndCode = new String[captureCount + 1];
+        for (int i = 0; i < captureCount; i++) {
+            paramsAndCode[i] = "$" + i;
+        }
+        paramsAndCode[captureCount] = body;
+        NativeFunction fn = new NativeFunction(paramsAndCode);
+        return bindCaptures(fn, captures);
+    }
+
+    private static native Object bindCaptures(NativeFunction fn,
+            JsArray<Object> captures)
+    /*-{
+        var args = [undefined];
+        for (var i = 0; i < captures.length; i++) {
+            args.push(captures[i]);
+        }
+        return Function.prototype.bind.apply(fn, args);
     }-*/;
 
     /**

--- a/flow-client/src/main/java/com/vaadin/client/flow/util/ClientJsonCodec.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/util/ClientJsonCodec.java
@@ -187,11 +187,28 @@ public class ClientJsonCodec {
         for (int i = 0; i < captureCount; i++) {
             captures.push(decodeWithTypeInfo(tree, capturesJson.get(i)));
         }
-        String[] paramsAndCode = new String[captureCount + 1];
+        // Optional 'args' field: names of runtime parameters the manifested
+        // function should accept at call time, after the bound captures.
+        JsonArray argsJson;
+        JsonValue argsValue = fnObject.get("args");
+        if (argsValue == null) {
+            argsJson = null;
+        } else {
+            if (argsValue.getType() != JsonType.ARRAY) {
+                throw new IllegalArgumentException(
+                        "@v-fn 'args' must be an array in " + originalJson);
+            }
+            argsJson = (JsonArray) argsValue;
+        }
+        int argCount = argsJson == null ? 0 : argsJson.length();
+        String[] paramsAndCode = new String[captureCount + argCount + 1];
         for (int i = 0; i < captureCount; i++) {
             paramsAndCode[i] = "$" + i;
         }
-        paramsAndCode[captureCount] = body;
+        for (int i = 0; i < argCount; i++) {
+            paramsAndCode[captureCount + i] = argsJson.getString(i);
+        }
+        paramsAndCode[captureCount + argCount] = body;
         NativeFunction fn = new NativeFunction(paramsAndCode);
         return bindCaptures(fn, captures);
     }

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -37,6 +37,7 @@ import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
 import com.vaadin.flow.component.internal.UIInternals.JavaScriptInvocation;
 import com.vaadin.flow.dom.DomListenerRegistration;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.JsFunction;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.UrlUtil;
 import com.vaadin.flow.shared.Registration;
@@ -338,6 +339,8 @@ public class Page implements Serializable {
      * attached)
      * <li>{@link tools.jackson.databind.node.BaseJsonNode} (sent as-is without
      * additional wrapping)
+     * <li>{@link JsFunction} (manifested as a callable JavaScript function with
+     * its captured parameters pre-bound)
      * </ul>
      * Note that the parameter variables can only be used in contexts where a
      * JavaScript variable can be used. You should for instance do

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -1792,6 +1792,8 @@ public class Element extends Node<Element> {
      * invocation is sent to the client, or as <code>null</code> if not
      * attached)
      * <li>{@link BaseJsonNode} (sent as-is without additional wrapping)
+     * <li>{@link JsFunction} (manifested as a callable JavaScript function with
+     * its captured parameters pre-bound)
      * </ul>
      * Note that the parameter variables can only be used in contexts where a
      * JavaScript variable can be used. You should for instance do

--- a/flow-server/src/main/java/com/vaadin/flow/dom/JsFunction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/JsFunction.java
@@ -32,10 +32,13 @@ import com.vaadin.flow.internal.JacksonCodec;
  * <p>
  * The {@link #getBody() body} is a JavaScript function body. Captures are
  * referenced positionally as {@code $0}, {@code $1}, &hellip; (the same naming
- * convention as {@code executeJs} parameters). On the client the value
- * materialises as a function with the captures pre-bound, so the parent
- * {@code executeJs} can invoke it as {@code $N(...)} without ever concatenating
- * user-supplied JavaScript with framework boilerplate.
+ * convention as {@code executeJs} parameters). Additional named runtime
+ * arguments can be declared with {@link #withArguments(String...)}: the
+ * materialised function then accepts them positionally and the body references
+ * them by name. On the client the value materialises as a function with the
+ * captures pre-bound, so the parent {@code executeJs} can invoke it as
+ * {@code $N(arg1, arg2, ...)} without ever concatenating user-supplied
+ * JavaScript with framework boilerplate.
  * <p>
  * Captures may be any value accepted as a parameter to
  * {@link Element#executeJs(String, Object...) executeJs}, including
@@ -54,11 +57,15 @@ public final class JsFunction implements Serializable {
 
     private final String body;
     private final List<@Nullable Object> captures;
+    private final List<String> argumentNames;
 
-    private JsFunction(String body, @Nullable Object[] captures) {
+    private JsFunction(String body, @Nullable Object[] captures,
+            String[] argumentNames) {
         this.body = body;
         this.captures = Collections
                 .unmodifiableList(Arrays.asList(captures.clone()));
+        this.argumentNames = Collections
+                .unmodifiableList(Arrays.asList(argumentNames.clone()));
     }
 
     /**
@@ -87,7 +94,35 @@ public final class JsFunction implements Serializable {
         Object capture : copy) {
             JacksonCodec.encodeWithTypeInfo(capture);
         }
-        return new JsFunction(body, copy);
+        return new JsFunction(body, copy, new String[0]);
+    }
+
+    /**
+     * Returns a copy of this function that declares the given names as
+     * positional runtime arguments. The materialised function accepts these
+     * arguments at call time, and the body references them by name.
+     * <p>
+     * Example:
+     *
+     * <pre>
+     * JsFunction alerter = JsFunction.of("alert(message);")
+     *         .withArguments("message");
+     * element.executeJs("$0('Hello')", alerter);
+     * </pre>
+     *
+     * @param argumentNames
+     *            the names of runtime arguments, in positional order; each must
+     *            be a valid JavaScript identifier
+     * @return a new {@code JsFunction} with the given argument names
+     */
+    public JsFunction withArguments(String... argumentNames) {
+        Objects.requireNonNull(argumentNames, "argumentNames");
+        for (String name : argumentNames) {
+            Objects.requireNonNull(name, "argumentNames must not contain null");
+        }
+        @Nullable
+        Object[] captureArray = captures.toArray();
+        return new JsFunction(body, captureArray, argumentNames);
     }
 
     /**
@@ -106,5 +141,16 @@ public final class JsFunction implements Serializable {
      */
     public List<@Nullable Object> getCaptures() {
         return captures;
+    }
+
+    /**
+     * The names of the runtime arguments declared via
+     * {@link #withArguments(String...)}, in positional order.
+     *
+     * @return an unmodifiable list of argument names; empty if none were
+     *         declared
+     */
+    public List<String> getArgumentNames() {
+        return argumentNames;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/JsFunction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/JsFunction.java
@@ -114,8 +114,14 @@ public final class JsFunction implements Serializable {
      *            the names of runtime arguments, in positional order; each must
      *            be a valid JavaScript identifier
      * @return a new {@code JsFunction} with the given argument names
+     * @throws IllegalStateException
+     *             if argument names have already been set on this instance
      */
     public JsFunction withArguments(String... argumentNames) {
+        if (!this.argumentNames.isEmpty()) {
+            throw new IllegalStateException(
+                    "withArguments has already been called on this JsFunction");
+        }
         return new JsFunction(body, captures, List.of(argumentNames));
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/dom/JsFunction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/JsFunction.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.dom;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+
+import com.vaadin.flow.internal.JacksonCodec;
+
+/**
+ * A JavaScript function value with captured parameters that can be passed to
+ * {@link Element#executeJs(String, Object...)} as a parameter and reified on
+ * the client as an actual callable JS function.
+ * <p>
+ * The {@link #getBody() body} is a JavaScript function body. Captures are
+ * referenced positionally as {@code $0}, {@code $1}, &hellip; (the same naming
+ * convention as {@code executeJs} parameters). On the client the value
+ * materialises as a function with the captures pre-bound, so the parent
+ * {@code executeJs} can invoke it as {@code $N(...)} without ever concatenating
+ * user-supplied JavaScript with framework boilerplate.
+ * <p>
+ * Captures may be any value accepted as a parameter to
+ * {@link Element#executeJs(String, Object...) executeJs}, including
+ * {@link Element} (attached elements arrive as DOM nodes, detached ones as
+ * {@code null}) and nested {@link JsFunction} instances. Capture types are
+ * validated when the value is created.
+ * <p>
+ * Inside the body, {@code this} is whatever the caller of the materialised
+ * function chooses (i.e. it follows normal JavaScript call semantics &ndash;
+ * not the host element). To use the host element from within the body, pass it
+ * as a capture.
+ *
+ * @author Vaadin Ltd
+ */
+public final class JsFunction implements Serializable {
+
+    private final String body;
+    private final List<@Nullable Object> captures;
+
+    private JsFunction(String body, @Nullable Object[] captures) {
+        this.body = body;
+        this.captures = Collections
+                .unmodifiableList(Arrays.asList(captures.clone()));
+    }
+
+    /**
+     * Creates a JavaScript function value with the given body and captured
+     * parameters.
+     *
+     * @param body
+     *            the JavaScript function body, with captures referenced as
+     *            {@code $0}, {@code $1}, &hellip;; not {@code null}
+     * @param captures
+     *            the values to capture; each must be a type supported as a
+     *            parameter to {@link Element#executeJs(String, Object...)}
+     * @return a new {@code JsFunction} instance
+     * @throws IllegalArgumentException
+     *             if any capture has a type that cannot be sent to the client
+     */
+    public static JsFunction of(String body, @Nullable Object... captures) {
+        Objects.requireNonNull(body, "body");
+        Objects.requireNonNull(captures, "captures");
+        @Nullable
+        Object[] copy = captures.clone();
+        // Dry-run encode each capture so unsupported types fail fast. Mirrors
+        // the validation done by the JavaScriptInvocation constructor for
+        // executeJs parameters.
+        for (@Nullable
+        Object capture : copy) {
+            JacksonCodec.encodeWithTypeInfo(capture);
+        }
+        return new JsFunction(body, copy);
+    }
+
+    /**
+     * The JavaScript function body.
+     *
+     * @return the body string
+     */
+    public String getBody() {
+        return body;
+    }
+
+    /**
+     * The captured values, in declaration order.
+     *
+     * @return an unmodifiable list of captures
+     */
+    public List<@Nullable Object> getCaptures() {
+        return captures;
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/dom/JsFunction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/JsFunction.java
@@ -59,13 +59,11 @@ public final class JsFunction implements Serializable {
     private final List<@Nullable Object> captures;
     private final List<String> argumentNames;
 
-    private JsFunction(String body, @Nullable Object[] captures,
-            String[] argumentNames) {
+    private JsFunction(String body, List<@Nullable Object> captures,
+            List<String> argumentNames) {
         this.body = body;
-        this.captures = Collections
-                .unmodifiableList(Arrays.asList(captures.clone()));
-        this.argumentNames = Collections
-                .unmodifiableList(Arrays.asList(argumentNames.clone()));
+        this.captures = captures;
+        this.argumentNames = argumentNames;
     }
 
     /**
@@ -94,7 +92,9 @@ public final class JsFunction implements Serializable {
         Object capture : copy) {
             JacksonCodec.encodeWithTypeInfo(capture);
         }
-        return new JsFunction(body, copy, new String[0]);
+        return new JsFunction(body,
+                Collections.unmodifiableList(Arrays.asList(copy)),
+                Collections.emptyList());
     }
 
     /**
@@ -116,13 +116,7 @@ public final class JsFunction implements Serializable {
      * @return a new {@code JsFunction} with the given argument names
      */
     public JsFunction withArguments(String... argumentNames) {
-        Objects.requireNonNull(argumentNames, "argumentNames");
-        for (String name : argumentNames) {
-            Objects.requireNonNull(name, "argumentNames must not contain null");
-        }
-        @Nullable
-        Object[] captureArray = captures.toArray();
-        return new JsFunction(body, captureArray, argumentNames);
+        return new JsFunction(body, captures, List.of(argumentNames));
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/internal/JacksonCodec.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JacksonCodec.java
@@ -113,6 +113,11 @@ public class JacksonCodec {
             captures.add(encodeWithTypeInfo(capture));
         }
         payload.set("captures", captures);
+        ArrayNode args = mapper.createArrayNode();
+        for (String name : value.getArgumentNames()) {
+            args.add(name);
+        }
+        payload.set("args", args);
         obj.set("@v-fn", payload);
         return obj;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/JacksonCodec.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JacksonCodec.java
@@ -28,6 +28,7 @@ import tools.jackson.databind.node.ObjectNode;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.JsFunction;
 import com.vaadin.flow.internal.nodefeature.ReturnChannelRegistration;
 
 /**
@@ -43,6 +44,8 @@ import com.vaadin.flow.internal.nodefeature.ReturnChannelRegistration;
  * <li>{@link JsonNode} and all its sub types
  * <li>{@link Element} (encoded as a reference to the element)
  * <li>{@link Component} (encoded as a reference to the root element)
+ * <li>{@link JsFunction} (encoded as a JS function literal that closes over its
+ * captured parameters on the client)
  * </ul>
  *
  * <p>
@@ -76,6 +79,8 @@ public class JacksonCodec {
             return encodeWithoutTypeInfo(value);
         } else if (value instanceof ReturnChannelRegistration) {
             return encodeReturnChannel((ReturnChannelRegistration) value);
+        } else if (value instanceof JsFunction) {
+            return encodeJsFunction((JsFunction) value);
         } else if (canEncodeWithoutTypeInfo(value.getClass())) {
             // Native JSON types - no wrapping needed
             return encodeWithoutTypeInfo(value);
@@ -95,6 +100,20 @@ public class JacksonCodec {
         channelArray.add(value.getStateNodeId());
         channelArray.add(value.getChannelId());
         obj.set("@v-return", channelArray);
+        return obj;
+    }
+
+    private static JsonNode encodeJsFunction(JsFunction value) {
+        ObjectMapper mapper = JacksonUtils.getMapper();
+        ObjectNode obj = mapper.createObjectNode();
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("body", value.getBody());
+        ArrayNode captures = mapper.createArrayNode();
+        for (Object capture : value.getCaptures()) {
+            captures.add(encodeWithTypeInfo(capture));
+        }
+        payload.set("captures", captures);
+        obj.set("@v-fn", payload);
         return obj;
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/dom/JsFunctionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/JsFunctionTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.dom;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class JsFunctionTest {
+
+    @Test
+    void withArguments_alreadySet_throws() {
+        JsFunction fn = JsFunction.of("return a;").withArguments("a");
+        assertThrows(IllegalStateException.class, () -> fn.withArguments("b"));
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
@@ -35,6 +35,7 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementFactory;
+import com.vaadin.flow.dom.JsFunction;
 import com.vaadin.flow.internal.nodefeature.ElementChildrenList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -146,6 +147,46 @@ class JacksonCodecTest {
         JsonNode json = JacksonCodec.encodeWithTypeInfo(element);
 
         assertJsonEquals(objectMapper.nullNode(), json);
+    }
+
+    @Test
+    void encodeWithTypeInfo_jsFunction_primitiveCaptures() {
+        JsFunction fn = JsFunction.of("return $0 + $1;", "hello", 42);
+
+        JsonNode json = JacksonCodec.encodeWithTypeInfo(fn);
+
+        ObjectNode payload = objectMapper.createObjectNode();
+        payload.put("body", "return $0 + $1;");
+        payload.set("captures",
+                objectMapper.createArrayNode().add("hello").add(42));
+        ObjectNode expected = objectMapper.createObjectNode();
+        expected.set("@v-fn", payload);
+
+        assertJsonEquals(expected, json);
+    }
+
+    @Test
+    void encodeWithTypeInfo_jsFunction_elementCaptureBecomesVNode() {
+        Element element = ElementFactory.createDiv();
+        StateTree tree = new StateTree(new UI().getInternals(),
+                ElementChildrenList.class);
+        tree.getRootNode().getFeature(ElementChildrenList.class).add(0,
+                element.getNode());
+
+        JsFunction fn = JsFunction.of("$0.focus();", element);
+
+        JsonNode json = JacksonCodec.encodeWithTypeInfo(fn);
+
+        ObjectNode expectedCapture = objectMapper.createObjectNode();
+        expectedCapture.put("@v-node", element.getNode().getId());
+        ObjectNode payload = objectMapper.createObjectNode();
+        payload.put("body", "$0.focus();");
+        payload.set("captures",
+                objectMapper.createArrayNode().add(expectedCapture));
+        ObjectNode expected = objectMapper.createObjectNode();
+        expected.set("@v-fn", payload);
+
+        assertJsonEquals(expected, json);
     }
 
     private static void assertJsonEquals(JsonNode expected, JsonNode actual) {

--- a/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/JacksonCodecTest.java
@@ -159,6 +159,7 @@ class JacksonCodecTest {
         payload.put("body", "return $0 + $1;");
         payload.set("captures",
                 objectMapper.createArrayNode().add("hello").add(42));
+        payload.set("args", objectMapper.createArrayNode());
         ObjectNode expected = objectMapper.createObjectNode();
         expected.set("@v-fn", payload);
 
@@ -183,6 +184,24 @@ class JacksonCodecTest {
         payload.put("body", "$0.focus();");
         payload.set("captures",
                 objectMapper.createArrayNode().add(expectedCapture));
+        payload.set("args", objectMapper.createArrayNode());
+        ObjectNode expected = objectMapper.createObjectNode();
+        expected.set("@v-fn", payload);
+
+        assertJsonEquals(expected, json);
+    }
+
+    @Test
+    void encodeWithTypeInfo_jsFunction_withArguments() {
+        JsFunction alerter = JsFunction.of("alert(message);")
+                .withArguments("message");
+
+        JsonNode json = JacksonCodec.encodeWithTypeInfo(alerter);
+
+        ObjectNode payload = objectMapper.createObjectNode();
+        payload.put("body", "alert(message);");
+        payload.set("captures", objectMapper.createArrayNode());
+        payload.set("args", objectMapper.createArrayNode().add("message"));
         ObjectNode expected = objectMapper.createObjectNode();
         expected.set("@v-fn", payload);
 

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/JsFunctionView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/JsFunctionView.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.dom.JsFunction;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+@Route(value = "com.vaadin.flow.uitest.ui.JsFunctionView", layout = ViewTestLayout.class)
+public class JsFunctionView extends AbstractDivView {
+
+    @Override
+    protected void onShow() {
+        Div captureResult = new Div();
+        captureResult.setId("captureResult");
+        Div argsResult = new Div();
+        argsResult.setId("argsResult");
+        Div elementCaptureResult = new Div();
+        elementCaptureResult.setId("elementCaptureResult");
+        Div thisRespectResult = new Div();
+        thisRespectResult.setId("thisRespectResult");
+
+        NativeButton captureButton = createButton("Run capture function",
+                "captureButton", e -> {
+                    JsFunction concat = JsFunction.of("return $0 + ' ' + $1;",
+                            "Hello", "World");
+                    captureResult.getElement()
+                            .executeJs("this.textContent = $0();", concat);
+                });
+
+        NativeButton argsButton = createButton("Run function with arguments",
+                "argsButton", e -> {
+                    JsFunction setText = JsFunction
+                            .of("return prefix + ':' + suffix;")
+                            .withArguments("prefix", "suffix");
+                    argsResult.getElement().executeJs(
+                            "this.textContent = $0('alpha', 'beta');", setText);
+                });
+
+        NativeButton elementCaptureButton = createButton(
+                "Run function capturing element", "elementCaptureButton", e -> {
+                    JsFunction mutate = JsFunction.of(
+                            "$0.textContent = 'mutated via capture';",
+                            elementCaptureResult.getElement());
+                    getElement().executeJs("$0();", mutate);
+                });
+
+        NativeButton thisRespectButton = createButton(
+                "Run function with caller-supplied this", "thisRespectButton",
+                e -> {
+                    JsFunction setOwnText = JsFunction
+                            .of("this.textContent = msg;").withArguments("msg");
+                    thisRespectResult.getElement().executeJs(
+                            "$0.call(this, 'this is the host element');",
+                            setOwnText);
+                });
+
+        add(captureButton, argsButton, elementCaptureButton, thisRespectButton,
+                captureResult, argsResult, elementCaptureResult,
+                thisRespectResult);
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/JsFunctionIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/JsFunctionIT.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class JsFunctionIT extends ChromeBrowserTest {
+
+    @Test
+    public void capturedValuesArePreBound() {
+        open();
+        findElement(By.id("captureButton")).click();
+        WebElement result = waitUntil(d -> findElement(By.id("captureResult")));
+        Assert.assertEquals("Hello World", result.getText());
+    }
+
+    @Test
+    public void runtimeArgumentsAreForwarded() {
+        open();
+        findElement(By.id("argsButton")).click();
+        WebElement result = waitUntil(d -> findElement(By.id("argsResult")));
+        Assert.assertEquals("alpha:beta", result.getText());
+    }
+
+    @Test
+    public void elementCaptureResolvesToDomNode() {
+        open();
+        findElement(By.id("elementCaptureButton")).click();
+        WebElement result = waitUntil(
+                d -> findElement(By.id("elementCaptureResult")));
+        Assert.assertEquals("mutated via capture", result.getText());
+    }
+
+    @Test
+    public void callerControlsThisBinding() {
+        open();
+        findElement(By.id("thisRespectButton")).click();
+        WebElement result = waitUntil(
+                d -> findElement(By.id("thisRespectResult")));
+        Assert.assertEquals("this is the host element", result.getText());
+    }
+}


### PR DESCRIPTION
Lets server code build a JS function value with captured parameters
and pass it as an executeJs parameter, removing the need to
string-concatenate framework boilerplate around user-supplied JS.
Captures may themselves be Elements or other JsFunctions; the codec
encodes them recursively as @v-fn, and the client reifies the value
as a callable function with the captures pre-bound.

Fixes #24373
