### PR TITLE
feat: ClipboardReadAction + typed JsBuilder.callback primitive

### DIFF
--- a/flow-client/src/main/frontend/Clipboard.ts
+++ b/flow-client/src/main/frontend/Clipboard.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Textual clipboard payload sent to the server, matching the Java
+ * ClipboardPayload record.
+ */
+interface VaadinClipboardPayload {
+  text: string | null;
+  html: string | null;
+}
+
+/**
+ * Reads the first item from the system clipboard and returns its text/plain
+ * and text/html representations. Either field is {@code null} if the
+ * corresponding MIME type is not present.
+ *
+ * The caller is expected to be inside a transient user gesture and to have
+ * been granted the {@code clipboard-read} permission; otherwise
+ * {@code navigator.clipboard.read} rejects and this function propagates the
+ * rejection.
+ */
+async function readClipboardPayload(): Promise<VaadinClipboardPayload | null> {
+  const items = await navigator.clipboard.read();
+  if (!items.length) {
+    return null;
+  }
+  const item = items[0];
+  const get = async (type: string): Promise<string | null> =>
+    item.types.includes(type) ? (await item.getType(type)).text() : null;
+  return {
+    text: await get('text/plain'),
+    html: await get('text/html')
+  };
+}
+
+const $wnd = window as any;
+$wnd.Vaadin ??= {};
+$wnd.Vaadin.Flow ??= {};
+$wnd.Vaadin.Flow.clipboard = {
+  readPayload: readClipboardPayload
+};
+
+// Empty export to ensure TypeScript emits this as an ES module,
+// which is required for Vite to load it via import.
+export {};

--- a/flow-client/src/main/frontend/Flow.ts
+++ b/flow-client/src/main/frontend/Flow.ts
@@ -4,6 +4,7 @@ import {
   type ConnectionStateChangeListener,
   type ConnectionStateStore
 } from '@vaadin/common-frontend';
+import './Clipboard';
 import './Geolocation';
 import { currentVisibility } from './PageVisibility';
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/ClipboardPayload.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/ClipboardPayload.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.trigger.internal;
+
+import java.io.Serializable;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Textual clipboard contents delivered to {@link ClipboardReadAction}'s
+ * handler. Either field may be {@code null} if the corresponding MIME type was
+ * not present on the clipboard item.
+ * <p>
+ * For internal use only. May be renamed or removed in a future release.
+ *
+ * @param text
+ *            {@code text/plain} contents, or {@code null} if not present
+ * @param html
+ *            {@code text/html} contents, or {@code null} if not present
+ */
+public record ClipboardPayload(@Nullable String text,
+        @Nullable String html) implements Serializable {
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/ClipboardReadAction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/ClipboardReadAction.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.trigger.internal;
+
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+
+import com.vaadin.flow.function.SerializableConsumer;
+
+/**
+ * Reads the user's clipboard via {@code navigator.clipboard.read()} when the
+ * bound trigger fires and delivers the textual contents to the handler on the
+ * UI thread.
+ * <p>
+ * The Clipboard API requires the call to happen inside a short-lived user
+ * gesture (click, key press, …) AND the user to grant the
+ * {@code clipboard-read} permission — without both, the browser rejects the
+ * read. Bind this action to a {@link Trigger} that fires during such a gesture,
+ * typically a {@link ClickTrigger}.
+ * <p>
+ * The handler receives a {@link ClipboardPayload} with the {@code text/plain}
+ * and {@code text/html} representations of the first clipboard item, or
+ * {@code null} if the read fails for any reason (permission denied, no item,
+ * unsupported browser, …). Error detail is intentionally not exposed — see
+ * {@link PromiseAction}'s subclasses for the success/error-split shape if that
+ * distinction matters.
+ *
+ * <pre>{@code
+ * new ClickTrigger(pasteButton).triggers(new ClipboardReadAction(payload -> {
+ *     if (payload == null) {
+ *         notification.show("Clipboard read denied");
+ *     } else {
+ *         editor.setValue(
+ *                 payload.html() != null ? payload.html() : payload.text());
+ *     }
+ * }));
+ * }</pre>
+ *
+ * For internal use only. May be renamed or removed in a future release.
+ */
+public class ClipboardReadAction extends Action {
+
+    private final SerializableConsumer<@Nullable ClipboardPayload> handler;
+
+    /**
+     * Creates an action that reads the user's clipboard and delivers the
+     * contents to {@code handler}.
+     *
+     * @param handler
+     *            invoked on the UI thread with the clipboard contents, or
+     *            {@code null} if the read failed; not {@code null}
+     */
+    public ClipboardReadAction(
+            SerializableConsumer<@Nullable ClipboardPayload> handler) {
+        this.handler = Objects.requireNonNull(handler,
+                "handler must not be null");
+    }
+
+    @Override
+    protected void appendStatement(JsBuilder builder, StringBuilder out) {
+        String cb = builder.callback(ClipboardPayload.class, handler);
+        // The actual clipboard read + {text, html} extraction lives in
+        // Clipboard.ts (window.Vaadin.Flow.clipboard.readPayload); this
+        // Action just routes its resolved value (or null on any failure)
+        // to the typed server callback.
+        out.append("window.Vaadin.Flow.clipboard.readPayload()")
+                .append(".then(p=>").append(cb).append("(p))")
+                .append(".catch(()=>").append(cb).append("(null))");
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/JsBuilder.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/JsBuilder.java
@@ -22,9 +22,14 @@ import java.util.List;
 import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.JsonNode;
 
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.flow.internal.nodefeature.ReturnChannelMap;
+import com.vaadin.flow.internal.nodefeature.ReturnChannelRegistration;
 
 /**
  * Collects element references and produces JS placeholders for them while a
@@ -94,6 +99,66 @@ final class JsBuilder implements Serializable {
         String ref = "$" + params.size();
         params.add(value);
         return ref;
+    }
+
+    /**
+     * Allocates a {@code $N} placeholder for a server-side callback function: a
+     * JS function {@code (payload) => …} that, when called from client JS,
+     * deserialises its first argument to {@code T} via Jackson and invokes
+     * {@code handler} on the UI thread.
+     * <p>
+     * Use this from {@link Action#appendStatement} when an action needs to ship
+     * a typed payload back from the browser — async API outcomes, extracted
+     * event data, anything Jackson can deserialise.
+     * <p>
+     * Each call registers a fresh {@link ReturnChannelRegistration} on the
+     * trigger's host node; channels are not deduplicated across calls.
+     *
+     * @param payloadType
+     *            type to deserialise the first JS argument into; never
+     *            {@code null}
+     * @param handler
+     *            invoked on the UI thread with the deserialised payload, or
+     *            {@code null} if the JS argument is {@code null}/missing; never
+     *            {@code null}
+     * @return the JS placeholder ({@code "$N"}) referencing the callback
+     * @param <T>
+     *            payload type
+     */
+    <T> String callback(Class<T> payloadType,
+            SerializableConsumer<@Nullable T> handler) {
+        return capture(registerChannel(arg -> handler.accept(arg == null ? null
+                : JacksonUtils.readValue(arg, payloadType))));
+    }
+
+    /**
+     * Like {@link #callback(Class, SerializableConsumer)} but accepts a
+     * {@link TypeReference} so the payload type can be a parameterised type
+     * (e.g. {@code new TypeReference<List<Foo>>(){}}).
+     *
+     * @param payloadType
+     *            type reference to deserialise the first JS argument into;
+     *            never {@code null}
+     * @param handler
+     *            invoked on the UI thread with the deserialised payload, or
+     *            {@code null} if the JS argument is {@code null}/missing; never
+     *            {@code null}
+     * @return the JS placeholder ({@code "$N"}) referencing the callback
+     * @param <T>
+     *            payload type
+     */
+    <T> String callback(TypeReference<T> payloadType,
+            SerializableConsumer<@Nullable T> handler) {
+        return capture(registerChannel(arg -> handler.accept(arg == null ? null
+                : JacksonUtils.readValue(arg, payloadType))));
+    }
+
+    private ReturnChannelRegistration registerChannel(
+            SerializableConsumer<@Nullable JsonNode> dispatcher) {
+        return trigger.getHost().getNode().getFeature(ReturnChannelMap.class)
+                .registerChannel(args -> dispatcher
+                        .accept(args.isEmpty() || args.get(0).isNull() ? null
+                                : args.get(0)));
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/ClipboardReadActionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/ClipboardReadActionTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.trigger.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
+import com.vaadin.flow.component.internal.UIInternals.JavaScriptInvocation;
+import com.vaadin.flow.dom.JsFunction;
+import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.flow.internal.nodefeature.ReturnChannelRegistration;
+import com.vaadin.tests.util.MockUI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClipboardReadActionTest {
+
+    @Test
+    void handlerJsCallsClipboardReadPayloadAndRoutesToCallback() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        ui.getElement().appendChild(button.getElement());
+
+        new DomEventTrigger(button, "click")
+                .triggers(new ClipboardReadAction(p -> {
+                }));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        // The action delegates to Clipboard.ts and only renders the routing
+        // glue — the actual clipboard read lives in
+        // window.Vaadin.Flow.clipboard.
+        assertEquals(
+                "window.Vaadin.Flow.clipboard.readPayload()"
+                        + ".then(p=>$0(p)).catch(()=>$0(null));",
+                handlerOf(singleInstallFn(ui)).getBody());
+    }
+
+    @Test
+    void channelInvocation_withPayload_handsTypedRecordToHandler() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        ui.getElement().appendChild(button.getElement());
+
+        List<ClipboardPayload> received = new ArrayList<>();
+        new DomEventTrigger(button, "click")
+                .triggers(new ClipboardReadAction(received::add));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        ObjectNode payload = JacksonUtils.createObjectNode();
+        payload.put("text", "hello");
+        payload.put("html", "<b>hello</b>");
+        ArrayNode args = JacksonUtils.createArrayNode();
+        args.add(payload);
+        singleReturnChannel(ui).invoke(args);
+
+        assertEquals(1, received.size());
+        assertEquals("hello", received.get(0).text());
+        assertEquals("<b>hello</b>", received.get(0).html());
+    }
+
+    @Test
+    void channelInvocation_withNull_handsNullToHandler() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        ui.getElement().appendChild(button.getElement());
+
+        List<ClipboardPayload> received = new ArrayList<>();
+        received.add(new ClipboardPayload("sentinel", null));
+        new DomEventTrigger(button, "click")
+                .triggers(new ClipboardReadAction(received::add));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        ArrayNode args = JacksonUtils.createArrayNode();
+        args.add(JacksonUtils.nullNode());
+        singleReturnChannel(ui).invoke(args);
+
+        assertEquals(2, received.size());
+        assertNull(received.get(1));
+    }
+
+    private static ReturnChannelRegistration singleReturnChannel(UI ui) {
+        List<ReturnChannelRegistration> channels = handlerOf(
+                singleInstallFn(ui)).getCaptures().stream()
+                .filter(o -> o instanceof ReturnChannelRegistration)
+                .map(o -> (ReturnChannelRegistration) o).toList();
+        assertEquals(1, channels.size(),
+                "Expected exactly one captured return channel");
+        return channels.get(0);
+    }
+
+    private static JsFunction singleInstallFn(UI ui) {
+        List<PendingJavaScriptInvocation> pending = ui.getInternals()
+                .dumpPendingJavaScriptInvocations();
+        assertEquals(1, pending.size(), "Expected exactly one pending JS");
+        return installFn(pending.get(0).getInvocation());
+    }
+
+    private static JsFunction installFn(JavaScriptInvocation invocation) {
+        Object o = invocation.getParameters().get(2);
+        assertTrue(o instanceof JsFunction, "Expected $2 to be a JsFunction");
+        return (JsFunction) o;
+    }
+
+    private static JsFunction handlerOf(JsFunction installFn) {
+        Object o = installFn.getCaptures().get(0);
+        assertTrue(o instanceof JsFunction,
+                "Expected install $0 to be the handler JsFunction");
+        return (JsFunction) o;
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerClipboardReadView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerClipboardReadView.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.trigger.internal.ClickTrigger;
+import com.vaadin.flow.component.trigger.internal.ClipboardReadAction;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+/**
+ * Wires a {@link ClickTrigger} on a button to a {@link ClipboardReadAction}
+ * that writes the received {@code ClipboardPayload} (or {@code "null"}) into a
+ * status div, so the IT can assert both paths. The IT replaces
+ * {@code navigator.clipboard.read} with a recording shim so the assertions
+ * don't depend on browser clipboard permissions.
+ */
+@Route(value = "com.vaadin.flow.uitest.ui.TriggerClipboardReadView", layout = ViewTestLayout.class)
+public class TriggerClipboardReadView extends AbstractDivView {
+
+    @Override
+    protected void onShow() {
+        NativeButton readButton = new NativeButton("Read");
+        readButton.setId("read");
+        Div status = new Div();
+        status.setId("status");
+
+        add(readButton, status);
+
+        new ClickTrigger(readButton).triggers(new ClipboardReadAction(p -> {
+            if (p == null) {
+                status.setText("null");
+            } else {
+                status.setText("text=" + p.text() + ";html=" + p.html());
+            }
+        }));
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerClipboardReadIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerClipboardReadIT.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class TriggerClipboardReadIT extends ChromeBrowserTest {
+
+    @Test
+    public void clickReadsClipboard_andServerReceivesPayload() {
+        open();
+        installResolvingClipboardShim("clipped", "<b>clipped</b>");
+
+        WebElement button = findElement(By.id("read"));
+        WebElement status = findElement(By.id("status"));
+
+        button.click();
+
+        waitUntil(d -> status.getText() != null
+                && status.getText().startsWith("text="));
+        Assert.assertEquals("text=clipped;html=<b>clipped</b>",
+                status.getText());
+    }
+
+    @Test
+    public void clipboardReadRejection_propagatesAsNullPayload() {
+        open();
+        installRejectingClipboardShim();
+
+        WebElement button = findElement(By.id("read"));
+        WebElement status = findElement(By.id("status"));
+
+        button.click();
+
+        waitUntil(d -> "null".equals(status.getText()));
+    }
+
+    // Replace navigator.clipboard.read with a Promise that resolves to a
+    // single fake ClipboardItem exposing text/plain and text/html blobs.
+    private void installResolvingClipboardShim(String text, String html) {
+        String script = "const t = arguments[0]; const h = arguments[1];"
+                + "const fake = {" + "  types: ['text/plain','text/html'],"
+                + "  getType: mime => Promise.resolve({"
+                + "    text: () => Promise.resolve(mime === 'text/plain' ? t : h)"
+                + "  })" + "};"
+                + "Object.defineProperty(navigator, 'clipboard', {"
+                + "  configurable: true, value: {"
+                + "    read: () => Promise.resolve([fake])" + "  }" + "});";
+        ((JavascriptExecutor) getDriver()).executeScript(script, text, html);
+    }
+
+    private void installRejectingClipboardShim() {
+        ((JavascriptExecutor) getDriver())
+                .executeScript("Object.defineProperty(navigator, 'clipboard', {"
+                        + "  configurable: true, value: {"
+                        + "    read: () => Promise.reject(new Error('DeniedByTest'))"
+                        + "  }" + "});");
+    }
+}


### PR DESCRIPTION
Adds a typed server-callback primitive to the trigger framework and the first action that needs it: reading the user's clipboard.

`JsBuilder.callback(...)` — three overloads — allocates a `$N` placeholder for a JS function `(payload) => …` that, when called from client JS, deserialises its first argument to T via Jackson and invokes the handler on the UI thread:

- `<T> callback(Class<T>, Consumer<https://github.com/nullable T>)`
- `<T> callback(TypeReference<T>, Consumer<https://github.com/nullable T>)` for
  parameterised types (`List<X>`, `Map<String, X>`, …)
- `callback(SerializableRunnable)` for the no-payload case

Each call registers a fresh `ReturnChannelRegistration` on the trigger's host node; channels are not deduplicated across calls (the previous per-(action, host) dedup in PromiseAction was a micro-opt that didn't survive generalising the primitive). Channels go away when the host node detaches.

PromiseAction is rewritten on top of `callback(...)`. Its previous single-channel `(boolean, message)` tuple dispatch is  
two callbacks — a runnable for the success leg, a String-typed consumer for the error leg — and the rendered JS becomes
`.then(()=>$ok()).catch(e=>$err(msg))`. The `channelByNode` map and inline dispatch method are gone; PromiseAction now has no state beyond the two optional consumers.

`ClipboardReadAction` is a direct `Action` subclass (not `PromiseAction`, because the resolved value is a typed payload, not just success/failure). It takes a `SerializableConsumer<https://github.com/nullable ClipboardPayload>` handler that
receives the clipboard contents on success or `null` on any failure (rejection, empty items, unsupported API). The handler is single because clipboard read failures rarely carry useful detail — callers who need success/error distinction can switch to PromiseAction-style.

`ClipboardPayload(https://github.com/nullable String text, https://github.com/nullable String html)` is the typed payload — first ClipboardItem's `text/plain` and `text/html` representations.

The actual clipboard read + `{text, html}` extraction lives in `flow-client/src/main/frontend/Clipboard.ts`, mirroring
`Geolocation.ts`: it attaches a `readPayload()` function to `window.Vaadin.Flow.clipboard`, imported by `Flow.ts` so it loads
with the framework. The Action's `appendStatement` just renders the routing glue — `window.Vaadin.Flow.clipboard.readPayload()` `.then(p=>$N(p)).catch(()=>$N(null))` — keeping the multi-statement
JS out of Java string concatenation.

The IT (`TriggerClipboardReadView`/`IT`) shims `navigator.clipboard.read` with a fake `ClipboardItem` that resolves
the two MIME types and a rejecting variant, exercising the TS layer end-to-end and asserting the server-side status div reflects the payload (or "null").