### PR TITLE
feat: CallbackAction + SetSignalAction — trigger actions for server-side callbacks

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/CallbackAction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/CallbackAction.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.trigger.internal;
+
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+
+import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.flow.internal.StateNode;
+import com.vaadin.flow.internal.nodefeature.ReturnChannelMap;
+import com.vaadin.flow.internal.nodefeature.ReturnChannelRegistration;
+
+/**
+ * Forwards a value from the trigger's handler scope back to the server and
+ * hands it to a {@link SerializableConsumer} on the UI thread. The generic
+ * counterpart to client-side actions like {@link SetPropertyAction} — same
+ * input/source story, except the destination is a Java callback instead of a JS
+ * assignment.
+ * <p>
+ * Use this as the bridge from a trigger to arbitrary server-side state — log a
+ * value, fire a custom event, push to a queue, etc. The {@link SetSignalAction}
+ * subclass is the named convenience for the common case of forwarding into a
+ * {@link com.vaadin.flow.signals.local.ValueSignal}.
+ * <p>
+ * Example — log the screen-X coordinate of each click:
+ *
+ * <pre>{@code
+ * ClickTrigger click = new ClickTrigger(button);
+ * click.triggers(new CallbackAction<>(Integer.class,
+ *         x -> logger.info("clicked at {}", x), click.screenX()));
+ * }</pre>
+ *
+ * <p>
+ * The rendered JS calls a {@link ReturnChannelRegistration} that, on the
+ * server, decodes the JSON value as {@code T} and invokes the callback. A null
+ * value on the wire (a JSON {@code null} or a missing argument) is rejected
+ * with {@link IllegalStateException} — callbacks see decoded, non-null values
+ * only. A separate channel is registered per host node, so the same action
+ * instance can be wired to triggers hosted on different elements without
+ * leaking registrations across them.
+ * <p>
+ * For internal use only. May be renamed or removed in a future release.
+ *
+ * @param <T>
+ *            the type the JSON value is decoded to and the callback receives
+ */
+public class CallbackAction<T> extends Action {
+
+    private final Class<T> valueType;
+    private final SerializableConsumer<T> callback;
+    private final Action.Input<? extends T> source;
+    private final Map<StateNode, ReturnChannelRegistration> channelByNode = new IdentityHashMap<>();
+
+    /**
+     * Creates an action that, when the trigger fires, evaluates {@code source}
+     * on the client, sends the value to the server, decodes it as
+     * {@code valueType}, and hands it to {@code callback} on the UI thread.
+     *
+     * @param valueType
+     *            runtime type the JSON value is decoded to before being passed
+     *            to {@code callback}, not {@code null}
+     * @param callback
+     *            invoked on the UI thread with the decoded value, not
+     *            {@code null}
+     * @param source
+     *            input that produces the value on the client when the trigger
+     *            fires, not {@code null}
+     */
+    public CallbackAction(Class<T> valueType, SerializableConsumer<T> callback,
+            Action.Input<? extends T> source) {
+        this.valueType = Objects.requireNonNull(valueType,
+                "valueType must not be null");
+        this.callback = Objects.requireNonNull(callback,
+                "callback must not be null");
+        this.source = Objects.requireNonNull(source, "source must not be null");
+    }
+
+    @Override
+    protected final void appendStatement(JsBuilder builder, StringBuilder out) {
+        String channelRef = builder
+                .capture(channelFor(builder.trigger().getHost().getNode()));
+        out.append(channelRef).append('(');
+        source.appendExpression(builder, out);
+        out.append(')');
+    }
+
+    private ReturnChannelRegistration channelFor(StateNode hostNode) {
+        return channelByNode.computeIfAbsent(hostNode,
+                node -> node.getFeature(ReturnChannelMap.class)
+                        .registerChannel(this::dispatch));
+    }
+
+    private void dispatch(ArrayNode args) {
+        JsonNode raw = args.get(0);
+        // The source input is expected to evaluate to a defined value at fire
+        // time; a JSON null on the wire (or a missing argument) almost
+        // certainly indicates a misuse — for example, mapping an action's
+        // input from a property that doesn't exist on the target.
+        if (raw == null || raw.isNull()) {
+            throw new IllegalStateException(
+                    "CallbackAction received a null value from the client;"
+                            + " the source input must produce a non-null"
+                            + " value");
+        }
+        callback.accept(JacksonUtils.readValue(raw, valueType));
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/SetSignalAction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/SetSignalAction.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.trigger.internal;
+
+import java.util.Objects;
+
+import com.vaadin.flow.signals.local.ValueSignal;
+import com.vaadin.flow.signals.shared.SharedValueSignal;
+
+/**
+ * Named {@link CallbackAction} that calls {@code set} on a writable signal —
+ * the common case of bridging a client-side trigger into server-side signal
+ * state. Overloads accept {@link ValueSignal} (local) and
+ * {@link SharedValueSignal} (shared, including subclasses like
+ * {@code SharedNumberSignal}); for other server-side destinations (logging,
+ * custom events, queues, …) use {@link CallbackAction} directly with a method
+ * reference.
+ *
+ * <pre>{@code
+ * ValueSignal<String> valueSignal = new ValueSignal<>("");
+ * DomEventTrigger input = new DomEventTrigger(textField, "input");
+ * input.triggers(new SetSignalAction<>(valueSignal, String.class,
+ *         new PropertyInput<>(textField, "value", String.class)));
+ * }</pre>
+ *
+ * <p>
+ * The signal's own equality checker debounces redundant updates, so emitting
+ * identical values back-to-back does not retrigger downstream effects.
+ * <p>
+ * For internal use only. May be renamed or removed in a future release.
+ *
+ * @param <T>
+ *            the type the signal holds and the JSON value is decoded to
+ */
+public class SetSignalAction<T> extends CallbackAction<T> {
+
+    /**
+     * Creates an action that, when the trigger fires, evaluates {@code source}
+     * on the client, sends the value to the server, decodes it as
+     * {@code valueType}, and assigns it to {@code signal} via
+     * {@link ValueSignal#set(Object)}.
+     *
+     * @param signal
+     *            the local value signal to update on the server, not
+     *            {@code null}
+     * @param valueType
+     *            runtime type the JSON value is decoded to before being passed
+     *            to {@link ValueSignal#set(Object)}, not {@code null}
+     * @param source
+     *            input that produces the value on the client when the trigger
+     *            fires, not {@code null}
+     */
+    public SetSignalAction(ValueSignal<? super T> signal, Class<T> valueType,
+            Action.Input<? extends T> source) {
+        super(valueType,
+                Objects.requireNonNull(signal, "signal must not be null")::set,
+                source);
+    }
+
+    /**
+     * Creates an action that, when the trigger fires, evaluates {@code source}
+     * on the client, sends the value to the server, decodes it as
+     * {@code valueType}, and assigns it to {@code signal} via
+     * {@link SharedValueSignal#set(Object)}. The returned
+     * {@code SignalOperation} is discarded — wire this overload when
+     * fire-and-forget semantics for the shared write are acceptable.
+     *
+     * @param signal
+     *            the shared value signal to update on the server, not
+     *            {@code null}
+     * @param valueType
+     *            runtime type the JSON value is decoded to before being passed
+     *            to {@link SharedValueSignal#set(Object)}, not {@code null}
+     * @param source
+     *            input that produces the value on the client when the trigger
+     *            fires, not {@code null}
+     */
+    public SetSignalAction(SharedValueSignal<? super T> signal,
+            Class<T> valueType, Action.Input<? extends T> source) {
+        super(valueType,
+                Objects.requireNonNull(signal, "signal must not be null")::set,
+                source);
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/SetSignalAction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/SetSignalAction.java
@@ -18,16 +18,12 @@ package com.vaadin.flow.component.trigger.internal;
 import java.util.Objects;
 
 import com.vaadin.flow.signals.local.ValueSignal;
-import com.vaadin.flow.signals.shared.SharedValueSignal;
 
 /**
- * Named {@link CallbackAction} that calls {@code set} on a writable signal —
- * the common case of bridging a client-side trigger into server-side signal
- * state. Overloads accept {@link ValueSignal} (local) and
- * {@link SharedValueSignal} (shared, including subclasses like
- * {@code SharedNumberSignal}); for other server-side destinations (logging,
- * custom events, queues, …) use {@link CallbackAction} directly with a method
- * reference.
+ * Named {@link CallbackAction} that calls {@code set} on a {@link ValueSignal}
+ * — the common case of bridging a client-side trigger into server-side signal
+ * state. For other server-side destinations (logging, custom events, queues, …)
+ * use {@link CallbackAction} directly with a method reference.
  *
  * <pre>{@code
  * ValueSignal<String> valueSignal = new ValueSignal<>("");
@@ -65,31 +61,6 @@ public class SetSignalAction<T> extends CallbackAction<T> {
      */
     public SetSignalAction(ValueSignal<? super T> signal, Class<T> valueType,
             Action.Input<? extends T> source) {
-        super(valueType,
-                Objects.requireNonNull(signal, "signal must not be null")::set,
-                source);
-    }
-
-    /**
-     * Creates an action that, when the trigger fires, evaluates {@code source}
-     * on the client, sends the value to the server, decodes it as
-     * {@code valueType}, and assigns it to {@code signal} via
-     * {@link SharedValueSignal#set(Object)}. The returned
-     * {@code SignalOperation} is discarded — wire this overload when
-     * fire-and-forget semantics for the shared write are acceptable.
-     *
-     * @param signal
-     *            the shared value signal to update on the server, not
-     *            {@code null}
-     * @param valueType
-     *            runtime type the JSON value is decoded to before being passed
-     *            to {@link SharedValueSignal#set(Object)}, not {@code null}
-     * @param source
-     *            input that produces the value on the client when the trigger
-     *            fires, not {@code null}
-     */
-    public SetSignalAction(SharedValueSignal<? super T> signal,
-            Class<T> valueType, Action.Input<? extends T> source) {
         super(valueType,
                 Objects.requireNonNull(signal, "signal must not be null")::set,
                 source);

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/CallbackActionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/CallbackActionTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.trigger.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.node.ArrayNode;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
+import com.vaadin.flow.component.internal.UIInternals.JavaScriptInvocation;
+import com.vaadin.flow.dom.JsFunction;
+import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.flow.internal.nodefeature.ReturnChannelRegistration;
+import com.vaadin.tests.util.MockUI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CallbackActionTest {
+
+    @Test
+    void channelInvocation_decodesValueAndInvokesCallback() {
+        UI ui = new MockUI();
+        TagComponent input = new TagComponent("input");
+        ui.getElement().appendChild(input.getElement());
+
+        List<String> received = new ArrayList<>();
+        DomEventTrigger trigger = new DomEventTrigger(input, "input");
+        trigger.triggers(new CallbackAction<>(String.class, received::add,
+                new PropertyInput<>(input, "value", String.class)));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        ArrayNode args = JacksonUtils.createArrayNode();
+        args.add("hello");
+        singleReturnChannel(ui).invoke(args);
+
+        assertEquals(List.of("hello"), received);
+    }
+
+    @Test
+    void handlerBody_callsChannelWithSourceExpression() {
+        UI ui = new MockUI();
+        TagComponent input = new TagComponent("input");
+        ui.getElement().appendChild(input.getElement());
+
+        DomEventTrigger trigger = new DomEventTrigger(input, "input");
+        trigger.triggers(new CallbackAction<>(String.class, v -> {
+        }, new PropertyInput<>(input, "value", String.class)));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        JsFunction handler = handlerOf(singleInstallFn(ui));
+        // $0 = the return channel (the host element is `this`, so no element
+        // capture comes first). The body forwards the source expression
+        // straight into the channel call.
+        assertEquals("$0(this[\"value\"]);", handler.getBody());
+        assertEquals(1, handler.getCaptures().size());
+        assertTrue(
+                handler.getCaptures()
+                        .get(0) instanceof ReturnChannelRegistration,
+                "Expected the single capture to be the return channel");
+    }
+
+    @Test
+    void nullArgument_throwsIllegalState() {
+        UI ui = new MockUI();
+        TagComponent input = new TagComponent("input");
+        ui.getElement().appendChild(input.getElement());
+
+        DomEventTrigger trigger = new DomEventTrigger(input, "input");
+        trigger.triggers(new CallbackAction<>(String.class, v -> {
+        }, new PropertyInput<>(input, "value", String.class)));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        ArrayNode args = JacksonUtils.createArrayNode();
+        args.add(JacksonUtils.nullNode());
+        assertThrows(IllegalStateException.class,
+                () -> singleReturnChannel(ui).invoke(args));
+    }
+
+    private static ReturnChannelRegistration singleReturnChannel(UI ui) {
+        List<ReturnChannelRegistration> channels = handlerOf(
+                singleInstallFn(ui)).getCaptures().stream()
+                .filter(o -> o instanceof ReturnChannelRegistration)
+                .map(o -> (ReturnChannelRegistration) o).toList();
+        assertEquals(1, channels.size(),
+                "Expected exactly one captured return channel");
+        return channels.get(0);
+    }
+
+    private static JsFunction singleInstallFn(UI ui) {
+        List<PendingJavaScriptInvocation> pending = ui.getInternals()
+                .dumpPendingJavaScriptInvocations();
+        assertEquals(1, pending.size(), "Expected exactly one pending JS");
+        return installFn(pending.get(0).getInvocation());
+    }
+
+    private static JsFunction installFn(JavaScriptInvocation invocation) {
+        Object o = invocation.getParameters().get(2);
+        assertTrue(o instanceof JsFunction, "Expected $2 to be a JsFunction");
+        return (JsFunction) o;
+    }
+
+    private static JsFunction handlerOf(JsFunction installFn) {
+        Object o = installFn.getCaptures().get(0);
+        assertTrue(o instanceof JsFunction,
+                "Expected install $0 to be the handler JsFunction");
+        return (JsFunction) o;
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/SetSignalActionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/SetSignalActionTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.trigger.internal;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.node.ArrayNode;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
+import com.vaadin.flow.component.internal.UIInternals.JavaScriptInvocation;
+import com.vaadin.flow.dom.JsFunction;
+import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.flow.internal.nodefeature.ReturnChannelRegistration;
+import com.vaadin.flow.signals.local.ValueSignal;
+import com.vaadin.tests.util.MockUI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SetSignalActionTest {
+
+    @Test
+    void channelInvocation_updatesSignal() {
+        // Wire-level mechanics are exercised in CallbackActionTest; this test
+        // just verifies the SetSignalAction subclass wires signal::set as the
+        // callback so an invocation reaches the signal.
+        UI ui = new MockUI();
+        TagComponent input = new TagComponent("input");
+        ui.getElement().appendChild(input.getElement());
+
+        ValueSignal<String> signal = new ValueSignal<>("");
+        DomEventTrigger trigger = new DomEventTrigger(input, "input");
+        trigger.triggers(new SetSignalAction<>(signal, String.class,
+                new PropertyInput<>(input, "value", String.class)));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        ArrayNode args = JacksonUtils.createArrayNode();
+        args.add("hello");
+        singleReturnChannel(ui).invoke(args);
+
+        assertEquals("hello", signal.peek());
+    }
+
+    @Test
+    void signalWithSuperType_acceptsNarrowerValueType() {
+        // PECS: ValueSignal<? super T> lets a supertype-parameterised signal
+        // accept a narrower valueType — e.g. a ValueSignal<Object> consuming
+        // String values produced by the source.
+        UI ui = new MockUI();
+        TagComponent input = new TagComponent("input");
+        ui.getElement().appendChild(input.getElement());
+
+        ValueSignal<Object> signal = new ValueSignal<>("");
+        DomEventTrigger trigger = new DomEventTrigger(input, "input");
+        trigger.triggers(new SetSignalAction<>(signal, String.class,
+                new PropertyInput<>(input, "value", String.class)));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        ArrayNode args = JacksonUtils.createArrayNode();
+        args.add("hello");
+        singleReturnChannel(ui).invoke(args);
+
+        assertEquals("hello", signal.peek());
+    }
+
+    private static ReturnChannelRegistration singleReturnChannel(UI ui) {
+        List<ReturnChannelRegistration> channels = handlerOf(
+                singleInstallFn(ui)).getCaptures().stream()
+                .filter(o -> o instanceof ReturnChannelRegistration)
+                .map(o -> (ReturnChannelRegistration) o).toList();
+        assertEquals(1, channels.size(),
+                "Expected exactly one captured return channel");
+        return channels.get(0);
+    }
+
+    private static JsFunction singleInstallFn(UI ui) {
+        List<PendingJavaScriptInvocation> pending = ui.getInternals()
+                .dumpPendingJavaScriptInvocations();
+        assertEquals(1, pending.size(), "Expected exactly one pending JS");
+        return installFn(pending.get(0).getInvocation());
+    }
+
+    private static JsFunction installFn(JavaScriptInvocation invocation) {
+        Object o = invocation.getParameters().get(2);
+        assertTrue(o instanceof JsFunction, "Expected $2 to be a JsFunction");
+        return (JsFunction) o;
+    }
+
+    private static JsFunction handlerOf(JsFunction installFn) {
+        Object o = installFn.getCaptures().get(0);
+        assertTrue(o instanceof JsFunction,
+                "Expected install $0 to be the handler JsFunction");
+        return (JsFunction) o;
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerSetSignalView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerSetSignalView.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Input;
+import com.vaadin.flow.component.trigger.internal.DomEventTrigger;
+import com.vaadin.flow.component.trigger.internal.PropertyInput;
+import com.vaadin.flow.component.trigger.internal.SetSignalAction;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.signals.Signal;
+import com.vaadin.flow.signals.local.ValueSignal;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+/**
+ * Wires a {@code DomEventTrigger} on an {@link Input}'s {@code input} event to
+ * a {@link SetSignalAction} that pushes the field's current {@code value}
+ * property into a {@link ValueSignal}. A {@link Signal#effect} mirrors the
+ * signal value into a status {@link Div}, so the IT can assert that typing into
+ * the field propagates client → signal → effect → DOM.
+ */
+@Route(value = "com.vaadin.flow.uitest.ui.TriggerSetSignalView", layout = ViewTestLayout.class)
+public class TriggerSetSignalView extends AbstractDivView {
+
+    @Override
+    protected void onShow() {
+        Input field = new Input();
+        field.setId("source");
+        Div status = new Div();
+        status.setId("status");
+        add(field, status);
+
+        ValueSignal<String> signal = new ValueSignal<>("");
+        Signal.effect(this, () -> status.setText(signal.get()));
+
+        new DomEventTrigger(field, "input")
+                .triggers(new SetSignalAction<>(signal, String.class,
+                        new PropertyInput<>(field, "value", String.class)));
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerSetSignalIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerSetSignalIT.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class TriggerSetSignalIT extends ChromeBrowserTest {
+
+    @Test
+    public void typingIntoInput_pushesValueIntoSignal_andEffectUpdatesStatus() {
+        open();
+
+        WebElement field = findElement(By.id("source"));
+        WebElement status = findElement(By.id("status"));
+
+        field.sendKeys("hi");
+
+        // Each "input" event fires the trigger, which decodes the field's
+        // value property and assigns it to the ValueSignal. A Signal.effect
+        // on the server mirrors the signal into the status div.
+        waitUntil(d -> "hi".equals(status.getText()));
+
+        field.sendKeys(" there");
+        waitUntil(d -> "hi there".equals(status.getText()));
+    }
+}


### PR DESCRIPTION
CallbackAction<T> forwards a value from a trigger's handler scope back to the server via a ReturnChannelRegistration, decodes it as T, and hands it to a SerializableConsumer<T> on the UI thread. Use it to bridge any client-side trigger into arbitrary server-side state — log a value, fire a custom event, push to a queue, etc.

SetSignalAction is a thin named subclass for the common case of `signal::set`. Signal parameters are typed as `? super T` so a wider signal can be paired with a narrower valueType.
