### PR TITLE
refactor(dom): use ancestor-aware visibility in DomEvent spoof check

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/dom/DomEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/DomEvent.java
@@ -121,7 +121,11 @@ public class DomEvent extends EventObject {
         }
         final Element mappedElementOrNull = matchingNode.get();
         // prevent spoofing invisible elements by sending bad state node ids
-        if (mappedElementOrNull != null && !mappedElementOrNull.isVisible()) {
+        // — use the state-node check that also walks ancestors so an
+        // element whose own flag is true but whose ancestor was hidden is
+        // also rejected.
+        if (mappedElementOrNull != null
+                && !mappedElementOrNull.getNode().isVisible()) {
             return null;
         }
         return mappedElementOrNull;


### PR DESCRIPTION
DomEvent.fetchElement() rejected events referring to elements whose own visibility flag was false, to prevent clients from spoofing events on hidden elements. The own-flag check misses the case where the element's flag is true but an ancestor was hidden via setVisible(false) — from the client's perspective the element isn't in the DOM either, so a claim that the event originated there is the same kind of spoof.

Switch to the state-node check that walks ancestors. Behaviour change at the edge: events from elements with self-visible-but-ancestor-hidden are now rejected instead of accepted.
