### PR TITLE
refactor: use JsFunction for deferred scrollIntoView

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -2106,12 +2106,13 @@ public class Element extends Node<Element> {
         ObjectNode json = ScrollIntoViewOption.buildOptions(options);
 
         // Use setTimeout to work on newly created elements
+        JsFunction scroll;
         if (json == null) {
-            executeJs("setTimeout(function(){$0.scrollIntoView()},0)", this);
+            scroll = JsFunction.of("$0.scrollIntoView();", this);
         } else {
-            executeJs("setTimeout(function(){$0.scrollIntoView($1)},0)", this,
-                    json);
+            scroll = JsFunction.of("$0.scrollIntoView($1);", this, json);
         }
+        executeJs("setTimeout($0, 0)", scroll);
 
         return getSelf();
     }
@@ -2133,8 +2134,9 @@ public class Element extends Node<Element> {
         // created element
         String options = scrollOptions == null ? "" : scrollOptions.toJson();
 
-        executeJs("var el = this; setTimeout(function() {el.scrollIntoView("
-                + options + ");}, 0);");
+        JsFunction scroll = JsFunction.of("$0.scrollIntoView(" + options + ");",
+                this);
+        executeJs("setTimeout($0, 0)", scroll);
         return getSelf();
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
@@ -54,6 +54,7 @@ import com.vaadin.flow.dom.DisabledUpdateMode;
 import com.vaadin.flow.dom.DomEvent;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementFactory;
+import com.vaadin.flow.dom.JsFunction;
 import com.vaadin.flow.i18n.I18NProvider;
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
@@ -1982,6 +1983,9 @@ public class ComponentTest {
         assertEquals(1, pendingJs.size());
         JavaScriptInvocation inv = pendingJs.get(0).getInvocation();
         MatcherAssert.assertThat(inv.getExpression(),
+                CoreMatchers.containsString("setTimeout($0, 0)"));
+        JsFunction fn = (JsFunction) inv.getParameters().get(0);
+        MatcherAssert.assertThat(fn.getBody(),
                 CoreMatchers.containsString(expectedJs));
     }
 
@@ -2052,15 +2056,17 @@ public class ComponentTest {
         assertEquals(1, pendingJs.size());
         JavaScriptInvocation inv = pendingJs.get(0).getInvocation();
 
-        // Verify it uses parameter passing
-        String expression = inv.getExpression();
-        MatcherAssert.assertThat(expression,
+        // The outer expression defers to a JsFunction
+        MatcherAssert.assertThat(inv.getExpression(),
+                CoreMatchers.containsString("setTimeout($0, 0)"));
+        JsFunction fn = (JsFunction) inv.getParameters().get(0);
+
+        // The JsFunction body uses parameter passing for the options
+        MatcherAssert.assertThat(fn.getBody(),
                 CoreMatchers.containsString("$0.scrollIntoView($1)"));
 
-        // Verify parameters contain expected JSON parts
-        List<Object> params = inv.getParameters();
-        assertTrue(params.size() >= 2, "Should have at least 2 parameters");
-        String paramJson = params.get(1).toString();
+        // The options object is captured at index 1
+        String paramJson = fn.getCaptures().get(1).toString();
         for (String expectedPart : expectedJsonParts) {
             MatcherAssert.assertThat(paramJson,
                     CoreMatchers.containsString(expectedPart));


### PR DESCRIPTION
Replace the `setTimeout(function(){$0.scrollIntoView(...)},0)` blocks in Element.scrollIntoView (including the deprecated ScrollOptions overload) with JsFunction bodies invoked via `setTimeout($0, 0)`. The element and the options object become captures of the JsFunction.

The deprecated overload still concatenates the JSON string into the body since fixing that is out of scope; the method is being removed.
