### PR TITLE
feat: add virtual-aware component tree traversal helpers

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
@@ -38,6 +38,7 @@ import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.DomEvent;
 import com.vaadin.flow.dom.DomListenerRegistration;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.ShadowRoot;
 import com.vaadin.flow.function.SerializableTriConsumer;
 import com.vaadin.flow.i18n.LocaleChangeEvent;
 import com.vaadin.flow.i18n.LocaleChangeObserver;
@@ -778,6 +779,95 @@ public class ComponentUtil {
         parent.getElement().getChildren().forEach(childElement -> ComponentUtil
                 .findComponents(childElement, childComponents::add));
         return childComponents.build();
+    }
+
+    /**
+     * Gets the child components of the given parent component, including
+     * components attached as virtual children.
+     * <p>
+     * Like {@link #getChildren(Component)}, this finds child components by
+     * traversing each child {@link Element} tree. In addition, it also descends
+     * into elements attached via
+     * {@link Element#appendVirtualChild(Element...)}, which covers e.g. slotted
+     * components added through helpers like {@code addToFooter} on web
+     * component wrappers, overlays attached to the {@link UI}, and the
+     * client-side routing wrapper.
+     * <p>
+     * Children injected into a template via {@code @Id} are still excluded:
+     * shadow root contents are not traversed.
+     * <p>
+     * The order is regular DOM children first (in DOM order), followed by
+     * virtual children in their attachment order.
+     *
+     * @param parent
+     *            the parent component from which to get the child components
+     * @return the child components of the given parent component, including
+     *         virtual children
+     */
+    public static Stream<Component> getAllChildren(Component parent) {
+        if (parent instanceof Composite) {
+            return parent.getChildren();
+        }
+        if (!parent.getElement().getComponent().isPresent()) {
+            throw new IllegalStateException(
+                    "You cannot use getAllChildren() on a wrapped component. Use Component.wrapAndMap to include the component in the hierarchy");
+        }
+
+        Builder<Component> childComponents = Stream.builder();
+        forEachChildElement(parent.getElement(),
+                childElement -> findComponentsIncludingVirtual(childElement,
+                        childComponents::add));
+        return childComponents.build();
+    }
+
+    /**
+     * Streams all descendant components of the given parent component in
+     * pre-order (each component before its own descendants). The parent itself
+     * is not included.
+     * <p>
+     * Traversal uses {@link #getAllChildren(Component)} at every level, so
+     * virtual children (slotted components, overlays, the routing wrapper) are
+     * included. Shadow root contents are not traversed.
+     *
+     * @param parent
+     *            the parent component to start the traversal from
+     * @return a stream of all descendant components in pre-order
+     */
+    public static Stream<Component> streamDescendants(Component parent) {
+        Builder<Component> descendants = Stream.builder();
+        collectDescendants(parent, descendants);
+        return descendants.build();
+    }
+
+    private static void collectDescendants(Component parent,
+            Builder<Component> descendants) {
+        getAllChildren(parent).forEach(child -> {
+            descendants.add(child);
+            collectDescendants(child, descendants);
+        });
+    }
+
+    private static void findComponentsIncludingVirtual(Element element,
+            Consumer<Component> componentConsumer) {
+        Optional<Component> maybeComponent = element.getComponent();
+        if (maybeComponent.isPresent()) {
+            componentConsumer.accept(maybeComponent.get());
+            return;
+        }
+        forEachChildElement(element,
+                child -> findComponentsIncludingVirtual(child,
+                        componentConsumer));
+    }
+
+    private static void forEachChildElement(Element parent,
+            Consumer<Element> action) {
+        parent.getChildren().forEach(action);
+        parent.getNode().getFeatureIfInitialized(VirtualChildrenList.class)
+                .ifPresent(list -> list.forEachChild(node -> {
+                    if (!ShadowRoot.isShadowRoot(node)) {
+                        action.accept(Element.get(node));
+                    }
+                }));
     }
 
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentUtilTest.java
@@ -16,11 +16,15 @@
 package com.vaadin.flow.component;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import com.vaadin.flow.component.ComponentTest.TestComponent;
 import com.vaadin.flow.component.ComponentTest.TestDiv;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.ElementFactory;
 import com.vaadin.flow.shared.Registration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -132,6 +136,67 @@ class ComponentUtilTest {
 
         assertTrue(retrievedClasses.isEmpty(),
                 "The retrieved classes should be empty for an unregistered tag");
+    }
+
+    @Test
+    void getAllChildren_includesVirtualChildren() {
+        // parent
+        // ├── regular (direct DOM child)
+        // └── virtual (appendVirtualChild)
+        TestComponent parent = new TestComponent(ElementFactory.createDiv());
+        TestComponent regular = new TestComponent(ElementFactory.createSpan());
+        TestComponent virtual = new TestComponent(ElementFactory.createDiv());
+
+        parent.getElement().appendChild(regular.getElement());
+        parent.getElement().appendVirtualChild(virtual.getElement());
+
+        assertEquals(List.of(regular), parent.getChildren().toList(),
+                "getChildren must keep ignoring virtual children");
+        assertEquals(List.of(regular, virtual),
+                ComponentUtil.getAllChildren(parent).toList(),
+                "getAllChildren must return regular children first, virtual children last");
+    }
+
+    @Test
+    void getAllChildren_skipsNonComponentWrapperElement() {
+        // parent
+        // └── (plain element, no component)
+        // └── virtual (appendVirtualChild on the wrapper)
+        TestComponent parent = new TestComponent(ElementFactory.createDiv());
+        Element wrapper = ElementFactory.createDiv();
+        TestComponent virtual = new TestComponent(ElementFactory.createSpan());
+
+        parent.getElement().appendChild(wrapper);
+        wrapper.appendVirtualChild(virtual.getElement());
+
+        assertEquals(List.of(virtual),
+                ComponentUtil.getAllChildren(parent).toList(),
+                "Walker must descend through plain elements and find virtual children on them");
+    }
+
+    @Test
+    void streamDescendants_preOrderIncludingVirtual() {
+        // parent
+        // ├── child1
+        // │ ├── grandchild1 (regular)
+        // │ └── grandchild2 (virtual)
+        // └── child2 (virtual)
+        TestComponent parent = new TestComponent(ElementFactory.createDiv());
+        TestComponent child1 = new TestComponent(ElementFactory.createDiv());
+        TestComponent grandchild1 = new TestComponent(
+                ElementFactory.createSpan());
+        TestComponent grandchild2 = new TestComponent(
+                ElementFactory.createSpan());
+        TestComponent child2 = new TestComponent(ElementFactory.createDiv());
+
+        parent.getElement().appendChild(child1.getElement());
+        parent.getElement().appendVirtualChild(child2.getElement());
+        child1.getElement().appendChild(grandchild1.getElement());
+        child1.getElement().appendVirtualChild(grandchild2.getElement());
+
+        assertEquals(List.of(child1, grandchild1, grandchild2, child2),
+                ComponentUtil.streamDescendants(parent).toList(),
+                "streamDescendants must walk pre-order and include virtual children");
     }
 
 }


### PR DESCRIPTION
Adds ComponentUtil.getAllChildren and ComponentUtil.streamDescendants. Unlike Component.getChildren, these include components attached as virtual children (slotted helpers like addToFooter, overlays attached to the UI, the client-side routing wrapper), so tools that need a complete component tree no longer have to reach into internal APIs such as VirtualChildrenList.
