### PR TITLE
test: split TriggerTest into per-class tests

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/ClickTriggerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/ClickTriggerTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.trigger.internal;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
+import com.vaadin.flow.dom.JsFunction;
+import com.vaadin.tests.util.MockUI;
+
+import static com.vaadin.flow.component.trigger.internal.TriggerTestUtil.actionOf;
+import static com.vaadin.flow.component.trigger.internal.TriggerTestUtil.installFns;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ClickTriggerTest {
+
+    @Test
+    void screenCoordinates_renderEventProperties() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        TagComponent xField = new TagComponent("input");
+        TagComponent yField = new TagComponent("input");
+        ui.getElement().appendChild(button.getElement(), xField.getElement(),
+                yField.getElement());
+
+        ClickTrigger click = new ClickTrigger(button);
+        click.triggers(
+                new SetPropertyAction<>(xField, "value", click.screenX()),
+                new SetPropertyAction<>(yField, "value", click.screenY()));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        // HandlerInput renders as a JsFunction taking `event` and capturing
+        // the property name; the body itself is a constant.
+        List<JsFunction> installs = installFns(ui);
+        JsFunction source0 = (JsFunction) actionOf(installs.get(0))
+                .getCaptures().get(2);
+        assertEquals(List.of("event"), source0.getArgumentNames());
+        assertEquals("return event[$0]", source0.getBody());
+        assertEquals("screenX", source0.getCaptures().get(0));
+
+        JsFunction source1 = (JsFunction) actionOf(installs.get(1))
+                .getCaptures().get(2);
+        assertEquals("return event[$0]", source1.getBody());
+        assertEquals("screenY", source1.getCaptures().get(0));
+    }
+
+    @Test
+    void argumentFromOtherTrigger_isRejectedAtBuildTime() {
+        TagComponent button1 = new TagComponent("button");
+        TagComponent button2 = new TagComponent("button");
+        TagComponent field = new TagComponent("input");
+
+        ClickTrigger click1 = new ClickTrigger(button1);
+        ClickTrigger click2 = new ClickTrigger(button2);
+
+        // Input made by click1 cannot be used in click2's handler.
+        assertThrows(IllegalArgumentException.class, () -> click2.triggers(
+                new SetPropertyAction<>(field, "value", click1.screenX())));
+    }
+
+    @Test
+    void argumentUsedInOwningTrigger_acceptedAcrossMultipleTriggersCalls() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        TagComponent xField = new TagComponent("input");
+        TagComponent yField = new TagComponent("input");
+        ui.getElement().appendChild(button.getElement(), xField.getElement(),
+                yField.getElement());
+
+        ClickTrigger click = new ClickTrigger(button);
+        // Same Input instance used across two separate triggers() calls on
+        // its owning trigger.
+        Action.Input<Integer> x = click.screenX();
+        click.triggers(new SetPropertyAction<>(xField, "value", x));
+        click.triggers(new SetPropertyAction<>(yField, "value", x));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        List<PendingJavaScriptInvocation> pending = ui.getInternals()
+                .dumpPendingJavaScriptInvocations();
+        assertEquals(2, pending.size());
+    }
+
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/DomEventTriggerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/DomEventTriggerTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.trigger.internal;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.dom.JsFunction;
+import com.vaadin.tests.util.MockUI;
+
+import static com.vaadin.flow.component.trigger.internal.TriggerTestUtil.actionOf;
+import static com.vaadin.flow.component.trigger.internal.TriggerTestUtil.singleInstallFn;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class DomEventTriggerTest {
+
+    @Test
+    void setProperty_emitsAddEventListenerOnAttach() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        TagComponent field = new TagComponent("input");
+        ui.getElement().appendChild(button.getElement(), field.getElement());
+
+        new DomEventTrigger(button, "click")
+                .triggers(new SetPropertyAction<>(field, "value", ""));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        // Install JS references action at $0 and event name at $1 — no user
+        // content leaks into the body, both are captures.
+        JsFunction install = singleInstallFn(ui);
+        assertEquals(
+                "this.addEventListener($1, $0);"
+                        + "return () => this.removeEventListener($1, $0);",
+                install.getBody());
+        assertEquals("click", install.getCaptures().get(1));
+
+        // The install $0 is the action's JsFunction directly — no intermediate
+        // composed handler layer. The action is also the DOM event listener.
+        JsFunction action = actionOf(install);
+        assertEquals(List.of("event"), action.getArgumentNames());
+
+        // SetPropertyAction body shape; target captured as $0, property name
+        // string capture at $1, source JsFunction invoked as $2(event).
+        assertEquals("$0[$1] = $2(event)", action.getBody());
+        assertSame(field.getElement(), action.getCaptures().get(0));
+        assertEquals("value", action.getCaptures().get(1));
+    }
+
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/TriggerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/TriggerTest.java
@@ -35,39 +35,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class TriggerTest {
 
     @Test
-    void domEventTrigger_setProperty_emitsAddEventListenerOnAttach() {
-        UI ui = new MockUI();
-        TagComponent button = new TagComponent("button");
-        TagComponent field = new TagComponent("input");
-        ui.getElement().appendChild(button.getElement(), field.getElement());
-
-        new DomEventTrigger(button, "click")
-                .triggers(new SetPropertyAction<>(field, "value", ""));
-
-        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
-
-        // Install JS references action at $0 and event name at $1 — no user
-        // content leaks into the body, both are captures.
-        JsFunction install = singleInstallFn(ui);
-        assertEquals(
-                "this.addEventListener($1, $0);"
-                        + "return () => this.removeEventListener($1, $0);",
-                install.getBody());
-        assertEquals("click", install.getCaptures().get(1));
-
-        // The install $0 is the action's JsFunction directly — no intermediate
-        // composed handler layer. The action is also the DOM event listener.
-        JsFunction action = actionOf(install);
-        assertEquals(List.of("event"), action.getArgumentNames());
-
-        // SetPropertyAction body shape; target captured as $0, property name
-        // string capture at $1, source JsFunction invoked as $2(event).
-        assertEquals("$0[$1] = $2(event)", action.getBody());
-        assertSame(field.getElement(), action.getCaptures().get(0));
-        assertEquals("value", action.getCaptures().get(1));
-    }
-
-    @Test
     void multipleActions_eachInstalledAsItsOwnListener() {
         UI ui = new MockUI();
         TagComponent button = new TagComponent("button");
@@ -188,74 +155,6 @@ class TriggerTest {
         DomEventTrigger trigger = new DomEventTrigger(button, "click");
         assertThrows(IllegalArgumentException.class,
                 () -> trigger.triggers(new Action[0]));
-    }
-
-    @Test
-    void clickTrigger_screenCoordinates_renderEventProperties() {
-        UI ui = new MockUI();
-        TagComponent button = new TagComponent("button");
-        TagComponent xField = new TagComponent("input");
-        TagComponent yField = new TagComponent("input");
-        ui.getElement().appendChild(button.getElement(), xField.getElement(),
-                yField.getElement());
-
-        ClickTrigger click = new ClickTrigger(button);
-        click.triggers(
-                new SetPropertyAction<>(xField, "value", click.screenX()),
-                new SetPropertyAction<>(yField, "value", click.screenY()));
-
-        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
-
-        // HandlerInput renders as a JsFunction taking `event` and capturing
-        // the property name; the body itself is a constant.
-        List<JsFunction> installs = installFns(ui);
-        JsFunction source0 = (JsFunction) actionOf(installs.get(0))
-                .getCaptures().get(2);
-        assertEquals(List.of("event"), source0.getArgumentNames());
-        assertEquals("return event[$0]", source0.getBody());
-        assertEquals("screenX", source0.getCaptures().get(0));
-
-        JsFunction source1 = (JsFunction) actionOf(installs.get(1))
-                .getCaptures().get(2);
-        assertEquals("return event[$0]", source1.getBody());
-        assertEquals("screenY", source1.getCaptures().get(0));
-    }
-
-    @Test
-    void argumentFromOtherTrigger_isRejectedAtBuildTime() {
-        TagComponent button1 = new TagComponent("button");
-        TagComponent button2 = new TagComponent("button");
-        TagComponent field = new TagComponent("input");
-
-        ClickTrigger click1 = new ClickTrigger(button1);
-        ClickTrigger click2 = new ClickTrigger(button2);
-
-        // Input made by click1 cannot be used in click2's handler.
-        assertThrows(IllegalArgumentException.class, () -> click2.triggers(
-                new SetPropertyAction<>(field, "value", click1.screenX())));
-    }
-
-    @Test
-    void argumentUsedInOwningTrigger_acceptedAcrossMultipleTriggersCalls() {
-        UI ui = new MockUI();
-        TagComponent button = new TagComponent("button");
-        TagComponent xField = new TagComponent("input");
-        TagComponent yField = new TagComponent("input");
-        ui.getElement().appendChild(button.getElement(), xField.getElement(),
-                yField.getElement());
-
-        ClickTrigger click = new ClickTrigger(button);
-        // Same Input instance used across two separate triggers() calls on
-        // its owning trigger.
-        Action.Input<Integer> x = click.screenX();
-        click.triggers(new SetPropertyAction<>(xField, "value", x));
-        click.triggers(new SetPropertyAction<>(yField, "value", x));
-
-        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
-
-        List<PendingJavaScriptInvocation> pending = ui.getInternals()
-                .dumpPendingJavaScriptInvocations();
-        assertEquals(2, pending.size());
     }
 
 }


### PR DESCRIPTION
  ## Summary

  - Split `TriggerTest` so each test class exercises a single subject: generic `Trigger` contract tests stay in `TriggerTest`, `DomEventTrigger`-specific
  install behavior moves to a new `DomEventTriggerTest`, and `ClickTrigger`-specific tests move to a new `ClickTriggerTest`.

  ## Details

  - `TriggerTest` now covers only the abstract `Trigger` contract: multi-action installs, per-action element capture, host-as-target capture, multiple
  `triggers()` calls, `remove()` dispose emission, and the empty-actions rejection. It uses `DomEventTrigger` purely as a concrete instantiation.
  - `DomEventTriggerTest` holds the test that asserts `DomEventTrigger.install()` emits the `addEventListener`/`removeEventListener` install body with the
  action at `$0` and the event name at `$1`.
  - `ClickTriggerTest` holds the `screenX`/`screenY` rendering test and the two `Input`-scoping tests that use `ClickTrigger.screenX()` as the input source
   (cross-trigger rejection, same-trigger reuse across multiple `triggers()` calls).

Related-to https://github.com/vaadin/flow/pull/24361
