### PR TITLE
fix: unpack prod bundle on Windows mapped network drives

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/CompressUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/CompressUtil.java
@@ -20,6 +20,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
@@ -143,17 +144,21 @@ public class CompressUtil {
 
     private static File newFile(File destinationDir, ZipEntry zipEntry)
             throws IOException {
-        File destFile = new File(destinationDir, zipEntry.getName());
+        // Canonicalize the destination directory once. Resolving each entry
+        // lexically against this base (instead of canonicalizing the
+        // not-yet-created target file) avoids inconsistent path forms, e.g. on
+        // Windows mapped network drives where getCanonicalPath() returns the
+        // UNC form for an existing directory but the drive-letter form for a
+        // non-existent child, which made a legitimate entry look "outside".
+        Path destDir = destinationDir.getCanonicalFile().toPath();
+        Path destFile = destDir.resolve(zipEntry.getName()).normalize();
 
-        String destDirPath = destinationDir.getCanonicalPath();
-        String destFilePath = destFile.getCanonicalPath();
-
-        if (!destFilePath.startsWith(destDirPath + File.separator)) {
+        if (!destFile.startsWith(destDir)) {
             throw new IOException("Entry is outside of the target dir: "
                     + zipEntry.getName());
         }
 
-        return destFile;
+        return destFile.toFile();
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/internal/CompressUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/CompressUtilTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.internal;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class CompressUtilTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void uncompressFile_legitimateNestedEntry_isExtracted()
+            throws IOException {
+        // Mirrors a real prod.bundle: a nested file entry without an explicit
+        // directory entry for its parent folder.
+        File zip = temporaryFolder.newFile("prod.bundle");
+        try (ZipOutputStream zipOut = new ZipOutputStream(
+                new FileOutputStream(zip))) {
+            zipOut.putNextEntry(new ZipEntry("config/bundle-size.html"));
+            zipOut.write("<html></html>".getBytes(StandardCharsets.UTF_8));
+            zipOut.closeEntry();
+        }
+
+        File target = temporaryFolder.newFolder("unpacked");
+        CompressUtil.uncompressFile(zip, target);
+
+        File extracted = new File(target, "config/bundle-size.html");
+        Assert.assertTrue(
+                "Legitimate nested entry should have been extracted, but the "
+                        + "Zip Slip guard rejected it",
+                extracted.exists());
+        Assert.assertEquals("<html></html>",
+                Files.readString(extracted.toPath()));
+    }
+
+    @Test
+    public void uncompressFile_zipSlipEntry_isRejected() throws IOException {
+        File zip = temporaryFolder.newFile("evil.bundle");
+        try (ZipOutputStream zipOut = new ZipOutputStream(
+                new FileOutputStream(zip))) {
+            zipOut.putNextEntry(new ZipEntry("../evil.txt"));
+            zipOut.write("pwned".getBytes(StandardCharsets.UTF_8));
+            zipOut.closeEntry();
+        }
+
+        File target = temporaryFolder.newFolder("unpacked");
+
+        Assert.assertThrows(CompressionException.class,
+                () -> CompressUtil.uncompressFile(zip, target));
+        Assert.assertFalse(
+                "Zip Slip entry must not be written outside the target dir",
+                new File(target.getParentFile(), "evil.txt").exists());
+    }
+}


### PR DESCRIPTION
The Zip Slip guard in `CompressUtil.newFile` canonicalized the target dir and the not-yet-created entry separately; on mapped/`subst` drives `getCanonicalPath()` returns inconsistent forms, so legitimate entries were rejected.

Canonicalize the destination once and resolve entries lexically, checking containment with `Path.startsWith`.

Fixes #24558
