### PR TITLE
chore: bump frontend dependency (25.1)

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/react-router/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/react-router/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "react": "19.2.7",
     "react-dom": "19.2.7",
-    "react-router": "7.13.2"
+    "react-router": "7.17.0"
   },
   "devDependencies": {
     "@types/react": "19.2.16",


### PR DESCRIPTION
vulnerabilities have been found from the version we used in 25.1. let us update it to the latest version 

[CVE-2026-40181](https://nvd.nist.gov/vuln/detail/CVE-2026-40181) React Router s same-origin redirect with path starting // causes open redirect via protocol-relative URL reinterpretation (osv-bomber,oss-bomber,osv-scan)
[CVE-2026-42211](https://nvd.nist.gov/vuln/detail/CVE-2026-42211) React Router s vendored turbo-stream v2 allows arbitrary constructor invocation via TYPE_ERROR deserialization leading to Unauth RCE (osv-bomber,oss-bomber,osv-scan)
[CVE-2026-42342](https://nvd.nist.gov/vuln/detail/CVE-2026-42342) _React Router vulnerable to DoS via unbounded path expansion in _manifest endpoint (osv-bomber,oss-bomber,osv-scan)
[CVE-2026-34077](https://nvd.nist.gov/vuln/detail/CVE-2026-34077) React Router vulnerable to Denial of Service via reflected user input in single-fetch (osv-bomber,oss-bomber,osv-scan)