### PR TITLE
feat: JsFunction.withParameter and named captures for triggers

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/CallbackAction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/CallbackAction.java
@@ -96,11 +96,10 @@ public class CallbackAction<T> extends Action {
 
     @Override
     protected final JsFunction toJs(Trigger trigger) {
-        // $0 = the return channel; $1 = the source input's JsFunction.
-        // Invoking the source with `event` produces its value, which is
-        // forwarded straight into the channel call.
-        return JsFunction.of("$0($1(event));",
-                channelFor(trigger.getHost().getNode()), source.toJs(trigger))
+        return JsFunction.of("channel(source(event));")
+                .withParameter("channel",
+                        channelFor(trigger.getHost().getNode()))
+                .withParameter("source", source.toJs(trigger))
                 .withArguments("event");
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/DomEventTrigger.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/DomEventTrigger.java
@@ -79,12 +79,10 @@ public class DomEventTrigger extends Trigger {
 
     @Override
     protected Registration install(JsFunction action) {
-        // Action at $0 (the convention the framework documents in
-        // Trigger#install), event name at $1 — both captures of the install
-        // JsFunction, no string concatenation around either.
-        return getHost().addJsInitializer("""
-                this.addEventListener($1, $0);\
-                return () => this.removeEventListener($1, $0);""", action,
-                eventName);
+        return getHost().addJsInitializer(JsFunction.of("""
+                this.addEventListener(eventName, action);\
+                return () => this.removeEventListener(eventName, action);""")
+                .withParameter("action", action)
+                .withParameter("eventName", eventName));
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/HandlerInput.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/HandlerInput.java
@@ -49,9 +49,8 @@ final class HandlerInput<T> extends Action.Input<T> {
                     "Input is scoped to a different trigger and cannot be"
                             + " used here");
         }
-        // $0 = property name (string capture, Jackson-quoted on the client),
-        // event = the handler argument the framework passes in.
-        return JsFunction.of("return event[$0]", propertyName)
+        return JsFunction.of("return event[propertyName]")
+                .withParameter("propertyName", propertyName)
                 .withArguments("event");
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/PromiseAction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/PromiseAction.java
@@ -171,11 +171,12 @@ public abstract class PromiseAction<T> extends Action {
         }
         ReturnChannelRegistration channel = channelFor(
                 trigger.getHost().getNode());
-        // $0(observer)($1(event)(promise), $2(channel)) — invoke the inner
-        // function to get a Promise, then hand it plus the return channel to
-        // the shared observer JsFunction which subscribes to .then/.catch.
-        return JsFunction
-                .of("$0($1(event), $2)", OBSERVE_PROMISE, inner, channel)
+        // Invoke the inner function to get a Promise, then hand it plus the
+        // return channel to the shared observer JsFunction which subscribes
+        // to .then/.catch.
+        return JsFunction.of("observer(inner(event), channel)")
+                .withParameter("observer", OBSERVE_PROMISE)
+                .withParameter("inner", inner).withParameter("channel", channel)
                 .withArguments("event");
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/PropertyInput.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/PropertyInput.java
@@ -64,9 +64,8 @@ public class PropertyInput<T> extends Action.Input<T> {
 
     @Override
     protected JsFunction toJs(Trigger trigger) {
-        // Both target (Element) and propertyName (String) are JsFunction
-        // captures — JsFunction's wire encoding handles Element-to-DOM-ref
-        // mapping and JSON-quotes the property name.
-        return JsFunction.of("return $0[$1]", target, propertyName);
+        return JsFunction.of("return target[propertyName]")
+                .withParameter("target", target)
+                .withParameter("propertyName", propertyName);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/RequestFullscreenAction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/RequestFullscreenAction.java
@@ -112,8 +112,7 @@ public class RequestFullscreenAction extends PromiseAction<Void> {
 
     @Override
     protected JsFunction toPromiseJs(Trigger trigger) {
-        // $0 = target element captured by JsFunction; reified on the client
-        // as the DOM node.
-        return JsFunction.of("return $0.requestFullscreen()", target);
+        return JsFunction.of("return target.requestFullscreen()")
+                .withParameter("target", target);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/SetPropertyAction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/SetPropertyAction.java
@@ -116,10 +116,10 @@ public class SetPropertyAction<T> extends Action {
 
     @Override
     protected JsFunction toJs(Trigger trigger) {
-        // $0 = target element (captured), $1 = property name (string
-        // capture, Jackson-quoted on the client), $2 = source JsFunction
-        // (invoked with event so handler-scoped inputs work).
-        return JsFunction.of("$0[$1] = $2(event)", target, propertyName,
-                source.toJs(trigger)).withArguments("event");
+        return JsFunction.of("target[propertyName] = source(event)")
+                .withParameter("target", target)
+                .withParameter("propertyName", propertyName)
+                .withParameter("source", source.toJs(trigger))
+                .withArguments("event");
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/SignalInput.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/SignalInput.java
@@ -95,10 +95,11 @@ public class SignalInput<T> extends Action.Input<T> {
     @Override
     protected JsFunction toJs(Trigger trigger) {
         installEffectIfNeeded();
-        // $0 = the owner element (resolved to a DOM ref on the wire); $1 =
-        // the mirrored property name. Matches PropertyInput's shape — both
-        // read a property from a known element.
-        return JsFunction.of("return $0[$1]", owner.getElement(), propertyName);
+        // Same shape as PropertyInput — both read a named property from a
+        // known element.
+        return JsFunction.of("return target[propertyName]")
+                .withParameter("target", owner.getElement())
+                .withParameter("propertyName", propertyName);
     }
 
     private void installEffectIfNeeded() {

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/Trigger.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/Trigger.java
@@ -103,20 +103,25 @@ public abstract class Trigger implements Serializable {
      * to {@link #triggers(Action...)}.
      * <p>
      * Implementations typically call
-     * {@link Element#addJsInitializer(String, Object...)
-     * getHost().addJsInitializer} with an install expression that hands the
-     * action {@link JsFunction} to whatever client API the trigger wraps:
+     * {@link Element#addJsInitializer(JsFunction) getHost().addJsInitializer}
+     * with a {@link JsFunction} whose body hands the action to whatever client
+     * API the trigger wraps. Use
+     * {@link JsFunction#withParameter(String, Object)} to expose the action and
+     * any literal install values under readable names:
      *
      * <pre>{@code
-     * return getHost().addJsInitializer(
-     *         "this.addEventListener($1, $0);"
-     *                 + "return () => this.removeEventListener($1, $0);",
-     *         action, eventName);
+     * return getHost().addJsInitializer(JsFunction
+     *         .of("this.addEventListener(eventName, action);"
+     *                 + "return () => this.removeEventListener(eventName, action);")
+     *         .withParameter("action", action)
+     *         .withParameter("eventName", eventName));
      * }</pre>
      *
-     * The expression runs with {@code this} bound to the host element. The
-     * captures are made available as {@code $0}, {@code $1}, … in the order
-     * passed.
+     * The expression runs with {@code this} bound to the host element. Named
+     * captures from {@link JsFunction#withParameter(String, Object)} are
+     * exposed under the given names; positional captures from
+     * {@link JsFunction#of(String, Object...)} are exposed as {@code $0},
+     * {@code $1}, ….
      *
      * @param action
      *            the rendered action {@link JsFunction}; takes one runtime

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/WriteToClipboardAction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/WriteToClipboardAction.java
@@ -124,7 +124,8 @@ public class WriteToClipboardAction extends PromiseAction<String> {
         JsFunction html = htmlInput != null ? htmlInput.toJs(trigger)
                 : NULL_INPUT_FN;
         return JsFunction.of(
-                "return window.Vaadin.Flow.clipboard.writePayload($0(event), $1(event))",
-                text, html).withArguments("event");
+                "return window.Vaadin.Flow.clipboard.writePayload(text(event), html(event))")
+                .withParameter("text", text).withParameter("html", html)
+                .withArguments("event");
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -1877,6 +1877,11 @@ public class Element extends Node<Element> {
      * function, {@code null}, or {@code undefined} (the latter being the
      * implicit value when there is no {@code return}). Returning any other
      * value, including a promise, is logged as an error on the client.
+     * <p>
+     * To pass values by name instead of <code>$0</code>, <code>$1</code>, ...,
+     * build a {@link JsFunction} with
+     * {@link JsFunction#withParameter(String, Object)} and use
+     * {@link #addJsInitializer(JsFunction)}.
      *
      * @param expression
      *            the JavaScript expression to invoke, not <code>null</code>
@@ -1888,8 +1893,37 @@ public class Element extends Node<Element> {
     public Registration addJsInitializer(String expression,
             Object... parameters) {
         Objects.requireNonNull(expression, "Expression cannot be null");
-        return new ElementJsInitializerRegistration(getNode(), expression,
-                parameters == null ? new Object[0] : parameters);
+        return addJsInitializer(JsFunction.of(expression,
+                parameters == null ? new Object[0] : parameters));
+    }
+
+    /**
+     * Registers a JavaScript initializer that runs in the browser each time a
+     * client-side DOM node is created for this element, and whose returned
+     * cleanup callback is invoked when that DOM node is discarded or the
+     * returned registration is removed.
+     * <p>
+     * Behaves like {@link #addJsInitializer(String, Object...)}, but accepts a
+     * pre-built {@link JsFunction}. This lets the caller compose the
+     * initializer with named parameters, e.g.
+     *
+     * <pre>
+     * element.addJsInitializer(JsFunction.of("setup(target)")
+     *         .withParameter("target", someElement));
+     * </pre>
+     *
+     * The function's body is executed with this element as <code>this</code>;
+     * any positional captures and named parameters are exposed to the body the
+     * same way as for {@link #executeJs(String, Object...)}.
+     *
+     * @param function
+     *            the initializer function, not <code>null</code>
+     * @return a registration that, when removed, invokes the cleanup callback
+     *         on the client
+     */
+    public Registration addJsInitializer(JsFunction function) {
+        Objects.requireNonNull(function, "Function cannot be null");
+        return new ElementJsInitializerRegistration(getNode(), function);
     }
 
     private PendingJavaScriptResult scheduleJavaScriptInvocation(

--- a/flow-server/src/main/java/com/vaadin/flow/dom/JsFunction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/JsFunction.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.dom;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -58,12 +59,14 @@ public final class JsFunction implements Serializable {
     private final String body;
     private final List<@Nullable Object> captures;
     private final List<String> argumentNames;
+    private final List<String> parameterNames;
 
     private JsFunction(String body, List<@Nullable Object> captures,
-            List<String> argumentNames) {
+            List<String> argumentNames, List<String> parameterNames) {
         this.body = body;
         this.captures = captures;
         this.argumentNames = argumentNames;
+        this.parameterNames = parameterNames;
     }
 
     /**
@@ -94,7 +97,7 @@ public final class JsFunction implements Serializable {
         }
         return new JsFunction(body,
                 Collections.unmodifiableList(Arrays.asList(copy)),
-                Collections.emptyList());
+                Collections.emptyList(), Collections.emptyList());
     }
 
     /**
@@ -122,7 +125,64 @@ public final class JsFunction implements Serializable {
             throw new IllegalStateException(
                     "withArguments has already been called on this JsFunction");
         }
-        return new JsFunction(body, captures, List.of(argumentNames));
+        return new JsFunction(body, captures, List.of(argumentNames),
+                parameterNames);
+    }
+
+    /**
+     * Returns a copy of this function with an additional named capture. The
+     * function body can reference the value as {@code parameterName}; the
+     * implementation prepends {@code let <parameterName>=$<index>;} to the body
+     * and appends the value to the captures list (so positional {@code $N}
+     * access continues to work for captures added via
+     * {@link #of(String, Object...)}).
+     * <p>
+     * Each call adds one parameter; calls may be chained. Parameter names must
+     * be unique within a function and must not collide with names declared by
+     * {@link #withArguments(String...)}.
+     * <p>
+     * Example:
+     *
+     * <pre>
+     * element.addJsInitializer(JsFunction.of("setup(target)")
+     *         .withParameter("target", someElement));
+     * </pre>
+     *
+     * @param parameterName
+     *            the JavaScript identifier under which the value is exposed to
+     *            the body, not {@code null}; must not duplicate an existing
+     *            parameter or argument name
+     * @param value
+     *            the value to capture; must be a type supported as a parameter
+     *            to {@link Element#executeJs(String, Object...)}
+     * @return a new {@code JsFunction} with the additional parameter
+     * @throws IllegalArgumentException
+     *             if the name conflicts with an existing parameter or argument,
+     *             or if the value has a type that cannot be sent to the client
+     */
+    public JsFunction withParameter(String parameterName,
+            @Nullable Object value) {
+        Objects.requireNonNull(parameterName, "parameterName");
+        if (parameterNames.contains(parameterName)) {
+            throw new IllegalArgumentException("Parameter '" + parameterName
+                    + "' is already declared on this JsFunction");
+        }
+        if (argumentNames.contains(parameterName)) {
+            throw new IllegalArgumentException("Parameter '" + parameterName
+                    + "' conflicts with a runtime argument of the same name");
+        }
+        // Dry-run encode so unsupported types fail fast, same as of().
+        JacksonCodec.encodeWithTypeInfo(value);
+
+        List<@Nullable Object> newCaptures = new ArrayList<>(captures);
+        newCaptures.add(value);
+        String newBody = "let " + parameterName + "=$" + captures.size() + ";"
+                + body;
+        List<String> newParameterNames = new ArrayList<>(parameterNames);
+        newParameterNames.add(parameterName);
+        return new JsFunction(newBody,
+                Collections.unmodifiableList(newCaptures), argumentNames,
+                Collections.unmodifiableList(newParameterNames));
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/ElementJsInitializerRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/ElementJsInitializerRegistration.java
@@ -81,18 +81,14 @@ public final class ElementJsInitializerRegistration implements Registration {
      *
      * @param node
      *            the owning state node, not {@code null}
-     * @param expression
-     *            the user-supplied expression, not {@code null}
-     * @param parameters
-     *            the user-supplied parameters, captured by the JsFunction
+     * @param userFunction
+     *            the user-supplied initializer function, not {@code null}
      */
-    public ElementJsInitializerRegistration(StateNode node, String expression,
-            Object[] parameters) {
+    public ElementJsInitializerRegistration(StateNode node,
+            JsFunction userFunction) {
         this.node = Objects.requireNonNull(node, "node");
-        Objects.requireNonNull(expression, "expression");
-        // JsFunction.of validates each capture, so unsupported parameter
-        // types fail fast here rather than at execution time.
-        this.userFunction = JsFunction.of(expression, parameters);
+        this.userFunction = Objects.requireNonNull(userFunction,
+                "userFunction");
 
         attachListenerRegistration = node.addAttachListener(this::onAttach);
         if (node.isAttached()) {

--- a/flow-server/src/test/java/com/vaadin/flow/component/clipboard/ClipboardTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/clipboard/ClipboardTest.java
@@ -90,10 +90,12 @@ class ClipboardTest {
 
         Clipboard.onClick(button).writeText(field);
 
-        // PropertyInput renders as `return $0[$1]` and captures (element,
-        // "value").
+        // PropertyInput renders as `return target[propertyName]` and
+        // captures (element, "value").
         JsFunction textInput = (JsFunction) actionFn(ui).getCaptures().get(0);
-        assertEquals("return $0[$1]", textInput.getBody());
+        assertEquals(
+                "let propertyName=$1;let target=$0;return target[propertyName]",
+                textInput.getBody());
         assertSame(field.getElement(), textInput.getCaptures().get(0));
         assertEquals("value", textInput.getCaptures().get(1));
     }
@@ -137,7 +139,9 @@ class ClipboardTest {
         Clipboard.onClick(button).write(ClipboardContent.create().text(field));
 
         JsFunction textInput = (JsFunction) actionFn(ui).getCaptures().get(0);
-        assertEquals("return $0[$1]", textInput.getBody());
+        assertEquals(
+                "let propertyName=$1;let target=$0;return target[propertyName]",
+                textInput.getBody());
         assertEquals("value", textInput.getCaptures().get(1));
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/CallbackActionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/CallbackActionTest.java
@@ -69,16 +69,17 @@ class CallbackActionTest {
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
 
         JsFunction action = actionOf(singleInstallFn(ui));
-        // $0 = the return channel; $1 = the source input's JsFunction. The
-        // body forwards the source-fn's value straight into the channel call.
-        assertEquals("$0($1(event));", action.getBody());
+        // Body forwards the source-fn's value straight into the channel call;
+        // both are exposed by name via withParameter.
+        assertEquals("let source=$1;let channel=$0;channel(source(event));",
+                action.getBody());
         assertEquals(2, action.getCaptures().size());
         assertTrue(
                 action.getCaptures()
                         .get(0) instanceof ReturnChannelRegistration,
-                "Expected $0 to be the return channel");
+                "Expected the return channel as the first capture");
         assertTrue(action.getCaptures().get(1) instanceof JsFunction,
-                "Expected $1 to be the source input JsFunction");
+                "Expected the source input JsFunction as the second capture");
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/ClickTriggerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/ClickTriggerTest.java
@@ -53,12 +53,14 @@ class ClickTriggerTest {
         JsFunction source0 = (JsFunction) actionOf(installs.get(0))
                 .getCaptures().get(2);
         assertEquals(List.of("event"), source0.getArgumentNames());
-        assertEquals("return event[$0]", source0.getBody());
+        assertEquals("let propertyName=$0;return event[propertyName]",
+                source0.getBody());
         assertEquals("screenX", source0.getCaptures().get(0));
 
         JsFunction source1 = (JsFunction) actionOf(installs.get(1))
                 .getCaptures().get(2);
-        assertEquals("return event[$0]", source1.getBody());
+        assertEquals("let propertyName=$0;return event[propertyName]",
+                source1.getBody());
         assertEquals("screenY", source1.getCaptures().get(0));
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/DomEventTriggerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/DomEventTriggerTest.java
@@ -42,23 +42,29 @@ class DomEventTriggerTest {
 
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
 
-        // Install JS references action at $0 and event name at $1 — no user
-        // content leaks into the body, both are captures.
+        // Install JS exposes the action and event name as named parameters;
+        // captures still carry the values, no user content leaks into the
+        // body.
         JsFunction install = singleInstallFn(ui);
-        assertEquals(
-                "this.addEventListener($1, $0);"
-                        + "return () => this.removeEventListener($1, $0);",
+        assertEquals("let eventName=$1;let action=$0;"
+                + "this.addEventListener(eventName, action);"
+                + "return () => this.removeEventListener(eventName, action);",
                 install.getBody());
         assertEquals("click", install.getCaptures().get(1));
 
-        // The install $0 is the action's JsFunction directly — no intermediate
-        // composed handler layer. The action is also the DOM event listener.
+        // The first install capture is the action's JsFunction directly — no
+        // intermediate composed handler layer. The action is also the DOM
+        // event listener.
         JsFunction action = actionOf(install);
         assertEquals(List.of("event"), action.getArgumentNames());
 
-        // SetPropertyAction body shape; target captured as $0, property name
-        // string capture at $1, source JsFunction invoked as $2(event).
-        assertEquals("$0[$1] = $2(event)", action.getBody());
+        // SetPropertyAction body shape; target, property name, and source
+        // input are all exposed by name via withParameter — captures stay
+        // (target, propertyName, source).
+        assertEquals(
+                "let source=$2;let propertyName=$1;let target=$0;"
+                        + "target[propertyName] = source(event)",
+                action.getBody());
         assertSame(field.getElement(), action.getCaptures().get(0));
         assertEquals("value", action.getCaptures().get(1));
     }

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/PromiseActionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/PromiseActionTest.java
@@ -74,11 +74,12 @@ class PromiseActionTest {
 
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
 
-        // Action body: observer(inner(event), channel) — $0 is OBSERVE_PROMISE,
-        // $1 is the inner JsFunction returning the promise, $2 is the return
-        // channel.
+        // Action body: observer(inner(event), channel) — all three are
+        // exposed by name; captures still carry observer, inner and the
+        // return channel in declaration order.
         JsFunction action = actionOf(singleInstallFn(ui));
-        assertEquals("$0($1(event), $2)", action.getBody());
+        assertEquals("let channel=$2;let inner=$1;let observer=$0;"
+                + "observer(inner(event), channel)", action.getBody());
 
         List<@Nullable Object> captures = action.getCaptures();
         assertEquals(3, captures.size(),

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/ReadFromClipboardActionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/ReadFromClipboardActionTest.java
@@ -53,7 +53,8 @@ class ReadFromClipboardActionTest {
         // Action wraps the inner promise function with OBSERVE_PROMISE +
         // return channel. The inner just invokes the Clipboard.ts helper.
         JsFunction action = actionOf(singleInstallFn(ui));
-        assertEquals("$0($1(event), $2)", action.getBody());
+        assertEquals("let channel=$2;let inner=$1;let observer=$0;"
+                + "observer(inner(event), channel)", action.getBody());
 
         JsFunction inner = (JsFunction) action.getCaptures().get(1);
         assertEquals("return window.Vaadin.Flow.clipboard.readPayload()",

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/RequestFullscreenActionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/RequestFullscreenActionTest.java
@@ -42,9 +42,10 @@ class RequestFullscreenActionTest {
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
 
         // Fire-and-forget collapses to the inner promise function directly.
-        // $0 is the target element captured by JsFunction.
+        // The target element is exposed by name and is the only capture.
         JsFunction action = actionOf(singleInstallFn(ui));
-        assertEquals("return $0.requestFullscreen()", action.getBody());
+        assertEquals("let target=$0;return target.requestFullscreen()",
+                action.getBody());
         assertSame(panel.getElement(), action.getCaptures().get(0));
     }
 
@@ -63,12 +64,15 @@ class RequestFullscreenActionTest {
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
 
         // With callbacks, PromiseAction wraps the inner function with
-        // OBSERVE_PROMISE; the inner still captures the target as $0.
+        // OBSERVE_PROMISE and routes through a return channel; all three are
+        // exposed by name.
         JsFunction action = actionOf(singleInstallFn(ui));
-        assertEquals("$0($1(event), $2)", action.getBody());
+        assertEquals("let channel=$2;let inner=$1;let observer=$0;"
+                + "observer(inner(event), channel)", action.getBody());
 
         JsFunction inner = (JsFunction) action.getCaptures().get(1);
-        assertEquals("return $0.requestFullscreen()", inner.getBody());
+        assertEquals("let target=$0;return target.requestFullscreen()",
+                inner.getBody());
         assertSame(panel.getElement(), inner.getCaptures().get(0));
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/SignalInputTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/SignalInputTest.java
@@ -90,12 +90,15 @@ class SignalInputTest {
 
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
 
-        // SignalInput renders as `return $0[$1]` with the property name as
-        // capture $1. Reach into the action's captures to find the text
-        // input's JsFunction, then verify the generated property-name shape.
+        // SignalInput renders as `return target[propertyName]` with the
+        // property name as the second capture. Reach into the action's
+        // captures to find the text input's JsFunction, then verify the
+        // generated property-name shape.
         JsFunction action = actionOf(singleInstallFn(ui));
         JsFunction textInput = (JsFunction) action.getCaptures().get(0);
-        assertEquals("return $0[$1]", textInput.getBody());
+        assertEquals(
+                "let propertyName=$1;let target=$0;return target[propertyName]",
+                textInput.getBody());
         String property = (String) textInput.getCaptures().get(1);
         assertTrue(PROPERTY_NAME.matcher(property).matches(),
                 "Unexpected property name: " + property);
@@ -141,7 +144,8 @@ class SignalInputTest {
                 new ValueSignal<>("b"));
 
         // Property name is the second capture of the rendered JsFunction
-        // (`return $0[$1]`, where $1 is the propertyName literal).
+        // (`return target[propertyName]`, with propertyName as a named
+        // capture at index 1).
         JsFunction fnA = a.toJs(new DomEventTrigger(owner, "click"));
         JsFunction fnB = b.toJs(new DomEventTrigger(owner, "click"));
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/WriteToClipboardActionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/WriteToClipboardActionTest.java
@@ -52,13 +52,16 @@ class WriteToClipboardActionTest {
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
 
         JsFunction action = actionOf(singleInstallFn(ui));
-        assertEquals(
-                "return window.Vaadin.Flow.clipboard.writePayload($0(event), $1(event))",
+        assertEquals("let html=$1;let text=$0;"
+                + "return window.Vaadin.Flow.clipboard.writePayload(text(event), html(event))",
                 action.getBody());
 
-        // $0 is the text input — a PropertyInput that reads from the field.
+        // First capture is the text input — a PropertyInput that reads from
+        // the field.
         JsFunction text = (JsFunction) action.getCaptures().get(0);
-        assertEquals("return $0[$1]", text.getBody());
+        assertEquals(
+                "let propertyName=$1;let target=$0;return target[propertyName]",
+                text.getBody());
 
         // $1 is the html slot — the no-op "return null" stand-in.
         JsFunction html = (JsFunction) action.getCaptures().get(1);
@@ -79,8 +82,8 @@ class WriteToClipboardActionTest {
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
 
         JsFunction action = actionOf(singleInstallFn(ui));
-        assertEquals(
-                "return window.Vaadin.Flow.clipboard.writePayload($0(event), $1(event))",
+        assertEquals("let html=$1;let text=$0;"
+                + "return window.Vaadin.Flow.clipboard.writePayload(text(event), html(event))",
                 action.getBody());
 
         JsFunction text = (JsFunction) action.getCaptures().get(0);
@@ -103,8 +106,8 @@ class WriteToClipboardActionTest {
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
 
         JsFunction action = actionOf(singleInstallFn(ui));
-        assertEquals(
-                "return window.Vaadin.Flow.clipboard.writePayload($0(event), $1(event))",
+        assertEquals("let html=$1;let text=$0;"
+                + "return window.Vaadin.Flow.clipboard.writePayload(text(event), html(event))",
                 action.getBody());
 
         // $0 is the text slot — the no-op stand-in.
@@ -137,11 +140,12 @@ class WriteToClipboardActionTest {
         // calls writePayload — the action class itself does no string
         // assembly beyond the static body constant.
         JsFunction action = actionOf(singleInstallFn(ui));
-        assertEquals("$0($1(event), $2)", action.getBody());
+        assertEquals("let channel=$2;let inner=$1;let observer=$0;"
+                + "observer(inner(event), channel)", action.getBody());
 
         JsFunction inner = (JsFunction) action.getCaptures().get(1);
-        assertEquals(
-                "return window.Vaadin.Flow.clipboard.writePayload($0(event), $1(event))",
+        assertEquals("let html=$1;let text=$0;"
+                + "return window.Vaadin.Flow.clipboard.writePayload(text(event), html(event))",
                 inner.getBody());
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
@@ -2477,6 +2477,27 @@ class ElementTest extends AbstractNodeTest {
     }
 
     @Test
+    void addJsInitializer_jsFunctionWithNamedParameter_capturesValue() {
+        UI ui = new MockUI();
+        Element element = ElementFactory.createDiv();
+        element.addJsInitializer(JsFunction.of("return () => target.focus();")
+                .withParameter("target", element));
+        ui.getElement().appendChild(element);
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        List<PendingJavaScriptInvocation> pending = ui.getInternals()
+                .dumpPendingJavaScriptInvocations();
+        assertEquals(1, pending.size());
+
+        JsFunction userFn = (JsFunction) pending.get(0).getInvocation()
+                .getParameters().get(2);
+        assertEquals("let target=$0;return () => target.focus();",
+                userFn.getBody());
+        assertEquals(List.of(element), userFn.getCaptures());
+    }
+
+    @Test
     void addJsInitializer_sameRoundTripDetachReattach_doesNotRerun() {
         UI ui = new MockUI();
         Element element = ElementFactory.createDiv();

--- a/flow-server/src/test/java/com/vaadin/flow/dom/JsFunctionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/JsFunctionTest.java
@@ -15,8 +15,11 @@
  */
 package com.vaadin.flow.dom;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class JsFunctionTest {
@@ -25,5 +28,42 @@ class JsFunctionTest {
     void withArguments_alreadySet_throws() {
         JsFunction fn = JsFunction.of("return a;").withArguments("a");
         assertThrows(IllegalStateException.class, () -> fn.withArguments("b"));
+    }
+
+    @Test
+    void withParameter_prependsLetAndAppendsCapture() {
+        JsFunction fn = JsFunction.of("return target.id;")
+                .withParameter("target", "value");
+        assertEquals("let target=$0;return target.id;", fn.getBody());
+        assertEquals(List.of("value"), fn.getCaptures());
+    }
+
+    @Test
+    void withParameter_chained_indexesIncrement() {
+        JsFunction fn = JsFunction.of("a + b").withParameter("a", 1)
+                .withParameter("b", 2);
+        assertEquals("let b=$1;let a=$0;a + b", fn.getBody());
+        assertEquals(List.of(1, 2), fn.getCaptures());
+    }
+
+    @Test
+    void withParameter_afterOfCaptures_indexesContinue() {
+        JsFunction fn = JsFunction.of("$0 + b", "x").withParameter("b", 1);
+        assertEquals("let b=$1;$0 + b", fn.getBody());
+        assertEquals(List.of("x", 1), fn.getCaptures());
+    }
+
+    @Test
+    void withParameter_duplicateName_throws() {
+        JsFunction fn = JsFunction.of("x").withParameter("x", 1);
+        assertThrows(IllegalArgumentException.class,
+                () -> fn.withParameter("x", 2));
+    }
+
+    @Test
+    void withParameter_collidesWithArgumentName_throws() {
+        JsFunction fn = JsFunction.of("x").withArguments("x");
+        assertThrows(IllegalArgumentException.class,
+                () -> fn.withParameter("x", 1));
     }
 }


### PR DESCRIPTION
Adds a JsFunction.withParameter(name, value) primitive that prepends `let <name>=$<N>;` and appends the value as a capture, so a function body can reference values by name instead of by positional `$N`:

    element.addJsInitializer(JsFunction.of("setup(target)")
            .withParameter("target", someElement));

The new addJsInitializer(JsFunction) overload accepts pre-built JsFunctions; the existing addJsInitializer(String, Object...) form delegates to it, and ElementJsInitializerRegistration now takes the JsFunction directly instead of rebuilding it from a string/array.

Sweeps the trigger/action/input toJs and toPromiseJs bodies to use the new named form so each rendered fragment reads as its own JS:

  DomEventTrigger        addEventListener(eventName, action) / removeEventListener(...)
  CallbackAction         channel(source(event))
  PromiseAction          observer(inner(event), channel)
  HandlerInput           return event[propertyName]
  PropertyInput          return target[propertyName]
  SetPropertyAction      target[propertyName] = source(event)
  SignalInput            return target[propertyName]
  RequestFullscreenAction return target.requestFullscreen()
  WriteToClipboardAction writePayload(text(event), html(event))

The companion "// \$N = ..." comments are gone — the names in the body now match the captures. Trigger.install's Javadoc example uses the same form so subclasses are pointed at the named API.

Duplicate parameter names, and names that collide with a previously declared withArguments name, are rejected.
