### PR TITLE
refactor: split the ServerRpcHandler#handleRpc method

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
@@ -358,6 +358,12 @@ public class ServerRpcHandler implements Serializable {
             throw new InvalidUIDLSecurityKeyException();
         }
 
+        handleRpc(ui, message, request, rpcRequest);
+    }
+
+    protected void handleRpc(UI ui, String message, VaadinRequest request,
+            RpcRequest rpcRequest) throws MessageIdSyncException {
+
         String hashMessage = message;
         if (hashMessage.length() > 64 * 1024) {
             hashMessage = message.substring(0, 64 * 1024);
@@ -453,6 +459,10 @@ public class ServerRpcHandler implements Serializable {
             // signature for source and binary compatibility
             throw new ResynchronizationRequiredException();
         }
+        handleUnloadBeaconRequest(ui, rpcRequest);
+    }
+
+    protected void handleUnloadBeaconRequest(UI ui, RpcRequest rpcRequest) {
         if (rpcRequest.isUnloadBeaconRequest()) {
             if (isPreserveOnRefreshTarget(ui)) {
                 getLogger().debug(

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
@@ -313,16 +313,17 @@ public class ServerRpcHandler implements Serializable {
      *            The {@link Reader} used to read the JSON.
      * @param request
      *            The request through which the RPC was received
+     * @return {@link RpcRequest} or null
      * @throws IOException
      *             If reading the message fails.
      * @throws InvalidUIDLSecurityKeyException
      *             If the received security key does not match the one stored in
      *             the session.
      */
-    public void handleRpc(UI ui, Reader reader, VaadinRequest request)
+    public RpcRequest handleRpc(UI ui, Reader reader, VaadinRequest request)
             throws IOException, InvalidUIDLSecurityKeyException,
             MessageIdSyncException {
-        handleRpc(ui, SynchronizedRequestHandler.getRequestBody(reader),
+        return handleRpc(ui, SynchronizedRequestHandler.getRequestBody(reader),
                 request);
     }
 
@@ -336,17 +337,18 @@ public class ServerRpcHandler implements Serializable {
      *            The JSON message from the request.
      * @param request
      *            The request through which the RPC was received
+     * @return {@link RpcRequest} or null
      * @throws InvalidUIDLSecurityKeyException
      *             If the received security key does not match the one stored in
      *             the session.
      */
-    public void handleRpc(UI ui, String message, VaadinRequest request)
+    public RpcRequest handleRpc(UI ui, String message, VaadinRequest request)
             throws InvalidUIDLSecurityKeyException, MessageIdSyncException {
         ui.getSession().setLastRequestTimestamp(System.currentTimeMillis());
 
         if (message == null || message.isEmpty()) {
             // The client sometimes sends empty messages, this is probably a bug
-            return;
+            return null;
         }
 
         RpcRequest rpcRequest = new RpcRequest(message, request.getService()
@@ -437,7 +439,7 @@ public class ServerRpcHandler implements Serializable {
                 getLogger().warn(
                         "MPR is in use, so full page reload will be done to achieve re-sync.");
                 ui.getPage().reload();
-                return;
+                return rpcRequest;
             }
 
             // Run detach listeners and re-attach all nodes again to the
@@ -462,6 +464,7 @@ public class ServerRpcHandler implements Serializable {
                 getLogger().debug("UI closed with a beacon request");
             }
         }
+        return rpcRequest;
     }
 
     private void enforceIfNeeded(VaadinRequest request, RpcRequest rpcRequest) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
@@ -313,17 +313,16 @@ public class ServerRpcHandler implements Serializable {
      *            The {@link Reader} used to read the JSON.
      * @param request
      *            The request through which the RPC was received
-     * @return {@link RpcRequest} or null
      * @throws IOException
      *             If reading the message fails.
      * @throws InvalidUIDLSecurityKeyException
      *             If the received security key does not match the one stored in
      *             the session.
      */
-    public RpcRequest handleRpc(UI ui, Reader reader, VaadinRequest request)
+    public void handleRpc(UI ui, Reader reader, VaadinRequest request)
             throws IOException, InvalidUIDLSecurityKeyException,
             MessageIdSyncException {
-        return handleRpc(ui, SynchronizedRequestHandler.getRequestBody(reader),
+        handleRpc(ui, SynchronizedRequestHandler.getRequestBody(reader),
                 request);
     }
 
@@ -337,18 +336,17 @@ public class ServerRpcHandler implements Serializable {
      *            The JSON message from the request.
      * @param request
      *            The request through which the RPC was received
-     * @return {@link RpcRequest} or null
      * @throws InvalidUIDLSecurityKeyException
      *             If the received security key does not match the one stored in
      *             the session.
      */
-    public RpcRequest handleRpc(UI ui, String message, VaadinRequest request)
+    public void handleRpc(UI ui, String message, VaadinRequest request)
             throws InvalidUIDLSecurityKeyException, MessageIdSyncException {
         ui.getSession().setLastRequestTimestamp(System.currentTimeMillis());
 
         if (message == null || message.isEmpty()) {
             // The client sometimes sends empty messages, this is probably a bug
-            return null;
+            return;
         }
 
         RpcRequest rpcRequest = new RpcRequest(message, request.getService()
@@ -439,7 +437,7 @@ public class ServerRpcHandler implements Serializable {
                 getLogger().warn(
                         "MPR is in use, so full page reload will be done to achieve re-sync.");
                 ui.getPage().reload();
-                return rpcRequest;
+                return;
             }
 
             // Run detach listeners and re-attach all nodes again to the
@@ -464,7 +462,6 @@ public class ServerRpcHandler implements Serializable {
                 getLogger().debug("UI closed with a beacon request");
             }
         }
-        return rpcRequest;
     }
 
     private void enforceIfNeeded(VaadinRequest request, RpcRequest rpcRequest) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/UidlRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/UidlRequestHandlerTest.java
@@ -302,7 +302,7 @@ class UidlRequestHandlerTest {
 
         ServerRpcHandler serverRpcHandler = new ServerRpcHandler() {
             @Override
-            public RpcRequest handleRpc(UI ui, String requestBody,
+            public void handleRpc(UI ui, String requestBody,
                     VaadinRequest request) {
                 throw new DauEnforcementException(
                         new EnforcementException("test"));
@@ -338,7 +338,7 @@ class UidlRequestHandlerTest {
 
         ServerRpcHandler serverRpcHandler = new ServerRpcHandler() {
             @Override
-            public RpcRequest handleRpc(UI ui, String requestBody,
+            public void handleRpc(UI ui, String requestBody,
                     VaadinRequest request)
                     throws ServerRpcHandler.MessageIdSyncException {
                 throw new ServerRpcHandler.MessageIdSyncException(1, 5);
@@ -387,7 +387,7 @@ class UidlRequestHandlerTest {
 
         ServerRpcHandler serverRpcHandler = new ServerRpcHandler() {
             @Override
-            public RpcRequest handleRpc(UI ui, String requestBody,
+            public void handleRpc(UI ui, String requestBody,
                     VaadinRequest request) throws MessageIdSyncException {
                 throw new ServerRpcHandler.MessageIdSyncException(1, 5);
             }
@@ -434,7 +434,7 @@ class UidlRequestHandlerTest {
 
         ServerRpcHandler serverRpcHandler = new ServerRpcHandler() {
             @Override
-            public RpcRequest handleRpc(UI ui, String requestBody,
+            public void handleRpc(UI ui, String requestBody,
                     VaadinRequest request) throws MessageIdSyncException {
                 throw new ServerRpcHandler.MessageIdSyncException(1, 5);
             }

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/UidlRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/UidlRequestHandlerTest.java
@@ -302,7 +302,7 @@ class UidlRequestHandlerTest {
 
         ServerRpcHandler serverRpcHandler = new ServerRpcHandler() {
             @Override
-            public void handleRpc(UI ui, String requestBody,
+            public RpcRequest handleRpc(UI ui, String requestBody,
                     VaadinRequest request) {
                 throw new DauEnforcementException(
                         new EnforcementException("test"));
@@ -338,7 +338,7 @@ class UidlRequestHandlerTest {
 
         ServerRpcHandler serverRpcHandler = new ServerRpcHandler() {
             @Override
-            public void handleRpc(UI ui, String requestBody,
+            public RpcRequest handleRpc(UI ui, String requestBody,
                     VaadinRequest request)
                     throws ServerRpcHandler.MessageIdSyncException {
                 throw new ServerRpcHandler.MessageIdSyncException(1, 5);
@@ -387,7 +387,7 @@ class UidlRequestHandlerTest {
 
         ServerRpcHandler serverRpcHandler = new ServerRpcHandler() {
             @Override
-            public void handleRpc(UI ui, String requestBody,
+            public RpcRequest handleRpc(UI ui, String requestBody,
                     VaadinRequest request) throws MessageIdSyncException {
                 throw new ServerRpcHandler.MessageIdSyncException(1, 5);
             }
@@ -434,7 +434,7 @@ class UidlRequestHandlerTest {
 
         ServerRpcHandler serverRpcHandler = new ServerRpcHandler() {
             @Override
-            public void handleRpc(UI ui, String requestBody,
+            public RpcRequest handleRpc(UI ui, String requestBody,
                     VaadinRequest request) throws MessageIdSyncException {
                 throw new ServerRpcHandler.MessageIdSyncException(1, 5);
             }


### PR DESCRIPTION
The ServerRpcHandler#handleRpc method parses the json and produces RpcRequest object which is then internally passed as parameter to handleInvocations() method, but discarded afterwards.

Split the handleRpc() method, separating parsing of RpcRequest and its processing. Extract the UnloadBeaconRequest to separate method.

Motivation: there are situations requiring to extend the ServerRpcHandler logic and since the RpcRequest is lost, it needs to be re-parsed from json once again.
(Specific scenario - "UNLOAD" beacon requests are ignored when @PreserveOnRefresh is used, but that request needs to be specially processed anyway).
