### PR TITLE
test: fix flaky SwaggerIT behind reverse proxy

### DIFF
--- a/flow-tests/vaadin-spring-tests/test-spring-boot-reverseproxy/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-reverseproxy/pom.xml
@@ -129,6 +129,7 @@
                   <artifactId>vaadin-test-spring-common</artifactId>
                   <version>${project.version}</version>
                   <type>test-jar</type>
+                  <classifier>tests</classifier>
                   <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
                 </artifactItem>
               </artifactItems>

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-reverseproxy/src/main/resources/application.properties
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-reverseproxy/src/main/resources/application.properties
@@ -2,3 +2,5 @@ server.port=8888
 proxy.port=9999
 proxy.path=/public/path
 springdoc.swagger-ui.configUrl=/public/path/v3/api-docs/swagger-config
+springdoc.swagger-ui.url=/public/path/v3/api-docs
+springdoc.swagger-ui.disable-swagger-default-url=true

--- a/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/SwaggerIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/SwaggerIT.java
@@ -27,8 +27,11 @@ public class SwaggerIT extends AbstractSpringTest {
     @Test
     public void swaggerUIShown() {
         open();
-        waitUntil(
-                driver -> driver.getPageSource().contains("OpenAPI definition")
-                        || driver.getPageSource().contains("Swagger Petstore"));
+        // Swagger UI must render the application's own OpenAPI definition. The
+        // page must not fall back to the bundled petstore demo, which would
+        // mean the spec was not reachable (e.g. wrong URL behind a proxy) and
+        // would make the test depend on external network availability.
+        waitUntil(driver -> driver.getPageSource()
+                .contains("OpenAPI definition"));
     }
 }


### PR DESCRIPTION
SwaggerIT randomly timed out in test-spring-boot-reverseproxy. Behind the proxy, Swagger UI could not load the application's own OpenAPI definition and fell back to its bundled petstore demo. The assertion accepted "Swagger Petstore" as success, so the test passed only when CI could reach the external petstore.swagger.io and timed out otherwise.

The path-rewriting proxy only forwards requests under the /public/path prefix, but springdoc generated unprefixed URLs (both the swagger config URL and the spec URL), so those requests were rejected and Swagger UI never loaded the local spec.

Fixes:
- application.properties: point both springdoc.swagger-ui.configUrl and springdoc.swagger-ui.url at the prefixed, proxy-reachable /public/path paths, and set disable-swagger-default-url so the UI never falls back to the external petstore demo.
- SwaggerIT: assert only "OpenAPI definition" so the test verifies the application's own spec is rendered and no longer depends on external network availability.
- pom.xml: add the "tests" classifier to the vaadin-test-spring-common test-jar unpack so the IT classes are extracted into test-classes (the previous configuration unpacked the wrong artifact).
