### PR TITLE
docs: add @since 25.2 to API introduced in 25.2

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/Options.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/Options.java
@@ -218,6 +218,8 @@ public class Options implements Serializable {
      *            the application configuration to be applied
      * @return the updated {@code Options} instance with the specified
      *         application configuration
+     *
+     * @since 25.2
      */
     public Options withApplicationConfiguration(
             ApplicationConfiguration applicationConfiguration) {
@@ -1244,6 +1246,8 @@ public class Options implements Serializable {
      * @param defaultValue
      *            the value to return if the property is not set
      * @return the property value, or empty if configuration is unavailable
+     *
+     * @since 25.2
      */
     public Optional<String> getApplicationStringProperty(String name,
             String defaultValue) {
@@ -1263,6 +1267,8 @@ public class Options implements Serializable {
      * @param defaultValue
      *            the value to return if the property is not set
      * @return the property value, or empty if configuration is unavailable
+     *
+     * @since 25.2
      */
     public Optional<Boolean> getApplicationBooleanProperty(String name,
             boolean defaultValue) {

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TypeScriptBootstrapModifier.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TypeScriptBootstrapModifier.java
@@ -50,6 +50,7 @@ public interface TypeScriptBootstrapModifier extends Serializable {
      *            the input typescript split into lines
      * @param options
      *            options used by the build
+     * @since 25.2
      */
     default void modify(List<String> bootstrapTypeScript, Options options) {
         modify(bootstrapTypeScript, options,

--- a/flow-dnd/src/main/java/com/vaadin/flow/component/dnd/AbstractDnDEvent.java
+++ b/flow-dnd/src/main/java/com/vaadin/flow/component/dnd/AbstractDnDEvent.java
@@ -27,6 +27,7 @@ import com.vaadin.flow.component.ComponentEvent;
  * @param <T>
  *            Type of the component associated with the event.
  * @author Vaadin Ltd
+ * @since 25.2
  */
 public abstract class AbstractDnDEvent<T extends Component>
         extends ComponentEvent<T> {

--- a/flow-dnd/src/main/java/com/vaadin/flow/component/dnd/DragStartEvent.java
+++ b/flow-dnd/src/main/java/com/vaadin/flow/component/dnd/DragStartEvent.java
@@ -92,6 +92,7 @@ public class DragStartEvent<T extends Component> extends AbstractDnDEvent<T> {
      * positioning dropped items.
      *
      * @return the x coordinate relative to the drag source element
+     * @since 25.2
      */
     public int getOffsetX() {
         return offsetX;
@@ -105,6 +106,7 @@ public class DragStartEvent<T extends Component> extends AbstractDnDEvent<T> {
      * positioning dropped items.
      *
      * @return the y coordinate relative to the drag source element
+     * @since 25.2
      */
     public int getOffsetY() {
         return offsetY;

--- a/flow-dnd/src/main/java/com/vaadin/flow/component/dnd/DropEvent.java
+++ b/flow-dnd/src/main/java/com/vaadin/flow/component/dnd/DropEvent.java
@@ -160,6 +160,7 @@ public class DropEvent<T extends Component> extends AbstractDnDEvent<T> {
      * container using absolute or relative positioning.
      *
      * @return the x coordinate relative to the drop target element
+     * @since 25.2
      */
     public int getOffsetX() {
         return offsetX;
@@ -173,6 +174,7 @@ public class DropEvent<T extends Component> extends AbstractDnDEvent<T> {
      * container using absolute or relative positioning.
      *
      * @return the y coordinate relative to the drop target element
+     * @since 25.2
      */
     public int getOffsetY() {
         return offsetY;
@@ -189,6 +191,7 @@ public class DropEvent<T extends Component> extends AbstractDnDEvent<T> {
      *
      * @return the drag start x offset if the drag source is in the same UI,
      *         otherwise {@code 0}
+     * @since 25.2
      */
     public int getDragStartOffsetX() {
         return getDragSourceComponent().map(component -> (Integer) ComponentUtil
@@ -206,6 +209,7 @@ public class DropEvent<T extends Component> extends AbstractDnDEvent<T> {
      *
      * @return the drag start y offset if the drag source is in the same UI,
      *         otherwise {@code 0}
+     * @since 25.2
      */
     public int getDragStartOffsetY() {
         return getDragSourceComponent().map(component -> (Integer) ComponentUtil

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
@@ -322,6 +322,7 @@ public class Anchor extends HtmlContainer
      *
      * @param href
      *            the href to set
+     * @since 25.2
      */
     public void setUnsafeHref(String href) {
         if (href == null) {

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/IFrame.java
@@ -195,6 +195,7 @@ public class IFrame extends HtmlComponent implements HasAriaLabel {
      *
      * @param src
      *            Source URL.
+     * @since 25.2
      */
     public void setUnsafeSrc(String src) {
         set(srcDescriptor, src);

--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentEvent.java
@@ -70,6 +70,7 @@ public class ComponentEvent<T extends Component> extends EventObject {
      * @param ui
      *            the UI associated with the event, or <code>null</code> if not
      *            available
+     * @since 25.2
      */
     public ComponentEvent(T source, boolean fromClient, UI ui) {
         super(source);
@@ -114,6 +115,7 @@ public class ComponentEvent<T extends Component> extends EventObject {
      * @throws IllegalStateException
      *             if the source component is not currently attached to a UI and
      *             no UI was provided at construction time
+     * @since 25.2
      */
     public UI getUI() {
         if (ui != null) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
@@ -861,6 +861,7 @@ public class ComponentUtil {
      *            the parent component from which to get the child components
      * @return the child components of the given parent component, including
      *         virtual children
+     * @since 25.2
      */
     public static Stream<Component> getAllChildren(Component parent) {
         if (parent instanceof Composite) {
@@ -890,6 +891,7 @@ public class ComponentUtil {
      * @param parent
      *            the parent component to start the traversal from
      * @return a stream of all descendant components in pre-order
+     * @since 25.2
      */
     public static Stream<Component> streamDescendants(Component parent) {
         Builder<Component> descendants = Stream.builder();

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasComponentsOfType.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasComponentsOfType.java
@@ -54,6 +54,7 @@ import com.vaadin.flow.signals.impl.Effect;
  *            the type of child components accepted by this container
  *
  * @author Vaadin Ltd
+ * @since 25.2
  */
 public interface HasComponentsOfType<T extends Component>
         extends HasElement, HasEnabled {

--- a/flow-server/src/main/java/com/vaadin/flow/component/Html.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Html.java
@@ -200,6 +200,7 @@ public class Html extends Component {
      *             if reading the stream fails
      * @throws NullPointerException
      *             if the supplier is <code>null</code>
+     * @since 25.2
      */
     public Html(InputStream stream,
             SerializableSupplier<Safelist> safelistSupplier) {
@@ -260,6 +261,7 @@ public class Html extends Component {
      *            not <code>null</code>
      * @throws NullPointerException
      *             if the supplier is <code>null</code>
+     * @since 25.2
      */
     public Html(String outerHtml,
             SerializableSupplier<Safelist> safelistSupplier) {
@@ -320,6 +322,7 @@ public class Html extends Component {
      *             empty, or doesn't have exactly one root element
      * @throws NullPointerException
      *             if the supplier is <code>null</code>
+     * @since 25.2
      */
     public Html(Signal<String> htmlSignal,
             SerializableSupplier<Safelist> safelistSupplier) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -738,6 +738,7 @@ public class UI extends Component
      *            serializable if the session is serialized
      * @return a registration for cancelling the task before it runs, not
      *         <code>null</code>
+     * @since 25.2
      */
     public Registration triggerAfter(Duration delay,
             SerializableRunnable task) {
@@ -918,6 +919,7 @@ public class UI extends Component
      *
      * @return a read-only signal holding the current router state, never
      *         {@code null}
+     * @since 25.2
      */
     public Signal<RouterState> routerStateSignal() {
         return internals.getRouterStateSignal();

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/Clipboard.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/Clipboard.java
@@ -74,6 +74,8 @@ import com.vaadin.flow.shared.Registration;
  * shape fits. {@code onFilePaste} is independent of {@code onPaste}; the same
  * paste gesture can deliver text/html via {@code onPaste} and files via
  * {@code onFilePaste} when both are registered.
+ *
+ * @since 25.2
  */
 public final class Clipboard implements Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/ClipboardBinding.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/ClipboardBinding.java
@@ -66,6 +66,8 @@ import com.vaadin.flow.server.streams.DownloadHandler;
  *         text -> Notification.show("Pasted " + text),
  *         err -> Notification.show("Failed: " + err.message()));
  * }</pre>
+ *
+ * @since 25.2
  */
 public final class ClipboardBinding implements Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/ClipboardContent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/ClipboardContent.java
@@ -38,6 +38,8 @@ import com.vaadin.flow.component.trigger.internal.PropertyInput;
  * Clipboard.onClick(button).write(ClipboardContent.create().text("Hello")
  *         .html("<b>Hello</b>").image(previewImage));
  * }</pre>
+ *
+ * @since 25.2
  */
 public final class ClipboardContent implements Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/ClipboardPayload.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/ClipboardPayload.java
@@ -28,6 +28,7 @@ import org.jspecify.annotations.Nullable;
  *            {@code text/plain} contents, or {@code null} if not present
  * @param html
  *            {@code text/html} contents, or {@code null} if not present
+ * @since 25.2
  */
 public record ClipboardPayload(@Nullable String text,
         @Nullable String html) implements Serializable {

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteComplete.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteComplete.java
@@ -54,6 +54,7 @@ import java.io.Serializable;
  * @param receivedFiles
  *            the number of files actually delivered for this paste; equals the
  *            {@link PasteStart#totalFiles()} value the paste started with
+ * @since 25.2
  */
 public record PasteComplete(long pasteId,
         int receivedFiles) implements Serializable {

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteEvent.java
@@ -73,6 +73,8 @@ import com.vaadin.flow.dom.Element;
  * </ul>
  *
  * The listener runs on the UI thread.
+ *
+ * @since 25.2
  */
 public final class PasteEvent implements Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteFile.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteFile.java
@@ -63,6 +63,7 @@ import com.vaadin.flow.function.SerializableConsumer;
  *            the size of the uploaded body in bytes
  * @param bytes
  *            the uploaded body
+ * @since 25.2
  */
 public record PasteFile(long pasteId, boolean newPaste, int totalFiles,
         String fileName, @Nullable String contentType, long size,

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteFileHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteFileHandler.java
@@ -76,6 +76,8 @@ import com.vaadin.flow.server.streams.UploadHandler;
  * sanitized. Treat it as untrusted &mdash; never use it directly as a
  * filesystem path without sanitizing it first.</li>
  * </ul>
+ *
+ * @since 25.2
  */
 public final class PasteFileHandler implements Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteOptions.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteOptions.java
@@ -37,6 +37,7 @@ import com.vaadin.flow.function.SerializableConsumer;
  *            regardless of focus; this is also the default when no options are
  *            passed to
  *            {@link Clipboard#onPaste(Component, SerializableConsumer)}.
+ * @since 25.2
  */
 public record PasteOptions(
         boolean includeInputFieldPastes) implements Serializable {

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteStart.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/PasteStart.java
@@ -32,6 +32,7 @@ import java.io.Serializable;
  *            of the files about to be delivered
  * @param totalFiles
  *            the number of files the browser said the paste contains
+ * @since 25.2
  */
 public record PasteStart(long pasteId, int totalFiles) implements Serializable {
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/fullscreen/Fullscreen.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/fullscreen/Fullscreen.java
@@ -41,6 +41,8 @@ import com.vaadin.flow.signals.Signal;
  *
  * To leave fullscreen, call {@link #exit()}; to observe the current state,
  * subscribe to {@link #stateSignal()}. Neither needs a user gesture.
+ *
+ * @since 25.2
  */
 public final class Fullscreen implements Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/fullscreen/FullscreenBinding.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/fullscreen/FullscreenBinding.java
@@ -49,6 +49,8 @@ import com.vaadin.flow.function.SerializableRunnable;
  * while fullscreen is active. The component is restored to its original
  * position when fullscreen exits, whether via {@link Fullscreen#exit()}, the
  * user pressing Escape, or a later request superseding this one.
+ *
+ * @since 25.2
  */
 public final class FullscreenBinding implements Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/fullscreen/FullscreenState.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/fullscreen/FullscreenState.java
@@ -26,6 +26,7 @@ package com.vaadin.flow.component.fullscreen;
  *
  * @see Fullscreen#stateSignal()
  * @see Fullscreen#exit()
+ * @since 25.2
  */
 public enum FullscreenState {
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/geolocation/Geolocation.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/geolocation/Geolocation.java
@@ -89,6 +89,8 @@ import com.vaadin.flow.signals.Signal;
  *     }
  * });
  * </pre>
+ *
+ * @since 25.2
  */
 public final class Geolocation implements Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/geolocation/GeolocationAvailability.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/geolocation/GeolocationAvailability.java
@@ -35,6 +35,8 @@ package com.vaadin.flow.component.geolocation;
  * <li>{@link #PROMPT} / {@link #UNKNOWN} — wait for an explicit user action
  * (click a button) before triggering a browser prompt.</li>
  * </ul>
+ *
+ * @since 25.2
  */
 public enum GeolocationAvailability {
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/geolocation/GeolocationClient.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/geolocation/GeolocationClient.java
@@ -36,6 +36,8 @@ import com.vaadin.flow.shared.Registration;
  * {@link #get}, the {@code onUpdate} consumer passed to {@link #startWatch},
  * and the {@code onChange} consumer passed to {@link #subscribeAvailability})
  * must be invoked on the UI thread.
+ *
+ * @since 25.2
  */
 @NullMarked
 public interface GeolocationClient extends Serializable {

--- a/flow-server/src/main/java/com/vaadin/flow/component/geolocation/GeolocationClientFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/geolocation/GeolocationClientFactory.java
@@ -35,6 +35,8 @@ import com.vaadin.flow.di.Lookup;
  * access is unreliable (split-classloader topologies such as Quarkus).
  * Application code does not reference this interface directly. May be renamed
  * or removed in a future release.
+ *
+ * @since 25.2
  */
 @NullMarked
 public interface GeolocationClientFactory extends Serializable {

--- a/flow-server/src/main/java/com/vaadin/flow/component/geolocation/GeolocationCoordinates.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/geolocation/GeolocationCoordinates.java
@@ -53,6 +53,7 @@ import org.jspecify.annotations.Nullable;
  * @param speed
  *            ground speed in metres per second, or {@code null} when the device
  *            cannot measure it
+ * @since 25.2
  */
 public record GeolocationCoordinates(double latitude, double longitude,
         double accuracy, @Nullable Double altitude,

--- a/flow-server/src/main/java/com/vaadin/flow/component/geolocation/GeolocationError.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/geolocation/GeolocationError.java
@@ -52,6 +52,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *            Useful for log lines and bug reports — the wording is not
  *            standardised across browsers and must not be shown to end users
  *            as-is
+ * @since 25.2
  */
 public record GeolocationError(int code,
         @JsonProperty("message") String debugInfo)

--- a/flow-server/src/main/java/com/vaadin/flow/component/geolocation/GeolocationErrorCode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/geolocation/GeolocationErrorCode.java
@@ -25,6 +25,8 @@ package com.vaadin.flow.component.geolocation;
  * Each constant holds an integer identifier. Applications rarely need to look
  * at {@link #code()} directly; it is exposed for logging and for round-tripping
  * with {@link GeolocationError#code()}.
+ *
+ * @since 25.2
  */
 public enum GeolocationErrorCode {
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/geolocation/GeolocationOptions.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/geolocation/GeolocationOptions.java
@@ -67,6 +67,7 @@ import org.jspecify.annotations.Nullable;
  *            hardware again. {@code 0} means "never use a cached reading";
  *            {@code null} also means {@code 0}. Larger values save battery and
  *            return faster at the cost of freshness
+ * @since 25.2
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record GeolocationOptions(@Nullable Boolean enableHighAccuracy,

--- a/flow-server/src/main/java/com/vaadin/flow/component/geolocation/GeolocationPending.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/geolocation/GeolocationPending.java
@@ -20,6 +20,8 @@ package com.vaadin.flow.component.geolocation;
  * {@link GeolocationWatcher#positionSignal()} until the browser reports its
  * first position or error. One-shot {@link Geolocation#getPosition} callers
  * never observe this value.
+ *
+ * @since 25.2
  */
 public record GeolocationPending() implements GeolocationResult {
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/geolocation/GeolocationPosition.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/geolocation/GeolocationPosition.java
@@ -32,6 +32,7 @@ import java.time.Instant;
  *            the moment the reading was taken, as milliseconds since the Unix
  *            epoch (1970-01-01T00:00:00Z). Use {@link #timestampAsInstant()}
  *            for an {@link Instant}
+ * @since 25.2
  */
 public record GeolocationPosition(GeolocationCoordinates coords,
         long timestamp) implements GeolocationOutcome {

--- a/flow-server/src/main/java/com/vaadin/flow/component/geolocation/GeolocationResult.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/geolocation/GeolocationResult.java
@@ -36,6 +36,8 @@ import java.io.Serializable;
  * case GeolocationError err -&gt; showError(err.errorCode());
  * }
  * </pre>
+ *
+ * @since 25.2
  */
 public sealed interface GeolocationResult extends Serializable
         permits GeolocationOutcome, GeolocationPending {

--- a/flow-server/src/main/java/com/vaadin/flow/component/geolocation/GeolocationWatcher.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/geolocation/GeolocationWatcher.java
@@ -53,6 +53,8 @@ import com.vaadin.flow.signals.local.ValueSignal;
  * immediately, otherwise it starts on first attach. Calling {@link #stop()}
  * before the first attach cancels the pending activation; the watcher can still
  * be activated later by calling {@link #resume()} on an attached owner.
+ *
+ * @since 25.2
  */
 public class GeolocationWatcher implements Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -528,6 +528,7 @@ public class Page implements Serializable {
      * </ul>
      *
      * @return the read-only visibility signal
+     * @since 25.2
      */
     public Signal<PageVisibility> pageVisibilitySignal() {
         return pageVisibilityReadOnly;

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/PageVisibility.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/PageVisibility.java
@@ -25,6 +25,7 @@ package com.vaadin.flow.component.page;
  * from the client.
  *
  * @see Page#pageVisibilitySignal()
+ * @since 25.2
  */
 public enum PageVisibility {
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/wakelock/WakeLock.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/wakelock/WakeLock.java
@@ -66,6 +66,8 @@ import com.vaadin.flow.signals.Signal;
  * <li>Some browsers release the lock on low battery or when the device enters
  * power-saving mode; {@link #activeSignal()} reflects this immediately.</li>
  * </ul>
+ *
+ * @since 25.2
  */
 public final class WakeLock {
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/wakelock/WakeLockAvailability.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/wakelock/WakeLockAvailability.java
@@ -27,6 +27,8 @@ import com.vaadin.flow.component.UI;
  * Typical usage: hide a "keep screen on" toggle entirely when the value is
  * {@link #UNSUPPORTED} (no user action can change this), and otherwise offer it
  * and observe {@link WakeLock#activeSignal(UI)} for the actual state.
+ *
+ * @since 25.2
  */
 public enum WakeLockAvailability {
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/wakelock/WakeLockError.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/wakelock/WakeLockError.java
@@ -27,6 +27,7 @@ import java.util.Objects;
  * @param message
  *            human-readable detail suitable for diagnostics; never {@code null}
  *            but may be empty
+ * @since 25.2
  */
 public record WakeLockError(WakeLockErrorCode code,
         String message) implements Serializable {

--- a/flow-server/src/main/java/com/vaadin/flow/component/wakelock/WakeLockErrorCode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/wakelock/WakeLockErrorCode.java
@@ -19,6 +19,8 @@ package com.vaadin.flow.component.wakelock;
  * Reason a
  * {@link WakeLock#request(com.vaadin.flow.function.SerializableConsumer)
  * WakeLock.request(onError)} call failed.
+ *
+ * @since 25.2
  */
 public enum WakeLockErrorCode {
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/di/Instantiator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/di/Instantiator.java
@@ -230,6 +230,7 @@ public interface Instantiator extends Serializable {
      *
      * @return the default page title generator, or {@code null} if none has
      *         been defined
+     * @since 25.2
      */
     default PageTitleGenerator getPageTitleGenerator() {
         return null;

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -1884,6 +1884,7 @@ public class Element extends Node<Element> {
      *            parameters to pass to the expression
      * @return a registration that, when removed, invokes the cleanup callback
      *         on the client
+     * @since 25.2
      */
     public Registration addJsInitializer(String expression,
             Object... parameters) {

--- a/flow-server/src/main/java/com/vaadin/flow/dom/JsFunction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/JsFunction.java
@@ -52,6 +52,7 @@ import com.vaadin.flow.internal.JacksonCodec;
  * as a capture.
  *
  * @author Vaadin Ltd
+ * @since 25.2
  */
 public final class JsFunction implements Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
@@ -148,6 +148,7 @@ public interface DeploymentConfiguration
      *
      * @return the {@code X-Frame-Options} value to use, or an empty string if
      *         the header should not be sent
+     * @since 25.2
      */
     default String getFrameOptions() {
         return getStringProperty(InitParameters.SERVLET_PARAMETER_FRAME_OPTIONS,

--- a/flow-server/src/main/java/com/vaadin/flow/router/DynamicPageTitle.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/DynamicPageTitle.java
@@ -43,6 +43,7 @@ import java.lang.annotation.Target;
  * example as an i18n message key) rather than used as the title directly.
  *
  * @author Vaadin Ltd
+ * @since 25.2
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/flow-server/src/main/java/com/vaadin/flow/router/PageTitleContext.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/PageTitleContext.java
@@ -44,6 +44,7 @@ import com.vaadin.flow.component.Component;
  *            the {@link PageTitle#value()} declared on the route, or an empty
  *            string when none is declared
  * @author Vaadin Ltd
+ * @since 25.2
  */
 public record PageTitleContext(Class<? extends Component> navigationTarget,
         RouteParameters routeParameters, QueryParameters queryParameters,

--- a/flow-server/src/main/java/com/vaadin/flow/router/PageTitleGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/PageTitleGenerator.java
@@ -54,6 +54,7 @@ import java.io.Serializable;
  * navigation target itself.
  *
  * @author Vaadin Ltd
+ * @since 25.2
  */
 @FunctionalInterface
 public interface PageTitleGenerator extends Serializable {

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteConfiguration.java
@@ -108,6 +108,7 @@ public class RouteConfiguration implements Serializable {
      *            not {@code null}
      * @return the logical parent reference, or an empty {@link Optional} if the
      *         target has no logical parent
+     * @since 25.2
      */
     public Optional<RouteParentReference> getRouteParent(
             Class<? extends Component> navigationTarget,
@@ -135,6 +136,7 @@ public class RouteConfiguration implements Serializable {
      *            not {@code null}
      * @return the chain of the target and its logical ancestors, ordered from
      *         root to the navigation target, never empty
+     * @since 25.2
      */
     public List<RouteParentReference> getRouteHierarchy(
             Class<? extends Component> navigationTarget,

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteParent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteParent.java
@@ -38,6 +38,7 @@ import com.vaadin.flow.component.Component;
  * breadcrumb trail.
  *
  * @author Vaadin Ltd
+ * @since 25.2
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteParentContext.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteParentContext.java
@@ -34,6 +34,7 @@ import com.vaadin.flow.component.Component;
  *            the route parameters the navigation target is resolved with;
  *            {@link RouteParameters#empty()} when no parameters are available
  * @author Vaadin Ltd
+ * @since 25.2
  */
 public record RouteParentContext(Class<? extends Component> navigationTarget,
         RouteParameters routeParameters) implements Serializable {

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteParentReference.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteParentReference.java
@@ -36,6 +36,7 @@ import com.vaadin.flow.component.Component;
  * @param routeParameters
  *            the route parameters to resolve the navigation target with
  * @author Vaadin Ltd
+ * @since 25.2
  */
 public record RouteParentReference(Class<? extends Component> navigationTarget,
         RouteParameters routeParameters) implements Serializable {

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteParentResolver.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteParentResolver.java
@@ -59,6 +59,7 @@ import java.util.Optional;
  * route itself.
  *
  * @author Vaadin Ltd
+ * @since 25.2
  */
 @FunctionalInterface
 public interface RouteParentResolver extends Serializable {

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouterState.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouterState.java
@@ -50,6 +50,7 @@ import com.vaadin.flow.component.HasElement;
  * @param navigationTarget
  *            the class of the leaf route target. {@code null} before the first
  *            navigation completes.
+ * @since 25.2
  */
 public record RouterState(Location location, RouteParameters routeParameters,
         List<HasElement> activeChain,

--- a/flow-server/src/main/java/com/vaadin/flow/signals/local/ListSignal.java
+++ b/flow-server/src/main/java/com/vaadin/flow/signals/local/ListSignal.java
@@ -219,6 +219,7 @@ public class ListSignal<T extends @Nullable Object>
      * @param values
      *            the values to insert, not <code>null</code>
      * @return an unmodifiable list of signals for the inserted entries
+     * @since 25.2
      */
     public List<ValueSignal<T>> insertAllLast(Collection<? extends T> values) {
         Objects.requireNonNull(values, "Values must not be null");
@@ -245,6 +246,7 @@ public class ListSignal<T extends @Nullable Object>
      * @param values
      *            the values to insert, not <code>null</code>
      * @return an unmodifiable list of signals for the inserted entries
+     * @since 25.2
      */
     public List<ValueSignal<T>> insertAllFirst(Collection<? extends T> values) {
         return insertAllAt(0, values);
@@ -270,6 +272,7 @@ public class ListSignal<T extends @Nullable Object>
      * @return an unmodifiable list of signals for the inserted entries
      * @throws IndexOutOfBoundsException
      *             if index is negative or greater than size()
+     * @since 25.2
      */
     public List<ValueSignal<T>> insertAllAt(int index,
             Collection<? extends T> values) {

--- a/flow-server/src/main/java/com/vaadin/flow/signals/operations/BulkInsertOperation.java
+++ b/flow-server/src/main/java/com/vaadin/flow/signals/operations/BulkInsertOperation.java
@@ -27,6 +27,7 @@ import com.vaadin.flow.signals.Signal;
  *
  * @param <T>
  *            the type of the newly inserted signals
+ * @since 25.2
  */
 public class BulkInsertOperation<T extends Signal<?>>
         extends SignalOperation<Void> {

--- a/flow-server/src/main/java/com/vaadin/flow/signals/shared/SharedListSignal.java
+++ b/flow-server/src/main/java/com/vaadin/flow/signals/shared/SharedListSignal.java
@@ -315,6 +315,7 @@ public class SharedListSignal<T extends @Nullable Object>
      *            the values to insert, not <code>null</code>
      * @return a bulk insert operation containing the inserted signals and a
      *         single result future for the entire batch
+     * @since 25.2
      */
     public BulkInsertOperation<SharedValueSignal<T>> insertAllLast(
             Collection<? extends T> values) {
@@ -332,6 +333,7 @@ public class SharedListSignal<T extends @Nullable Object>
      *            the values to insert, not <code>null</code>
      * @return a bulk insert operation containing the inserted signals and a
      *         single result future for the entire batch
+     * @since 25.2
      */
     public BulkInsertOperation<SharedValueSignal<T>> insertAllFirst(
             Collection<? extends T> values) {
@@ -356,6 +358,7 @@ public class SharedListSignal<T extends @Nullable Object>
      *            <code>null</code>
      * @return a bulk insert operation containing the inserted signals and a
      *         single result future for the entire batch
+     * @since 25.2
      */
     public BulkInsertOperation<SharedValueSignal<T>> insertAllAt(
             Collection<? extends T> values, ListPosition at) {


### PR DESCRIPTION
Adds the missing `@since` javadoc tags surfaced by the 25.2 release audit: class-level tags for the new clipboard, geolocation, fullscreen, wake lock, page visibility, route hierarchy and signals operation types, and method-level tags for new members on pre-existing classes (UI, Page, Element, ComponentUtil, ComponentEvent, Html, RouteConfiguration, Instantiator, DeploymentConfiguration, ListSignal, SharedListSignal, Anchor, IFrame, DnD events, TypeScriptBootstrapModifier, Options).

Every tagged API was verified to be absent from the 25.1.0 release tag.
