### PR TITLE
refactor: expose trigger outputs as static Action.Input fields

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/Action.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/Action.java
@@ -31,7 +31,11 @@ import com.vaadin.flow.dom.JsFunction;
  * An Action usually consumes one or more {@linkplain Input inputs} that supply
  * its values — a literal, the current value of a DOM property, an event-scoped
  * expression — so the data the action acts on is read on the client at fire
- * time rather than captured on the server.
+ * time rather than captured on the server. A trigger family may expose its
+ * event state as one or more {@code Input}s, typically as
+ * {@code public static final} fields (for example
+ * {@link MouseEventTrigger.Output#screenX}); other inputs read state
+ * independent of any trigger (for example {@link PropertyInput}).
  * <p>
  * <em>For Action implementors:</em> override {@link #toJs(Trigger)} to produce
  * the JavaScript that the trigger handler invokes; reference inputs through

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/Action.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/Action.java
@@ -34,7 +34,7 @@ import com.vaadin.flow.dom.JsFunction;
  * time rather than captured on the server. A trigger family may expose its
  * event state as one or more {@code Input}s, typically as
  * {@code public static final} fields (for example
- * {@link MouseEventTrigger.Output#screenX}); other inputs read state
+ * {@link MouseEventTrigger.EventData#screenX}); other inputs read state
  * independent of any trigger (for example {@link PropertyInput}).
  * <p>
  * <em>For Action implementors:</em> override {@link #toJs(Trigger)} to produce

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/CallbackAction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/CallbackAction.java
@@ -46,7 +46,8 @@ import com.vaadin.flow.internal.nodefeature.ReturnChannelRegistration;
  * <pre>{@code
  * ClickTrigger click = new ClickTrigger(button);
  * click.triggers(new CallbackAction<>(Integer.class,
- *         x -> logger.info("clicked at {}", x), click.screenX()));
+ *         x -> logger.info("clicked at {}", x),
+ *         ClickTrigger.EventData.screenX));
  * }</pre>
  *
  * <p>

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/ClickTrigger.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/ClickTrigger.java
@@ -20,8 +20,8 @@ import com.vaadin.flow.component.Component;
 /**
  * Fires on the host component's {@code click} DOM event. The event's
  * coordinates and modifier-key state are available as static
- * {@link Action.Input} sources on {@link MouseEventTrigger.Output} (also
- * reachable as {@code ClickTrigger.Output} through inheritance).
+ * {@link Action.Input} sources on {@link MouseEventTrigger.EventData} (also
+ * reachable as {@code ClickTrigger.EventData} through inheritance).
  * <p>
  * Example — on click, mirror the screen coordinates of the click into two input
  * fields' {@code value} properties:
@@ -30,9 +30,9 @@ import com.vaadin.flow.component.Component;
  * ClickTrigger click = new ClickTrigger(button);
  * click.triggers(
  *         new SetPropertyAction<>(xField, "value",
- *                 ClickTrigger.Output.screenX),
+ *                 ClickTrigger.EventData.screenX),
  *         new SetPropertyAction<>(yField, "value",
- *                 ClickTrigger.Output.screenY));
+ *                 ClickTrigger.EventData.screenY));
  * }</pre>
  *
  * <p>

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/ClickTrigger.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/ClickTrigger.java
@@ -23,7 +23,8 @@ import com.vaadin.flow.component.Component;
  * {@link Action.Input} sources on {@link MouseEventTrigger.Output} (also
  * reachable as {@code ClickTrigger.Output} through inheritance).
  * <p>
- * Example:
+ * Example — on click, mirror the screen coordinates of the click into two input
+ * fields' {@code value} properties:
  *
  * <pre>{@code
  * ClickTrigger click = new ClickTrigger(button);

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/DomEventTrigger.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/DomEventTrigger.java
@@ -63,7 +63,7 @@ public class DomEventTrigger extends Trigger {
      * time, valid in the handler of any trigger that is an instance of
      * {@code ownerClass}. Used by trigger families that expose their event
      * properties as {@code public static final} fields — see
-     * {@link MouseEventTrigger.Output}.
+     * {@link MouseEventTrigger.EventData}.
      *
      * @param name
      *            the event property name, not {@code null}

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/DomEventTrigger.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/DomEventTrigger.java
@@ -60,21 +60,23 @@ public class DomEventTrigger extends Trigger {
 
     /**
      * Returns an {@link Action.Input} that yields {@code event[name]} at fire
-     * time — the value of a property on the DOM event object.
-     * <p>
-     * The returned input is only valid in actions wired to this trigger; using
-     * it elsewhere throws {@link IllegalArgumentException} at the
-     * {@link #triggers(Action...)} call site.
+     * time, valid in the handler of any trigger that is an instance of
+     * {@code ownerClass}. Used by trigger families that expose their event
+     * properties as {@code public static final} fields — see
+     * {@link MouseEventTrigger.Output}.
      *
      * @param name
-     *            the event property name (e.g. {@code "screenX"},
-     *            {@code "key"}), not {@code null}
-     * @return an input that resolves to {@code event[name]} on fire
+     *            the event property name, not {@code null}
+     * @param ownerClass
+     *            the trigger class the expression is valid for, not
+     *            {@code null}
      * @param <T>
      *            the runtime type of the value produced
+     * @return an input that resolves to {@code event[name]} on fire
      */
-    public <T> Action.Input<T> property(String name) {
-        return new HandlerInput<>(name, this);
+    static <T> Action.Input<T> eventProperty(String name,
+            Class<? extends DomEventTrigger> ownerClass) {
+        return new HandlerInput<>(name, ownerClass);
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/DoubleClickTrigger.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/DoubleClickTrigger.java
@@ -18,34 +18,32 @@ package com.vaadin.flow.component.trigger.internal;
 import com.vaadin.flow.component.Component;
 
 /**
- * Fires on the host component's {@code click} DOM event. The event's
+ * Fires on the host component's {@code dblclick} DOM event. The event's
  * coordinates and modifier-key state are available as static
  * {@link Action.Input} sources on {@link MouseEventTrigger.Output} (also
- * reachable as {@code ClickTrigger.Output} through inheritance).
+ * reachable as {@code DoubleClickTrigger.Output} through inheritance).
  * <p>
  * Example:
  *
  * <pre>{@code
- * ClickTrigger click = new ClickTrigger(button);
- * click.triggers(
- *         new SetPropertyAction<>(xField, "value",
- *                 ClickTrigger.Output.screenX),
- *         new SetPropertyAction<>(yField, "value",
- *                 ClickTrigger.Output.screenY));
+ * DoubleClickTrigger dbl = new DoubleClickTrigger(panel);
+ * dbl.triggers(new SetPropertyAction<>(field, "value",
+ *         DoubleClickTrigger.Output.clientX));
  * }</pre>
  *
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  */
-public class ClickTrigger extends MouseEventTrigger {
+public class DoubleClickTrigger extends MouseEventTrigger {
 
     /**
-     * Creates a click trigger on the given host component's root element.
+     * Creates a double-click trigger on the given host component's root
+     * element.
      *
      * @param host
      *            the component to listen on, not {@code null}
      */
-    public ClickTrigger(Component host) {
-        super(host, "click");
+    public DoubleClickTrigger(Component host) {
+        super(host, "dblclick");
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/DoubleClickTrigger.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/DoubleClickTrigger.java
@@ -20,8 +20,8 @@ import com.vaadin.flow.component.Component;
 /**
  * Fires on the host component's {@code dblclick} DOM event. The event's
  * coordinates and modifier-key state are available as static
- * {@link Action.Input} sources on {@link MouseEventTrigger.Output} (also
- * reachable as {@code DoubleClickTrigger.Output} through inheritance).
+ * {@link Action.Input} sources on {@link MouseEventTrigger.EventData} (also
+ * reachable as {@code DoubleClickTrigger.EventData} through inheritance).
  * <p>
  * Example — on double-click, mirror the viewport X coordinate into a field's
  * {@code value} property:
@@ -29,7 +29,7 @@ import com.vaadin.flow.component.Component;
  * <pre>{@code
  * DoubleClickTrigger dbl = new DoubleClickTrigger(panel);
  * dbl.triggers(new SetPropertyAction<>(field, "value",
- *         DoubleClickTrigger.Output.clientX));
+ *         DoubleClickTrigger.EventData.clientX));
  * }</pre>
  *
  * <p>

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/DoubleClickTrigger.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/DoubleClickTrigger.java
@@ -23,7 +23,8 @@ import com.vaadin.flow.component.Component;
  * {@link Action.Input} sources on {@link MouseEventTrigger.Output} (also
  * reachable as {@code DoubleClickTrigger.Output} through inheritance).
  * <p>
- * Example:
+ * Example — on double-click, mirror the viewport X coordinate into a field's
+ * {@code value} property:
  *
  * <pre>{@code
  * DoubleClickTrigger dbl = new DoubleClickTrigger(panel);

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/HandlerInput.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/HandlerInput.java
@@ -23,9 +23,13 @@ import com.vaadin.flow.dom.JsFunction;
  * Input that reads a property from a trigger handler's {@code event} argument
  * (e.g. {@code event.screenX} for a {@link DomEventTrigger}).
  * <p>
- * Carries the owning trigger so that {@link Trigger#triggers(Action...)}
- * refuses to render an input created by trigger A into the handler of trigger B
- * (where the referenced {@code event} would not be in scope).
+ * Carries the trigger class the expression is valid for so that
+ * {@link Trigger#triggers(Action...)} refuses to render an input meant for one
+ * trigger family into the handler of an unrelated trigger (where the referenced
+ * variable would not be in scope). Class-based scoping lets a single input
+ * instance be exposed as a {@code public static final} field (see
+ * {@link MouseEventTrigger.Output}) and reused across every instance of the
+ * owning class and its subclasses.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
@@ -35,19 +39,19 @@ import com.vaadin.flow.dom.JsFunction;
 final class HandlerInput<T> extends Action.Input<T> {
 
     private final String propertyName;
-    private final Trigger owner;
+    private final Class<? extends Trigger> ownerClass;
 
-    HandlerInput(String propertyName, Trigger owner) {
+    HandlerInput(String propertyName, Class<? extends Trigger> ownerClass) {
         this.propertyName = Objects.requireNonNull(propertyName);
-        this.owner = Objects.requireNonNull(owner);
+        this.ownerClass = Objects.requireNonNull(ownerClass);
     }
 
     @Override
     protected JsFunction toJs(Trigger trigger) {
-        if (trigger != owner) {
-            throw new IllegalArgumentException(
-                    "Input is scoped to a different trigger and cannot be"
-                            + " used here");
+        if (!ownerClass.isInstance(trigger)) {
+            throw new IllegalArgumentException("Input is scoped to "
+                    + ownerClass.getSimpleName() + " and cannot be used in a "
+                    + trigger.getClass().getSimpleName() + " handler");
         }
         // $0 = property name (string capture, Jackson-quoted on the client),
         // event = the handler argument the framework passes in.

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/HandlerInput.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/HandlerInput.java
@@ -28,7 +28,7 @@ import com.vaadin.flow.dom.JsFunction;
  * trigger family into the handler of an unrelated trigger (where the referenced
  * variable would not be in scope). Class-based scoping lets a single input
  * instance be exposed as a {@code public static final} field (see
- * {@link MouseEventTrigger.Output}) and reused across every instance of the
+ * {@link MouseEventTrigger.EventData}) and reused across every instance of the
  * owning class and its subclasses.
  * <p>
  * For internal use only. May be renamed or removed in a future release.

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/MouseEventTrigger.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/MouseEventTrigger.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.trigger.internal;
 
+import java.io.Serializable;
+
 import com.vaadin.flow.component.Component;
 
 /**
@@ -74,7 +76,7 @@ public class MouseEventTrigger extends DomEventTrigger {
      * remain reachable through the subclass (so {@code ClickTrigger.Output
      * .screenX} continues to resolve to {@link #screenX}).
      */
-    public static class Output {
+    public abstract static class Output implements Serializable {
 
         /**
          * The class exists purely as a namespace for the static

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/MouseEventTrigger.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/MouseEventTrigger.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.trigger.internal;
+
+import com.vaadin.flow.component.Component;
+
+/**
+ * Common super class for triggers that fire on a DOM {@code MouseEvent} —
+ * {@link ClickTrigger}, {@link DoubleClickTrigger}, and any future mouse-event
+ * trigger. Exposes the {@code MouseEvent} properties shared by all of them as
+ * static {@link Action.Input} fields on {@link Output}.
+ * <p>
+ * The {@code Output} fields are bound to {@code MouseEventTrigger.class}, so
+ * the same field instance can be used as the source for any
+ * {@code MouseEventTrigger} subclass:
+ *
+ * <pre>{@code
+ * ClickTrigger click = new ClickTrigger(button);
+ * click.triggers(new SetPropertyAction<>(xField, "value",
+ *         ClickTrigger.Output.screenX));
+ *
+ * DoubleClickTrigger dbl = new DoubleClickTrigger(button);
+ * dbl.triggers(new SetPropertyAction<>(xField, "value",
+ *         DoubleClickTrigger.Output.screenX));
+ * }</pre>
+ *
+ * <p>
+ * For internal use only. May be renamed or removed in a future release.
+ */
+public class MouseEventTrigger extends DomEventTrigger {
+
+    /**
+     * Creates a mouse-event trigger that fires when the host receives a DOM
+     * event with the given name. Subclasses such as {@link ClickTrigger} bind a
+     * specific event name; instantiate this class directly only when none of
+     * the dedicated subclasses fits (e.g. for {@code "mouseover"}).
+     *
+     * @param host
+     *            the component whose root element listens for the event, not
+     *            {@code null}
+     * @param eventName
+     *            the DOM mouse-event name (e.g. {@code "click"},
+     *            {@code "mousedown"}), not {@code null}
+     */
+    public MouseEventTrigger(Component host, String eventName) {
+        super(host, eventName);
+    }
+
+    /**
+     * The {@code MouseEvent} properties exposed as static {@link Action.Input}
+     * sources. Use these as the value source of an {@link Action} wired to any
+     * {@link MouseEventTrigger} subclass.
+     * <p>
+     * Each field is bound to {@link MouseEventTrigger}; using it in the handler
+     * of an unrelated trigger (e.g. a keyboard trigger) throws
+     * {@link IllegalArgumentException} at {@link Trigger#triggers(Action...)}
+     * time.
+     * <p>
+     * Trigger subclasses that need their own properties may declare their own
+     * nested {@code Output} extending this class — the inherited static fields
+     * remain reachable through the subclass (so {@code ClickTrigger.Output
+     * .screenX} continues to resolve to {@link #screenX}).
+     */
+    public static class Output {
+
+        /**
+         * The class exists purely as a namespace for the static
+         * {@link Action.Input} fields.
+         */
+        protected Output() {
+        }
+
+        /** {@code event.screenX} — X coordinate relative to the screen. */
+        public static final Action.Input<Integer> screenX = eventProperty(
+                "screenX", MouseEventTrigger.class);
+
+        /** {@code event.screenY} — Y coordinate relative to the screen. */
+        public static final Action.Input<Integer> screenY = eventProperty(
+                "screenY", MouseEventTrigger.class);
+
+        /** {@code event.clientX} — X coordinate relative to the viewport. */
+        public static final Action.Input<Integer> clientX = eventProperty(
+                "clientX", MouseEventTrigger.class);
+
+        /** {@code event.clientY} — Y coordinate relative to the viewport. */
+        public static final Action.Input<Integer> clientY = eventProperty(
+                "clientY", MouseEventTrigger.class);
+
+        /**
+         * {@code event.button} — which mouse button changed state: {@code 0}
+         * main (usually left), {@code 1} auxiliary (usually middle), {@code 2}
+         * secondary (usually right), {@code 3}/{@code 4} fourth (back) / fifth
+         * (forward) browser buttons.
+         */
+        public static final Action.Input<Integer> button = eventProperty(
+                "button", MouseEventTrigger.class);
+
+        /** {@code event.shiftKey} — whether shift was held during the event. */
+        public static final Action.Input<Boolean> shiftKey = eventProperty(
+                "shiftKey", MouseEventTrigger.class);
+
+        /** {@code event.ctrlKey} — whether ctrl was held during the event. */
+        public static final Action.Input<Boolean> ctrlKey = eventProperty(
+                "ctrlKey", MouseEventTrigger.class);
+
+        /** {@code event.altKey} — whether alt was held during the event. */
+        public static final Action.Input<Boolean> altKey = eventProperty(
+                "altKey", MouseEventTrigger.class);
+
+        /** {@code event.metaKey} — whether meta was held during the event. */
+        public static final Action.Input<Boolean> metaKey = eventProperty(
+                "metaKey", MouseEventTrigger.class);
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/MouseEventTrigger.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/MouseEventTrigger.java
@@ -27,7 +27,9 @@ import com.vaadin.flow.component.Component;
  * <p>
  * The {@code Output} fields are bound to {@code MouseEventTrigger.class}, so
  * the same field instance can be used as the source for any
- * {@code MouseEventTrigger} subclass:
+ * {@code MouseEventTrigger} subclass — both snippets below mirror the click's
+ * screen X coordinate into {@code xField.value}, one on single click, one on
+ * double click:
  *
  * <pre>{@code
  * ClickTrigger click = new ClickTrigger(button);
@@ -65,6 +67,11 @@ public class MouseEventTrigger extends DomEventTrigger {
      * The {@code MouseEvent} properties exposed as static {@link Action.Input}
      * sources. Use these as the value source of an {@link Action} wired to any
      * {@link MouseEventTrigger} subclass.
+     * <p>
+     * The class is named {@code Output} from the trigger's perspective — these
+     * are the values the trigger produces from the fired event. The same fields
+     * are typed as {@link Action.Input} from the {@link Action}'s perspective —
+     * what an action consumes. One value, two roles in the data flow.
      * <p>
      * Each field is bound to {@link MouseEventTrigger}; using it in the handler
      * of an unrelated trigger (e.g. a keyboard trigger) throws

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/MouseEventTrigger.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/MouseEventTrigger.java
@@ -23,9 +23,9 @@ import com.vaadin.flow.component.Component;
  * Common super class for triggers that fire on a DOM {@code MouseEvent} —
  * {@link ClickTrigger}, {@link DoubleClickTrigger}, and any future mouse-event
  * trigger. Exposes the {@code MouseEvent} properties shared by all of them as
- * static {@link Action.Input} fields on {@link Output}.
+ * static {@link Action.Input} fields on {@link EventData}.
  * <p>
- * The {@code Output} fields are bound to {@code MouseEventTrigger.class}, so
+ * The {@code EventData} fields are bound to {@code MouseEventTrigger.class}, so
  * the same field instance can be used as the source for any
  * {@code MouseEventTrigger} subclass — both snippets below mirror the click's
  * screen X coordinate into {@code xField.value}, one on single click, one on
@@ -34,11 +34,11 @@ import com.vaadin.flow.component.Component;
  * <pre>{@code
  * ClickTrigger click = new ClickTrigger(button);
  * click.triggers(new SetPropertyAction<>(xField, "value",
- *         ClickTrigger.Output.screenX));
+ *         ClickTrigger.EventData.screenX));
  *
  * DoubleClickTrigger dbl = new DoubleClickTrigger(button);
  * dbl.triggers(new SetPropertyAction<>(xField, "value",
- *         DoubleClickTrigger.Output.screenX));
+ *         DoubleClickTrigger.EventData.screenX));
  * }</pre>
  *
  * <p>
@@ -65,13 +65,9 @@ public class MouseEventTrigger extends DomEventTrigger {
 
     /**
      * The {@code MouseEvent} properties exposed as static {@link Action.Input}
-     * sources. Use these as the value source of an {@link Action} wired to any
-     * {@link MouseEventTrigger} subclass.
-     * <p>
-     * The class is named {@code Output} from the trigger's perspective — these
-     * are the values the trigger produces from the fired event. The same fields
-     * are typed as {@link Action.Input} from the {@link Action}'s perspective —
-     * what an action consumes. One value, two roles in the data flow.
+     * sources. Each field reads one property off the DOM event that fires the
+     * trigger; pass any of them as the value source of an {@link Action} wired
+     * to a {@link MouseEventTrigger} subclass.
      * <p>
      * Each field is bound to {@link MouseEventTrigger}; using it in the handler
      * of an unrelated trigger (e.g. a keyboard trigger) throws
@@ -79,17 +75,18 @@ public class MouseEventTrigger extends DomEventTrigger {
      * time.
      * <p>
      * Trigger subclasses that need their own properties may declare their own
-     * nested {@code Output} extending this class — the inherited static fields
-     * remain reachable through the subclass (so {@code ClickTrigger.Output
-     * .screenX} continues to resolve to {@link #screenX}).
+     * nested {@code EventData} extending this class — the inherited static
+     * fields remain reachable through the subclass, so
+     * {@code ClickTrigger.EventData.screenX} continues to resolve to
+     * {@link #screenX}.
      */
-    public abstract static class Output implements Serializable {
+    public abstract static class EventData implements Serializable {
 
         /**
          * The class exists purely as a namespace for the static
          * {@link Action.Input} fields.
          */
-        protected Output() {
+        protected EventData() {
         }
 
         /** {@code event.screenX} — X coordinate relative to the screen. */

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/SetPropertyAction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/SetPropertyAction.java
@@ -33,15 +33,15 @@ import com.vaadin.flow.dom.JsFunction;
  * <p>
  * The value to assign can be either a literal (constant, serialised at build
  * time) or an {@link Action.Input} that produces the value on the client when
- * the trigger fires — for example, {@link ClickTrigger#screenX()
- * click.screenX()} feeds the click's screen coordinate.
+ * the trigger fires — for example, {@link MouseEventTrigger.Output#screenX}
+ * feeds the click's screen coordinate.
  * <p>
  * Common idioms:
  * <ul>
  * <li>Disable a button: {@code new SetPropertyAction(button, "disabled", true)}
  * <li>Clear an input: {@code new SetPropertyAction(input, "value", "")}
  * <li>Mirror a click coordinate:
- * {@code new SetPropertyAction(field, "value", click.screenX())}
+ * {@code new SetPropertyAction(field, "value", ClickTrigger.Output.screenX)}
  * </ul>
  *
  * Server-side state is not updated by this action; the change lives in the

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/SetPropertyAction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/SetPropertyAction.java
@@ -33,7 +33,7 @@ import com.vaadin.flow.dom.JsFunction;
  * <p>
  * The value to assign can be either a literal (constant, serialised at build
  * time) or an {@link Action.Input} that produces the value on the client when
- * the trigger fires — for example, {@link MouseEventTrigger.Output#screenX}
+ * the trigger fires — for example, {@link MouseEventTrigger.EventData#screenX}
  * feeds the click's screen coordinate.
  * <p>
  * Common idioms:
@@ -41,7 +41,7 @@ import com.vaadin.flow.dom.JsFunction;
  * <li>Disable a button: {@code new SetPropertyAction(button, "disabled", true)}
  * <li>Clear an input: {@code new SetPropertyAction(input, "value", "")}
  * <li>Mirror a click coordinate:
- * {@code new SetPropertyAction(field, "value", ClickTrigger.Output.screenX)}
+ * {@code new SetPropertyAction(field, "value", ClickTrigger.EventData.screenX)}
  * </ul>
  *
  * Server-side state is not updated by this action; the change lives in the

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/ClickTriggerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/ClickTriggerTest.java
@@ -42,9 +42,9 @@ class ClickTriggerTest {
 
         new ClickTrigger(button).triggers(
                 new SetPropertyAction<>(xField, "value",
-                        ClickTrigger.Output.screenX),
+                        ClickTrigger.EventData.screenX),
                 new SetPropertyAction<>(yField, "value",
-                        ClickTrigger.Output.screenY));
+                        ClickTrigger.EventData.screenY));
 
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
 
@@ -64,8 +64,8 @@ class ClickTriggerTest {
     }
 
     @Test
-    void mouseEventOutput_sharedAcrossInstances_renderedPerHandler() {
-        // The same static Output field is the source for two separate
+    void mouseEventData_sharedAcrossInstances_renderedPerHandler() {
+        // The same static EventData field is the source for two separate
         // ClickTrigger instances on different hosts — both renders succeed
         // because the input is bound to the trigger class, not an instance.
         UI ui = new MockUI();
@@ -75,7 +75,7 @@ class ClickTriggerTest {
         ui.getElement().appendChild(button1.getElement(), button2.getElement(),
                 field.getElement());
 
-        Action.Input<Integer> sharedX = ClickTrigger.Output.screenX;
+        Action.Input<Integer> sharedX = ClickTrigger.EventData.screenX;
         new ClickTrigger(button1)
                 .triggers(new SetPropertyAction<>(field, "value", sharedX));
         new ClickTrigger(button2)
@@ -89,7 +89,7 @@ class ClickTriggerTest {
     }
 
     @Test
-    void mouseEventOutput_acceptedAcrossMultipleTriggersCalls() {
+    void mouseEventData_acceptedAcrossMultipleTriggersCalls() {
         UI ui = new MockUI();
         TagComponent button = new TagComponent("button");
         TagComponent xField = new TagComponent("input");
@@ -98,9 +98,9 @@ class ClickTriggerTest {
                 yField.getElement());
 
         ClickTrigger click = new ClickTrigger(button);
-        // Same static Output field used across two separate triggers() calls
+        // Same static EventData field used across two separate triggers() calls
         // on the same trigger instance.
-        Action.Input<Integer> x = ClickTrigger.Output.screenX;
+        Action.Input<Integer> x = ClickTrigger.EventData.screenX;
         click.triggers(new SetPropertyAction<>(xField, "value", x));
         click.triggers(new SetPropertyAction<>(yField, "value", x));
 
@@ -112,8 +112,8 @@ class ClickTriggerTest {
     }
 
     @Test
-    void mouseEventOutput_rejectedInNonMouseEventTrigger() {
-        // ClickTrigger.Output.screenX is bound to MouseEventTrigger; a plain
+    void mouseEventData_rejectedInNonMouseEventTrigger() {
+        // ClickTrigger.EventData.screenX is bound to MouseEventTrigger; a plain
         // DomEventTrigger is not a MouseEventTrigger so wiring it through such
         // a handler must fail at triggers() time.
         TagComponent input = new TagComponent("input");
@@ -122,7 +122,7 @@ class ClickTriggerTest {
         DomEventTrigger keypress = new DomEventTrigger(input, "keypress");
         assertThrows(IllegalArgumentException.class,
                 () -> keypress.triggers(new SetPropertyAction<>(field, "value",
-                        ClickTrigger.Output.screenX)));
+                        ClickTrigger.EventData.screenX)));
     }
 
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/ClickTriggerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/ClickTriggerTest.java
@@ -40,10 +40,11 @@ class ClickTriggerTest {
         ui.getElement().appendChild(button.getElement(), xField.getElement(),
                 yField.getElement());
 
-        ClickTrigger click = new ClickTrigger(button);
-        click.triggers(
-                new SetPropertyAction<>(xField, "value", click.screenX()),
-                new SetPropertyAction<>(yField, "value", click.screenY()));
+        new ClickTrigger(button).triggers(
+                new SetPropertyAction<>(xField, "value",
+                        ClickTrigger.Output.screenX),
+                new SetPropertyAction<>(yField, "value",
+                        ClickTrigger.Output.screenY));
 
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
 
@@ -63,21 +64,32 @@ class ClickTriggerTest {
     }
 
     @Test
-    void argumentFromOtherTrigger_isRejectedAtBuildTime() {
+    void mouseEventOutput_sharedAcrossInstances_renderedPerHandler() {
+        // The same static Output field is the source for two separate
+        // ClickTrigger instances on different hosts — both renders succeed
+        // because the input is bound to the trigger class, not an instance.
+        UI ui = new MockUI();
         TagComponent button1 = new TagComponent("button");
         TagComponent button2 = new TagComponent("button");
         TagComponent field = new TagComponent("input");
+        ui.getElement().appendChild(button1.getElement(), button2.getElement(),
+                field.getElement());
 
-        ClickTrigger click1 = new ClickTrigger(button1);
-        ClickTrigger click2 = new ClickTrigger(button2);
+        Action.Input<Integer> sharedX = ClickTrigger.Output.screenX;
+        new ClickTrigger(button1)
+                .triggers(new SetPropertyAction<>(field, "value", sharedX));
+        new ClickTrigger(button2)
+                .triggers(new SetPropertyAction<>(field, "value", sharedX));
 
-        // Input made by click1 cannot be used in click2's handler.
-        assertThrows(IllegalArgumentException.class, () -> click2.triggers(
-                new SetPropertyAction<>(field, "value", click1.screenX())));
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        List<PendingJavaScriptInvocation> pending = ui.getInternals()
+                .dumpPendingJavaScriptInvocations();
+        assertEquals(2, pending.size());
     }
 
     @Test
-    void argumentUsedInOwningTrigger_acceptedAcrossMultipleTriggersCalls() {
+    void mouseEventOutput_acceptedAcrossMultipleTriggersCalls() {
         UI ui = new MockUI();
         TagComponent button = new TagComponent("button");
         TagComponent xField = new TagComponent("input");
@@ -86,9 +98,9 @@ class ClickTriggerTest {
                 yField.getElement());
 
         ClickTrigger click = new ClickTrigger(button);
-        // Same Input instance used across two separate triggers() calls on
-        // its owning trigger.
-        Action.Input<Integer> x = click.screenX();
+        // Same static Output field used across two separate triggers() calls
+        // on the same trigger instance.
+        Action.Input<Integer> x = ClickTrigger.Output.screenX;
         click.triggers(new SetPropertyAction<>(xField, "value", x));
         click.triggers(new SetPropertyAction<>(yField, "value", x));
 
@@ -97,6 +109,20 @@ class ClickTriggerTest {
         List<PendingJavaScriptInvocation> pending = ui.getInternals()
                 .dumpPendingJavaScriptInvocations();
         assertEquals(2, pending.size());
+    }
+
+    @Test
+    void mouseEventOutput_rejectedInNonMouseEventTrigger() {
+        // ClickTrigger.Output.screenX is bound to MouseEventTrigger; a plain
+        // DomEventTrigger is not a MouseEventTrigger so wiring it through such
+        // a handler must fail at triggers() time.
+        TagComponent input = new TagComponent("input");
+        TagComponent field = new TagComponent("input");
+
+        DomEventTrigger keypress = new DomEventTrigger(input, "keypress");
+        assertThrows(IllegalArgumentException.class,
+                () -> keypress.triggers(new SetPropertyAction<>(field, "value",
+                        ClickTrigger.Output.screenX)));
     }
 
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/DoubleClickTriggerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/DoubleClickTriggerTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.trigger.internal;
+
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.dom.JsFunction;
+import com.vaadin.tests.util.MockUI;
+
+import static com.vaadin.flow.component.trigger.internal.TriggerTestUtil.actionOf;
+import static com.vaadin.flow.component.trigger.internal.TriggerTestUtil.singleInstallFn;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DoubleClickTriggerTest {
+
+    @Test
+    void usesDblclickAndSharesMouseEventOutput() {
+        UI ui = new MockUI();
+        TagComponent panel = new TagComponent("div");
+        TagComponent field = new TagComponent("input");
+        ui.getElement().appendChild(panel.getElement(), field.getElement());
+
+        new DoubleClickTrigger(panel).triggers(new SetPropertyAction<>(field,
+                "value", DoubleClickTrigger.Output.clientX));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        // Install body is the generic DomEventTrigger install; the event name
+        // is a capture at $1, distinguishing dblclick from click only via that
+        // capture.
+        JsFunction install = singleInstallFn(ui);
+        assertEquals(
+                "this.addEventListener($1, $0);"
+                        + "return () => this.removeEventListener($1, $0);",
+                install.getBody());
+        assertEquals("dblclick", install.getCaptures().get(1));
+
+        // The Output field is inherited from MouseEventTrigger.Output and
+        // resolves to the same event[clientX] expression as on ClickTrigger.
+        JsFunction source = (JsFunction) actionOf(install).getCaptures().get(2);
+        assertEquals("clientX", source.getCaptures().get(0));
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/DoubleClickTriggerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/DoubleClickTriggerTest.java
@@ -28,14 +28,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class DoubleClickTriggerTest {
 
     @Test
-    void usesDblclickAndSharesMouseEventOutput() {
+    void usesDblclickAndSharesMouseEventData() {
         UI ui = new MockUI();
         TagComponent panel = new TagComponent("div");
         TagComponent field = new TagComponent("input");
         ui.getElement().appendChild(panel.getElement(), field.getElement());
 
         new DoubleClickTrigger(panel).triggers(new SetPropertyAction<>(field,
-                "value", DoubleClickTrigger.Output.clientX));
+                "value", DoubleClickTrigger.EventData.clientX));
 
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
 
@@ -49,7 +49,7 @@ class DoubleClickTriggerTest {
                 install.getBody());
         assertEquals("dblclick", install.getCaptures().get(1));
 
-        // The Output field is inherited from MouseEventTrigger.Output and
+        // The EventData field is inherited from MouseEventTrigger.EventData and
         // resolves to the same event[clientX] expression as on ClickTrigger.
         JsFunction source = (JsFunction) actionOf(install).getCaptures().get(2);
         assertEquals("clientX", source.getCaptures().get(0));


### PR DESCRIPTION
ClickTrigger's per-instance accessors are replaced by static fields on a new MouseEventTrigger superclass; DoubleClickTrigger is added as a sibling. HandlerInput is now scoped by trigger class instead of instance, letting one Action.Input be shared across every instance of the owning class and its subclasses while still being rejected in unrelated trigger families. MouseEventTrigger.Output is left extensible (non-final, protected constructor) so subclasses can add event-specific fields when needed.

Related to #24449 