### PR TITLE
refactor(dnd): use ancestor-aware visibility in DragSource.setDragImage

### DIFF
--- a/flow-dnd/src/main/java/com/vaadin/flow/component/dnd/DragSource.java
+++ b/flow-dnd/src/main/java/com/vaadin/flow/component/dnd/DragSource.java
@@ -356,7 +356,8 @@ public interface DragSource<T extends Component> extends HasElement {
      *            the y-offset of the drag image
      */
     default void setDragImage(Component dragImage, int offsetX, int offsetY) {
-        if (dragImage != null && !dragImage.isVisible()) {
+        if (dragImage != null
+                && !ComponentUtil.isEffectivelyVisible(dragImage)) {
             throw new IllegalStateException(
                     "Drag image element is not visible and will not show.\nMake element visible to use as drag image!");
         }


### PR DESCRIPTION
DragSource.setDragImage(component, ...) throws IllegalStateException if the drag image is not visible. The previous check only looked at the component's own visibility flag, so a drag image whose own flag is true but whose parent layout is hidden passed the guard — and then the drag failed at runtime because the image was not in the DOM.

Switch to ComponentUtil.isEffectivelyVisible so the exception fires for the real failure case too. Behaviour change at the edge: callers that relied on the old looser definition will now get the exception they were probably hoping for.
