### PR TITLE
feat: add UI.triggerAfter for deferred server-side callbacks

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -706,7 +706,7 @@ public class UI extends Component
     }
 
     /**
-     * Runs a task on the server once the given delay has elapsed.
+     * Runs a task on the server once the given delay has elapsed in the browser.
      * <p>
      * The delay is measured by the browser: a one-shot timer is armed on the
      * client when the response of the current request is sent, and the task is

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -38,6 +39,8 @@ import com.vaadin.flow.component.internal.UIInternals;
 import com.vaadin.flow.component.page.History;
 import com.vaadin.flow.component.page.LoadingIndicatorConfiguration;
 import com.vaadin.flow.component.page.Page;
+import com.vaadin.flow.component.trigger.internal.CallbackAction;
+import com.vaadin.flow.component.trigger.internal.TimeoutTrigger;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableRunnable;
@@ -700,6 +703,55 @@ public class UI extends Component
     public int getPollInterval() {
         return getNode().getFeature(PollConfigurationMap.class)
                 .getPollInterval();
+    }
+
+    /**
+     * Runs a task on the server once the given delay has elapsed.
+     * <p>
+     * The delay is measured by the browser: a one-shot timer is armed on the
+     * client when the response of the current request is sent, and the task is
+     * run on the server when the client makes a round trip back as the timer
+     * elapses. The task runs in the same way as any other event handler, with
+     * the session locked. This makes it possible to defer a single piece of
+     * server-side work for a short while without enabling
+     * {@link PushConfiguration push} just for that purpose.
+     * <p>
+     * The returned {@link Registration} can be used to cancel the task by
+     * clearing the client timer, so a task cancelled before its delay elapses
+     * does not run. A cancellation that races an already-elapsed timer (the
+     * round trip is in flight) may still run once.
+     * <p>
+     * Because the timer lives in the browser, the task is not run if the page
+     * is reloaded, navigated away from or closed before the delay elapses.
+     * <p>
+     * This method must be called while holding the session lock, i.e. from a
+     * regular request such as an event listener or from inside
+     * {@link #access(Command)}. The same applies to
+     * {@link Registration#remove()} on the returned registration.
+     *
+     * @param delay
+     *            the delay after which the task should be run, not
+     *            <code>null</code> and not negative
+     * @param task
+     *            the task to run on the server, not <code>null</code>; must be
+     *            serializable if the session is serialized
+     * @return a registration for cancelling the task before it runs, not
+     *         <code>null</code>
+     */
+    public Registration triggerAfter(Duration delay,
+            SerializableRunnable task) {
+        Objects.requireNonNull(delay, "Delay cannot be null");
+        Objects.requireNonNull(task, "Task cannot be null");
+        if (delay.isNegative()) {
+            throw new IllegalArgumentException("Delay cannot be negative");
+        }
+
+        TimeoutTrigger trigger = new TimeoutTrigger(this, delay);
+        trigger.triggers(new CallbackAction<>(task));
+
+        // Removing the trigger clears the client timer, so a task cancelled
+        // before its delay elapses never runs.
+        return trigger::remove;
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -706,7 +706,8 @@ public class UI extends Component
     }
 
     /**
-     * Runs a task on the server once the given delay has elapsed in the browser.
+     * Runs a task on the server once the given delay has elapsed in the
+     * browser.
      * <p>
      * The delay is measured by the browser: a one-shot timer is armed on the
      * client when the response of the current request is sent, and the task is

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/CallbackAction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/CallbackAction.java
@@ -19,11 +19,13 @@ import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ArrayNode;
 
 import com.vaadin.flow.dom.JsFunction;
 import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.function.SerializableRunnable;
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.internal.nodefeature.ReturnChannelMap;
@@ -59,16 +61,21 @@ import com.vaadin.flow.internal.nodefeature.ReturnChannelRegistration;
  * instance can be wired to triggers hosted on different elements without
  * leaking registrations across them.
  * <p>
+ * A value-less variant — constructed with just a {@link SerializableRunnable} —
+ * forwards no value: the trigger firing is the whole signal. It renders
+ * {@code $0()} and runs the callback when invoked. Useful for triggers that
+ * carry no payload, such as {@link TimeoutTrigger}.
+ * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
  * @param <T>
- *            the type the JSON value is decoded to and the callback receives
+ *            the type the JSON value is decoded to and the callback receives;
+ *            unused by the value-less variant
  */
 public class CallbackAction<T> extends Action {
 
-    private final Class<T> valueType;
-    private final SerializableConsumer<T> callback;
-    private final Action.Input<? extends T> source;
+    private final Action.@Nullable Input<? extends T> source;
+    private final SerializableConsumer<ArrayNode> dispatch;
     private final Map<StateNode, ReturnChannelRegistration> channelByNode = new IdentityHashMap<>();
 
     /**
@@ -88,41 +95,57 @@ public class CallbackAction<T> extends Action {
      */
     public CallbackAction(Class<T> valueType, SerializableConsumer<T> callback,
             Action.Input<? extends T> source) {
-        this.valueType = Objects.requireNonNull(valueType,
-                "valueType must not be null");
-        this.callback = Objects.requireNonNull(callback,
-                "callback must not be null");
+        Objects.requireNonNull(valueType, "valueType must not be null");
+        Objects.requireNonNull(callback, "callback must not be null");
         this.source = Objects.requireNonNull(source, "source must not be null");
+        this.dispatch = args -> {
+            JsonNode raw = args.get(0);
+            // The source input is expected to evaluate to a defined value at
+            // fire time; a JSON null on the wire (or a missing argument) almost
+            // certainly indicates a misuse — for example, mapping an action's
+            // input from a property that doesn't exist on the target.
+            if (raw == null || raw.isNull()) {
+                throw new IllegalStateException(
+                        "CallbackAction received a null value from the client;"
+                                + " the source input must produce a non-null"
+                                + " value");
+            }
+            callback.accept(JacksonUtils.readValue(raw, valueType));
+        };
+    }
+
+    /**
+     * Creates a value-less action that runs {@code callback} on the UI thread
+     * when the trigger fires, forwarding no value from the client.
+     *
+     * @param callback
+     *            invoked on the UI thread when the trigger fires, not
+     *            {@code null}
+     */
+    public CallbackAction(SerializableRunnable callback) {
+        Objects.requireNonNull(callback, "callback must not be null");
+        this.source = null;
+        this.dispatch = args -> callback.run();
     }
 
     @Override
     protected final JsFunction toJs(Trigger trigger) {
+        ReturnChannelRegistration channel = channelFor(
+                trigger.getHost().getNode());
+        if (source == null) {
+            // Value-less: there is nothing to forward, so the channel is called
+            // with no arguments.
+            return JsFunction.of("$0();", channel);
+        }
         // $0 = the return channel; $1 = the source input's JsFunction.
         // Invoking the source with `event` produces its value, which is
         // forwarded straight into the channel call.
-        return JsFunction.of("$0($1(event));",
-                channelFor(trigger.getHost().getNode()), source.toJs(trigger))
+        return JsFunction.of("$0($1(event));", channel, source.toJs(trigger))
                 .withArguments("event");
     }
 
     private ReturnChannelRegistration channelFor(StateNode hostNode) {
-        return channelByNode.computeIfAbsent(hostNode,
-                node -> node.getFeature(ReturnChannelMap.class)
-                        .registerChannel(this::dispatch));
-    }
-
-    private void dispatch(ArrayNode args) {
-        JsonNode raw = args.get(0);
-        // The source input is expected to evaluate to a defined value at fire
-        // time; a JSON null on the wire (or a missing argument) almost
-        // certainly indicates a misuse — for example, mapping an action's
-        // input from a property that doesn't exist on the target.
-        if (raw == null || raw.isNull()) {
-            throw new IllegalStateException(
-                    "CallbackAction received a null value from the client;"
-                            + " the source input must produce a non-null"
-                            + " value");
-        }
-        callback.accept(JacksonUtils.readValue(raw, valueType));
+        return channelByNode.computeIfAbsent(hostNode, node -> node
+                .getFeature(ReturnChannelMap.class).registerChannel(dispatch));
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/TimeoutTrigger.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/TimeoutTrigger.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.trigger.internal;
+
+import java.time.Duration;
+import java.util.Objects;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.dom.JsFunction;
+import com.vaadin.flow.shared.Registration;
+
+/**
+ * Fires once, on the client, after the given delay has elapsed. The delay is
+ * measured by the browser via a single {@code setTimeout} armed when the host
+ * is initialized on the client; when it elapses the bound actions run. Pair it
+ * with a value-less {@link CallbackAction} (or any other action) to run
+ * server-side work a short while later without enabling push.
+ * <p>
+ * Unlike event- or observer-based triggers, this one fires a single time. The
+ * timer is cleared if the trigger is {@link #remove() removed} before it
+ * elapses; because it lives in the browser, it also never fires if the host's
+ * client DOM goes away (page reload, navigation, …) first.
+ * <p>
+ * For internal use only. May be renamed or removed in a future release.
+ */
+public class TimeoutTrigger extends Trigger {
+
+    private final long delayMillis;
+
+    /**
+     * Creates a trigger that fires once, the given delay after the host is
+     * initialized on the client.
+     *
+     * @param host
+     *            the component whose client-side initialization arms the timer,
+     *            not {@code null}
+     * @param delay
+     *            how long to wait before firing, not {@code null} and not
+     *            negative
+     */
+    public TimeoutTrigger(Component host, Duration delay) {
+        super(host);
+        Objects.requireNonNull(delay, "delay must not be null");
+        if (delay.isNegative()) {
+            throw new IllegalArgumentException("delay must not be negative");
+        }
+        this.delayMillis = delay.toMillis();
+    }
+
+    @Override
+    protected Registration install(JsFunction action) {
+        // Action at $0 (the convention the framework documents in
+        // Trigger#install), delay in milliseconds at $1 — both captures of the
+        // install JsFunction, no string concatenation around either. The
+        // returned function clears the timer when the registration is removed.
+        return getHost().addJsInitializer("""
+                const id = setTimeout(() => $0(), $1);\
+                return () => clearTimeout(id);""", action, delayMillis);
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/UITriggerAfterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/UITriggerAfterTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.node.ObjectNode;
+
+import com.vaadin.flow.internal.JacksonUtils;
+import com.vaadin.flow.internal.nodefeature.ReturnChannelMap;
+import com.vaadin.flow.server.communication.ReturnChannelHandler;
+import com.vaadin.flow.shared.JsonConstants;
+import com.vaadin.tests.util.MockUI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class UITriggerAfterTest {
+    private final MockUI ui = new MockUI();
+
+    @Test
+    void triggerAfter_channelInvoked_runsTask() {
+        AtomicInteger count = new AtomicInteger();
+
+        ui.triggerAfter(Duration.ofMillis(100), count::incrementAndGet);
+
+        handleMessage(onlyChannelId());
+
+        assertEquals(1, count.get(),
+                "Task should have been run when the channel was invoked");
+    }
+
+    @Test
+    void triggerAfter_negativeDelay_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ui.triggerAfter(Duration.ofMillis(-1), () -> {
+                }));
+    }
+
+    /**
+     * Finds the id of the single channel that {@code triggerAfter} registered
+     * on the UI node, simulating the client round trip that the timer would
+     * otherwise make.
+     */
+    private int onlyChannelId() {
+        ReturnChannelMap map = ui.getElement().getNode()
+                .getFeature(ReturnChannelMap.class);
+        for (int id = 0; id < 100; id++) {
+            if (map.get(id) != null) {
+                return id;
+            }
+        }
+        throw new AssertionError("No channel was registered");
+    }
+
+    private void handleMessage(int channelId) {
+        ObjectNode invocationJson = JacksonUtils.createObjectNode();
+        invocationJson.put(JsonConstants.RPC_NODE,
+                ui.getElement().getNode().getId());
+        invocationJson.put(JsonConstants.RPC_CHANNEL, channelId);
+        invocationJson.set(JsonConstants.RPC_CHANNEL_ARGUMENTS,
+                JacksonUtils.createArrayNode());
+
+        new ReturnChannelHandler().handle(ui, invocationJson);
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/CallbackActionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/CallbackActionTest.java
@@ -82,6 +82,32 @@ class CallbackActionTest {
     }
 
     @Test
+    void valueLess_handlerCallsChannelWithNoArgsAndRunsCallback() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        ui.getElement().appendChild(button.getElement());
+
+        List<String> received = new ArrayList<>();
+        DomEventTrigger trigger = new DomEventTrigger(button, "click");
+        trigger.triggers(new CallbackAction<>(() -> received.add("ran")));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        // No value to forward, so the channel ($0) is called with no arguments.
+        JsFunction action = actionOf(singleInstallFn(ui));
+        assertEquals("$0();", action.getBody());
+        assertTrue(
+                action.getCaptures()
+                        .get(0) instanceof ReturnChannelRegistration,
+                "Expected $0 to be the return channel");
+
+        ((ReturnChannelRegistration) action.getCaptures().get(0))
+                .invoke(JacksonUtils.createArrayNode());
+
+        assertEquals(List.of("ran"), received);
+    }
+
+    @Test
     void nullArgument_throwsIllegalState() {
         UI ui = new MockUI();
         TagComponent input = new TagComponent("input");

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/TimeoutTriggerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/TimeoutTriggerTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.trigger.internal;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.dom.JsFunction;
+import com.vaadin.tests.util.MockUI;
+
+import static com.vaadin.flow.component.trigger.internal.TriggerTestUtil.singleInstallFn;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TimeoutTriggerTest {
+
+    @Test
+    void install_armsSetTimeoutWithDelay() {
+        UI ui = new MockUI();
+        TagComponent host = new TagComponent("div");
+        ui.getElement().appendChild(host.getElement());
+
+        new TimeoutTrigger(host, Duration.ofMillis(250))
+                .triggers(new SetPropertyAction<>(host, "value", ""));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        // Action at $0, delay in milliseconds at $1; the returned function
+        // clears the timer on removal. No user content leaks into the body.
+        JsFunction install = singleInstallFn(ui);
+        assertEquals("const id = setTimeout(() => $0(), $1);"
+                + "return () => clearTimeout(id);", install.getBody());
+        assertEquals(250L, install.getCaptures().get(1));
+    }
+
+    @Test
+    void negativeDelay_throws() {
+        UI ui = new MockUI();
+        TagComponent host = new TagComponent("div");
+        ui.getElement().appendChild(host.getElement());
+
+        assertThrows(IllegalArgumentException.class,
+                () -> new TimeoutTrigger(host, Duration.ofMillis(-1)));
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerAfterView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerAfterView.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import java.time.Duration;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+@Route(value = "com.vaadin.flow.uitest.ui.TriggerAfterView", layout = ViewTestLayout.class)
+public class TriggerAfterView extends AbstractDivView {
+
+    static final String WAITING = "waiting";
+    static final String FIRED = "fired";
+
+    public TriggerAfterView() {
+        Div status = new Div();
+        status.setId("status");
+        status.setText(WAITING);
+
+        // Run a server-side task ~500 ms after the request that arms it,
+        // triggered by a client timer round trip. No push enabled.
+        add(createButton("Trigger after", "triggerAfter",
+                e -> UI.getCurrent().triggerAfter(Duration.ofMillis(500),
+                        () -> status.setText(FIRED))));
+
+        add(status);
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerAfterIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerAfterIT.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class TriggerAfterIT extends ChromeBrowserTest {
+
+    @Test
+    public void task_runsOnServerAfterDelay() {
+        open();
+
+        WebElement status = findElement(By.id("status"));
+        Assert.assertEquals("waiting", status.getText());
+
+        findElement(By.id("triggerAfter")).click();
+
+        // The task fires through a client-timer-triggered round trip, without
+        // push being enabled.
+        waitUntil(driver -> "fired".equals(status.getText()));
+    }
+}


### PR DESCRIPTION
Add `UI.triggerAfter(Duration, SerializableRunnable)`, which runs a task on the
server once the given delay has elapsed. The delay is measured by the browser
via a one-shot client timer that makes a normal round trip when it elapses, so
a single deferred event can be handled without enabling push.

This change:
- adds UI.triggerAfter, a facade that wires the trigger and action and returns
  a Registration; removing it clears the client timer, so a task cancelled
  before its delay elapses does not run;
- adds TimeoutTrigger, which arms a one-shot setTimeout on the host element and
  clears it on removal;
- extends CallbackAction with a value-less constructor (SerializableRunnable)
  that forwards no value and renders $0(), used by triggerAfter.
