### PR TITLE
feat: add RouterState.isNavigationPending() to detect pre-navigation state

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/RouterState.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouterState.java
@@ -49,7 +49,8 @@ import com.vaadin.flow.component.HasElement;
  *            first navigation completes.
  * @param navigationTarget
  *            the class of the leaf route target. {@code null} before the first
- *            navigation completes.
+ *            navigation completes. Use {@link #isNavigationPending()} to check
+ *            for this state.
  */
 public record RouterState(Location location, RouteParameters routeParameters,
         List<HasElement> activeChain,
@@ -71,5 +72,15 @@ public record RouterState(Location location, RouteParameters routeParameters,
     public Optional<HasElement> currentView() {
         return activeChain.isEmpty() ? Optional.empty()
                 : Optional.of(activeChain.get(0));
+    }
+
+    /**
+     * Returns whether the first navigation is still pending.
+     *
+     * @return {@code true} before the first navigation completes, otherwise
+     *         {@code false}
+     */
+    public boolean isNavigationPending() {
+        return navigationTarget == null;
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterStateTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterStateTest.java
@@ -27,6 +27,7 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.dom.Element;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -94,5 +95,22 @@ class RouterStateTest {
                 RouteParameters.empty(), Collections.emptyList(), null);
 
         assertTrue(state.currentView().isEmpty());
+    }
+
+    @Test
+    void isNavigationPendingReturnsTrueBeforeFirstNavigation() {
+        RouterState state = new RouterState(new Location(""),
+                RouteParameters.empty(), Collections.emptyList(), null);
+
+        assertTrue(state.isNavigationPending());
+    }
+
+    @Test
+    void isNavigationPendingReturnsFalseWhenNavigationTargetIsSet() {
+        RouterState state = new RouterState(new Location("foo"),
+                RouteParameters.empty(), Collections.emptyList(),
+                TestView.class);
+
+        assertFalse(state.isNavigationPending());
     }
 }


### PR DESCRIPTION
## Summary

`RouterState` gains `isNavigationPending()`, returning true while `navigationTarget` is still null (before the first navigation completes), so user code can detect the pre-navigation state without an NPE.

## Why this matters

In #24471, dereferencing `RouterState.navigationTarget()` in browserless tests, or in a running app before the first navigation, throws an NPE. @mcollovati noted the Javadoc already documents the null window, making the NPE an application bug, and proposed exactly this helper so the state is easy to detect. The `navigationTarget` component Javadoc now references the safe check, so users discover it where they would otherwise hit the null.

## Testing

`RouterStateTest` covers both states: pending (null target, `isNavigationPending()` true, `currentView()` empty) and completed (target set, pending false).

Fixes #24471
