### PR TITLE
docs: normalize HasOrderedComponents deprecation version to 25.1

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/HasOrderedComponents.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasOrderedComponents.java
@@ -25,9 +25,9 @@ package com.vaadin.flow.component;
  * compatibility, but it is not needed anymore.
  *
  * @since 1.0
- * @deprecated since 25.1.0, for removal in 26.0.0.
+ * @deprecated since 25.1, for removal in 26.
  */
-@Deprecated(since = "25.1.0", forRemoval = true)
+@Deprecated(since = "25.1", forRemoval = true)
 public interface HasOrderedComponents extends HasComponents {
 
 }


### PR DESCRIPTION
The 25.2 release audit suspected the @Deprecated(since = "25.1.0") value was wrong for a change merged in the 25.2 window. Verification against the release tags shows the deprecation (#23773) was cherry-picked into 25.1.0, so the version is correct; only the three-segment format deviated from the repository convention (two-segment, e.g. "25.1").
