### PR TITLE
refactor: use JsFunction for deferred history state pushes

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/page/History.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/History.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import tools.jackson.databind.node.BaseJsonNode;
 
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.dom.JsFunction;
 import com.vaadin.flow.router.Location;
 import com.vaadin.flow.router.NavigationTrigger;
 import com.vaadin.flow.shared.ApplicationConstants;
@@ -234,9 +235,10 @@ public class History implements Serializable {
                     "window.dispatchEvent(new CustomEvent('vaadin-navigate', { detail: { state: $0, url: $1, replace: false, callback: $2 } }));",
                     state, pathWithQueryParameters, callback);
         } else {
-            ui.getPage().executeJs(
-                    "setTimeout(() => { window.history.pushState($0, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigated')); })",
+            JsFunction pushAndNotify = JsFunction.of(
+                    "window.history.pushState($0, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigated'));",
                     state, pathWithQueryParameters);
+            ui.getPage().executeJs("setTimeout($0)", pushAndNotify);
         }
     }
 
@@ -322,9 +324,10 @@ public class History implements Serializable {
                     "window.dispatchEvent(new CustomEvent('vaadin-navigate', { detail: { state: $0, url: $1, replace: true, callback: $2 } }));",
                     state, pathWithQueryParameters, callback);
         } else {
-            ui.getPage().executeJs(
-                    "setTimeout(() => { window.history.replaceState($0, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigated')); })",
+            JsFunction replaceAndNotify = JsFunction.of(
+                    "window.history.replaceState($0, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigated'));",
                     state, pathWithQueryParameters);
+            ui.getPage().executeJs("setTimeout($0)", replaceAndNotify);
         }
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
@@ -40,6 +40,7 @@ import com.vaadin.flow.component.page.AppShellConfigurator;
 import com.vaadin.flow.component.page.History;
 import com.vaadin.flow.component.page.Page;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.JsFunction;
 import com.vaadin.flow.dom.impl.BasicElementStateProvider;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.CurrentInstance;
@@ -69,7 +70,10 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 class JavaScriptBootstrapUITest {
 
-    private static final String CLIENT_PUSHSTATE_TO = "setTimeout(() => { window.history.pushState($0, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigated')); })";
+    // Non-react pushState defers via a JsFunction; the body is captured here
+    // for assertions about its captures.
+    private static final String CLIENT_PUSHSTATE_TO = "setTimeout($0)";
+    private static final String CLIENT_PUSHSTATE_BODY = "window.history.pushState($0, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigated'));";
     private static final String REACT_PUSHSTATE_TO = "window.dispatchEvent(new CustomEvent('vaadin-navigate', { detail: { state: $0, url: $1, replace: false, callback: $2 } }));";
 
     private MockServletServiceSessionSetup mocks;
@@ -497,9 +501,12 @@ class JavaScriptBootstrapUITest {
                 assertEquals("clean/1", execValues[0]);
             } else {
                 assertEquals(CLIENT_PUSHSTATE_TO, execJs.getValue());
-                assertEquals(2, execValues.length);
-                assertNull(execValues[0]);
-                assertEquals("clean/1", execValues[1]);
+                assertEquals(1, execValues.length);
+                JsFunction fn = (JsFunction) execValues[0];
+                assertEquals(CLIENT_PUSHSTATE_BODY, fn.getBody());
+                assertEquals(2, fn.getCaptures().size());
+                assertNull(fn.getCaptures().get(0));
+                assertEquals("clean/1", fn.getCaptures().get(1));
             }
         }
     }

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/HistoryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/HistoryTest.java
@@ -21,12 +21,15 @@ import org.mockito.Mockito;
 import tools.jackson.databind.JsonNode;
 
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.dom.JsFunction;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class HistoryTest {
 
@@ -69,8 +72,9 @@ class HistoryTest {
     private VaadinSession session = Mockito.mock(VaadinSession.class);
     private DeploymentConfiguration configuration;
 
-    private static final String PUSH_STATE_JS = "setTimeout(() => { window.history.pushState($0, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigated')); })";
-    private static final String REPLACE_STATE_JS = "setTimeout(() => { window.history.replaceState($0, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigated')); })";
+    private static final String SET_TIMEOUT_WRAPPER = "setTimeout($0)";
+    private static final String PUSH_STATE_BODY = "window.history.pushState($0, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigated'));";
+    private static final String REPLACE_STATE_BODY = "window.history.replaceState($0, '', $1); window.dispatchEvent(new CustomEvent('vaadin-navigated'));";
 
     private static final String PUSH_STATE_REACT = "window.dispatchEvent(new CustomEvent('vaadin-navigate', { detail: { state: $0, url: $1, replace: false, callback: $2 } }));";
     private static final String REPLACE_STATE_REACT = "window.dispatchEvent(new CustomEvent('vaadin-navigate', { detail: { state: $0, url: $1, replace: true, callback: $2 } }));";
@@ -87,95 +91,86 @@ class HistoryTest {
         Mockito.when(configuration.isReactEnabled()).thenReturn(false);
     }
 
+    /**
+     * Asserts that the last executeJs call wrapped the given body in a
+     * {@code setTimeout($0)} JsFunction with the given state and path captures.
+     */
+    private void assertSetTimeoutWrapped(String expectedBody,
+            String expectedStateJsonOrNull, String expectedPath) {
+        assertEquals(SET_TIMEOUT_WRAPPER, page.expression,
+                "expected setTimeout wrapper");
+        assertEquals(1, page.parameters.length,
+                "expected single JsFunction parameter");
+        JsFunction fn = assertInstanceOf(JsFunction.class, page.parameters[0],
+                "parameter should be a JsFunction");
+        assertEquals(expectedBody, fn.getBody(), "JsFunction body");
+        assertEquals(2, fn.getCaptures().size(), "JsFunction capture count");
+        Object stateCapture = fn.getCaptures().get(0);
+        if (expectedStateJsonOrNull == null) {
+            assertNull(stateCapture, "state capture should be null");
+        } else {
+            assertEquals(expectedStateJsonOrNull,
+                    ((JsonNode) stateCapture).toString(), "state capture JSON");
+        }
+        assertEquals(expectedPath, fn.getCaptures().get(1), "path capture");
+    }
+
     @Test
     void pushState_locationWithQueryParameters_queryParametersRetained() {
         history.pushState(JacksonUtils.readTree("{'foo':'bar'}"),
                 "context/view?param=4");
 
-        assertEquals(PUSH_STATE_JS, page.expression,
-                "push state JS not included");
-        assertEquals("{\"foo\":\"bar\"}",
-                ((JsonNode) page.parameters[0]).toString(),
-                "push state not included");
-        assertEquals("context/view?param=4", page.parameters[1],
-                "invalid location");
+        assertSetTimeoutWrapped(PUSH_STATE_BODY, "{\"foo\":\"bar\"}",
+                "context/view?param=4");
 
         history.pushState(JacksonUtils.readTree("{'foo':'bar'}"),
                 "context/view/?param=4");
 
-        assertEquals(PUSH_STATE_JS, page.expression,
-                "push state JS not included");
-        assertEquals("{\"foo\":\"bar\"}",
-                ((JsonNode) page.parameters[0]).toString(),
-                "push state not included");
-        assertEquals("context/view/?param=4", page.parameters[1],
-                "invalid location");
+        assertSetTimeoutWrapped(PUSH_STATE_BODY, "{\"foo\":\"bar\"}",
+                "context/view/?param=4");
     }
 
     @Test
     void pushState_locationWithFragment_fragmentRetained() {
         history.pushState(null, "context/view#foobar");
 
-        assertEquals(PUSH_STATE_JS, page.expression,
-                "push state JS not included");
-        assertEquals(null, page.parameters[0]);
-        assertEquals("context/view#foobar", page.parameters[1],
-                "fragment not retained");
+        assertSetTimeoutWrapped(PUSH_STATE_BODY, null, "context/view#foobar");
 
         history.pushState(null, "context/view/#foobar");
 
-        assertEquals(PUSH_STATE_JS, page.expression,
-                "push state JS not included");
-        assertEquals(null, page.parameters[0]);
-        assertEquals("context/view/#foobar", page.parameters[1],
-                "fragment not retained");
+        assertSetTimeoutWrapped(PUSH_STATE_BODY, null, "context/view/#foobar");
     }
 
     @Test // #11628
     void pushState_locationWithQueryParametersAndFragment_QueryParametersAndFragmentRetained() {
         history.pushState(null, "context/view?foo=bar#foobar");
 
-        assertEquals(PUSH_STATE_JS, page.expression,
-                "push state JS not included");
-        assertEquals(null, page.parameters[0]);
-        assertEquals("context/view?foo=bar#foobar", page.parameters[1],
-                "invalid location");
+        assertSetTimeoutWrapped(PUSH_STATE_BODY, null,
+                "context/view?foo=bar#foobar");
 
         history.pushState(null, "context/view/?foo=bar#foobar");
 
-        assertEquals(PUSH_STATE_JS, page.expression,
-                "push state JS not included");
-        assertEquals(null, page.parameters[0]);
-        assertEquals("context/view/?foo=bar#foobar", page.parameters[1],
-                "invalid location");
+        assertSetTimeoutWrapped(PUSH_STATE_BODY, null,
+                "context/view/?foo=bar#foobar");
     }
 
     @Test // #11628
     void replaceState_locationWithQueryParametersAndFragment_QueryParametersAndFragmentRetained() {
         history.replaceState(null, "context/view?foo=bar#foobar");
 
-        assertEquals(REPLACE_STATE_JS, page.expression,
-                "replace state JS not included");
-        assertEquals(null, page.parameters[0]);
-        assertEquals("context/view?foo=bar#foobar", page.parameters[1],
-                "invalid location");
+        assertSetTimeoutWrapped(REPLACE_STATE_BODY, null,
+                "context/view?foo=bar#foobar");
 
         history.replaceState(null, "context/view/?foo=bar#foobar");
 
-        assertEquals(REPLACE_STATE_JS, page.expression,
-                "replace state JS not included");
-        assertEquals(null, page.parameters[0]);
-        assertEquals("context/view/?foo=bar#foobar", page.parameters[1],
-                "invalid location");
+        assertSetTimeoutWrapped(REPLACE_STATE_BODY, null,
+                "context/view/?foo=bar#foobar");
     }
 
     @Test // #11628
     void replaceState_locationEmpty_pushesPeriod() {
         history.replaceState(null, "");
-        assertEquals(REPLACE_STATE_JS, page.expression,
-                "replace state JS not included");
-        assertEquals(null, page.parameters[0]);
-        assertEquals(".", page.parameters[1], "location should be '.'");
+        assertSetTimeoutWrapped(REPLACE_STATE_BODY, null, ".");
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
@@ -49,6 +49,7 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.page.ExtendedClientDetails;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.JsFunction;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.i18n.LocaleChangeEvent;
 import com.vaadin.flow.i18n.LocaleChangeObserver;
@@ -3012,8 +3013,10 @@ public class RouterTest extends RoutingTestBase {
 
         long historyInvocations = ui.getInternals()
                 .dumpPendingJavaScriptInvocations().stream()
-                .filter(js -> js.getInvocation().getExpression()
-                        .contains("history.pushState"))
+                .filter(js -> js.getInvocation().getParameters().stream()
+                        .anyMatch(p -> p instanceof JsFunction
+                                && ((JsFunction) p).getBody()
+                                        .contains("history.pushState")))
                 .count();
         assertEquals(1, historyInvocations);
 


### PR DESCRIPTION
Replace the `setTimeout(() => { window.history.pushState(...);
window.dispatchEvent(...); })` arrow-function deferral in
History.pushState and History.replaceState with a JsFunction whose body
performs the history mutation and event dispatch, invoked via
`setTimeout($0)`. State and path are now captures of the JsFunction
rather than parameters of the outer expression.
