### PR TITLE
refactor: use JsFunction for the window resize listener

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -467,15 +467,15 @@ public class Page implements Serializable {
     private void ensureResizeListener() {
         if (resizeReceiver == null) {
             // "republish" on the UI element, so can be listened with core APIs
-            ui.getElement().executeJs("""
-                        const el = this;
-                        window.addEventListener('resize', evt => {
-                            const event = new Event("window-resize");
-                            event.w = document.documentElement.clientWidth;
-                            event.h = document.documentElement.clientHeight;
-                            el.dispatchEvent(event);
-                        });
-                    """);
+            Element uiElement = ui.getElement();
+            JsFunction onResize = JsFunction.of("""
+                    const event = new Event("window-resize");
+                    event.w = document.documentElement.clientWidth;
+                    event.h = document.documentElement.clientHeight;
+                    $0.dispatchEvent(event);
+                    """, uiElement);
+            uiElement.executeJs("window.addEventListener('resize', $0);",
+                    onResize);
             resizeReceiver = ui.getElement()
                     .addEventListener("window-resize", e -> {
                         int w = e.getEventData().get("event.w").intValue();


### PR DESCRIPTION
Replace the inline `const el = this; window.addEventListener('resize', evt => {...})` construction in Page.ensureResizeListener with a JsFunction that captures the UI element. The resize callback becomes a first-class function value, removing the `const el = this` aliasing.
