### PR TITLE
feat: DownloadAction for the action trigger framework

### DIFF
--- a/flow-client/src/main/frontend/Download.ts
+++ b/flow-client/src/main/frontend/Download.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Triggers a file download from the given URL using the standard
+ * <a href download> click pattern.
+ *
+ * The anchor is synthesised, clicked synchronously inside the caller's
+ * gesture context, and removed. The browser then either navigates to the
+ * URL (server responds with Content-Disposition: attachment) or saves the
+ * resource directly when the download attribute applies.
+ *
+ * The {@code download} attribute is honoured only for same-origin URLs;
+ * cross-origin responses must set Content-Disposition themselves for the
+ * filename to take effect.
+ */
+function startDownload(url: string, filename?: string): void {
+  const a = document.createElement('a');
+  a.href = url;
+  // Always set `download` so the browser saves the response rather than
+  // navigating to it. Empty value lets the browser pick the filename from
+  // Content-Disposition or the URL pathname; a non-empty value is the
+  // suggested filename (honoured only same-origin). Cross-origin responses
+  // without Content-Disposition: attachment still navigate — that's a
+  // server-side concern this client helper can't override.
+  a.download = filename ?? '';
+  // Opt out of Vaadin's client-side router so the click reaches the
+  // browser's native download handling instead of being intercepted as an
+  // in-app navigation. Matches Anchor.setHref(DownloadHandler).
+  a.setAttribute('router-ignore', '');
+  a.rel = 'noopener';
+  // Hidden but in the document — some browsers ignore clicks on detached
+  // anchors.
+  a.style.display = 'none';
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+}
+
+const $wnd = window as any;
+$wnd.Vaadin ??= {};
+$wnd.Vaadin.Flow ??= {};
+$wnd.Vaadin.Flow.download = {
+  start: startDownload
+};
+
+// Empty export to ensure TypeScript emits this as an ES module,
+// which is required for Vite to load it via import.
+export {};

--- a/flow-client/src/main/frontend/Download.ts
+++ b/flow-client/src/main/frontend/Download.ts
@@ -41,7 +41,6 @@ function startDownload(url: string, filename?: string): void {
   // browser's native download handling instead of being intercepted as an
   // in-app navigation. Matches Anchor.setHref(DownloadHandler).
   a.setAttribute('router-ignore', '');
-  a.rel = 'noopener';
   // Hidden but in the document — some browsers ignore clicks on detached
   // anchors.
   a.style.display = 'none';

--- a/flow-client/src/main/frontend/Flow.ts
+++ b/flow-client/src/main/frontend/Flow.ts
@@ -6,6 +6,7 @@ import {
 } from '@vaadin/common-frontend';
 import './Clipboard';
 import { currentFullscreenState } from './Fullscreen';
+import './Download';
 import './ElementResize';
 import './Geolocation';
 import { currentVisibility } from './PageVisibility';

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/DownloadAction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/DownloadAction.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.trigger.internal;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.JsFunction;
+import com.vaadin.flow.server.StreamResourceRegistry;
+import com.vaadin.flow.server.streams.DownloadHandler;
+
+/**
+ * Starts a file download in the browser when the bound trigger fires. The URL
+ * is loaded into a synthesised {@code <a href download>} that is clicked
+ * synchronously inside the trigger's handler — so the call happens inside the
+ * user gesture and is not subject to popup blockers.
+ * <p>
+ * Three ways to specify what to download:
+ * <ul>
+ * <li><b>A URL the application already knows</b> — a server endpoint, an
+ * external CDN, a {@code blob:} URL minted on the client, anything addressable.
+ * Use {@link #DownloadAction(String)} or
+ * {@link #DownloadAction(String, String)} to also suggest a filename.</li>
+ * <li><b>A {@link DownloadHandler} for server-generated content</b> — see
+ * {@link DownloadHandler#forFile}, {@link DownloadHandler#forClassResource},
+ * {@link DownloadHandler#fromInputStream}, or any lambda. Use
+ * {@link #DownloadAction(DownloadHandler)}. The action lazily registers a
+ * stream resource scoped to the trigger host element; the resource is
+ * unregistered when the host detaches and re-registered on re-attach, keeping
+ * the URL stable for the lifetime of the action. Filename comes from the
+ * {@link DownloadHandler} itself (its URL postfix and/or
+ * {@code Content-Disposition} header).</li>
+ * <li><b>A value resolved from client state at fire time</b> — use
+ * {@link #DownloadAction(Action.Input)} or
+ * {@link #DownloadAction(Action.Input, Action.Input)} when the URL (or
+ * filename) is only known on the client, e.g. the current value of an input
+ * field, or a {@code blob:} URL the client just produced.</li>
+ * </ul>
+ * <p>
+ * The {@code download} attribute that suggests a filename is honoured only for
+ * same-origin URLs. For cross-origin downloads the server must send the
+ * filename in a {@code Content-Disposition} header itself.
+ * <p>
+ * No outcome callback: the browser does not notify when (or whether) the file
+ * is actually saved.
+ *
+ * <pre>{@code
+ * // Static URL
+ * new ClickTrigger(button).triggers(
+ *         new DownloadAction("/api/reports/2026-Q1.pdf", "report.pdf"));
+ *
+ * // Server-generated content
+ * new ClickTrigger(button)
+ *         .triggers(new DownloadAction(DownloadHandler.forFile(reportFile)));
+ *
+ * // URL taken from a text field at fire time
+ * Action.Input<String> currentUrl = new PropertyInput<>(urlField, "value",
+ *         String.class);
+ * new ClickTrigger(button).triggers(new DownloadAction(currentUrl));
+ * }</pre>
+ *
+ * For internal use only. May be renamed or removed in a future release.
+ */
+public class DownloadAction extends Action {
+
+    private final Action.Input<String> urlInput;
+    private final Action.@Nullable Input<String> filenameInput;
+
+    /**
+     * Downloads from a known URL with no filename hint.
+     *
+     * @param url
+     *            the URL to download from, not {@code null}
+     */
+    public DownloadAction(String url) {
+        this.urlInput = literal(url, "url");
+        this.filenameInput = null;
+    }
+
+    /**
+     * Downloads from a known URL and suggests {@code filename} as the saved
+     * name. The hint is ignored by the browser for cross-origin URLs; provide a
+     * {@code Content-Disposition} response header in that case.
+     *
+     * @param url
+     *            the URL to download from, not {@code null}
+     * @param filename
+     *            the suggested filename, not {@code null}
+     */
+    public DownloadAction(String url, String filename) {
+        this.urlInput = literal(url, "url");
+        this.filenameInput = literal(filename, "filename");
+    }
+
+    /**
+     * Downloads from a {@link DownloadHandler}. The handler is registered as a
+     * stream resource scoped to the trigger host element the first time this
+     * action is wired to a trigger; re-attaching the host re-registers the
+     * resource with the same URL.
+     *
+     * @param handler
+     *            produces the response when the URL is fetched, not
+     *            {@code null}
+     */
+    public DownloadAction(DownloadHandler handler) {
+        this.urlInput = new HandlerBinding(
+                Objects.requireNonNull(handler, "handler must not be null"));
+        this.filenameInput = null;
+    }
+
+    /**
+     * Downloads from a URL resolved on the client at fire time. Use this when
+     * the URL is only known in the browser — for example, the current contents
+     * of an input field, or a {@code blob:} URL the client just minted.
+     *
+     * @param url
+     *            input supplying the URL when the trigger fires, not
+     *            {@code null}
+     */
+    public DownloadAction(Action.Input<String> url) {
+        this.urlInput = Objects.requireNonNull(url, "url must not be null");
+        this.filenameInput = null;
+    }
+
+    /**
+     * Like {@link #DownloadAction(Action.Input)} but also resolves the
+     * suggested filename on the client.
+     *
+     * @param url
+     *            input supplying the URL when the trigger fires, not
+     *            {@code null}
+     * @param filename
+     *            input supplying the suggested filename when the trigger fires,
+     *            not {@code null}
+     */
+    public DownloadAction(Action.Input<String> url,
+            Action.Input<String> filename) {
+        this.urlInput = Objects.requireNonNull(url, "url must not be null");
+        this.filenameInput = Objects.requireNonNull(filename,
+                "filename must not be null");
+    }
+
+    @Override
+    protected JsFunction toJs(Trigger trigger) {
+        // Two body shapes — with or without a filename argument — keep the
+        // emitted JS minimal. Both URL and filename are JsFunctions invoked
+        // with event so any handler-scoped inputs read live state.
+        if (filenameInput == null) {
+            return JsFunction.of("window.Vaadin.Flow.download.start($0(event))",
+                    urlInput.toJs(trigger)).withArguments("event");
+        }
+        return JsFunction
+                .of("window.Vaadin.Flow.download.start($0(event), $1(event))",
+                        urlInput.toJs(trigger), filenameInput.toJs(trigger))
+                .withArguments("event");
+    }
+
+    private static LiteralInput<String> literal(String value, String name) {
+        return new LiteralInput<>(
+                Objects.requireNonNull(value, name + " must not be null"));
+    }
+
+    /**
+     * Manages the {@link DownloadHandler}-backed flavour: one
+     * {@link StreamResourceRegistry.ElementStreamResource} per trigger host.
+     * Lifecycle (register on attach, unregister on detach, re-register on
+     * re-attach) is delegated to
+     * {@link Element#setAttribute(String, AbstractStreamResource)} — the same
+     * machinery {@code Image.setSrc(DownloadHandler)} and
+     * {@code Anchor.setHref(DownloadHandler)} use. The attribute name is
+     * derived from the resource's UUID id, so it is unique per binding and
+     * harmless on any host element. The URI baked into the JS is the same one
+     * the framework re-publishes on the attribute, kept stable by the
+     * resource's id.
+     */
+    private static final class HandlerBinding extends Action.Input<String>
+            implements Serializable {
+
+        private static final String ATTR_PREFIX = "data-flow-download-";
+
+        private final DownloadHandler handler;
+        private final Map<Element, URI> uriByHost = new IdentityHashMap<>();
+
+        HandlerBinding(DownloadHandler handler) {
+            this.handler = handler;
+        }
+
+        @Override
+        protected JsFunction toJs(Trigger trigger) {
+            // Register-and-resolve in one step: the URI is stable per
+            // (handler, host) pair, so multiple toJs() calls for the same
+            // host reuse the same resource.
+            URI uri = uriByHost.computeIfAbsent(trigger.getHost(),
+                    this::registerForHost);
+            return JsFunction.of("return $0", uri.toASCIIString());
+        }
+
+        private URI registerForHost(Element host) {
+            StreamResourceRegistry.ElementStreamResource resource = new StreamResourceRegistry.ElementStreamResource(
+                    handler, host);
+            host.setAttribute(ATTR_PREFIX + resource.getId(), resource);
+            return StreamResourceRegistry.getURI(resource);
+        }
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/DownloadActionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/DownloadActionTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.trigger.internal;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.dom.JsFunction;
+import com.vaadin.flow.server.StreamResourceRegistry;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.server.streams.DownloadHandler;
+import com.vaadin.tests.util.MockUI;
+
+import static com.vaadin.flow.component.trigger.internal.TriggerTestUtil.actionOf;
+import static com.vaadin.flow.component.trigger.internal.TriggerTestUtil.singleInstallFn;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DownloadActionTest {
+
+    @Test
+    void urlString_actionCallsStartWithOneArgument() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        ui.getElement().appendChild(button.getElement());
+
+        new DomEventTrigger(button, "click")
+                .triggers(new DownloadAction("/api/report.pdf"));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        JsFunction action = actionOf(singleInstallFn(ui));
+        assertEquals("window.Vaadin.Flow.download.start($0(event))",
+                action.getBody());
+        assertLiteralInputValue(action, 0, "/api/report.pdf");
+    }
+
+    @Test
+    void urlStringWithFilename_actionCallsStartWithTwoArguments() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        ui.getElement().appendChild(button.getElement());
+
+        new DomEventTrigger(button, "click").triggers(
+                new DownloadAction("/api/report.pdf", "Q1 \"report\".pdf"));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        // Two-argument body shape; filename value (with embedded quote) goes
+        // verbatim into the input function's capture — Jackson handles the
+        // escaping on the wire, no hand-quoting in the JS.
+        JsFunction action = actionOf(singleInstallFn(ui));
+        assertEquals("window.Vaadin.Flow.download.start($0(event), $1(event))",
+                action.getBody());
+        assertLiteralInputValue(action, 0, "/api/report.pdf");
+        assertLiteralInputValue(action, 1, "Q1 \"report\".pdf");
+    }
+
+    @Test
+    void inputUrl_capturesPropertyInputThatReadsAtFireTime() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        TagComponent field = new TagComponent("input");
+        ui.getElement().appendChild(button.getElement(), field.getElement());
+
+        new DomEventTrigger(button, "click").triggers(new DownloadAction(
+                new PropertyInput<>(field, "value", String.class)));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        JsFunction action = actionOf(singleInstallFn(ui));
+        JsFunction urlFn = (JsFunction) action.getCaptures().get(0);
+        assertEquals("return $0[$1]", urlFn.getBody());
+        assertEquals("value", urlFn.getCaptures().get(1));
+    }
+
+    @Test
+    void downloadHandler_capturesRegisteredResourceUri() {
+        UI ui = new MockUI();
+        // The mock session has no resource registry by default; install a
+        // real one so the action can register its DownloadHandler.
+        VaadinSession session = ui.getSession();
+        Mockito.when(session.getResourceRegistry())
+                .thenReturn(new StreamResourceRegistry(session));
+        TagComponent button = new TagComponent("button");
+        ui.getElement().appendChild(button.getElement());
+
+        DownloadHandler handler = event -> event.getOutputStream()
+                .write("hi".getBytes());
+        new DomEventTrigger(button, "click")
+                .triggers(new DownloadAction(handler));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        // The URI itself contains a UUID we don't control, so just assert
+        // the structural shape: the URL input captures the registered
+        // Vaadin dynamic-resource path as a plain String.
+        JsFunction action = actionOf(singleInstallFn(ui));
+        JsFunction urlFn = (JsFunction) action.getCaptures().get(0);
+        Object uri = urlFn.getCaptures().get(0);
+        assertTrue(
+                uri instanceof String && ((String) uri)
+                        .startsWith("VAADIN/dynamic/resource/"),
+                "Expected a Vaadin dynamic-resource URI, got: " + uri);
+    }
+
+    private static void assertLiteralInputValue(JsFunction action,
+            int captureIndex, String expectedValue) {
+        Object capture = action.getCaptures().get(captureIndex);
+        assertTrue(capture instanceof JsFunction,
+                "expected JsFunction at capture " + captureIndex);
+        JsFunction inputFn = (JsFunction) capture;
+        assertEquals("return $0", inputFn.getBody(),
+                "expected LiteralInput shape");
+        assertEquals(expectedValue, inputFn.getCaptures().get(0));
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerDownloadView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerDownloadView.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+import com.vaadin.flow.component.html.Input;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.trigger.internal.ClickTrigger;
+import com.vaadin.flow.component.trigger.internal.DownloadAction;
+import com.vaadin.flow.component.trigger.internal.PropertyInput;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.streams.DownloadHandler;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+/**
+ * Four buttons exercising each {@link DownloadAction} constructor flavour:
+ * static URL, static URL with a filename hint that includes a quote so the JSON
+ * escaping round-trips, a {@link DownloadHandler} that streams a known body so
+ * the IT can fetch it back, and an {@link Input}-backed {@link PropertyInput}
+ * resolved at fire time. The IT replaces
+ * {@code window.Vaadin.Flow.download.start} with a recording shim so the
+ * assertions don't depend on the browser actually saving the file.
+ */
+@Route(value = "com.vaadin.flow.uitest.ui.TriggerDownloadView", layout = ViewTestLayout.class)
+public class TriggerDownloadView extends AbstractDivView {
+
+    /**
+     * Filename suggested by the {@code #download-url-filename} button. The
+     * embedded quote is what makes the assertion meaningful — it forces JSON
+     * escaping in the rendered JS and proves the value reaches the browser
+     * unchanged.
+     */
+    static final String SUGGESTED_FILENAME = "Q1 \"report\".pdf";
+
+    /**
+     * Body served by the {@code #download-handler} button's
+     * {@link DownloadHandler}. The IT fetches the recorded URL and asserts this
+     * exact string, verifying that {@link Element#setAttribute}-driven
+     * stream-resource registration actually wired the URL to the handler.
+     */
+    static final String HANDLER_BODY = "handler-body-content";
+
+    @Override
+    protected void onShow() {
+        NativeButton urlButton = new NativeButton("Download URL");
+        urlButton.setId("download-url");
+        NativeButton urlWithFilenameButton = new NativeButton(
+                "Download URL + filename");
+        urlWithFilenameButton.setId("download-url-filename");
+        NativeButton handlerButton = new NativeButton("Download via handler");
+        handlerButton.setId("download-handler");
+        NativeButton inputButton = new NativeButton("Download URL from input");
+        inputButton.setId("download-input");
+        Input urlField = new Input();
+        urlField.setId("url-source");
+
+        add(urlButton, urlWithFilenameButton, handlerButton, inputButton,
+                urlField);
+
+        new ClickTrigger(urlButton)
+                .triggers(new DownloadAction("/static/sample.bin"));
+        new ClickTrigger(urlWithFilenameButton).triggers(
+                new DownloadAction("/static/sample.bin", SUGGESTED_FILENAME));
+        new ClickTrigger(handlerButton)
+                .triggers(new DownloadAction((DownloadHandler) event -> {
+                    try (OutputStream out = event.getOutputStream()) {
+                        out.write(
+                                HANDLER_BODY.getBytes(StandardCharsets.UTF_8));
+                    }
+                }));
+        new ClickTrigger(inputButton).triggers(new DownloadAction(
+                new PropertyInput<>(urlField, "value", String.class)));
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerDownloadView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerDownloadView.java
@@ -23,6 +23,7 @@ import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.trigger.internal.ClickTrigger;
 import com.vaadin.flow.component.trigger.internal.DownloadAction;
 import com.vaadin.flow.component.trigger.internal.PropertyInput;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.streams.DownloadHandler;
 import com.vaadin.flow.uitest.servlet.ViewTestLayout;

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerDownloadIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerDownloadIT.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class TriggerDownloadIT extends ChromeBrowserTest {
+
+    @Test
+    public void clickUrl_invokesStartWithUrlAndNoFilename() {
+        open();
+        installRecordingShim();
+
+        findElement(By.id("download-url")).click();
+
+        Map<String, Object> recorded = waitForFirstDownload();
+        Assert.assertEquals("/static/sample.bin", recorded.get("url"));
+        Assert.assertNull(recorded.get("filename"));
+    }
+
+    @Test
+    public void clickUrlWithFilename_invokesStartWithBothAndQuotesRoundTrip() {
+        open();
+        installRecordingShim();
+
+        findElement(By.id("download-url-filename")).click();
+
+        Map<String, Object> recorded = waitForFirstDownload();
+        Assert.assertEquals("/static/sample.bin", recorded.get("url"));
+        // The Java-side literal includes a quote; JSON encoding into the
+        // emitted JS must preserve it byte-for-byte when it reaches the
+        // browser.
+        Assert.assertEquals(TriggerDownloadView.SUGGESTED_FILENAME,
+                recorded.get("filename"));
+    }
+
+    @Test
+    public void clickHandler_emitsRegisteredResourceUrl_andUrlServesHandlerBody() {
+        open();
+        installRecordingShim();
+
+        findElement(By.id("download-handler")).click();
+
+        Map<String, Object> recorded = waitForFirstDownload();
+        String url = (String) recorded.get("url");
+        // StreamResourceRegistry composes URIs under VAADIN/dynamic/resource.
+        Assert.assertTrue("Expected a Vaadin dynamic-resource URL, got: " + url,
+                url.contains("VAADIN/dynamic/resource"));
+
+        // End-to-end check that Element.setAttribute(name, resource) actually
+        // wired the URL to the DownloadHandler: fetching the recorded URL
+        // from the browser should return the bytes the handler wrote.
+        String body = fetchText(url);
+        Assert.assertEquals(TriggerDownloadView.HANDLER_BODY, body);
+    }
+
+    @Test
+    public void clickInput_resolvesUrlFromInputValueAtFireTime() {
+        open();
+        installRecordingShim();
+
+        WebElement field = findElement(By.id("url-source"));
+        ((JavascriptExecutor) getDriver()).executeScript(
+                "arguments[0].value = '/from-input/file.bin';", field);
+
+        findElement(By.id("download-input")).click();
+
+        Map<String, Object> recorded = waitForFirstDownload();
+        Assert.assertEquals("/from-input/file.bin", recorded.get("url"));
+    }
+
+    // Replace window.Vaadin.Flow.download.start with a recorder so the IT
+    // never actually triggers a save dialog or navigation. Each invocation
+    // pushes {url, filename} onto window.__downloads.
+    private void installRecordingShim() {
+        ((JavascriptExecutor) getDriver())
+                .executeScript("window.__downloads = [];"
+                        + "window.Vaadin.Flow.download.start = "
+                        + "  (url, filename) => window.__downloads.push("
+                        + "    {url: url, filename: filename ?? null});");
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> waitForFirstDownload() {
+        return (Map<String, Object>) waitUntil(d -> {
+            Object value = ((JavascriptExecutor) d).executeScript(
+                    "return (window.__downloads && window.__downloads.length)"
+                            + " ? window.__downloads[0] : null;");
+            return value;
+        });
+    }
+
+    private String fetchText(String url) {
+        // executeAsyncScript: last arg is the callback to invoke when done.
+        return (String) ((JavascriptExecutor) getDriver())
+                .executeAsyncScript("const url = arguments[0];"
+                        + "const done = arguments[arguments.length - 1];"
+                        + "fetch(url).then(r => r.text()).then(done)"
+                        + "  .catch(e => done('FETCH_ERROR:' + e));", url);
+    }
+}


### PR DESCRIPTION
Introduces a new server-side action for triggering file downloads in the browser, along with the corresponding client-side implementation. The main goal is to allow server code to initiate downloads using various sources (static URLs, server-generated content, or client-resolved URLs), with support for suggesting filenames and handling dynamic resources.

**New download action feature:**

* Added `DownloadAction` class to the server (`DownloadAction.java`), enabling server-side triggers for browser downloads from static URLs, server-generated streams, or client-resolved values, with optional filename suggestions. This includes proper handling for registering and unregistering server-generated resources per element.

**Client-side support:**

* Implemented the `startDownload` function in `Download.ts`, which synthesizes and clicks an anchor element to initiate a download, and exposed it under `window.Vaadin.Flow.download.start`.
* Registered the new download module in the main client entrypoint (`Flow.ts`).