### PR TITLE
feat: add Clipboard.onPaste for server-side paste handling

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/Clipboard.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/Clipboard.java
@@ -18,9 +18,15 @@ package com.vaadin.flow.component.clipboard;
 import java.io.Serializable;
 import java.util.Objects;
 
+import tools.jackson.databind.JsonNode;
+
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.trigger.internal.ClickTrigger;
+import com.vaadin.flow.dom.DomListenerRegistration;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.shared.Registration;
 
 /**
  * Entry point for the browser clipboard API. Bind clipboard actions to a user
@@ -36,8 +42,38 @@ import com.vaadin.flow.component.trigger.internal.ClickTrigger;
  *
  * The Clipboard API requires a fresh user gesture for each write, so actions
  * only run during the DOM event that fires the underlying trigger.
+ * <p>
+ * Read-side support is exposed through
+ * {@link #onPaste(Component, SerializableConsumer) onPaste}, which forwards the
+ * browser's native {@code paste} event to a server-side listener as a
+ * {@link PasteEvent}. Unlike the write API, {@code onPaste} does not need a
+ * click binding &mdash; it attaches a DOM listener directly to the given
+ * component and fires on every paste gesture targeting it (or any of its
+ * descendants, since {@code paste} bubbles). Pass the
+ * {@link com.vaadin.flow.component.UI UI} as the component for UI-wide scope;
+ * the {@link #onPaste(Component, PasteOptions, SerializableConsumer) options
+ * overload} lets the application skip pastes whose target is a form field
+ * &mdash; useful for page-wide listeners that should only react to pastes
+ * intended for the page as a whole.
  */
 public final class Clipboard implements Serializable {
+
+    // The same string is used both as the JS expression evaluated client-side
+    // and as the lookup key in DomEvent#getEventData() server-side. Any drift
+    // between the two would silently produce a null value, so the expressions
+    // are kept in a single constant each. `?.` guards against synthetic events
+    // without a DataTransfer; `|| null` collapses the empty string (the
+    // browser's value for an absent MIME type) and the optional-chain
+    // short-circuit into JSON null.
+    private static final String PASTE_TEXT_EXPR = "event.clipboardData?.getData('text/plain') || null";
+    private static final String PASTE_HTML_EXPR = "event.clipboardData?.getData('text/html') || null";
+
+    // Walks event.composedPath() so the check sees through open shadow DOMs
+    // (e.g. a Vaadin web component's internal <input>). Matches input,
+    // textarea, or anything with isContentEditable; the filter passes only
+    // when none of those are in the path.
+    private static final String PASTE_FILTER_SKIP_EDITABLE = "!event.composedPath().some(function(e){"
+            + "return e.tagName&&(e.tagName==='INPUT'||e.tagName==='TEXTAREA'||e.isContentEditable===true);})";
 
     private Clipboard() {
         // utility class
@@ -59,5 +95,119 @@ public final class Clipboard implements Serializable {
             T component) {
         Objects.requireNonNull(component, "component must not be null");
         return new ClipboardBinding(new ClickTrigger(component));
+    }
+
+    /**
+     * Registers a listener for browser {@code paste} events on the given
+     * component. The listener is invoked on the UI thread once per paste
+     * gesture targeting {@code component} (or any descendant, since
+     * {@code paste} bubbles) with a {@link PasteEvent} carrying the
+     * {@code text/plain} and {@code text/html} representations of the pasted
+     * content.
+     *
+     * <p>
+     * The browser only fires {@code paste} when the target element is focused
+     * at the moment the user invokes paste. For non-editable elements such as a
+     * {@code Div} this means the element must be made focusable, typically via
+     * {@code tabindex="0"}. See {@link PasteEvent} for the rest of the browser
+     * caveats.
+     *
+     * <p>
+     * Example:
+     *
+     * <pre>{@code
+     * Div pasteTarget = new Div();
+     * pasteTarget.getElement().setAttribute("tabindex", "0");
+     * add(pasteTarget);
+     *
+     * Clipboard.onPaste(pasteTarget, event -> {
+     *     if (event.hasHtml()) {
+     *         renderHtml(event.getHtml());
+     *     } else if (event.hasText()) {
+     *         renderText(event.getText());
+     *     }
+     * });
+     * }</pre>
+     *
+     * @param component
+     *            the component to listen for paste events on, not {@code null}
+     * @param listener
+     *            the listener invoked for each paste, not {@code null}
+     * @return a {@link Registration} whose {@link Registration#remove() remove}
+     *         detaches the paste listener
+     */
+    public static Registration onPaste(Component component,
+            SerializableConsumer<PasteEvent> listener) {
+        return onPaste(component, PasteOptions.includingInputFields(),
+                listener);
+    }
+
+    /**
+     * Registers a listener for browser {@code paste} events on the given
+     * component with the given {@link PasteOptions}. The listener is invoked on
+     * the UI thread for each paste gesture targeting {@code component} (or any
+     * descendant, since {@code paste} bubbles) whose target matches the
+     * options. For UI-wide scope, pass the {@link com.vaadin.flow.component.UI
+     * UI} as the component; the UI's root element is {@code <body>} so it
+     * receives every paste event that bubbles up from anywhere on the page.
+     * <p>
+     * The component does not need to be attached at registration time — the
+     * underlying DOM listener is bound to the component's element and is
+     * applied when the element is attached to a UI.
+     * <p>
+     * Pass {@link PasteOptions#defaults()} to skip pastes whose target is an
+     * input, textarea, or {@code contenteditable} element (typically what a
+     * page-wide listener wants). Pass
+     * {@link PasteOptions#includingInputFields()} to observe every paste
+     * regardless of focus.
+     *
+     * @param component
+     *            the component to listen for paste events on, not {@code null}
+     * @param options
+     *            paste filtering options, not {@code null}
+     * @param listener
+     *            the listener invoked for each matching paste, not {@code null}
+     * @return a {@link Registration} whose {@link Registration#remove() remove}
+     *         detaches the paste listener
+     */
+    public static Registration onPaste(Component component,
+            PasteOptions options, SerializableConsumer<PasteEvent> listener) {
+        Objects.requireNonNull(component, "component must not be null");
+        Objects.requireNonNull(options, "options must not be null");
+        Objects.requireNonNull(listener, "listener must not be null");
+        return register(component, options, listener);
+    }
+
+    private static Registration register(Component host, PasteOptions options,
+            SerializableConsumer<PasteEvent> listener) {
+        DomListenerRegistration registration = host.getElement()
+                .addEventListener("paste", domEvent -> {
+                    JsonNode data = domEvent.getEventData();
+                    // mapEventTargetElement() does the DOM ancestor walk in
+                    // the browser to find the closest Flow-tracked element to
+                    // event.target. That gives DOM-truth (not state-tree
+                    // order, which can diverge from DOM for virtual children,
+                    // slotted content, etc.).
+                    Element targetElement = domEvent.getEventTarget()
+                            .orElse(null);
+                    // The JS `|| null` already collapses "" and missing MIME
+                    // types to JSON null; asStringOpt() then yields empty for
+                    // those, so callers see null (not "").
+                    listener.accept(new PasteEvent(host,
+                            data.optional(PASTE_TEXT_EXPR)
+                                    .flatMap(JsonNode::asStringOpt)
+                                    .orElse(null),
+                            data.optional(PASTE_HTML_EXPR)
+                                    .flatMap(JsonNode::asStringOpt)
+                                    .orElse(null),
+                            targetElement));
+                });
+        registration.addEventData(PASTE_TEXT_EXPR);
+        registration.addEventData(PASTE_HTML_EXPR);
+        registration.mapEventTargetElement();
+        if (!options.includeInputFieldPastes()) {
+            registration.setFilter(PASTE_FILTER_SKIP_EDITABLE);
+        }
+        return registration::remove;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteEvent.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.clipboard;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.dom.Element;
+
+/**
+ * Server-side representation of a browser {@code paste} event delivered to a
+ * listener registered with
+ * {@link Clipboard#onPaste(Component, com.vaadin.flow.function.SerializableConsumer)
+ * Clipboard.onPaste}.
+ * <p>
+ * The event carries the two textual MIME types the browser exposes on
+ * {@code event.clipboardData}: {@code text/plain} via {@link #getText()} and
+ * {@code text/html} via {@link #getHtml()}. Either may be {@code null} when the
+ * paste did not include that representation. {@link #getTargetElement()}
+ * resolves to the closest Flow-tracked {@link Element} ancestor of the paste's
+ * DOM target.
+ *
+ * <h2>Empty vs. absent</h2>
+ *
+ * The browser returns the empty string {@code ""} both when the requested MIME
+ * type is not present on the clipboard and when the user pasted an empty string
+ * of that type. There is no way to distinguish the two. {@code PasteEvent}
+ * collapses both into {@code null}, so callers can simply check
+ * {@code event.hasHtml()} (or {@code event.getHtml() != null}) without an extra
+ * {@code !isEmpty()} guard.
+ *
+ * <h2>What is not on it</h2>
+ *
+ * Files and binary clipboard items (pasted screenshots, files dragged from the
+ * OS file picker, anything that arrives as {@code event.clipboardData.files} or
+ * a {@code DataTransferItem} of kind {@code "file"}) are not delivered by this
+ * event. File-paste support is tracked separately.
+ *
+ * <h2>Browser caveats</h2>
+ *
+ * <ul>
+ * <li>The browser only fires {@code paste} when the target element is focused
+ * at the moment the user invokes paste. Non-editable elements (such as a plain
+ * {@code Div}) need to be made focusable &mdash; typically via
+ * {@code tabindex="0"} &mdash; before they will receive paste events.</li>
+ * <li>On editable targets ({@code <input>}, {@code <textarea>}, elements with
+ * {@code contenteditable}), the browser still performs its native paste
+ * insertion. {@code onPaste} does <em>not</em> call {@code preventDefault()};
+ * the listener observes the paste, it does not replace it.</li>
+ * <li>On Safari, some plain-text pastes do not include a {@code text/html}
+ * representation even when Chromium would synthesise a wrapper, so
+ * {@link #getHtml()} may be {@code null} on Safari for the same paste that
+ * yields a non-null HTML value on Chrome.</li>
+ * </ul>
+ *
+ * The listener runs on the UI thread.
+ */
+public final class PasteEvent implements Serializable {
+
+    private final Component source;
+    private final @Nullable String text;
+    private final @Nullable String html;
+    private final @Nullable Element targetElement;
+
+    PasteEvent(Component source, @Nullable String text, @Nullable String html,
+            @Nullable Element targetElement) {
+        this.source = Objects.requireNonNull(source);
+        this.text = text;
+        this.html = html;
+        this.targetElement = targetElement;
+    }
+
+    /**
+     * Returns the component the paste listener was registered on &mdash; the
+     * component passed to
+     * {@link Clipboard#onPaste(Component, com.vaadin.flow.function.SerializableConsumer)
+     * Clipboard.onPaste}. For listeners registered against a
+     * {@link com.vaadin.flow.component.UI UI} this is the UI itself.
+     *
+     * @return the source component, never {@code null}
+     */
+    public Component getSource() {
+        return source;
+    }
+
+    /**
+     * Returns the closest Flow-tracked {@link Element} ancestor of the
+     * browser's paste target. The ancestor walk is performed by the browser
+     * against the live DOM (not the server-side state tree), so the result
+     * reflects the DOM hierarchy the user actually pasted into. For pastes
+     * inside a Vaadin web component this is typically the web component's host
+     * element, not an internal shadow-DOM child.
+     * <p>
+     * Use {@link Element#getComponent()} to look up the enclosing
+     * {@link Component}, if any. Returns {@code null} only in the rare case
+     * that no Flow-tracked element encloses the paste target in the DOM.
+     *
+     * @return the closest enclosing Flow-tracked element, or {@code null} if
+     *         Flow could not resolve one
+     */
+    public @Nullable Element getTargetElement() {
+        return targetElement;
+    }
+
+    /**
+     * Returns the {@code text/plain} content of the paste, or {@code null} if
+     * the paste did not include a non-empty plain-text representation.
+     *
+     * @return the pasted plain text, or {@code null}
+     */
+    public @Nullable String getText() {
+        return text;
+    }
+
+    /**
+     * Returns the {@code text/html} content of the paste, or {@code null} if
+     * the paste did not include a non-empty HTML representation.
+     *
+     * @return the pasted HTML, or {@code null}
+     */
+    public @Nullable String getHtml() {
+        return html;
+    }
+
+    /**
+     * Returns whether the paste included a non-empty {@code text/plain}
+     * representation.
+     *
+     * @return {@code true} if {@link #getText()} is non-{@code null}
+     */
+    public boolean hasText() {
+        return text != null;
+    }
+
+    /**
+     * Returns whether the paste included a non-empty {@code text/html}
+     * representation.
+     *
+     * @return {@code true} if {@link #getHtml()} is non-{@code null}
+     */
+    public boolean hasHtml() {
+        return html != null;
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteOptions.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteOptions.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.clipboard;
+
+import java.io.Serializable;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.function.SerializableConsumer;
+
+/**
+ * Configuration for
+ * {@link Clipboard#onPaste(Component, PasteOptions, SerializableConsumer)
+ * Clipboard.onPaste}.
+ *
+ * @param includeInputFieldPastes
+ *            whether to forward pastes whose composed path crosses an editable
+ *            target ({@code <input>}, {@code <textarea>}, or an element with
+ *            {@code contenteditable}). The {@link #defaults()} factory sets
+ *            this to {@code false} &mdash; pastes into a focused form field,
+ *            including a focused field inside a Vaadin web component's shadow
+ *            DOM, are skipped &mdash; which is typically what page-wide
+ *            listeners want. The {@link #includingInputFields()} factory sets
+ *            this to {@code true}, so the listener observes every paste
+ *            regardless of focus; this is also the default when no options are
+ *            passed to
+ *            {@link Clipboard#onPaste(Component, SerializableConsumer)}.
+ */
+public record PasteOptions(
+        boolean includeInputFieldPastes) implements Serializable {
+
+    /**
+     * Returns the default options: editable-target pastes are skipped.
+     *
+     * @return default options, equivalent to {@code new PasteOptions(false)}
+     */
+    public static PasteOptions defaults() {
+        return new PasteOptions(false);
+    }
+
+    /**
+     * @return options that also forward pastes targeting input fields, text
+     *         areas, and {@code contenteditable} elements; equivalent to
+     *         {@code new PasteOptions(true)}.
+     */
+    public static PasteOptions includingInputFields() {
+        return new PasteOptions(true);
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/clipboard/ClipboardTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/clipboard/ClipboardTest.java
@@ -16,8 +16,10 @@
 package com.vaadin.flow.component.clipboard;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.node.ObjectNode;
 
 import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.ClickNotifier;
@@ -26,10 +28,15 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
 import com.vaadin.flow.component.internal.UIInternals.JavaScriptInvocation;
+import com.vaadin.flow.dom.DomEvent;
 import com.vaadin.flow.dom.JsFunction;
+import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
 import com.vaadin.tests.util.MockUI;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -194,6 +201,69 @@ class ClipboardTest {
         // TestButton's root is <test-button>, not <img>.
         assertThrows(IllegalArgumentException.class,
                 () -> Clipboard.onClick(button).writeImage(button));
+    }
+
+    @Test
+    void onPaste_dispatchesPasteEventWithTextAndHtml() {
+        UI ui = new MockUI();
+        TestButton target = new TestButton();
+        ui.getElement().appendChild(target.getElement());
+
+        AtomicReference<PasteEvent> received = new AtomicReference<>();
+        Clipboard.onPaste(target, received::set);
+
+        // Must match the JS expressions in Clipboard.onPaste byte-for-byte —
+        // DomListenerRegistration uses the expression string as the JSON key
+        // under which the evaluated result appears in DomEvent#getEventData().
+        String textExpr = "event.clipboardData?.getData('text/plain') || null";
+        String htmlExpr = "event.clipboardData?.getData('text/html') || null";
+        ObjectNode data = JacksonUtils.createObjectNode();
+        data.put(textExpr, "plain");
+        data.put(htmlExpr, "<b>html</b>");
+
+        target.getElement().getNode().getFeature(ElementListenerMap.class)
+                .fireEvent(new DomEvent(target.getElement(), "paste", data));
+
+        PasteEvent event = received.get();
+        assertNotNull(event);
+        assertSame(target, event.getSource());
+        assertEquals("plain", event.getText());
+        assertEquals("<b>html</b>", event.getHtml());
+        assertTrue(event.hasText());
+        assertTrue(event.hasHtml());
+        // No target mapping in the fabricated event data, so the resolver
+        // returns null. The IT verifies real target resolution end-to-end.
+        assertNull(event.getTargetElement());
+    }
+
+    @Test
+    void onPaste_options_attachesToHostElement_withoutCurrentUI() {
+        // The Component-accepting onPaste must not rely on UI.getCurrent(),
+        // so callers from a background thread can pass the UI (or any
+        // component) directly. MockUI's constructor sets UI.setCurrent as a
+        // side effect; clear it so the test only exercises the explicit
+        // component path. PasteOptions.includingInputFields() skips the
+        // editable-target filter, so the fabricated event doesn't need to
+        // carry the filter key — the filter behaviour is covered end-to-end
+        // by TriggerPasteIT.
+        UI ui = new MockUI();
+        UI.setCurrent(null);
+
+        AtomicReference<PasteEvent> received = new AtomicReference<>();
+        Clipboard.onPaste(ui, PasteOptions.includingInputFields(),
+                received::set);
+
+        String textExpr = "event.clipboardData?.getData('text/plain') || null";
+        ObjectNode data = JacksonUtils.createObjectNode();
+        data.put(textExpr, "from-bg");
+
+        ui.getElement().getNode().getFeature(ElementListenerMap.class)
+                .fireEvent(new DomEvent(ui.getElement(), "paste", data));
+
+        PasteEvent event = received.get();
+        assertNotNull(event);
+        assertSame(ui, event.getSource());
+        assertEquals("from-bg", event.getText());
     }
 
     /**

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerPasteView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerPasteView.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.clipboard.Clipboard;
+import com.vaadin.flow.component.clipboard.PasteEvent;
+import com.vaadin.flow.component.clipboard.PasteOptions;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Input;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+/**
+ * Registers three paste listeners so the IT can prove each variant:
+ * <ul>
+ * <li>A listener on the focusable {@code #target} div (the view's child) writes
+ * to {@code #status}.</li>
+ * <li>A view-scoped listener with default {@link PasteOptions} (editable
+ * targets skipped) writes to {@code #status-global}.</li>
+ * <li>A view-scoped listener with {@link PasteOptions#includingInputFields()}
+ * writes to {@code #status-global-include}.</li>
+ * </ul>
+ * Each "global" status line carries the resolved target element's id so the IT
+ * can distinguish a paste on the div from a paste on the {@code #input} field.
+ */
+@Route(value = "com.vaadin.flow.uitest.ui.TriggerPasteView", layout = ViewTestLayout.class)
+public class TriggerPasteView extends AbstractDivView {
+
+    @Override
+    protected void onShow() {
+        Div target = new Div();
+        target.setId("target");
+        // paste only fires on focused elements; tabindex makes the div
+        // focusable.
+        target.getElement().setAttribute("tabindex", "0");
+        target.setText("Focus me and paste");
+
+        Div status = new Div();
+        status.setId("status");
+
+        Input input = new Input();
+        input.setId("input");
+
+        Div statusGlobal = new Div();
+        statusGlobal.setId("status-global");
+
+        Div statusGlobalInclude = new Div();
+        statusGlobalInclude.setId("status-global-include");
+
+        add(target, status, input, statusGlobal, statusGlobalInclude);
+
+        Clipboard.onPaste(target, event -> status.setText(
+                "text=" + event.getText() + ";html=" + event.getHtml()));
+
+        Clipboard.onPaste(this, PasteOptions.defaults(),
+                event -> statusGlobal.setText(formatGlobal(event)));
+
+        Clipboard.onPaste(this, PasteOptions.includingInputFields(),
+                event -> statusGlobalInclude.setText(formatGlobal(event)));
+    }
+
+    private static String formatGlobal(PasteEvent event) {
+        Element target = event.getTargetElement();
+        String id = target != null ? target.getAttribute("id") : null;
+        return "target=" + (id != null ? id : "null") + ";text="
+                + event.getText();
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerPasteIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerPasteIT.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class TriggerPasteIT extends ChromeBrowserTest {
+
+    @Test
+    public void pasteWithTextOnly_serverReceivesText() {
+        open();
+        dispatchPaste("hello", null);
+        WebElement status = waitForStatus();
+        Assert.assertEquals("text=hello;html=null", status.getText());
+    }
+
+    @Test
+    public void pasteWithHtmlOnly_serverReceivesHtml() {
+        open();
+        dispatchPaste(null, "<b>hi</b>");
+        WebElement status = waitForStatus();
+        Assert.assertEquals("text=null;html=<b>hi</b>", status.getText());
+    }
+
+    @Test
+    public void pasteWithBoth_serverReceivesBoth() {
+        open();
+        dispatchPaste("hi", "<b>hi</b>");
+        WebElement status = waitForStatus();
+        Assert.assertEquals("text=hi;html=<b>hi</b>", status.getText());
+    }
+
+    @Test
+    public void pasteWithNeither_serverReceivesBothNull() {
+        open();
+        dispatchPaste(null, null);
+        WebElement status = waitForStatus();
+        Assert.assertEquals("text=null;html=null", status.getText());
+    }
+
+    @Test
+    public void pasteWithEmptyText_serverReceivesNull() {
+        // The browser returns "" both when the MIME type is absent and when an
+        // empty string was pasted. Clipboard.onPaste collapses "" into null at
+        // the JS expression boundary, so an explicitly-empty paste must arrive
+        // server-side as text=null, not text=.
+        open();
+        dispatchPaste("", null);
+        WebElement status = waitForStatus();
+        Assert.assertEquals("text=null;html=null", status.getText());
+    }
+
+    @Test
+    public void pasteOnDiv_globalListenersAlsoFire() {
+        // Pasting on the focusable target div fires the component-scoped
+        // listener AND both global listeners; the default global skips
+        // editable targets but a div is not editable, so it passes.
+        open();
+        dispatchPaste("hi", null);
+        waitForStatus();
+        Assert.assertEquals("target=target;text=hi",
+                findElement(By.id("status-global")).getText());
+        Assert.assertEquals("target=target;text=hi",
+                findElement(By.id("status-global-include")).getText());
+    }
+
+    @Test
+    public void pasteOnInput_defaultGlobalSkipped_includeGlobalFires() {
+        // Pasting on the input bypasses the component listener (input is
+        // outside the target div's subtree), is filtered out by the default
+        // global listener (composed path contains <input>), and fires only on
+        // the include-input global. Wait on the one that fires, then verify
+        // the other two stayed empty in the same client roundtrip.
+        open();
+        dispatchPasteOn("input", "hi", null);
+        waitUntil(d -> "target=input;text=hi"
+                .equals(findElement(By.id("status-global-include")).getText()));
+        Assert.assertEquals("", findElement(By.id("status-global")).getText());
+        Assert.assertEquals("", findElement(By.id("status")).getText());
+    }
+
+    private WebElement waitForStatus() {
+        WebElement status = findElement(By.id("status"));
+        waitUntil(d -> status.getText() != null
+                && status.getText().startsWith("text="));
+        return status;
+    }
+
+    private void dispatchPaste(String text, String html) {
+        dispatchPasteOn("target", text, html);
+    }
+
+    // Builds a synthetic ClipboardEvent('paste') with a populated DataTransfer
+    // and dispatches it on the element with the given id. Java nulls map to JS
+    // null via executeScript, matching the `!== null` guards.
+    private void dispatchPasteOn(String targetId, String text, String html) {
+        String script = """
+                const el = document.getElementById(arguments[2]);
+                el.focus();
+                const dt = new DataTransfer();
+                if (arguments[0] !== null) dt.setData('text/plain', arguments[0]);
+                if (arguments[1] !== null) dt.setData('text/html',  arguments[1]);
+                el.dispatchEvent(new ClipboardEvent('paste', {
+                    clipboardData: dt, bubbles: true, cancelable: true
+                }));
+                """;
+        ((JavascriptExecutor) getDriver()).executeScript(script, text, html,
+                targetId);
+    }
+}


### PR DESCRIPTION
    Adds Clipboard.onPaste(Component, listener) — and a PasteOptions
    overload — that forwards the browser's native paste event to a
    server-side listener as a PasteEvent carrying text/plain, text/html,
    the source Component, and the closest Flow-tracked target Element.
    Pass any Component for scope: the listener fires for pastes targeting
    that component or its descendants. For UI-wide scope, pass the UI.
    
    Internals:
      - The listener is a plain Element.addEventListener("paste", ...)
        wrapper. Two addEventData JS expressions pull text/plain and
        text/html out of event.clipboardData; `?.` guards synthetic events
        without a DataTransfer and `|| null` collapses the browser's "" to
        JSON null at the wire boundary so callers don't need !isEmpty()
        guards.
      - PasteOptions.defaults() installs a setFilter that walks
        event.composedPath() and rejects pastes whose target (or any
        ancestor in the composed path, including through open shadow DOMs
        like <vaadin-text-field>'s inner <input>) is an input, textarea,
        or contenteditable element. Filtering happens client-side, so
        skipped pastes never round-trip. PasteOptions.includingInputFields()
        is the no-filter form and is the default when no options are
        passed.
      - getTargetElement() is populated via mapEventTargetElement(): the
        browser walks event.target's DOM ancestors to find the closest
        state-node element. Using composedPath via that mechanism means
        the result reflects DOM hierarchy, not the server-side state tree
        (which can diverge for virtual children, slotted content, etc.).
        Callers reach the enclosing Component via Element.getComponent().
      - No UI.getCurrent dependency: the DOM listener binds directly to
        the component's element and is applied on attach, so callers from
        a background thread can register without needing the UI lock to
        set up.
    
    Out of scope for this commit: file/image paste, copy/cut listeners,
    and a preventDefault hook.

    Tests cover the wiring (component + UI hosts, with and without a
    current UI), and a TriggerPasteIT dispatches synthetic ClipboardEvents
    with a populated DataTransfer to verify text-only, html-only, both,
    neither, empty-string collapse, and the editable-target filter (a
    paste on a sibling <input> is skipped by the default options and
    fires only with includingInputFields()).
