### PR TITLE
feat: add popover opt-out configuration for loading indicator

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/communication/LoadingIndicatorConfigurator.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/LoadingIndicatorConfigurator.java
@@ -64,6 +64,12 @@ public class LoadingIndicatorConfigurator {
         defaultThemeProperty.addChangeListener(event -> setApplyDefaultTheme(
                 event.getSource().getValueOrDefault(
                         LoadingIndicatorConfigurationMap.DEFAULT_THEME_APPLIED_DEFAULT)));
+
+        MapProperty popoverOptOutProperty = configMap.getProperty(
+                LoadingIndicatorConfigurationMap.POPOVER_OPT_OUT_KEY);
+        popoverOptOutProperty.addChangeListener(event -> setPopoverOptOut(
+                event.getSource().getValueOrDefault(LoadingIndicatorConfigurationMap.POPOVER_OPT_OUT_KEY_DEFAULT)
+        ));
     }
 
     /**
@@ -100,5 +106,9 @@ public class LoadingIndicatorConfigurator {
 
     private static void setApplyDefaultTheme(boolean apply) {
         ConnectionIndicator.setProperty("applyDefaultTheme", apply);
+    }
+
+    private static void setPopoverOptOut(boolean popoverOptOut) {
+        ConnectionIndicator.setProperty("popoverOptOut", popoverOptOut);
     }
 }

--- a/flow-client/src/main/java/com/vaadin/client/communication/LoadingIndicatorConfigurator.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/LoadingIndicatorConfigurator.java
@@ -67,9 +67,9 @@ public class LoadingIndicatorConfigurator {
 
         MapProperty popoverOptOutProperty = configMap.getProperty(
                 LoadingIndicatorConfigurationMap.POPOVER_OPT_OUT_KEY);
-        popoverOptOutProperty.addChangeListener(event -> setPopoverOptOut(
-                event.getSource().getValueOrDefault(LoadingIndicatorConfigurationMap.POPOVER_OPT_OUT_KEY_DEFAULT)
-        ));
+        popoverOptOutProperty.addChangeListener(
+                event -> setPopoverOptOut(event.getSource().getValueOrDefault(
+                        LoadingIndicatorConfigurationMap.POPOVER_OPT_OUT_KEY_DEFAULT)));
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/LoadingIndicatorConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/LoadingIndicatorConfiguration.java
@@ -111,15 +111,16 @@ public interface LoadingIndicatorConfiguration extends Serializable {
     boolean isPopoverOptOut();
 
     /**
-     * Configures whether the loading indicator should not use built-in
-     * Popover API functionality.
+     * Configures whether the loading indicator should not use built-in Popover
+     * API functionality.
      * <p>
      * When set to true, the loading indicator will not rely on Popover API
      * components for showing itself, allowing more flexible custom positioning
      * and styling.
      *
      * @param popoverOptOut
-     *              {@code true} to disable Popover API usage, {@code false} to enable it
+     *            {@code true} to disable Popover API usage, {@code false} to
+     *            enable it
      */
     void setPopoverOptOut(boolean popoverOptOut);
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/LoadingIndicatorConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/LoadingIndicatorConfiguration.java
@@ -101,4 +101,25 @@ public interface LoadingIndicatorConfiguration extends Serializable {
      *            {@code true} to apply default theming, {@code false} for not
      */
     void setApplyDefaultTheme(boolean applyDefaultTheme);
+
+    /**
+     * Returns whether the loading indicator has disabled the builtin Popover
+     * API functionality.
+     *
+     * @return {@code true} to disable using Popover API, {@code false} for not
+     */
+    boolean isPopoverOptOut();
+
+    /**
+     * Configures whether the loading indicator should not use built-in
+     * Popover API functionality.
+     * <p>
+     * When set to true, the loading indicator will not rely on Popover API
+     * components for showing itself, allowing more flexible custom positioning
+     * and styling.
+     *
+     * @param popoverOptOut
+     *              {@code true} to disable Popover API usage, {@code false} to enable it
+     */
+    void setPopoverOptOut(boolean popoverOptOut);
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/LoadingIndicatorConfigurationMap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/LoadingIndicatorConfigurationMap.java
@@ -36,6 +36,8 @@ public class LoadingIndicatorConfigurationMap extends NodeMap
     public static final int THIRD_DELAY_DEFAULT = 5000;
     public static final String DEFAULT_THEME_APPLIED_KEY = "theme";
     public static final boolean DEFAULT_THEME_APPLIED_DEFAULT = true;
+    public static final String POPOVER_OPT_OUT_KEY = "popoverOptOut";
+    public static final boolean POPOVER_OPT_OUT_KEY_DEFAULT = false;
 
     /**
      * Creates a new map for the given node.
@@ -86,5 +88,15 @@ public class LoadingIndicatorConfigurationMap extends NodeMap
     @Override
     public void setApplyDefaultTheme(boolean applyDefaultTheme) {
         put(DEFAULT_THEME_APPLIED_KEY, applyDefaultTheme);
+    }
+
+    @Override
+    public boolean isPopoverOptOut() {
+        return getOrDefault(POPOVER_OPT_OUT_KEY, POPOVER_OPT_OUT_KEY_DEFAULT);
+    }
+
+    @Override
+    public void setPopoverOptOut(boolean popoverOptOut) {
+        put(POPOVER_OPT_OUT_KEY, popoverOptOut);
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/LoadingIndicatorConfigurationMapTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/LoadingIndicatorConfigurationMapTest.java
@@ -66,8 +66,7 @@ class LoadingIndicatorConfigurationMapTest
 
     @Test
     void setGetPopoverOptOut() {
-        testBoolean(map,
-                LoadingIndicatorConfigurationMap.POPOVER_OPT_OUT_KEY,
+        testBoolean(map, LoadingIndicatorConfigurationMap.POPOVER_OPT_OUT_KEY,
                 map::setPopoverOptOut, map::isPopoverOptOut);
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/LoadingIndicatorConfigurationMapTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/LoadingIndicatorConfigurationMapTest.java
@@ -34,6 +34,9 @@ class LoadingIndicatorConfigurationMapTest
         assertEquals(
                 LoadingIndicatorConfigurationMap.DEFAULT_THEME_APPLIED_DEFAULT,
                 map.isApplyDefaultTheme());
+        assertEquals(
+                LoadingIndicatorConfigurationMap.POPOVER_OPT_OUT_KEY_DEFAULT,
+                map.isPopoverOptOut());
     }
 
     @Test
@@ -59,5 +62,12 @@ class LoadingIndicatorConfigurationMapTest
         testBoolean(map,
                 LoadingIndicatorConfigurationMap.DEFAULT_THEME_APPLIED_KEY,
                 map::setApplyDefaultTheme, map::isApplyDefaultTheme);
+    }
+
+    @Test
+    void setGetPopoverOptOut() {
+        testBoolean(map,
+                LoadingIndicatorConfigurationMap.POPOVER_OPT_OUT_KEY,
+                map::setPopoverOptOut, map::isPopoverOptOut);
     }
 }


### PR DESCRIPTION
Fixes #24072
Depends on vaadin/flow-hilla-common#26

- Add Popover opt-out property with default value (false)
- Implement listener for popover opt-out changes
- Update ConfigurationMap to support the new setting
- Add getter/setter methods in LoadingIndicatorConfiguration.java
- Include test cases for popover opt-out functionality
