### PR TITLE
feat: PromiseAction + CopyTextToClipboardAction + RequestFullscreenAction

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/CopyTextToClipboardAction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/CopyTextToClipboardAction.java
@@ -17,8 +17,10 @@ package com.vaadin.flow.component.trigger.internal;
 
 import java.util.Objects;
 
+import org.jspecify.annotations.Nullable;
+import tools.jackson.databind.JsonNode;
+
 import com.vaadin.flow.function.SerializableConsumer;
-import com.vaadin.flow.function.SerializableRunnable;
 
 /**
  * Copies a value to the user's clipboard via
@@ -28,17 +30,20 @@ import com.vaadin.flow.function.SerializableRunnable;
  * gesture (click, key press, …). Bind this action to a {@link Trigger} that
  * fires during such a gesture, typically a {@link ClickTrigger}.
  * <p>
- * Outcome handling is inherited from {@link PromiseAction}: use the no-arg
- * outcome constructor for fire-and-forget, or the overload taking
- * {@code onSuccess}/{@code onError} consumers to react to the {@code writeText}
- * promise on the UI thread.
+ * Outcome handling extends {@link PromiseAction}: use the no-arg outcome
+ * constructor for fire-and-forget, or the overload taking
+ * {@code onCopied}/{@code onError} consumers. {@code onCopied} receives the
+ * exact string that was copied — useful when the input was a
+ * {@link PropertyInput} whose value is only known on the client (e.g. the
+ * current contents of an input field). {@code onError} receives a
+ * {@link PromiseAction.Error} record with the browser's error name and message.
  *
  * <pre>{@code
  * Action.Input<String> value = new PropertyInput<>(textField, "value",
  *         String.class);
  * CopyTextToClipboardAction copy = new CopyTextToClipboardAction(value,
- *         () -> notification.show("Copied"),
- *         err -> notification.show("Copy failed: " + err));
+ *         copied -> notification.show("Copied: " + copied),
+ *         err -> notification.show("Copy failed: " + err.message()));
  * new ClickTrigger(button).triggers(copy);
  * }</pre>
  *
@@ -63,23 +68,22 @@ public class CopyTextToClipboardAction extends PromiseAction {
 
     /**
      * Creates a clipboard-copy action whose outcome is reported back to the
-     * server via {@code onSuccess}/{@code onError}. See {@link PromiseAction}
-     * for the contract on both consumers.
+     * server.
      *
      * @param textInput
      *            input supplying the text to copy, not {@code null}
-     * @param onSuccess
-     *            invoked on the UI thread after the client reports
-     *            {@code writeText} resolved, not {@code null}
-     * @param onError
-     *            invoked on the UI thread with the browser's error message
-     *            after the client reports {@code writeText} rejected, not
+     * @param onCopied
+     *            invoked on the UI thread with the string that was copied after
+     *            the client reports {@code writeText} resolved, not
      *            {@code null}
+     * @param onError
+     *            invoked on the UI thread with the browser's error after the
+     *            client reports {@code writeText} rejected, not {@code null}
      */
     public CopyTextToClipboardAction(Action.Input<String> textInput,
-            SerializableRunnable onSuccess,
-            SerializableConsumer<String> onError) {
-        super(onSuccess, onError);
+            SerializableConsumer<String> onCopied,
+            SerializableConsumer<Error> onError) {
+        super(adaptOnCopied(onCopied), onError);
         this.textInput = Objects.requireNonNull(textInput,
                 "textInput must not be null");
     }
@@ -87,8 +91,21 @@ public class CopyTextToClipboardAction extends PromiseAction {
     @Override
     protected void appendPromiseExpression(JsBuilder builder,
             StringBuilder out) {
-        out.append("navigator.clipboard.writeText(");
+        // Bind the text expression once on the client, write it, then
+        // resolve the promise with the same value so onCopied sees the
+        // exact string that reached the clipboard.
+        out.append("((v) => navigator.clipboard.writeText(v).then(() => v))(");
         textInput.appendExpression(builder, out);
         out.append(")");
+    }
+
+    private static SerializableConsumer<Success> adaptOnCopied(
+            SerializableConsumer<String> onCopied) {
+        Objects.requireNonNull(onCopied, "onCopied must not be null");
+        return success -> onCopied.accept(asString(success.value()));
+    }
+
+    private static String asString(@Nullable JsonNode value) {
+        return value == null || value.isNull() ? "" : value.asString();
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/CopyTextToClipboardAction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/CopyTextToClipboardAction.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.trigger.internal;
+
+import java.util.Objects;
+
+import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.function.SerializableRunnable;
+
+/**
+ * Copies a value to the user's clipboard via
+ * {@code navigator.clipboard.writeText} when the bound trigger fires.
+ * <p>
+ * The Clipboard API requires the call to happen inside a short-lived user
+ * gesture (click, key press, …). Bind this action to a {@link Trigger} that
+ * fires during such a gesture, typically a {@link ClickTrigger}.
+ * <p>
+ * Outcome handling is inherited from {@link PromiseAction}: use the no-arg
+ * outcome constructor for fire-and-forget, or the overload taking
+ * {@code onSuccess}/{@code onError} consumers to react to the {@code writeText}
+ * promise on the UI thread.
+ *
+ * <pre>{@code
+ * Action.Input<String> value = new PropertyInput<>(textField, "value",
+ *         String.class);
+ * CopyTextToClipboardAction copy = new CopyTextToClipboardAction(value,
+ *         () -> notification.show("Copied"),
+ *         err -> notification.show("Copy failed: " + err));
+ * new ClickTrigger(button).triggers(copy);
+ * }</pre>
+ *
+ * For internal use only. May be renamed or removed in a future release.
+ */
+public class CopyTextToClipboardAction extends PromiseAction {
+
+    private final Action.Input<String> textInput;
+
+    /**
+     * Creates a fire-and-forget clipboard-copy action: the rendered JS just
+     * calls {@code writeText} and the server never sees the result.
+     *
+     * @param textInput
+     *            input supplying the text to copy, not {@code null}
+     */
+    public CopyTextToClipboardAction(Action.Input<String> textInput) {
+        super();
+        this.textInput = Objects.requireNonNull(textInput,
+                "textInput must not be null");
+    }
+
+    /**
+     * Creates a clipboard-copy action whose outcome is reported back to the
+     * server via {@code onSuccess}/{@code onError}. See {@link PromiseAction}
+     * for the contract on both consumers.
+     *
+     * @param textInput
+     *            input supplying the text to copy, not {@code null}
+     * @param onSuccess
+     *            invoked on the UI thread after the client reports
+     *            {@code writeText} resolved, not {@code null}
+     * @param onError
+     *            invoked on the UI thread with the browser's error message
+     *            after the client reports {@code writeText} rejected, not
+     *            {@code null}
+     */
+    public CopyTextToClipboardAction(Action.Input<String> textInput,
+            SerializableRunnable onSuccess,
+            SerializableConsumer<String> onError) {
+        super(onSuccess, onError);
+        this.textInput = Objects.requireNonNull(textInput,
+                "textInput must not be null");
+    }
+
+    @Override
+    protected void appendPromiseExpression(JsBuilder builder,
+            StringBuilder out) {
+        out.append("navigator.clipboard.writeText(");
+        textInput.appendExpression(builder, out);
+        out.append(")");
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/JsBuilder.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/JsBuilder.java
@@ -41,7 +41,7 @@ import com.vaadin.flow.internal.JacksonUtils;
 final class JsBuilder implements Serializable {
 
     private final Trigger trigger;
-    private final List<Object> params = new ArrayList<>();
+    private final List<@Nullable Object> params = new ArrayList<>();
     private final Map<Element, String> paramByElement = new IdentityHashMap<>();
 
     JsBuilder(Trigger trigger) {
@@ -76,8 +76,29 @@ final class JsBuilder implements Serializable {
     }
 
     /**
-     * Returns the element captures collected by this builder, in the order they
-     * were first referenced — these become the captures of the handler
+     * Allocates a fresh {@code $N} placeholder for an arbitrary capture value
+     * and returns the reference. Use this for non-{@link Element} values such
+     * as {@link com.vaadin.flow.internal.nodefeature.ReturnChannelRegistration}
+     * — which materialises on the client as a function that calls the
+     * server-side handler — so an action can splice the resulting JS function
+     * into its expression. Each call allocates a new placeholder; values are
+     * not de-duplicated.
+     *
+     * @param value
+     *            the value to capture; must be a type supported as a parameter
+     *            to {@link com.vaadin.flow.dom.Element#executeJs}, may be
+     *            {@code null}
+     * @return the JS placeholder ({@code "$N"}) referencing the captured value
+     */
+    String capture(@Nullable Object value) {
+        String ref = "$" + params.size();
+        params.add(value);
+        return ref;
+    }
+
+    /**
+     * Returns the captures collected by this builder, in the order they were
+     * first referenced — these become the captures of the handler
      * {@link com.vaadin.flow.dom.JsFunction}.
      */
     Object[] captures() {

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/LiteralInput.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/LiteralInput.java
@@ -15,24 +15,46 @@
  */
 package com.vaadin.flow.component.trigger.internal;
 
-import org.jspecify.annotations.Nullable;
+import java.util.Objects;
 
 /**
  * Input backed by a server-side literal that is JSON-encoded into the JS at
  * build time. Lets actions take {@code Action.Input<? extends T>} uniformly
- * while still accepting plain constants from callers.
+ * while still accepting plain constants from callers — e.g. copying a fixed
+ * string to the clipboard:
+ *
+ * <pre>{@code
+ * new ClickTrigger(button).triggers(
+ *         new CopyTextToClipboardAction(new LiteralInput<>("hello"), () -> {
+ *         }, err -> {
+ *         }));
+ * }</pre>
+ *
+ * <p>
+ * The value is required to be non-null: {@code null} as a literal payload
+ * almost never matches a sensible browser API call (e.g.
+ * {@code writeText(null)} writes the string {@code "null"} to the clipboard).
+ * Actions that need to emit a literal {@code null} should do so through their
+ * own mechanism — see {@link SetPropertyAction}'s null-clearing convenience
+ * constructor.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
  * @param <T>
  *            the runtime type of the value
  */
-final class LiteralInput<T> extends Action.Input<T> {
+public final class LiteralInput<T> extends Action.Input<T> {
 
-    private final @Nullable T value;
+    private final T value;
 
-    LiteralInput(@Nullable T value) {
-        this.value = value;
+    /**
+     * Creates a literal input wrapping the given value.
+     *
+     * @param value
+     *            the value to encode, not {@code null}
+     */
+    public LiteralInput(T value) {
+        this.value = Objects.requireNonNull(value, "value must not be null");
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/PromiseAction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/PromiseAction.java
@@ -21,11 +21,11 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.jspecify.annotations.Nullable;
+import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ArrayNode;
 
 import com.vaadin.flow.dom.JsFunction;
 import com.vaadin.flow.function.SerializableConsumer;
-import com.vaadin.flow.function.SerializableRunnable;
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.internal.nodefeature.ReturnChannelMap;
@@ -43,22 +43,22 @@ import com.vaadin.flow.internal.nodefeature.ReturnChannelRegistration;
  * JS expression by overriding
  * {@link #appendPromiseExpression(JsBuilder, StringBuilder)}.
  * <p>
- * Two construction modes, mirroring the
- * {@link com.vaadin.flow.component.geolocation.Geolocation Geolocation} API:
+ * Two construction modes:
  * <ul>
  * <li>Fire-and-forget — {@link #PromiseAction()} — the rendered JS is just the
  * promise expression; the server never sees the outcome.</li>
  * <li>With outcome handling —
- * {@link #PromiseAction(SerializableRunnable, SerializableConsumer)} — supply
- * an {@code onSuccess} runnable and an {@code onError} consumer (both required;
- * pass {@code () -> {}} or {@code err -> {}} to opt out of one). The handlers
+ * {@link #PromiseAction(SerializableConsumer, SerializableConsumer)} — supply
+ * an {@code onSuccess} consumer receiving a {@link Success} record and an
+ * {@code onError} consumer receiving an {@link Error} record (both required;
+ * pass {@code s -> {}} or {@code err -> {}} to opt out of one). The handlers
  * run on the UI thread after the client reports the outcome of the
  * promise.</li>
  * </ul>
  * Under the hood, the with-outcome mode renders one call to a shared
  * {@link JsFunction} that subscribes to the promise and pushes an
- * {@link Outcome} record through a lazily-registered
- * {@link ReturnChannelRegistration} on the trigger host node.
+ * {@link Outcome} through a lazily-registered {@link ReturnChannelRegistration}
+ * on the trigger host node.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  */
@@ -67,17 +67,22 @@ public abstract class PromiseAction extends Action {
     /**
      * Wrapper JS: subscribes to {@code promise} and forwards the resolved value
      * or rejection reason to {@code channel} as an {@link Outcome}-shaped
-     * object. Shared across all subclasses with callbacks — the only per-call
-     * inputs are the promise expression and the return channel.
+     * object. Resolved values are forwarded verbatim — subclasses whose promise
+     * resolves to a meaningful value (e.g. the text that was just copied)
+     * surface it through {@link Success#value()}. Errors are split into
+     * {@code name} (typically the {@code DOMException} class such as
+     * {@code "NotAllowedError"} — useful for switching) and a free-form
+     * {@code message}.
      */
     private static final JsFunction OBSERVE_PROMISE = JsFunction.of("""
-            promise.then(() => channel({ok: true}))\
-            .catch(e => channel({ok: false, \
-            error: e && e.message ? e.message : String(e)}));""")
+            promise.then(value => channel({ok: true, value: value}))\
+            .catch(e => channel({ok: false, error: {\
+            name: (e && e.name) ? e.name : '',\
+            message: (e && e.message) ? e.message : String(e)}}));""")
             .withArguments("promise", "channel");
 
-    private final @Nullable SerializableRunnable onSuccess;
-    private final @Nullable SerializableConsumer<String> onError;
+    private final @Nullable SerializableConsumer<Success> onSuccess;
+    private final @Nullable SerializableConsumer<Error> onError;
     private final Map<StateNode, ReturnChannelRegistration> channelByNode = new IdentityHashMap<>();
 
     /**
@@ -91,21 +96,21 @@ public abstract class PromiseAction extends Action {
 
     /**
      * Creates an action whose promise outcome is reported back to the server.
-     * {@code onSuccess} runs after the promise resolves; {@code onError}
-     * receives the browser's error message after the promise rejects. Both run
-     * on the UI thread. Both consumers are required and must be non-null — pass
-     * {@code () -> {}} or {@code err -> {}} to opt out of one.
+     * {@code onSuccess} runs after the promise resolves and receives a
+     * {@link Success} record carrying the resolved value (if the subclass'
+     * promise produced one); {@code onError} runs after the promise rejects and
+     * receives an {@link Error} record with the browser's error name and
+     * message. Both run on the UI thread.
      *
      * @param onSuccess
      *            invoked on the UI thread after the client reports the promise
      *            resolved, not {@code null}
      * @param onError
-     *            invoked on the UI thread with the browser's error message
-     *            after the client reports the promise rejected, not
-     *            {@code null}
+     *            invoked on the UI thread with the browser's error after the
+     *            client reports the promise rejected, not {@code null}
      */
-    protected PromiseAction(SerializableRunnable onSuccess,
-            SerializableConsumer<String> onError) {
+    protected PromiseAction(SerializableConsumer<Success> onSuccess,
+            SerializableConsumer<Error> onError) {
         this.onSuccess = Objects.requireNonNull(onSuccess,
                 "onSuccess must not be null");
         this.onError = Objects.requireNonNull(onError,
@@ -114,10 +119,15 @@ public abstract class PromiseAction extends Action {
 
     /**
      * Subclasses append a JS expression that evaluates to a {@code Promise}
-     * when the trigger fires. The result of that promise is what
-     * {@code onSuccess}/{@code onError} observe; the resolved value itself is
-     * not delivered to the server (only success vs. failure and the rejection
-     * message).
+     * when the trigger fires. The value the promise resolves with is what
+     * {@link Success#value()} receives on the server (a Jackson
+     * {@link JsonNode}). To deliver a typed value, subclasses can wrap their
+     * API call in an IIFE — for example, copying a string and resolving with
+     * it:
+     *
+     * <pre>{@code
+     * ((v) => navigator.clipboard.writeText(v).then(() => v))(<textExpr>)
+     * }</pre>
      *
      * @param builder
      *            collects element parameter references, not {@code null}
@@ -127,9 +137,20 @@ public abstract class PromiseAction extends Action {
     protected abstract void appendPromiseExpression(JsBuilder builder,
             StringBuilder out);
 
+    /**
+     * Final by design — subclasses customise the rendered JS through
+     * {@link #appendPromiseExpression}, never by overriding the wiring that
+     * subscribes to the promise. Keeping the {@code .then}/{@code .catch} glue
+     * identical across subclasses is what makes the {@link Outcome} wire
+     * contract stable.
+     */
     @Override
     protected final void appendStatement(JsBuilder builder, StringBuilder out) {
-        if (onSuccess == null) {
+        // The constructors enforce that onSuccess and onError are either
+        // both null (fire-and-forget) or both non-null (with-outcome) — so
+        // checking one already determines the mode. Asserting on both keeps
+        // the invariant defensive against constructor changes.
+        if (onSuccess == null && onError == null) {
             appendPromiseExpression(builder, out);
             return;
         }
@@ -150,22 +171,56 @@ public abstract class PromiseAction extends Action {
     private void dispatch(ArrayNode args) {
         // Channel is only registered when callbacks were supplied, so these
         // are non-null at the point of dispatch.
-        SerializableRunnable success = Objects.requireNonNull(onSuccess);
-        SerializableConsumer<String> error = Objects.requireNonNull(onError);
+        SerializableConsumer<Success> success = Objects
+                .requireNonNull(onSuccess);
+        SerializableConsumer<Error> error = Objects.requireNonNull(onError);
         Outcome outcome = JacksonUtils.readValue(args.get(0), Outcome.class);
         if (outcome.ok()) {
-            success.run();
+            success.accept(new Success(outcome.value()));
         } else {
-            error.accept(outcome.error() == null ? "" : outcome.error());
+            Error err = outcome.error();
+            error.accept(err == null ? new Error("", "") : err);
         }
     }
 
     /**
-     * Wire shape exchanged between {@link #OBSERVE_PROMISE} and
-     * {@link #dispatch}. {@code error} is only meaningful when
-     * {@code ok == false}.
+     * Information delivered to the {@code onSuccess} consumer after the promise
+     * resolves. {@link #value()} is whatever JS value the promise produced (or
+     * {@code null} if it was {@code undefined}); subclasses that have nothing
+     * meaningful to deliver resolve with {@code undefined} and leave this
+     * {@code null}.
+     *
+     * @param value
+     *            the resolved value as a Jackson {@link JsonNode}, or
+     *            {@code null} if the promise resolved with {@code undefined}
      */
-    private record Outcome(boolean ok,
-            @Nullable String error) implements Serializable {
+    public record Success(@Nullable JsonNode value) implements Serializable {
+    }
+
+    /**
+     * Information delivered to the {@code onError} consumer after the promise
+     * rejects. {@link #name()} carries the rejection's class name — typically a
+     * {@code DOMException} like {@code "NotAllowedError"},
+     * {@code "AbortError"}, … — which is what callers usually switch on.
+     * {@link #message()} carries the free-form description and is best used for
+     * logging or display.
+     *
+     * @param name
+     *            the rejection's {@code name} property, or the empty string if
+     *            the rejection had none
+     * @param message
+     *            the rejection's {@code message} property, or {@code String(e)}
+     *            if there was no {@code message}
+     */
+    public record Error(String name, String message) implements Serializable {
+    }
+
+    /**
+     * Wire shape exchanged between {@link #OBSERVE_PROMISE} and
+     * {@link #dispatch}. {@code value} is meaningful when {@code ok == true};
+     * {@code error} is meaningful when {@code ok == false}.
+     */
+    private record Outcome(boolean ok, @Nullable JsonNode value,
+            @Nullable Error error) implements Serializable {
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/PromiseAction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/PromiseAction.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.trigger.internal;
+
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+import tools.jackson.databind.node.ArrayNode;
+
+import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.function.SerializableRunnable;
+import com.vaadin.flow.internal.StateNode;
+import com.vaadin.flow.internal.nodefeature.ReturnChannelMap;
+import com.vaadin.flow.internal.nodefeature.ReturnChannelRegistration;
+
+/**
+ * Base class for actions that run a JS expression yielding a <a href=
+ * "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>
+ * and optionally report the outcome back to the server.
+ * <p>
+ * Many gesture-bound browser APIs are asynchronous — clipboard, fullscreen,
+ * file picker, share, web payment, … — and follow the same shape: call the API,
+ * then handle the resolved value or the rejection. This class collapses that
+ * pattern into one place so subclasses only need to emit the promise-yielding
+ * JS expression by overriding
+ * {@link #appendPromiseExpression(JsBuilder, StringBuilder)}.
+ * <p>
+ * Two construction modes, mirroring the
+ * {@link com.vaadin.flow.component.geolocation.Geolocation Geolocation} API:
+ * <ul>
+ * <li>Fire-and-forget — {@link #PromiseAction()} — the rendered JS is just the
+ * promise expression; the server never sees the outcome.</li>
+ * <li>With outcome handling —
+ * {@link #PromiseAction(SerializableRunnable, SerializableConsumer)} — supply
+ * an {@code onSuccess} runnable and an {@code onError} consumer (both required;
+ * pass {@code () -> {}} or {@code err -> {}} to opt out of one). The handlers
+ * run on the UI thread after the client reports the outcome of the
+ * promise.</li>
+ * </ul>
+ * Under the hood, the with-outcome mode lazily registers one
+ * {@link ReturnChannelRegistration} per trigger host node and appends
+ * {@code .then(()=>$N(true,null)).catch(e=>$N(false, msg))} to the promise
+ * expression, so the client invokes the channel after the promise resolves or
+ * rejects.
+ * <p>
+ * For internal use only. May be renamed or removed in a future release.
+ */
+public abstract class PromiseAction extends Action {
+
+    private final @Nullable SerializableRunnable onSuccess;
+    private final @Nullable SerializableConsumer<String> onError;
+    private final Map<StateNode, ReturnChannelRegistration> channelByNode = new IdentityHashMap<>();
+
+    /**
+     * Creates a fire-and-forget action: the promise's outcome is not reported
+     * back to the server.
+     */
+    protected PromiseAction() {
+        this.onSuccess = null;
+        this.onError = null;
+    }
+
+    /**
+     * Creates an action whose promise outcome is reported back to the server.
+     * {@code onSuccess} runs after the promise resolves; {@code onError}
+     * receives the browser's error message after the promise rejects. Both run
+     * on the UI thread. Both consumers are required and must be non-null — pass
+     * {@code () -> {}} or {@code err -> {}} to opt out of one.
+     *
+     * @param onSuccess
+     *            invoked on the UI thread after the client reports the promise
+     *            resolved, not {@code null}
+     * @param onError
+     *            invoked on the UI thread with the browser's error message
+     *            after the client reports the promise rejected, not
+     *            {@code null}
+     */
+    protected PromiseAction(SerializableRunnable onSuccess,
+            SerializableConsumer<String> onError) {
+        this.onSuccess = Objects.requireNonNull(onSuccess,
+                "onSuccess must not be null");
+        this.onError = Objects.requireNonNull(onError,
+                "onError must not be null");
+    }
+
+    /**
+     * Subclasses append a JS expression that evaluates to a {@code Promise}
+     * when the trigger fires. The result of that promise is what
+     * {@code onSuccess}/{@code onError} observe; the resolved value itself is
+     * not delivered to the server (only the success/failure flag and the
+     * rejection message).
+     *
+     * @param builder
+     *            collects element parameter references, not {@code null}
+     * @param out
+     *            buffer to append into, not {@code null}
+     */
+    protected abstract void appendPromiseExpression(JsBuilder builder,
+            StringBuilder out);
+
+    @Override
+    protected final void appendStatement(JsBuilder builder, StringBuilder out) {
+        appendPromiseExpression(builder, out);
+        if (onSuccess == null) {
+            return;
+        }
+        StateNode hostNode = builder.trigger().getHost().getNode();
+        ReturnChannelRegistration channel = channelByNode.computeIfAbsent(
+                hostNode, node -> node.getFeature(ReturnChannelMap.class)
+                        .registerChannel(this::dispatch));
+        String channelRef = builder.capture(channel);
+        out.append(".then(()=>").append(channelRef).append("(true,null))")
+                .append(".catch(e=>").append(channelRef)
+                .append("(false, e && e.message ? e.message : String(e)))");
+    }
+
+    private void dispatch(ArrayNode args) {
+        // Channel is only registered when callbacks were supplied, so these
+        // are non-null at the point of dispatch.
+        SerializableRunnable success = Objects.requireNonNull(onSuccess);
+        SerializableConsumer<String> error = Objects.requireNonNull(onError);
+        boolean succeeded = !args.isEmpty() && args.get(0).asBoolean(false);
+        if (succeeded) {
+            success.run();
+        } else {
+            String message = (args.size() > 1 && !args.get(1).isNull())
+                    ? args.get(1).asString()
+                    : "";
+            error.accept(message);
+        }
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/PromiseAction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/PromiseAction.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.trigger.internal;
 
+import java.io.Serializable;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -22,8 +23,10 @@ import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.node.ArrayNode;
 
+import com.vaadin.flow.dom.JsFunction;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableRunnable;
+import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.internal.nodefeature.ReturnChannelMap;
 import com.vaadin.flow.internal.nodefeature.ReturnChannelRegistration;
@@ -52,15 +55,26 @@ import com.vaadin.flow.internal.nodefeature.ReturnChannelRegistration;
  * run on the UI thread after the client reports the outcome of the
  * promise.</li>
  * </ul>
- * Under the hood, the with-outcome mode lazily registers one
- * {@link ReturnChannelRegistration} per trigger host node and appends
- * {@code .then(()=>$N(true,null)).catch(e=>$N(false, msg))} to the promise
- * expression, so the client invokes the channel after the promise resolves or
- * rejects.
+ * Under the hood, the with-outcome mode renders one call to a shared
+ * {@link JsFunction} that subscribes to the promise and pushes an
+ * {@link Outcome} record through a lazily-registered
+ * {@link ReturnChannelRegistration} on the trigger host node.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  */
 public abstract class PromiseAction extends Action {
+
+    /**
+     * Wrapper JS: subscribes to {@code promise} and forwards the resolved value
+     * or rejection reason to {@code channel} as an {@link Outcome}-shaped
+     * object. Shared across all subclasses with callbacks — the only per-call
+     * inputs are the promise expression and the return channel.
+     */
+    private static final JsFunction OBSERVE_PROMISE = JsFunction.of("""
+            promise.then(() => channel({ok: true}))\
+            .catch(e => channel({ok: false, \
+            error: e && e.message ? e.message : String(e)}));""")
+            .withArguments("promise", "channel");
 
     private final @Nullable SerializableRunnable onSuccess;
     private final @Nullable SerializableConsumer<String> onError;
@@ -102,8 +116,8 @@ public abstract class PromiseAction extends Action {
      * Subclasses append a JS expression that evaluates to a {@code Promise}
      * when the trigger fires. The result of that promise is what
      * {@code onSuccess}/{@code onError} observe; the resolved value itself is
-     * not delivered to the server (only the success/failure flag and the
-     * rejection message).
+     * not delivered to the server (only success vs. failure and the rejection
+     * message).
      *
      * @param builder
      *            collects element parameter references, not {@code null}
@@ -115,18 +129,22 @@ public abstract class PromiseAction extends Action {
 
     @Override
     protected final void appendStatement(JsBuilder builder, StringBuilder out) {
-        appendPromiseExpression(builder, out);
         if (onSuccess == null) {
+            appendPromiseExpression(builder, out);
             return;
         }
-        StateNode hostNode = builder.trigger().getHost().getNode();
-        ReturnChannelRegistration channel = channelByNode.computeIfAbsent(
-                hostNode, node -> node.getFeature(ReturnChannelMap.class)
+        String observe = builder.capture(OBSERVE_PROMISE);
+        String channel = builder
+                .capture(channelFor(builder.trigger().getHost().getNode()));
+        out.append(observe).append('(');
+        appendPromiseExpression(builder, out);
+        out.append(", ").append(channel).append(')');
+    }
+
+    private ReturnChannelRegistration channelFor(StateNode hostNode) {
+        return channelByNode.computeIfAbsent(hostNode,
+                node -> node.getFeature(ReturnChannelMap.class)
                         .registerChannel(this::dispatch));
-        String channelRef = builder.capture(channel);
-        out.append(".then(()=>").append(channelRef).append("(true,null))")
-                .append(".catch(e=>").append(channelRef)
-                .append("(false, e && e.message ? e.message : String(e)))");
     }
 
     private void dispatch(ArrayNode args) {
@@ -134,14 +152,20 @@ public abstract class PromiseAction extends Action {
         // are non-null at the point of dispatch.
         SerializableRunnable success = Objects.requireNonNull(onSuccess);
         SerializableConsumer<String> error = Objects.requireNonNull(onError);
-        boolean succeeded = !args.isEmpty() && args.get(0).asBoolean(false);
-        if (succeeded) {
+        Outcome outcome = JacksonUtils.readValue(args.get(0), Outcome.class);
+        if (outcome.ok()) {
             success.run();
         } else {
-            String message = (args.size() > 1 && !args.get(1).isNull())
-                    ? args.get(1).asString()
-                    : "";
-            error.accept(message);
+            error.accept(outcome.error() == null ? "" : outcome.error());
         }
+    }
+
+    /**
+     * Wire shape exchanged between {@link #OBSERVE_PROMISE} and
+     * {@link #dispatch}. {@code error} is only meaningful when
+     * {@code ok == false}.
+     */
+    private record Outcome(boolean ok,
+            @Nullable String error) implements Serializable {
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/PromiseAction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/PromiseAction.java
@@ -200,10 +200,9 @@ public abstract class PromiseAction extends Action {
     /**
      * Information delivered to the {@code onError} consumer after the promise
      * rejects. {@link #name()} carries the rejection's class name — typically a
-     * {@code DOMException} like {@code "NotAllowedError"},
-     * {@code "AbortError"}, … — which is what callers usually switch on.
-     * {@link #message()} carries the free-form description and is best used for
-     * logging or display.
+     * {@code DOMException} like {@code "NotAllowedError"} — which is what
+     * callers usually switch on. {@link #message()} carries the free-form
+     * description and is best used for logging or display.
      *
      * @param name
      *            the rejection's {@code name} property, or the empty string if

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/RequestFullscreenAction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/RequestFullscreenAction.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.trigger.internal;
+
+import java.util.Objects;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.function.SerializableRunnable;
+
+/**
+ * Asks the browser to fullscreen the target component's root element via
+ * {@code Element.requestFullscreen()} when the bound trigger fires.
+ * <p>
+ * The Fullscreen API requires transient user activation (a click, key press, …)
+ * — calling {@code requestFullscreen} from a server push or constructor is
+ * rejected by the browser. Bind this action to a {@link Trigger} that fires
+ * during such a gesture, typically a {@link ClickTrigger}, so the call happens
+ * synchronously inside the handler and inherits the gesture.
+ * <p>
+ * Note that fullscreening an arbitrary component element does not interact well
+ * with Vaadin theming or overlay components — those expect the fullscreen
+ * element to be {@code document.documentElement}. This action is intentionally
+ * low-level; the higher-level {@code Component.requestFullscreen()} facade
+ * handles the wrapping needed for full Vaadin compatibility.
+ * <p>
+ * Outcome handling is inherited from {@link PromiseAction}: use the target-only
+ * constructor for fire-and-forget, or the overload taking
+ * {@code onSuccess}/{@code onError} consumers to react to the
+ * {@code requestFullscreen} promise on the UI thread.
+ *
+ * <pre>{@code
+ * RequestFullscreenAction goFs = new RequestFullscreenAction(panel,
+ *         () -> notification.show("Fullscreen entered"),
+ *         err -> notification.show("Fullscreen denied: " + err));
+ * new ClickTrigger(button).triggers(goFs);
+ * }</pre>
+ *
+ * For internal use only. May be renamed or removed in a future release.
+ */
+public class RequestFullscreenAction extends PromiseAction {
+
+    private final Element target;
+
+    /**
+     * Creates a fire-and-forget fullscreen action: the rendered JS just calls
+     * {@code requestFullscreen()} and the server never sees the outcome.
+     *
+     * @param target
+     *            the component whose root element to fullscreen, not
+     *            {@code null}
+     */
+    public RequestFullscreenAction(Component target) {
+        super();
+        this.target = Objects.requireNonNull(target, "target must not be null")
+                .getElement();
+    }
+
+    /**
+     * Creates a fullscreen action whose outcome is reported back to the server
+     * via {@code onSuccess}/{@code onError}. See {@link PromiseAction} for the
+     * contract on both consumers.
+     *
+     * @param target
+     *            the component whose root element to fullscreen, not
+     *            {@code null}
+     * @param onSuccess
+     *            invoked on the UI thread after the client reports
+     *            {@code requestFullscreen} resolved, not {@code null}
+     * @param onError
+     *            invoked on the UI thread with the browser's error message
+     *            after the client reports {@code requestFullscreen} rejected,
+     *            not {@code null}
+     */
+    public RequestFullscreenAction(Component target,
+            SerializableRunnable onSuccess,
+            SerializableConsumer<String> onError) {
+        super(onSuccess, onError);
+        this.target = Objects.requireNonNull(target, "target must not be null")
+                .getElement();
+    }
+
+    @Override
+    protected void appendPromiseExpression(JsBuilder builder,
+            StringBuilder out) {
+        out.append(builder.reference(target)).append(".requestFullscreen()");
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/RequestFullscreenAction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/RequestFullscreenAction.java
@@ -32,21 +32,27 @@ import com.vaadin.flow.function.SerializableRunnable;
  * during such a gesture, typically a {@link ClickTrigger}, so the call happens
  * synchronously inside the handler and inherits the gesture.
  * <p>
- * Note that fullscreening an arbitrary component element does not interact well
- * with Vaadin theming or overlay components — those expect the fullscreen
- * element to be {@code document.documentElement}. This action is intentionally
- * low-level; the higher-level {@code Component.requestFullscreen()} facade
- * handles the wrapping needed for full Vaadin compatibility.
+ * This action is intentionally low-level: it calls {@code requestFullscreen}
+ * directly on the target's root element. That doesn't interact well with Vaadin
+ * theming or overlay components, which expect the fullscreen element to be
+ * {@code document.documentElement}. A higher-level
+ * {@code Component.requestFullscreen()} facade — see PR vaadin/flow#24326 —
+ * handles the wrapping needed for full Vaadin compatibility; this action is the
+ * trigger-framework primitive it builds on (or a direct option when the Vaadin
+ * wrapping isn't needed).
  * <p>
- * Outcome handling is inherited from {@link PromiseAction}: use the target-only
+ * Outcome handling extends {@link PromiseAction}: use the target-only
  * constructor for fire-and-forget, or the overload taking
- * {@code onSuccess}/{@code onError} consumers to react to the
- * {@code requestFullscreen} promise on the UI thread.
+ * {@code onSuccess}/{@code onError} consumers. The promise resolves with
+ * {@code undefined} so {@code onSuccess} carries no value, but {@code onError}
+ * receives a {@link PromiseAction.Error} record with the browser's error name
+ * and message — useful for distinguishing e.g. {@code NotAllowedError} (no
+ * gesture / permissions policy) from {@code AbortError}.
  *
  * <pre>{@code
  * RequestFullscreenAction goFs = new RequestFullscreenAction(panel,
  *         () -> notification.show("Fullscreen entered"),
- *         err -> notification.show("Fullscreen denied: " + err));
+ *         err -> notification.show("Fullscreen denied: " + err.message()));
  * new ClickTrigger(button).triggers(goFs);
  * }</pre>
  *
@@ -71,9 +77,7 @@ public class RequestFullscreenAction extends PromiseAction {
     }
 
     /**
-     * Creates a fullscreen action whose outcome is reported back to the server
-     * via {@code onSuccess}/{@code onError}. See {@link PromiseAction} for the
-     * contract on both consumers.
+     * Creates a fullscreen action whose outcome is reported back to the server.
      *
      * @param target
      *            the component whose root element to fullscreen, not
@@ -82,14 +86,14 @@ public class RequestFullscreenAction extends PromiseAction {
      *            invoked on the UI thread after the client reports
      *            {@code requestFullscreen} resolved, not {@code null}
      * @param onError
-     *            invoked on the UI thread with the browser's error message
-     *            after the client reports {@code requestFullscreen} rejected,
-     *            not {@code null}
+     *            invoked on the UI thread with the browser's error after the
+     *            client reports {@code requestFullscreen} rejected, not
+     *            {@code null}
      */
     public RequestFullscreenAction(Component target,
             SerializableRunnable onSuccess,
-            SerializableConsumer<String> onError) {
-        super(onSuccess, onError);
+            SerializableConsumer<Error> onError) {
+        super(adaptOnSuccess(onSuccess), onError);
         this.target = Objects.requireNonNull(target, "target must not be null")
                 .getElement();
     }
@@ -98,5 +102,11 @@ public class RequestFullscreenAction extends PromiseAction {
     protected void appendPromiseExpression(JsBuilder builder,
             StringBuilder out) {
         out.append(builder.reference(target)).append(".requestFullscreen()");
+    }
+
+    private static SerializableConsumer<Success> adaptOnSuccess(
+            SerializableRunnable onSuccess) {
+        Objects.requireNonNull(onSuccess, "onSuccess must not be null");
+        return success -> onSuccess.run();
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/RequestFullscreenAction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/RequestFullscreenAction.java
@@ -46,8 +46,8 @@ import com.vaadin.flow.function.SerializableRunnable;
  * {@code onSuccess}/{@code onError} consumers. The promise resolves with
  * {@code undefined} so {@code onSuccess} carries no value, but {@code onError}
  * receives a {@link PromiseAction.Error} record with the browser's error name
- * and message — useful for distinguishing e.g. {@code NotAllowedError} (no
- * gesture / permissions policy) from {@code AbortError}.
+ * and message — the spec-documented rejection is {@code NotAllowedError} (no
+ * gesture / permissions policy).
  *
  * <pre>{@code
  * RequestFullscreenAction goFs = new RequestFullscreenAction(panel,

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/SetPropertyAction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/SetPropertyAction.java
@@ -53,13 +53,31 @@ import com.vaadin.flow.dom.Element;
  */
 public class SetPropertyAction<T> extends Action {
 
+    /**
+     * Singleton input emitting the JS literal {@code null}. Used by the
+     * {@link #SetPropertyAction(Component, String, Object) null-accepting
+     * convenience constructor} so {@link LiteralInput} can stay non-null.
+     */
+    private static final Action.Input<Object> NULL_LITERAL = new Action.Input<>() {
+        @Override
+        protected void appendExpression(JsBuilder builder, StringBuilder out) {
+            out.append("null");
+        }
+    };
+
+    @SuppressWarnings("unchecked")
+    private static <T> Action.Input<T> nullLiteral() {
+        return (Action.Input<T>) NULL_LITERAL;
+    }
+
     private final Element target;
     private final String propertyName;
     private final Action.Input<? extends T> source;
 
     /**
      * Creates an action that assigns the given literal value to the given JS
-     * property on {@code target} when the trigger fires.
+     * property on {@code target} when the trigger fires. Passing {@code null}
+     * clears the property (renders {@code target[prop] = null;}).
      *
      * @param target
      *            the component whose root element to modify, not {@code null}
@@ -68,11 +86,13 @@ public class SetPropertyAction<T> extends Action {
      * @param value
      *            the value to assign — {@code String}, {@code Boolean},
      *            {@code Number}, or any Jackson-serialisable object; may be
-     *            {@code null}
+     *            {@code null} to emit a JS {@code null} (e.g. to clear an
+     *            input's value)
      */
     public SetPropertyAction(Component target, String propertyName,
             @Nullable T value) {
-        this(target, propertyName, new LiteralInput<>(value));
+        this(target, propertyName,
+                value == null ? nullLiteral() : new LiteralInput<>(value));
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/CopyTextToClipboardActionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/CopyTextToClipboardActionTest.java
@@ -48,7 +48,7 @@ class CopyTextToClipboardActionTest {
     }
 
     @Test
-    void withCallbacks_handlerJsWrapsWriteTextWithThenCatch() {
+    void withCallbacks_handlerCallsObserverWithWriteTextPromise() {
         UI ui = new MockUI();
         TagComponent button = new TagComponent("button");
         TagComponent field = new TagComponent("input");
@@ -63,12 +63,10 @@ class CopyTextToClipboardActionTest {
 
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
 
-        String body = handlerOf(singleInstallFn(ui)).getBody();
-        assertTrue(
-                body.startsWith("navigator.clipboard.writeText($0[\"value\"])"),
-                body);
-        assertTrue(body.contains(".then("), body);
-        assertTrue(body.contains(".catch("), body);
+        // $0 = OBSERVE_PROMISE JsFunction, $1 = return channel, $2 = field;
+        // the .then/.catch glue lives inside $0, not in the handler body.
+        assertEquals("$0(navigator.clipboard.writeText($2[\"value\"]), $1);",
+                handlerOf(singleInstallFn(ui)).getBody());
     }
 
     private static JsFunction singleInstallFn(UI ui) {

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/CopyTextToClipboardActionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/CopyTextToClipboardActionTest.java
@@ -48,6 +48,26 @@ class CopyTextToClipboardActionTest {
     }
 
     @Test
+    void fireAndForget_literalInput_encodesValueAsJsonLiteral() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        ui.getElement().appendChild(button.getElement());
+
+        new DomEventTrigger(button, "click")
+                .triggers(new CopyTextToClipboardAction(
+                        new LiteralInput<>("hello \"world\"\n")));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        // The literal is JSON-encoded, so the quotes and newline inside are
+        // escaped — proves callers can't accidentally break out of the
+        // string by passing values that contain quotes or newlines.
+        assertEquals(
+                "navigator.clipboard.writeText(\"hello \\\"world\\\"\\n\");",
+                handlerOf(singleInstallFn(ui)).getBody());
+    }
+
+    @Test
     void withCallbacks_handlerCallsObserverWithWriteTextPromise() {
         UI ui = new MockUI();
         TagComponent button = new TagComponent("button");

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/CopyTextToClipboardActionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/CopyTextToClipboardActionTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.trigger.internal;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
+import com.vaadin.flow.component.internal.UIInternals.JavaScriptInvocation;
+import com.vaadin.flow.dom.JsFunction;
+import com.vaadin.tests.util.MockUI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CopyTextToClipboardActionTest {
+
+    @Test
+    void fireAndForget_handlerJsIsPlainWriteText() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        TagComponent field = new TagComponent("input");
+        ui.getElement().appendChild(button.getElement(), field.getElement());
+
+        new DomEventTrigger(button, "click")
+                .triggers(new CopyTextToClipboardAction(
+                        new PropertyInput<>(field, "value", String.class)));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        assertEquals("navigator.clipboard.writeText($0[\"value\"]);",
+                handlerOf(singleInstallFn(ui)).getBody());
+    }
+
+    @Test
+    void withCallbacks_handlerJsWrapsWriteTextWithThenCatch() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        TagComponent field = new TagComponent("input");
+        ui.getElement().appendChild(button.getElement(), field.getElement());
+
+        new DomEventTrigger(button, "click")
+                .triggers(new CopyTextToClipboardAction(
+                        new PropertyInput<>(field, "value", String.class),
+                        () -> {
+                        }, err -> {
+                        }));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        String body = handlerOf(singleInstallFn(ui)).getBody();
+        assertTrue(
+                body.startsWith("navigator.clipboard.writeText($0[\"value\"])"),
+                body);
+        assertTrue(body.contains(".then("), body);
+        assertTrue(body.contains(".catch("), body);
+    }
+
+    private static JsFunction singleInstallFn(UI ui) {
+        List<PendingJavaScriptInvocation> pending = ui.getInternals()
+                .dumpPendingJavaScriptInvocations();
+        assertEquals(1, pending.size(), "Expected exactly one pending JS");
+        return installFn(pending.get(0).getInvocation());
+    }
+
+    private static JsFunction installFn(JavaScriptInvocation invocation) {
+        Object o = invocation.getParameters().get(2);
+        assertTrue(o instanceof JsFunction, "Expected $2 to be a JsFunction");
+        return (JsFunction) o;
+    }
+
+    private static JsFunction handlerOf(JsFunction installFn) {
+        Object o = installFn.getCaptures().get(0);
+        assertTrue(o instanceof JsFunction,
+                "Expected install $0 to be the handler JsFunction");
+        return (JsFunction) o;
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/CopyTextToClipboardActionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/CopyTextToClipboardActionTest.java
@@ -15,14 +15,19 @@
  */
 package com.vaadin.flow.component.trigger.internal;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
 import com.vaadin.flow.component.internal.UIInternals.JavaScriptInvocation;
 import com.vaadin.flow.dom.JsFunction;
+import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.flow.internal.nodefeature.ReturnChannelRegistration;
 import com.vaadin.tests.util.MockUI;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -43,7 +48,10 @@ class CopyTextToClipboardActionTest {
 
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
 
-        assertEquals("navigator.clipboard.writeText($0[\"value\"]);",
+        // Fire-and-forget uses the simple writeText call — no IIFE wrap
+        // because the resolved value isn't needed.
+        assertEquals(
+                "((v) => navigator.clipboard.writeText(v).then(() => v))($0[\"value\"]);",
                 handlerOf(singleInstallFn(ui)).getBody());
     }
 
@@ -63,7 +71,7 @@ class CopyTextToClipboardActionTest {
         // escaped — proves callers can't accidentally break out of the
         // string by passing values that contain quotes or newlines.
         assertEquals(
-                "navigator.clipboard.writeText(\"hello \\\"world\\\"\\n\");",
+                "((v) => navigator.clipboard.writeText(v).then(() => v))(\"hello \\\"world\\\"\\n\");",
                 handlerOf(singleInstallFn(ui)).getBody());
     }
 
@@ -77,16 +85,80 @@ class CopyTextToClipboardActionTest {
         new DomEventTrigger(button, "click")
                 .triggers(new CopyTextToClipboardAction(
                         new PropertyInput<>(field, "value", String.class),
-                        () -> {
+                        copied -> {
                         }, err -> {
                         }));
 
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
 
         // $0 = OBSERVE_PROMISE JsFunction, $1 = return channel, $2 = field;
-        // the .then/.catch glue lives inside $0, not in the handler body.
-        assertEquals("$0(navigator.clipboard.writeText($2[\"value\"]), $1);",
+        // the IIFE binds the text to v so the promise resolves with the
+        // copied value.
+        assertEquals(
+                "$0(((v) => navigator.clipboard.writeText(v).then(() => v))($2[\"value\"]), $1);",
                 handlerOf(singleInstallFn(ui)).getBody());
+    }
+
+    @Test
+    void onCopied_receivesTheStringFromTheResolvedPromise() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        TagComponent field = new TagComponent("input");
+        ui.getElement().appendChild(button.getElement(), field.getElement());
+
+        List<String> copied = new ArrayList<>();
+        new DomEventTrigger(button, "click")
+                .triggers(new CopyTextToClipboardAction(
+                        new PropertyInput<>(field, "value", String.class),
+                        copied::add, err -> {
+                        }));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        ObjectNode outcome = JacksonUtils.createObjectNode();
+        outcome.put("ok", true);
+        outcome.put("value", "hello clipboard");
+        ArrayNode args = JacksonUtils.createArrayNode();
+        args.add(outcome);
+        singleReturnChannel(ui).invoke(args);
+
+        assertEquals(List.of("hello clipboard"), copied);
+    }
+
+    @Test
+    void onCopied_receivesEmptyStringWhenJsResolvedWithoutValue() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        TagComponent field = new TagComponent("input");
+        ui.getElement().appendChild(button.getElement(), field.getElement());
+
+        List<String> copied = new ArrayList<>();
+        new DomEventTrigger(button, "click")
+                .triggers(new CopyTextToClipboardAction(
+                        new PropertyInput<>(field, "value", String.class),
+                        copied::add, err -> {
+                        }));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        ObjectNode outcome = JacksonUtils.createObjectNode();
+        outcome.put("ok", true);
+        // No "value" field — defensive: don't blow up, treat as empty.
+        ArrayNode args = JacksonUtils.createArrayNode();
+        args.add(outcome);
+        singleReturnChannel(ui).invoke(args);
+
+        assertEquals(List.of(""), copied);
+    }
+
+    private static ReturnChannelRegistration singleReturnChannel(UI ui) {
+        List<ReturnChannelRegistration> channels = handlerOf(
+                singleInstallFn(ui)).getCaptures().stream()
+                .filter(o -> o instanceof ReturnChannelRegistration)
+                .map(o -> (ReturnChannelRegistration) o).toList();
+        assertEquals(1, channels.size(),
+                "Expected exactly one captured return channel");
+        return channels.get(0);
     }
 
     private static JsFunction singleInstallFn(UI ui) {

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/PromiseActionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/PromiseActionTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ArrayNode;
 import tools.jackson.databind.node.ObjectNode;
 
@@ -28,13 +29,14 @@ import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
 import com.vaadin.flow.component.internal.UIInternals.JavaScriptInvocation;
 import com.vaadin.flow.dom.JsFunction;
 import com.vaadin.flow.function.SerializableConsumer;
-import com.vaadin.flow.function.SerializableRunnable;
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.internal.nodefeature.ReturnChannelRegistration;
 import com.vaadin.tests.util.MockUI;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PromiseActionTest {
@@ -65,7 +67,7 @@ class PromiseActionTest {
         ui.getElement().appendChild(button.getElement());
 
         new DomEventTrigger(button, "click")
-                .triggers(new StubPromiseAction(() -> {
+                .triggers(new StubPromiseAction(s -> {
                 }, err -> {
                 }));
 
@@ -86,51 +88,85 @@ class PromiseActionTest {
     }
 
     @Test
-    void returnChannelInvocation_withOkOutcome_runsOnSuccess() {
+    void okChannelInvocation_withValue_runsOnSuccessWithJsonNode() {
         UI ui = new MockUI();
         TagComponent button = new TagComponent("button");
         ui.getElement().appendChild(button.getElement());
 
-        List<String> succeeded = new ArrayList<>();
-        List<String> failed = new ArrayList<>();
-        new DomEventTrigger(button, "click").triggers(
-                new StubPromiseAction(() -> succeeded.add("ok"), failed::add));
+        List<PromiseAction.Success> received = new ArrayList<>();
+        List<PromiseAction.Error> failed = new ArrayList<>();
+        new DomEventTrigger(button, "click")
+                .triggers(new StubPromiseAction(received::add, failed::add));
 
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
 
         ObjectNode outcome = JacksonUtils.createObjectNode();
         outcome.put("ok", true);
+        outcome.put("value", "hello");
         ArrayNode args = JacksonUtils.createArrayNode();
         args.add(outcome);
         singleReturnChannel(ui).invoke(args);
 
-        assertEquals(List.of("ok"), succeeded);
+        assertEquals(1, received.size());
+        JsonNode value = received.get(0).value();
+        assertNotNull(value,
+                "value should not be null when JS resolved with one");
+        assertEquals("hello", value.asString());
         assertEquals(List.of(), failed);
     }
 
     @Test
-    void returnChannelInvocation_withFailureOutcome_runsOnErrorWithMessage() {
+    void okChannelInvocation_withNoValue_runsOnSuccessWithNullValue() {
         UI ui = new MockUI();
         TagComponent button = new TagComponent("button");
         ui.getElement().appendChild(button.getElement());
 
-        List<String> succeeded = new ArrayList<>();
-        List<String> failed = new ArrayList<>();
-        new DomEventTrigger(button, "click").triggers(
-                new StubPromiseAction(() -> succeeded.add("ok"), failed::add));
+        List<PromiseAction.Success> received = new ArrayList<>();
+        new DomEventTrigger(button, "click")
+                .triggers(new StubPromiseAction(received::add, err -> {
+                }));
 
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
 
         ObjectNode outcome = JacksonUtils.createObjectNode();
+        outcome.put("ok", true);
+        // No "value" field — JS resolved with undefined.
+        ArrayNode args = JacksonUtils.createArrayNode();
+        args.add(outcome);
+        singleReturnChannel(ui).invoke(args);
+
+        assertEquals(1, received.size());
+        assertNull(received.get(0).value(),
+                "missing JS 'value' should surface as null on the server");
+    }
+
+    @Test
+    void errChannelInvocation_runsOnErrorWithNameAndMessage() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        ui.getElement().appendChild(button.getElement());
+
+        List<PromiseAction.Success> succeeded = new ArrayList<>();
+        List<PromiseAction.Error> failed = new ArrayList<>();
+        new DomEventTrigger(button, "click")
+                .triggers(new StubPromiseAction(succeeded::add, failed::add));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        ObjectNode error = JacksonUtils.createObjectNode();
+        error.put("name", "NotAllowedError");
+        error.put("message", "blocked by permission policy");
+        ObjectNode outcome = JacksonUtils.createObjectNode();
         outcome.put("ok", false);
-        outcome.put("error", "NotAllowedError: blocked by permission policy");
+        outcome.set("error", error);
         ArrayNode args = JacksonUtils.createArrayNode();
         args.add(outcome);
         singleReturnChannel(ui).invoke(args);
 
         assertEquals(List.of(), succeeded);
-        assertEquals(List.of("NotAllowedError: blocked by permission policy"),
-                failed);
+        assertEquals(1, failed.size());
+        assertEquals("NotAllowedError", failed.get(0).name());
+        assertEquals("blocked by permission policy", failed.get(0).message());
     }
 
     private static boolean captureContainsReturnChannel(JsFunction handler) {
@@ -174,8 +210,8 @@ class PromiseActionTest {
             super();
         }
 
-        StubPromiseAction(SerializableRunnable onSuccess,
-                SerializableConsumer<String> onError) {
+        StubPromiseAction(SerializableConsumer<Success> onSuccess,
+                SerializableConsumer<Error> onError) {
             super(onSuccess, onError);
         }
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/PromiseActionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/PromiseActionTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.trigger.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.node.ArrayNode;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
+import com.vaadin.flow.component.internal.UIInternals.JavaScriptInvocation;
+import com.vaadin.flow.dom.JsFunction;
+import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.function.SerializableRunnable;
+import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.flow.internal.nodefeature.ReturnChannelRegistration;
+import com.vaadin.tests.util.MockUI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PromiseActionTest {
+
+    private static final String PROMISE_EXPR = "Promise.resolve(42)";
+
+    @Test
+    void fireAndForget_handlerJsIsJustThePromise_noServerCallback() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        ui.getElement().appendChild(button.getElement());
+
+        new DomEventTrigger(button, "click").triggers(new StubPromiseAction());
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        JsFunction handler = handlerOf(singleInstallFn(ui));
+        assertEquals(PROMISE_EXPR + ";", handler.getBody(),
+                "fire-and-forget overload skips the round-trip");
+        assertFalse(captureContainsReturnChannel(handler),
+                "fire-and-forget overload captures no return channel");
+    }
+
+    @Test
+    void withCallbacks_handlerJsAppendsThenCatch_andCapturesReturnChannel() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        ui.getElement().appendChild(button.getElement());
+
+        new DomEventTrigger(button, "click")
+                .triggers(new StubPromiseAction(() -> {
+                }, err -> {
+                }));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        JsFunction handler = handlerOf(singleInstallFn(ui));
+        String body = handler.getBody();
+        assertTrue(body.startsWith(PROMISE_EXPR), body);
+        assertTrue(body.contains(".then(()=>$0(true,null))"), body);
+        assertTrue(body.contains(".catch(e=>$0(false, "), body);
+        assertTrue(captureContainsReturnChannel(handler),
+                "with callbacks a return channel is captured");
+    }
+
+    @Test
+    void returnChannelInvocation_withSuccess_runsOnSuccess() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        ui.getElement().appendChild(button.getElement());
+
+        List<String> succeeded = new ArrayList<>();
+        List<String> failed = new ArrayList<>();
+        new DomEventTrigger(button, "click").triggers(
+                new StubPromiseAction(() -> succeeded.add("ok"), failed::add));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        ReturnChannelRegistration channel = singleReturnChannel(ui);
+        ArrayNode args = JacksonUtils.createArrayNode();
+        args.add(true);
+        args.add(JacksonUtils.nullNode());
+        channel.invoke(args);
+
+        assertEquals(List.of("ok"), succeeded);
+        assertEquals(List.of(), failed);
+    }
+
+    @Test
+    void returnChannelInvocation_withFailure_runsOnErrorWithMessage() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        ui.getElement().appendChild(button.getElement());
+
+        List<String> succeeded = new ArrayList<>();
+        List<String> failed = new ArrayList<>();
+        new DomEventTrigger(button, "click").triggers(
+                new StubPromiseAction(() -> succeeded.add("ok"), failed::add));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        ReturnChannelRegistration channel = singleReturnChannel(ui);
+        ArrayNode args = JacksonUtils.createArrayNode();
+        args.add(false);
+        args.add("NotAllowedError: blocked by permission policy");
+        channel.invoke(args);
+
+        assertEquals(List.of(), succeeded);
+        assertEquals(List.of("NotAllowedError: blocked by permission policy"),
+                failed);
+    }
+
+    private static boolean captureContainsReturnChannel(JsFunction handler) {
+        return handler.getCaptures().stream()
+                .anyMatch(o -> o instanceof ReturnChannelRegistration);
+    }
+
+    private static ReturnChannelRegistration singleReturnChannel(UI ui) {
+        List<ReturnChannelRegistration> channels = handlerOf(
+                singleInstallFn(ui)).getCaptures().stream()
+                .filter(o -> o instanceof ReturnChannelRegistration)
+                .map(o -> (ReturnChannelRegistration) o).toList();
+        assertEquals(1, channels.size(),
+                "Expected exactly one captured return channel");
+        return channels.get(0);
+    }
+
+    private static JsFunction singleInstallFn(UI ui) {
+        List<PendingJavaScriptInvocation> pending = ui.getInternals()
+                .dumpPendingJavaScriptInvocations();
+        assertEquals(1, pending.size(), "Expected exactly one pending JS");
+        return installFn(pending.get(0).getInvocation());
+    }
+
+    private static JsFunction installFn(JavaScriptInvocation invocation) {
+        Object o = invocation.getParameters().get(2);
+        assertTrue(o instanceof JsFunction, "Expected $2 to be a JsFunction");
+        return (JsFunction) o;
+    }
+
+    private static JsFunction handlerOf(JsFunction installFn) {
+        Object o = installFn.getCaptures().get(0);
+        assertTrue(o instanceof JsFunction,
+                "Expected install $0 to be the handler JsFunction");
+        return (JsFunction) o;
+    }
+
+    /** Minimal PromiseAction that emits a constant promise expression. */
+    private static final class StubPromiseAction extends PromiseAction {
+        StubPromiseAction() {
+            super();
+        }
+
+        StubPromiseAction(SerializableRunnable onSuccess,
+                SerializableConsumer<String> onError) {
+            super(onSuccess, onError);
+        }
+
+        @Override
+        protected void appendPromiseExpression(JsBuilder builder,
+                StringBuilder out) {
+            out.append(PROMISE_EXPR);
+        }
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/PromiseActionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/PromiseActionTest.java
@@ -18,8 +18,10 @@ package com.vaadin.flow.component.trigger.internal;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
@@ -57,7 +59,7 @@ class PromiseActionTest {
     }
 
     @Test
-    void withCallbacks_handlerJsAppendsThenCatch_andCapturesReturnChannel() {
+    void withCallbacks_handlerJsCallsObserverWithPromiseAndChannel() {
         UI ui = new MockUI();
         TagComponent button = new TagComponent("button");
         ui.getElement().appendChild(button.getElement());
@@ -70,16 +72,21 @@ class PromiseActionTest {
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
 
         JsFunction handler = handlerOf(singleInstallFn(ui));
-        String body = handler.getBody();
-        assertTrue(body.startsWith(PROMISE_EXPR), body);
-        assertTrue(body.contains(".then(()=>$0(true,null))"), body);
-        assertTrue(body.contains(".catch(e=>$0(false, "), body);
-        assertTrue(captureContainsReturnChannel(handler),
-                "with callbacks a return channel is captured");
+        // Single function call: observer($promiseExpr, $channel).
+        // $0 = the static OBSERVE_PROMISE JsFunction, $1 = the return channel.
+        assertEquals("$0(" + PROMISE_EXPR + ", $1);", handler.getBody());
+
+        List<@Nullable Object> captures = handler.getCaptures();
+        assertEquals(2, captures.size(),
+                "expected observer + channel captures");
+        assertTrue(captures.get(0) instanceof JsFunction,
+                "first capture should be the observer JsFunction");
+        assertTrue(captures.get(1) instanceof ReturnChannelRegistration,
+                "second capture should be the return channel");
     }
 
     @Test
-    void returnChannelInvocation_withSuccess_runsOnSuccess() {
+    void returnChannelInvocation_withOkOutcome_runsOnSuccess() {
         UI ui = new MockUI();
         TagComponent button = new TagComponent("button");
         ui.getElement().appendChild(button.getElement());
@@ -91,18 +98,18 @@ class PromiseActionTest {
 
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
 
-        ReturnChannelRegistration channel = singleReturnChannel(ui);
+        ObjectNode outcome = JacksonUtils.createObjectNode();
+        outcome.put("ok", true);
         ArrayNode args = JacksonUtils.createArrayNode();
-        args.add(true);
-        args.add(JacksonUtils.nullNode());
-        channel.invoke(args);
+        args.add(outcome);
+        singleReturnChannel(ui).invoke(args);
 
         assertEquals(List.of("ok"), succeeded);
         assertEquals(List.of(), failed);
     }
 
     @Test
-    void returnChannelInvocation_withFailure_runsOnErrorWithMessage() {
+    void returnChannelInvocation_withFailureOutcome_runsOnErrorWithMessage() {
         UI ui = new MockUI();
         TagComponent button = new TagComponent("button");
         ui.getElement().appendChild(button.getElement());
@@ -114,11 +121,12 @@ class PromiseActionTest {
 
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
 
-        ReturnChannelRegistration channel = singleReturnChannel(ui);
+        ObjectNode outcome = JacksonUtils.createObjectNode();
+        outcome.put("ok", false);
+        outcome.put("error", "NotAllowedError: blocked by permission policy");
         ArrayNode args = JacksonUtils.createArrayNode();
-        args.add(false);
-        args.add("NotAllowedError: blocked by permission policy");
-        channel.invoke(args);
+        args.add(outcome);
+        singleReturnChannel(ui).invoke(args);
 
         assertEquals(List.of(), succeeded);
         assertEquals(List.of("NotAllowedError: blocked by permission policy"),

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/RequestFullscreenActionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/RequestFullscreenActionTest.java
@@ -62,7 +62,7 @@ class RequestFullscreenActionTest {
     }
 
     @Test
-    void withCallbacks_handlerJsWrapsRequestFullscreenWithThenCatch() {
+    void withCallbacks_handlerCallsObserverWithRequestFullscreenPromise() {
         UI ui = new MockUI();
         TagComponent button = new TagComponent("button");
         TagComponent panel = new TagComponent("div");
@@ -75,10 +75,10 @@ class RequestFullscreenActionTest {
 
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
 
-        String body = handlerOf(singleInstallFn(ui)).getBody();
-        assertTrue(body.startsWith("$0.requestFullscreen()"), body);
-        assertTrue(body.contains(".then("), body);
-        assertTrue(body.contains(".catch("), body);
+        // $0 = OBSERVE_PROMISE JsFunction, $1 = return channel, $2 = panel;
+        // the .then/.catch glue lives inside $0, not in the handler body.
+        assertEquals("$0($2.requestFullscreen(), $1);",
+                handlerOf(singleInstallFn(ui)).getBody());
     }
 
     private static JsFunction singleInstallFn(UI ui) {

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/RequestFullscreenActionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/RequestFullscreenActionTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.trigger.internal;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
+import com.vaadin.flow.component.internal.UIInternals.JavaScriptInvocation;
+import com.vaadin.flow.dom.JsFunction;
+import com.vaadin.tests.util.MockUI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RequestFullscreenActionTest {
+
+    @Test
+    void fireAndForget_handlerCallsRequestFullscreenOnTarget() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        TagComponent panel = new TagComponent("div");
+        ui.getElement().appendChild(button.getElement(), panel.getElement());
+
+        new DomEventTrigger(button, "click")
+                .triggers(new RequestFullscreenAction(panel));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        assertEquals("$0.requestFullscreen();",
+                handlerOf(singleInstallFn(ui)).getBody());
+    }
+
+    @Test
+    void targetEqualsHost_renderedAsThis() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        ui.getElement().appendChild(button.getElement());
+
+        new DomEventTrigger(button, "click")
+                .triggers(new RequestFullscreenAction(button));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        assertEquals("this.requestFullscreen();",
+                handlerOf(singleInstallFn(ui)).getBody());
+    }
+
+    @Test
+    void withCallbacks_handlerJsWrapsRequestFullscreenWithThenCatch() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        TagComponent panel = new TagComponent("div");
+        ui.getElement().appendChild(button.getElement(), panel.getElement());
+
+        new DomEventTrigger(button, "click")
+                .triggers(new RequestFullscreenAction(panel, () -> {
+                }, err -> {
+                }));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        String body = handlerOf(singleInstallFn(ui)).getBody();
+        assertTrue(body.startsWith("$0.requestFullscreen()"), body);
+        assertTrue(body.contains(".then("), body);
+        assertTrue(body.contains(".catch("), body);
+    }
+
+    private static JsFunction singleInstallFn(UI ui) {
+        List<PendingJavaScriptInvocation> pending = ui.getInternals()
+                .dumpPendingJavaScriptInvocations();
+        assertEquals(1, pending.size(), "Expected exactly one pending JS");
+        return installFn(pending.get(0).getInvocation());
+    }
+
+    private static JsFunction installFn(JavaScriptInvocation invocation) {
+        Object o = invocation.getParameters().get(2);
+        assertTrue(o instanceof JsFunction, "Expected $2 to be a JsFunction");
+        return (JsFunction) o;
+    }
+
+    private static JsFunction handlerOf(JsFunction installFn) {
+        Object o = installFn.getCaptures().get(0);
+        assertTrue(o instanceof JsFunction,
+                "Expected install $0 to be the handler JsFunction");
+        return (JsFunction) o;
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerCopyTextToClipboardView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerCopyTextToClipboardView.java
@@ -61,13 +61,14 @@ public class TriggerCopyTextToClipboardView extends AbstractDivView {
         Action.Input<String> value = new PropertyInput<>(field, "value",
                 String.class);
         CopyTextToClipboardAction copy = new CopyTextToClipboardAction(value,
-                () -> status.setText("ok"),
-                err -> status.setText("err:" + err));
+                copied -> status.setText("ok:" + copied), err -> status
+                        .setText("err:" + err.name() + ":" + err.message()));
         new ClickTrigger(copyButton).triggers(copy);
 
         CopyTextToClipboardAction copyStatic = new CopyTextToClipboardAction(
-                new LiteralInput<>(STATIC_TEXT), () -> status.setText("ok"),
-                err -> status.setText("err:" + err));
+                new LiteralInput<>(STATIC_TEXT),
+                copied -> status.setText("ok:" + copied), err -> status
+                        .setText("err:" + err.name() + ":" + err.message()));
         new ClickTrigger(copyStaticButton).triggers(copyStatic);
     }
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerCopyTextToClipboardView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerCopyTextToClipboardView.java
@@ -21,31 +21,42 @@ import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.trigger.internal.Action;
 import com.vaadin.flow.component.trigger.internal.ClickTrigger;
 import com.vaadin.flow.component.trigger.internal.CopyTextToClipboardAction;
+import com.vaadin.flow.component.trigger.internal.LiteralInput;
 import com.vaadin.flow.component.trigger.internal.PropertyInput;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 
 /**
- * Wires a {@link ClickTrigger} on a button to a
- * {@link CopyTextToClipboardAction} that copies the current value of an
- * {@link Input} to the clipboard. The action's success/error consumers write
- * the outcome into a status {@link Div} so the IT can assert both paths. The IT
- * replaces {@code navigator.clipboard.writeText} with a recording shim so the
- * assertions don't depend on browser clipboard permissions.
+ * Two buttons exercising {@link CopyTextToClipboardAction}: one copies the
+ * current value of an {@link Input} (via {@link PropertyInput}), the other
+ * copies a fixed string (via {@link LiteralInput}) that includes a quote and a
+ * newline to verify the JSON escaping round-trips through the browser. Each
+ * action's success/error consumers write the outcome into the status
+ * {@link Div}. The IT replaces {@code navigator.clipboard.writeText} with a
+ * recording shim so the assertions don't depend on browser clipboard
+ * permissions.
  */
 @Route(value = "com.vaadin.flow.uitest.ui.TriggerCopyTextToClipboardView", layout = ViewTestLayout.class)
 public class TriggerCopyTextToClipboardView extends AbstractDivView {
+
+    /**
+     * Literal copied by the {@code #copy-static} button — see the IT for the
+     * matching expected value.
+     */
+    static final String STATIC_TEXT = "hello \"world\"\n";
 
     @Override
     protected void onShow() {
         Input field = new Input();
         field.setId("source");
-        NativeButton copyButton = new NativeButton("Copy");
+        NativeButton copyButton = new NativeButton("Copy input value");
         copyButton.setId("copy");
+        NativeButton copyStaticButton = new NativeButton("Copy static text");
+        copyStaticButton.setId("copy-static");
         Div status = new Div();
         status.setId("status");
 
-        add(field, copyButton, status);
+        add(field, copyButton, copyStaticButton, status);
 
         Action.Input<String> value = new PropertyInput<>(field, "value",
                 String.class);
@@ -53,5 +64,10 @@ public class TriggerCopyTextToClipboardView extends AbstractDivView {
                 () -> status.setText("ok"),
                 err -> status.setText("err:" + err));
         new ClickTrigger(copyButton).triggers(copy);
+
+        CopyTextToClipboardAction copyStatic = new CopyTextToClipboardAction(
+                new LiteralInput<>(STATIC_TEXT), () -> status.setText("ok"),
+                err -> status.setText("err:" + err));
+        new ClickTrigger(copyStaticButton).triggers(copyStatic);
     }
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerCopyTextToClipboardView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerCopyTextToClipboardView.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Input;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.trigger.internal.Action;
+import com.vaadin.flow.component.trigger.internal.ClickTrigger;
+import com.vaadin.flow.component.trigger.internal.CopyTextToClipboardAction;
+import com.vaadin.flow.component.trigger.internal.PropertyInput;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+/**
+ * Wires a {@link ClickTrigger} on a button to a
+ * {@link CopyTextToClipboardAction} that copies the current value of an
+ * {@link Input} to the clipboard. The action's success/error consumers write
+ * the outcome into a status {@link Div} so the IT can assert both paths. The IT
+ * replaces {@code navigator.clipboard.writeText} with a recording shim so the
+ * assertions don't depend on browser clipboard permissions.
+ */
+@Route(value = "com.vaadin.flow.uitest.ui.TriggerCopyTextToClipboardView", layout = ViewTestLayout.class)
+public class TriggerCopyTextToClipboardView extends AbstractDivView {
+
+    @Override
+    protected void onShow() {
+        Input field = new Input();
+        field.setId("source");
+        NativeButton copyButton = new NativeButton("Copy");
+        copyButton.setId("copy");
+        Div status = new Div();
+        status.setId("status");
+
+        add(field, copyButton, status);
+
+        Action.Input<String> value = new PropertyInput<>(field, "value",
+                String.class);
+        CopyTextToClipboardAction copy = new CopyTextToClipboardAction(value,
+                () -> status.setText("ok"),
+                err -> status.setText("err:" + err));
+        new ClickTrigger(copyButton).triggers(copy);
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerRequestFullscreenView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerRequestFullscreenView.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.trigger.internal.ClickTrigger;
+import com.vaadin.flow.component.trigger.internal.RequestFullscreenAction;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+/**
+ * Wires a {@link ClickTrigger} on a button to a {@link RequestFullscreenAction}
+ * that requests fullscreen for a target {@link Div}. The action's success/error
+ * consumers write the outcome into a status div so the IT can assert both
+ * paths. The IT replaces {@code Element.prototype.requestFullscreen} with a
+ * recording shim so the assertions don't depend on browser fullscreen
+ * permissions (which CI Chrome routinely denies).
+ */
+@Route(value = "com.vaadin.flow.uitest.ui.TriggerRequestFullscreenView", layout = ViewTestLayout.class)
+public class TriggerRequestFullscreenView extends AbstractDivView {
+
+    @Override
+    protected void onShow() {
+        Div panel = new Div();
+        panel.setId("panel");
+        panel.setText("panel");
+        NativeButton goButton = new NativeButton("Fullscreen");
+        goButton.setId("go");
+        Div status = new Div();
+        status.setId("status");
+
+        add(panel, goButton, status);
+
+        RequestFullscreenAction goFs = new RequestFullscreenAction(panel,
+                () -> status.setText("ok"),
+                err -> status.setText("err:" + err));
+        new ClickTrigger(goButton).triggers(goFs);
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerRequestFullscreenView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerRequestFullscreenView.java
@@ -46,8 +46,8 @@ public class TriggerRequestFullscreenView extends AbstractDivView {
         add(panel, goButton, status);
 
         RequestFullscreenAction goFs = new RequestFullscreenAction(panel,
-                () -> status.setText("ok"),
-                err -> status.setText("err:" + err));
+                () -> status.setText("ok"), err -> status
+                        .setText("err:" + err.name() + ":" + err.message()));
         new ClickTrigger(goButton).triggers(goFs);
     }
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerCopyTextToClipboardIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerCopyTextToClipboardIT.java
@@ -48,6 +48,26 @@ public class TriggerCopyTextToClipboardIT extends ChromeBrowserTest {
     }
 
     @Test
+    public void clickCopiesStaticString_andTheLiteralRoundTripsVerbatim() {
+        open();
+        installResolvingClipboardShim();
+
+        WebElement button = findElement(By.id("copy-static"));
+        WebElement status = findElement(By.id("status"));
+
+        button.click();
+
+        // The Java-side literal (`hello "world"\n`) is JSON-encoded into the
+        // emitted JS at build time, so the value the browser receives back
+        // through the writeText shim is exactly the original String — quotes
+        // and newline intact.
+        Object copied = waitUntil(d -> ((JavascriptExecutor) d)
+                .executeScript("return window.__copied;"));
+        Assert.assertEquals(TriggerCopyTextToClipboardView.STATIC_TEXT, copied);
+        waitUntil(d -> "ok".equals(status.getText()));
+    }
+
+    @Test
     public void writeTextRejection_propagatesAsFailureToTheServer() {
         open();
         installRejectingClipboardShim();

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerCopyTextToClipboardIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerCopyTextToClipboardIT.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class TriggerCopyTextToClipboardIT extends ChromeBrowserTest {
+
+    @Test
+    public void clickCopiesValue_andServerReceivesSuccess() {
+        open();
+        installResolvingClipboardShim();
+
+        WebElement field = findElement(By.id("source"));
+        WebElement button = findElement(By.id("copy"));
+        WebElement status = findElement(By.id("status"));
+
+        ((JavascriptExecutor) getDriver()).executeScript(
+                "arguments[0].value = 'hello clipboard';", field);
+
+        button.click();
+
+        Object copied = waitUntil(d -> ((JavascriptExecutor) d)
+                .executeScript("return window.__copied;"));
+        Assert.assertEquals("hello clipboard", copied);
+
+        // Server-side completion listener writes the outcome into #status.
+        waitUntil(d -> "ok".equals(status.getText()));
+    }
+
+    @Test
+    public void writeTextRejection_propagatesAsFailureToTheServer() {
+        open();
+        installRejectingClipboardShim();
+
+        WebElement button = findElement(By.id("copy"));
+        WebElement status = findElement(By.id("status"));
+
+        button.click();
+
+        // Server-side completion listener reports the failure.
+        waitUntil(d -> status.getText() != null
+                && status.getText().startsWith("err:"));
+        Assert.assertTrue(status.getText().contains("DeniedByTest"));
+    }
+
+    private void installResolvingClipboardShim() {
+        ((JavascriptExecutor) getDriver())
+                .executeScript("window.__copied = null;"
+                        + "Object.defineProperty(navigator, 'clipboard', {"
+                        + "  configurable: true, value: {"
+                        + "    writeText: t => { window.__copied = t; return Promise.resolve(); }"
+                        + "  }" + "});");
+    }
+
+    private void installRejectingClipboardShim() {
+        ((JavascriptExecutor) getDriver())
+                .executeScript("Object.defineProperty(navigator, 'clipboard', {"
+                        + "  configurable: true, value: {"
+                        + "    writeText: t => Promise.reject(new Error('DeniedByTest'))"
+                        + "  }" + "});");
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerCopyTextToClipboardIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerCopyTextToClipboardIT.java
@@ -26,7 +26,7 @@ import com.vaadin.flow.testutil.ChromeBrowserTest;
 public class TriggerCopyTextToClipboardIT extends ChromeBrowserTest {
 
     @Test
-    public void clickCopiesValue_andServerReceivesSuccess() {
+    public void clickCopiesValue_andServerReceivesCopiedTextOnSuccess() {
         open();
         installResolvingClipboardShim();
 
@@ -43,8 +43,10 @@ public class TriggerCopyTextToClipboardIT extends ChromeBrowserTest {
                 .executeScript("return window.__copied;"));
         Assert.assertEquals("hello clipboard", copied);
 
-        // Server-side completion listener writes the outcome into #status.
-        waitUntil(d -> "ok".equals(status.getText()));
+        // onSuccess receives the copied string back from the resolved
+        // promise — the server learns what actually reached the clipboard
+        // even though the value came from a client-side PropertyInput.
+        waitUntil(d -> "ok:hello clipboard".equals(status.getText()));
     }
 
     @Test
@@ -64,11 +66,12 @@ public class TriggerCopyTextToClipboardIT extends ChromeBrowserTest {
         Object copied = waitUntil(d -> ((JavascriptExecutor) d)
                 .executeScript("return window.__copied;"));
         Assert.assertEquals(TriggerCopyTextToClipboardView.STATIC_TEXT, copied);
-        waitUntil(d -> "ok".equals(status.getText()));
+        waitUntil(d -> ("ok:" + TriggerCopyTextToClipboardView.STATIC_TEXT)
+                .equals(status.getText()));
     }
 
     @Test
-    public void writeTextRejection_propagatesAsFailureToTheServer() {
+    public void writeTextRejection_propagatesAsFailureWithNameAndMessage() {
         open();
         installRejectingClipboardShim();
 
@@ -77,10 +80,12 @@ public class TriggerCopyTextToClipboardIT extends ChromeBrowserTest {
 
         button.click();
 
-        // Server-side completion listener reports the failure.
+        // The shim throws a DOMException with name "NotAllowedError" so the
+        // server-side onError consumer sees both fields populated.
         waitUntil(d -> status.getText() != null
                 && status.getText().startsWith("err:"));
-        Assert.assertTrue(status.getText().contains("DeniedByTest"));
+        Assert.assertEquals("err:NotAllowedError:DeniedByTest",
+                status.getText());
     }
 
     private void installResolvingClipboardShim() {
@@ -96,7 +101,8 @@ public class TriggerCopyTextToClipboardIT extends ChromeBrowserTest {
         ((JavascriptExecutor) getDriver())
                 .executeScript("Object.defineProperty(navigator, 'clipboard', {"
                         + "  configurable: true, value: {"
-                        + "    writeText: t => Promise.reject(new Error('DeniedByTest'))"
+                        + "    writeText: t => Promise.reject("
+                        + "      new DOMException('DeniedByTest', 'NotAllowedError'))"
                         + "  }" + "});");
     }
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerCopyTextToClipboardIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerCopyTextToClipboardIT.java
@@ -55,7 +55,6 @@ public class TriggerCopyTextToClipboardIT extends ChromeBrowserTest {
         installResolvingClipboardShim();
 
         WebElement button = findElement(By.id("copy-static"));
-        WebElement status = findElement(By.id("status"));
 
         button.click();
 
@@ -66,8 +65,11 @@ public class TriggerCopyTextToClipboardIT extends ChromeBrowserTest {
         Object copied = waitUntil(d -> ((JavascriptExecutor) d)
                 .executeScript("return window.__copied;"));
         Assert.assertEquals(TriggerCopyTextToClipboardView.STATIC_TEXT, copied);
+        // `STATIC_TEXT` ends with `\n`; read raw textContent (Selenium's
+        // getText() collapses/trims whitespace and would drop it).
         waitUntil(d -> ("ok:" + TriggerCopyTextToClipboardView.STATIC_TEXT)
-                .equals(status.getText()));
+                .equals(((JavascriptExecutor) d).executeScript(
+                        "return document.getElementById('status').textContent;")));
     }
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerRequestFullscreenIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerRequestFullscreenIT.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class TriggerRequestFullscreenIT extends ChromeBrowserTest {
+
+    @Test
+    public void clickRequestsFullscreen_andServerReceivesSuccess() {
+        open();
+        installResolvingFullscreenShim();
+
+        WebElement button = findElement(By.id("go"));
+        WebElement status = findElement(By.id("status"));
+
+        button.click();
+
+        Boolean called = (Boolean) ((JavascriptExecutor) getDriver())
+                .executeScript("return window.__fsCalled === true;");
+        Assert.assertTrue("requestFullscreen shim should have been invoked",
+                called);
+
+        waitUntil(d -> "ok".equals(status.getText()));
+    }
+
+    @Test
+    public void requestFullscreenRejection_propagatesAsFailureToTheServer() {
+        open();
+        installRejectingFullscreenShim();
+
+        WebElement button = findElement(By.id("go"));
+        WebElement status = findElement(By.id("status"));
+
+        button.click();
+
+        waitUntil(d -> status.getText() != null
+                && status.getText().startsWith("err:"));
+        Assert.assertTrue(status.getText().contains("DeniedByTest"));
+    }
+
+    // Replace Element.prototype.requestFullscreen with a resolving shim so the
+    // IT doesn't depend on the browser actually granting fullscreen (which
+    // headless CI Chrome routinely denies).
+    private void installResolvingFullscreenShim() {
+        ((JavascriptExecutor) getDriver())
+                .executeScript("window.__fsCalled = false;"
+                        + "Element.prototype.requestFullscreen = function() {"
+                        + "  window.__fsCalled = true;"
+                        + "  return Promise.resolve();" + "};");
+    }
+
+    private void installRejectingFullscreenShim() {
+        ((JavascriptExecutor) getDriver()).executeScript(
+                "Element.prototype.requestFullscreen = function() {"
+                        + "  return Promise.reject(new Error('DeniedByTest'));"
+                        + "};");
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerRequestFullscreenIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerRequestFullscreenIT.java
@@ -44,7 +44,7 @@ public class TriggerRequestFullscreenIT extends ChromeBrowserTest {
     }
 
     @Test
-    public void requestFullscreenRejection_propagatesAsFailureToTheServer() {
+    public void requestFullscreenRejection_propagatesAsFailureWithNameAndMessage() {
         open();
         installRejectingFullscreenShim();
 
@@ -53,9 +53,12 @@ public class TriggerRequestFullscreenIT extends ChromeBrowserTest {
 
         button.click();
 
+        // The shim throws a DOMException with name "NotAllowedError" so the
+        // server-side onError consumer sees both fields populated.
         waitUntil(d -> status.getText() != null
                 && status.getText().startsWith("err:"));
-        Assert.assertTrue(status.getText().contains("DeniedByTest"));
+        Assert.assertEquals("err:NotAllowedError:DeniedByTest",
+                status.getText());
     }
 
     // Replace Element.prototype.requestFullscreen with a resolving shim so the
@@ -72,7 +75,8 @@ public class TriggerRequestFullscreenIT extends ChromeBrowserTest {
     private void installRejectingFullscreenShim() {
         ((JavascriptExecutor) getDriver()).executeScript(
                 "Element.prototype.requestFullscreen = function() {"
-                        + "  return Promise.reject(new Error('DeniedByTest'));"
+                        + "  return Promise.reject("
+                        + "    new DOMException('DeniedByTest', 'NotAllowedError'));"
                         + "};");
     }
 }


### PR DESCRIPTION
Adds a `PromiseAction` base class in the trigger framework and two concrete subclasses — `CopyTextToClipboardAction` and `RequestFullscreenAction` — on top of the executeJs-based trigger framework introduced in step 1.

`PromiseAction` is the generic primitive: many gesture-bound browser APIs are asynchronous (clipboard, fullscreen, file picker, share, payments, …) and follow the same shape — call the API, then handle the resolved value or the rejection. Subclasses override `appendPromiseExpression(JsBuilder, StringBuilder)` to emit the promise-yielding JS; the base wires the outcome reporting.

Two construction modes, mirroring the Geolocation API:

- No-arg `super()` — fire-and-forget; the rendered JS is just the promise expression and the server never sees the outcome.
- `super(onSuccess, onError)` — `onSuccess` runs after the promise resolves; `onError` receives the browser's error message after the promise rejects. Both run on the UI thread; both are required (pass `() -> {}` or `err -> {}` to opt out of one, matching the Geolocation pattern).

The with-outcome mode lazily registers one
`ReturnChannelRegistration` per trigger host node and appends `.then(()=>$N(true,null)).catch(e=>$N(false, msg))` to the promise expression, so the client invokes the channel after the promise resolves or rejects. `JsBuilder.capture(Object)` is the new package-private hook that lets actions allocate a `$N` placeholder for non-Element captures (the return channel here, which materialises client-side as a callable JS function).

Concrete subclasses:

- `CopyTextToClipboardAction` — supplies `navigator.clipboard.writeText(textExpr)` as the promise expression. Takes an `Action.Input<String>` for the text. Named verb-first so parallels like `CopyImageToClipboardAction` and `PasteFromClipboardAction` read naturally.
- `RequestFullscreenAction` — supplies `<target>.requestFullscreen()` as the promise expression. Takes a target `Component` whose root element will be fullscreened.

Both ITs (`TriggerCopyTextToClipboardView`/`IT`,
`TriggerRequestFullscreenView`/`IT`) shim the underlying browser API to resolving/rejecting promises and assert the server-side status div updates accordingly — avoiding dependence on browser clipboard / fullscreen permissions in CI.
