### PR TITLE
refactor: store Html safelist as a serializable supplier

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/Html.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Html.java
@@ -32,6 +32,7 @@ import org.jsoup.safety.Safelist;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementEffect;
 import com.vaadin.flow.dom.SignalBinding;
+import com.vaadin.flow.function.SerializableSupplier;
 import com.vaadin.flow.internal.nodefeature.SignalBindingFeature;
 import com.vaadin.flow.signals.BindingActiveException;
 import com.vaadin.flow.signals.Signal;
@@ -47,15 +48,54 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * component. Passing raw input data to the user will possibly lead to
  * cross-site scripting attacks.
  * <p>
- * To help with sanitization, every HTML-accepting method has an overload that
- * additionally takes a jsoup {@link Safelist}. These overloads run the content
- * through {@link Jsoup#clean(String, Safelist)} before using it, so any element
- * or attribute that the safelist doesn't permit is removed:
+ * To help with sanitization, a jsoup {@link Safelist} of permitted elements and
+ * attributes can be configured through a safelist-accepting constructor. Once
+ * configured, all content applied to the component &mdash; the initial value
+ * and any value later set through {@link #setHtmlContent(String)} or pushed by
+ * a bound signal &mdash; is sanitized with it, so any element or attribute that
+ * the safelist doesn't permit is removed. The safelist is fixed at construction
+ * and cannot be changed afterwards.
+ * <p>
+ * jsoup's {@link Safelist} is <b>not</b> {@link java.io.Serializable}, but a
+ * Vaadin component must be serializable (sessions can be persisted to disk or
+ * replicated across a cluster). Storing a {@code Safelist} directly would break
+ * session serialization, so the safelist is supplied through a
+ * {@link SerializableSupplier} &mdash; a serializable factory that is invoked
+ * to build the safelist &mdash; rather than as a {@code Safelist} instance.
+ * <p>
+ * For the supplier to be serializable, it must not capture a (non-serializable)
+ * {@code Safelist} instance. Use a method reference to a factory, or a lambda
+ * that builds a new safelist inline:
  *
- * <pre>
- * new Html(untrustedHtml, Safelist.basic());
- * </pre>
+ * <pre>{@code
+ * // Method reference to one of the standard jsoup factories:
+ * new Html(untrustedHtml, Safelist::basic);
  *
+ * // Lambda that builds a fresh safelist inline (captures nothing):
+ * new Html(untrustedHtml,
+ *         () -> Safelist.basic().addTags("figure", "figcaption"));
+ *
+ * // A reusable supplier kept in a static field:
+ * static final SerializableSupplier<Safelist> SAFELIST = () -> Safelist
+ *         .relaxed().addAttributes("a", "target");
+ * new Html(untrustedHtml, SAFELIST);
+ * }</pre>
+ *
+ * Do <b>not</b> capture an already-built {@code Safelist} in the supplier: that
+ * puts the non-serializable instance back into the component's state and fails
+ * session serialization:
+ *
+ * <pre>{@code
+ * Safelist safelist = Safelist.basic();
+ * // BAD: captures the non-serializable Safelist instance
+ * new Html(untrustedHtml, () -> safelist);
+ * }</pre>
+ *
+ * The supplier is invoked when the component is created (and again lazily on
+ * the next sanitization after deserialization, since the cached safelist is
+ * {@code transient}), not on every sanitization, so it should return an
+ * equivalent safelist on each call and must not return {@code null}.
+ * <p>
  * The safelist must permit the fragment's single root element; otherwise the
  * root is stripped and the resulting fragment no longer has exactly one root
  * element.
@@ -65,8 +105,9 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * be accessed through {@link #getElement()} and the inner HTML through
  * {@link #getInnerHtml()}.
  * <p>
- * The HTML fragment cannot be changed after creation. You should create a new
- * instance to encapsulate another fragment.
+ * The inner content and attributes can be changed after creation through
+ * {@link #setHtmlContent(String)} or by binding a signal, but the root tag
+ * cannot be changed.
  * <p>
  * Note that this component doesn't support svg element as a root node. See
  * separate {@link Svg} component if you want to display SVG images.
@@ -78,6 +119,22 @@ public class Html extends Component {
 
     private static final PropertyDescriptor<String, String> innerHtmlDescriptor = PropertyDescriptors
             .propertyWithDefault("innerHTML", "");
+
+    /**
+     * Supplies the jsoup safelist used to sanitize all content applied to this
+     * component, or {@code null} when no safelist was configured. A supplier is
+     * stored (rather than a {@link Safelist}) because {@code Safelist} is not
+     * serializable.
+     */
+    private SerializableSupplier<Safelist> safelistSupplier;
+
+    /**
+     * Cached safelist obtained from {@link #safelistSupplier}, so the supplier
+     * is not invoked on every sanitization. Transient because {@link Safelist}
+     * is not serializable; it is rebuilt from the supplier on demand after
+     * deserialization.
+     */
+    private transient Safelist safelist;
 
     /**
      * Creates an instance based on the HTML fragment read from the stream. The
@@ -117,12 +174,13 @@ public class Html extends Component {
 
     /**
      * Creates an instance based on the HTML fragment read from the stream,
-     * sanitized using the given {@link Safelist}. The fragment must have
-     * exactly one root element after sanitization.
+     * sanitized using the safelist obtained from the given supplier. The
+     * fragment must have exactly one root element after sanitization.
      * <p>
-     * The content is run through {@link Jsoup#clean(String, Safelist)} before
-     * being used, so any element or attribute that the safelist doesn't permit
-     * is removed. The safelist must permit the root element.
+     * The supplier is also stored on the component, so any later content change
+     * via {@link #setHtmlContent(String)} or a bound signal is sanitized with
+     * it as well. Any element or attribute that the safelist doesn't permit is
+     * removed. The safelist must permit the root element.
      * <p>
      * A best effort is done to parse broken HTML but no guarantees are given
      * for how invalid HTML is handled.
@@ -132,22 +190,25 @@ public class Html extends Component {
      *
      * @param stream
      *            the input stream which provides the HTML in UTF-8
-     * @param safelist
-     *            the safelist of permitted elements and attributes, not
-     *            <code>null</code>
+     * @param safelistSupplier
+     *            supplies the safelist of permitted elements and attributes,
+     *            not <code>null</code>
      * @throws UncheckedIOException
      *             if reading the stream fails
+     * @throws NullPointerException
+     *             if the supplier is <code>null</code>
      */
-    public Html(InputStream stream, Safelist safelist) {
+    public Html(InputStream stream,
+            SerializableSupplier<Safelist> safelistSupplier) {
         super(null);
         if (stream == null) {
             throw new IllegalArgumentException("HTML stream cannot be null");
         }
-        Objects.requireNonNull(safelist, "Safelist cannot be null");
+        initSafelist(safelistSupplier);
         try {
             String outerHtml = UTF_8
                     .decode(DataUtil.readToByteBuffer(stream, 0)).toString();
-            setOuterHtml(sanitize(outerHtml, safelist), false);
+            setOuterHtml(outerHtml, false);
         } catch (IOException e) {
             throw new UncheckedIOException("Unable to read HTML from stream",
                     e);
@@ -169,21 +230,19 @@ public class Html extends Component {
      */
     public Html(String outerHtml) {
         super(null);
-        if (outerHtml == null || outerHtml.isEmpty()) {
-            throw new IllegalArgumentException("HTML cannot be null or empty");
-        }
-
+        // null/empty is rejected by setOuterHtml
         setOuterHtml(outerHtml, false);
     }
 
     /**
      * Creates an instance based on the given HTML fragment, sanitized using the
-     * given {@link Safelist}. The fragment must have exactly one root element
-     * after sanitization.
+     * safelist obtained from the given supplier. The fragment must have exactly
+     * one root element after sanitization.
      * <p>
-     * The content is run through {@link Jsoup#clean(String, Safelist)} before
-     * being used, so any element or attribute that the safelist doesn't permit
-     * is removed. The safelist must permit the root element.
+     * The supplier is also stored on the component, so any later content change
+     * via {@link #setHtmlContent(String)} or a bound signal is sanitized with
+     * it as well. Any element or attribute that the safelist doesn't permit is
+     * removed. The safelist must permit the root element.
      * <p>
      * A best effort is done to parse broken HTML but no guarantees are given
      * for how invalid HTML is handled.
@@ -193,18 +252,18 @@ public class Html extends Component {
      *
      * @param outerHtml
      *            the HTML to wrap
-     * @param safelist
-     *            the safelist of permitted elements and attributes, not
-     *            <code>null</code>
+     * @param safelistSupplier
+     *            supplies the safelist of permitted elements and attributes,
+     *            not <code>null</code>
+     * @throws NullPointerException
+     *             if the supplier is <code>null</code>
      */
-    public Html(String outerHtml, Safelist safelist) {
+    public Html(String outerHtml,
+            SerializableSupplier<Safelist> safelistSupplier) {
         super(null);
-        if (outerHtml == null || outerHtml.isEmpty()) {
-            throw new IllegalArgumentException("HTML cannot be null or empty");
-        }
-        Objects.requireNonNull(safelist, "Safelist cannot be null");
-
-        setOuterHtml(sanitize(outerHtml, safelist), false);
+        initSafelist(safelistSupplier);
+        // null/empty html is rejected by setOuterHtml
+        setOuterHtml(outerHtml, false);
     }
 
     /**
@@ -238,45 +297,52 @@ public class Html extends Component {
 
     /**
      * Creates an instance based on the given HTML fragment signal, with every
-     * value sanitized using the given {@link Safelist}. The signal's current
-     * value must have exactly one root element after sanitization. Subsequent
-     * changes to the signal will update the component's content (root tag
-     * cannot be changed after creation).
+     * value sanitized using the safelist obtained from the given supplier. The
+     * signal's current value must have exactly one root element after
+     * sanitization. Subsequent changes to the signal will update the
+     * component's content (root tag cannot be changed after creation).
      * <p>
-     * Both the initial value and every subsequent value are run through
-     * {@link Jsoup#clean(String, Safelist)}, so any element or attribute that
-     * the safelist doesn't permit is removed. The safelist must permit the root
-     * element.
+     * The supplier is stored on the component, so both the initial value and
+     * every subsequent value are sanitized with it. Any element or attribute
+     * that the safelist doesn't permit is removed. The safelist must permit the
+     * root element.
      *
      * @param htmlSignal
      *            the signal that provides the HTML outer content
-     * @param safelist
-     *            the safelist of permitted elements and attributes, not
-     *            <code>null</code>
+     * @param safelistSupplier
+     *            supplies the safelist of permitted elements and attributes,
+     *            not <code>null</code>
      * @throws IllegalArgumentException
      *             if the signal is {@code null} or its current value is null or
      *             empty, or doesn't have exactly one root element
+     * @throws NullPointerException
+     *             if the supplier is <code>null</code>
      */
-    public Html(Signal<String> htmlSignal, Safelist safelist) {
+    public Html(Signal<String> htmlSignal,
+            SerializableSupplier<Safelist> safelistSupplier) {
         super(null);
         if (htmlSignal == null) {
             throw new IllegalArgumentException("HTML signal cannot be null");
         }
-        Objects.requireNonNull(safelist, "Safelist cannot be null");
+        initSafelist(safelistSupplier);
         String outerHtml = htmlSignal.peek();
         if (outerHtml == null || outerHtml.isEmpty()) {
             throw new IllegalArgumentException("HTML cannot be null or empty");
         }
-        // Initialize from the sanitized current signal value (sets the root
-        // element and attrs)
-        setOuterHtml(sanitize(outerHtml, safelist), false);
-        // Bind further updates, sanitizing each value (root tag cannot change)
-        bindHtmlContent(htmlSignal, safelist);
+        // Initialize from the current signal value, sanitized through the
+        // stored safelist (sets the root element and attrs)
+        setOuterHtml(outerHtml, false);
+        // Bind further updates; each value is sanitized through the stored
+        // safelist as well (root tag cannot change)
+        bindHtmlContent(htmlSignal);
     }
 
     /**
      * Sets the content based on the given HTML fragment. The fragment must have
      * exactly one root element, which matches the existing one.
+     * <p>
+     * If a safelist supplier was provided at construction, the content is
+     * sanitized with it before being used.
      * <p>
      * A best effort is done to parse broken HTML but no guarantees are given
      * for how invalid HTML is handled.
@@ -293,30 +359,46 @@ public class Html extends Component {
     }
 
     /**
-     * Sets the content based on the given HTML fragment, sanitized using the
-     * given {@link Safelist}. The fragment must have exactly one root element
-     * after sanitization, which matches the existing one.
-     * <p>
-     * The content is run through {@link Jsoup#clean(String, Safelist)} before
-     * being used, so any element or attribute that the safelist doesn't permit
-     * is removed. The safelist must permit the root element.
-     * <p>
-     * A best effort is done to parse broken HTML but no guarantees are given
-     * for how invalid HTML is handled.
-     * <p>
-     * Any heading or trailing whitespace is removed while parsing but any
-     * whitespace inside the root tag is preserved.
+     * Returns the safelist instance for sanitization, lazily (re)building it
+     * from the supplier when not cached (e.g. after deserialization).
      *
-     * @param html
-     *            the HTML to wrap
-     * @param safelist
-     *            the safelist of permitted elements and attributes, not
-     *            <code>null</code>
+     * @return the safelist, or {@code null} if no supplier is configured
      */
-    public void setHtmlContent(String html, Safelist safelist) {
-        Objects.requireNonNull(safelist, "Safelist cannot be null");
-        ensureNoHtmlContentBinding();
-        setOuterHtml(sanitize(html, safelist), true);
+    private Safelist getSafelistInstance() {
+        if (safelist == null && safelistSupplier != null) {
+            safelist = resolveSafelist(safelistSupplier);
+        }
+        return safelist;
+    }
+
+    /**
+     * Validates and stores the given non-null safelist supplier, eagerly
+     * resolving and caching the safelist. Used by the safelist-accepting
+     * constructors.
+     *
+     * @param safelistSupplier
+     *            the safelist supplier, not {@code null}
+     */
+    private void initSafelist(SerializableSupplier<Safelist> safelistSupplier) {
+        Objects.requireNonNull(safelistSupplier,
+                "Safelist supplier cannot be null");
+        this.safelist = resolveSafelist(safelistSupplier);
+        this.safelistSupplier = safelistSupplier;
+    }
+
+    /**
+     * Resolves the safelist from the given supplier, validating that the
+     * supplier does not return {@code null}.
+     *
+     * @param safelistSupplier
+     *            the safelist supplier, may be {@code null}
+     * @return the safelist, or {@code null} if the supplier is {@code null}
+     */
+    private static Safelist resolveSafelist(
+            SerializableSupplier<Safelist> safelistSupplier) {
+        return safelistSupplier == null ? null
+                : Objects.requireNonNull(safelistSupplier.get(),
+                        "Safelist supplier must not return null");
     }
 
     /**
@@ -334,20 +416,17 @@ public class Html extends Component {
                 });
     }
 
-    /**
-     * Removes any element or attribute not permitted by the given safelist,
-     * without pretty-printing the result so that whitespace inside the fragment
-     * is preserved as-is.
-     */
-    private static String sanitize(String html, Safelist safelist) {
-        Document dirty = Jsoup.parseBodyFragment(html);
-        Document clean = new Cleaner(safelist).clean(dirty);
-        clean.outputSettings().prettyPrint(false);
-        return clean.body().html();
-    }
-
     private void setOuterHtml(String outerHtml, boolean update) {
-        Document doc = Jsoup.parseBodyFragment(outerHtml);
+        if (outerHtml == null || outerHtml.isEmpty()) {
+            throw new IllegalArgumentException("HTML cannot be null or empty");
+        }
+        // Sanitize through the configured safelist, if any, before parsing
+        String effectiveHtml = outerHtml;
+        Safelist currentSafelist = getSafelistInstance();
+        if (currentSafelist != null) {
+            effectiveHtml = sanitize(outerHtml, currentSafelist);
+        }
+        Document doc = Jsoup.parseBodyFragment(effectiveHtml);
         int nrChildren = doc.body().children().size();
         if (nrChildren != 1) {
             String message = "HTML must contain exactly one top level element (ignoring text nodes). Found "
@@ -377,6 +456,18 @@ public class Html extends Component {
 
         doc.outputSettings().prettyPrint(false);
         setInnerHtml(root.html());
+    }
+
+    /**
+     * Removes any element or attribute not permitted by the given safelist,
+     * without pretty-printing the result so that whitespace inside the fragment
+     * is preserved as-is.
+     */
+    private static String sanitize(String html, Safelist safelist) {
+        Document dirty = Jsoup.parseBodyFragment(html);
+        Document clean = new Cleaner(safelist).clean(dirty);
+        clean.outputSettings().prettyPrint(false);
+        return clean.body().html();
     }
 
     private void setAttribute(Attribute attribute) {
@@ -415,6 +506,10 @@ public class Html extends Component {
      * is attached. When the component is detached, signal value changes have no
      * effect.
      * <p>
+     * If a safelist supplier was provided at construction, every value &mdash;
+     * the initial one and each subsequent change &mdash; is sanitized with it,
+     * so any element or attribute that the safelist doesn't permit is removed.
+     * <p>
      * While a Signal is bound to the HTML content, any attempt to set the HTML
      * content manually via {@link #setHtmlContent(String)} throws
      * {@link com.vaadin.flow.signals.BindingActiveException}. The same happens
@@ -422,7 +517,8 @@ public class Html extends Component {
      * <p>
      * The first value of the signal must have exactly one root element. When
      * updating the content, the root tag name must remain the same as the
-     * component's current root tag.
+     * component's current root tag. A {@code null} or empty signal value is
+     * rejected with an {@link IllegalArgumentException}.
      *
      * @param htmlSignal
      *            the signal to bind, not <code>null</code>
@@ -440,55 +536,6 @@ public class Html extends Component {
 
         SignalBinding<String> binding = ElementEffect.bind(getElement(),
                 htmlSignal, (element, value) -> setOuterHtml(value, true));
-        feature.setBinding(SignalBindingFeature.HTML_CONTENT, htmlSignal);
-        return binding;
-    }
-
-    /**
-     * Binds a {@link com.vaadin.flow.signals.Signal}'s value to this
-     * component's HTML content (outer HTML), sanitizing every value using the
-     * given {@link Safelist}. The content is set immediately with the current
-     * signal value when the binding is created, and is kept synchronized with
-     * any subsequent signal value changes while the component is attached. When
-     * the component is detached, signal value changes have no effect.
-     * <p>
-     * Every value is run through {@link Jsoup#clean(String, Safelist)}, so any
-     * element or attribute that the safelist doesn't permit is removed. The
-     * safelist must permit the root element.
-     * <p>
-     * While a Signal is bound to the HTML content, any attempt to set the HTML
-     * content manually via {@link #setHtmlContent(String)} throws
-     * {@link com.vaadin.flow.signals.BindingActiveException}. The same happens
-     * when trying to bind a new Signal while one is already bound.
-     * <p>
-     * The first value of the signal must have exactly one root element. When
-     * updating the content, the root tag name must remain the same as the
-     * component's current root tag.
-     *
-     * @param htmlSignal
-     *            the signal to bind, not <code>null</code>
-     * @param safelist
-     *            the safelist of permitted elements and attributes, not
-     *            <code>null</code>
-     * @throws com.vaadin.flow.signals.BindingActiveException
-     *             thrown when there is already an existing binding
-     */
-    public SignalBinding<String> bindHtmlContent(Signal<String> htmlSignal,
-            Safelist safelist) {
-        Objects.requireNonNull(htmlSignal, "Signal cannot be null");
-        Objects.requireNonNull(safelist, "Safelist cannot be null");
-        SignalBindingFeature feature = getElement().getNode()
-                .getFeature(SignalBindingFeature.class);
-
-        if (feature.hasBinding(SignalBindingFeature.HTML_CONTENT)) {
-            throw new BindingActiveException();
-        }
-
-        SignalBinding<String> binding = ElementEffect.bind(getElement(),
-                htmlSignal,
-                (element, value) -> setOuterHtml(
-                        value == null ? value : sanitize(value, safelist),
-                        true));
         feature.setBinding(SignalBindingFeature.HTML_CONTENT, htmlSignal);
         return binding;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/component/Html.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Html.java
@@ -68,12 +68,13 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * that builds a new safelist inline:
  *
  * <pre>{@code
- * // Method reference to one of the standard jsoup factories:
- * new Html(untrustedHtml, Safelist::basic);
+ * // Method reference to a standard jsoup factory; relaxed() permits common
+ * // block elements such as <div>:
+ * new Html(untrustedHtml, Safelist::relaxed);
  *
- * // Lambda that builds a fresh safelist inline (captures nothing):
- * new Html(untrustedHtml,
- *         () -> Safelist.basic().addTags("figure", "figcaption"));
+ * // Lambda that builds a fresh safelist inline (captures nothing); basic()
+ * // does not permit <div>, so it is added explicitly:
+ * new Html(untrustedHtml, () -> Safelist.basic().addTags("div"));
  *
  * // A reusable supplier kept in a static field:
  * static final SerializableSupplier<Safelist> SAFELIST = () -> Safelist
@@ -98,7 +99,9 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * <p>
  * The safelist must permit the fragment's single root element; otherwise the
  * root is stripped and the resulting fragment no longer has exactly one root
- * element.
+ * element. Note that {@link Safelist#basic()} does not permit {@code <div>}, so
+ * a {@code <div>}-rooted fragment requires e.g.
+ * {@code Safelist.basic().addTags("div")} or {@link Safelist#relaxed()}.
  * <p>
  * This component does not expand the HTML fragment into a server side DOM tree
  * so you cannot traverse or modify the HTML on the server. The root element can

--- a/flow-server/src/test/java/com/vaadin/flow/component/HTMLTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HTMLTest.java
@@ -16,13 +16,17 @@
 package com.vaadin.flow.component;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.nio.charset.StandardCharsets;
 
 import org.jsoup.safety.Safelist;
 import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.function.SerializableSupplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -174,10 +178,11 @@ class HTMLTest {
 
     @Test
     void stringWithSafelist_disallowedContentRemoved() {
-        Safelist safelist = new Safelist().addTags("span", "b")
-                .addAttributes("span", "title");
-        Html html = new Html("<span title='ok' onclick='evil()'>hi<b>there</b>"
-                + "<script>steal()</script></span>", safelist);
+        Html html = new Html(
+                "<span title='ok' onclick='evil()'>hi<b>there</b>"
+                        + "<script>steal()</script></span>",
+                () -> new Safelist().addTags("span", "b").addAttributes("span",
+                        "title"));
 
         assertEquals(Tag.SPAN, html.getElement().getTag());
         assertEquals("ok", html.getElement().getAttribute("title"));
@@ -189,7 +194,7 @@ class HTMLTest {
     void stringWithSafelist_whitespacePreserved() {
         Html html = new Html(
                 "    <div><pre> text </pre> <b>bold</b>    <b>b2</b>  </div>  ",
-                Safelist.basic().addTags("div"));
+                () -> Safelist.basic().addTags("div"));
         assertEquals("<pre> text </pre> <b>bold</b>    <b>b2</b>  ",
                 html.getInnerHtml());
     }
@@ -199,22 +204,23 @@ class HTMLTest {
         // none() permits no tags, so the only root element is removed and the
         // remaining text leaves no top-level element
         assertThrows(IllegalArgumentException.class,
-                () -> new Html("<span>hello</span>", Safelist.none()));
+                () -> new Html("<span>hello</span>", Safelist::none));
     }
 
     @Test
-    void stringWithSafelist_nullSafelist_throws() {
+    void stringWithSafelist_nullSupplier_throws() {
         assertThrows(NullPointerException.class,
-                () -> new Html("<span>hi</span>", (Safelist) null));
+                () -> new Html("<span>hi</span>",
+                        (SerializableSupplier<Safelist>) null));
     }
 
     @Test
     void streamWithSafelist_disallowedContentRemoved() {
-        Safelist safelist = new Safelist().addTags("div");
-        Html html = new Html(new ByteArrayInputStream(
-                "<div onclick='evil()'><script>x()</script>text</div>"
-                        .getBytes(StandardCharsets.UTF_8)),
-                safelist);
+        Html html = new Html(
+                new ByteArrayInputStream(
+                        "<div onclick='evil()'><script>x()</script>text</div>"
+                                .getBytes(StandardCharsets.UTF_8)),
+                () -> new Safelist().addTags("div"));
 
         assertEquals("div", html.getElement().getTag());
         assertNull(html.getElement().getAttribute("onclick"));
@@ -222,22 +228,23 @@ class HTMLTest {
     }
 
     @Test
-    void streamWithSafelist_nullSafelist_throws() {
+    void streamWithSafelist_nullSupplier_throws() {
         assertThrows(NullPointerException.class,
                 () -> new Html(
                         new ByteArrayInputStream(
                                 "<div></div>".getBytes(StandardCharsets.UTF_8)),
-                        (Safelist) null));
+                        (SerializableSupplier<Safelist>) null));
     }
 
     @Test
-    void setHtmlContentWithSafelist_disallowedContentRemoved() {
-        Safelist safelist = new Safelist().addTags("span");
-        Html html = new Html("<span>initial</span>");
+    void constructorSafelist_appliedToLaterSetHtmlContent() {
+        // the safelist provided at construction also sanitizes content set
+        // afterwards through setHtmlContent
+        Html html = new Html("<span>initial</span>",
+                () -> new Safelist().addTags("span"));
 
         html.setHtmlContent(
-                "<span onclick='evil()'>clean<script>x()</script></span>",
-                safelist);
+                "<span onclick='evil()'>clean<script>x()</script></span>");
 
         assertEquals(Tag.SPAN, html.getElement().getTag());
         assertNull(html.getElement().getAttribute("onclick"));
@@ -245,10 +252,41 @@ class HTMLTest {
     }
 
     @Test
-    void setHtmlContentWithSafelist_nullSafelist_throws() {
-        Html html = new Html("<span>initial</span>");
+    void constructorSafelist_supplierReturnsNull_throws() {
+        // the supplier is resolved immediately, so a null-returning supplier is
+        // rejected at construction rather than on first sanitization
         assertThrows(NullPointerException.class,
-                () -> html.setHtmlContent("<span>x</span>", (Safelist) null));
+                () -> new Html("<span>x</span>", () -> null));
+    }
+
+    @Test
+    void safelistConfiguredHtml_survivesSerialization() throws Exception {
+        // The jsoup Safelist is not serializable; storing a
+        // SerializableSupplier<Safelist> keeps the component serializable and
+        // the sanitization working after a session round-trip.
+        Html html = new Html("<div>init</div>",
+                () -> new Safelist().addTags("div"));
+
+        Html copy = serializeAndDeserialize(html);
+
+        // the supplier survived and the transient safelist is rebuilt on
+        // demand, so disallowed content is still removed
+        copy.setHtmlContent(
+                "<div onclick='evil()'>clean<script>x()</script></div>");
+        assertNull(copy.getElement().getAttribute("onclick"));
+        assertEquals("clean", copy.getInnerHtml());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T serializeAndDeserialize(T instance) throws Exception {
+        ByteArrayOutputStream bs = new ByteArrayOutputStream();
+        try (ObjectOutputStream out = new ObjectOutputStream(bs)) {
+            out.writeObject(instance);
+        }
+        try (ObjectInputStream in = new ObjectInputStream(
+                new ByteArrayInputStream(bs.toByteArray()))) {
+            return (T) in.readObject();
+        }
     }
 
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/HtmlBindHtmlContentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HtmlBindHtmlContentTest.java
@@ -19,6 +19,7 @@ import org.jsoup.safety.Safelist;
 import org.junit.jupiter.api.Test;
 
 import com.vaadin.flow.dom.SignalsUnitTest;
+import com.vaadin.flow.function.SerializableSupplier;
 import com.vaadin.flow.signals.BindingActiveException;
 import com.vaadin.flow.signals.local.ValueSignal;
 
@@ -137,16 +138,16 @@ class HtmlBindHtmlContentTest extends SignalsUnitTest {
                 "<div id='b'>after</div>");
         html.bindHtmlContent(signal);
 
-        // sending null will cause NPE in setHtmlContent inside effect function;
-        // state should not change, and an error should be captured by
-        // SignalsUnitTest error handler
+        // sending null is rejected with an IllegalArgumentException inside the
+        // effect function; state should not change, and an error should be
+        // captured by the SignalsUnitTest error handler
         signal.set(null);
 
         assertEquals("after", html.getInnerHtml());
         assertEquals("b", html.getElement().getAttribute("id"));
         // one error captured
         assertEquals(1, events.size());
-        assertEquals(NullPointerException.class,
+        assertEquals(IllegalArgumentException.class,
                 events.getFirst().getThrowable().getClass());
         // clear events for next verification in SignalsUnitTest.after
         events.clear();
@@ -180,10 +181,9 @@ class HtmlBindHtmlContentTest extends SignalsUnitTest {
 
     @Test
     void signalConstructorWithSafelist_initialAndUpdatesSanitized() {
-        Safelist safelist = new Safelist().addTags("div");
         ValueSignal<String> signal = new ValueSignal<>(
                 "<div onclick='evil()'>v1<script>x()</script></div>");
-        Html html = new Html(signal, safelist);
+        Html html = new Html(signal, () -> new Safelist().addTags("div"));
         UI.getCurrent().add(html);
 
         // initial value sanitized
@@ -198,65 +198,34 @@ class HtmlBindHtmlContentTest extends SignalsUnitTest {
     }
 
     @Test
-    void signalConstructorWithSafelist_nullSafelist_throws() {
+    void signalConstructorWithSafelist_nullSupplier_throws() {
         assertThrows(NullPointerException.class,
                 () -> new Html(new ValueSignal<>("<div>x</div>"),
-                        (Safelist) null));
+                        (SerializableSupplier<Safelist>) null));
     }
 
     @Test
-    void bindHtmlContentWithSafelist_updatesSanitized() {
-        Safelist safelist = new Safelist().addTags("div");
-        Html html = new Html("<div>init</div>");
-        UI.getCurrent().add(html);
-
-        ValueSignal<String> signal = new ValueSignal<>(
-                "<div onclick='evil()'>bound<script>x()</script></div>");
-        html.bindHtmlContent(signal, safelist);
-
-        assertNull(html.getElement().getAttribute("onclick"));
-        assertEquals("bound", html.getInnerHtml());
-
-        signal.set("<div onmouseover='evil()'>changed</div>");
-        assertNull(html.getElement().getAttribute("onmouseover"));
-        assertEquals("changed", html.getInnerHtml());
-    }
-
-    @Test
-    void bindHtmlContentWithSafelist_nullSafelist_throws() {
-        Html html = new Html("<div>init</div>");
-        UI.getCurrent().add(html);
-        assertThrows(NullPointerException.class,
-                () -> html.bindHtmlContent(new ValueSignal<>("<div>x</div>"),
-                        (Safelist) null));
-    }
-
-    @Test
-    void bindHtmlContentWithSafelist_withNullValue_recordsErrorAndDoesNotChange() {
-        Safelist safelist = new Safelist().addTags("div");
-        Html html = new Html("<div>init</div>");
-        UI.getCurrent().add(html);
+    void bindWithSafelist_withNullValue_recordsErrorAndDoesNotChange() {
         ValueSignal<String> signal = new ValueSignal<>("<div>after</div>");
-        html.bindHtmlContent(signal, safelist);
+        Html html = new Html(signal, () -> new Safelist().addTags("div"));
+        UI.getCurrent().add(html);
 
-        // A null value must not reach Jsoup.clean; it follows the same path as
-        // the non-sanitizing binding, recording an NPE without changing state
+        // A null value is rejected with a clear IllegalArgumentException
+        // instead of reaching Jsoup; state does not change.
         signal.set(null);
 
         assertEquals("after", html.getInnerHtml());
         assertEquals(1, events.size());
-        assertEquals(NullPointerException.class,
+        assertEquals(IllegalArgumentException.class,
                 events.getFirst().getThrowable().getClass());
         events.clear();
     }
 
     @Test
-    void bindHtmlContentWithSafelist_valueBecomesInvalidAfterClean_recordsErrorAndDoesNotChange() {
-        Safelist safelist = new Safelist().addTags("div");
-        Html html = new Html("<div>init</div>");
-        UI.getCurrent().add(html);
+    void bindWithSafelist_valueBecomesInvalidAfterClean_recordsErrorAndDoesNotChange() {
         ValueSignal<String> signal = new ValueSignal<>("<div>ok</div>");
-        html.bindHtmlContent(signal, safelist);
+        Html html = new Html(signal, () -> new Safelist().addTags("div"));
+        UI.getCurrent().add(html);
 
         assertEquals("ok", html.getInnerHtml());
 


### PR DESCRIPTION
The `Safelist` overloads on `Html` took a jsoup `Safelist` directly, which
is not serializable and only sanitized the single call it was given.

Accept a `SerializableSupplier<Safelist>` in the constructors and store it
on the component, so it survives session serialization and sanitizes all
later content updates through `setHtmlContent` and bound signals. The
safelist is fixed at construction; the per-call `Safelist` overloads are
removed.

Part of #24528
