### PR TITLE
feat: validate URL schemes in Anchor, IFrame and Page#open

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
@@ -26,7 +26,9 @@ import com.vaadin.flow.component.HtmlContainer;
 import com.vaadin.flow.component.PropertyDescriptor;
 import com.vaadin.flow.component.PropertyDescriptors;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.internal.UrlUtil;
 import com.vaadin.flow.server.AbstractStreamResource;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.StreamResource;
 import com.vaadin.flow.server.StreamResourceRegistry;
 import com.vaadin.flow.server.streams.AbstractDownloadHandler;
@@ -268,8 +270,43 @@ public class Anchor extends HtmlContainer
      *
      * @param href
      *            the href to set
+     * @throws IllegalArgumentException
+     *             if the URL uses a scheme that is not considered safe; see
+     *             {@link #setUnsafeHref(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public void setHref(String href) {
+        if (href == null) {
+            throw new IllegalArgumentException("Href must not be null");
+        }
+        if (!UrlUtil.isSafeUrl(href)) {
+            throw new IllegalArgumentException(String.format(
+                    "The href \"%s\" uses a scheme that is not considered safe. "
+                            + "Configure the safe schemes with the \"%s\" property, "
+                            + "or use setUnsafeHref(String) if this URL is intentional and trusted.",
+                    href, InitParameters.URL_SAFE_SCHEMES));
+        }
+        this.href = href;
+        assignHrefAttribute();
+    }
+
+    /**
+     * Sets the URL that this anchor links to without validating its scheme.
+     * <p>
+     * Unlike {@link #setHref(String)}, this method does not reject URLs based
+     * on the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use it
+     * only for URLs that are fully under your control and known to be safe,
+     * such as a hard-coded {@code javascript:} or {@code data:} URL. Passing
+     * untrusted input here can expose the application to cross-site scripting
+     * (XSS) attacks.
+     *
+     * @see #setHref(String)
+     *
+     * @param href
+     *            the href to set
+     */
+    public void setUnsafeHref(String href) {
         if (href == null) {
             throw new IllegalArgumentException("Href must not be null");
         }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
@@ -281,11 +281,8 @@ public class Anchor extends HtmlContainer
             throw new IllegalArgumentException("Href must not be null");
         }
         if (!UrlUtil.isSafeUrl(href)) {
-            throw new IllegalArgumentException(String.format(
-                    "The href \"%s\" uses a scheme that is not considered safe. "
-                            + "Configure the safe schemes with the \"%s\" property, "
-                            + "or use setUnsafeHref(String) if this URL is intentional and trusted.",
-                    href, InitParameters.URL_SAFE_SCHEMES));
+            throw new IllegalArgumentException(UrlUtil.getUnsafeUrlMessage(
+                    "href", href, "setUnsafeHref(String)"));
         }
         this.href = href;
         assignHrefAttribute();

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
@@ -72,6 +72,11 @@ public class Anchor extends HtmlContainer
      *            the href to set
      * @param text
      *            the text content to set
+     * @throws IllegalArgumentException
+     *             if {@code href} uses a scheme that is not considered safe;
+     *             see {@link #setUnsafeHref(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public Anchor(String href, String text) {
         setHref(href);
@@ -98,6 +103,11 @@ public class Anchor extends HtmlContainer
      *            the href to set
      * @param textSignal
      *            the signal to bind, not {@code null}
+     * @throws IllegalArgumentException
+     *             if {@code href} uses a scheme that is not considered safe;
+     *             see {@link #setUnsafeHref(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      * @since 25.1
      */
     public Anchor(String href, Signal<String> textSignal) {
@@ -119,6 +129,11 @@ public class Anchor extends HtmlContainer
      *            the text content to set
      * @param target
      *            the target window, tab or frame
+     * @throws IllegalArgumentException
+     *             if {@code href} uses a scheme that is not considered safe;
+     *             see {@link #setUnsafeHref(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public Anchor(String href, String text, AnchorTarget target) {
         setHref(href);
@@ -250,6 +265,11 @@ public class Anchor extends HtmlContainer
      *            the href to set
      * @param components
      *            the components to add
+     * @throws IllegalArgumentException
+     *             if {@code href} uses a scheme that is not considered safe;
+     *             see {@link #setUnsafeHref(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public Anchor(String href, Component... components) {
         setHref(href);

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
@@ -133,6 +133,11 @@ public class IFrame extends HtmlComponent implements HasAriaLabel {
      *
      * @param src
      *            Source URL
+     * @throws IllegalArgumentException
+     *             if {@code src} uses a scheme that is not considered safe; see
+     *             {@link #setUnsafeSrc(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public IFrame(String src) {
         setSrc(src);

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
@@ -24,7 +24,9 @@ import com.vaadin.flow.component.HtmlComponent;
 import com.vaadin.flow.component.PropertyDescriptor;
 import com.vaadin.flow.component.PropertyDescriptors;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.internal.UrlUtil;
 import com.vaadin.flow.server.AbstractStreamResource;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.StreamResource;
 import com.vaadin.flow.server.streams.AbstractDownloadHandler;
 import com.vaadin.flow.server.streams.DownloadHandler;
@@ -160,8 +162,39 @@ public class IFrame extends HtmlComponent implements HasAriaLabel {
      *
      * @param src
      *            Source URL.
+     * @throws IllegalArgumentException
+     *             if the URL uses a scheme that is not considered safe; see
+     *             {@link #setUnsafeSrc(String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public void setSrc(String src) {
+        if (src != null && !UrlUtil.isSafeUrl(src)) {
+            throw new IllegalArgumentException(String.format(
+                    "The src \"%s\" uses a scheme that is not considered safe. "
+                            + "Configure the safe schemes with the \"%s\" property, "
+                            + "or use setUnsafeSrc(String) if this URL is intentional and trusted.",
+                    src, InitParameters.URL_SAFE_SCHEMES));
+        }
+        set(srcDescriptor, src);
+    }
+
+    /**
+     * Sets the source of the iframe without validating its scheme.
+     * <p>
+     * Unlike {@link #setSrc(String)}, this method does not reject URLs based on
+     * the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use it only
+     * for URLs that are fully under your control and known to be safe, such as
+     * a hard-coded {@code javascript:} or {@code data:} URL. Passing untrusted
+     * input here can expose the application to cross-site scripting (XSS)
+     * attacks.
+     *
+     * @see #setSrc(String)
+     *
+     * @param src
+     *            Source URL.
+     */
+    public void setUnsafeSrc(String src) {
         set(srcDescriptor, src);
     }
 

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
@@ -170,11 +170,8 @@ public class IFrame extends HtmlComponent implements HasAriaLabel {
      */
     public void setSrc(String src) {
         if (src != null && !UrlUtil.isSafeUrl(src)) {
-            throw new IllegalArgumentException(String.format(
-                    "The src \"%s\" uses a scheme that is not considered safe. "
-                            + "Configure the safe schemes with the \"%s\" property, "
-                            + "or use setUnsafeSrc(String) if this URL is intentional and trusted.",
-                    src, InitParameters.URL_SAFE_SCHEMES));
+            throw new IllegalArgumentException(UrlUtil
+                    .getUnsafeUrlMessage("src", src, "setUnsafeSrc(String)"));
         }
         set(srcDescriptor, src);
     }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
@@ -26,6 +26,7 @@ import com.vaadin.flow.component.PropertyDescriptor;
 import com.vaadin.flow.component.PropertyDescriptors;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.server.AbstractStreamResource;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.StreamResource;
 import com.vaadin.flow.server.streams.AbstractDownloadHandler;
 import com.vaadin.flow.server.streams.DownloadHandler;
@@ -196,6 +197,10 @@ public class Image extends HtmlContainer
 
     /**
      * Sets the image URL.
+     * <p>
+     * Unlike {@link Anchor#setHref(String)} and {@link IFrame#setSrc(String)},
+     * image URLs are not validated against the
+     * {@value InitParameters#URL_SAFE_SCHEMES} configuration.
      *
      * @param src
      *            the image URL

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
@@ -430,14 +430,14 @@ class AnchorTest extends ComponentTest {
     }
 
     @Test
-    void setHref_disallowedScheme_throws() {
+    void setHref_unsafeScheme_throws() {
         Anchor anchor = new Anchor();
         assertThrows(IllegalArgumentException.class,
                 () -> anchor.setHref("javascript:alert(1)"));
     }
 
     @Test
-    void setUnsafeHref_disallowedScheme_setsHrefWithoutValidation() {
+    void setUnsafeHref_unsafeScheme_setsHrefWithoutValidation() {
         Anchor anchor = new Anchor();
         anchor.setUnsafeHref("javascript:alert(1)");
         assertEquals("javascript:alert(1)",

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
@@ -32,6 +32,7 @@ import com.vaadin.flow.server.streams.ServletResourceDownloadHandler;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AnchorTest extends ComponentTest {
@@ -426,6 +427,21 @@ class AnchorTest extends ComponentTest {
 
         assertTrue(anchor.isDownload(),
                 "Custom download handlers should by default add download attribute");
+    }
+
+    @Test
+    void setHref_disallowedScheme_throws() {
+        Anchor anchor = new Anchor();
+        assertThrows(IllegalArgumentException.class,
+                () -> anchor.setHref("javascript:alert(1)"));
+    }
+
+    @Test
+    void setUnsafeHref_disallowedScheme_setsHrefWithoutValidation() {
+        Anchor anchor = new Anchor();
+        anchor.setUnsafeHref("javascript:alert(1)");
+        assertEquals("javascript:alert(1)",
+                anchor.getElement().getAttribute("href"));
     }
 
     private void mockUI() {

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
@@ -28,6 +28,7 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.server.AbstractStreamResource;
 import com.vaadin.flow.server.streams.DownloadHandler;
 import com.vaadin.flow.server.streams.ServletResourceDownloadHandler;
+import com.vaadin.flow.signals.local.ValueSignal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -442,6 +443,32 @@ class AnchorTest extends ComponentTest {
         anchor.setUnsafeHref("javascript:alert(1)");
         assertEquals("javascript:alert(1)",
                 anchor.getElement().getAttribute("href"));
+    }
+
+    @Test
+    void constructor_stringHrefStringText_unsafeScheme_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new Anchor("javascript:alert(1)", "Click"));
+    }
+
+    @Test
+    void constructor_stringHrefSignalText_unsafeScheme_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new Anchor("javascript:alert(1)",
+                        new ValueSignal<>("Click")));
+    }
+
+    @Test
+    void constructor_stringHrefStringTextTarget_unsafeScheme_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new Anchor("javascript:alert(1)", "Click",
+                        AnchorTarget.BLANK));
+    }
+
+    @Test
+    void constructor_stringHrefComponents_unsafeScheme_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new Anchor("javascript:alert(1)"));
     }
 
     private void mockUI() {

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
@@ -263,6 +263,11 @@ class HtmlComponentSmokeTest {
             return true;
         }
 
+        if (method.getDeclaringClass() == IFrame.class
+                && method.getName().equals("setUnsafeSrc")) {
+            return true;
+        }
+
         if (method.getDeclaringClass() == HtmlObject.class
                 && method.getName().startsWith("setData")
                 && method.getParameterTypes()[0] == DownloadHandler.class) {
@@ -272,6 +277,11 @@ class HtmlComponentSmokeTest {
         if (method.getDeclaringClass() == Anchor.class
                 && method.getName().startsWith("setHref")
                 && method.getParameterTypes()[0] == DownloadHandler.class) {
+            return true;
+        }
+
+        if (method.getDeclaringClass() == Anchor.class
+                && method.getName().equals("setUnsafeHref")) {
             return true;
         }
 

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/IFrameTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/IFrameTest.java
@@ -119,14 +119,14 @@ class IFrameTest extends ComponentTest {
     }
 
     @Test
-    void setSrc_disallowedScheme_throws() {
+    void setSrc_unsafeScheme_throws() {
         IFrame iframe = new IFrame();
         assertThrows(IllegalArgumentException.class,
                 () -> iframe.setSrc("javascript:alert(1)"));
     }
 
     @Test
-    void setUnsafeSrc_disallowedScheme_setsSrcWithoutValidation() {
+    void setUnsafeSrc_unsafeScheme_setsSrcWithoutValidation() {
         IFrame iframe = new IFrame();
         iframe.setUnsafeSrc("javascript:alert(1)");
         assertEquals("javascript:alert(1)", iframe.getSrc());

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/IFrameTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/IFrameTest.java
@@ -131,4 +131,10 @@ class IFrameTest extends ComponentTest {
         iframe.setUnsafeSrc("javascript:alert(1)");
         assertEquals("javascript:alert(1)", iframe.getSrc());
     }
+
+    @Test
+    void constructor_unsafeSrc_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new IFrame("javascript:alert(1)"));
+    }
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/IFrameTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/IFrameTest.java
@@ -30,6 +30,7 @@ import com.vaadin.flow.server.streams.InputStreamDownloadHandler;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class IFrameTest extends ComponentTest {
@@ -115,5 +116,19 @@ class IFrameTest extends ComponentTest {
         assertFalse(handler.isInline());
         new TestIFrame(handler);
         assertTrue(handler.isInline());
+    }
+
+    @Test
+    void setSrc_disallowedScheme_throws() {
+        IFrame iframe = new IFrame();
+        assertThrows(IllegalArgumentException.class,
+                () -> iframe.setSrc("javascript:alert(1)"));
+    }
+
+    @Test
+    void setUnsafeSrc_disallowedScheme_setsSrcWithoutValidation() {
+        IFrame iframe = new IFrame();
+        iframe.setUnsafeSrc("javascript:alert(1)");
+        assertEquals("javascript:alert(1)", iframe.getSrc());
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -40,6 +40,7 @@ import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.JsFunction;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.UrlUtil;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.shared.ui.Dependency;
 import com.vaadin.flow.shared.ui.Dependency.Type;
@@ -596,8 +597,63 @@ public class Page implements Serializable {
      *            the URL to open.
      * @param windowName
      *            the name of the window.
+     * @throws IllegalArgumentException
+     *             if the URL uses a scheme that is not considered safe; see
+     *             {@link #openUnsafe(String, String)} and the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public void open(String url, String windowName) {
+        if (!UrlUtil.isSafeUrl(url)) {
+            throw new IllegalArgumentException(String.format(
+                    "The URL \"%s\" uses a scheme that is not considered safe. "
+                            + "Configure the safe schemes with the \"%s\" property, "
+                            + "or use openUnsafe(String, String) if this URL is intentional and trusted.",
+                    url, InitParameters.URL_SAFE_SCHEMES));
+        }
+        openInternal(url, windowName);
+    }
+
+    /**
+     * Opens the given url in a new tab without validating its scheme.
+     * <p>
+     * Unlike {@link #open(String)}, this method does not reject URLs based on
+     * the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use it only
+     * for URLs that are fully under your control and known to be safe. Passing
+     * untrusted input here can expose the application to cross-site scripting
+     * (XSS) attacks.
+     *
+     * @see #open(String)
+     *
+     * @param url
+     *            the URL to open.
+     */
+    public void openUnsafe(String url) {
+        openInternal(url, "_blank");
+    }
+
+    /**
+     * Opens the given URL in a window with the given name without validating
+     * its scheme.
+     * <p>
+     * Unlike {@link #open(String, String)}, this method does not reject URLs
+     * based on the {@value InitParameters#URL_SAFE_SCHEMES} configuration. Use
+     * it only for URLs that are fully under your control and known to be safe.
+     * Passing untrusted input here can expose the application to cross-site
+     * scripting (XSS) attacks.
+     *
+     * @see #open(String, String)
+     *
+     * @param url
+     *            the URL to open.
+     * @param windowName
+     *            the name of the window.
+     */
+    public void openUnsafe(String url, String windowName) {
+        openInternal(url, windowName);
+    }
+
+    private void openInternal(String url, String windowName) {
         // The vaadin-redirect-pending event might be useful to block other
         // client side
         // reload/redirection triggered by other components, for example Vite.

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -675,6 +675,12 @@ public class Page implements Serializable {
      *
      * @param uri
      *            the URI to show
+     * @throws IllegalArgumentException
+     *             if {@code uri} is {@code null}, or if the URI uses a scheme
+     *             that is not considered safe; call
+     *             {@code openUnsafe(uri, "_self")} to bypass scheme validation,
+     *             and see the {@value InitParameters#URL_SAFE_SCHEMES}
+     *             configuration property
      */
     public void setLocation(String uri) {
         open(uri, "_self");
@@ -686,6 +692,13 @@ public class Page implements Serializable {
      *
      * @param uri
      *            the URI to show
+     * @throws IllegalArgumentException
+     *             if {@code uri} is {@code null}, or if the URI uses a scheme
+     *             that is not considered safe; call
+     *             {@code openUnsafe(uri.toString(), "_self")} to bypass scheme
+     *             validation, and see the
+     *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
+     *             property
      */
     public void setLocation(URI uri) {
         setLocation(uri.toString());

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -605,11 +605,8 @@ public class Page implements Serializable {
      */
     public void open(String url, String windowName) {
         if (!UrlUtil.isSafeUrl(url)) {
-            throw new IllegalArgumentException(String.format(
-                    "The URL \"%s\" uses a scheme that is not considered safe. "
-                            + "Configure the safe schemes with the \"%s\" property, "
-                            + "or use openUnsafe(String, String) if this URL is intentional and trusted.",
-                    url, InitParameters.URL_SAFE_SCHEMES));
+            throw new IllegalArgumentException(UrlUtil.getUnsafeUrlMessage(
+                    "URL", url, "openUnsafe(String, String)"));
         }
         openInternal(url, windowName);
     }

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -560,6 +560,11 @@ public class Page implements Serializable {
      *
      * @param url
      *            the URL to open.
+     * @throws IllegalArgumentException
+     *             if {@code url} is {@code null}, or if the URL uses a scheme
+     *             that is not considered safe; see {@link #openUnsafe(String)}
+     *             and the {@value InitParameters#URL_SAFE_SCHEMES}
+     *             configuration property
      */
     public void open(String url) {
         open(url, "_blank");
@@ -598,12 +603,16 @@ public class Page implements Serializable {
      * @param windowName
      *            the name of the window.
      * @throws IllegalArgumentException
-     *             if the URL uses a scheme that is not considered safe; see
+     *             if {@code url} is {@code null}, or if the URL uses a scheme
+     *             that is not considered safe; see
      *             {@link #openUnsafe(String, String)} and the
      *             {@value InitParameters#URL_SAFE_SCHEMES} configuration
      *             property
      */
     public void open(String url, String windowName) {
+        if (url == null) {
+            throw new IllegalArgumentException("URL must not be null");
+        }
         if (!UrlUtil.isSafeUrl(url)) {
             throw new IllegalArgumentException(UrlUtil.getUnsafeUrlMessage(
                     "URL", url, "openUnsafe(String, String)"));

--- a/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -252,6 +253,21 @@ public interface DeploymentConfiguration
                         POLYFILLS_DEFAULT_VALUE).split("[, ]+"))
                 .stream().filter(polyfill -> !polyfill.isEmpty())
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns the set of URL schemes considered safe in URLs set on components
+     * such as {@code Anchor}, {@code IFrame} and in
+     * {@link com.vaadin.flow.component.page.Page#open(String, String)}.
+     * <p>
+     * Concrete implementations read this from the
+     * {@link InitParameters#URL_SAFE_SCHEMES} property; the default returns
+     * {@link Constants#DEFAULT_URL_SAFE_SCHEMES}.
+     *
+     * @return the set of safe URL schemes, never {@code null}
+     */
+    default Set<String> getUrlSafeSchemes() {
+        return Constants.DEFAULT_URL_SAFE_SCHEMES;
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
@@ -310,7 +310,8 @@ public class UrlUtil {
 
     /**
      * Checks whether the scheme of the given URL is part of the given set of
-     * safe schemes. See {@link #isSafeUrl(String)} for the validation rules.
+     * safe schemes. See {@link #isSafeUrl(String)} for the validation rules. A
+     * {@code null} URL is considered unsafe.
      *
      * @param url
      *            the URL to check, may be {@code null}

--- a/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
@@ -256,8 +256,9 @@ public class UrlUtil {
             "https", "mailto", "tel", "ftp");
 
     /**
-     * Special {@link InitParameters#URL_SAFE_SCHEMES} value that marks every
-     * scheme as safe, disabling scheme validation.
+     * Special {@link InitParameters#URL_SAFE_SCHEMES} entry that marks every
+     * scheme as safe, disabling scheme validation. Mixing this entry with other
+     * schemes still disables validation.
      */
     public static final String ALL_SCHEMES_SAFE = "*";
 

--- a/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
@@ -20,12 +20,13 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.VaadinService;
 
@@ -245,44 +246,26 @@ public class UrlUtil {
     }
 
     /**
-     * The URL schemes that are considered safe by default when no custom set is
-     * configured through the {@link InitParameters#URL_SAFE_SCHEMES} property.
-     * <p>
-     * Script-capable schemes such as {@code javascript} and {@code data} are
-     * intentionally excluded as they can be used to execute scripts in the
-     * browser when used as a link or frame target.
-     */
-    public static final Set<String> DEFAULT_SAFE_SCHEMES = Set.of("http",
-            "https", "mailto", "tel", "ftp");
-
-    /**
-     * Special {@link InitParameters#URL_SAFE_SCHEMES} entry that marks every
-     * scheme as safe, disabling scheme validation. Mixing this entry with other
-     * schemes still disables validation.
-     */
-    public static final String ALL_SCHEMES_SAFE = "*";
-
-    /**
      * Checks whether the scheme of the given URL is considered safe by the
      * current deployment configuration.
      * <p>
-     * The set of safe schemes is read from the
-     * {@link InitParameters#URL_SAFE_SCHEMES} configuration property, falling
-     * back to {@link #DEFAULT_SAFE_SCHEMES} when the property is not set or
-     * when no {@link VaadinService} is available. Relative URLs (without a
-     * scheme) are always considered safe, whereas URLs containing control
-     * characters are rejected as they can be used to obfuscate the scheme.
-     * <p>
-     * When called from a thread without a current {@link VaadinService}, the
-     * configured safe schemes are not read and {@link #DEFAULT_SAFE_SCHEMES} is
-     * used instead.
+     * The set of safe schemes is read from the current {@link VaadinService}'s
+     * {@link DeploymentConfiguration#getUrlSafeSchemes()}, falling back to
+     * {@link Constants#DEFAULT_URL_SAFE_SCHEMES} when no {@link VaadinService}
+     * is available. Relative URLs (without a scheme) are always considered
+     * safe, whereas URLs containing control characters are rejected as they can
+     * be used to obfuscate the scheme.
      *
      * @param url
      *            the URL to check, may be {@code null}
      * @return {@code true} if the URL is safe, {@code false} otherwise
      */
     public static boolean isSafeUrl(String url) {
-        return isSafeUrl(url, getConfiguredSafeSchemes());
+        VaadinService service = VaadinService.getCurrent();
+        Set<String> safeSchemes = service == null
+                ? Constants.DEFAULT_URL_SAFE_SCHEMES
+                : service.getDeploymentConfiguration().getUrlSafeSchemes();
+        return isSafeUrl(url, safeSchemes);
     }
 
     /**
@@ -319,7 +302,8 @@ public class UrlUtil {
      *            the URL to check, may be {@code null}
      * @param safeSchemes
      *            the set of safe lower-case schemes, or a set containing
-     *            {@link #ALL_SCHEMES_SAFE} to treat any scheme as safe
+     *            {@link Constants#URL_SAFE_SCHEMES_WILDCARD} to treat any
+     *            scheme as safe
      * @return {@code true} if the URL is safe, {@code false} otherwise
      */
     static boolean isSafeUrl(String url, Set<String> safeSchemes) {
@@ -328,7 +312,7 @@ public class UrlUtil {
         }
         // A wildcard entry treats every scheme as safe, keeping the behaviour
         // fully backwards compatible for applications that opt out.
-        if (safeSchemes.contains(ALL_SCHEMES_SAFE)) {
+        if (safeSchemes.contains(Constants.URL_SAFE_SCHEMES_WILDCARD)) {
             return true;
         }
         String trimmed = url.trim();
@@ -383,28 +367,5 @@ public class UrlUtil {
 
     private static boolean isAlpha(char c) {
         return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
-    }
-
-    private static Set<String> getConfiguredSafeSchemes() {
-        VaadinService service = VaadinService.getCurrent();
-        if (service == null) {
-            return DEFAULT_SAFE_SCHEMES;
-        }
-        return parseSafeSchemes(service.getDeploymentConfiguration()
-                .getStringProperty(InitParameters.URL_SAFE_SCHEMES, null));
-    }
-
-    static Set<String> parseSafeSchemes(String configured) {
-        if (configured == null || configured.isBlank()) {
-            return DEFAULT_SAFE_SCHEMES;
-        }
-        Set<String> schemes = new HashSet<>();
-        for (String scheme : configured.split(",")) {
-            String trimmed = scheme.trim();
-            if (!trimmed.isEmpty()) {
-                schemes.add(trimmed.toLowerCase(Locale.ROOT));
-            }
-        }
-        return schemes.isEmpty() ? DEFAULT_SAFE_SCHEMES : schemes;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
@@ -271,6 +271,10 @@ public class UrlUtil {
      * when no {@link VaadinService} is available. Relative URLs (without a
      * scheme) are always considered safe, whereas URLs containing control
      * characters are rejected as they can be used to obfuscate the scheme.
+     * <p>
+     * When called from a thread without a current {@link VaadinService}, the
+     * configured safe schemes are not read and {@link #DEFAULT_SAFE_SCHEMES} is
+     * used instead.
      *
      * @param url
      *            the URL to check, may be {@code null}

--- a/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
@@ -20,8 +20,14 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import com.vaadin.flow.server.InitParameters;
+import com.vaadin.flow.server.VaadinService;
 
 /**
  * Internal utility class for URL handling.
@@ -236,5 +242,138 @@ public class UrlUtil {
             return ".";
         }
         return ret.substring(0, ret.length() - 1);
+    }
+
+    /**
+     * The URL schemes that are considered safe by default when no custom set is
+     * configured through the {@link InitParameters#URL_SAFE_SCHEMES} property.
+     * <p>
+     * Script-capable schemes such as {@code javascript} and {@code data} are
+     * intentionally excluded as they can be used to execute scripts in the
+     * browser when used as a link or frame target.
+     */
+    public static final Set<String> DEFAULT_SAFE_SCHEMES = Set.of("http",
+            "https", "mailto", "tel", "ftp");
+
+    /**
+     * Special {@link InitParameters#URL_SAFE_SCHEMES} value that marks every
+     * scheme as safe, disabling scheme validation.
+     */
+    public static final String ALL_SCHEMES_SAFE = "*";
+
+    /**
+     * Checks whether the scheme of the given URL is considered safe by the
+     * current deployment configuration.
+     * <p>
+     * The set of safe schemes is read from the
+     * {@link InitParameters#URL_SAFE_SCHEMES} configuration property, falling
+     * back to {@link #DEFAULT_SAFE_SCHEMES} when the property is not set or
+     * when no {@link VaadinService} is available. Relative URLs (without a
+     * scheme) are always considered safe, whereas URLs containing control
+     * characters are rejected as they can be used to obfuscate the scheme.
+     *
+     * @param url
+     *            the URL to check, may be {@code null}
+     * @return {@code true} if the URL is safe, {@code false} otherwise
+     */
+    public static boolean isSafeUrl(String url) {
+        return isSafeUrl(url, getConfiguredSafeSchemes());
+    }
+
+    /**
+     * Checks whether the scheme of the given URL is part of the given set of
+     * safe schemes. See {@link #isSafeUrl(String)} for the validation rules.
+     *
+     * @param url
+     *            the URL to check, may be {@code null}
+     * @param safeSchemes
+     *            the set of safe lower-case schemes, or a set containing
+     *            {@link #ALL_SCHEMES_SAFE} to treat any scheme as safe
+     * @return {@code true} if the URL is safe, {@code false} otherwise
+     */
+    static boolean isSafeUrl(String url, Set<String> safeSchemes) {
+        if (url == null) {
+            return false;
+        }
+        // A wildcard entry treats every scheme as safe, keeping the behaviour
+        // fully backwards compatible for applications that opt out.
+        if (safeSchemes.contains(ALL_SCHEMES_SAFE)) {
+            return true;
+        }
+        String trimmed = url.trim();
+        if (trimmed.isEmpty()) {
+            return true;
+        }
+        // Reject control characters which browsers may strip, allowing a
+        // different URL to be acted upon than the one validated here (for
+        // example "java\tscript:alert(1)").
+        for (int i = 0; i < trimmed.length(); i++) {
+            if (Character.isISOControl(trimmed.charAt(i))) {
+                return false;
+            }
+        }
+        String scheme = extractScheme(trimmed);
+        if (scheme == null) {
+            // Relative URLs have no scheme and cannot trigger scheme-based
+            // script execution.
+            return true;
+        }
+        return safeSchemes.contains(scheme.toLowerCase(Locale.ROOT));
+    }
+
+    /**
+     * Extracts the scheme from the given URL, or returns {@code null} if the
+     * URL is relative (has no scheme). The scheme is determined according to
+     * RFC 3986: a letter followed by any number of letters, digits,
+     * {@code '+'}, {@code '-'} or {@code '.'}, terminated by a {@code ':'} that
+     * occurs before any {@code '/'}, {@code '?'} or {@code '#'}.
+     * <p>
+     * The scheme is extracted without parsing the whole URL so that valid
+     * relative URLs containing characters that a strict URI parser would reject
+     * (such as spaces) are not falsely flagged.
+     */
+    private static String extractScheme(String url) {
+        for (int i = 0; i < url.length(); i++) {
+            char c = url.charAt(i);
+            if (c == ':') {
+                return i == 0 ? null : url.substring(0, i);
+            }
+            boolean validSchemeChar = (i == 0) ? isAlpha(c)
+                    : (isAlpha(c) || (c >= '0' && c <= '9') || c == '+'
+                            || c == '-' || c == '.');
+            if (!validSchemeChar) {
+                // The ':' (if any) belongs to the path or query, so there is no
+                // scheme and the URL is relative.
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private static boolean isAlpha(char c) {
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+    }
+
+    private static Set<String> getConfiguredSafeSchemes() {
+        VaadinService service = VaadinService.getCurrent();
+        if (service == null) {
+            return DEFAULT_SAFE_SCHEMES;
+        }
+        return parseSafeSchemes(service.getDeploymentConfiguration()
+                .getStringProperty(InitParameters.URL_SAFE_SCHEMES, null));
+    }
+
+    static Set<String> parseSafeSchemes(String configured) {
+        if (configured == null || configured.isBlank()) {
+            return DEFAULT_SAFE_SCHEMES;
+        }
+        Set<String> schemes = new HashSet<>();
+        for (String scheme : configured.split(",")) {
+            String trimmed = scheme.trim();
+            if (!trimmed.isEmpty()) {
+                schemes.add(trimmed.toLowerCase(Locale.ROOT));
+            }
+        }
+        return schemes.isEmpty() ? DEFAULT_SAFE_SCHEMES : schemes;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
@@ -25,6 +25,9 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.InitParameters;
@@ -254,7 +257,7 @@ public class UrlUtil {
      * {@link Constants#DEFAULT_URL_SAFE_SCHEMES} when no {@link VaadinService}
      * is available. Relative URLs (without a scheme) are always considered
      * safe, whereas URLs containing control characters are rejected as they can
-     * be used to obfuscate the scheme.
+     * be used to obfuscate the scheme. A {@code null} URL is considered unsafe.
      *
      * @param url
      *            the URL to check, may be {@code null}
@@ -262,9 +265,20 @@ public class UrlUtil {
      */
     public static boolean isSafeUrl(String url) {
         VaadinService service = VaadinService.getCurrent();
-        Set<String> safeSchemes = service == null
-                ? Constants.DEFAULT_URL_SAFE_SCHEMES
-                : service.getDeploymentConfiguration().getUrlSafeSchemes();
+        Set<String> safeSchemes;
+        if (service == null) {
+            if (getLogger().isDebugEnabled()) {
+                getLogger()
+                        .debug("No VaadinService available on current thread; "
+                                + "falling back to default safe URL schemes. "
+                                + "Any custom {} configuration will not apply "
+                                + "here.", InitParameters.URL_SAFE_SCHEMES);
+            }
+            safeSchemes = Constants.DEFAULT_URL_SAFE_SCHEMES;
+        } else {
+            safeSchemes = service.getDeploymentConfiguration()
+                    .getUrlSafeSchemes();
+        }
         return isSafeUrl(url, safeSchemes);
     }
 
@@ -367,5 +381,9 @@ public class UrlUtil {
 
     private static boolean isAlpha(char c) {
         return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+    }
+
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(UrlUtil.class);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
@@ -281,6 +281,32 @@ public class UrlUtil {
     }
 
     /**
+     * Builds the message for the {@link IllegalArgumentException} that a
+     * validating URL setter throws when given a URL whose scheme is not
+     * considered safe. The message points to both the
+     * {@link InitParameters#URL_SAFE_SCHEMES} configuration property and the
+     * setter that bypasses validation.
+     *
+     * @param type
+     *            the kind of URL being set, for example {@code "href"},
+     *            {@code "src"} or {@code "path"}
+     * @param url
+     *            the rejected URL
+     * @param unsafeMethod
+     *            the signature of the method that bypasses validation, for
+     *            example {@code "setUnsafeHref(String)"}
+     * @return the exception message
+     */
+    public static String getUnsafeUrlMessage(String type, String url,
+            String unsafeMethod) {
+        return String.format(
+                "The %s \"%s\" uses a scheme that is not considered safe. "
+                        + "Configure the safe schemes with the \"%s\" property, "
+                        + "or use %s if this URL is intentional and trusted.",
+                type, url, InitParameters.URL_SAFE_SCHEMES, unsafeMethod);
+    }
+
+    /**
      * Checks whether the scheme of the given URL is part of the given set of
      * safe schemes. See {@link #isSafeUrl(String)} for the validation rules.
      *

--- a/flow-server/src/main/java/com/vaadin/flow/server/AbstractDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AbstractDeploymentConfiguration.java
@@ -15,7 +15,10 @@
  */
 package com.vaadin.flow.server;
 
+import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.function.DeploymentConfiguration;
@@ -30,6 +33,8 @@ import com.vaadin.flow.function.DeploymentConfiguration;
  */
 public abstract class AbstractDeploymentConfiguration extends
         AbstractPropertyConfiguration implements DeploymentConfiguration {
+
+    private volatile Set<String> urlSafeSchemes;
 
     /**
      * Creates a new configuration based on {@code properties}.
@@ -50,6 +55,32 @@ public abstract class AbstractDeploymentConfiguration extends
     @Override
     public String getClassLoaderName() {
         return getStringProperty("ClassLoader", null);
+    }
+
+    @Override
+    public Set<String> getUrlSafeSchemes() {
+        Set<String> cached = urlSafeSchemes;
+        if (cached == null) {
+            cached = parseUrlSafeSchemes(
+                    getStringProperty(InitParameters.URL_SAFE_SCHEMES, null));
+            urlSafeSchemes = cached;
+        }
+        return cached;
+    }
+
+    private static Set<String> parseUrlSafeSchemes(String configured) {
+        if (configured == null || configured.isBlank()) {
+            return Constants.DEFAULT_URL_SAFE_SCHEMES;
+        }
+        Set<String> schemes = new HashSet<>();
+        for (String scheme : configured.split(",")) {
+            String trimmed = scheme.trim();
+            if (!trimmed.isEmpty()) {
+                schemes.add(trimmed.toLowerCase(Locale.ROOT));
+            }
+        }
+        return schemes.isEmpty() ? Constants.DEFAULT_URL_SAFE_SCHEMES
+                : Set.copyOf(schemes);
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.server;
 
 import java.io.Serializable;
+import java.util.Set;
 
 /**
  * Constants used by the server side framework.
@@ -430,6 +431,24 @@ public final class Constants implements Serializable {
      * maximum number of files allowed per multipart stream upload requests.
      */
     public static final long DEFAULT_FILE_COUNT_MAX = 10000;
+
+    /**
+     * Default set of URL schemes considered safe when no custom set is
+     * configured through {@link InitParameters#URL_SAFE_SCHEMES}.
+     * <p>
+     * Script-capable schemes such as {@code javascript} and {@code data} are
+     * intentionally excluded as they can be used to execute scripts in the
+     * browser when used as a link or frame target.
+     */
+    public static final Set<String> DEFAULT_URL_SAFE_SCHEMES = Set.of("http",
+            "https", "mailto", "tel", "ftp");
+
+    /**
+     * Special {@link InitParameters#URL_SAFE_SCHEMES} entry that marks every
+     * scheme as safe, disabling scheme validation. Mixing this entry with other
+     * schemes still disables validation.
+     */
+    public static final String URL_SAFE_SCHEMES_WILDCARD = "*";
 
     private Constants() {
         // prevent instantiation constants class only

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -317,9 +317,8 @@ public class InitParameters implements Serializable {
 
     /**
      * Configuration name for the comma-separated list of URL schemes that are
-     * considered safe in URLs set on components such as
-     * {@link com.vaadin.flow.component.html.Anchor},
-     * {@link com.vaadin.flow.component.html.IFrame} and in
+     * considered safe in URLs set on components such as {@code Anchor},
+     * {@code IFrame} and in
      * {@link com.vaadin.flow.component.page.Page#open(String, String)}.
      * <p>
      * When not set, a built-in default set of safe schemes is used (for example

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -324,7 +324,7 @@ public class InitParameters implements Serializable {
      * When not set, a built-in default set of safe schemes is used (for example
      * {@code http}, {@code https}, {@code mailto}, {@code tel} and
      * {@code ftp}), which excludes script-capable schemes such as
-     * {@code javascript} and {@code data}. The single value {@code *} marks
+     * {@code javascript} and {@code data}. Any entry equal to {@code *} marks
      * every scheme as safe, disabling scheme validation. URLs whose scheme is
      * not safe can still be set through the dedicated {@code setUnsafe*}
      * methods.

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -315,4 +315,21 @@ public class InitParameters implements Serializable {
      */
     public static final String MINIMUM_FRONTEND_PACKAGE_AGE_DAYS = "npm.minimumFrontendPackageAgeDays";
 
+    /**
+     * Configuration name for the comma-separated list of URL schemes that are
+     * considered safe in URLs set on components such as
+     * {@link com.vaadin.flow.component.html.Anchor},
+     * {@link com.vaadin.flow.component.html.IFrame} and in
+     * {@link com.vaadin.flow.component.page.Page#open(String, String)}.
+     * <p>
+     * When not set, a built-in default set of safe schemes is used (for example
+     * {@code http}, {@code https}, {@code mailto}, {@code tel} and
+     * {@code ftp}), which excludes script-capable schemes such as
+     * {@code javascript} and {@code data}. The single value {@code *} marks
+     * every scheme as safe, disabling scheme validation. URLs whose scheme is
+     * not safe can still be set through the dedicated {@code setUnsafe*}
+     * methods.
+     */
+    public static final String URL_SAFE_SCHEMES = "com.vaadin.safeUrlSchemes";
+
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
@@ -418,6 +418,28 @@ class PageTest {
     }
 
     @Test
+    void openUnsafe_twoArg_opensWithoutValidation() {
+        AtomicReference<String> capture = new AtomicReference<>();
+        List<Object> params = new ArrayList<>();
+        Page page = new Page(new MockUI()) {
+            @Override
+            public PendingJavaScriptResult executeJs(String expression,
+                    Object... parameters) {
+                capture.set(expression);
+                params.addAll(Arrays.asList(parameters));
+                return Mockito.mock(PendingJavaScriptResult.class);
+            }
+        };
+
+        page.openUnsafe("javascript:alert(1)", "_blank");
+
+        assertTrue(capture.get().contains("window.open"),
+                "Should call window.open");
+        assertEquals("javascript:alert(1)", params.get(0));
+        assertEquals("_blank", params.get(1));
+    }
+
+    @Test
     void setColorScheme_setsStyleProperty() {
         AtomicReference<String> capturedExpression = new AtomicReference<>();
         AtomicReference<Object[]> capturedParams = new AtomicReference<>();

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
@@ -351,6 +351,43 @@ class PageTest {
     }
 
     @Test
+    void open_disallowedScheme_throws() {
+        Page page = new Page(new MockUI()) {
+            @Override
+            public PendingJavaScriptResult executeJs(String expression,
+                    Object... parameters) {
+                return fail("Disallowed URL should not reach the client");
+            }
+        };
+
+        assertThrows(IllegalArgumentException.class,
+                () -> page.open("javascript:alert(1)"));
+        assertThrows(IllegalArgumentException.class,
+                () -> page.open("javascript:alert(1)", "_blank"));
+    }
+
+    @Test
+    void openUnsafe_disallowedScheme_opensWithoutValidation() {
+        AtomicReference<String> capture = new AtomicReference<>();
+        List<Object> params = new ArrayList<>();
+        Page page = new Page(new MockUI()) {
+            @Override
+            public PendingJavaScriptResult executeJs(String expression,
+                    Object... parameters) {
+                capture.set(expression);
+                params.addAll(Arrays.asList(parameters));
+                return Mockito.mock(PendingJavaScriptResult.class);
+            }
+        };
+
+        page.openUnsafe("javascript:alert(1)");
+
+        assertTrue(capture.get().contains("window.open"),
+                "Should call window.open");
+        assertEquals("javascript:alert(1)", params.get(0));
+    }
+
+    @Test
     void setColorScheme_setsStyleProperty() {
         AtomicReference<String> capturedExpression = new AtomicReference<>();
         AtomicReference<Object[]> capturedParams = new AtomicReference<>();

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
@@ -367,6 +367,22 @@ class PageTest {
     }
 
     @Test
+    void open_nullUrl_throwsWithUsefulMessage() {
+        Page page = new Page(new MockUI()) {
+            @Override
+            public PendingJavaScriptResult executeJs(String expression,
+                    Object... parameters) {
+                return fail("Null URL should not reach the client");
+            }
+        };
+
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> page.open(null, "_blank"));
+        assertEquals("URL must not be null", ex.getMessage());
+    }
+
+    @Test
     void openUnsafe_unsafeScheme_opensWithoutValidation() {
         AtomicReference<String> capture = new AtomicReference<>();
         List<Object> params = new ArrayList<>();

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
@@ -351,12 +351,12 @@ class PageTest {
     }
 
     @Test
-    void open_disallowedScheme_throws() {
+    void open_unsafeScheme_throws() {
         Page page = new Page(new MockUI()) {
             @Override
             public PendingJavaScriptResult executeJs(String expression,
                     Object... parameters) {
-                return fail("Disallowed URL should not reach the client");
+                return fail("Unsafe URL should not reach the client");
             }
         };
 
@@ -367,7 +367,7 @@ class PageTest {
     }
 
     @Test
-    void openUnsafe_disallowedScheme_opensWithoutValidation() {
+    void openUnsafe_unsafeScheme_opensWithoutValidation() {
         AtomicReference<String> capture = new AtomicReference<>();
         List<Object> params = new ArrayList<>();
         Page page = new Page(new MockUI()) {

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
@@ -367,6 +367,20 @@ class PageTest {
     }
 
     @Test
+    void setLocation_unsafeScheme_throws() {
+        Page page = new Page(new MockUI()) {
+            @Override
+            public PendingJavaScriptResult executeJs(String expression,
+                    Object... parameters) {
+                return fail("Unsafe URL should not reach the client");
+            }
+        };
+
+        assertThrows(IllegalArgumentException.class,
+                () -> page.setLocation("javascript:alert(1)"));
+    }
+
+    @Test
     void open_nullUrl_throwsWithUsefulMessage() {
         Page page = new Page(new MockUI()) {
             @Override

--- a/flow-server/src/test/java/com/vaadin/flow/internal/UrlUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/UrlUtilTest.java
@@ -24,7 +24,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.function.DeploymentConfiguration;
-import com.vaadin.flow.server.InitParameters;
+import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.server.VaadinServletService;
@@ -214,70 +214,72 @@ class UrlUtilTest {
     @Test
     void isSafeUrl_safeScheme_returnsTrue() {
         assertTrue(UrlUtil.isSafeUrl("https://vaadin.com",
-                UrlUtil.DEFAULT_SAFE_SCHEMES));
+                Constants.DEFAULT_URL_SAFE_SCHEMES));
     }
 
     @Test
     void isSafeUrl_unsafeScheme_returnsFalse() {
         assertFalse(UrlUtil.isSafeUrl("javascript:alert(1)",
-                UrlUtil.DEFAULT_SAFE_SCHEMES));
+                Constants.DEFAULT_URL_SAFE_SCHEMES));
         assertFalse(UrlUtil.isSafeUrl("data:text/html,<script>",
-                UrlUtil.DEFAULT_SAFE_SCHEMES));
+                Constants.DEFAULT_URL_SAFE_SCHEMES));
     }
 
     @Test
     void isSafeUrl_schemeMatchIsCaseInsensitive_returnsFalse() {
         assertFalse(UrlUtil.isSafeUrl("JavaScript:alert(1)",
-                UrlUtil.DEFAULT_SAFE_SCHEMES));
+                Constants.DEFAULT_URL_SAFE_SCHEMES));
     }
 
     @Test
     void isSafeUrl_relativeUrl_returnsTrue() {
         assertTrue(UrlUtil.isSafeUrl("/path/to/view",
-                UrlUtil.DEFAULT_SAFE_SCHEMES));
-        assertTrue(UrlUtil.isSafeUrl("foo", UrlUtil.DEFAULT_SAFE_SCHEMES));
+                Constants.DEFAULT_URL_SAFE_SCHEMES));
+        assertTrue(
+                UrlUtil.isSafeUrl("foo", Constants.DEFAULT_URL_SAFE_SCHEMES));
     }
 
     @Test
     void isSafeUrl_relativeUrlWithSpecialCharacters_returnsTrue() {
         // A strict URI parser would reject this, but it is a valid relative URL
         assertTrue(UrlUtil.isSafeUrl("/search?q=a b&x=[1]",
-                UrlUtil.DEFAULT_SAFE_SCHEMES));
+                Constants.DEFAULT_URL_SAFE_SCHEMES));
         // A colon in the path must not be mistaken for a scheme separator
         assertTrue(UrlUtil.isSafeUrl("/path:with:colon",
-                UrlUtil.DEFAULT_SAFE_SCHEMES));
+                Constants.DEFAULT_URL_SAFE_SCHEMES));
     }
 
     @Test
     void isSafeUrl_emptyOrBlank_returnsTrue() {
-        assertTrue(UrlUtil.isSafeUrl("", UrlUtil.DEFAULT_SAFE_SCHEMES));
-        assertTrue(UrlUtil.isSafeUrl("   ", UrlUtil.DEFAULT_SAFE_SCHEMES));
+        assertTrue(UrlUtil.isSafeUrl("", Constants.DEFAULT_URL_SAFE_SCHEMES));
+        assertTrue(
+                UrlUtil.isSafeUrl("   ", Constants.DEFAULT_URL_SAFE_SCHEMES));
     }
 
     @Test
     void isSafeUrl_null_returnsFalse() {
-        assertFalse(UrlUtil.isSafeUrl(null, UrlUtil.DEFAULT_SAFE_SCHEMES));
+        assertFalse(
+                UrlUtil.isSafeUrl(null, Constants.DEFAULT_URL_SAFE_SCHEMES));
     }
 
     @Test
     void isSafeUrl_controlCharacterObfuscation_returnsFalse() {
         assertFalse(UrlUtil.isSafeUrl("java\tscript:alert(1)",
-                UrlUtil.DEFAULT_SAFE_SCHEMES));
+                Constants.DEFAULT_URL_SAFE_SCHEMES));
     }
 
     @Test
     void isSafeUrl_wildcard_allowsAnyScheme() {
         assertTrue(UrlUtil.isSafeUrl("javascript:alert(1)",
-                Set.of(UrlUtil.ALL_SCHEMES_SAFE)));
+                Set.of(Constants.URL_SAFE_SCHEMES_WILDCARD)));
     }
 
     @Test
     void isSafeUrl_configuredSchemes_replaceDefaults() {
         DeploymentConfiguration config = Mockito
                 .mock(DeploymentConfiguration.class);
-        Mockito.when(
-                config.getStringProperty(InitParameters.URL_SAFE_SCHEMES, null))
-                .thenReturn("custom, https");
+        Mockito.when(config.getUrlSafeSchemes())
+                .thenReturn(Set.of("custom", "https"));
         VaadinService service = Mockito.mock(VaadinService.class);
         Mockito.when(service.getDeploymentConfiguration()).thenReturn(config);
 
@@ -294,9 +296,8 @@ class UrlUtilTest {
     void isSafeUrl_configuredWildcard_allowsAnyScheme() {
         DeploymentConfiguration config = Mockito
                 .mock(DeploymentConfiguration.class);
-        Mockito.when(
-                config.getStringProperty(InitParameters.URL_SAFE_SCHEMES, null))
-                .thenReturn("*");
+        Mockito.when(config.getUrlSafeSchemes())
+                .thenReturn(Set.of(Constants.URL_SAFE_SCHEMES_WILDCARD));
         VaadinService service = Mockito.mock(VaadinService.class);
         Mockito.when(service.getDeploymentConfiguration()).thenReturn(config);
 
@@ -305,19 +306,5 @@ class UrlUtilTest {
             mock.when(VaadinService::getCurrent).thenReturn(service);
             assertTrue(UrlUtil.isSafeUrl("javascript:alert(1)"));
         }
-    }
-
-    @Test
-    void parseSafeSchemes_nullOrBlank_returnsDefault() {
-        assertEquals(UrlUtil.DEFAULT_SAFE_SCHEMES,
-                UrlUtil.parseSafeSchemes(null));
-        assertEquals(UrlUtil.DEFAULT_SAFE_SCHEMES,
-                UrlUtil.parseSafeSchemes("   "));
-    }
-
-    @Test
-    void parseSafeSchemes_commaSeparated_isTrimmedAndLowerCased() {
-        assertEquals(Set.of("https", "myapp"),
-                UrlUtil.parseSafeSchemes(" HTTPS , MyApp "));
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/UrlUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/UrlUtilTest.java
@@ -20,8 +20,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.InitParameters;
+import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.server.VaadinServletService;
 
@@ -265,6 +269,42 @@ class UrlUtilTest {
     void isSafeUrl_wildcard_allowsAnyScheme() {
         assertTrue(UrlUtil.isSafeUrl("javascript:alert(1)",
                 Set.of(UrlUtil.ALL_SCHEMES_SAFE)));
+    }
+
+    @Test
+    void isSafeUrl_configuredSchemes_replaceDefaults() {
+        DeploymentConfiguration config = Mockito
+                .mock(DeploymentConfiguration.class);
+        Mockito.when(
+                config.getStringProperty(InitParameters.URL_SAFE_SCHEMES, null))
+                .thenReturn("custom, https");
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(service.getDeploymentConfiguration()).thenReturn(config);
+
+        try (MockedStatic<VaadinService> mock = Mockito
+                .mockStatic(VaadinService.class)) {
+            mock.when(VaadinService::getCurrent).thenReturn(service);
+            assertTrue(UrlUtil.isSafeUrl("custom:foo"));
+            assertFalse(UrlUtil.isSafeUrl("mailto:a@b.com"));
+            assertFalse(UrlUtil.isSafeUrl("javascript:alert(1)"));
+        }
+    }
+
+    @Test
+    void isSafeUrl_configuredWildcard_allowsAnyScheme() {
+        DeploymentConfiguration config = Mockito
+                .mock(DeploymentConfiguration.class);
+        Mockito.when(
+                config.getStringProperty(InitParameters.URL_SAFE_SCHEMES, null))
+                .thenReturn("*");
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(service.getDeploymentConfiguration()).thenReturn(config);
+
+        try (MockedStatic<VaadinService> mock = Mockito
+                .mockStatic(VaadinService.class)) {
+            mock.when(VaadinService::getCurrent).thenReturn(service);
+            assertTrue(UrlUtil.isSafeUrl("javascript:alert(1)"));
+        }
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/internal/UrlUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/UrlUtilTest.java
@@ -17,6 +17,8 @@ package com.vaadin.flow.internal;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -203,5 +205,79 @@ class UrlUtilTest {
         String result = UrlUtil.appendQueryParameter("/styles.css", "v-c",
                 null);
         assertEquals("/styles.css", result);
+    }
+
+    @Test
+    void isSafeUrl_allowedScheme_returnsTrue() {
+        assertTrue(UrlUtil.isSafeUrl("https://vaadin.com",
+                UrlUtil.DEFAULT_SAFE_SCHEMES));
+    }
+
+    @Test
+    void isSafeUrl_disallowedScheme_returnsFalse() {
+        assertFalse(UrlUtil.isSafeUrl("javascript:alert(1)",
+                UrlUtil.DEFAULT_SAFE_SCHEMES));
+        assertFalse(UrlUtil.isSafeUrl("data:text/html,<script>",
+                UrlUtil.DEFAULT_SAFE_SCHEMES));
+    }
+
+    @Test
+    void isSafeUrl_schemeMatchIsCaseInsensitive_returnsFalse() {
+        assertFalse(UrlUtil.isSafeUrl("JavaScript:alert(1)",
+                UrlUtil.DEFAULT_SAFE_SCHEMES));
+    }
+
+    @Test
+    void isSafeUrl_relativeUrl_returnsTrue() {
+        assertTrue(UrlUtil.isSafeUrl("/path/to/view",
+                UrlUtil.DEFAULT_SAFE_SCHEMES));
+        assertTrue(UrlUtil.isSafeUrl("foo", UrlUtil.DEFAULT_SAFE_SCHEMES));
+    }
+
+    @Test
+    void isSafeUrl_relativeUrlWithSpecialCharacters_returnsTrue() {
+        // A strict URI parser would reject this, but it is a valid relative URL
+        assertTrue(UrlUtil.isSafeUrl("/search?q=a b&x=[1]",
+                UrlUtil.DEFAULT_SAFE_SCHEMES));
+        // A colon in the path must not be mistaken for a scheme separator
+        assertTrue(UrlUtil.isSafeUrl("/path:with:colon",
+                UrlUtil.DEFAULT_SAFE_SCHEMES));
+    }
+
+    @Test
+    void isSafeUrl_emptyOrBlank_returnsTrue() {
+        assertTrue(UrlUtil.isSafeUrl("", UrlUtil.DEFAULT_SAFE_SCHEMES));
+        assertTrue(UrlUtil.isSafeUrl("   ", UrlUtil.DEFAULT_SAFE_SCHEMES));
+    }
+
+    @Test
+    void isSafeUrl_null_returnsFalse() {
+        assertFalse(UrlUtil.isSafeUrl(null, UrlUtil.DEFAULT_SAFE_SCHEMES));
+    }
+
+    @Test
+    void isSafeUrl_controlCharacterObfuscation_returnsFalse() {
+        assertFalse(UrlUtil.isSafeUrl("java\tscript:alert(1)",
+                UrlUtil.DEFAULT_SAFE_SCHEMES));
+    }
+
+    @Test
+    void isSafeUrl_wildcard_allowsAnyScheme() {
+        assertTrue(UrlUtil.isSafeUrl("javascript:alert(1)",
+                Set.of(UrlUtil.ALL_SCHEMES_SAFE)));
+    }
+
+    @Test
+    void parseSafeSchemes_nullOrBlank_returnsDefault() {
+        assertEquals(UrlUtil.DEFAULT_SAFE_SCHEMES,
+                UrlUtil.parseSafeSchemes(null));
+        assertEquals(UrlUtil.DEFAULT_SAFE_SCHEMES,
+                UrlUtil.parseSafeSchemes("   "));
+    }
+
+    @Test
+    void parseSafeSchemes_commaSeparated_isTrimmedAndLowerCased() {
+        assertEquals(Set.of("https", "myapp"),
+                UrlUtil.parseSafeSchemes(" HTTPS , MyApp "));
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/UrlUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/UrlUtilTest.java
@@ -208,13 +208,13 @@ class UrlUtilTest {
     }
 
     @Test
-    void isSafeUrl_allowedScheme_returnsTrue() {
+    void isSafeUrl_safeScheme_returnsTrue() {
         assertTrue(UrlUtil.isSafeUrl("https://vaadin.com",
                 UrlUtil.DEFAULT_SAFE_SCHEMES));
     }
 
     @Test
-    void isSafeUrl_disallowedScheme_returnsFalse() {
+    void isSafeUrl_unsafeScheme_returnsFalse() {
         assertFalse(UrlUtil.isSafeUrl("javascript:alert(1)",
                 UrlUtil.DEFAULT_SAFE_SCHEMES));
         assertFalse(UrlUtil.isSafeUrl("data:text/html,<script>",

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
@@ -58,6 +58,7 @@ import com.vaadin.flow.router.RouterTest.CombinedObserverTarget.Enter;
 import com.vaadin.flow.router.RouterTest.CombinedObserverTarget.Leave;
 import com.vaadin.flow.router.internal.DefaultErrorHandler;
 import com.vaadin.flow.router.internal.HasUrlParameterFormat;
+import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.HttpStatusCode;
 import com.vaadin.flow.server.InvalidRouteConfigurationException;
 import com.vaadin.flow.server.VaadinService;
@@ -1877,6 +1878,8 @@ public class RouterTest extends RoutingTestBase {
         Mockito.when(service.getRouter()).thenReturn(router);
 
         Mockito.when(configuration.isProductionMode()).thenReturn(true);
+        Mockito.when(configuration.getUrlSafeSchemes())
+                .thenReturn(Constants.DEFAULT_URL_SAFE_SCHEMES);
     }
 
     @AfterEach

--- a/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.server;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 
@@ -27,6 +28,7 @@ import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.shared.communication.PushMode;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Test for {@link AbstractDeploymentConfiguration}
@@ -51,6 +53,31 @@ class AbstractDeploymentConfigurationTest {
         DeploymentConfiguration config = getConfig("ClassLoader", classLoader);
         assertEquals(classLoader, config.getClassLoaderName(),
                 "Unexpected classLoader configuration option value");
+    }
+
+    @Test
+    void getUrlSafeSchemes_propertyNotSet_returnsDefault() {
+        DeploymentConfiguration config = getConfig(null, null);
+        assertEquals(Constants.DEFAULT_URL_SAFE_SCHEMES,
+                config.getUrlSafeSchemes());
+    }
+
+    @Test
+    void getUrlSafeSchemes_commaSeparated_isTrimmedAndLowerCased() {
+        DeploymentConfiguration config = getConfig(
+                InitParameters.URL_SAFE_SCHEMES, " HTTPS , MyApp ");
+        assertEquals(Set.of("https", "myapp"), config.getUrlSafeSchemes());
+    }
+
+    @Test
+    void getUrlSafeSchemes_memoizedAcrossCalls() {
+        DeploymentConfiguration config = getConfig(
+                InitParameters.URL_SAFE_SCHEMES, "custom");
+        Set<String> first = config.getUrlSafeSchemes();
+        Set<String> second = config.getUrlSafeSchemes();
+        assertEquals(Set.of("custom"), first);
+        assertSame(first, second,
+                "Subsequent calls should return the cached instance");
     }
 
     private DeploymentConfiguration getConfig(String property, String value) {


### PR DESCRIPTION
Re-introduce URL-scheme validation for link and navigation sinks after the revert of #24371, using application-wide configuration plus a per-instance opt-out instead of the previous thread-unsafe static setter.

Safe schemes are read from the new com.vaadin.safeUrlSchemes (InitParameters.URL_SAFE_SCHEMES) configuration property, defaulting to http, https, mailto, tel and ftp so that script-capable schemes such as javascript and data are rejected. Setting the property to "*" marks every scheme as safe and keeps the previous behaviour. Relative URLs are always considered safe; the scheme is extracted manually rather than via URI parsing so that valid relative URLs (e.g. containing spaces) are not falsely rejected.

For trusted, hard-coded URLs whose scheme is not configured as safe, each sink offers an unsafe variant that bypasses validation: Anchor#setUnsafeHref, IFrame#setUnsafeSrc and Page#openUnsafe.
