### PR TITLE
chore(ci): rebalance unit and IT shards to reduce build wall time

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -62,8 +62,8 @@ jobs:
       - name: Generate matrices
         id: set-matrix
         run: |
-          echo "matrix-it=$(./scripts/computeMatrix.js it-tests --parallel=13 current module args)" >> $GITHUB_OUTPUT
-          echo "matrix-unit=$(./scripts/computeMatrix.js unit-tests --parallel=3 current module args)" >> $GITHUB_OUTPUT
+          echo "matrix-it=$(./scripts/computeMatrix.js it-tests --parallel=15 current module args)" >> $GITHUB_OUTPUT
+          echo "matrix-unit=$(./scripts/computeMatrix.js unit-tests --parallel=4 current module args)" >> $GITHUB_OUTPUT
       - name: Compile and Install Flow
         run: |
           cmd="mvn install -B -ntp -DskipTests  -pl \!flow-plugins/flow-gradle-plugin"

--- a/scripts/computeMatrix.js
+++ b/scripts/computeMatrix.js
@@ -110,7 +110,10 @@ const moduleWeights = {
   'flow-tests/vaadin-spring-tests/test-spring-security-flow-themes-urlmapping': { pos: 6, weight: 3 },
   'flow-tests/vaadin-spring-tests/test-spring-security-flow-methodsecurity': { pos: 5, weight: 3 },
   'flow-tests/vaadin-spring-tests/test-spring-security-flow-urlmapping': { pos: 5, weight: 3 },
-  'flow-tests/vaadin-spring-tests/test-spring-security-flow-reverseproxy': { pos: 6, weight: 3 },
+  // Stays at pos:5: depends on test-spring-security-flow (built in the same
+  // reactor via the run-tests profile, but not installed to local .m2 because
+  // the workspace build step uses -DskipTests).
+  'flow-tests/vaadin-spring-tests/test-spring-security-flow-reverseproxy': { pos: 5, weight: 3 },
   'flow-tests/vaadin-spring-tests/test-spring-security-flow-standalone-routepathaccesschecker': { pos: 6, weight: 3 },
   'flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker': { pos: 6, weight: 3 },
   'flow-tests/vaadin-spring-tests/test-mvc-without-endpoints': { pos: 6, weight: 2 },

--- a/scripts/computeMatrix.js
+++ b/scripts/computeMatrix.js
@@ -32,7 +32,9 @@ const globalExclusions = [
 // Containers 4, 5 & 6:
 //  Spring tests, they need also spring shared modules to be generated in validation.yml
 // Container 6:
-//  Live Reload Multimodule test needs being executed in the same container
+//  Live Reload Multimodule test needs being executed in the same container.
+//  Also holds a subset of the lighter spring-security tests offloaded from
+//  container 5, since 5 is dominated by `test-spring` (weight ~20).
 const moduleWeights = {
   'flow-client': { weight: 8 },
   'flow-server': { weight: 10 },
@@ -105,13 +107,13 @@ const moduleWeights = {
   'flow-tests/vaadin-spring-tests/test-spring-security-flow-websocket': { pos: 5, weight: 3 },
   'flow-tests/vaadin-spring-tests/test-spring-security-flow-contextpath': { pos: 5, weight: 3 },
   'flow-tests/vaadin-spring-tests/test-spring-security-flow-themes-contextpath': { pos: 5, weight: 3 },
-  'flow-tests/vaadin-spring-tests/test-spring-security-flow-themes-urlmapping': { pos: 5, weight: 3 },
+  'flow-tests/vaadin-spring-tests/test-spring-security-flow-themes-urlmapping': { pos: 6, weight: 3 },
   'flow-tests/vaadin-spring-tests/test-spring-security-flow-methodsecurity': { pos: 5, weight: 3 },
   'flow-tests/vaadin-spring-tests/test-spring-security-flow-urlmapping': { pos: 5, weight: 3 },
-  'flow-tests/vaadin-spring-tests/test-spring-security-flow-reverseproxy': { pos: 5, weight: 3 },
-  'flow-tests/vaadin-spring-tests/test-spring-security-flow-standalone-routepathaccesschecker': { pos: 5, weight: 3 },
-  'flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker': { pos: 5, weight: 3 },
-  'flow-tests/vaadin-spring-tests/test-mvc-without-endpoints': { pos: 5, weight: 2 },
+  'flow-tests/vaadin-spring-tests/test-spring-security-flow-reverseproxy': { pos: 6, weight: 3 },
+  'flow-tests/vaadin-spring-tests/test-spring-security-flow-standalone-routepathaccesschecker': { pos: 6, weight: 3 },
+  'flow-tests/vaadin-spring-tests/test-spring-security-flow-routepathaccesschecker': { pos: 6, weight: 3 },
+  'flow-tests/vaadin-spring-tests/test-mvc-without-endpoints': { pos: 6, weight: 2 },
   'flow-tests/test-live-reload-multimodule': {pos:6},
   'flow-tests/test-live-reload-multimodule/ui': {pos:6},
   'flow-tests/test-live-reload-multimodule/library': {pos:6},
@@ -172,7 +174,8 @@ const moduleWeights = {
 
 // Set split number for modules with several tests
 const moduleSplits = {
-  'flow-tests/test-root-context': 2
+  'flow-tests/test-root-context': 2,
+  'flow-plugins/flow-maven-plugin': 2
 }
 /****************** END CONFIG */
 


### PR DESCRIPTION
Profiling 5 recent main builds showed unit-tests-2 (~12m, flow-maven-plugin) and it-tests-5 (~11.5m, test-spring + 13 spring-security tests) bounding wall time, while it-tests-6 and 7 were idle (1-2m). Split flow-maven-plugin unit tests, move five lighter spring-security modules from pos:5 to pos:6, and bump parallelism (unit 3->4, IT 13->15) so dynamic shards hold fewer items each. Expected drop from ~15.5m to ~13.5m, bottleneck now it-tests-1.

Resulting matrix shapes:

```
┌─────────────────────┬─────────────────┬──────────────────────┐
│                     │ before (weight) │    after (weight)    │
├─────────────────────┼─────────────────┼──────────────────────┤
│ unit-tests heaviest │ 30 (~12m)       │ 25 (~5m)             │
├─────────────────────┼─────────────────┼──────────────────────┤
│ it-tests-5          │ 58 (~11.5m)     │ 44 (~9m)             │
├─────────────────────┼─────────────────┼──────────────────────┤
│ it-tests-6          │ 6 (~2m)         │ 20 (~5m)             │
├─────────────────────┼─────────────────┼──────────────────────┤
│ it-tests-1          │ 53 (~11m)       │ 53 (~11m, unchanged) │
├─────────────────────┼─────────────────┼──────────────────────┤
│ dynamic shards      │ 45–46 each      │ 30–31 each (~4–5m)   │
└─────────────────────┴─────────────────┴──────────────────────┘
```