### PR TITLE
fix: declare signal class tokens as Class<@NonNull T>

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/signals/shared/SharedListSignal.java
+++ b/flow-server/src/main/java/com/vaadin/flow/signals/shared/SharedListSignal.java
@@ -155,7 +155,7 @@ public class SharedListSignal<T extends @Nullable Object>
         }
     }
 
-    private final Class<T> elementType;
+    private final Class<@NonNull T> elementType;
 
     /**
      * Creates a new list signal with the given element type. The signal does
@@ -164,7 +164,7 @@ public class SharedListSignal<T extends @Nullable Object>
      * @param elementType
      *            the element type, not <code>null</code>
      */
-    public SharedListSignal(Class<T> elementType) {
+    public SharedListSignal(Class<@NonNull T> elementType) {
         this(new LocalAsynchronousSignalTree(), Id.ZERO, ANYTHING_GOES,
                 elementType);
     }
@@ -186,7 +186,7 @@ public class SharedListSignal<T extends @Nullable Object>
      *            the element type, not <code>null</code>
      */
     protected SharedListSignal(SignalTree tree, Id id,
-            CommandValidator validator, Class<T> elementType) {
+            CommandValidator validator, Class<@NonNull T> elementType) {
         super(tree, id, validator);
         this.elementType = Objects.requireNonNull(elementType);
     }

--- a/flow-server/src/main/java/com/vaadin/flow/signals/shared/SharedMapSignal.java
+++ b/flow-server/src/main/java/com/vaadin/flow/signals/shared/SharedMapSignal.java
@@ -49,7 +49,7 @@ import com.vaadin.flow.signals.shared.impl.SignalTree;
 public class SharedMapSignal<T extends @Nullable Object> extends
         AbstractSharedSignal<@NonNull Map<String, SharedValueSignal<T>>> {
 
-    private Class<T> elementType;
+    private Class<@NonNull T> elementType;
 
     /**
      * Creates a new map signal with the given element type. The signal does not
@@ -58,7 +58,7 @@ public class SharedMapSignal<T extends @Nullable Object> extends
      * @param elementType
      *            the element type, not <code>null</code>
      */
-    public SharedMapSignal(Class<T> elementType) {
+    public SharedMapSignal(Class<@NonNull T> elementType) {
         this(new LocalAsynchronousSignalTree(), Id.ZERO, ANYTHING_GOES,
                 elementType);
     }
@@ -80,7 +80,7 @@ public class SharedMapSignal<T extends @Nullable Object> extends
      *            the element type, not <code>null</code>
      */
     protected SharedMapSignal(SignalTree tree, Id id,
-            CommandValidator validator, Class<T> elementType) {
+            CommandValidator validator, Class<@NonNull T> elementType) {
         super(tree, id, validator);
         this.elementType = Objects.requireNonNull(elementType);
     }

--- a/flow-server/src/main/java/com/vaadin/flow/signals/shared/SharedValueSignal.java
+++ b/flow-server/src/main/java/com/vaadin/flow/signals/shared/SharedValueSignal.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.signals.shared;
 import java.util.List;
 import java.util.Objects;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import com.vaadin.flow.function.SerializableConsumer;
@@ -45,7 +46,7 @@ import com.vaadin.flow.signals.shared.impl.SignalTree;
  */
 public class SharedValueSignal<T extends @Nullable Object>
         extends AbstractSharedSignal<T> {
-    private final Class<T> valueType;
+    private final Class<@NonNull T> valueType;
 
     /**
      * Creates a new value signal with the given initial value. The type of the
@@ -58,7 +59,7 @@ public class SharedValueSignal<T extends @Nullable Object>
     @SuppressWarnings("unchecked")
     public SharedValueSignal(T initialValue) {
         this(new LocalAsynchronousSignalTree(), Id.ZERO, ANYTHING_GOES,
-                (Class<T>) initialValue.getClass());
+                (Class<@NonNull T>) initialValue.getClass());
         set(initialValue);
     }
 
@@ -69,7 +70,7 @@ public class SharedValueSignal<T extends @Nullable Object>
      * @param valueType
      *            the value type, not <code>null</code>
      */
-    public SharedValueSignal(Class<T> valueType) {
+    public SharedValueSignal(Class<@NonNull T> valueType) {
         this(new LocalAsynchronousSignalTree(), Id.ZERO, ANYTHING_GOES,
                 Objects.requireNonNull(valueType));
     }
@@ -91,7 +92,7 @@ public class SharedValueSignal<T extends @Nullable Object>
      *            the value type, not <code>null</code>
      */
     protected SharedValueSignal(SignalTree tree, Id id,
-            CommandValidator validator, Class<T> valueType) {
+            CommandValidator validator, Class<@NonNull T> valueType) {
         super(tree, id, validator);
         this.valueType = Objects.requireNonNull(valueType);
     }


### PR DESCRIPTION
NullAway 0.13.2+ analyzes constructor diamond operators and rejects
passing String.class (`Class<String>`) to a `SharedXSignal<@Nullable String>`
whose constructor takes `Class<T>`, since `Class<T>` is invariant.

Per JSpecify guidance (NullAway uber/NullAway#1595), declare the type-token parameter
(and backing field) as `Class<@NonNull T>` -- the projection use case. A
class token never carries nullness, so this lets callers pass a plain
class literal for a nullable element type with no cast. 