### PR TITLE
ci: Replace pull_request_target with pull_request in CI workflows

### DIFF
--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -72,7 +72,7 @@ jobs:
           retention-days: 30
 
       - name: Find existing comment
-        if: ${{ !github.event.pull_request.head.repo.fork }}
+        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
         uses: peter-evans/find-comment@v4
         id: find-comment
         with:
@@ -81,7 +81,7 @@ jobs:
           body-includes: '<!-- tc-formatter -->'
 
       - name: Create or update comment
-        if: ${{ !github.event.pull_request.head.repo.fork && steps.formatter.outputs.modified != '0' }}
+        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && steps.formatter.outputs.modified != '0'
         uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}

--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -1,7 +1,7 @@
 name: Formatter
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
     # spotless available in 25.x
     branches: [main]
@@ -72,7 +72,7 @@ jobs:
           retention-days: 30
 
       - name: Find existing comment
-        if: github.event_name == 'pull_request_target'
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: peter-evans/find-comment@v4
         id: find-comment
         with:
@@ -81,7 +81,7 @@ jobs:
           body-includes: '<!-- tc-formatter -->'
 
       - name: Create or update comment
-        if: github.event_name == 'pull_request_target' && steps.formatter.outputs.modified != '0'
+        if: ${{ !github.event.pull_request.head.repo.fork && steps.formatter.outputs.modified != '0' }}
         uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}

--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -1,7 +1,7 @@
 name: Sonar PR Analysis
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
     branches: [main]
   merge_group:
@@ -25,7 +25,7 @@ env:
 
 jobs:
   sonar-analysis:
-    environment: ${{ github.event.pull_request.head.repo.fork && 'pr-tests' || '' }}
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     name: Sonar Analysis
     runs-on: ubuntu-latest
     timeout-minutes: 120

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -317,7 +317,7 @@ jobs:
           PR_NUMBER: ${{ github.event.number }}
         run: node scripts/autoMerge.js
   api-diff-labeling:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -270,6 +270,7 @@ jobs:
         with:
           name: tests-output
           pattern: tests-output-*
+      - uses: actions/checkout@v5
       - uses: actions/download-artifact@v5
         with:
           name: tests-output

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: ['25.1', '25.0', '24.10', '24.9', '23.7', '23.6']
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
     branches: [main]
   merge_group:
@@ -23,7 +23,6 @@ env:
   JAVA_VERSION: ${{ (startsWith(github.base_ref || github.ref_name, '23.') && '11') || (startsWith(github.base_ref || github.ref_name, '24.') && '17') || '21' }}
 jobs:
   build:
-    environment: ${{ github.event.pull_request.head.repo.fork && 'pr-tests' || '' }}
     timeout-minutes: 30
     runs-on: ubuntu-24.04
     outputs:
@@ -32,6 +31,7 @@ jobs:
     steps:
       - run: echo "Concurrency Group = ${_HEAD_REF:-$_REF_NAME}"
       - name: Check secrets
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         run: |
           [ -z "${{secrets.TB_LICENSE}}" ] \
             && echo "🚫 **TB_LICENSE** is not defined, check that **${{github.repository}}** repo has a valid secret" \
@@ -78,6 +78,7 @@ jobs:
           path: workspace.tar
   unit-tests:
     needs: build
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -154,6 +155,7 @@ jobs:
           path: tests-report-*.tgz
   it-tests:
     needs: build
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -259,7 +261,7 @@ jobs:
     # failure() || success() it would be skipped when any matrix entry
     # was cancelled, and a skipped required check satisfies branch
     # protection — letting auto-merge proceed past a cancelled IT.
-    if: ${{ always() }}
+    if: ${{ always() && !github.event.pull_request.head.repo.fork }}
     needs: [unit-tests, it-tests]
     runs-on: ubuntu-24.04
     steps:
@@ -268,9 +270,6 @@ jobs:
         with:
           name: tests-output
           pattern: tests-output-*
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{env._HEAD_SHA}}
       - uses: actions/download-artifact@v5
         with:
           name: tests-output
@@ -317,8 +316,7 @@ jobs:
           PR_NUMBER: ${{ github.event.number }}
         run: node scripts/autoMerge.js
   api-diff-labeling:
-    environment: ${{ github.event.pull_request.head.repo.fork && 'pr-tests' || '' }}
-    if: github.event_name == 'pull_request_target'
+    if: github.event_name == 'pull_request'
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
## Summary

Replaces the `pull_request_target` event with `pull_request` in all three affected workflows: `formatter.yml`, `sonar-pr.yml` and `validation.yml`.

Changes per workflow:

`formatter.yml`: trigger changed, comment steps now skip for fork PRs (write permissions not available in that context).

`sonar-pr.yml`: trigger changed, environment gate removed, job skips for fork PRs since `SONAR_TOKEN` is not available.

`validation.yml`: trigger changed, environment gate removed, `unit-tests` and `it-tests` jobs skip entirely for fork PRs. `test-results` also skips for fork PRs to avoid artifact download failures. `Check secrets` step is restored but runs only for non-fork PRs. `api-diff-labeling` condition updated from `pull_request_target` to `pull_request`.

Fork PRs will have the `build` job run (compile, matrix generation) but no tests. Reviewers must validate fork PRs manually by checking out the branch.