### PR TITLE
chore: Allow npm minor version updates in maintenance branches

### DIFF
--- a/scripts/update-frontend-dependencies.sh
+++ b/scripts/update-frontend-dependencies.sh
@@ -17,7 +17,7 @@ currentBranch=$(git rev-parse --abbrev-ref HEAD)
 if [ "$currentBranch" = "main" ]; then
   updateTarget="latest"
 else
-  updateTarget="patch"
+  updateTarget="minor"
 fi
 
 echo "Current branch: $currentBranch"


### PR DESCRIPTION
There is a lot of deprecated versions of react router and others. Even security issues are not fixed for older minor releases