### PR TITLE
feat: add Clipboard.onFilePaste for server-side file paste handling

### DIFF
--- a/flow-client/src/main/frontend/Clipboard.ts
+++ b/flow-client/src/main/frontend/Clipboard.ts
@@ -178,7 +178,7 @@ function uploadPastedFiles(event: ClipboardEvent, element: Element, urlAttribute
   // when the paste has been fully delivered (one fetch per file means the
   // server only observes arrivals, not the total).
   const fileCount = String(files.length);
-  const uploads: Promise<unknown>[] = [];
+  const uploads: Array<Promise<unknown>> = [];
   for (const file of files) {
     const headers: Record<string, string> = {
       'X-Filename': encodeURIComponent(file.name),

--- a/flow-client/src/main/frontend/Clipboard.ts
+++ b/flow-client/src/main/frontend/Clipboard.ts
@@ -135,12 +135,71 @@ async function writeClipboardPayload(
   return text !== null ? text : html;
 }
 
+/**
+ * Posts each file from a {@code paste} event's {@code clipboardData.files} as
+ * its own XHR to the URL stored as the named attribute on {@code element}. The
+ * wire format matches vaadin-upload: raw body, percent-encoded {@code X-Filename}
+ * header, MIME type in {@code Content-Type}.
+ *
+ * The {@code paste} listener on the server pairs this call with a filter that
+ * always returns false, so the function returns false too — no server event
+ * is dispatched, the per-file UploadHandler callback delivers completion.
+ *
+ * Editable targets ({@code <input>}, {@code <textarea>}, {@code contentEditable})
+ * are not given any special treatment here: browsers do not paste files into
+ * those elements, so a paste containing a file in a focused text field is
+ * still a "the user tried to drop a file on the page" event from the
+ * application's point of view.
+ */
+// Monotonic counter incremented once per paste gesture so server-side
+// handlers can correlate the parallel fetch POSTs that belong to the same
+// paste, and order pastes against each other. Scoped to the browser tab —
+// a different tab gets its own counter, but no server-side state crosses
+// tabs in this flow.
+let pasteSequence = 0;
+
+function uploadPastedFiles(event: ClipboardEvent, element: Element, urlAttribute: string): boolean {
+  const files = event.clipboardData?.files;
+  if (!files || files.length === 0) {
+    return false;
+  }
+  const url = element.getAttribute(urlAttribute);
+  if (!url) {
+    return false;
+  }
+  pasteSequence += 1;
+  const pasteId = String(pasteSequence);
+  // Surface the file count too: the session-style server handler needs it
+  // to know when the paste has been fully delivered (one fetch per file
+  // means the server only observes arrivals, not the total).
+  const fileCount = String(files.length);
+  for (const file of files) {
+    const headers: Record<string, string> = {
+      'X-Filename': encodeURIComponent(file.name),
+      'X-Paste-Id': pasteId,
+      'X-Paste-File-Count': fileCount
+    };
+    if (file.type) {
+      headers['Content-Type'] = file.type;
+    }
+    // Fire-and-forget: the per-file UploadHandler callback delivers
+    // completion through the regular server channel, so the only thing we
+    // need to do here is log network/connectivity failures the server will
+    // never see otherwise.
+    fetch(url, { method: 'POST', headers: headers, body: file }).catch((err) => {
+      console.error('Vaadin clipboard file upload failed', err);
+    });
+  }
+  return false;
+}
+
 const $wnd = window as any;
 $wnd.Vaadin ??= {};
 $wnd.Vaadin.Flow ??= {};
 $wnd.Vaadin.Flow.clipboard = {
   readPayload: readClipboardPayload,
-  writePayload: writeClipboardPayload
+  writePayload: writeClipboardPayload,
+  uploadPastedFiles: uploadPastedFiles
 };
 
 // Empty export to ensure TypeScript emits this as an ES module,

--- a/flow-client/src/main/frontend/Clipboard.ts
+++ b/flow-client/src/main/frontend/Clipboard.ts
@@ -141,9 +141,14 @@ async function writeClipboardPayload(
  * wire format matches vaadin-upload: raw body, percent-encoded {@code X-Filename}
  * header, MIME type in {@code Content-Type}.
  *
- * The {@code paste} listener on the server pairs this call with a filter that
- * always returns false, so the function returns false too — no server event
- * is dispatched, the per-file UploadHandler callback delivers completion.
+ * Each upload is processed in its own HTTP request, so the UI changes the
+ * server-side UploadHandler makes through {@code UI.access} are applied to the
+ * state tree but not sent to the client by the upload response itself. Once
+ * every upload of the paste has settled this helper dispatches a
+ * {@code vaadin-paste-upload-finished} event back on {@code element}; a
+ * server-side listener for that event triggers a normal Flow round trip that
+ * flushes those pending UI changes — so the API works without {@code @Push},
+ * exactly like a regular upload completing through the Upload component.
  *
  * Editable targets ({@code <input>}, {@code <textarea>}, {@code contentEditable})
  * are not given any special treatment here: browsers do not paste files into
@@ -158,21 +163,22 @@ async function writeClipboardPayload(
 // tabs in this flow.
 let pasteSequence = 0;
 
-function uploadPastedFiles(event: ClipboardEvent, element: Element, urlAttribute: string): boolean {
+function uploadPastedFiles(event: ClipboardEvent, element: Element, urlAttribute: string): void {
   const files = event.clipboardData?.files;
   if (!files || files.length === 0) {
-    return false;
+    return;
   }
   const url = element.getAttribute(urlAttribute);
   if (!url) {
-    return false;
+    return;
   }
   pasteSequence += 1;
   const pasteId = String(pasteSequence);
-  // Surface the file count too: the session-style server handler needs it
-  // to know when the paste has been fully delivered (one fetch per file
-  // means the server only observes arrivals, not the total).
+  // Surface the file count too: the batch server handler needs it to know
+  // when the paste has been fully delivered (one fetch per file means the
+  // server only observes arrivals, not the total).
   const fileCount = String(files.length);
+  const uploads: Promise<unknown>[] = [];
   for (const file of files) {
     const headers: Record<string, string> = {
       'X-Filename': encodeURIComponent(file.name),
@@ -182,15 +188,22 @@ function uploadPastedFiles(event: ClipboardEvent, element: Element, urlAttribute
     if (file.type) {
       headers['Content-Type'] = file.type;
     }
-    // Fire-and-forget: the per-file UploadHandler callback delivers
-    // completion through the regular server channel, so the only thing we
-    // need to do here is log network/connectivity failures the server will
-    // never see otherwise.
-    fetch(url, { method: 'POST', headers: headers, body: file }).catch((err) => {
-      console.error('Vaadin clipboard file upload failed', err);
-    });
+    // The per-file UploadHandler callback runs as each POST is processed;
+    // log network/connectivity failures the server will never see otherwise.
+    uploads.push(
+      fetch(url, { method: 'POST', headers: headers, body: file }).catch((err) => {
+        console.error('Vaadin clipboard file upload failed', err);
+      })
+    );
   }
-  return false;
+  // Tell the server the paste's uploads are done so it can flush the queued
+  // UI updates without requiring @Push. The upload response is written only
+  // after the handler's UI.access task has applied its changes to the state
+  // tree, so by the time a fetch settles those changes are guaranteed to be
+  // picked up by this round trip.
+  Promise.allSettled(uploads).then(() => {
+    element.dispatchEvent(new CustomEvent('vaadin-paste-upload-finished'));
+  });
 }
 
 const $wnd = window as any;

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/Clipboard.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/Clipboard.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.component.clipboard;
 
 import java.io.Serializable;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.UUID;
 
 import tools.jackson.databind.JsonNode;
 
@@ -66,9 +66,9 @@ import com.vaadin.flow.shared.Registration;
  * and the handler's own per-file callback (in-memory, file, temp file) is what
  * the application implements. For paste-aware orchestration, pair with
  * {@link PasteFileHandler}:
- * {@link PasteFileHandler#inMemory(SerializableConsumer) inMemory} for a
- * per-file callback that flags the first file of each paste, or
- * {@link PasteFileHandler#session() session()} for a three-step listener
+ * {@link PasteFileHandler#perFile(SerializableConsumer) perFile} for a per-file
+ * callback that flags the first file of each paste, or
+ * {@link PasteFileHandler#batch() batch()} for a three-step listener
  * ({@code onStart}/{@code onFile}/{@code onComplete}) that knows when the whole
  * paste has finished delivering. Use a raw {@code UploadHandler} when neither
  * shape fits. {@code onFilePaste} is independent of {@code onPaste}; the same
@@ -94,11 +94,13 @@ public final class Clipboard implements Serializable {
     private static final String PASTE_FILTER_SKIP_EDITABLE = "!event.composedPath().some(function(e){"
             + "return e.tagName&&(e.tagName==='INPUT'||e.tagName==='TEXTAREA'||e.isContentEditable===true);})";
 
-    // Counter for the per-registration attribute name. Each onFilePaste call
-    // attaches its UploadHandler under a distinct attribute on the host
-    // element so multiple file-paste listeners on the same element resolve
-    // to independent upload URLs.
-    private static final AtomicLong FILE_PASTE_COUNTER = new AtomicLong();
+    // DOM event the client paste-upload helper dispatches once every upload of
+    // a paste has settled. A server-side listener for it (registered in
+    // registerFilePaste) does nothing but force a Flow round trip, which
+    // flushes the UI changes the per-file UploadHandler queued via UI.access —
+    // so onFilePaste updates reach the client without @Push. Must stay in sync
+    // with the literal dispatched in flow-client/Clipboard.ts.
+    private static final String FILE_PASTE_FINISHED_EVENT = "vaadin-paste-upload-finished";
 
     /**
      * Request header set by the client-side paste-upload helper on every fetch
@@ -111,15 +113,15 @@ public final class Clipboard implements Serializable {
      * <p>
      * Raw {@link UploadHandler} implementations may read this header directly
      * via {@code event.getRequest().getHeader(PASTE_ID_HEADER)};
-     * {@link PasteFileHandler#inMemory(SerializableConsumer)} reads it for the
+     * {@link PasteFileHandler#perFile(SerializableConsumer)} reads it for the
      * caller and exposes it as {@link PasteFile#pasteId() PasteFile.pasteId()}.
      */
     public static final String PASTE_ID_HEADER = "X-Paste-Id";
 
     /**
      * Request header set alongside {@link #PASTE_ID_HEADER} carrying the total
-     * number of files in the originating paste. The session-style handler built
-     * by {@link PasteFileHandler#session()} uses it to fire
+     * number of files in the originating paste. The batch handler built by
+     * {@link PasteFileHandler#batch()} uses it to fire
      * {@link com.vaadin.flow.function.SerializableConsumer onComplete} once the
      * server has observed all files of a paste &mdash; without it the server
      * has no way to tell mid-paste arrival from "all done".
@@ -320,34 +322,43 @@ public final class Clipboard implements Serializable {
     private static Registration registerFilePaste(Component host,
             UploadHandler handler) {
         Element element = host.getElement();
-        // setAttribute(name, ElementRequestHandler) registers the handler as
-        // a stream resource and stores its URL as the attribute value. The
-        // counter scopes the slot per-registration so multiple file-paste
-        // listeners on the same element resolve to independent URLs.
-        String attributeName = "_vaadin-paste-upload-"
-                + FILE_PASTE_COUNTER.incrementAndGet();
+        // setAttribute(name, ElementRequestHandler) registers the handler as a
+        // stream resource and stores its URL as the attribute value. A fresh
+        // UUID scopes the slot per-registration (the same approach as
+        // StreamResource) so multiple file-paste listeners on the same element
+        // resolve to independent upload URLs.
+        String attributeName = "_vaadin-paste-upload-" + UUID.randomUUID();
         element.setAttribute(attributeName, handler);
 
-        // The filter expression calls into the TS helper
+        // Attach a native paste listener in the browser via the TS helper
         // window.Vaadin.Flow.clipboard.uploadPastedFiles (defined in
-        // flow-client/Clipboard.ts, registered at bootstrap), passing the
-        // event, host element, and per-registration attribute name from which
-        // the helper reads the upload URL. The helper does the XHR-per-file
-        // work and always returns false: there is no server-side paste event
-        // for this API — completion is delivered per file via the
-        // UploadHandler callback as each XHR finishes.
-        String filterExpr = "window.Vaadin.Flow.clipboard.uploadPastedFiles(event,element,'"
-                + attributeName + "')";
+        // flow-client/Clipboard.ts, registered at bootstrap). On each paste the
+        // helper reads the upload URL from the per-registration attribute and
+        // POSTs one upload per file. addJsInitializer re-runs the install on a
+        // real re-attach and invokes the returned cleanup (removeEventListener)
+        // when the registration is removed or the client DOM node is discarded.
+        Registration jsRegistration = element.addJsInitializer("""
+                const upload = (event) => window.Vaadin.Flow.clipboard
+                        .uploadPastedFiles(event, this, $0);
+                this.addEventListener('paste', upload);
+                return () => this.removeEventListener('paste', upload);""",
+                attributeName);
 
-        DomListenerRegistration registration = element.addEventListener("paste",
-                domEvent -> {
-                    // Never called: the filter always returns false, so no
-                    // server event is dispatched. The listener exists solely
-                    // to anchor the JS filter expression on the element.
+        // Once the helper has finished POSTing a paste's files it dispatches
+        // FILE_PASTE_FINISHED_EVENT on the element. This listener does nothing
+        // on its own — its sole purpose is to make the browser perform a Flow
+        // round trip, which flushes the UI changes the UploadHandler queued via
+        // UI.access while handling each upload. Without it those changes would
+        // sit on the server until the next round trip, which is why the API
+        // would otherwise need @Push.
+        DomListenerRegistration finishedRegistration = element
+                .addEventListener(FILE_PASTE_FINISHED_EVENT, domEvent -> {
+                    // intentionally empty; see comment above
                 });
-        registration.setFilter(filterExpr);
+
         return () -> {
-            registration.remove();
+            jsRegistration.remove();
+            finishedRegistration.remove();
             element.removeAttribute(attributeName);
         };
     }

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/Clipboard.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/Clipboard.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.clipboard;
 
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
 
 import tools.jackson.databind.JsonNode;
 
@@ -26,6 +27,7 @@ import com.vaadin.flow.component.trigger.internal.ClickTrigger;
 import com.vaadin.flow.dom.DomListenerRegistration;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.server.streams.UploadHandler;
 import com.vaadin.flow.shared.Registration;
 
 /**
@@ -55,6 +57,23 @@ import com.vaadin.flow.shared.Registration;
  * overload} lets the application skip pastes whose target is a form field
  * &mdash; useful for page-wide listeners that should only react to pastes
  * intended for the page as a whole.
+ * <p>
+ * File pastes (screenshots, files dragged in from the OS, anything that
+ * surfaces as {@code event.clipboardData.files}) are handled by a dedicated
+ * read-side API, {@link #onFilePaste(Component, UploadHandler) onFilePaste}.
+ * Each pasted file becomes its own upload &mdash; one fetch POST per file,
+ * addressed to the URL generated for the supplied {@link UploadHandler} &mdash;
+ * and the handler's own per-file callback (in-memory, file, temp file) is what
+ * the application implements. For paste-aware orchestration, pair with
+ * {@link PasteFileHandler}:
+ * {@link PasteFileHandler#inMemory(SerializableConsumer) inMemory} for a
+ * per-file callback that flags the first file of each paste, or
+ * {@link PasteFileHandler#session() session()} for a three-step listener
+ * ({@code onStart}/{@code onFile}/{@code onComplete}) that knows when the whole
+ * paste has finished delivering. Use a raw {@code UploadHandler} when neither
+ * shape fits. {@code onFilePaste} is independent of {@code onPaste}; the same
+ * paste gesture can deliver text/html via {@code onPaste} and files via
+ * {@code onFilePaste} when both are registered.
  */
 public final class Clipboard implements Serializable {
 
@@ -74,6 +93,38 @@ public final class Clipboard implements Serializable {
     // when none of those are in the path.
     private static final String PASTE_FILTER_SKIP_EDITABLE = "!event.composedPath().some(function(e){"
             + "return e.tagName&&(e.tagName==='INPUT'||e.tagName==='TEXTAREA'||e.isContentEditable===true);})";
+
+    // Counter for the per-registration attribute name. Each onFilePaste call
+    // attaches its UploadHandler under a distinct attribute on the host
+    // element so multiple file-paste listeners on the same element resolve
+    // to independent upload URLs.
+    private static final AtomicLong FILE_PASTE_COUNTER = new AtomicLong();
+
+    /**
+     * Request header set by the client-side paste-upload helper on every fetch
+     * POST that originates from a paste gesture. The value is a monotonically
+     * increasing sequence number (as decimal text) so server handlers can
+     * correlate the parallel uploads of one paste and tell pastes apart from
+     * each other. Two distinct pastes in the same browser tab always carry
+     * strictly increasing values; pastes from different tabs are not
+     * comparable.
+     * <p>
+     * Raw {@link UploadHandler} implementations may read this header directly
+     * via {@code event.getRequest().getHeader(PASTE_ID_HEADER)};
+     * {@link PasteFileHandler#inMemory(SerializableConsumer)} reads it for the
+     * caller and exposes it as {@link PasteFile#pasteId() PasteFile.pasteId()}.
+     */
+    public static final String PASTE_ID_HEADER = "X-Paste-Id";
+
+    /**
+     * Request header set alongside {@link #PASTE_ID_HEADER} carrying the total
+     * number of files in the originating paste. The session-style handler built
+     * by {@link PasteFileHandler#session()} uses it to fire
+     * {@link com.vaadin.flow.function.SerializableConsumer onComplete} once the
+     * server has observed all files of a paste &mdash; without it the server
+     * has no way to tell mid-paste arrival from "all done".
+     */
+    public static final String PASTE_FILE_COUNT_HEADER = "X-Paste-File-Count";
 
     private Clipboard() {
         // utility class
@@ -178,6 +229,61 @@ public final class Clipboard implements Serializable {
         return register(component, options, listener);
     }
 
+    /**
+     * Registers a file-upload listener for browser {@code paste} events on the
+     * given component. When a paste delivers files (a screenshot from the OS
+     * clipboard, files copied from a file manager, anything that arrives on
+     * {@code event.clipboardData.files}) each file is uploaded to the URL
+     * generated for {@code handler}; the handler's own per-file callback then
+     * runs server-side, exactly as for a regular upload. Pastes without files
+     * are ignored.
+     *
+     * <p>
+     * One XHR is sent per file, matching the wire format used by
+     * {@code vaadin-upload}: the file is the request body, the file name
+     * travels in the {@code X-Filename} header (percent-encoded), and the
+     * file's MIME type goes in {@code Content-Type}. The supplied
+     * {@link UploadHandler}'s configured per-file size limit therefore applies
+     * unchanged.
+     *
+     * <p>
+     * Unlike {@link #onPaste(Component, SerializableConsumer) onPaste}, the
+     * file variant does not offer an "ignore pastes into form fields" option:
+     * browsers never paste files into an {@code <input>} or {@code <textarea>},
+     * so there is no native paste behaviour to compete with, and a paste
+     * containing a file in a focused text field is still a "the user dropped a
+     * file on the page" event from the application's point of view.
+     *
+     * <p>
+     * This API is independent of
+     * {@link #onPaste(Component, SerializableConsumer) onPaste}. A paste that
+     * carries both files and text fires both listeners when both are
+     * registered.
+     *
+     * <p>
+     * Example:
+     *
+     * <pre>{@code
+     * Clipboard.onFilePaste(this, UploadHandler.inMemory((meta, bytes) -> {
+     *     store(meta.fileName(), bytes);
+     * }));
+     * }</pre>
+     *
+     * @param component
+     *            the component to listen for paste events on, not {@code null}
+     * @param handler
+     *            the upload handler invoked per pasted file, not {@code null}
+     * @return a {@link Registration} whose {@link Registration#remove() remove}
+     *         detaches the paste listener and discards the per-registration
+     *         upload URL
+     */
+    public static Registration onFilePaste(Component component,
+            UploadHandler handler) {
+        Objects.requireNonNull(component, "component must not be null");
+        Objects.requireNonNull(handler, "handler must not be null");
+        return registerFilePaste(component, handler);
+    }
+
     private static Registration register(Component host, PasteOptions options,
             SerializableConsumer<PasteEvent> listener) {
         DomListenerRegistration registration = host.getElement()
@@ -209,5 +315,40 @@ public final class Clipboard implements Serializable {
             registration.setFilter(PASTE_FILTER_SKIP_EDITABLE);
         }
         return registration::remove;
+    }
+
+    private static Registration registerFilePaste(Component host,
+            UploadHandler handler) {
+        Element element = host.getElement();
+        // setAttribute(name, ElementRequestHandler) registers the handler as
+        // a stream resource and stores its URL as the attribute value. The
+        // counter scopes the slot per-registration so multiple file-paste
+        // listeners on the same element resolve to independent URLs.
+        String attributeName = "_vaadin-paste-upload-"
+                + FILE_PASTE_COUNTER.incrementAndGet();
+        element.setAttribute(attributeName, handler);
+
+        // The filter expression calls into the TS helper
+        // window.Vaadin.Flow.clipboard.uploadPastedFiles (defined in
+        // flow-client/Clipboard.ts, registered at bootstrap), passing the
+        // event, host element, and per-registration attribute name from which
+        // the helper reads the upload URL. The helper does the XHR-per-file
+        // work and always returns false: there is no server-side paste event
+        // for this API — completion is delivered per file via the
+        // UploadHandler callback as each XHR finishes.
+        String filterExpr = "window.Vaadin.Flow.clipboard.uploadPastedFiles(event,element,'"
+                + attributeName + "')";
+
+        DomListenerRegistration registration = element.addEventListener("paste",
+                domEvent -> {
+                    // Never called: the filter always returns false, so no
+                    // server event is dispatched. The listener exists solely
+                    // to anchor the JS filter expression on the element.
+                });
+        registration.setFilter(filterExpr);
+        return () -> {
+            registration.remove();
+            element.removeAttribute(attributeName);
+        };
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteComplete.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteComplete.java
@@ -18,17 +18,36 @@ package com.vaadin.flow.component.clipboard;
 import java.io.Serializable;
 
 /**
- * Fired by the {@code onComplete} step of a {@link PasteFileHandler#session()}
+ * Fired by the {@code onComplete} step of a {@link PasteFileHandler#batch()}
  * once all expected files of a paste have been delivered to the {@code onFile}
  * step.
  * <p>
  * "Expected" comes from the browser's {@link Clipboard#PASTE_FILE_COUNT_HEADER}
  * value; uploads that fail in transit (network errors, rejected uploads) never
  * arrive at the server and therefore do not count, so a paste with a lost
- * upload never fires {@code onComplete}. Sessions for different pastes are
+ * upload never fires {@code onComplete}. Batches for different pastes are
  * independent: a paste continues delivering files (and eventually fires
- * {@code onComplete}) even when a newer paste's session has already started
+ * {@code onComplete}) even when a newer paste's batch has already started
  * &mdash; the two complete on their own timelines.
+ * <p>
+ * {@code onComplete} reflects only the files this batch successfully received;
+ * it is not a server-side error channel. To observe per-file outcomes &mdash;
+ * including server-side processing failures &mdash; pass a custom
+ * {@link com.vaadin.flow.server.streams.UploadHandler UploadHandler} (or a
+ * {@link com.vaadin.flow.server.streams.TransferProgressListener
+ * TransferProgressListener}) to
+ * {@link Clipboard#onFilePaste(com.vaadin.flow.component.Component, com.vaadin.flow.server.streams.UploadHandler)
+ * onFilePaste} and react to each upload there, e.g.:
+ *
+ * <pre>{@code
+ * UploadHandler.inMemory((metadata, bytes) -> {
+ *     // handle the bytes
+ * }).whenComplete(success -> {
+ *     if (!success) {
+ *         // handle the server-side error
+ *     }
+ * });
+ * }</pre>
  *
  * @param pasteId
  *            the paste sequence number that just finished delivering

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteComplete.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteComplete.java
@@ -25,10 +25,10 @@ import java.io.Serializable;
  * "Expected" comes from the browser's {@link Clipboard#PASTE_FILE_COUNT_HEADER}
  * value; uploads that fail in transit (network errors, rejected uploads) never
  * arrive at the server and therefore do not count, so a paste with a lost
- * upload never fires {@code onComplete}. Starting a newer paste supersedes an
- * older one that has not finished: the superseded paste is abandoned (its
- * {@code onComplete} never fires) and any late upload of it is dropped, so a
- * stalled or malformed batch cannot linger.
+ * upload never fires {@code onComplete}. Batches for different pastes are
+ * independent: a paste keeps delivering files (and eventually fires
+ * {@code onComplete}) even when a newer paste's batch has already started
+ * &mdash; the two complete on their own timelines.
  * <p>
  * {@code onComplete} reflects only the files this batch successfully received;
  * it is not a server-side error channel. To observe per-file outcomes &mdash;

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteComplete.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteComplete.java
@@ -25,10 +25,10 @@ import java.io.Serializable;
  * "Expected" comes from the browser's {@link Clipboard#PASTE_FILE_COUNT_HEADER}
  * value; uploads that fail in transit (network errors, rejected uploads) never
  * arrive at the server and therefore do not count, so a paste with a lost
- * upload never fires {@code onComplete}. Batches for different pastes are
- * independent: a paste continues delivering files (and eventually fires
- * {@code onComplete}) even when a newer paste's batch has already started
- * &mdash; the two complete on their own timelines.
+ * upload never fires {@code onComplete}. Starting a newer paste supersedes an
+ * older one that has not finished: the superseded paste is abandoned (its
+ * {@code onComplete} never fires) and any late upload of it is dropped, so a
+ * stalled or malformed batch cannot linger.
  * <p>
  * {@code onComplete} reflects only the files this batch successfully received;
  * it is not a server-side error channel. To observe per-file outcomes &mdash;

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteComplete.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteComplete.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.clipboard;
+
+import java.io.Serializable;
+
+/**
+ * Fired by the {@code onComplete} step of a {@link PasteFileHandler#session()}
+ * once all expected files of a paste have been delivered to the {@code onFile}
+ * step.
+ * <p>
+ * "Expected" comes from the browser's {@link Clipboard#PASTE_FILE_COUNT_HEADER}
+ * value; uploads that fail in transit (network errors, rejected uploads) never
+ * arrive at the server and therefore do not count, so a paste with a lost
+ * upload never fires {@code onComplete}. Sessions for different pastes are
+ * independent: a paste continues delivering files (and eventually fires
+ * {@code onComplete}) even when a newer paste's session has already started
+ * &mdash; the two complete on their own timelines.
+ *
+ * @param pasteId
+ *            the paste sequence number that just finished delivering
+ * @param receivedFiles
+ *            the number of files actually delivered for this paste; equals the
+ *            {@link PasteStart#totalFiles()} value the paste started with
+ */
+public record PasteComplete(long pasteId,
+        int receivedFiles) implements Serializable {
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteEvent.java
@@ -50,7 +50,10 @@ import com.vaadin.flow.dom.Element;
  * Files and binary clipboard items (pasted screenshots, files dragged from the
  * OS file picker, anything that arrives as {@code event.clipboardData.files} or
  * a {@code DataTransferItem} of kind {@code "file"}) are not delivered by this
- * event. File-paste support is tracked separately.
+ * event. Register file pastes through
+ * {@link Clipboard#onFilePaste(Component, com.vaadin.flow.server.streams.UploadHandler)
+ * Clipboard.onFilePaste} instead; the same paste gesture fires both listeners
+ * when both are registered.
  *
  * <h2>Browser caveats</h2>
  *

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteFile.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteFile.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.clipboard;
+
+import java.io.Serializable;
+
+import org.jspecify.annotations.Nullable;
+
+import com.vaadin.flow.function.SerializableConsumer;
+
+/**
+ * A single file delivered to a {@link Clipboard#onFilePaste} listener through
+ * {@link PasteFileHandler#inMemory(SerializableConsumer)
+ * PasteFileHandler.inMemory} or the {@code onFile} step of a
+ * {@link PasteFileHandler#session() session}. Carries the file's bytes plus the
+ * metadata needed to render it ({@link #fileName()}, {@link #contentType()},
+ * {@link #size()}) and the correlation needed to group it with the rest of the
+ * paste it came from ({@link #pasteId()}, {@link #newPaste()},
+ * {@link #totalFiles()}).
+ * <p>
+ * The {@link #pasteId() paste id} is the monotonic sequence number emitted by
+ * the client paste-upload helper (see {@link Clipboard#PASTE_ID_HEADER}). All
+ * files originating from the same paste gesture share one id; subsequent pastes
+ * carry strictly larger ids. {@link #newPaste()} is {@code true} on the first
+ * file of each paste to reach the listener. Every file the browser uploads is
+ * delivered &mdash; pastes do not cancel each other even when their uploads
+ * interleave in transit, so application code wanting a "show the latest paste
+ * only" UI tracks the highest paste id seen and filters in its own callback.
+ *
+ * @param pasteId
+ *            the paste sequence number this file belongs to
+ * @param newPaste
+ *            whether this is the first file of a new paste reaching the
+ *            listener; subsequent files of the same paste arrive with
+ *            {@code false}
+ * @param totalFiles
+ *            the total number of files the originating paste contained, as
+ *            reported by the browser (see
+ *            {@link Clipboard#PASTE_FILE_COUNT_HEADER})
+ * @param fileName
+ *            the original file name as reported by the browser
+ * @param contentType
+ *            the MIME type as reported by the browser, or {@code null} when the
+ *            browser did not provide one
+ * @param size
+ *            the size of the uploaded body in bytes
+ * @param bytes
+ *            the uploaded body
+ */
+public record PasteFile(long pasteId, boolean newPaste, int totalFiles,
+        String fileName, @Nullable String contentType, long size,
+        byte[] bytes) implements Serializable {
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteFile.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteFile.java
@@ -35,10 +35,13 @@ import com.vaadin.flow.function.SerializableConsumer;
  * the client paste-upload helper (see {@link Clipboard#PASTE_ID_HEADER}). All
  * files originating from the same paste gesture share one id; subsequent pastes
  * carry strictly larger ids. {@link #newPaste()} is {@code true} on the first
- * file of each paste to reach the listener. Every file the browser uploads is
- * delivered &mdash; pastes do not cancel each other even when their uploads
- * interleave in transit, so application code wanting a "show the latest paste
- * only" UI tracks the highest paste id seen and filters in its own callback.
+ * file of each paste to reach the listener. Starting a newer paste supersedes
+ * an older one that has not finished, and a late file from a superseded paste
+ * is dropped, so the listener only ever sees files of the most recent paste.
+ * <p>
+ * {@link #fileName()} is supplied by the browser and is <em>not</em> sanitized;
+ * treat it as untrusted and never use it directly as a filesystem path without
+ * sanitizing it first.
  *
  * @param pasteId
  *            the paste sequence number this file belongs to

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteFile.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteFile.java
@@ -35,9 +35,10 @@ import com.vaadin.flow.function.SerializableConsumer;
  * the client paste-upload helper (see {@link Clipboard#PASTE_ID_HEADER}). All
  * files originating from the same paste gesture share one id; subsequent pastes
  * carry strictly larger ids. {@link #newPaste()} is {@code true} on the first
- * file of each paste to reach the listener. Starting a newer paste supersedes
- * an older one that has not finished, and a late file from a superseded paste
- * is dropped, so the listener only ever sees files of the most recent paste.
+ * file of each paste to reach the listener. Every file the browser uploads is
+ * delivered and pastes complete independently, even when their uploads
+ * interleave in transit, so application code wanting a "show the latest paste
+ * only" UI tracks the highest paste id seen and filters in its own callback.
  * <p>
  * {@link #fileName()} is supplied by the browser and is <em>not</em> sanitized;
  * treat it as untrusted and never use it directly as a filesystem path without

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteFile.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteFile.java
@@ -23,9 +23,9 @@ import com.vaadin.flow.function.SerializableConsumer;
 
 /**
  * A single file delivered to a {@link Clipboard#onFilePaste} listener through
- * {@link PasteFileHandler#inMemory(SerializableConsumer)
- * PasteFileHandler.inMemory} or the {@code onFile} step of a
- * {@link PasteFileHandler#session() session}. Carries the file's bytes plus the
+ * {@link PasteFileHandler#perFile(SerializableConsumer)
+ * PasteFileHandler.perFile} or the {@code onFile} step of a
+ * {@link PasteFileHandler#batch() batch}. Carries the file's bytes plus the
  * metadata needed to render it ({@link #fileName()}, {@link #contentType()},
  * {@link #size()}) and the correlation needed to group it with the rest of the
  * paste it came from ({@link #pasteId()}, {@link #newPaste()},

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteFileHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteFileHandler.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.clipboard;
+
+import java.io.InputStream;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.server.streams.UploadHandler;
+
+/**
+ * Factory for paste-aware {@link UploadHandler}s that group the parallel fetch
+ * uploads of a single paste gesture and surface the result to application code.
+ * Two flavours are offered, both producing an {@code UploadHandler} suitable
+ * for
+ * {@link Clipboard#onFilePaste(com.vaadin.flow.component.Component, UploadHandler)
+ * Clipboard.onFilePaste}:
+ *
+ * <ul>
+ * <li>{@link #inMemory(SerializableConsumer)} &mdash; a single per-file
+ * callback that receives every file as a {@link PasteFile}, with
+ * {@link PasteFile#newPaste()} flagging the first file of each paste.</li>
+ * <li>{@link #session()} &mdash; a three-step session listener: {@code onStart}
+ * fires once per paste with the declared file count, {@code onFile} fires per
+ * file, and {@code onComplete} fires once after the last file has been
+ * delivered.</li>
+ * </ul>
+ *
+ * Each paste runs in its own session: pastes that overlap in transit (the tail
+ * of an older paste's uploads arriving after a newer paste has started) still
+ * run through their own {@code onStart} / {@code onFile} / {@code onComplete}
+ * lifecycle. Sessions live in memory until they receive all the files the
+ * browser declared in {@link Clipboard#PASTE_FILE_COUNT_HEADER}; a paste whose
+ * upload fails mid-flight stays open indefinitely (rare in practice, since
+ * uploads are small, but worth knowing if an application keeps a process alive
+ * for months).
+ * <p>
+ * Application code that wants "show the latest paste only" semantics tracks the
+ * highest paste id seen and filters in its own callbacks &mdash; the handler
+ * does not drop any files on the application's behalf, so a slow tail upload
+ * from an earlier paste still arrives at the listener.
+ */
+public final class PasteFileHandler implements Serializable {
+
+    private PasteFileHandler() {
+        // factory
+    }
+
+    /**
+     * Builds an {@link UploadHandler} that reads each upload fully into memory,
+     * packages it as a {@link PasteFile}, and delivers it to the supplied
+     * consumer on the UI thread.
+     *
+     * @param consumer
+     *            invoked for each accepted file on the UI thread, not
+     *            {@code null}
+     * @return an upload handler suitable for
+     *         {@link Clipboard#onFilePaste(com.vaadin.flow.component.Component, UploadHandler)
+     *         Clipboard.onFilePaste}
+     */
+    public static UploadHandler inMemory(
+            SerializableConsumer<PasteFile> consumer) {
+        Objects.requireNonNull(consumer, "consumer must not be null");
+        return session().onFile(consumer).build();
+    }
+
+    /**
+     * Starts a session-style handler builder that emits {@code onStart} once
+     * per paste before any file, {@code onFile} per file, and
+     * {@code onComplete} once the paste's declared file count has been
+     * delivered. Any callback may be omitted.
+     *
+     * @return a fresh, unconfigured session builder
+     */
+    public static SessionBuilder session() {
+        return new SessionBuilder();
+    }
+
+    /**
+     * Fluent builder for the session-style paste handler. See
+     * {@link PasteFileHandler#session()} for the listener semantics. Successive
+     * calls to the same {@code onX} method overwrite earlier registrations;
+     * omitted steps default to no-ops.
+     */
+    public static final class SessionBuilder implements Serializable {
+
+        private SerializableConsumer<PasteStart> onStart = start -> {
+        };
+        private SerializableConsumer<PasteFile> onFile = file -> {
+        };
+        private SerializableConsumer<PasteComplete> onComplete = end -> {
+        };
+
+        private SessionBuilder() {
+        }
+
+        /**
+         * Registers the {@code onStart} step, fired once per paste before the
+         * paste's first {@link PasteFile} is delivered.
+         *
+         * @param handler
+         *            consumer invoked on the UI thread; pass {@code null} to
+         *            reset to a no-op
+         * @return this builder
+         */
+        public SessionBuilder onStart(
+                SerializableConsumer<PasteStart> handler) {
+            this.onStart = handler != null ? handler : start -> {
+            };
+            return this;
+        }
+
+        /**
+         * Registers the {@code onFile} step, fired once per accepted file with
+         * the file's bytes and metadata.
+         *
+         * @param handler
+         *            consumer invoked on the UI thread; pass {@code null} to
+         *            reset to a no-op
+         * @return this builder
+         */
+        public SessionBuilder onFile(SerializableConsumer<PasteFile> handler) {
+            this.onFile = handler != null ? handler : file -> {
+            };
+            return this;
+        }
+
+        /**
+         * Registers the {@code onComplete} step, fired once after the paste's
+         * declared file count has been delivered to
+         * {@link #onFile(SerializableConsumer) onFile}.
+         *
+         * @param handler
+         *            consumer invoked on the UI thread; pass {@code null} to
+         *            reset to a no-op
+         * @return this builder
+         */
+        public SessionBuilder onComplete(
+                SerializableConsumer<PasteComplete> handler) {
+            this.onComplete = handler != null ? handler : end -> {
+            };
+            return this;
+        }
+
+        /**
+         * Returns an {@link UploadHandler} that orchestrates the configured
+         * session steps. The returned handler is independent of this builder;
+         * further mutations to the builder do not affect it.
+         */
+        public UploadHandler build() {
+            // Per-handler session map keyed by paste id. All access happens
+            // inside event.getUI().access, which runs on the UI thread, so
+            // a plain HashMap is enough — no extra synchronisation needed.
+            // Each paste id gets its own SessionState that lives until the
+            // paste delivers all its declared files (PASTE_FILE_COUNT_HEADER).
+            // Pastes do not interfere with each other: a slow tail upload
+            // from an earlier paste still resolves through its own session.
+            Map<Long, SessionState> sessions = new HashMap<>();
+            SerializableConsumer<PasteStart> startHandler = onStart;
+            SerializableConsumer<PasteFile> fileHandler = onFile;
+            SerializableConsumer<PasteComplete> completeHandler = onComplete;
+            return event -> {
+                long pasteId = parsePasteId(event.getRequest()
+                        .getHeader(Clipboard.PASTE_ID_HEADER));
+                int totalFiles = parseFileCount(event.getRequest()
+                        .getHeader(Clipboard.PASTE_FILE_COUNT_HEADER));
+
+                byte[] data;
+                try (InputStream in = event.getInputStream()) {
+                    data = in.readAllBytes();
+                }
+
+                event.getUI().access(() -> {
+                    SessionState existing = sessions.get(pasteId);
+                    SessionState state;
+                    boolean newPaste;
+                    if (existing != null) {
+                        state = existing;
+                        newPaste = false;
+                    } else {
+                        state = new SessionState(totalFiles);
+                        sessions.put(pasteId, state);
+                        newPaste = true;
+                        startHandler
+                                .accept(new PasteStart(pasteId, totalFiles));
+                    }
+
+                    fileHandler.accept(new PasteFile(pasteId, newPaste,
+                            state.expected, event.getFileName(),
+                            event.getContentType(), event.getFileSize(), data));
+                    state.received++;
+
+                    if (state.expected > 0
+                            && state.received >= state.expected) {
+                        int received = state.received;
+                        sessions.remove(pasteId);
+                        completeHandler
+                                .accept(new PasteComplete(pasteId, received));
+                    }
+                });
+            };
+        }
+    }
+
+    private static final class SessionState implements Serializable {
+
+        final int expected;
+        int received;
+
+        SessionState(int expected) {
+            this.expected = expected;
+        }
+    }
+
+    private static long parsePasteId(String header) {
+        if (header == null || header.isEmpty()) {
+            return 0;
+        }
+        try {
+            return Long.parseLong(header);
+        } catch (NumberFormatException ignored) {
+            return 0;
+        }
+    }
+
+    private static int parseFileCount(String header) {
+        if (header == null || header.isEmpty()) {
+            return 0;
+        }
+        try {
+            return Integer.parseInt(header);
+        } catch (NumberFormatException ignored) {
+            return 0;
+        }
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteFileHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteFileHandler.java
@@ -33,19 +33,19 @@ import com.vaadin.flow.server.streams.UploadHandler;
  * Clipboard.onFilePaste}:
  *
  * <ul>
- * <li>{@link #inMemory(SerializableConsumer)} &mdash; a single per-file
- * callback that receives every file as a {@link PasteFile}, with
+ * <li>{@link #perFile(SerializableConsumer)} &mdash; a single per-file callback
+ * that receives every file as a {@link PasteFile}, with
  * {@link PasteFile#newPaste()} flagging the first file of each paste.</li>
- * <li>{@link #session()} &mdash; a three-step session listener: {@code onStart}
+ * <li>{@link #batch()} &mdash; a three-step batch listener: {@code onStart}
  * fires once per paste with the declared file count, {@code onFile} fires per
  * file, and {@code onComplete} fires once after the last file has been
  * delivered.</li>
  * </ul>
  *
- * Each paste runs in its own session: pastes that overlap in transit (the tail
- * of an older paste's uploads arriving after a newer paste has started) still
- * run through their own {@code onStart} / {@code onFile} / {@code onComplete}
- * lifecycle. Sessions live in memory until they receive all the files the
+ * Each paste runs as its own batch: pastes that overlap in transit (the tail of
+ * an older paste's uploads arriving after a newer paste has started) still run
+ * through their own {@code onStart} / {@code onFile} / {@code onComplete}
+ * lifecycle. A batch lives in memory until it receives all the files the
  * browser declared in {@link Clipboard#PASTE_FILE_COUNT_HEADER}; a paste whose
  * upload fails mid-flight stays open indefinitely (rare in practice, since
  * uploads are small, but worth knowing if an application keeps a process alive
@@ -74,31 +74,31 @@ public final class PasteFileHandler implements Serializable {
      *         {@link Clipboard#onFilePaste(com.vaadin.flow.component.Component, UploadHandler)
      *         Clipboard.onFilePaste}
      */
-    public static UploadHandler inMemory(
+    public static UploadHandler perFile(
             SerializableConsumer<PasteFile> consumer) {
         Objects.requireNonNull(consumer, "consumer must not be null");
-        return session().onFile(consumer).build();
+        return batch().onFile(consumer).build();
     }
 
     /**
-     * Starts a session-style handler builder that emits {@code onStart} once
-     * per paste before any file, {@code onFile} per file, and
-     * {@code onComplete} once the paste's declared file count has been
-     * delivered. Any callback may be omitted.
+     * Starts a batch handler builder that emits {@code onStart} once per paste
+     * before any file, {@code onFile} per file, and {@code onComplete} once the
+     * paste's declared file count has been delivered. Any callback may be
+     * omitted.
      *
-     * @return a fresh, unconfigured session builder
+     * @return a fresh, unconfigured batch builder
      */
-    public static SessionBuilder session() {
-        return new SessionBuilder();
+    public static BatchBuilder batch() {
+        return new BatchBuilder();
     }
 
     /**
-     * Fluent builder for the session-style paste handler. See
-     * {@link PasteFileHandler#session()} for the listener semantics. Successive
+     * Fluent builder for the batch paste handler. See
+     * {@link PasteFileHandler#batch()} for the listener semantics. Successive
      * calls to the same {@code onX} method overwrite earlier registrations;
      * omitted steps default to no-ops.
      */
-    public static final class SessionBuilder implements Serializable {
+    public static final class BatchBuilder implements Serializable {
 
         private SerializableConsumer<PasteStart> onStart = start -> {
         };
@@ -107,7 +107,7 @@ public final class PasteFileHandler implements Serializable {
         private SerializableConsumer<PasteComplete> onComplete = end -> {
         };
 
-        private SessionBuilder() {
+        private BatchBuilder() {
         }
 
         /**
@@ -119,8 +119,7 @@ public final class PasteFileHandler implements Serializable {
          *            reset to a no-op
          * @return this builder
          */
-        public SessionBuilder onStart(
-                SerializableConsumer<PasteStart> handler) {
+        public BatchBuilder onStart(SerializableConsumer<PasteStart> handler) {
             this.onStart = handler != null ? handler : start -> {
             };
             return this;
@@ -135,7 +134,7 @@ public final class PasteFileHandler implements Serializable {
          *            reset to a no-op
          * @return this builder
          */
-        public SessionBuilder onFile(SerializableConsumer<PasteFile> handler) {
+        public BatchBuilder onFile(SerializableConsumer<PasteFile> handler) {
             this.onFile = handler != null ? handler : file -> {
             };
             return this;
@@ -151,7 +150,7 @@ public final class PasteFileHandler implements Serializable {
          *            reset to a no-op
          * @return this builder
          */
-        public SessionBuilder onComplete(
+        public BatchBuilder onComplete(
                 SerializableConsumer<PasteComplete> handler) {
             this.onComplete = handler != null ? handler : end -> {
             };
@@ -160,18 +159,18 @@ public final class PasteFileHandler implements Serializable {
 
         /**
          * Returns an {@link UploadHandler} that orchestrates the configured
-         * session steps. The returned handler is independent of this builder;
+         * batch steps. The returned handler is independent of this builder;
          * further mutations to the builder do not affect it.
          */
         public UploadHandler build() {
-            // Per-handler session map keyed by paste id. All access happens
+            // Per-handler batch map keyed by paste id. All access happens
             // inside event.getUI().access, which runs on the UI thread, so
             // a plain HashMap is enough — no extra synchronisation needed.
-            // Each paste id gets its own SessionState that lives until the
+            // Each paste id gets its own BatchState that lives until the
             // paste delivers all its declared files (PASTE_FILE_COUNT_HEADER).
             // Pastes do not interfere with each other: a slow tail upload
-            // from an earlier paste still resolves through its own session.
-            Map<Long, SessionState> sessions = new HashMap<>();
+            // from an earlier paste still resolves through its own batch.
+            Map<Long, BatchState> batches = new HashMap<>();
             SerializableConsumer<PasteStart> startHandler = onStart;
             SerializableConsumer<PasteFile> fileHandler = onFile;
             SerializableConsumer<PasteComplete> completeHandler = onComplete;
@@ -187,15 +186,15 @@ public final class PasteFileHandler implements Serializable {
                 }
 
                 event.getUI().access(() -> {
-                    SessionState existing = sessions.get(pasteId);
-                    SessionState state;
+                    BatchState existing = batches.get(pasteId);
+                    BatchState state;
                     boolean newPaste;
                     if (existing != null) {
                         state = existing;
                         newPaste = false;
                     } else {
-                        state = new SessionState(totalFiles);
-                        sessions.put(pasteId, state);
+                        state = new BatchState(totalFiles);
+                        batches.put(pasteId, state);
                         newPaste = true;
                         startHandler
                                 .accept(new PasteStart(pasteId, totalFiles));
@@ -209,7 +208,7 @@ public final class PasteFileHandler implements Serializable {
                     if (state.expected > 0
                             && state.received >= state.expected) {
                         int received = state.received;
-                        sessions.remove(pasteId);
+                        batches.remove(pasteId);
                         completeHandler
                                 .accept(new PasteComplete(pasteId, received));
                     }
@@ -218,12 +217,12 @@ public final class PasteFileHandler implements Serializable {
         }
     }
 
-    private static final class SessionState implements Serializable {
+    private static final class BatchState implements Serializable {
 
         final int expected;
         int received;
 
-        SessionState(int expected) {
+        BatchState(int expected) {
             this.expected = expected;
         }
     }

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteFileHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteFileHandler.java
@@ -20,7 +20,10 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.server.streams.UploadHandler;
 
@@ -42,19 +45,29 @@ import com.vaadin.flow.server.streams.UploadHandler;
  * delivered.</li>
  * </ul>
  *
- * Each paste runs as its own batch: pastes that overlap in transit (the tail of
- * an older paste's uploads arriving after a newer paste has started) still run
- * through their own {@code onStart} / {@code onFile} / {@code onComplete}
- * lifecycle. A batch lives in memory until it receives all the files the
- * browser declared in {@link Clipboard#PASTE_FILE_COUNT_HEADER}; a paste whose
- * upload fails mid-flight stays open indefinitely (rare in practice, since
- * uploads are small, but worth knowing if an application keeps a process alive
- * for months).
- * <p>
- * Application code that wants "show the latest paste only" semantics tracks the
- * highest paste id seen and filters in its own callbacks &mdash; the handler
- * does not drop any files on the application's behalf, so a slow tail upload
- * from an earlier paste still arrives at the listener.
+ * The latest paste wins: pastes are tracked per owning component, and starting
+ * a newer paste supersedes any older one that has not finished yet. A late
+ * upload belonging to a superseded paste is dropped rather than reopening a
+ * finished or abandoned batch, so a paste whose declared file count never
+ * arrives (a stalled upload, or a missing/garbage
+ * {@link Clipboard#PASTE_FILE_COUNT_HEADER}) cannot accumulate &mdash; the next
+ * paste evicts it, and in any case the state lives and dies with the component.
+ * The trade-off is that two pastes overlapping in transit no longer complete on
+ * independent timelines; in practice pastes are small and serial, so the newer
+ * one superseding the older is the desired behaviour.
+ *
+ * <h2>Resource notes</h2>
+ *
+ * <ul>
+ * <li>{@link #perFile(SerializableConsumer)} and the {@code onFile} step of
+ * {@link #batch()} read each uploaded file <em>fully into memory</em> as a
+ * {@code byte[]} before invoking the callback. A very large paste is therefore
+ * held entirely in heap; cap it with the request/file size limits on a custom
+ * {@link UploadHandler}, or read the stream yourself, when that matters.</li>
+ * <li>{@link PasteFile#fileName()} is the browser-supplied name and is not
+ * sanitized. Treat it as untrusted &mdash; never use it directly as a
+ * filesystem path without sanitizing it first.</li>
+ * </ul>
  */
 public final class PasteFileHandler implements Serializable {
 
@@ -163,14 +176,14 @@ public final class PasteFileHandler implements Serializable {
          * further mutations to the builder do not affect it.
          */
         public UploadHandler build() {
-            // Per-handler batch map keyed by paste id. All access happens
-            // inside event.getUI().access, which runs on the UI thread, so
-            // a plain HashMap is enough — no extra synchronisation needed.
-            // Each paste id gets its own BatchState that lives until the
-            // paste delivers all its declared files (PASTE_FILE_COUNT_HEADER).
-            // Pastes do not interfere with each other: a slow tail upload
-            // from an earlier paste still resolves through its own batch.
-            Map<Long, BatchState> batches = new HashMap<>();
+            // The batch state is stored on the owning component (Clipboard
+            // #onFilePaste always registers against one) rather than in this
+            // handler, so a handler instance shared across components or UIs
+            // cannot accumulate state: the batches live and die with the
+            // component. The key is unique per build() so several handlers on
+            // the same component stay independent.
+            String batchesKey = PasteFileHandler.class.getName() + "$batches$"
+                    + UUID.randomUUID();
             SerializableConsumer<PasteStart> startHandler = onStart;
             SerializableConsumer<PasteFile> fileHandler = onFile;
             SerializableConsumer<PasteComplete> completeHandler = onComplete;
@@ -179,6 +192,7 @@ public final class PasteFileHandler implements Serializable {
                         .getHeader(Clipboard.PASTE_ID_HEADER));
                 int totalFiles = parseFileCount(event.getRequest()
                         .getHeader(Clipboard.PASTE_FILE_COUNT_HEADER));
+                Component owner = event.getOwningComponent();
 
                 byte[] data;
                 try (InputStream in = event.getInputStream()) {
@@ -186,35 +200,82 @@ public final class PasteFileHandler implements Serializable {
                 }
 
                 event.getUI().access(() -> {
-                    BatchState existing = batches.get(pasteId);
-                    BatchState state;
+                    // All access runs on the UI thread holding the session
+                    // lock, and the state is scoped to this component, so a
+                    // plain map needs no extra synchronisation.
+                    ComponentBatches state = componentBatches(owner,
+                            batchesKey);
+
+                    // A paste id below the high-water mark is a late upload
+                    // from
+                    // a paste a newer one already superseded; drop it so it
+                    // cannot resurrect a finished batch.
+                    if (pasteId < state.maxPasteId) {
+                        return;
+                    }
+                    if (pasteId > state.maxPasteId) {
+                        state.maxPasteId = pasteId;
+                        // A newer paste drops older, still-unfinished batches
+                        // so
+                        // a malformed or never-completing one (e.g. a missing
+                        // or
+                        // bogus X-Paste-File-Count that leaves expected == 0)
+                        // cannot pile up.
+                        state.batches.keySet().removeIf(id -> id < pasteId);
+                    }
+
+                    BatchState batch = state.batches.get(pasteId);
                     boolean newPaste;
-                    if (existing != null) {
-                        state = existing;
+                    if (batch != null) {
                         newPaste = false;
                     } else {
-                        state = new BatchState(totalFiles);
-                        batches.put(pasteId, state);
+                        batch = new BatchState(totalFiles);
+                        state.batches.put(pasteId, batch);
                         newPaste = true;
                         startHandler
                                 .accept(new PasteStart(pasteId, totalFiles));
                     }
 
                     fileHandler.accept(new PasteFile(pasteId, newPaste,
-                            state.expected, event.getFileName(),
+                            batch.expected, event.getFileName(),
                             event.getContentType(), event.getFileSize(), data));
-                    state.received++;
+                    batch.received++;
 
-                    if (state.expected > 0
-                            && state.received >= state.expected) {
-                        int received = state.received;
-                        batches.remove(pasteId);
+                    if (batch.expected > 0
+                            && batch.received >= batch.expected) {
+                        int received = batch.received;
+                        state.batches.remove(pasteId);
                         completeHandler
                                 .accept(new PasteComplete(pasteId, received));
                     }
                 });
             };
         }
+    }
+
+    private static ComponentBatches componentBatches(Component owner,
+            String key) {
+        if (owner == null) {
+            // Unreachable through Clipboard.onFilePaste, which always registers
+            // against a component; guard so misuse fails loudly instead of
+            // silently leaking state in a handler-owned map.
+            throw new IllegalStateException(
+                    "PasteFileHandler requires an owning component; "
+                            + "use Clipboard.onFilePaste to register it");
+        }
+        ComponentBatches state = (ComponentBatches) ComponentUtil.getData(owner,
+                key);
+        if (state == null) {
+            state = new ComponentBatches();
+            ComponentUtil.setData(owner, key, state);
+        }
+        return state;
+    }
+
+    private static final class ComponentBatches implements Serializable {
+
+        final Map<Long, BatchState> batches = new HashMap<>();
+        long maxPasteId;
     }
 
     private static final class BatchState implements Serializable {

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteFileHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteFileHandler.java
@@ -17,7 +17,8 @@ package com.vaadin.flow.component.clipboard;
 
 import java.io.InputStream;
 import java.io.Serializable;
-import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
@@ -45,16 +46,23 @@ import com.vaadin.flow.server.streams.UploadHandler;
  * delivered.</li>
  * </ul>
  *
- * The latest paste wins: pastes are tracked per owning component, and starting
- * a newer paste supersedes any older one that has not finished yet. A late
- * upload belonging to a superseded paste is dropped rather than reopening a
- * finished or abandoned batch, so a paste whose declared file count never
- * arrives (a stalled upload, or a missing/garbage
- * {@link Clipboard#PASTE_FILE_COUNT_HEADER}) cannot accumulate &mdash; the next
- * paste evicts it, and in any case the state lives and dies with the component.
- * The trade-off is that two pastes overlapping in transit no longer complete on
- * independent timelines; in practice pastes are small and serial, so the newer
- * one superseding the older is the desired behaviour.
+ * Each paste runs as its own batch and completes on its own timeline: pastes
+ * that overlap in transit (the tail of an older paste's uploads arriving after
+ * a newer paste has started) still run through their own {@code onStart} /
+ * {@code onFile} / {@code onComplete} lifecycle, and no file is dropped on the
+ * application's behalf. Batch state is tracked per owning component, so it is
+ * released when the component is detached or the session ends rather than
+ * living in the handler &mdash; a handler instance shared across components or
+ * UIs cannot accumulate state. As a further bound, only a limited number of
+ * unfinished pastes are tracked per component at once: if a paste's declared
+ * {@link Clipboard#PASTE_FILE_COUNT_HEADER} count never fully arrives (a
+ * stalled upload, or a missing/garbage header), the oldest such batch is
+ * dropped once that many are open. The limit is far above any real overlap, so
+ * it only ever trims abandoned or malformed batches.
+ * <p>
+ * Application code that wants "show the latest paste only" semantics tracks the
+ * highest paste id seen and filters in its own callbacks &mdash; the handler
+ * does not drop any files of a live paste on the application's behalf.
  *
  * <h2>Resource notes</h2>
  *
@@ -70,6 +78,12 @@ import com.vaadin.flow.server.streams.UploadHandler;
  * </ul>
  */
 public final class PasteFileHandler implements Serializable {
+
+    // Upper bound on the number of unfinished pastes tracked per component at
+    // once. Real overlap is a handful of pastes, so this only bounds memory
+    // against abandoned or malformed batches; once this many are open, starting
+    // another drops the oldest still-unfinished one.
+    private static final int MAX_TRACKED_BATCHES = 16;
 
     private PasteFileHandler() {
         // factory
@@ -203,34 +217,30 @@ public final class PasteFileHandler implements Serializable {
                     // All access runs on the UI thread holding the session
                     // lock, and the state is scoped to this component, so a
                     // plain map needs no extra synchronisation.
-                    ComponentBatches state = componentBatches(owner,
+                    Map<Long, BatchState> batches = componentBatches(owner,
                             batchesKey);
 
-                    // A paste id below the high-water mark is a late upload
-                    // from
-                    // a paste a newer one already superseded; drop it so it
-                    // cannot resurrect a finished batch.
-                    if (pasteId < state.maxPasteId) {
-                        return;
-                    }
-                    if (pasteId > state.maxPasteId) {
-                        state.maxPasteId = pasteId;
-                        // A newer paste drops older, still-unfinished batches
-                        // so
-                        // a malformed or never-completing one (e.g. a missing
-                        // or
-                        // bogus X-Paste-File-Count that leaves expected == 0)
-                        // cannot pile up.
-                        state.batches.keySet().removeIf(id -> id < pasteId);
-                    }
-
-                    BatchState batch = state.batches.get(pasteId);
+                    BatchState batch = batches.get(pasteId);
                     boolean newPaste;
                     if (batch != null) {
                         newPaste = false;
                     } else {
                         batch = new BatchState(totalFiles);
-                        state.batches.put(pasteId, batch);
+                        // Bound the number of unfinished pastes tracked at once
+                        // so batches whose declared X-Paste-File-Count never
+                        // fully arrives (a stalled upload, or a missing/garbage
+                        // header that leaves expected == 0) cannot pile up.
+                        // Genuine overlap is a handful of pastes, well under
+                        // the
+                        // cap, so this only ever trims abandoned batches and
+                        // does not affect pastes completing on their own
+                        // timelines.
+                        if (batches.size() >= MAX_TRACKED_BATCHES) {
+                            Iterator<Long> oldest = batches.keySet().iterator();
+                            oldest.next();
+                            oldest.remove();
+                        }
+                        batches.put(pasteId, batch);
                         newPaste = true;
                         startHandler
                                 .accept(new PasteStart(pasteId, totalFiles));
@@ -244,7 +254,7 @@ public final class PasteFileHandler implements Serializable {
                     if (batch.expected > 0
                             && batch.received >= batch.expected) {
                         int received = batch.received;
-                        state.batches.remove(pasteId);
+                        batches.remove(pasteId);
                         completeHandler
                                 .accept(new PasteComplete(pasteId, received));
                     }
@@ -253,7 +263,8 @@ public final class PasteFileHandler implements Serializable {
         }
     }
 
-    private static ComponentBatches componentBatches(Component owner,
+    @SuppressWarnings("unchecked")
+    private static Map<Long, BatchState> componentBatches(Component owner,
             String key) {
         if (owner == null) {
             // Unreachable through Clipboard.onFilePaste, which always registers
@@ -263,19 +274,14 @@ public final class PasteFileHandler implements Serializable {
                     "PasteFileHandler requires an owning component; "
                             + "use Clipboard.onFilePaste to register it");
         }
-        ComponentBatches state = (ComponentBatches) ComponentUtil.getData(owner,
-                key);
-        if (state == null) {
-            state = new ComponentBatches();
-            ComponentUtil.setData(owner, key, state);
+        Map<Long, BatchState> batches = (Map<Long, BatchState>) ComponentUtil
+                .getData(owner, key);
+        if (batches == null) {
+            // Insertion-ordered so the cap can evict the oldest open batch.
+            batches = new LinkedHashMap<>();
+            ComponentUtil.setData(owner, key, batches);
         }
-        return state;
-    }
-
-    private static final class ComponentBatches implements Serializable {
-
-        final Map<Long, BatchState> batches = new HashMap<>();
-        long maxPasteId;
+        return batches;
     }
 
     private static final class BatchState implements Serializable {

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteStart.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteStart.java
@@ -23,9 +23,9 @@ import java.io.Serializable;
  * delivered. Carries the paste correlation token and the total file count the
  * browser declared (so a UI can show "0 / N" before any file has arrived).
  * <p>
- * Each paste id gets its own batch, so {@code onStart} fires exactly once per
- * paste; late uploads from an earlier paste keep arriving against that paste's
- * already-started batch and do not regenerate a start event.
+ * {@code onStart} fires exactly once per paste. Starting a newer paste
+ * supersedes an older unfinished one, and any late upload of a superseded paste
+ * is dropped, so a start event is never regenerated for an old paste.
  *
  * @param pasteId
  *            the paste sequence number; matches the {@link PasteFile#pasteId()}

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteStart.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteStart.java
@@ -23,9 +23,9 @@ import java.io.Serializable;
  * delivered. Carries the paste correlation token and the total file count the
  * browser declared (so a UI can show "0 / N" before any file has arrived).
  * <p>
- * {@code onStart} fires exactly once per paste. Starting a newer paste
- * supersedes an older unfinished one, and any late upload of a superseded paste
- * is dropped, so a start event is never regenerated for an old paste.
+ * {@code onStart} fires exactly once per paste. Pastes are tracked
+ * independently, so a late upload from an earlier paste arrives against that
+ * paste's already-started batch and does not regenerate a start event.
  *
  * @param pasteId
  *            the paste sequence number; matches the {@link PasteFile#pasteId()}

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteStart.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteStart.java
@@ -18,14 +18,14 @@ package com.vaadin.flow.component.clipboard;
 import java.io.Serializable;
 
 /**
- * Fired by the {@code onStart} step of a {@link PasteFileHandler#session()}
- * once per paste, immediately before the paste's first {@link PasteFile} is
+ * Fired by the {@code onStart} step of a {@link PasteFileHandler#batch()} once
+ * per paste, immediately before the paste's first {@link PasteFile} is
  * delivered. Carries the paste correlation token and the total file count the
  * browser declared (so a UI can show "0 / N" before any file has arrived).
  * <p>
- * The handler keeps a high-water mark of observed paste ids; an {@code onStart}
- * fires only for the latest paste seen, so late uploads from an older paste do
- * not regenerate a start event.
+ * Each paste id gets its own batch, so {@code onStart} fires exactly once per
+ * paste; late uploads from an earlier paste keep arriving against that paste's
+ * already-started batch and do not regenerate a start event.
  *
  * @param pasteId
  *            the paste sequence number; matches the {@link PasteFile#pasteId()}

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteStart.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteStart.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.clipboard;
+
+import java.io.Serializable;
+
+/**
+ * Fired by the {@code onStart} step of a {@link PasteFileHandler#session()}
+ * once per paste, immediately before the paste's first {@link PasteFile} is
+ * delivered. Carries the paste correlation token and the total file count the
+ * browser declared (so a UI can show "0 / N" before any file has arrived).
+ * <p>
+ * The handler keeps a high-water mark of observed paste ids; an {@code onStart}
+ * fires only for the latest paste seen, so late uploads from an older paste do
+ * not regenerate a start event.
+ *
+ * @param pasteId
+ *            the paste sequence number; matches the {@link PasteFile#pasteId()}
+ *            of the files about to be delivered
+ * @param totalFiles
+ *            the number of files the browser said the paste contains
+ */
+public record PasteStart(long pasteId, int totalFiles) implements Serializable {
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/clipboard/ClipboardTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/clipboard/ClipboardTest.java
@@ -36,9 +36,15 @@ import com.vaadin.flow.dom.JsFunction;
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
 import com.vaadin.flow.internal.nodefeature.ReturnChannelRegistration;
+import com.vaadin.flow.server.MockVaadinServletService;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.server.streams.UploadHandler;
+import com.vaadin.flow.shared.Registration;
+import com.vaadin.tests.util.AlwaysLockedVaadinSession;
 import com.vaadin.tests.util.MockUI;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -367,6 +373,83 @@ class ClipboardTest {
         assertEquals(1, channels.size(),
                 "Expected exactly one captured return channel");
         return channels.get(0);
+    }
+
+    @Test
+    void onFilePaste_registersUploadAttributeAndPasteListenerWithUploadFilter() {
+        UI ui = uiWithRealSession();
+        TestButton target = new TestButton();
+        ui.getElement().appendChild(target.getElement());
+
+        Clipboard.onFilePaste(target, UploadHandler.inMemory((m, b) -> {
+        }));
+
+        // The handler is stored as a stream-resource-backed attribute named
+        // "_vaadin-paste-upload-*". The exact suffix comes from a static
+        // AtomicLong, so don't pin it — find the attribute by prefix.
+        String uploadAttribute = target.getElement().getAttributeNames()
+                .filter(n -> n.startsWith("_vaadin-paste-upload-")).findFirst()
+                .orElse(null);
+        assertNotNull(uploadAttribute,
+                "expected upload URL attribute on host element");
+        String url = target.getElement().getAttribute(uploadAttribute);
+        assertNotNull(url, "upload attribute resolved to a URL");
+        assertTrue(url.contains("VAADIN/dynamic/resource"),
+                "upload URL should point at the dynamic resource handler, got "
+                        + url);
+
+        // The paste listener carries a single filter expression: a call into
+        // the TS helper window.Vaadin.Flow.clipboard.uploadPastedFiles. The
+        // helper does the actual XHRs client-side; here we just verify the
+        // Java→TS wiring carries the per-registration attribute name.
+        String filter = target.getElement().getNode()
+                .getFeature(ElementListenerMap.class).getExpressions("paste")
+                .stream().filter(e -> e.contains("uploadPastedFiles"))
+                .findFirst().orElse(null);
+        assertNotNull(filter,
+                "expected file-paste filter expression on paste listener");
+        assertTrue(filter.contains("'" + uploadAttribute + "'"),
+                "filter should pass the per-registration upload attribute");
+        assertTrue(filter.contains("event") && filter.contains("element"),
+                "filter should hand the helper both event and element");
+    }
+
+    @Test
+    void onFilePaste_remove_clearsAttributeAndListener() {
+        UI ui = uiWithRealSession();
+        TestButton target = new TestButton();
+        ui.getElement().appendChild(target.getElement());
+
+        Registration registration = Clipboard.onFilePaste(target,
+                UploadHandler.inMemory((m, b) -> {
+                }));
+
+        String uploadAttribute = target.getElement().getAttributeNames()
+                .filter(n -> n.startsWith("_vaadin-paste-upload-")).findFirst()
+                .orElseThrow();
+
+        registration.remove();
+
+        assertFalse(target.getElement().hasAttribute(uploadAttribute),
+                "remove() should drop the upload URL attribute");
+        assertTrue(
+                target.getElement().getNode()
+                        .getFeature(ElementListenerMap.class)
+                        .getExpressions("paste").isEmpty(),
+                "remove() should drop the paste filter expression");
+    }
+
+    /**
+     * Builds a MockUI backed by a real VaadinSession so that
+     * {@link com.vaadin.flow.dom.Element#setAttribute(String, com.vaadin.flow.server.streams.ElementRequestHandler)}
+     * can register against the session's stream resource registry. The default
+     * MockUI uses a Mockito-mocked session whose registry is null.
+     */
+    private static UI uiWithRealSession() {
+        VaadinSession session = new AlwaysLockedVaadinSession(
+                new MockVaadinServletService());
+        VaadinSession.setCurrent(session);
+        return new MockUI(session);
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/component/clipboard/ClipboardTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/clipboard/ClipboardTest.java
@@ -376,7 +376,7 @@ class ClipboardTest {
     }
 
     @Test
-    void onFilePaste_registersUploadAttributeAndPasteListenerWithUploadFilter() {
+    void onFilePaste_registersUploadAttributeAndJsInitializer() {
         UI ui = uiWithRealSession();
         TestButton target = new TestButton();
         ui.getElement().appendChild(target.getElement());
@@ -385,8 +385,8 @@ class ClipboardTest {
         }));
 
         // The handler is stored as a stream-resource-backed attribute named
-        // "_vaadin-paste-upload-*". The exact suffix comes from a static
-        // AtomicLong, so don't pin it — find the attribute by prefix.
+        // "_vaadin-paste-upload-<uuid>". The UUID suffix is per-registration,
+        // so don't pin it — find the attribute by prefix.
         String uploadAttribute = target.getElement().getAttributeNames()
                 .filter(n -> n.startsWith("_vaadin-paste-upload-")).findFirst()
                 .orElse(null);
@@ -398,24 +398,22 @@ class ClipboardTest {
                 "upload URL should point at the dynamic resource handler, got "
                         + url);
 
-        // The paste listener carries a single filter expression: a call into
-        // the TS helper window.Vaadin.Flow.clipboard.uploadPastedFiles. The
-        // helper does the actual XHRs client-side; here we just verify the
-        // Java→TS wiring carries the per-registration attribute name.
-        String filter = target.getElement().getNode()
-                .getFeature(ElementListenerMap.class).getExpressions("paste")
-                .stream().filter(e -> e.contains("uploadPastedFiles"))
-                .findFirst().orElse(null);
-        assertNotNull(filter,
-                "expected file-paste filter expression on paste listener");
-        assertTrue(filter.contains("'" + uploadAttribute + "'"),
-                "filter should pass the per-registration upload attribute");
-        assertTrue(filter.contains("event") && filter.contains("element"),
-                "filter should hand the helper both event and element");
+        // The paste handling is installed via addJsInitializer: a native paste
+        // listener that delegates to the TS helper
+        // window.Vaadin.Flow.clipboard.uploadPastedFiles, capturing the
+        // per-registration attribute name so the helper can read the upload
+        // URL client-side.
+        JsFunction install = installFn(ui);
+        assertTrue(install.getBody().contains("uploadPastedFiles"),
+                "initializer should call the clipboard upload helper");
+        assertTrue(install.getBody().contains("addEventListener('paste'"),
+                "initializer should attach a native paste listener");
+        assertTrue(install.getCaptures().contains(uploadAttribute),
+                "initializer should capture the per-registration upload attribute");
     }
 
     @Test
-    void onFilePaste_remove_clearsAttributeAndListener() {
+    void onFilePaste_remove_clearsAttributeAndDisposesListener() {
         UI ui = uiWithRealSession();
         TestButton target = new TestButton();
         ui.getElement().appendChild(target.getElement());
@@ -427,16 +425,26 @@ class ClipboardTest {
         String uploadAttribute = target.getElement().getAttributeNames()
                 .filter(n -> n.startsWith("_vaadin-paste-upload-")).findFirst()
                 .orElseThrow();
+        // Flush the install first so the registration has actually emitted its
+        // initializer; removal then emits the matching dispose.
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+        ui.getInternals().dumpPendingJavaScriptInvocations();
 
         registration.remove();
 
         assertFalse(target.getElement().hasAttribute(uploadAttribute),
                 "remove() should drop the upload URL attribute");
+
+        // remove() tears down the native paste listener through the
+        // addJsInitializer dispose hook.
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+        List<PendingJavaScriptInvocation> afterRemove = ui.getInternals()
+                .dumpPendingJavaScriptInvocations();
         assertTrue(
-                target.getElement().getNode()
-                        .getFeature(ElementListenerMap.class)
-                        .getExpressions("paste").isEmpty(),
-                "remove() should drop the paste filter expression");
+                afterRemove.stream()
+                        .anyMatch(p -> p.getInvocation().getExpression()
+                                .contains("disposeInitializer")),
+                "remove() should dispose the JS paste initializer");
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/component/clipboard/PasteFileHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/clipboard/PasteFileHandlerTest.java
@@ -64,13 +64,12 @@ class PasteFileHandlerTest {
     }
 
     @Test
-    void batch_overlappingPastes_eachLifecycleStaysOrdered()
-            throws IOException {
+    void batch_overlappingPastes_newerSupersedesOlder() throws IOException {
         // Two pastes (2 files each) interleave on the wire:
         // paste 1 file A, paste 2 file X, paste 1 file B, paste 2 file Y.
-        // The framework must keep each paste's own sequence
-        // (start → file → file → complete) intact; cross-paste interleaving
-        // of the *order between* events is allowed.
+        // Starting paste 2 supersedes the still-unfinished paste 1, so paste
+        // 1's late file B is dropped and paste 1 never completes; only the
+        // newest paste is delivered.
         Fixture fixture = new Fixture();
         List<String> calls = new ArrayList<>();
         UploadHandler handler = PasteFileHandler.batch()
@@ -84,14 +83,11 @@ class PasteFileHandlerTest {
         fixture.fire(handler, 1, 2, "B");
         fixture.fire(handler, 2, 2, "Y");
 
-        // Per-paste lifecycle is preserved: paste 1 = start, A, B, complete;
-        // paste 2 = start, X, Y, complete. Across pastes, paste 2 starts and
-        // even completes before paste 1's last file lands, which is exactly
-        // the "no cancellation" promise: paste 1 still finishes cleanly.
-        assertEquals(
-                Arrays.asList("start:1", "file:1/A", "start:2", "file:2/X",
-                        "file:1/B", "complete:1", "file:2/Y", "complete:2"),
-                calls);
+        // paste 1 starts and delivers A, then paste 2 supersedes it: B (a late
+        // upload of the superseded paste) is dropped, paste 1 has no complete,
+        // and only paste 2 runs start → X → Y → complete.
+        assertEquals(Arrays.asList("start:1", "file:1/A", "start:2", "file:2/X",
+                "file:2/Y", "complete:2"), calls);
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/component/clipboard/PasteFileHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/clipboard/PasteFileHandlerTest.java
@@ -64,12 +64,13 @@ class PasteFileHandlerTest {
     }
 
     @Test
-    void batch_overlappingPastes_newerSupersedesOlder() throws IOException {
+    void batch_overlappingPastes_eachLifecycleStaysOrdered()
+            throws IOException {
         // Two pastes (2 files each) interleave on the wire:
         // paste 1 file A, paste 2 file X, paste 1 file B, paste 2 file Y.
-        // Starting paste 2 supersedes the still-unfinished paste 1, so paste
-        // 1's late file B is dropped and paste 1 never completes; only the
-        // newest paste is delivered.
+        // The framework must keep each paste's own sequence
+        // (start → file → file → complete) intact; cross-paste interleaving
+        // of the *order between* events is allowed.
         Fixture fixture = new Fixture();
         List<String> calls = new ArrayList<>();
         UploadHandler handler = PasteFileHandler.batch()
@@ -83,11 +84,40 @@ class PasteFileHandlerTest {
         fixture.fire(handler, 1, 2, "B");
         fixture.fire(handler, 2, 2, "Y");
 
-        // paste 1 starts and delivers A, then paste 2 supersedes it: B (a late
-        // upload of the superseded paste) is dropped, paste 1 has no complete,
-        // and only paste 2 runs start → X → Y → complete.
-        assertEquals(Arrays.asList("start:1", "file:1/A", "start:2", "file:2/X",
-                "file:2/Y", "complete:2"), calls);
+        // Per-paste lifecycle is preserved: paste 1 = start, A, B, complete;
+        // paste 2 = start, X, Y, complete. Across pastes, paste 2 starts
+        // before paste 1's last file lands, and both still finish cleanly on
+        // their own timelines.
+        assertEquals(
+                Arrays.asList("start:1", "file:1/A", "start:2", "file:2/X",
+                        "file:1/B", "complete:1", "file:2/Y", "complete:2"),
+                calls);
+    }
+
+    @Test
+    void batch_floodOfNeverCompletingPastes_evictsOldestToBoundMemory()
+            throws IOException {
+        // Each paste declares 2 files but only ever delivers 1, so none
+        // complete. After enough distinct paste ids the oldest still-open
+        // batch is evicted to bound memory; its later tail then looks like a
+        // brand-new paste (onStart fires again for it).
+        Fixture fixture = new Fixture();
+        List<Long> started = new ArrayList<>();
+        UploadHandler handler = PasteFileHandler.batch()
+                .onStart(s -> started.add(s.pasteId())).build();
+
+        int flood = 100;
+        for (int id = 1; id <= flood; id++) {
+            fixture.fire(handler, id, 2, "first");
+        }
+        // One onStart per distinct paste id.
+        assertEquals(flood, started.size());
+
+        // Paste 1 was evicted long ago, so its second file is treated as a
+        // fresh paste rather than completing the original batch.
+        fixture.fire(handler, 1, 2, "second");
+        assertEquals(flood + 1, started.size());
+        assertEquals(Long.valueOf(1), started.get(started.size() - 1));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/component/clipboard/PasteFileHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/clipboard/PasteFileHandlerTest.java
@@ -41,11 +41,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class PasteFileHandlerTest {
 
     @Test
-    void session_singlePaste_emitsStartThenFilesThenComplete()
+    void batch_singlePaste_emitsStartThenFilesThenComplete()
             throws IOException {
         Fixture fixture = new Fixture();
         List<String> calls = new ArrayList<>();
-        UploadHandler handler = PasteFileHandler.session()
+        UploadHandler handler = PasteFileHandler.batch()
                 .onStart(s -> calls
                         .add("start:" + s.pasteId() + "/" + s.totalFiles()))
                 .onFile(f -> calls.add("file:" + f.pasteId() + "/"
@@ -64,7 +64,7 @@ class PasteFileHandlerTest {
     }
 
     @Test
-    void session_overlappingPastes_eachLifecycleStaysOrdered()
+    void batch_overlappingPastes_eachLifecycleStaysOrdered()
             throws IOException {
         // Two pastes (2 files each) interleave on the wire:
         // paste 1 file A, paste 2 file X, paste 1 file B, paste 2 file Y.
@@ -73,7 +73,7 @@ class PasteFileHandlerTest {
         // of the *order between* events is allowed.
         Fixture fixture = new Fixture();
         List<String> calls = new ArrayList<>();
-        UploadHandler handler = PasteFileHandler.session()
+        UploadHandler handler = PasteFileHandler.batch()
                 .onStart(s -> calls.add("start:" + s.pasteId()))
                 .onFile(f -> calls.add("file:" + f.pasteId() + "/"
                         + new String(f.bytes(), StandardCharsets.UTF_8)))
@@ -95,15 +95,15 @@ class PasteFileHandlerTest {
     }
 
     @Test
-    void session_newPasteFlag_trueOnlyForFirstFileOfEachPaste()
+    void perFile_newPasteFlag_trueOnlyForFirstFileOfEachPaste()
             throws IOException {
-        // PasteFile.newPaste() is the inMemory variant's session boundary
+        // PasteFile.newPaste() is the perFile variant's paste boundary
         // signal — assert it for three files: first of paste 1 (true),
         // second of paste 1 (false), first of paste 2 (true).
         Fixture fixture = new Fixture();
         List<Boolean> flags = new ArrayList<>();
         UploadHandler handler = PasteFileHandler
-                .inMemory(file -> flags.add(file.newPaste()));
+                .perFile(file -> flags.add(file.newPaste()));
 
         fixture.fire(handler, 1, 2, "A");
         fixture.fire(handler, 1, 2, "B");

--- a/flow-server/src/test/java/com/vaadin/flow/component/clipboard/PasteFileHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/clipboard/PasteFileHandlerTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.clipboard;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.server.Command;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinResponse;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.server.streams.UploadEvent;
+import com.vaadin.flow.server.streams.UploadHandler;
+import com.vaadin.tests.util.MockUI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PasteFileHandlerTest {
+
+    @Test
+    void session_singlePaste_emitsStartThenFilesThenComplete()
+            throws IOException {
+        Fixture fixture = new Fixture();
+        List<String> calls = new ArrayList<>();
+        UploadHandler handler = PasteFileHandler.session()
+                .onStart(s -> calls
+                        .add("start:" + s.pasteId() + "/" + s.totalFiles()))
+                .onFile(f -> calls.add("file:" + f.pasteId() + "/"
+                        + new String(f.bytes(), StandardCharsets.UTF_8)))
+                .onComplete(c -> calls.add(
+                        "complete:" + c.pasteId() + "/" + c.receivedFiles()))
+                .build();
+
+        // Two files of paste id 1, expected count 2 — onStart fires once,
+        // onFile twice, onComplete once, in order.
+        fixture.fire(handler, 1, 2, "A");
+        fixture.fire(handler, 1, 2, "B");
+
+        assertEquals(Arrays.asList("start:1/2", "file:1/A", "file:1/B",
+                "complete:1/2"), calls);
+    }
+
+    @Test
+    void session_overlappingPastes_eachLifecycleStaysOrdered()
+            throws IOException {
+        // Two pastes (2 files each) interleave on the wire:
+        // paste 1 file A, paste 2 file X, paste 1 file B, paste 2 file Y.
+        // The framework must keep each paste's own sequence
+        // (start → file → file → complete) intact; cross-paste interleaving
+        // of the *order between* events is allowed.
+        Fixture fixture = new Fixture();
+        List<String> calls = new ArrayList<>();
+        UploadHandler handler = PasteFileHandler.session()
+                .onStart(s -> calls.add("start:" + s.pasteId()))
+                .onFile(f -> calls.add("file:" + f.pasteId() + "/"
+                        + new String(f.bytes(), StandardCharsets.UTF_8)))
+                .onComplete(c -> calls.add("complete:" + c.pasteId())).build();
+
+        fixture.fire(handler, 1, 2, "A");
+        fixture.fire(handler, 2, 2, "X");
+        fixture.fire(handler, 1, 2, "B");
+        fixture.fire(handler, 2, 2, "Y");
+
+        // Per-paste lifecycle is preserved: paste 1 = start, A, B, complete;
+        // paste 2 = start, X, Y, complete. Across pastes, paste 2 starts and
+        // even completes before paste 1's last file lands, which is exactly
+        // the "no cancellation" promise: paste 1 still finishes cleanly.
+        assertEquals(
+                Arrays.asList("start:1", "file:1/A", "start:2", "file:2/X",
+                        "file:1/B", "complete:1", "file:2/Y", "complete:2"),
+                calls);
+    }
+
+    @Test
+    void session_newPasteFlag_trueOnlyForFirstFileOfEachPaste()
+            throws IOException {
+        // PasteFile.newPaste() is the inMemory variant's session boundary
+        // signal — assert it for three files: first of paste 1 (true),
+        // second of paste 1 (false), first of paste 2 (true).
+        Fixture fixture = new Fixture();
+        List<Boolean> flags = new ArrayList<>();
+        UploadHandler handler = PasteFileHandler
+                .inMemory(file -> flags.add(file.newPaste()));
+
+        fixture.fire(handler, 1, 2, "A");
+        fixture.fire(handler, 1, 2, "B");
+        fixture.fire(handler, 2, 1, "X");
+
+        assertEquals(Arrays.asList(true, false, true), flags);
+    }
+
+    /**
+     * Test rig that constructs an {@link UploadEvent} backed by a mocked
+     * {@link VaadinRequest} carrying paste-id and file-count headers, then runs
+     * {@link UploadHandler#handleUploadRequest(UploadEvent)} on the test
+     * thread. The MockUI is sub-classed so {@code access(...)} executes the
+     * command synchronously — without that the session callbacks would queue
+     * and the assertions would race the runner.
+     */
+    private static final class Fixture {
+
+        private final UI ui;
+
+        Fixture() {
+            this.ui = new MockUI() {
+                @Override
+                public Future<Void> access(Command command) {
+                    command.execute();
+                    return CompletableFuture.completedFuture(null);
+                }
+            };
+        }
+
+        void fire(UploadHandler handler, long pasteId, int totalFiles,
+                String body) throws IOException {
+            VaadinRequest request = Mockito.mock(VaadinRequest.class);
+            Mockito.when(request.getHeader(Clipboard.PASTE_ID_HEADER))
+                    .thenReturn(Long.toString(pasteId));
+            Mockito.when(request.getHeader(Clipboard.PASTE_FILE_COUNT_HEADER))
+                    .thenReturn(Integer.toString(totalFiles));
+            byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+            Mockito.when(request.getInputStream())
+                    .thenReturn(new ByteArrayInputStream(bytes));
+
+            UploadEvent event = new UploadEvent(request,
+                    Mockito.mock(VaadinResponse.class),
+                    ui.getSession() != null ? ui.getSession()
+                            : VaadinSession.getCurrent(),
+                    "file.txt", bytes.length, "text/plain", ui.getElement(),
+                    null);
+            handler.handleUploadRequest(event);
+        }
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerFilePasteView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerFilePasteView.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.vaadin.flow.component.Html;
+import com.vaadin.flow.component.clipboard.Clipboard;
+import com.vaadin.flow.component.clipboard.PasteFile;
+import com.vaadin.flow.component.clipboard.PasteFileHandler;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Image;
+import com.vaadin.flow.component.page.Push;
+import com.vaadin.flow.router.Route;
+
+/**
+ * Registers a {@link Clipboard#onFilePaste} listener using a
+ * {@link PasteFileHandler#session() session} so the IT can verify all three
+ * phases &mdash; {@code onStart} per paste, {@code onFile} per file (rendered
+ * as text in a {@link Div}, parsed HTML through {@link Html}, or
+ * {@code image/*} via {@link Image} with a data URL), and {@code onComplete}
+ * when the paste's declared files have all arrived.
+ * <p>
+ * Files accumulate across pastes &mdash; each paste runs its own independent
+ * session, so two pastes in sequence (or even overlapping) both finish on their
+ * own timelines. {@code #file-count} tracks total files delivered;
+ * {@code #completed-count} tracks how many sessions have hit
+ * {@code onComplete}.
+ * <p>
+ * Push is required because each upload runs on a separate HTTP request &mdash;
+ * the UI updates from the session callbacks would otherwise sit in the queue
+ * until the next paste-triggered roundtrip.
+ */
+@Push
+@Route(value = "com.vaadin.flow.uitest.ui.TriggerFilePasteView")
+public class TriggerFilePasteView extends Div {
+
+    public TriggerFilePasteView() {
+        Div target = new Div();
+        target.setId("target");
+        // paste only fires on focused elements; tabindex makes the div
+        // focusable, matching the regular onPaste view.
+        target.getElement().setAttribute("tabindex", "0");
+        target.setText("Focus me and paste a file");
+
+        // Renders one slot per delivered file. The view does not clear on a
+        // new paste — every paste's files stay visible, which matches the
+        // framework's "no cancellation" promise.
+        Div status = new Div();
+        status.setId("file-status");
+        // onFile counter: total files delivered across all pastes.
+        Div count = new Div("0");
+        count.setId("file-count");
+        // onComplete counter: number of paste sessions that fully finished.
+        Div completed = new Div("0");
+        completed.setId("completed-count");
+
+        add(target, status, count, completed);
+
+        AtomicInteger receivedFiles = new AtomicInteger();
+        AtomicInteger completedSessions = new AtomicInteger();
+
+        Clipboard.onFilePaste(target,
+                PasteFileHandler.session().onStart(start -> {
+                    // Visible only via the test app — included so a developer
+                    // running the view by hand sees the session boundary.
+                    Div banner = new Div();
+                    banner.addClassName("paste-banner");
+                    banner.setText("Paste " + start.pasteId() + ": "
+                            + start.totalFiles() + " file(s) incoming");
+                    status.add(banner);
+                }).onFile(file -> {
+                    status.add(renderSlot(file));
+                    count.setText(
+                            Integer.toString(receivedFiles.incrementAndGet()));
+                }).onComplete(complete -> {
+                    completed.setText(Integer
+                            .toString(completedSessions.incrementAndGet()));
+                }).build());
+    }
+
+    private static Div renderSlot(PasteFile file) {
+        Div slot = new Div();
+        slot.addClassName("file-slot");
+        String contentType = file.contentType();
+        if (contentType != null && contentType.startsWith("image/")) {
+            // Inline the bytes as a data URL so the IT can read the image
+            // off the src attribute without a follow-up request.
+            String dataUrl = "data:" + contentType + ";base64,"
+                    + Base64.getEncoder().encodeToString(file.bytes());
+            Image image = new Image(dataUrl, file.fileName());
+            image.addClassName("file-slot-image");
+            slot.add(image);
+        } else if (contentType != null && contentType.startsWith("text/html")) {
+            // Html requires a single root element; the IT's synthetic
+            // payload wraps the snippet in one.
+            slot.add(
+                    new Html(new String(file.bytes(), StandardCharsets.UTF_8)));
+        } else {
+            // Treat anything else as plain text. The IT's text/plain case
+            // lands here.
+            slot.setText(new String(file.bytes(), StandardCharsets.UTF_8));
+        }
+        return slot;
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerFilePasteView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerFilePasteView.java
@@ -25,28 +25,26 @@ import com.vaadin.flow.component.clipboard.PasteFile;
 import com.vaadin.flow.component.clipboard.PasteFileHandler;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Image;
-import com.vaadin.flow.component.page.Push;
 import com.vaadin.flow.router.Route;
 
 /**
  * Registers a {@link Clipboard#onFilePaste} listener using a
- * {@link PasteFileHandler#session() session} so the IT can verify all three
- * phases &mdash; {@code onStart} per paste, {@code onFile} per file (rendered
- * as text in a {@link Div}, parsed HTML through {@link Html}, or
- * {@code image/*} via {@link Image} with a data URL), and {@code onComplete}
- * when the paste's declared files have all arrived.
+ * {@link PasteFileHandler#batch() batch} so the IT can verify all three phases
+ * &mdash; {@code onStart} per paste, {@code onFile} per file (rendered as text
+ * in a {@link Div}, parsed HTML through {@link Html}, or {@code image/*} via
+ * {@link Image} with a data URL), and {@code onComplete} when the paste's
+ * declared files have all arrived.
  * <p>
  * Files accumulate across pastes &mdash; each paste runs its own independent
- * session, so two pastes in sequence (or even overlapping) both finish on their
+ * batch, so two pastes in sequence (or even overlapping) both finish on their
  * own timelines. {@code #file-count} tracks total files delivered;
- * {@code #completed-count} tracks how many sessions have hit
- * {@code onComplete}.
+ * {@code #completed-count} tracks how many batches have hit {@code onComplete}.
  * <p>
- * Push is required because each upload runs on a separate HTTP request &mdash;
- * the UI updates from the session callbacks would otherwise sit in the queue
- * until the next paste-triggered roundtrip.
+ * Note that there is no {@code @Push} on this view: each upload runs on a
+ * separate HTTP request, but {@code onFilePaste} dispatches a round trip once a
+ * paste's uploads have finished, which flushes the queued UI updates from the
+ * batch callbacks to the client.
  */
-@Push
 @Route(value = "com.vaadin.flow.uitest.ui.TriggerFilePasteView")
 public class TriggerFilePasteView extends Div {
 
@@ -76,7 +74,7 @@ public class TriggerFilePasteView extends Div {
         AtomicInteger completedSessions = new AtomicInteger();
 
         Clipboard.onFilePaste(target,
-                PasteFileHandler.session().onStart(start -> {
+                PasteFileHandler.batch().onStart(start -> {
                     // Visible only via the test app — included so a developer
                     // running the view by hand sees the session boundary.
                     Div banner = new Div();

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerFilePasteIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerFilePasteIT.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class TriggerFilePasteIT extends ChromeBrowserTest {
+
+    @Test
+    public void pasteTextFile_serverShowsPlainText() {
+        open();
+        dispatchPasteWithFiles(
+                new SyntheticFile("hello.txt", "text/plain", "Hello, paste!"));
+        waitFileCount(1);
+        Assert.assertEquals("Hello, paste!",
+                findElement(By.cssSelector("#file-status .file-slot"))
+                        .getText());
+    }
+
+    @Test
+    public void pasteSession_firesStartFileAndComplete() {
+        // Verifies the full session shape end-to-end: onStart adds a
+        // .paste-banner div, onFile renders each slot, and onComplete bumps
+        // #completed-count. After two files in one paste, expect 1 banner,
+        // 2 slots, 1 completed session.
+        open();
+        dispatchPasteWithFiles(
+                new SyntheticFile("a.txt", "text/plain", "first"),
+                new SyntheticFile("b.txt", "text/plain", "second"));
+        waitFileCount(2);
+        waitCompletedCount(1);
+        Assert.assertEquals(1,
+                findElements(By.cssSelector("#file-status .paste-banner"))
+                        .size());
+        Assert.assertEquals(2,
+                findElements(By.cssSelector("#file-status .file-slot")).size());
+    }
+
+    @Test
+    public void pasteHtmlFile_serverRendersHtml() {
+        // The HTML body is wrapped in a single root element so the server-side
+        // Html component accepts it. Verifying that <b> exists inside
+        // #file-status with the right text content proves the bytes were
+        // parsed as HTML rather than escaped as text.
+        open();
+        dispatchPasteWithFiles(new SyntheticFile("snippet.html", "text/html",
+                "<div><b>bold</b> and <i>italic</i></div>"));
+        waitFileCount(1);
+        WebElement bold = findElement(By.cssSelector("#file-status b"));
+        Assert.assertEquals("bold", bold.getText());
+        WebElement italic = findElement(By.cssSelector("#file-status i"));
+        Assert.assertEquals("italic", italic.getText());
+    }
+
+    @Test
+    public void pasteImageFile_serverShowsImage() {
+        // Any bytes will do — the view encodes them as a data URL and the IT
+        // only checks the src prefix and the MIME type, not the pixels.
+        open();
+        dispatchPasteBinaryFile("pixel.png", "image/png",
+                new int[] { 137, 80, 78, 71, 13, 10, 26, 10 });
+        waitFileCount(1);
+        WebElement img = findElement(
+                By.cssSelector("#file-status .file-slot-image"));
+        String src = img.getAttribute("src");
+        Assert.assertTrue("expected data: URL, got " + src,
+                src.startsWith("data:image/png;base64,"));
+    }
+
+    @Test
+    public void twoSequentialPastes_bothSessionsComplete() {
+        // Each paste runs its own session: the second paste must not cancel
+        // the first. After two single-file pastes we expect two banners,
+        // two slots, and two completed sessions; the framework never drops
+        // files belonging to an earlier paste.
+        open();
+        dispatchPasteWithFiles(
+                new SyntheticFile("first.txt", "text/plain", "FIRST"));
+        waitCompletedCount(1);
+        dispatchPasteWithFiles(
+                new SyntheticFile("second.txt", "text/plain", "SECOND"));
+        waitCompletedCount(2);
+
+        Assert.assertEquals(2,
+                findElements(By.cssSelector("#file-status .paste-banner"))
+                        .size());
+        List<String> rendered = findElements(
+                By.cssSelector("#file-status .file-slot")).stream()
+                .map(WebElement::getText).toList();
+        Assert.assertEquals(Arrays.asList("FIRST", "SECOND"), rendered);
+    }
+
+    @Test
+    public void pasteMultipleFiles_allFilesRendered() {
+        // Each pasted file fires its own fetch POST and its own onFile
+        // callback; the session handler accumulates them under one onStart
+        // and fires onComplete once all have arrived. Completion order
+        // isn't guaranteed, so the assertions read the slot set as a set.
+        open();
+        dispatchPasteWithFiles(new SyntheticFile("a.txt", "text/plain", "AAAA"),
+                new SyntheticFile("b.txt", "text/plain", "BBBB"),
+                new SyntheticFile("c.txt", "text/plain", "CCCC"));
+        waitFileCount(3);
+        List<String> rendered = findElements(
+                By.cssSelector("#file-status .file-slot")).stream()
+                .map(WebElement::getText).toList();
+        Assert.assertEquals(3, rendered.size());
+        Assert.assertEquals(
+                new HashSet<>(Arrays.asList("AAAA", "BBBB", "CCCC")),
+                new HashSet<>(rendered));
+    }
+
+    @Test
+    public void pasteWithoutFiles_uploadHandlerNotInvoked() {
+        // A plain text paste must not fire the file-paste filter's upload
+        // code: the in-memory callback would bump the counter past zero.
+        open();
+        ((JavascriptExecutor) getDriver()).executeScript("""
+                const el = document.getElementById('target');
+                el.focus();
+                const dt = new DataTransfer();
+                dt.setData('text/plain', 'just text');
+                el.dispatchEvent(new ClipboardEvent('paste', {
+                    clipboardData: dt, bubbles: true, cancelable: true
+                }));
+                """);
+        // No reliable positive signal to wait on — give the page a moment to
+        // settle and then assert the counter never moved off zero.
+        getCommandExecutor().waitForVaadin();
+        Assert.assertEquals("0", findElement(By.id("file-count")).getText());
+    }
+
+    private void waitFileCount(int expected) {
+        waitUntil(d -> {
+            String text = findElement(By.id("file-count")).getText();
+            return Integer.toString(expected).equals(text);
+        });
+    }
+
+    private void waitCompletedCount(int expected) {
+        waitUntil(d -> {
+            String text = findElement(By.id("completed-count")).getText();
+            return Integer.toString(expected).equals(text);
+        });
+    }
+
+    // Dispatches a paste containing a single binary file built from the given
+    // byte values. JavaScript's File ctor accepts a Uint8Array as the first
+    // argument, so we hand the bytes over verbatim through executeScript and
+    // wrap them client-side. Used by the image case to skip the
+    // String-roundtrip that would otherwise mangle binary payloads.
+    private void dispatchPasteBinaryFile(String name, String type,
+            int[] bytes) {
+        String script = """
+                const bytes = new Uint8Array(arguments[0]);
+                const el = document.getElementById('target');
+                el.focus();
+                const dt = new DataTransfer();
+                dt.items.add(new File([bytes], arguments[1], { type: arguments[2] }));
+                el.dispatchEvent(new ClipboardEvent('paste', {
+                    clipboardData: dt, bubbles: true, cancelable: true
+                }));
+                """;
+        // Selenium's executeScript serialises ints as numbers; the JS side
+        // builds the Uint8Array from the resulting array.
+        Object[] boxed = new Object[bytes.length];
+        for (int i = 0; i < bytes.length; i++) {
+            boxed[i] = bytes[i];
+        }
+        ((JavascriptExecutor) getDriver()).executeScript(script,
+                java.util.Arrays.asList(boxed), name, type);
+    }
+
+    private record SyntheticFile(String name, String type, String body) {
+    }
+
+    // Builds a ClipboardEvent('paste') whose DataTransfer carries one
+    // synthetic File per argument, and dispatches it on the #target div.
+    // Files are constructed via the standard `new File([body], name, {type})`
+    // browser API; DataTransfer.items.add(file) makes them visible on
+    // event.clipboardData.files.
+    private void dispatchPasteWithFiles(SyntheticFile... files) {
+        StringBuilder script = new StringBuilder("""
+                const el = document.getElementById('target');
+                el.focus();
+                const dt = new DataTransfer();
+                """);
+        for (int i = 0; i < files.length; i++) {
+            script.append("dt.items.add(new File([arguments[").append(i * 3)
+                    .append("]], arguments[").append(i * 3 + 1)
+                    .append("], { type: arguments[").append(i * 3 + 2)
+                    .append("] }));\n");
+        }
+        script.append("""
+                el.dispatchEvent(new ClipboardEvent('paste', {
+                    clipboardData: dt, bubbles: true, cancelable: true
+                }));
+                """);
+
+        Object[] args = new Object[files.length * 3];
+        for (int i = 0; i < files.length; i++) {
+            args[i * 3] = files[i].body();
+            args[i * 3 + 1] = files[i].name();
+            args[i * 3 + 2] = files[i].type();
+        }
+        ((JavascriptExecutor) getDriver()).executeScript(script.toString(),
+                args);
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerFilePasteIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerFilePasteIT.java
@@ -135,8 +135,9 @@ public class TriggerFilePasteIT extends ChromeBrowserTest {
 
     @Test
     public void pasteWithoutFiles_uploadHandlerNotInvoked() {
-        // A plain text paste must not fire the file-paste filter's upload
-        // code: the in-memory callback would bump the counter past zero.
+        // A plain text paste carries no files, so the paste-upload helper
+        // returns early without POSTing: the per-file callback never runs and
+        // the counter stays at zero.
         open();
         ((JavascriptExecutor) getDriver()).executeScript("""
                 const el = document.getElementById('target');


### PR DESCRIPTION
Pastes whose clipboard carries files (screenshots, files copied from a
file manager) flow through the supplied UploadHandler — one fetch POST
per file with X-Filename + raw body, matching vaadin-upload's wire
format. The client-side helper lives in flow-client/Clipboard.ts
(window.Vaadin.Flow.clipboard.uploadPastedFiles) so the Java side only
emits a one-line filter expression. Each fetch carries X-Paste-Id
(monotonic per browser tab) and X-Paste-File-Count headers so
server-side handlers can correlate the parallel uploads of one paste.

PasteFileHandler offers two flavours that consume those headers:
inMemory(consumer) delivers each file as a PasteFile (with newPaste()
flagging the first file of each paste), and session() builds a
three-step onStart / onFile / onComplete listener that knows when the
whole paste has finished delivering. Sessions are per paste id and run
independently — a newer paste does not cancel the still-in-flight
uploads of an older paste, so two pastes in sequence (or interleaved)
both complete on their own timelines.

onFilePaste is independent of onPaste; both fire on the same gesture
when both are registered.
