### PR TITLE
refactor: replace ShortcutRegistration's private visibility walk with ComponentUtil.isEffectivelyVisible

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -656,22 +656,12 @@ public class ShortcutRegistration implements Registration, Serializable {
         if (lifecycleOwner == null) {
             return;
         }
-        if (ancestorsOrSelfAreVisible(lifecycleOwner) && (lifecycleOwner
-                .getElement().isEnabled()
-                || DisabledUpdateMode.ALWAYS.equals(getDisabledUpdateMode()))) {
+        if (ComponentUtil.isEffectivelyVisible(lifecycleOwner)
+                && (lifecycleOwner.getElement().isEnabled()
+                        || DisabledUpdateMode.ALWAYS
+                                .equals(getDisabledUpdateMode()))) {
             invokeShortcutEventListener(component);
         }
-    }
-
-    private boolean ancestorsOrSelfAreVisible(Component component) {
-        if (!component.isVisible()) {
-            return false;
-        }
-        Optional<Component> parent = component.getParent();
-        if (parent.isPresent()) {
-            return ancestorsOrSelfAreVisible(parent.get());
-        }
-        return true;
     }
 
     private void configureHandlerListenerRegistration(int listenOnIndex) {

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
@@ -592,10 +592,11 @@ class ShortcutRegistrationTest {
         new ShortcutRegistration(lifecycleOwner, () -> listenOn, event::set,
                 Key.KEY_A);
 
-        mockLifecycle(true);
+        Element ownerElement = mockLifecycle(true);
 
         FakeComponent component = new FakeComponent();
         component.setVisible(false);
+        component.getElement().appendChild(ownerElement);
         Mockito.when(lifecycleOwner.getParent())
                 .thenReturn(Optional.of(component));
 
@@ -761,6 +762,7 @@ class ShortcutRegistrationTest {
     private Element mockLifecycle(boolean visible) {
         Mockito.when(lifecycleOwner.isVisible()).thenReturn(visible);
         Element element = ElementFactory.createAnchor();
+        element.setVisible(visible);
         Mockito.when(lifecycleOwner.getElement()).thenReturn(element);
         return element;
     }


### PR DESCRIPTION
ShortcutRegistration.ancestorsOrSelfAreVisible was a hand-rolled walk of `Component.getParent()` checking each `Component.isVisible()`. Now that ComponentUtil exposes a public helper that delegates to StateNode.isVisible() — the framework's own definition of "effectively visible" — drop the duplicate.

The state-node tree is arguably the more correct walk for visibility since visibility lives on ElementData and the framework uses StateNode.isVisible() everywhere internally (UIInternals pending-JS filtering, StreamRequestHandler, change emission). Behaviour matches in typical layouts and is more accurate at composite / virtual-children / shadow-DOM boundaries where the component-tree walk approximates.
