### PR TITLE
feat: SignalInput — read a server-side Signal at trigger fire time

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/SignalInput.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/SignalInput.java
@@ -58,17 +58,10 @@ import com.vaadin.flow.signals.Signal;
  */
 public class SignalInput<T> extends Action.Input<T> {
 
-    // JVM-wide counter for generating per-SignalInput property names. We only
-    // need uniqueness within a given owner element's property namespace; a
-    // global counter is just the simplest way to deliver that. The counter is
-    // not reset and runs against Long.MAX_VALUE (~9.2 × 10^18) — at one
-    // SignalInput construction per nanosecond it would take ~292 years to
-    // exhaust. On the truly unlikely overflow, AtomicLong wraps to
-    // Long.MIN_VALUE and continues with negative suffixes; those are valid
-    // JS property keys and the only risk is a collision with another live
-    // SignalInput on the same owner — vanishingly small in practice. Class
-    // reload during devmode hotdeploy resets the counter, but the old
-    // SignalInput instances reload with it, so no live collision can result.
+    // Generates unique property-name suffixes; a long won't realistically
+    // overflow. Class reload during devmode hotdeploy resets it, but the
+    // matching SignalInput instances reload with it, so no live collision
+    // can result.
     private static final AtomicLong PROPERTY_INDEX = new AtomicLong();
 
     private final Component owner;

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/SignalInput.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/SignalInput.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.trigger.internal;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.signals.Signal;
+
+/**
+ * Reads the current value of a server-side {@link Signal} at the moment a
+ * trigger fires.
+ * <p>
+ * When this input is rendered into a trigger's handler — at the
+ * {@link Trigger#triggers(Action...)} call site — a component-scoped
+ * {@link Signal#effect(Component, com.vaadin.flow.signals.function.EffectAction)
+ * effect} is installed once. It mirrors the signal value to a uniquely-named
+ * JavaScript property on the {@code owner} component's element via
+ * {@link Element#executeJs}; every subsequent signal change pushes the new
+ * value to the client. The trigger reads that property at fire time, so the
+ * value seen reflects whatever the signal held the last time it propagated.
+ * <p>
+ * Constructing a {@code SignalInput} has no side effects — no effect is
+ * installed and no JS is queued until the input is wired into a trigger.
+ * <p>
+ * The {@code owner} drives the lifecycle: while it is detached the effect is
+ * suspended (and the property on the client retains the last pushed value); on
+ * re-attach the effect re-emits the current value.
+ *
+ * <pre>{@code
+ * ValueSignal<String> textSignal = new ValueSignal<>("Hello");
+ * new ClickTrigger(copyButton).triggers(new WriteToClipboardAction(
+ *         new SignalInput<>(this, textSignal), null));
+ * textSignal.set("Goodbye");
+ * // Clicking the button after the set copies "Goodbye".
+ * }</pre>
+ *
+ * <p>
+ * For internal use only. May be renamed or removed in a future release.
+ *
+ * @param <T>
+ *            the runtime type of the value produced
+ */
+public class SignalInput<T> extends Action.Input<T> {
+
+    // JVM-wide counter for generating per-SignalInput property names. We only
+    // need uniqueness within a given owner element's property namespace; a
+    // global counter is just the simplest way to deliver that. The counter is
+    // not reset and runs against Long.MAX_VALUE (~9.2 × 10^18) — at one
+    // SignalInput construction per nanosecond it would take ~292 years to
+    // exhaust. On the truly unlikely overflow, AtomicLong wraps to
+    // Long.MIN_VALUE and continues with negative suffixes; those are valid
+    // JS property keys and the only risk is a collision with another live
+    // SignalInput on the same owner — vanishingly small in practice. Class
+    // reload during devmode hotdeploy resets the counter, but the old
+    // SignalInput instances reload with it, so no live collision can result.
+    private static final AtomicLong PROPERTY_INDEX = new AtomicLong();
+
+    private final Component owner;
+    private final Signal<T> signal;
+    private final String propertyName;
+    private boolean installed;
+
+    /**
+     * Creates a signal-backed input. No effect is installed until the input is
+     * actually rendered into a trigger handler.
+     *
+     * @param owner
+     *            the component whose lifecycle bounds the signal effect and
+     *            whose element holds the mirrored value; not {@code null}
+     * @param signal
+     *            the signal whose value should be read at fire time, not
+     *            {@code null}
+     */
+    public SignalInput(Component owner, Signal<T> signal) {
+        this.owner = Objects.requireNonNull(owner, "owner must not be null");
+        this.signal = Objects.requireNonNull(signal, "signal must not be null");
+        // A unique property name lets multiple SignalInputs share an owner
+        // without overwriting each other's mirrored value. The name is
+        // internal — chosen to be unlikely to collide with anything the
+        // application sets on the element.
+        this.propertyName = "__vTriggerSignalInput_"
+                + PROPERTY_INDEX.getAndIncrement();
+    }
+
+    @Override
+    protected void appendExpression(JsBuilder builder, StringBuilder out) {
+        installEffectIfNeeded();
+        out.append(builder.reference(owner.getElement())).append("[")
+                .append(JsBuilder.json(propertyName)).append("]");
+    }
+
+    private void installEffectIfNeeded() {
+        if (installed) {
+            return;
+        }
+        installed = true;
+        Element target = owner.getElement();
+        Signal.effect(owner, () -> target.executeJs("this[$0]=$1", propertyName,
+                signal.get()));
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/SignalInputTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/SignalInputTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.trigger.internal;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
+import com.vaadin.flow.component.internal.UIInternals.JavaScriptInvocation;
+import com.vaadin.flow.dom.JsFunction;
+import com.vaadin.flow.internal.CurrentInstance;
+import com.vaadin.flow.server.MockVaadinServletService;
+import com.vaadin.flow.server.MockVaadinSession;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.signals.local.ValueSignal;
+import com.vaadin.tests.util.MockUI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SignalInputTest {
+
+    private static final Pattern PROPERTY_NAME = Pattern
+            .compile("__vTriggerSignalInput_\\d+");
+
+    private MockVaadinServletService service;
+    private VaadinSession session;
+    private MockUI ui;
+
+    @BeforeEach
+    void setUp() {
+        service = new MockVaadinServletService();
+        VaadinService.setCurrent(service);
+        session = new MockVaadinSession(service);
+        session.lock();
+        ui = new MockUI(session);
+    }
+
+    @AfterEach
+    void tearDown() {
+        session.unlock();
+        CurrentInstance.clearAll();
+        service.destroy();
+    }
+
+    @Test
+    void constructor_hasNoSideEffects_noEffectInstalledUntilRendered() {
+        TagComponent owner = new TagComponent("div");
+        ui.getElement().appendChild(owner.getElement());
+
+        new SignalInput<>(owner, new ValueSignal<>("hello"));
+
+        // Just creating the input must not queue any JS — the effect is
+        // installed lazily when the input is wired into a trigger.
+        assertEquals(List.of(), dumpExecuteJsCalls(),
+                "Constructor must not queue any executeJs");
+    }
+
+    @Test
+    void handlerJs_readsUniquePropertyOnOwnerElement() {
+        TagComponent button = new TagComponent("button");
+        TagComponent owner = new TagComponent("div");
+        ui.getElement().appendChild(button.getElement(), owner.getElement());
+
+        ValueSignal<String> signal = new ValueSignal<>("hello");
+        new DomEventTrigger(button, "click").triggers(
+                new WriteToClipboardAction(new SignalInput<>(owner, signal),
+                        null));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        // The trigger handler reads the mirrored signal value from a
+        // uniquely-named property on the owner element ($0). The property
+        // name is generated, so assert on the shape and substitute it back
+        // into the expected body.
+        String body = handlerOf(singleInstallFn(ui)).getBody();
+        Matcher m = PROPERTY_NAME.matcher(body);
+        assertTrue(m.find(), "Expected property name in handler body: " + body);
+        String property = m.group();
+        assertEquals(
+                "((t) => navigator.clipboard.write([new ClipboardItem({\"text/plain\":t})]).then(() => t))($0[\""
+                        + property + "\"]);",
+                body);
+    }
+
+    @Test
+    void signalChange_pushesValueToOwnerElementProperty() {
+        TagComponent button = new TagComponent("button");
+        TagComponent owner = new TagComponent("div");
+        ui.getElement().appendChild(button.getElement(), owner.getElement());
+
+        ValueSignal<String> signal = new ValueSignal<>("first");
+        new DomEventTrigger(button, "click").triggers(
+                new WriteToClipboardAction(new SignalInput<>(owner, signal),
+                        null));
+
+        // After triggers(), the effect has been installed and the initial
+        // pass queued an executeJs that mirrors the signal to the owner.
+        // Drop the install JsFunction; what's left is just the mirror call.
+        JavaScriptInvocation initial = onlyMirrorCall(dumpExecuteJsCalls());
+        assertTrue(initial.getExpression().contains("this[$0]=$1"),
+                "Unexpected expression: " + initial.getExpression());
+        String property = (String) initial.getParameters().get(0);
+        assertTrue(PROPERTY_NAME.matcher(property).matches(),
+                "Unexpected property name: " + property);
+        assertEquals("first", initial.getParameters().get(1));
+
+        signal.set("second");
+
+        JavaScriptInvocation update = onlyMirrorCall(dumpExecuteJsCalls());
+        assertEquals(property, update.getParameters().get(0));
+        assertEquals("second", update.getParameters().get(1));
+    }
+
+    @Test
+    void multipleSignalInputs_getDistinctPropertyNames() {
+        TagComponent owner = new TagComponent("div");
+        ui.getElement().appendChild(owner.getElement());
+
+        SignalInput<String> a = new SignalInput<>(owner,
+                new ValueSignal<>("a"));
+        SignalInput<String> b = new SignalInput<>(owner,
+                new ValueSignal<>("b"));
+
+        StringBuilder out = new StringBuilder();
+        a.appendExpression(new JsBuilder(new DomEventTrigger(owner, "click")),
+                out);
+        String exprA = out.toString();
+        out.setLength(0);
+        b.appendExpression(new JsBuilder(new DomEventTrigger(owner, "click")),
+                out);
+        String exprB = out.toString();
+
+        assertNotEquals(exprA, exprB,
+                "Each SignalInput must use its own property name");
+    }
+
+    private List<JavaScriptInvocation> dumpExecuteJsCalls() {
+        // executeJs goes through the element queue, flushed on the next
+        // before-client-response pass — same pattern as
+        // MockUI.dumpPendingJsInvocations.
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+        return ui.getInternals().dumpPendingJavaScriptInvocations().stream()
+                .map(PendingJavaScriptInvocation::getInvocation)
+                .filter(inv -> inv.getParameters().stream()
+                        .noneMatch(p -> p instanceof JsFunction))
+                .toList();
+    }
+
+    private static JavaScriptInvocation onlyMirrorCall(
+            List<JavaScriptInvocation> calls) {
+        assertEquals(1, calls.size(),
+                "Expected exactly one mirror-update executeJs");
+        return calls.get(0);
+    }
+
+    private static JsFunction singleInstallFn(UI ui) {
+        List<PendingJavaScriptInvocation> pending = ui.getInternals()
+                .dumpPendingJavaScriptInvocations();
+        JsFunction installFn = null;
+        for (PendingJavaScriptInvocation inv : pending) {
+            List<Object> params = inv.getInvocation().getParameters();
+            if (params.size() >= 3 && params.get(2) instanceof JsFunction) {
+                assertTrue(installFn == null,
+                        "Expected exactly one install JsFunction");
+                installFn = (JsFunction) params.get(2);
+            }
+        }
+        assertTrue(installFn != null, "Expected an install JsFunction");
+        return installFn;
+    }
+
+    private static JsFunction handlerOf(JsFunction installFn) {
+        return (JsFunction) installFn.getCaptures().get(0);
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerWriteToClipboardView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerWriteToClipboardView.java
@@ -18,22 +18,28 @@ package com.vaadin.flow.uitest.ui;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Input;
 import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.trigger.internal.Action;
 import com.vaadin.flow.component.trigger.internal.ClickTrigger;
 import com.vaadin.flow.component.trigger.internal.LiteralInput;
 import com.vaadin.flow.component.trigger.internal.PropertyInput;
+import com.vaadin.flow.component.trigger.internal.SignalInput;
 import com.vaadin.flow.component.trigger.internal.WriteToClipboardAction;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.signals.local.ValueSignal;
 import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 
 /**
- * Three buttons exercising {@link WriteToClipboardAction}: one copies the
- * current value of an {@link Input} as {@code text/plain} (via
- * {@link PropertyInput}), one copies a fixed string with embedded escape
- * characters to verify JSON encoding round-trips, and one packs both
- * {@code text/plain} and {@code text/html} into a single
- * {@link com.vaadin.flow.component.html.Div ClipboardItem} to verify the
- * multi-format path resolves with the text value. Each action's success/error
+ * Buttons exercising {@link WriteToClipboardAction}: one copies the current
+ * value of an {@link Input} as {@code text/plain} (via {@link PropertyInput}),
+ * one copies a fixed string with embedded escape characters to verify JSON
+ * encoding round-trips, one packs both {@code text/plain} and {@code text/html}
+ * into a single {@link com.vaadin.flow.component.html.Div ClipboardItem} to
+ * verify the multi-format path resolves with the text value, and one copies the
+ * current value of a server-side {@link ValueSignal} (via {@link SignalInput})
+ * — a second button mutates the signal so the IT can verify the copied value
+ * tracks the server signal. A {@link Span} bound to the signal via
+ * {@code bindText} acts as the sync point. Each action's success/error
  * consumers write the outcome into the status {@link Div}. The IT replaces
  * {@code navigator.clipboard.write} and {@code ClipboardItem} with recording
  * shims so the assertions don't depend on browser clipboard permissions.
@@ -50,6 +56,17 @@ public class TriggerWriteToClipboardView extends AbstractDivView {
     /** HTML slot copied by the {@code #copy-multi} button. */
     static final String MULTI_HTML = "<b>html</b>";
 
+    /**
+     * Initial value of the signal copied by the {@code #copy-signal} button.
+     */
+    static final String SIGNAL_INITIAL_TEXT = "signal initial";
+
+    /**
+     * Value the signal is mutated to when the {@code #change-signal} button is
+     * clicked.
+     */
+    static final String SIGNAL_UPDATED_TEXT = "signal updated";
+
     @Override
     protected void onShow() {
         Input field = new Input();
@@ -60,10 +77,18 @@ public class TriggerWriteToClipboardView extends AbstractDivView {
         copyStaticButton.setId("copy-static");
         NativeButton copyMultiButton = new NativeButton("Copy text + html");
         copyMultiButton.setId("copy-multi");
+        NativeButton copySignalButton = new NativeButton("Copy signal value");
+        copySignalButton.setId("copy-signal");
+        NativeButton changeSignalButton = new NativeButton(
+                "Change signal value");
+        changeSignalButton.setId("change-signal");
+        Span signalDisplay = new Span();
+        signalDisplay.setId("signal-value");
         Div status = new Div();
         status.setId("status");
 
-        add(field, copyButton, copyStaticButton, copyMultiButton, status);
+        add(field, copyButton, copyStaticButton, copyMultiButton,
+                copySignalButton, changeSignalButton, signalDisplay, status);
 
         Action.Input<String> value = new PropertyInput<>(field, "value",
                 String.class);
@@ -80,5 +105,14 @@ public class TriggerWriteToClipboardView extends AbstractDivView {
                 new LiteralInput<>(MULTI_TEXT), new LiteralInput<>(MULTI_HTML),
                 copied -> status.setText("ok:" + copied), err -> status
                         .setText("err:" + err.name() + ":" + err.message())));
+
+        ValueSignal<String> textSignal = new ValueSignal<>(SIGNAL_INITIAL_TEXT);
+        signalDisplay.getElement().bindText(textSignal);
+        new ClickTrigger(copySignalButton).triggers(new WriteToClipboardAction(
+                new SignalInput<>(this, textSignal), null,
+                copied -> status.setText("ok:" + copied), err -> status
+                        .setText("err:" + err.name() + ":" + err.message())));
+        changeSignalButton
+                .addClickListener(e -> textSignal.set(SIGNAL_UPDATED_TEXT));
     }
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerWriteToClipboardIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerWriteToClipboardIT.java
@@ -99,6 +99,51 @@ public class TriggerWriteToClipboardIT extends ChromeBrowserTest {
     }
 
     @Test
+    public void clickCopiesSignalValue_andTracksSignalAfterChange() {
+        open();
+        installResolvingClipboardShim();
+
+        WebElement copySignal = findElement(By.id("copy-signal"));
+        WebElement changeSignal = findElement(By.id("change-signal"));
+        WebElement signalDisplay = findElement(By.id("signal-value"));
+        WebElement status = findElement(By.id("status"));
+
+        // The bound span renders the signal value via bindText; wait for the
+        // initial render to land so we know the SignalInput's mirror has
+        // also reached the client.
+        waitUntil(d -> TriggerWriteToClipboardView.SIGNAL_INITIAL_TEXT
+                .equals(signalDisplay.getText()));
+
+        copySignal.click();
+
+        Object written = waitUntil(d -> ((JavascriptExecutor) d)
+                .executeScript("return window.__written;"));
+        Assert.assertEquals(TriggerWriteToClipboardView.SIGNAL_INITIAL_TEXT,
+                ((java.util.Map<?, ?>) written).get("text/plain"));
+        waitUntil(d -> ("ok:" + TriggerWriteToClipboardView.SIGNAL_INITIAL_TEXT)
+                .equals(status.getText()));
+
+        // Mutate the signal from the server. Both the bound span and the
+        // SignalInput's mirrored property update from the same effect pass,
+        // so the span's text is a deterministic sync point for the next
+        // copy click.
+        ((JavascriptExecutor) getDriver())
+                .executeScript("window.__written = null;");
+        changeSignal.click();
+        waitUntil(d -> TriggerWriteToClipboardView.SIGNAL_UPDATED_TEXT
+                .equals(signalDisplay.getText()));
+
+        copySignal.click();
+
+        Object writtenAgain = waitUntil(d -> ((JavascriptExecutor) d)
+                .executeScript("return window.__written;"));
+        Assert.assertEquals(TriggerWriteToClipboardView.SIGNAL_UPDATED_TEXT,
+                ((java.util.Map<?, ?>) writtenAgain).get("text/plain"));
+        waitUntil(d -> ("ok:" + TriggerWriteToClipboardView.SIGNAL_UPDATED_TEXT)
+                .equals(status.getText()));
+    }
+
+    @Test
     public void writeRejection_propagatesAsFailureWithNameAndMessage() {
         open();
         installRejectingClipboardShim();


### PR DESCRIPTION
Adds SignalInput<T>(Component owner, Signal<T> signal) under com.vaadin.flow.component.trigger.internal. A component-scoped Signal.effect mirrors the signal value to a uniquely-named JS property on the owner element via executeJs; the input's rendered expression reads that property at fire time, so actions such as CopyTextToClipboardAction can use a server-side signal as their value source without first projecting it onto a DOM property.

Includes unit tests covering the rendered expression, push-on-change, and per-input property naming, plus an IT that copies a ValueSignal, mutates it from a separate button, and verifies the next copy sees the updated value.
