### PR TITLE
test: increase WebPushIT notification wait timeout to reduce flakiness

### DIFF
--- a/flow-tests/test-webpush/src/test/java/com/vaadin/flow/webpush/WebPushIT.java
+++ b/flow-tests/test-webpush/src/test/java/com/vaadin/flow/webpush/WebPushIT.java
@@ -135,7 +135,8 @@ public class WebPushIT extends ChromeBrowserTest {
             Assert.assertTrue("", eventLog.$(DivElement.class).id("event-3")
                     .getText().equals("3: Sent notification"));
 
-            waitUntil(driver -> isNotificationPresent(driver));
+            // Use the same generous timeout as the subscribe step above.
+            waitUntil(driver -> isNotificationPresent(driver), 60);
         } finally {
             $(NativeButtonElement.class).id(UNSUBSCRIBE_ID).click();
         }


### PR DESCRIPTION
The notification check used the default 10s timeout, but delivery involves a round-trip through an external push service that can exceed 10s under CI load. Use the same 60s timeout as the subscribe step.
