### PR TITLE
feat: SizeTrigger + ElementResize.ts — trigger that fires on element resize

### DIFF
--- a/flow-client/src/main/frontend/ElementResize.ts
+++ b/flow-client/src/main/frontend/ElementResize.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Size data passed to the observe() callback. Field names match the Java
+ * Size record so the value can be Jackson-deserialised on the server when
+ * forwarded through a trigger-framework input.
+ */
+interface Size {
+  width: number;
+  height: number;
+}
+
+const $wnd = window as any;
+$wnd.Vaadin ??= {};
+$wnd.Vaadin.Flow ??= {};
+$wnd.Vaadin.Flow.elementResize = {
+  /**
+   * Installs a ResizeObserver on the given element and invokes the callback
+   * with the rounded content-box width and height each time the element
+   * resizes. Returns a function that disconnects the observer.
+   *
+   * Sub-pixel decimals from contentRect are rounded to integers to avoid
+   * spamming equal-after-rounding updates back to the server.
+   */
+  observe(element: Element, callback: (size: Size) => void): () => void {
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        if (!entry.target.isConnected) {
+          continue;
+        }
+        callback({
+          width: Math.round(entry.contentRect.width),
+          height: Math.round(entry.contentRect.height)
+        });
+      }
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }
+};
+
+// Empty export to ensure TypeScript emits this as an ES module,
+// which is required for Vite to load it via import.
+export {};

--- a/flow-client/src/main/frontend/Flow.ts
+++ b/flow-client/src/main/frontend/Flow.ts
@@ -6,6 +6,7 @@ import {
 } from '@vaadin/common-frontend';
 import './Clipboard';
 import { currentFullscreenState } from './Fullscreen';
+import './ElementResize';
 import './Geolocation';
 import { currentVisibility } from './PageVisibility';
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/Size.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Size.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component;
+
+import java.io.Serializable;
+
+/**
+ * Represents a 2D pixel size with a width and a height.
+ *
+ * @param width
+ *            the width in pixels
+ * @param height
+ *            the height in pixels
+ */
+public record Size(int width, int height) implements Serializable {
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/Size.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/Size.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.flow.component;
+package com.vaadin.flow.component.trigger.internal;
 
 import java.io.Serializable;
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/SizeTrigger.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/SizeTrigger.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.trigger.internal;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Size;
+import com.vaadin.flow.dom.JsFunction;
+import com.vaadin.flow.shared.Registration;
+
+/**
+ * Fires when the host component's root element changes size, as reported by the
+ * browser's {@code ResizeObserver} API. The bound actions run inside the
+ * observer callback with a synthetic event whose {@code width} and
+ * {@code height} hold the rounded pixel size of the element's content box.
+ * <p>
+ * The size values are exposed through {@link #width()}, {@link #height()} and
+ * {@link #size()} so downstream actions can consume them. The shape of the
+ * value produced by {@link #size()} matches the {@link Size} record so it can
+ * be deserialised directly on the server when forwarded through an action that
+ * decodes its input on the server.
+ * <p>
+ * Example — mirror the element's pixel size into two display fields:
+ *
+ * <pre>{@code
+ * SizeTrigger resize = new SizeTrigger(panel);
+ * resize.triggers(
+ *         new SetPropertyAction<>(widthSpan, "textContent", resize.width()),
+ *         new SetPropertyAction<>(heightSpan, "textContent", resize.height()));
+ * }</pre>
+ *
+ * <p>
+ * For internal use only. May be renamed or removed in a future release.
+ */
+public class SizeTrigger extends Trigger {
+
+    /**
+     * Creates a size trigger on the given host component's root element.
+     *
+     * @param host
+     *            the component whose root element is observed, not {@code null}
+     */
+    public SizeTrigger(Component host) {
+        super(host);
+    }
+
+    /**
+     * {@code event.width} — the element's rounded content-box width in pixels.
+     */
+    public Action.Input<Integer> width() {
+        return new HandlerInput<>("width", this);
+    }
+
+    /**
+     * {@code event.height} — the element's rounded content-box height in
+     * pixels.
+     */
+    public Action.Input<Integer> height() {
+        return new HandlerInput<>("height", this);
+    }
+
+    /**
+     * The synthetic event object as a whole, shaped as {@code {width, height}}
+     * — Jackson-deserialisable into the {@link Size} record when consumed by an
+     * action that decodes its input on the server.
+     */
+    public Action.Input<Size> size() {
+        return new Action.Input<>() {
+            @Override
+            protected JsFunction toJs(Trigger trigger) {
+                if (trigger != SizeTrigger.this) {
+                    throw new IllegalArgumentException(
+                            "Input is scoped to a different trigger and cannot"
+                                    + " be used here");
+                }
+                return JsFunction.of("return event").withArguments("event");
+            }
+        };
+    }
+
+    @Override
+    protected Registration install(JsFunction action) {
+        // ElementResize.observe() returns a disconnect function — exactly the
+        // cleanup shape addJsInitializer expects, so we just propagate it.
+        // The callback receives a {width, height} object that the action
+        // ($0) treats as its `event` argument.
+        return getHost().addJsInitializer(
+                "return window.Vaadin.Flow.elementResize.observe(this, $0);",
+                action);
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/SizeTrigger.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/SizeTrigger.java
@@ -15,8 +15,9 @@
  */
 package com.vaadin.flow.component.trigger.internal;
 
+import java.io.Serializable;
+
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.Size;
 import com.vaadin.flow.dom.JsFunction;
 import com.vaadin.flow.shared.Registration;
 
@@ -26,19 +27,20 @@ import com.vaadin.flow.shared.Registration;
  * observer callback with a synthetic event whose {@code width} and
  * {@code height} hold the rounded pixel size of the element's content box.
  * <p>
- * The size values are exposed through {@link #width()}, {@link #height()} and
- * {@link #size()} so downstream actions can consume them. The shape of the
- * value produced by {@link #size()} matches the {@link Size} record so it can
- * be deserialised directly on the server when forwarded through an action that
- * decodes its input on the server.
+ * The size values are exposed as static {@link Action.Input} sources on
+ * {@link EventData}. The whole-event source {@link EventData#size} is shaped to
+ * match the {@link Size} record so it can be deserialised directly on the
+ * server when forwarded through an action that decodes its input on the server.
  * <p>
  * Example — mirror the element's pixel size into two display fields:
  *
  * <pre>{@code
  * SizeTrigger resize = new SizeTrigger(panel);
  * resize.triggers(
- *         new SetPropertyAction<>(widthSpan, "textContent", resize.width()),
- *         new SetPropertyAction<>(heightSpan, "textContent", resize.height()));
+ *         new SetPropertyAction<>(widthSpan, "textContent",
+ *                 SizeTrigger.EventData.width),
+ *         new SetPropertyAction<>(heightSpan, "textContent",
+ *                 SizeTrigger.EventData.height));
  * }</pre>
  *
  * <p>
@@ -57,33 +59,52 @@ public class SizeTrigger extends Trigger {
     }
 
     /**
-     * {@code event.width} — the element's rounded content-box width in pixels.
+     * The resize-event properties exposed as static {@link Action.Input}
+     * sources. Each field reads off the synthetic {@code {width, height}} event
+     * that fires the trigger; pass any of them as the value source of an
+     * {@link Action} wired to a {@link SizeTrigger}.
+     * <p>
+     * Each field is bound to {@link SizeTrigger}; using it in the handler of an
+     * unrelated trigger throws {@link IllegalArgumentException} at
+     * {@link Trigger#triggers(Action...)} time.
      */
-    public Action.Input<Integer> width() {
-        return new HandlerInput<>("width", this);
-    }
+    public abstract static class EventData implements Serializable {
 
-    /**
-     * {@code event.height} — the element's rounded content-box height in
-     * pixels.
-     */
-    public Action.Input<Integer> height() {
-        return new HandlerInput<>("height", this);
-    }
+        /**
+         * The class exists purely as a namespace for the static
+         * {@link Action.Input} fields.
+         */
+        protected EventData() {
+        }
 
-    /**
-     * The synthetic event object as a whole, shaped as {@code {width, height}}
-     * — Jackson-deserialisable into the {@link Size} record when consumed by an
-     * action that decodes its input on the server.
-     */
-    public Action.Input<Size> size() {
-        return new Action.Input<>() {
+        /**
+         * {@code event.width} — the element's rounded content-box width in
+         * pixels.
+         */
+        public static final Action.Input<Integer> width = new HandlerInput<>(
+                "width", SizeTrigger.class);
+
+        /**
+         * {@code event.height} — the element's rounded content-box height in
+         * pixels.
+         */
+        public static final Action.Input<Integer> height = new HandlerInput<>(
+                "height", SizeTrigger.class);
+
+        /**
+         * The synthetic event object as a whole, shaped as
+         * {@code {width, height}} — Jackson-deserialisable into the
+         * {@link Size} record when consumed by an action that decodes its input
+         * on the server.
+         */
+        public static final Action.Input<Size> size = new Action.Input<>() {
             @Override
             protected JsFunction toJs(Trigger trigger) {
-                if (trigger != SizeTrigger.this) {
-                    throw new IllegalArgumentException(
-                            "Input is scoped to a different trigger and cannot"
-                                    + " be used here");
+                if (!(trigger instanceof SizeTrigger)) {
+                    throw new IllegalArgumentException("Input is scoped to "
+                            + SizeTrigger.class.getSimpleName()
+                            + " and cannot be used in a "
+                            + trigger.getClass().getSimpleName() + " handler");
                 }
                 return JsFunction.of("return event").withArguments("event");
             }

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/SizeTriggerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/SizeTriggerTest.java
@@ -39,8 +39,8 @@ class SizeTriggerTest {
         ui.getElement().appendChild(panel.getElement(), field.getElement());
 
         SizeTrigger resize = new SizeTrigger(panel);
-        resize.triggers(
-                new SetPropertyAction<>(field, "value", resize.width()));
+        resize.triggers(new SetPropertyAction<>(field, "value",
+                SizeTrigger.EventData.width));
 
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
 
@@ -66,8 +66,10 @@ class SizeTriggerTest {
 
         SizeTrigger resize = new SizeTrigger(panel);
         resize.triggers(
-                new SetPropertyAction<>(xField, "value", resize.width()),
-                new SetPropertyAction<>(yField, "value", resize.height()));
+                new SetPropertyAction<>(xField, "value",
+                        SizeTrigger.EventData.width),
+                new SetPropertyAction<>(yField, "value",
+                        SizeTrigger.EventData.height));
 
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
 
@@ -95,11 +97,11 @@ class SizeTriggerTest {
         ui.getElement().appendChild(panel.getElement(), field.getElement());
 
         SizeTrigger resize = new SizeTrigger(panel);
-        // size() produces the synthetic event object as a whole — its
+        // EventData.size produces the synthetic event object as a whole — its
         // source-input function returns `event` directly, with no property
         // capture.
-        resize.triggers(
-                new SetPropertyAction<>(field, "data-size", resize.size()));
+        resize.triggers(new SetPropertyAction<>(field, "data-size",
+                SizeTrigger.EventData.size));
 
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
 
@@ -111,28 +113,41 @@ class SizeTriggerTest {
     }
 
     @Test
-    void inputFromOtherTrigger_isRejected() {
+    void eventData_sharedAcrossInstances_accepted() {
+        // The static EventData fields are bound to the trigger class, not an
+        // instance, so the same field is a valid source for two separate
+        // SizeTrigger instances on different hosts.
         TagComponent panel1 = new TagComponent("div");
         TagComponent panel2 = new TagComponent("div");
         TagComponent field = new TagComponent("input");
 
-        SizeTrigger resize1 = new SizeTrigger(panel1);
-        SizeTrigger resize2 = new SizeTrigger(panel2);
-
-        assertThrows(IllegalArgumentException.class, () -> resize2.triggers(
-                new SetPropertyAction<>(field, "value", resize1.width())));
+        new SizeTrigger(panel1).triggers(new SetPropertyAction<>(field, "value",
+                SizeTrigger.EventData.width));
+        new SizeTrigger(panel2).triggers(new SetPropertyAction<>(field,
+                "data-size", SizeTrigger.EventData.size));
     }
 
     @Test
-    void sizeFromOtherTrigger_isRejected() {
-        TagComponent panel1 = new TagComponent("div");
-        TagComponent panel2 = new TagComponent("div");
+    void widthFromNonSizeTrigger_isRejected() {
+        TagComponent input = new TagComponent("input");
         TagComponent field = new TagComponent("input");
 
-        SizeTrigger resize1 = new SizeTrigger(panel1);
-        SizeTrigger resize2 = new SizeTrigger(panel2);
+        // EventData.width is bound to SizeTrigger; a plain DomEventTrigger is
+        // not a SizeTrigger, so wiring it through such a handler must fail.
+        DomEventTrigger keypress = new DomEventTrigger(input, "keypress");
+        assertThrows(IllegalArgumentException.class,
+                () -> keypress.triggers(new SetPropertyAction<>(field, "value",
+                        SizeTrigger.EventData.width)));
+    }
 
-        assertThrows(IllegalArgumentException.class, () -> resize2.triggers(
-                new SetPropertyAction<>(field, "data-size", resize1.size())));
+    @Test
+    void sizeFromNonSizeTrigger_isRejected() {
+        TagComponent input = new TagComponent("input");
+        TagComponent field = new TagComponent("input");
+
+        DomEventTrigger keypress = new DomEventTrigger(input, "keypress");
+        assertThrows(IllegalArgumentException.class,
+                () -> keypress.triggers(new SetPropertyAction<>(field,
+                        "data-size", SizeTrigger.EventData.size)));
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/SizeTriggerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/SizeTriggerTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.trigger.internal;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.dom.JsFunction;
+import com.vaadin.tests.util.MockUI;
+
+import static com.vaadin.flow.component.trigger.internal.TriggerTestUtil.actionOf;
+import static com.vaadin.flow.component.trigger.internal.TriggerTestUtil.installFns;
+import static com.vaadin.flow.component.trigger.internal.TriggerTestUtil.singleInstallFn;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SizeTriggerTest {
+
+    @Test
+    void install_delegatesToElementResizeHelperWithActionAsHandler() {
+        UI ui = new MockUI();
+        TagComponent panel = new TagComponent("div");
+        TagComponent field = new TagComponent("input");
+        ui.getElement().appendChild(panel.getElement(), field.getElement());
+
+        SizeTrigger resize = new SizeTrigger(panel);
+        resize.triggers(
+                new SetPropertyAction<>(field, "value", resize.width()));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        // Install JS hands the action ($0) to the per-UI ResizeObserver
+        // helper and returns its disconnect function, so the host's
+        // addJsInitializer cleanup pipeline detaches the observer on
+        // remove. No user content leaks into the body — the action is a
+        // capture.
+        JsFunction install = singleInstallFn(ui);
+        assertEquals(
+                "return window.Vaadin.Flow.elementResize.observe(this, $0);",
+                install.getBody());
+    }
+
+    @Test
+    void widthAndHeight_renderAsHandlerEventProperties() {
+        UI ui = new MockUI();
+        TagComponent panel = new TagComponent("div");
+        TagComponent xField = new TagComponent("input");
+        TagComponent yField = new TagComponent("input");
+        ui.getElement().appendChild(panel.getElement(), xField.getElement(),
+                yField.getElement());
+
+        SizeTrigger resize = new SizeTrigger(panel);
+        resize.triggers(
+                new SetPropertyAction<>(xField, "value", resize.width()),
+                new SetPropertyAction<>(yField, "value", resize.height()));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        // Each action's source input ($2) is a HandlerInput JsFunction
+        // taking `event` and capturing the property name; the body itself
+        // is the constant `return event[$0]`.
+        List<JsFunction> installs = installFns(ui);
+        JsFunction widthSource = (JsFunction) actionOf(installs.get(0))
+                .getCaptures().get(2);
+        assertEquals(List.of("event"), widthSource.getArgumentNames());
+        assertEquals("return event[$0]", widthSource.getBody());
+        assertEquals("width", widthSource.getCaptures().get(0));
+
+        JsFunction heightSource = (JsFunction) actionOf(installs.get(1))
+                .getCaptures().get(2);
+        assertEquals("return event[$0]", heightSource.getBody());
+        assertEquals("height", heightSource.getCaptures().get(0));
+    }
+
+    @Test
+    void size_rendersAsBareEventReference() {
+        UI ui = new MockUI();
+        TagComponent panel = new TagComponent("div");
+        TagComponent field = new TagComponent("input");
+        ui.getElement().appendChild(panel.getElement(), field.getElement());
+
+        SizeTrigger resize = new SizeTrigger(panel);
+        // size() produces the synthetic event object as a whole — its
+        // source-input function returns `event` directly, with no property
+        // capture.
+        resize.triggers(
+                new SetPropertyAction<>(field, "data-size", resize.size()));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        JsFunction sizeSource = (JsFunction) actionOf(singleInstallFn(ui))
+                .getCaptures().get(2);
+        assertEquals(List.of("event"), sizeSource.getArgumentNames());
+        assertEquals("return event", sizeSource.getBody());
+        assertEquals(List.of(), sizeSource.getCaptures());
+    }
+
+    @Test
+    void inputFromOtherTrigger_isRejected() {
+        TagComponent panel1 = new TagComponent("div");
+        TagComponent panel2 = new TagComponent("div");
+        TagComponent field = new TagComponent("input");
+
+        SizeTrigger resize1 = new SizeTrigger(panel1);
+        SizeTrigger resize2 = new SizeTrigger(panel2);
+
+        assertThrows(IllegalArgumentException.class, () -> resize2.triggers(
+                new SetPropertyAction<>(field, "value", resize1.width())));
+    }
+
+    @Test
+    void sizeFromOtherTrigger_isRejected() {
+        TagComponent panel1 = new TagComponent("div");
+        TagComponent panel2 = new TagComponent("div");
+        TagComponent field = new TagComponent("input");
+
+        SizeTrigger resize1 = new SizeTrigger(panel1);
+        SizeTrigger resize2 = new SizeTrigger(panel2);
+
+        assertThrows(IllegalArgumentException.class, () -> resize2.triggers(
+                new SetPropertyAction<>(field, "data-size", resize1.size())));
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerSizeView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerSizeView.java
@@ -56,9 +56,9 @@ public class TriggerSizeView extends AbstractDivView {
         SizeTrigger resize = new SizeTrigger(panel);
         resize.triggers(
                 new SetPropertyAction<>(widthDiv, "textContent",
-                        resize.width()),
+                        SizeTrigger.EventData.width),
                 new SetPropertyAction<>(heightDiv, "textContent",
-                        resize.height()));
+                        SizeTrigger.EventData.height));
 
         add(panel, widthDiv, heightDiv);
     }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerSizeView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerSizeView.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.trigger.internal.SetPropertyAction;
+import com.vaadin.flow.component.trigger.internal.SizeTrigger;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+/**
+ * Wires a {@link SizeTrigger} on a sized {@link Div} to two
+ * {@link SetPropertyAction}s that mirror the current width and height into
+ * separate display divs as their {@code textContent}. The browser dispatches a
+ * resize on first observation, so the display divs populate without any user
+ * interaction; resizing the panel via {@code style.width}/{@code style.height}
+ * from the IT triggers a fresh dispatch that updates them again.
+ */
+@Route(value = "com.vaadin.flow.uitest.ui.TriggerSizeView", layout = ViewTestLayout.class)
+public class TriggerSizeView extends AbstractDivView {
+
+    static final int INITIAL_WIDTH = 120;
+    static final int INITIAL_HEIGHT = 60;
+
+    @Override
+    protected void onShow() {
+        Div panel = new Div();
+        panel.setId("panel");
+        // Explicit pixel size and content-box sizing so `contentRect` (which
+        // SizeTrigger reads) reports the literal width/height — the IT
+        // compares against these constants.
+        panel.getStyle().set("width", INITIAL_WIDTH + "px")
+                .set("height", INITIAL_HEIGHT + "px")
+                .set("box-sizing", "content-box")
+                .set("background", "lightblue");
+
+        Div widthDiv = new Div();
+        widthDiv.setId("width");
+
+        Div heightDiv = new Div();
+        heightDiv.setId("height");
+
+        SizeTrigger resize = new SizeTrigger(panel);
+        resize.triggers(
+                new SetPropertyAction<>(widthDiv, "textContent",
+                        resize.width()),
+                new SetPropertyAction<>(heightDiv, "textContent",
+                        resize.height()));
+
+        add(panel, widthDiv, heightDiv);
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerSizeIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerSizeIT.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class TriggerSizeIT extends ChromeBrowserTest {
+
+    @Test
+    public void initialObservation_andResize_propagateToDisplayDivs() {
+        open();
+
+        WebElement widthDiv = findElement(By.id("width"));
+        WebElement heightDiv = findElement(By.id("height"));
+
+        // ResizeObserver fires once when observe() is first called, so the
+        // SetPropertyAction wired to width()/height() populates the display
+        // divs without any user interaction.
+        waitUntil(d -> String.valueOf(TriggerSizeView.INITIAL_WIDTH)
+                .equals(widthDiv.getText()));
+        waitUntil(d -> String.valueOf(TriggerSizeView.INITIAL_HEIGHT)
+                .equals(heightDiv.getText()));
+
+        // Resizing the panel via inline styles triggers a fresh ResizeObserver
+        // entry, which the trigger forwards through SetPropertyAction to
+        // update both textContent properties.
+        ((JavascriptExecutor) getDriver())
+                .executeScript("const p = document.getElementById('panel');"
+                        + "p.style.width = '240px';"
+                        + "p.style.height = '90px';");
+        waitUntil(d -> "240".equals(widthDiv.getText()));
+        waitUntil(d -> "90".equals(heightDiv.getText()));
+    }
+}


### PR DESCRIPTION
Adds a SizeTrigger that wires the browser's ResizeObserver into the trigger framework, exposing width(), height() and size() inputs. The JS helper lives in ElementResize.ts under window.Vaadin.Flow.elementResize to match the Clipboard/Geolocation pattern; the trigger's installJs just delegates to it. Combined with SetSignalAction this provides a purely server-side equivalent of an Element.sizeSignal() facade.
