### PR TITLE
refactor(data): use ancestor-aware visibility in Binder default isApplied

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -44,6 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasText;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.HasValue.ValueChangeEvent;
@@ -352,13 +353,15 @@ public class Binder<BEAN> implements Serializable {
         /**
          * Gets predicate for testing {@link #isApplied()}. By default,
          * non-visible components are ignored during validation and bean
-         * writing.
+         * writing. A component is considered non-visible if it or any of its
+         * ancestors has been hidden via {@code setVisible(false)} — see
+         * {@link ComponentUtil#isEffectivelyVisible(Component)}.
          *
          * @return predicate for testing {@link #isApplied()}
          */
         default SerializablePredicate<Binding<BEAN, TARGET>> getIsAppliedPredicate() {
             return binding -> !(binding.getField() instanceof Component c)
-                    || c.isVisible();
+                    || ComponentUtil.isEffectivelyVisible(c);
         }
 
         /**
@@ -4347,10 +4350,12 @@ public class Binder<BEAN> implements Serializable {
     /**
      * Sets whether all bindings of this Binder should be applied to fields that
      * are not currently visible. By default, bindings whose field is a
-     * {@link Component} with {@link Component#isVisible()} returning
-     * {@literal false} are skipped during validation and when writing values to
-     * the bean. Enabling this setting restores the pre-Vaadin 25 behavior where
-     * hidden fields are validated and written just like visible ones.
+     * {@link Component} that is not effectively visible (the component itself
+     * or any of its ancestors has been hidden via {@code setVisible(false)} —
+     * see {@link ComponentUtil#isEffectivelyVisible(Component)}) are skipped
+     * during validation and when writing values to the bean. Enabling this
+     * setting restores the pre-Vaadin 25 behavior where hidden fields are
+     * validated and written just like visible ones.
      * <p>
      * This is a Binder-level fallback: any binding that has its own predicate
      * set via {@link Binding#setIsAppliedPredicate(SerializablePredicate)}


### PR DESCRIPTION
Binder's default isAppliedPredicate skips bindings whose field is a non-visible Component during validation and bean writing. The previous check only considered the field's own visibility flag, so a field whose own flag is true but whose parent layout is hidden was still validated — even though the user could neither see the field nor correct any error reported on it.

Switch to ComponentUtil.isEffectivelyVisible and update the javadoc on both the default predicate and the related
setApplyBindingsToHiddenFields setter to spell out the new definition. Behaviour change at the edge: fields with ancestor-hidden state are now skipped just like fields with their own flag cleared.
