### PR TITLE
refactor: Various refactor proposals to trigger framework API

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/HandlerInput.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/HandlerInput.java
@@ -44,9 +44,13 @@ final class HandlerInput<T> extends Action.Input<T> {
     @Override
     protected void appendExpression(JsBuilder builder, StringBuilder out) {
         if (builder.trigger() != owner) {
-            throw new IllegalArgumentException(
-                    "Input is scoped to a different trigger and cannot be"
-                            + " used here");
+            throw new IllegalArgumentException("Input '" + jsExpression
+                    + "' was created by " + owner.getClass().getSimpleName()
+                    + " and cannot be used in "
+                    + builder.trigger().getClass().getSimpleName()
+                    + "'s handler — the variable it references is not in scope"
+                    + " there. Obtain an equivalent input from the surrounding"
+                    + " trigger instead.");
         }
         out.append(jsExpression);
     }

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/JsBuilder.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/JsBuilder.java
@@ -38,7 +38,7 @@ import com.vaadin.flow.internal.JacksonUtils;
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  */
-final class JsBuilder implements Serializable {
+public final class JsBuilder implements Serializable {
 
     private final Trigger trigger;
     private final List<Object> params = new ArrayList<>();
@@ -50,10 +50,12 @@ final class JsBuilder implements Serializable {
 
     /**
      * The trigger this builder is collecting JS for. Used by handler-scoped
-     * arguments ({@link HandlerInput}) to refuse being rendered into a
-     * different trigger's handler.
+     * inputs ({@link HandlerInput}) to refuse being rendered into a different
+     * trigger's handler.
+     *
+     * @return the surrounding trigger, never {@code null}
      */
-    Trigger trigger() {
+    public Trigger trigger() {
         return trigger;
     }
 
@@ -61,8 +63,12 @@ final class JsBuilder implements Serializable {
      * Returns a JS expression that evaluates to the given element at runtime.
      * Returns {@code "this"} for the host; otherwise allocates a parameter
      * placeholder.
+     *
+     * @param element
+     *            the element to reference, not {@code null}
+     * @return the JS expression, never {@code null}
      */
-    String reference(Element element) {
+    public String reference(Element element) {
         if (element == trigger.getHost()) {
             return "this";
         }
@@ -88,8 +94,12 @@ final class JsBuilder implements Serializable {
      * Encodes a value as a JS literal via Jackson. Strings are JSON-quoted,
      * numbers/booleans/null become themselves, records and POJOs become JS
      * object literals.
+     *
+     * @param value
+     *            the value to encode, may be {@code null}
+     * @return the JS literal, never {@code null}
      */
-    static String json(@Nullable Object value) {
+    public static String json(@Nullable Object value) {
         return JacksonUtils.createNode(value).toString();
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/PropertyInput.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/PropertyInput.java
@@ -27,9 +27,9 @@ import com.vaadin.flow.dom.Element;
  * Common targets and properties:
  * <ul>
  * <li>{@code TextField.value} →
- * {@code new PropertyInput<>(textField, "value", String.class)}
+ * {@code new PropertyInput<String>(textField, "value")}
  * <li>{@code Checkbox.checked} →
- * {@code new PropertyInput<>(checkbox, "checked", Boolean.class)}
+ * {@code new PropertyInput<Boolean>(checkbox, "checked")}
  * </ul>
  *
  * <p>
@@ -51,14 +51,10 @@ public class PropertyInput<T> extends Action.Input<T> {
      *            the component to read from, not {@code null}
      * @param propertyName
      *            the JS property name, not {@code null}
-     * @param valueType
-     *            runtime type of the produced value, not {@code null}
      */
-    public PropertyInput(Component target, String propertyName,
-            Class<T> valueType) {
+    public PropertyInput(Component target, String propertyName) {
         this.target = Objects.requireNonNull(target).getElement();
         this.propertyName = Objects.requireNonNull(propertyName);
-        Objects.requireNonNull(valueType);
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/Trigger.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/Trigger.java
@@ -79,6 +79,13 @@ public abstract class Trigger implements Serializable {
      * Wires the given actions to this trigger. They run in the order given the
      * next time this trigger fires. Each call adds another wiring; the existing
      * ones are kept.
+     * <p>
+     * Each call installs one new browser-side listener that runs the supplied
+     * actions in sequence. Calling {@code triggers(a, b)} once and calling
+     * {@code triggers(a)} then {@code triggers(b)} produce the same observable
+     * behaviour, but the first installs one listener while the second installs
+     * two. Prefer one call with multiple actions when the actions naturally
+     * belong together.
      *
      * @param actions
      *            the actions to run, not {@code null} or empty


### PR DESCRIPTION
- JsBuilder is now public so external Action subclasses can call reference()/trigger()/json() through the visible type signature; the internal-only intent stays in the Javadoc.
- HandlerInput's scope-violation error names the offending input, the owning trigger, the current trigger, and points at the fix.
- PropertyInput drops the never-stored Class<T> parameter; the generic remains as a compile-time witness fixed at the call site.
- Trigger.triggers(...) Javadoc explains the cost difference between one call with multiple actions and multiple calls.
