### PR TITLE
feat: expose page title resolution as public API

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteConfiguration.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.internal.CurrentInstance;
 import com.vaadin.flow.router.internal.AbstractRouteRegistry;
 import com.vaadin.flow.router.internal.BeforeEnterHandler;
@@ -141,6 +142,63 @@ public class RouteConfiguration implements Serializable {
             RouteParameters parameters) {
         return RouteUtil.getRouteHierarchy(handledRegistry, navigationTarget,
                 parameters);
+    }
+
+    /**
+     * Resolves the page title of the given navigation target without creating
+     * an instance of it.
+     * <p>
+     * The title is resolved in this order:
+     * <ol>
+     * <li>the per-route {@link DynamicPageTitle} generator;</li>
+     * <li>the application-wide default {@link PageTitleGenerator};</li>
+     * <li>the static {@link PageTitle#value()}.</li>
+     * </ol>
+     * Since the navigation target is not instantiated,
+     * {@link HasDynamicTitle#getPageTitle()} is not consulted; the title of an
+     * instantiated, currently shown route may therefore differ from the result
+     * of this method.
+     *
+     * @param navigationTarget
+     *            the navigation target to resolve the title for, not
+     *            {@code null}
+     * @param routeParameters
+     *            the route parameters the target is resolved with, not
+     *            {@code null}
+     * @param queryParameters
+     *            the query parameters the target is resolved with, not
+     *            {@code null}
+     * @return the resolved title, or an empty {@link Optional} if the target
+     *         declares no title and no default generator is available
+     */
+    public Optional<String> getPageTitle(
+            Class<? extends Component> navigationTarget,
+            RouteParameters routeParameters, QueryParameters queryParameters) {
+        VaadinService service = VaadinService.getCurrent();
+        Instantiator instantiator = service != null ? service.getInstantiator()
+                : null;
+        return RouteUtil.resolvePageTitle(instantiator, navigationTarget,
+                routeParameters, queryParameters);
+    }
+
+    /**
+     * Resolves the page title of the given route reference without creating an
+     * instance of its navigation target, applying the resolution rules of
+     * {@link #getPageTitle(Class, RouteParameters, QueryParameters)} with empty
+     * query parameters.
+     * <p>
+     * This is a convenience for resolving the titles of the entries returned by
+     * {@link #getRouteHierarchy(Class, RouteParameters)}, for example to build
+     * a breadcrumb trail.
+     *
+     * @param route
+     *            the route reference to resolve the title for, not {@code null}
+     * @return the resolved title, or an empty {@link Optional} if the target
+     *         declares no title and no default generator is available
+     */
+    public Optional<String> getPageTitle(RouteParentReference route) {
+        return getPageTitle(route.navigationTarget(), route.routeParameters(),
+                QueryParameters.empty());
     }
 
     /* Static getters for getting information on registered routes */

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouteConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouteConfigurationTest.java
@@ -145,6 +145,48 @@ class RouteConfigurationTest {
     }
 
     @Test
+    void getPageTitle_resolvesStaticAndDynamicTitlesForHierarchy() {
+        RouteConfiguration routeConfiguration = RouteConfiguration
+                .forRegistry(getRegistry(session));
+        routeConfiguration.update(() -> {
+            routeConfiguration.setAnnotatedRoute(OrdersView.class);
+            routeConfiguration.setAnnotatedRoute(OrderView.class);
+        });
+
+        List<String> titles = routeConfiguration
+                .getRouteHierarchy(OrderView.class,
+                        new RouteParameters("orderId", "1001"))
+                .stream().map(route -> routeConfiguration.getPageTitle(route)
+                        .orElseThrow())
+                .toList();
+
+        assertEquals(List.of("Orders", "Order 1001"), titles);
+    }
+
+    @Test
+    void getPageTitle_queryParametersPassedToGenerator() {
+        RouteConfiguration routeConfiguration = RouteConfiguration
+                .forRegistry(getRegistry(session));
+
+        Optional<String> title = routeConfiguration.getPageTitle(
+                QueryEchoView.class, RouteParameters.empty(),
+                QueryParameters.of("name", "Smith"));
+
+        assertEquals(Optional.of("Hello Smith"), title);
+    }
+
+    @Test
+    void getPageTitle_noTitleDeclared_returnsEmpty() {
+        RouteConfiguration routeConfiguration = RouteConfiguration
+                .forRegistry(getRegistry(session));
+
+        Optional<String> title = routeConfiguration.getPageTitle(MyRoute.class,
+                RouteParameters.empty(), QueryParameters.empty());
+
+        assertEquals(Optional.empty(), title);
+    }
+
+    @Test
     void routeConfigurationUpdateLock_configurationIsUpdatedOnlyAfterUnlock() {
         CountDownLatch waitReaderThread = new CountDownLatch(1);
         CountDownLatch waitUpdaterThread = new CountDownLatch(2);
@@ -592,13 +634,37 @@ class RouteConfigurationTest {
 
     @Tag("div")
     @Route("orders")
+    @PageTitle("Orders")
     private static class OrdersView extends Component {
     }
 
     @Tag("div")
     @Route("orders/:orderId")
     @RouteParent(OrdersView.class)
+    @DynamicPageTitle(OrderTitleGenerator.class)
     private static class OrderView extends Component {
+    }
+
+    public static class OrderTitleGenerator implements PageTitleGenerator {
+        @Override
+        public String generatePageTitle(PageTitleContext context) {
+            return "Order "
+                    + context.routeParameters().get("orderId").orElseThrow();
+        }
+    }
+
+    @Tag("div")
+    @Route("hello")
+    @DynamicPageTitle(QueryEchoTitleGenerator.class)
+    private static class QueryEchoView extends Component {
+    }
+
+    public static class QueryEchoTitleGenerator implements PageTitleGenerator {
+        @Override
+        public String generatePageTitle(PageTitleContext context) {
+            return "Hello " + context.queryParameters()
+                    .getSingleParameter("name").orElseThrow();
+        }
     }
 
     @Tag("div")


### PR DESCRIPTION
Add RouteConfiguration.getPageTitle for resolving the page title of a navigation target without instantiating it, applying the same DynamicPageTitle generator / default PageTitleGenerator / static PageTitle chain used during navigation. A RouteParentReference overload makes it easy to resolve titles for getRouteHierarchy entries, e.g. for breadcrumb trails.

Previously this resolution chain was only reachable through the internal RouteUtil.resolvePageTitle.
