### PR TITLE
refactor: rename ClipboardReadAction to ReadFromClipboardAction

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/ClipboardPayload.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/ClipboardPayload.java
@@ -20,7 +20,7 @@ import java.io.Serializable;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Textual clipboard contents delivered to {@link ClipboardReadAction}'s
+ * Textual clipboard contents delivered to {@link ReadFromClipboardAction}'s
  * handler. Either field may be {@code null} if the corresponding MIME type was
  * not present on the clipboard item.
  * <p>

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/ReadFromClipboardAction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/ReadFromClipboardAction.java
@@ -40,19 +40,21 @@ import com.vaadin.flow.function.SerializableConsumer;
  * {@code payload -> {}} or {@code err -> {}} explicitly.
  *
  * <pre>{@code
- * new ClickTrigger(pasteButton).triggers(new ClipboardReadAction(payload -> {
- *     if (payload == null) {
- *         notification.show("Clipboard is empty");
- *     } else {
- *         editor.setValue(
- *                 payload.html() != null ? payload.html() : payload.text());
- *     }
- * }, err -> notification.show("Clipboard read denied: " + err.message())));
+ * new ClickTrigger(pasteButton)
+ *         .triggers(new ReadFromClipboardAction(payload -> {
+ *             if (payload == null) {
+ *                 notification.show("Clipboard is empty");
+ *             } else {
+ *                 editor.setValue(payload.html() != null ? payload.html()
+ *                         : payload.text());
+ *             }
+ *         }, err -> notification
+ *                 .show("Clipboard read denied: " + err.message())));
  * }</pre>
  *
  * For internal use only. May be renamed or removed in a future release.
  */
-public class ClipboardReadAction extends PromiseAction<ClipboardPayload> {
+public class ReadFromClipboardAction extends PromiseAction<ClipboardPayload> {
 
     /**
      * Creates an action that reads the user's clipboard and delivers the
@@ -66,7 +68,7 @@ public class ClipboardReadAction extends PromiseAction<ClipboardPayload> {
      *            clipboard read failed (permission denied, unsupported, …); not
      *            {@code null}
      */
-    public ClipboardReadAction(
+    public ReadFromClipboardAction(
             SerializableConsumer<@Nullable ClipboardPayload> onPayload,
             SerializableConsumer<Error> onError) {
         super(ClipboardPayload.class, onPayload, onError);

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/ReadFromClipboardActionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/ReadFromClipboardActionTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class ClipboardReadActionTest {
+class ReadFromClipboardActionTest {
 
     @Test
     void handlerJsCallsObserverWithClipboardReadPromise() {
@@ -45,7 +45,7 @@ class ClipboardReadActionTest {
         ui.getElement().appendChild(button.getElement());
 
         new DomEventTrigger(button, "click")
-                .triggers(new ClipboardReadAction(p -> {
+                .triggers(new ReadFromClipboardAction(p -> {
                 }, err -> {
                 }));
 
@@ -65,7 +65,7 @@ class ClipboardReadActionTest {
 
         List<@Nullable ClipboardPayload> received = new ArrayList<>();
         new DomEventTrigger(button, "click")
-                .triggers(new ClipboardReadAction(received::add, err -> {
+                .triggers(new ReadFromClipboardAction(received::add, err -> {
                 }));
 
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
@@ -95,7 +95,7 @@ class ClipboardReadActionTest {
 
         List<@Nullable ClipboardPayload> received = new ArrayList<>();
         new DomEventTrigger(button, "click")
-                .triggers(new ClipboardReadAction(received::add, err -> {
+                .triggers(new ReadFromClipboardAction(received::add, err -> {
                 }));
 
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
@@ -120,7 +120,7 @@ class ClipboardReadActionTest {
 
         List<PromiseAction.Error> failed = new ArrayList<>();
         new DomEventTrigger(button, "click")
-                .triggers(new ClipboardReadAction(p -> {
+                .triggers(new ReadFromClipboardAction(p -> {
                 }, failed::add));
 
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerReadFromClipboardView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerReadFromClipboardView.java
@@ -18,19 +18,19 @@ package com.vaadin.flow.uitest.ui;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.trigger.internal.ClickTrigger;
-import com.vaadin.flow.component.trigger.internal.ClipboardReadAction;
+import com.vaadin.flow.component.trigger.internal.ReadFromClipboardAction;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 
 /**
- * Wires a {@link ClickTrigger} on a button to a {@link ClipboardReadAction}
+ * Wires a {@link ClickTrigger} on a button to a {@link ReadFromClipboardAction}
  * that writes the received {@code ClipboardPayload} (or {@code "null"}) into a
  * status div, so the IT can assert both paths. The IT replaces
  * {@code navigator.clipboard.read} with a recording shim so the assertions
  * don't depend on browser clipboard permissions.
  */
-@Route(value = "com.vaadin.flow.uitest.ui.TriggerClipboardReadView", layout = ViewTestLayout.class)
-public class TriggerClipboardReadView extends AbstractDivView {
+@Route(value = "com.vaadin.flow.uitest.ui.TriggerReadFromClipboardView", layout = ViewTestLayout.class)
+public class TriggerReadFromClipboardView extends AbstractDivView {
 
     @Override
     protected void onShow() {
@@ -41,7 +41,7 @@ public class TriggerClipboardReadView extends AbstractDivView {
 
         add(readButton, status);
 
-        new ClickTrigger(readButton).triggers(new ClipboardReadAction(p -> {
+        new ClickTrigger(readButton).triggers(new ReadFromClipboardAction(p -> {
             if (p == null) {
                 status.setText("null");
             } else {

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerReadFromClipboardIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerReadFromClipboardIT.java
@@ -23,7 +23,7 @@ import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
-public class TriggerClipboardReadIT extends ChromeBrowserTest {
+public class TriggerReadFromClipboardIT extends ChromeBrowserTest {
 
     @Test
     public void clickReadsClipboard_andServerReceivesPayload() {


### PR DESCRIPTION
Aligns the action's name with the verb-first / direction-preposition shape of its sibling CopyTextToClipboardAction. The Web API (navigator.clipboard.read) returns ClipboardItem[] which can carry any MIME type, not just text, so the name avoids a "Text" suffix.

Pure mechanical rename: action class + test + IT view + IT class + one javadoc reference in ClipboardPayload. No behaviour change.
