### PR TITLE
chore: bump frontend dependency (25.0)

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/react-router/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/react-router/package.json
@@ -2,12 +2,12 @@
   "private": true,
   "description": "A list of Flow dependencies when using React router",
   "dependencies": {
-    "react": "19.2.4",
-    "react-dom": "19.2.4",
-    "react-router": "7.12.0"
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
+    "react-router": "7.17.0"
   },
   "devDependencies": {
-    "@types/react": "19.2.13",
+    "@types/react": "19.2.16",
     "@types/react-dom": "19.2.3"
   }
 }


### PR DESCRIPTION
upgrade the frontend dependency to resolve vulnerabilities. 

same as in https://github.com/vaadin/flow/pull/24530