### PR TITLE
feat: add RouteHierarchy walker

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteHierarchy.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteHierarchy.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.router;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import com.vaadin.flow.component.Component;
+
+/**
+ * Walks the route hierarchy starting from a given {@link Route @Route}
+ * annotated class.
+ * <p>
+ * At each step, the walker first consults {@link RouteParent @RouteParent}: if
+ * the annotation is present, its target is itself {@code @Route}-annotated and
+ * has not yet been visited, that target becomes the parent. Otherwise the
+ * walker falls back to URL-prefix walking: it takes the current class's route
+ * template via {@link RouteConfiguration#getTemplate(Class)}, strips the last
+ * {@code /}-separated segment, and looks up the resulting path in the supplied
+ * {@link RouteConfiguration}. Traversal terminates when no parent can be
+ * resolved, when a candidate would form a cycle, or when the current template
+ * has no further segments to strip.
+ * <p>
+ * Cycles in the hierarchy are detected via a visited set and truncated rather
+ * than reported as errors. The resulting chain is therefore always finite and
+ * free of duplicates.
+ *
+ * @see Route
+ * @see RouteParent
+ * @see RouteConfiguration
+ */
+public final class RouteHierarchy {
+
+    private RouteHierarchy() {
+        // utility class - no instances
+    }
+
+    /**
+     * Returns the chain of route classes from the conceptual root down to and
+     * including {@code routeClass}.
+     * <p>
+     * The returned list is root-first: the root ancestor comes first and
+     * {@code routeClass} is always the last element. When {@code routeClass} is
+     * not annotated with {@link Route @Route}, an empty list is returned. When
+     * {@code routeClass} is a {@code @Route} view but no parent can be
+     * resolved, the returned list contains only {@code routeClass} itself.
+     * <p>
+     * The walk consults {@link RouteParent @RouteParent} first at each step and
+     * falls back to URL-prefix walking via
+     * {@link RouteConfiguration#getTemplate(Class)} and
+     * {@link RouteConfiguration#getRoute(String)}. Cycles are truncated.
+     *
+     * @param routeClass
+     *            the route class to start from, not {@code null}
+     * @param routeConfiguration
+     *            the route configuration used to resolve templates and ancestor
+     *            routes, not {@code null}
+     * @return root-first list of ancestor route classes inclusive of
+     *         {@code routeClass}, or an empty list when {@code routeClass} is
+     *         not annotated with {@link Route @Route}
+     * @see RouteParent
+     * @see RouteConfiguration
+     */
+    public static List<Class<? extends Component>> resolveAncestors(
+            Class<? extends Component> routeClass,
+            RouteConfiguration routeConfiguration) {
+        Objects.requireNonNull(routeClass, "routeClass");
+        Objects.requireNonNull(routeConfiguration, "routeConfiguration");
+        if (!routeClass.isAnnotationPresent(Route.class)) {
+            return Collections.emptyList();
+        }
+        List<Class<? extends Component>> chain = new ArrayList<>();
+        Set<Class<? extends Component>> visited = new HashSet<>();
+        Class<? extends Component> current = routeClass;
+        chain.add(current);
+        visited.add(current);
+
+        while (true) {
+            Optional<Class<? extends Component>> parent = findParent(current,
+                    routeConfiguration, visited);
+            if (parent.isEmpty()) {
+                break;
+            }
+            Class<? extends Component> parentClass = parent.get();
+            chain.add(parentClass);
+            visited.add(parentClass);
+            current = parentClass;
+        }
+        Collections.reverse(chain);
+        return Collections.unmodifiableList(chain);
+    }
+
+    /**
+     * Returns the immediate parent of {@code routeClass}, or an empty
+     * {@link Optional} when no parent can be resolved.
+     * <p>
+     * This is equivalent to taking the second-to-last entry of
+     * {@link #resolveAncestors(Class, RouteConfiguration)} for chains of length
+     * two or more, and empty otherwise. {@link RouteParent @RouteParent} is
+     * consulted first; URL-prefix walking is the fallback.
+     *
+     * @param routeClass
+     *            the route class to find the parent of, not {@code null}
+     * @param routeConfiguration
+     *            the route configuration used to resolve templates and ancestor
+     *            routes, not {@code null}
+     * @return an {@link Optional} describing the parent route class, or
+     *         {@link Optional#empty()} when {@code routeClass} has no
+     *         {@link Route @Route} annotation or no parent can be resolved
+     * @see RouteParent
+     * @see RouteConfiguration
+     */
+    public static Optional<Class<? extends Component>> resolveParent(
+            Class<? extends Component> routeClass,
+            RouteConfiguration routeConfiguration) {
+        Objects.requireNonNull(routeClass, "routeClass");
+        Objects.requireNonNull(routeConfiguration, "routeConfiguration");
+        if (!routeClass.isAnnotationPresent(Route.class)) {
+            return Optional.empty();
+        }
+        Set<Class<? extends Component>> visited = new HashSet<>();
+        visited.add(routeClass);
+        return findParent(routeClass, routeConfiguration, visited);
+    }
+
+    /**
+     * Resolves the parent of {@code current}, honouring {@link RouteParent}
+     * first and URL-prefix walking second.
+     *
+     * @param current
+     *            the class whose parent is being resolved
+     * @param routeConfiguration
+     *            the route configuration to consult
+     * @param visited
+     *            the set of classes already in the chain; candidates already
+     *            present are rejected to avoid cycles
+     * @return the parent class, or empty when no parent can be resolved
+     */
+    private static Optional<Class<? extends Component>> findParent(
+            Class<? extends Component> current,
+            RouteConfiguration routeConfiguration,
+            Set<Class<? extends Component>> visited) {
+        RouteParent annotation = current.getAnnotation(RouteParent.class);
+        if (annotation != null) {
+            Class<? extends Component> declared = annotation.value();
+            if (declared.isAnnotationPresent(Route.class)
+                    && !visited.contains(declared)) {
+                return Optional.of(declared);
+            }
+            // Fall through to URL-prefix walking when @RouteParent is present
+            // but its target is not @Route-annotated or would form a cycle.
+        }
+        Optional<String> template = routeConfiguration.getTemplate(current);
+        if (template.isEmpty()) {
+            return Optional.empty();
+        }
+        String currentTemplate = template.get();
+        if (currentTemplate.isEmpty()) {
+            // Already at the root URL - nothing to strip.
+            return Optional.empty();
+        }
+        int lastSlash = currentTemplate.lastIndexOf('/');
+        String stripped = (lastSlash >= 0)
+                ? currentTemplate.substring(0, lastSlash)
+                : "";
+        Optional<Class<? extends Component>> candidate = routeConfiguration
+                .getRoute(stripped);
+        if (candidate.isPresent() && !visited.contains(candidate.get())) {
+            return candidate;
+        }
+        return Optional.empty();
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouteHierarchyTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouteHierarchyTest.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.router;
+
+import jakarta.servlet.ServletContext;
+
+import java.io.File;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.MockServletContext;
+import com.vaadin.flow.server.MockVaadinContext;
+import com.vaadin.flow.server.RouteRegistry;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinServletContext;
+import com.vaadin.flow.server.VaadinServletService;
+import com.vaadin.flow.server.startup.ApplicationRouteRegistry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RouteHierarchyTest {
+
+    /**
+     * Extending class to expose the protected getRouteRegistry() for Mockito.
+     */
+    private static class MockService extends VaadinServletService {
+        @Override
+        public RouteRegistry getRouteRegistry() {
+            return super.getRouteRegistry();
+        }
+    }
+
+    private ApplicationRouteRegistry registry;
+    private MockService vaadinService;
+    private RouteConfiguration routeConfiguration;
+
+    @BeforeEach
+    void init() {
+        ServletContext servletContext = new MockServletContext();
+        VaadinServletContext vaadinContext = new MockVaadinContext(
+                servletContext);
+        registry = ApplicationRouteRegistry.getInstance(vaadinContext);
+
+        DeploymentConfiguration configuration = Mockito
+                .mock(DeploymentConfiguration.class);
+        Mockito.when(configuration.getFrontendFolder())
+                .thenReturn(new File("/frontend"));
+
+        vaadinService = Mockito.mock(MockService.class);
+        Mockito.when(vaadinService.getRouteRegistry()).thenReturn(registry);
+        Mockito.when(vaadinService.getContext()).thenReturn(vaadinContext);
+        Mockito.when(vaadinService.getDeploymentConfiguration())
+                .thenReturn(configuration);
+
+        VaadinService.setCurrent(vaadinService);
+        routeConfiguration = RouteConfiguration.forRegistry(registry);
+    }
+
+    @AfterEach
+    void tearDown() {
+        VaadinService.setCurrent(null);
+    }
+
+    // ----- Scenario 1: routeClass with no @Route annotation -----
+
+    @Tag(Tag.DIV)
+    static class PlainComponent extends Component {
+    }
+
+    @Test
+    void resolveAncestors_classWithoutRouteAnnotation_returnsEmptyList() {
+        List<Class<? extends Component>> ancestors = RouteHierarchy
+                .resolveAncestors(PlainComponent.class, routeConfiguration);
+        assertTrue(ancestors.isEmpty(),
+                "Expected empty list for class without @Route");
+    }
+
+    // ----- Scenario 2: @Route with no parent -----
+
+    @Tag(Tag.DIV)
+    @Route("foo")
+    static class FooView extends Component {
+    }
+
+    @Test
+    void resolveAncestors_singleRouteNoParent_returnsSingletonChain() {
+        routeConfiguration.setAnnotatedRoute(FooView.class);
+
+        List<Class<? extends Component>> ancestors = RouteHierarchy
+                .resolveAncestors(FooView.class, routeConfiguration);
+        assertEquals(List.of(FooView.class), ancestors);
+    }
+
+    // ----- Scenario 3: URL-prefix walking happy path -----
+
+    @Tag(Tag.DIV)
+    @Route("a")
+    static class AView extends Component {
+    }
+
+    @Tag(Tag.DIV)
+    @Route("a/b")
+    static class AbView extends Component {
+    }
+
+    @Test
+    void resolveAncestors_urlPrefixHappyPath_returnsTwoElementChain() {
+        routeConfiguration.setAnnotatedRoute(AView.class);
+        routeConfiguration.setAnnotatedRoute(AbView.class);
+
+        List<Class<? extends Component>> ancestors = RouteHierarchy
+                .resolveAncestors(AbView.class, routeConfiguration);
+        assertEquals(List.of(AView.class, AbView.class), ancestors);
+    }
+
+    // ----- Scenario 4: missing intermediate, single strip terminates -----
+
+    @Tag(Tag.DIV)
+    @Route("a/b/c")
+    static class AbcGapView extends Component {
+    }
+
+    @Tag(Tag.DIV)
+    @Route("ga")
+    static class GapAView extends Component {
+    }
+
+    @Test
+    void resolveAncestors_missingIntermediate_terminatesAfterOneStrip() {
+        // Register only "ga" (a different route) and "a/b/c", leaving "a/b"
+        // and "a" unregistered. Walker should strip once to "a/b", find no
+        // route there, and terminate with only the leaf in the chain.
+        routeConfiguration.setAnnotatedRoute(GapAView.class);
+        routeConfiguration.setAnnotatedRoute(AbcGapView.class);
+
+        List<Class<? extends Component>> ancestors = RouteHierarchy
+                .resolveAncestors(AbcGapView.class, routeConfiguration);
+        assertEquals(List.of(AbcGapView.class), ancestors);
+    }
+
+    // ----- Scenario 5: empty-template root @Route("") -----
+
+    @Tag(Tag.DIV)
+    @Route("")
+    static class HomeView extends Component {
+    }
+
+    @Tag(Tag.DIV)
+    @Route("docs")
+    static class DocsView extends Component {
+    }
+
+    @Test
+    void resolveAncestors_emptyTemplateRoot_isFoundAsParent() {
+        routeConfiguration.setAnnotatedRoute(HomeView.class);
+        routeConfiguration.setAnnotatedRoute(DocsView.class);
+
+        List<Class<? extends Component>> ancestors = RouteHierarchy
+                .resolveAncestors(DocsView.class, routeConfiguration);
+        assertEquals(List.of(HomeView.class, DocsView.class), ancestors);
+    }
+
+    // ----- Scenario 6: @RouteParent overrides URL-prefix walking -----
+
+    @Tag(Tag.DIV)
+    @Route("orders")
+    static class OrdersView extends Component {
+    }
+
+    @Tag(Tag.DIV)
+    @Route("orders/edit/:id")
+    @RouteParent(OrdersView.class)
+    static class EditOrderView extends Component {
+    }
+
+    @Test
+    void resolveAncestors_routeParentAnnotation_takesPrecedenceOverUrlPrefix() {
+        routeConfiguration.setAnnotatedRoute(OrdersView.class);
+        routeConfiguration.setAnnotatedRoute(EditOrderView.class);
+
+        List<Class<? extends Component>> ancestors = RouteHierarchy
+                .resolveAncestors(EditOrderView.class, routeConfiguration);
+        assertEquals(List.of(OrdersView.class, EditOrderView.class), ancestors);
+    }
+
+    // ----- Scenario 7: cycle detection via @RouteParent -----
+
+    @Tag(Tag.DIV)
+    @Route("cycle-a")
+    @RouteParent(CycleBView.class)
+    static class CycleAView extends Component {
+    }
+
+    @Tag(Tag.DIV)
+    @Route("cycle-b")
+    @RouteParent(CycleAView.class)
+    static class CycleBView extends Component {
+    }
+
+    @Test
+    void resolveAncestors_cycleViaRouteParent_truncatesWithoutDuplicates() {
+        routeConfiguration.setAnnotatedRoute(CycleAView.class);
+        routeConfiguration.setAnnotatedRoute(CycleBView.class);
+
+        List<Class<? extends Component>> ancestors = RouteHierarchy
+                .resolveAncestors(CycleAView.class, routeConfiguration);
+        // The chain must contain CycleAView and may contain CycleBView once,
+        // but never repeat. Length is at most 2.
+        assertTrue(ancestors.size() <= 2,
+                "Cycle should be truncated; chain length must be <= 2 but was "
+                        + ancestors.size());
+        assertTrue(ancestors.contains(CycleAView.class),
+                "Chain must include the starting class");
+        assertEquals(ancestors.size(), ancestors.stream().distinct().count(),
+                "Chain must not contain duplicate entries");
+    }
+
+    // ----- Scenario 8: @RouteParent points to non-@Route class, URL fallback
+    // works -----
+
+    @Tag(Tag.DIV)
+    static class NonRouteParent extends Component {
+    }
+
+    @Tag(Tag.DIV)
+    @Route("p")
+    static class PView extends Component {
+    }
+
+    @Tag(Tag.DIV)
+    @Route("p/q")
+    @RouteParent(NonRouteParent.class)
+    static class PqViewWithBadAnnotation extends Component {
+    }
+
+    @Test
+    void resolveAncestors_routeParentNotAnnotated_fallsBackToUrlPrefix() {
+        routeConfiguration.setAnnotatedRoute(PView.class);
+        routeConfiguration.setAnnotatedRoute(PqViewWithBadAnnotation.class);
+
+        List<Class<? extends Component>> ancestors = RouteHierarchy
+                .resolveAncestors(PqViewWithBadAnnotation.class,
+                        routeConfiguration);
+        assertEquals(List.of(PView.class, PqViewWithBadAnnotation.class),
+                ancestors);
+    }
+
+    // ----- Scenario 9: @RouteParent invalid, no URL fallback either -----
+
+    @Tag(Tag.DIV)
+    @Route("standalone")
+    @RouteParent(NonRouteParent.class)
+    static class StandaloneWithBadAnnotation extends Component {
+    }
+
+    @Test
+    void resolveAncestors_routeParentNotAnnotatedAndNoUrlFallback_terminates() {
+        // Only register the leaf; "standalone" has no URL-prefix ancestor
+        // since "" is not registered.
+        routeConfiguration.setAnnotatedRoute(StandaloneWithBadAnnotation.class);
+
+        List<Class<? extends Component>> ancestors = RouteHierarchy
+                .resolveAncestors(StandaloneWithBadAnnotation.class,
+                        routeConfiguration);
+        assertEquals(List.of(StandaloneWithBadAnnotation.class), ancestors);
+    }
+
+    // ----- Scenario 10: deep multi-step URL-prefix walking -----
+
+    @Tag(Tag.DIV)
+    @Route("a/b/c")
+    static class AbcView extends Component {
+    }
+
+    @Test
+    void resolveAncestors_deepChain_walksMultipleSteps() {
+        routeConfiguration.setAnnotatedRoute(AView.class);
+        routeConfiguration.setAnnotatedRoute(AbView.class);
+        routeConfiguration.setAnnotatedRoute(AbcView.class);
+
+        List<Class<? extends Component>> ancestors = RouteHierarchy
+                .resolveAncestors(AbcView.class, routeConfiguration);
+        assertEquals(List.of(AView.class, AbView.class, AbcView.class),
+                ancestors);
+    }
+
+    // ----- Scenario 11: resolveParent consistency with three-element chain
+    // -----
+
+    @Test
+    void resolveParent_threeElementChain_returnsSecondToLast() {
+        routeConfiguration.setAnnotatedRoute(AView.class);
+        routeConfiguration.setAnnotatedRoute(AbView.class);
+        routeConfiguration.setAnnotatedRoute(AbcView.class);
+
+        Optional<Class<? extends Component>> parent = RouteHierarchy
+                .resolveParent(AbcView.class, routeConfiguration);
+        assertEquals(Optional.of(AbView.class), parent);
+    }
+
+    // ----- Scenario 12: resolveParent on single-element chain -----
+
+    @Test
+    void resolveParent_singletonChain_returnsEmpty() {
+        routeConfiguration.setAnnotatedRoute(FooView.class);
+
+        Optional<Class<? extends Component>> parent = RouteHierarchy
+                .resolveParent(FooView.class, routeConfiguration);
+        assertEquals(Optional.empty(), parent);
+    }
+
+    // ----- Scenario 13: parameterised template (users/:id) -----
+
+    @Tag(Tag.DIV)
+    @Route("users")
+    static class UsersView extends Component {
+    }
+
+    @Tag(Tag.DIV)
+    @Route("users/:id")
+    static class UserDetailView extends Component {
+    }
+
+    @Test
+    void resolveAncestors_parameterisedTemplate_stripsParameterSegment() {
+        routeConfiguration.setAnnotatedRoute(UsersView.class);
+        routeConfiguration.setAnnotatedRoute(UserDetailView.class);
+
+        List<Class<? extends Component>> ancestors = RouteHierarchy
+                .resolveAncestors(UserDetailView.class, routeConfiguration);
+        assertEquals(List.of(UsersView.class, UserDetailView.class), ancestors);
+    }
+
+    // ----- Scenario 14: null arguments throw NPE -----
+
+    @Test
+    void nullArguments_throwNullPointerException() {
+        assertThrows(NullPointerException.class, () -> RouteHierarchy
+                .resolveAncestors(null, routeConfiguration));
+        assertThrows(NullPointerException.class,
+                () -> RouteHierarchy.resolveAncestors(FooView.class, null));
+        assertThrows(NullPointerException.class,
+                () -> RouteHierarchy.resolveParent(null, routeConfiguration));
+        assertThrows(NullPointerException.class,
+                () -> RouteHierarchy.resolveParent(FooView.class, null));
+    }
+}


### PR DESCRIPTION
## Summary
Adds com.vaadin.flow.router.RouteHierarchy — walks ancestor routes
for a given `@Route` class, consulting @RouteParent first and falling
back to URL-prefix walking. Cycle-safe.

Stacked on #24444 (adds @RouteParent). That PR should land first;
GitHub will auto-retarget this PR to main once it merges.

## Test plan
- [ ] mvn -pl flow-server test -Dtest=RouteHierarchyTest (14 cases)
- [ ] Reviewer sanity-checks the algorithm against the breadcrumbs
      flow-spec.md Step 3 contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)