### PR TITLE
ci: Replace pull_request_target with pull_request in CI workflows for 25.1

### DIFF
--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -1,10 +1,11 @@
 name: Formatter
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
     # spotless available in 25.x
     branches: [25.1]
+  merge_group:
 
 # Cancel previous runs if a new one is triggered
 concurrency:
@@ -71,6 +72,7 @@ jobs:
           retention-days: 30
 
       - name: Find existing comment
+        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
         uses: peter-evans/find-comment@v3
         id: find-comment
         with:
@@ -79,7 +81,7 @@ jobs:
           body-includes: '<!-- tc-formatter -->'
 
       - name: Create or update comment
-        if: steps.formatter.outputs.modified != '0'
+        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && steps.formatter.outputs.modified != '0'
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}

--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -5,7 +5,6 @@ on:
     types: [opened, synchronize, reopened]
     # spotless available in 25.x
     branches: [25.1]
-  merge_group:
 
 # Cancel previous runs if a new one is triggered
 concurrency:

--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -1,12 +1,13 @@
 name: Sonar PR Analysis
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
-    branches: [main]
+    branches: [25.1]
+  merge_group:
 
 concurrency:
-  group: sonar-pr-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -24,7 +25,7 @@ env:
 
 jobs:
   sonar-analysis:
-    environment: ${{ github.event.pull_request.head.repo.fork && 'pr-tests' || '' }}
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     name: Sonar Analysis
     runs-on: ubuntu-latest
     timeout-minutes: 120

--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [25.1]
-  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary

Replaces the \`pull_request_target\` event with \`pull_request\` in \`formatter.yml\` and \`sonar-pr.yml\`, mirroring the changes from #24390 on \`main\`.

\`formatter.yml\`: trigger changed, \`merge_group\` added, comment steps skip for fork PRs and in \`merge_group\` context.

\`sonar-pr.yml\`: trigger changed, \`branches\` filter corrected from \`main\` to \`25.1\` (copy-paste bug), \`merge_group\` added, environment gate replaced with job-level \`if\` condition to skip for fork PRs.

\`validation.yml\` already uses \`pull_request\` and requires no changes.