### PR TITLE
docs: add missing @since tags to API that shipped in 25.1

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -4361,6 +4361,8 @@ public class Binder<BEAN> implements Serializable {
      * @param applyBindingsToHiddenFields
      *            {@literal true} to make all bindings apply to hidden fields,
      *            {@literal false} to skip hidden fields (the default)
+     *
+     * @since 25.1.4
      */
     public void setApplyBindingsToHiddenFields(
             boolean applyBindingsToHiddenFields) {
@@ -4373,6 +4375,8 @@ public class Binder<BEAN> implements Serializable {
      *
      * @return {@literal true} if bindings are applied to hidden fields,
      *         {@literal false} if hidden fields are skipped (the default)
+     *
+     * @since 25.1.4
      */
     public boolean isApplyBindingsToHiddenFields() {
         return applyBindingsToHiddenFields;

--- a/flow-server/src/main/java/com/vaadin/flow/component/Component.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Component.java
@@ -463,6 +463,8 @@ public abstract class Component
      * @param testId
      *            the test id to set, or <code>null</code> to remove any
      *            previously set test id
+     *
+     * @since 25.1
      */
     public void setTestId(String testId) {
         if (testId == null) {
@@ -479,6 +481,8 @@ public abstract class Component
      * @see #setTestId(String)
      *
      * @return the test id, or {@code null} if no test id has been set
+     *
+     * @since 25.1
      */
     public String getTestId() {
         return getElement().getAttribute("data-testid");

--- a/flow-server/src/main/java/com/vaadin/flow/dom/BindingContext.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/BindingContext.java
@@ -38,6 +38,7 @@ import com.vaadin.flow.signals.EffectContext;
  *
  * @param <T>
  *            the type of the bound signal value
+ * @since 25.1
  */
 public class BindingContext<T extends @Nullable Object> extends EffectContext {
 

--- a/flow-server/src/main/java/com/vaadin/flow/dom/SignalBinding.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/SignalBinding.java
@@ -41,6 +41,7 @@ import com.vaadin.flow.function.SerializableConsumer;
  *
  * @param <T>
  *            the type of the bound signal value
+ * @since 25.1
  */
 public class SignalBinding<T extends @Nullable Object> implements Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/streams/DownloadHandler.java
@@ -444,6 +444,8 @@ public interface DownloadHandler extends ElementRequestHandler {
      *            <code>path</code> and also used as a download request URL
      *            postfix
      * @return DownloadHandler implementation for download from an input stream
+     *
+     * @since 25.1
      */
     static InputStreamDownloadHandler fromInputStream(
             InputStreamDownloadCallback callback, String fileNameOverride) {
@@ -495,6 +497,8 @@ public interface DownloadHandler extends ElementRequestHandler {
      * @param listener
      *            listener for transfer progress events
      * @return DownloadHandler implementation for download from an input stream
+     *
+     * @since 25.1
      */
     static InputStreamDownloadHandler fromInputStream(
             InputStreamDownloadCallback callback, String fileNameOverride,

--- a/flow-server/src/main/java/com/vaadin/flow/signals/Signal.java
+++ b/flow-server/src/main/java/com/vaadin/flow/signals/Signal.java
@@ -264,6 +264,8 @@ public interface Signal<T extends @Nullable Object> extends Serializable {
      * @param innerSignal
      *            the inner signal, not <code>null</code>
      * @return the cached signal not <code>null</code>
+     *
+     * @since 25.1
      */
     static <T extends @Nullable Object> Signal<T> cached(
             Signal<T> innerSignal) {

--- a/flow-server/src/main/java/com/vaadin/flow/signals/local/ListSignal.java
+++ b/flow-server/src/main/java/com/vaadin/flow/signals/local/ListSignal.java
@@ -97,6 +97,8 @@ public class ListSignal<T extends @Nullable Object>
      * for both the structure of the list and the values of all child signals.
      * 
      * @return a stream of signal values, not <code>null</code>
+     *
+     * @since 25.1
      */
     public Stream<T> getValues() {
         return get().stream().map(Signal::get);
@@ -107,6 +109,8 @@ public class ListSignal<T extends @Nullable Object>
      * dependencies.
      * 
      * @return a stream of signal values, not <code>null</code>
+     *
+     * @since 25.1
      */
     public Stream<T> peekValues() {
         return peek().stream().map(Signal::peek);

--- a/flow-server/src/main/java/com/vaadin/flow/signals/shared/SharedListSignal.java
+++ b/flow-server/src/main/java/com/vaadin/flow/signals/shared/SharedListSignal.java
@@ -206,6 +206,8 @@ public class SharedListSignal<T extends @Nullable Object>
      * for both the structure of the list and the values of all child signals.
      * 
      * @return a stream of signal values, not <code>null</code>
+     *
+     * @since 25.1
      */
     public Stream<T> getValues() {
         return get().stream().map(Signal::get);
@@ -216,6 +218,8 @@ public class SharedListSignal<T extends @Nullable Object>
      * dependencies.
      * 
      * @return a stream of signal values, not <code>null</code>
+     *
+     * @since 25.1
      */
     public Stream<T> peekValues() {
         return peek().stream().map(Signal::peek);


### PR DESCRIPTION
The 25.2 release audit flagged these as untagged new API; release-tag verification shows they were cherry-picked into the 25.1 line:

- @since 25.1 (shipped in 25.1.0): Component#setTestId/getTestId, Signal#cached, ListSignal#getValues/peekValues, SharedListSignal#getValues/peekValues, SignalBinding, BindingContext, DownloadHandler#fromInputStream overloads taking fileNameOverride
- @since 25.1.4 (first shipped in 25.1.4): Binder#setApplyBindingsToHiddenFields/isApplyBindingsToHiddenFields
