### PR TITLE
feat: add npm.excludePostinstallPackages option

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/Options.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/Options.java
@@ -148,6 +148,11 @@ public class Options implements Serializable {
      */
     private List<String> postinstallPackages = new ArrayList<>();
 
+    /**
+     * Npm packages to exclude from running postinstall scripts.
+     */
+    private List<String> excludePostinstallPackages = new ArrayList<>();
+
     private FeatureFlags featureFlags;
 
     private boolean frontendHotdeploy = false;
@@ -699,6 +704,23 @@ public class Options implements Serializable {
     }
 
     /**
+     * Sets the npm packages to exclude from running {@code postinstall} for.
+     * <p>
+     * Entries here are removed from the built-in default postinstall list (e.g.
+     * {@code esbuild}, {@code @vaadin/vaadin-usage-statistics}) as well as from
+     * any additional packages added via {@link #withPostinstallPackages(List)}.
+     *
+     * @param excludePostinstallPackages
+     *            the npm packages to exclude from postinstall
+     * @return the builder, for chaining
+     */
+    public Options withExcludePostinstallPackages(
+            List<String> excludePostinstallPackages) {
+        this.excludePostinstallPackages = excludePostinstallPackages;
+        return this;
+    }
+
+    /**
      * Get the npm folder used for this build.
      *
      * @return npmFolder
@@ -923,6 +945,10 @@ public class Options implements Serializable {
 
     public List<String> getPostinstallPackages() {
         return postinstallPackages;
+    }
+
+    public List<String> getExcludePostinstallPackages() {
+        return excludePostinstallPackages;
     }
 
     /**

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -382,6 +382,7 @@ public class TaskRunNpmInstall implements FallibleCommand {
         postinstallPackages.add("esbuild");
         postinstallPackages.add("@vaadin/vaadin-usage-statistics");
         postinstallPackages.addAll(options.getPostinstallPackages());
+        postinstallPackages.removeAll(options.getExcludePostinstallPackages());
 
         for (String postinstallPackage : postinstallPackages) {
             File packageJsonFile = getPackageJsonForModule(postinstallPackage);

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -345,6 +345,23 @@ class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
                 "Postinstall for 'foo' was not run");
     }
 
+    @Test
+    void runPnpmInstall_postInstall_excludedBuiltinPackageIsSkipped()
+            throws ExecutionFailedException, IOException {
+        setupPostinstallPackages();
+        options.withExcludePostinstallPackages(
+                List.of("@vaadin/vaadin-usage-statistics"));
+        TaskRunNpmInstall task = createTask();
+        task.execute();
+
+        assertFalse(
+                new File(
+                        new File(options.getNodeModulesFolder(),
+                                "@vaadin/vaadin-usage-statistics"),
+                        "postinstall-file.txt").exists(),
+                "Postinstall for '@vaadin/vaadin-usage-statistics' should have been skipped");
+    }
+
     // https://github.com/vaadin/flow/issues/17663
     @Test
     @Timeout(30)

--- a/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
+++ b/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
@@ -183,6 +183,15 @@ public class BuildDevBundleMojo extends AbstractMojo
     @Parameter(property = "npm.postinstallPackages", defaultValue = "")
     private List<String> postinstallPackages;
 
+    /**
+     * Npm packages to exclude from running post install scripts.
+     * <p>
+     * Used to skip built-in entries (e.g. {@code esbuild}) when their
+     * postinstall step is known to fail or is not needed.
+     */
+    @Parameter(property = "npm.excludePostinstallPackages", defaultValue = "")
+    private List<String> excludePostinstallPackages;
+
     @Parameter(property = InitParameters.REACT_ENABLE, defaultValue = "true")
     private boolean reactEnable;
 
@@ -514,6 +523,11 @@ public class BuildDevBundleMojo extends AbstractMojo
     @Override
     public List<String> postinstallPackages() {
         return postinstallPackages;
+    }
+
+    @Override
+    public List<String> excludePostinstallPackages() {
+        return excludePostinstallPackages;
     }
 
     @Override

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
@@ -276,6 +276,9 @@ internal class GradlePluginAdapter private constructor(
     override fun postinstallPackages(): List<String> =
         config.postinstallPackages.get()
 
+    override fun excludePostinstallPackages(): List<String> =
+        config.excludePostinstallPackages.get()
+
     override fun isFrontendHotdeploy(): Boolean = config.frontendHotdeploy.get()
 
     override fun ciBuild(): Boolean = config.ciBuild.get()

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/PrepareFrontendInputProperties.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/PrepareFrontendInputProperties.kt
@@ -142,6 +142,10 @@ internal class PrepareFrontendInputProperties(
         config.postinstallPackages
 
     @Input
+    fun getExcludePostInstallPackages(): ListProperty<String> =
+        config.excludePostinstallPackages
+
+    @Input
     fun getFrontendHotdeploy(): Provider<Boolean> = config.frontendHotdeploy
 
     @Input

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
@@ -236,6 +236,13 @@ public abstract class VaadinFlowPluginExtension @Inject constructor(private val 
      */
     public abstract val postinstallPackages: ListProperty<String>
 
+    /**
+     * Defines the npm packages to exclude from running postinstall scripts.
+     * Used to skip built-in entries (e.g. `esbuild`) when their postinstall
+     * step is known to fail or is not needed.
+     */
+    public abstract val excludePostinstallPackages: ListProperty<String>
+
     public val classpathFilter: ClasspathFilter = ClasspathFilter()
 
     /**
@@ -568,6 +575,10 @@ public class PluginEffectiveConfiguration(
         extension.postinstallPackages
             .convention(listOf())
 
+    public val excludePostinstallPackages: ListProperty<String> =
+        extension.excludePostinstallPackages
+            .convention(listOf())
+
     public val classpathFilter: ClasspathFilter = extension.classpathFilter
 
     public val processResourcesTaskName: Property<String> =
@@ -744,6 +755,7 @@ public class PluginEffectiveConfiguration(
             "resourceOutputDirectory=${resourceOutputDirectory.get()}, " +
             "projectBuildDir=${projectBuildDir.get()}, " +
             "postinstallPackages=${postinstallPackages.get()}, " +
+            "excludePostinstallPackages=${excludePostinstallPackages.get()}, " +
             "sourceSetName=${sourceSetName.get()}, " +
             "dependencyScope=${dependencyScope.get()}, " +
             "processResourcesTaskName=${processResourcesTaskName.get()}, " +

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -257,6 +257,15 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
     private List<String> postinstallPackages;
 
     /**
+     * Npm packages to exclude from running post install scripts.
+     * <p>
+     * Used to skip built-in entries (e.g. {@code esbuild}) when their
+     * postinstall step is known to fail or is not needed.
+     */
+    @Parameter(property = "vaadin.npm.excludePostinstallPackages", defaultValue = "")
+    private List<String> excludePostinstallPackages;
+
+    /**
      * Parameter to control if frontend development server should be used in
      * development mode or not.
      * <p>
@@ -708,6 +717,11 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
     @Override
     public List<String> postinstallPackages() {
         return postinstallPackages;
+    }
+
+    @Override
+    public List<String> excludePostinstallPackages() {
+        return excludePostinstallPackages;
     }
 
     @Override

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
@@ -199,6 +199,8 @@ class BuildFrontendMojoTest {
                 Paths.get(projectBase.toString(), "target").toString());
         ReflectionUtils.setVariableValueInObject(mojo, "postinstallPackages",
                 Collections.emptyList());
+        ReflectionUtils.setVariableValueInObject(mojo,
+                "excludePostinstallPackages", Collections.emptyList());
         Mockito.doReturn(
                 Set.of(jarResourcesSource.getParentFile().getParentFile()))
                 .when(mojo).getJarFiles();

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -363,6 +363,8 @@ public class BuildFrontendUtil {
                     .withNodeDownloadRoot(nodeDownloadRootURI)
                     .setJavaResourceFolder(adapter.javaResourceFolder())
                     .withPostinstallPackages(adapter.postinstallPackages())
+                    .withExcludePostinstallPackages(
+                            adapter.excludePostinstallPackages())
                     .withCiBuild(adapter.ciBuild())
                     .withForceProductionBuild(adapter.forceProductionBuild())
                     .withReact(adapter.isReactEnabled())
@@ -440,6 +442,8 @@ public class BuildFrontendUtil {
                     .withNodeDownloadRoot(nodeDownloadRootURI)
                     .setJavaResourceFolder(adapter.javaResourceFolder())
                     .withPostinstallPackages(adapter.postinstallPackages())
+                    .withExcludePostinstallPackages(
+                            adapter.excludePostinstallPackages())
                     .withBundleBuild(true)
                     .skipDevBundleBuild(adapter.skipDevBundleBuild())
                     .withCompressBundle(adapter.compressBundle())

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBase.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBase.java
@@ -310,6 +310,15 @@ public interface PluginAdapterBase {
      */
     List<String> postinstallPackages();
 
+    /**
+     * Npm packages to exclude from running postinstall scripts. Removes
+     * matching entries from the built-in defaults and from any packages added
+     * via {@link #postinstallPackages()}.
+     *
+     * @return a list of packages to exclude
+     */
+    List<String> excludePostinstallPackages();
+
     boolean isFrontendHotdeploy();
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -235,6 +235,13 @@ public class InitParameters implements Serializable {
     public static final String ADDITIONAL_POSTINSTALL_PACKAGES = "npm.postinstallPackages";
 
     /**
+     * Packages to exclude from running postinstall scripts. Used to skip
+     * built-in entries (e.g. {@code esbuild}) when their postinstall step is
+     * known to fail or is not needed.
+     */
+    public static final String EXCLUDE_POSTINSTALL_PACKAGES = "npm.excludePostinstallPackages";
+
+    /**
      * Configuration name for enabling development using the frontend
      * development server instead of using an application bundle.
      */

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
@@ -273,6 +273,9 @@ public class DevModeInitializer implements Serializable {
                         InitParameters.ADDITIONAL_POSTINSTALL_PACKAGES, "")
                 .split(",");
 
+        String[] excludePostinstallPackages = config.getStringProperty(
+                InitParameters.EXCLUDE_POSTINSTALL_PACKAGES, "").split(",");
+
         String frontendGeneratedFolderName = config.getStringProperty(
                 PROJECT_FRONTEND_GENERATED_DIR_TOKEN,
                 Paths.get(frontendFolder.getPath(), FrontendUtils.GENERATED)
@@ -303,6 +306,8 @@ public class DevModeInitializer implements Serializable {
                 .withProductionMode(config.isProductionMode())
                 .withPostinstallPackages(
                         Arrays.asList(additionalPostinstallPackages))
+                .withExcludePostinstallPackages(
+                        Arrays.asList(excludePostinstallPackages))
                 .withFrontendHotdeploy(
                         mode == Mode.DEVELOPMENT_FRONTEND_LIVERELOAD)
                 .withBundleBuild(mode == Mode.DEVELOPMENT_BUNDLE)


### PR DESCRIPTION
Adds a configuration option to exclude packages from running postinstall scripts. Mirrors the existing npm.postinstallPackages add-list and applies to both the built-in default entries (e.g. esbuild, @vaadin/vaadin-usage-statistics) and any packages added via postinstallPackages. Wired through Options, the Maven and Gradle plugins, and DevModeInitializer.

Refs #24333
