### PR TITLE
fix: expose upcoming navigation target via routerStateSignal during chain construction

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/RouterState.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouterState.java
@@ -32,9 +32,20 @@ import com.vaadin.flow.component.HasElement;
  * attach.
  * <p>
  * The snapshot covers the same data already available through
- * {@link AfterNavigationEvent} plus the navigation target class. It is produced
- * at the same point that {@code AfterNavigationEvent} is dispatched, so the
- * signal value and the listener notification are always consistent.
+ * {@link AfterNavigationEvent} plus the navigation target class. Each
+ * navigation produces two consecutive updates to the signal:
+ * <ol>
+ * <li>An early update emitted before the new chain is instantiated, exposing
+ * the upcoming {@link #location()}, {@link #routeParameters()} and
+ * {@link #navigationTarget()} while {@link #activeChain()} is still empty. This
+ * lets code running in layout/view constructors read the target of the
+ * navigation that is in progress.</li>
+ * <li>A final update emitted at the same point that
+ * {@code AfterNavigationEvent} is dispatched, after the new chain has been
+ * attached to the UI. At this point {@link #activeChain()} is populated, and
+ * the signal value is consistent with what {@link AfterNavigationListener}s
+ * observe.</li>
+ * </ol>
  *
  * @param location
  *            the location of the current view (path, query parameters,
@@ -46,10 +57,12 @@ import com.vaadin.flow.component.HasElement;
  * @param activeChain
  *            unmodifiable list of the currently active route target and its
  *            parent layouts, leaf first. Never {@code null}; empty before the
- *            first navigation completes.
+ *            first navigation completes and while a navigation is in progress
+ *            (between the early and final signal updates).
  * @param navigationTarget
- *            the class of the leaf route target. {@code null} before the first
- *            navigation completes.
+ *            the class of the leaf route target. {@code null} only before the
+ *            first navigation has started; once a navigation begins, the target
+ *            is set immediately so it is visible to layout/view constructors.
  */
 public record RouterState(Location location, RouteParameters routeParameters,
         List<HasElement> activeChain,

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -224,6 +224,16 @@ public abstract class AbstractNavigationStateRenderer
         // See https://github.com/vaadin/flow/issues/3619 for more info.
         pushHistoryStateIfNeeded(event, ui);
 
+        // Expose the upcoming navigation target via routerStateSignal before
+        // the chain is instantiated, so that code running in layout/view
+        // constructors (e.g. a Signal.map() bound via bindText) sees the new
+        // target instead of the previous one. The activeChain is left empty
+        // here because the new chain has not been built yet; it is filled in
+        // by handleAfterNavigationEvents once navigation completes.
+        // See https://github.com/vaadin/flow/issues/24471.
+        ui.getInternals().updateRouterState(new RouterState(event.getLocation(),
+                parameters, Collections.emptyList(), routeTargetType));
+
         result = handleBeforeNavigationEvents(event, routeTargetType,
                 parameters, chain);
         if (result.isPresent()) {

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
@@ -74,6 +74,7 @@ import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.flow.router.RouteParameters;
 import com.vaadin.flow.router.Router;
 import com.vaadin.flow.router.RouterLayout;
+import com.vaadin.flow.router.RouterState;
 import com.vaadin.flow.router.TestRouteRegistry;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.MockInstantiator;
@@ -387,6 +388,31 @@ class NavigationStateRendererTest {
         @Override
         public void beforeEnter(BeforeEnterEvent event) {
             beforeEnterCount.getAndIncrement();
+        }
+    }
+
+    // Captures RouterState snapshots seen by the layout/view constructors.
+    // Used to verify that UI#routerStateSignal() exposes the upcoming
+    // navigation target while route components are still being instantiated
+    // (see #24471).
+    private static final List<RouterState> capturedSignalDuringConstruction = Collections
+            .synchronizedList(new ArrayList<>());
+
+    @Tag("div")
+    private static class SignalCapturingLayout extends Component
+            implements RouterLayout {
+        SignalCapturingLayout() {
+            capturedSignalDuringConstruction
+                    .add(UI.getCurrent().routerStateSignal().peek());
+        }
+    }
+
+    @Route(value = "signal-capturing", layout = SignalCapturingLayout.class)
+    @Tag("div")
+    private static class SignalCapturingView extends Component {
+        SignalCapturingView() {
+            capturedSignalDuringConstruction
+                    .add(UI.getCurrent().routerStateSignal().peek());
         }
     }
 
@@ -1320,6 +1346,56 @@ class NavigationStateRendererTest {
                     (Class<? extends Component>) event.getNavigationTarget(),
                     new RouteParameters("id", id));
         }
+    }
+
+    @Test
+    void handle_routerStateSignal_reflectsUpcomingTargetDuringConstruction() {
+        // Fixes #24471: while the layout chain is being instantiated, the
+        // routerStateSignal value must already reflect the upcoming
+        // navigation (target/location/parameters). Otherwise code in a
+        // layout/view constructor that reads navigationTarget() — e.g.
+        // a Signal.map() inside bindText — sees the stale initial state
+        // and NPEs on the null navigationTarget.
+        capturedSignalDuringConstruction.clear();
+
+        MockVaadinServletService service = createMockServiceWithInstantiator();
+        MockVaadinSession session = new AlwaysLockedVaadinSession(service);
+        MockUI ui = new MockUI(session);
+
+        // Register the route + layout so the renderer can resolve the
+        // SignalCapturingLayout chain via getRouterLayoutTypes.
+        RouteConfiguration.forRegistry(router.getRegistry())
+                .setAnnotatedRoute(SignalCapturingView.class);
+
+        NavigationStateRenderer renderer = new NavigationStateRenderer(
+                navigationStateFromTarget(SignalCapturingView.class));
+
+        renderer.handle(
+                new NavigationEvent(router, new Location("signal-capturing"),
+                        ui, NavigationTrigger.UI_NAVIGATE));
+
+        assertEquals(2, capturedSignalDuringConstruction.size(),
+                "Both the layout and the view constructors should have run");
+
+        RouterState layoutSnapshot = capturedSignalDuringConstruction.get(0);
+        RouterState viewSnapshot = capturedSignalDuringConstruction.get(1);
+
+        assertEquals(SignalCapturingView.class,
+                layoutSnapshot.navigationTarget(),
+                "Layout constructor should see the upcoming navigation target");
+        assertEquals("signal-capturing", layoutSnapshot.location().getPath(),
+                "Layout constructor should see the upcoming location");
+        assertEquals(SignalCapturingView.class, viewSnapshot.navigationTarget(),
+                "View constructor should see the upcoming navigation target");
+        assertEquals("signal-capturing", viewSnapshot.location().getPath(),
+                "View constructor should see the upcoming location");
+
+        RouterState afterNav = ui.routerStateSignal().peek();
+        assertEquals(SignalCapturingView.class, afterNav.navigationTarget(),
+                "After navigation the signal should still hold the new target");
+        assertEquals("signal-capturing", afterNav.location().getPath());
+        assertFalse(afterNav.activeChain().isEmpty(),
+                "After navigation the active chain should be populated");
     }
 
     @Test


### PR DESCRIPTION
Updates routerStateSignal in AbstractNavigationStateRenderer.handle() before the new layout/view chain is instantiated, so code running in constructors (e.g. a Signal.map() bound via bindText) sees the upcoming location, route parameters and navigationTarget instead of the previous state. Previously the signal was only refreshed in handleAfterNavigationEvents, after construction, causing reactive mappings on navigationTarget() to NPE during the ElementEffect probe.

Fixes #24471
