### PR TITLE
chore: remove MasterDetailLayout component feature flag

### DIFF
--- a/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
+++ b/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
@@ -59,7 +59,6 @@ public class FeatureFlags implements Serializable {
     public static final Feature ACCESSIBLE_DISABLED_BUTTONS = CoreFeatureFlagProvider.ACCESSIBLE_DISABLED_BUTTONS;
     public static final Feature COMPONENT_STYLE_INJECTION = CoreFeatureFlagProvider.COMPONENT_STYLE_INJECTION;
     public static final Feature HILLA_FULLSTACK_SIGNALS = HillaFeatureFlagProvider.HILLA_FULLSTACK_SIGNALS;
-    public static final Feature MASTER_DETAIL_LAYOUT_COMPONENT = FlowComponentsFeatureFlagProvider.MASTER_DETAIL_LAYOUT_COMPONENT;
     public static final Feature LAYOUT_COMPONENT_IMPROVEMENTS = FlowComponentsFeatureFlagProvider.LAYOUT_COMPONENT_IMPROVEMENTS;
     public static final Feature DEFAULT_AUTO_RESPONSIVE_FORM_LAYOUT = FlowComponentsFeatureFlagProvider.DEFAULT_AUTO_RESPONSIVE_FORM_LAYOUT;
 

--- a/flow-server/src/main/java/com/vaadin/experimental/FlowComponentsFeatureFlagProvider.java
+++ b/flow-server/src/main/java/com/vaadin/experimental/FlowComponentsFeatureFlagProvider.java
@@ -24,11 +24,6 @@ import java.util.List;
  */
 public class FlowComponentsFeatureFlagProvider implements FeatureFlagProvider {
 
-    public static final Feature MASTER_DETAIL_LAYOUT_COMPONENT = new Feature(
-            "Master Detail Layout component", "masterDetailLayoutComponent",
-            "https://github.com/vaadin/platform/issues/7173", true,
-            "com.vaadin.flow.component.masterdetaillayout.MasterDetailLayout");
-
     public static final Feature LAYOUT_COMPONENT_IMPROVEMENTS = new Feature(
             "HorizontalLayout and VerticalLayout improvements",
             "layoutComponentImprovements",
@@ -42,8 +37,7 @@ public class FlowComponentsFeatureFlagProvider implements FeatureFlagProvider {
 
     @Override
     public List<Feature> getFeatures() {
-        return List.of(MASTER_DETAIL_LAYOUT_COMPONENT,
-                LAYOUT_COMPONENT_IMPROVEMENTS,
+        return List.of(LAYOUT_COMPONENT_IMPROVEMENTS,
                 DEFAULT_AUTO_RESPONSIVE_FORM_LAYOUT);
     }
 }


### PR DESCRIPTION
## Description

MasterDetailLayout component becomes stable in 25.2 - see following PRs:

- https://github.com/vaadin/web-components/pull/11773
- https://github.com/vaadin/flow-components/pull/9315

## Type of change

- Internal change