### PR TITLE
feat: resolve @StyleSheet/@JavaScript at runtime against the context root

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskCopyFrontendFiles.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskCopyFrontendFiles.java
@@ -36,9 +36,17 @@ import static com.vaadin.flow.server.Constants.RESOURCES_JAR_DEFAULT;
 /**
  * Copies all frontend resources from JAR files into a given folder.
  * <p>
- * The task considers "frontend resources" all files placed in
- * {@literal META-INF/frontend}, {@literal META-INF/resources/frontend} and
- * {@literal META-INF/resources/[**]/themes} folders.
+ * "Frontend resources" are bundle sources for {@code @JsModule} /
+ * {@code @CssImport} annotations. The recommended location for them in addon
+ * JARs is {@literal META-INF/frontend}. The legacy location
+ * {@literal META-INF/resources/frontend} is still scanned for backwards
+ * compatibility but is deprecated; a per-jar warning is emitted when it is
+ * used. Theme files under {@literal META-INF/resources/[**]/themes} are also
+ * copied.
+ * <p>
+ * Public runtime resources for {@code @StyleSheet} / {@code @JavaScript} should
+ * be placed under {@literal META-INF/resources/} and are served directly by the
+ * servlet container — they are not handled by this task.
  * <p>
  * For internal use only. May be renamed or removed in a future release.
  *
@@ -49,6 +57,7 @@ public class TaskCopyFrontendFiles
     private static final String WILDCARD_INCLUSION_APP_THEME_JAR = "**/themes/**/*";
     private final Options options;
     private final Set<File> resourceLocations;
+    private final Set<File> warnedLegacyLocations = new HashSet<>();
 
     /**
      * Scans the jar files given defined by {@code resourcesToScan}.
@@ -85,10 +94,13 @@ public class TaskCopyFrontendFiles
                         .addAll(TaskCopyLocalFrontendFiles.copyLocalResources(
                                 new File(location, RESOURCES_FRONTEND_DEFAULT),
                                 targetDirectory));
+                File legacyDir = new File(location,
+                        COMPATIBILITY_RESOURCES_FRONTEND_DEFAULT);
+                if (legacyDir.isDirectory()) {
+                    warnAboutDeprecatedFrontendLayout(location);
+                }
                 handledFiles.addAll(TaskCopyLocalFrontendFiles
-                        .copyLocalResources(new File(location,
-                                COMPATIBILITY_RESOURCES_FRONTEND_DEFAULT),
-                                targetDirectory));
+                        .copyLocalResources(legacyDir, targetDirectory));
                 // copies from resources, but excludes already copied from
                 // resources/frontend
                 handledFiles
@@ -100,6 +112,10 @@ public class TaskCopyFrontendFiles
                         .copyIncludedFilesFromJarTrimmingBasePath(location,
                                 RESOURCES_FRONTEND_DEFAULT, targetDirectory,
                                 "**/*"));
+                if (jarContentsManager.containsPath(location,
+                        COMPATIBILITY_RESOURCES_FRONTEND_DEFAULT + "/")) {
+                    warnAboutDeprecatedFrontendLayout(location);
+                }
                 handledFiles.addAll(jarContentsManager
                         .copyIncludedFilesFromJarTrimmingBasePath(location,
                                 COMPATIBILITY_RESOURCES_FRONTEND_DEFAULT,
@@ -134,6 +150,18 @@ public class TaskCopyFrontendFiles
 
     private Logger log() {
         return LoggerFactory.getLogger(this.getClass());
+    }
+
+    private void warnAboutDeprecatedFrontendLayout(File location) {
+        if (warnedLegacyLocations.add(location)) {
+            log().warn("Addon '{}' contains frontend sources under {}/. "
+                    + "This location is deprecated; migrate them to {}/ "
+                    + "(bundle sources for @JsModule/@CssImport) or to "
+                    + "META-INF/resources/ (runtime resources for "
+                    + "@StyleSheet/@JavaScript).", location.getName(),
+                    COMPATIBILITY_RESOURCES_FRONTEND_DEFAULT,
+                    RESOURCES_FRONTEND_DEFAULT);
+        }
     }
 
 }

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/scanner/ClassInfo.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/scanner/ClassInfo.java
@@ -31,6 +31,13 @@ public class ClassInfo {
     final LinkedHashSet<String> modulesDevelopmentOnly = new LinkedHashSet<>();
     final LinkedHashSet<String> scripts = new LinkedHashSet<>();
     final LinkedHashSet<String> scriptsDevelopmentOnly = new LinkedHashSet<>();
+    /**
+     * {@code @JsModule} values with a runtime URL prefix ({@code context://},
+     * {@code base://}, {@code http(s)://}, {@code //}, {@code /}). These are
+     * filtered out of the bundle and emit a build-time deprecation warning
+     * recommending migration to {@code @JavaScript}.
+     */
+    final LinkedHashSet<String> deprecatedRuntimeModules = new LinkedHashSet<>();
     final transient List<CssData> css = new ArrayList<>();
     String route = "";
     String layout;

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendClassVisitor.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendClassVisitor.java
@@ -31,6 +31,7 @@ import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.FrontendDependencyUrlResolver;
 import com.vaadin.flow.theme.NoTheme;
 import com.vaadin.flow.theme.Theme;
 
@@ -71,13 +72,19 @@ final class FrontendClassVisitor extends ClassVisitor {
         private String currentModule;
         private boolean currentTypeIsModule = false;
 
-        private LinkedHashSet<String> target;
-        private LinkedHashSet<String> targetDevelopmentOnly;
+        private final LinkedHashSet<String> target;
+        private final LinkedHashSet<String> targetDevelopmentOnly;
+        private final LinkedHashSet<String> deprecatedRuntimeTarget;
+        private final boolean isJavaScriptAnnotation;
 
         public JSAnnotationVisitor(LinkedHashSet<String> target,
-                LinkedHashSet<String> targetDevelopmentOnly) {
+                LinkedHashSet<String> targetDevelopmentOnly,
+                boolean isJavaScriptAnnotation,
+                LinkedHashSet<String> deprecatedRuntimeTarget) {
             this.target = target;
             this.targetDevelopmentOnly = targetDevelopmentOnly;
+            this.isJavaScriptAnnotation = isJavaScriptAnnotation;
+            this.deprecatedRuntimeTarget = deprecatedRuntimeTarget;
         }
 
         @Override
@@ -104,12 +111,23 @@ final class FrontendClassVisitor extends ClassVisitor {
         @Override
         public void visitEnd() {
             super.visitEnd();
-            // type=MODULE values are loaded at runtime as <script
-            // type="module">
-            // by UIInternals; they must not enter the bundle.
             if (currentModule != null && !currentTypeIsModule) {
-                // This visitor is called also for the $Container annotation
-                if (currentDevOnly) {
+                // type=MODULE @JavaScript values are loaded at runtime as
+                // <script type="module"> by UIInternals; skip them entirely.
+                // This visitor is called also for the $Container annotation.
+                boolean runtimeUrl = FrontendDependencyUrlResolver
+                        .isRuntimeDependencyUrl(currentModule);
+                if (isJavaScriptAnnotation && runtimeUrl) {
+                    // @JavaScript with a runtime prefix: load at runtime, not
+                    // bundled. No deprecation — this is the recommended form.
+                } else if (!isJavaScriptAnnotation && runtimeUrl) {
+                    // @JsModule with a runtime URL: keep working at runtime
+                    // via Page.addJsModule, but skip from the bundle and warn
+                    // users to migrate to @JavaScript.
+                    if (deprecatedRuntimeTarget != null) {
+                        deprecatedRuntimeTarget.add(currentModule);
+                    }
+                } else if (currentDevOnly) {
                     targetDevelopmentOnly.add(currentModule);
                 } else {
                     target.add(currentModule);
@@ -240,10 +258,11 @@ final class FrontendClassVisitor extends ClassVisitor {
         };
         // Visitor for @JsModule annotations
         jsModuleVisitor = new JSAnnotationVisitor(classInfo.modules,
-                classInfo.modulesDevelopmentOnly);
+                classInfo.modulesDevelopmentOnly, false,
+                classInfo.deprecatedRuntimeModules);
         // Visitor for @JavaScript annotations
         jScriptVisitor = new JSAnnotationVisitor(classInfo.scripts,
-                classInfo.scriptsDevelopmentOnly);
+                classInfo.scriptsDevelopmentOnly, true, null);
         // Visitor all other annotations
         annotationVisitor = new RepeatedAnnotationVisitor() {
             @Override

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendClassVisitor.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendClassVisitor.java
@@ -69,6 +69,7 @@ final class FrontendClassVisitor extends ClassVisitor {
 
         boolean currentDevOnly = false;
         private String currentModule;
+        private boolean currentTypeIsModule = false;
 
         private LinkedHashSet<String> target;
         private LinkedHashSet<String> targetDevelopmentOnly;
@@ -92,9 +93,21 @@ final class FrontendClassVisitor extends ClassVisitor {
         }
 
         @Override
+        public void visitEnum(String name, String descriptor, String value) {
+            // The "type" attribute only exists on @JavaScript; @JsModule has
+            // no such attribute, so this method is a no-op for it.
+            if ("type".equals(name) && "MODULE".equals(value)) {
+                currentTypeIsModule = true;
+            }
+        }
+
+        @Override
         public void visitEnd() {
             super.visitEnd();
-            if (currentModule != null) {
+            // type=MODULE values are loaded at runtime as <script
+            // type="module">
+            // by UIInternals; they must not enter the bundle.
+            if (currentModule != null && !currentTypeIsModule) {
                 // This visitor is called also for the $Container annotation
                 if (currentDevOnly) {
                     targetDevelopmentOnly.add(currentModule);
@@ -104,6 +117,7 @@ final class FrontendClassVisitor extends ClassVisitor {
             }
             currentModule = null;
             currentDevOnly = false;
+            currentTypeIsModule = false;
         }
 
     }

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
@@ -135,6 +135,7 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
             computePackages();
             computePwaConfiguration();
             aggregateEntryPointInformation();
+            warnAboutDeprecatedJavaScriptUses();
             long ms = (System.nanoTime() - start) / 1000000;
             log().info("Visited {} classes. Took {} ms.", visitedClasses.size(),
                     ms);
@@ -203,6 +204,43 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
             }
         }
 
+    }
+
+    private void warnAboutDeprecatedJavaScriptUses() {
+        Set<String> warnedJavaScriptKeys = new LinkedHashSet<>();
+        Set<String> warnedJsModuleKeys = new LinkedHashSet<>();
+        for (Entry<String, ClassInfo> entry : visitedClasses.entrySet()) {
+            String className = entry.getKey();
+            ClassInfo classInfo = entry.getValue();
+            if (classInfo == null) {
+                continue;
+            }
+            for (String value : classInfo.scripts) {
+                if (warnedJavaScriptKeys.add(className + ':' + value)) {
+                    log().warn(
+                            "@JavaScript on {} with value \"{}\" uses the deprecated bundled interpretation. "
+                                    + "Prepend context:// for a runtime <script> tag, set type=Type.MODULE for a runtime <script type=\"module\"> tag, or migrate to @JsModule for bundling.",
+                            className, value);
+                }
+            }
+            for (String value : classInfo.scriptsDevelopmentOnly) {
+                if (warnedJavaScriptKeys.add(className + ':' + value)) {
+                    log().warn(
+                            "@JavaScript on {} with value \"{}\" uses the deprecated bundled interpretation. "
+                                    + "Prepend context:// for a runtime <script> tag, set type=Type.MODULE for a runtime <script type=\"module\"> tag, or migrate to @JsModule for bundling.",
+                            className, value);
+                }
+            }
+            for (String value : classInfo.deprecatedRuntimeModules) {
+                if (warnedJsModuleKeys.add(className + ':' + value)) {
+                    log().warn(
+                            "@JsModule on {} with value \"{}\" is a runtime URL. "
+                                    + "@JsModule is for build-time bundle sources only; "
+                                    + "use @JavaScript(value=\"{}\", type=Type.MODULE) for a runtime <script type=\"module\"> tag.",
+                            className, value, value);
+                }
+            }
+        }
     }
 
     Set<String> collectReachableClasses(EntryPointData entryPointData) {

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
@@ -51,6 +51,7 @@ import com.vaadin.flow.server.frontend.scanner.samples.MyServiceListener;
 import com.vaadin.flow.server.frontend.scanner.samples.MyUIInitListener;
 import com.vaadin.flow.server.frontend.scanner.samples.RouteComponent;
 import com.vaadin.flow.server.frontend.scanner.samples.RouteComponentWithMethodReference;
+import com.vaadin.flow.server.frontend.scanner.samples.RuntimeJavaScriptComponent;
 import com.vaadin.flow.theme.AbstractTheme;
 import com.vaadin.flow.theme.Theme;
 import com.vaadin.flow.theme.ThemeDefinition;
@@ -96,6 +97,16 @@ class FrontendDependenciesTest {
 
         DepsTests.assertImportsExcludingUI(dependencies.getModules(), "foo.js");
         DepsTests.assertImports(dependencies.getScripts(), "bar.js");
+    }
+
+    @Test
+    void javaScriptWithTypeModule_excludedFromBundleImports() {
+        Mockito.when(classFinder.getAnnotatedClasses(Route.class)).thenReturn(
+                Collections.singleton(RuntimeJavaScriptComponent.class));
+        FrontendDependencies dependencies = new FrontendDependencies(
+                classFinder, false, null, true);
+
+        DepsTests.assertImports(dependencies.getScripts(), "bundled.js");
     }
 
     @Test

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
@@ -100,13 +100,24 @@ class FrontendDependenciesTest {
     }
 
     @Test
-    void javaScriptWithTypeModule_excludedFromBundleImports() {
+    void javaScriptWithRuntimePrefixOrTypeModule_excludedFromBundleImports() {
         Mockito.when(classFinder.getAnnotatedClasses(Route.class)).thenReturn(
                 Collections.singleton(RuntimeJavaScriptComponent.class));
         FrontendDependencies dependencies = new FrontendDependencies(
                 classFinder, false, null, true);
 
         DepsTests.assertImports(dependencies.getScripts(), "bundled.js");
+    }
+
+    @Test
+    void jsModuleWithRuntimeUrl_excludedFromBundleImports() {
+        Mockito.when(classFinder.getAnnotatedClasses(Route.class)).thenReturn(
+                Collections.singleton(RuntimeJavaScriptComponent.class));
+        FrontendDependencies dependencies = new FrontendDependencies(
+                classFinder, false, null, true);
+
+        DepsTests.assertImportsExcludingUI(dependencies.getModules(),
+                "./bundled-module.js");
     }
 
     @Test

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/scanner/samples/RuntimeJavaScriptComponent.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/scanner/samples/RuntimeJavaScriptComponent.java
@@ -17,10 +17,17 @@ package com.vaadin.flow.server.frontend.scanner.samples;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.dependency.JavaScript;
+import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.router.Route;
 
 @Route("runtime-js")
 @JavaScript("bundled.js")
+@JavaScript("context://runtime.js")
+@JavaScript("/absolute.js")
+@JavaScript("base://servlet-relative.js")
 @JavaScript(value = "module-runtime.js", type = JavaScript.Type.MODULE)
+@JsModule("./bundled-module.js")
+@JsModule("https://cdn.example.com/external-module.js")
+@JsModule("context://runtime-module.js")
 public class RuntimeJavaScriptComponent extends Component {
 }

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/scanner/samples/RuntimeJavaScriptComponent.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/scanner/samples/RuntimeJavaScriptComponent.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.frontend.scanner.samples;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.dependency.JavaScript;
+import com.vaadin.flow.router.Route;
+
+@Route("runtime-js")
+@JavaScript("bundled.js")
+@JavaScript(value = "module-runtime.js", type = JavaScript.Type.MODULE)
+public class RuntimeJavaScriptComponent extends Component {
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/dependency/CssImport.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/dependency/CssImport.java
@@ -26,17 +26,19 @@ import java.lang.annotation.Target;
 /**
  * Imports a CSS file into the application bundle.
  * <p>
- * The CSS files should be located in the place as JS module files:
- * <ul>
- * <li>inside {@code frontend} directory in your root project folder in case of
- * WAR project
- * <li>inside {@code META-INF/resources/frontend} directory (inside a project
- * resources folder) in case of JAR project (if you are using Maven this is
- * {@code src/main/resources/META-INF/resources/frontend} directory).
- * </ul>
+ * This is a <em>build-time</em> dependency: the referenced CSS file is a bundle
+ * source processed by Vite at build time and is not served as a static resource
+ * at runtime. Use {@link StyleSheet} when the CSS file should be served as a
+ * plain {@code <link rel="stylesheet">} at runtime.
  * <p>
- * The annotation doesn't have any effect in the compatibility mode: use it only
- * for Polymer 3 templates.
+ * Source locations (same as {@link JsModule}):
+ * <ul>
+ * <li>Application projects: {@code src/main/frontend/} (recommended), or the
+ * legacy top-level {@code frontend/} directory.</li>
+ * <li>Add-on JARs: {@code META-INF/frontend/} (recommended). The legacy
+ * location {@code META-INF/resources/frontend/} is still supported but
+ * deprecated and emits a build-time warning.</li>
+ * </ul>
  * <p>
  * Depending on the attributes provided, the CSS content will be appended in
  * different ways:
@@ -104,6 +106,7 @@ import java.lang.annotation.Target;
  * @since 2.0
  *
  * @see JsModule
+ * @see StyleSheet
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
@@ -112,7 +115,12 @@ import java.lang.annotation.Target;
 @Repeatable(CssImport.Container.class)
 public @interface CssImport {
     /**
-     * Location of the file with the CSS content.
+     * Bundler import specifier for the CSS file. Same rules as
+     * {@link JsModule#value()} — typically a relative path
+     * ({@code "./styles/foo.css"}) or a package specifier. Not a URL:
+     * {@code context://}, {@code base://}, and absolute URLs are not supported
+     * here. Use {@link StyleSheet} for files that should be served as runtime
+     * stylesheets.
      *
      * @return the value.
      */

--- a/flow-server/src/main/java/com/vaadin/flow/component/dependency/JavaScript.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/dependency/JavaScript.java
@@ -28,36 +28,43 @@ import com.vaadin.flow.component.page.Page;
 import com.vaadin.flow.shared.ui.LoadMode;
 
 /**
- * Defines JavaScript dependencies on a {@link Component} class. For adding
- * multiple JavaScript files for a single component, you can use this annotation
- * multiple times.
+ * Loads a JavaScript file into the browser at runtime. By default the file is
+ * loaded as a classic {@code <script>} element; set {@link #type()} to
+ * {@link Type#MODULE} to load it as a {@code <script type="module">} element
+ * instead. The referenced file is served as a static resource by the servlet
+ * container; it is not bundled. Use {@link JsModule} when the file should be
+ * processed as a bundle source by Vite at build time.
  * <p>
- * It is guaranteed that dependencies will be loaded only once. The files loaded
- * will be in the same order as the annotations were on the class. However,
- * loading order is only guaranteed on a class level; Annotations from different
- * classes may appear in different order, grouped by the annotated class. Also,
- * files identified by {@code @JavaScript} will be loaded after
- * {@link com.vaadin.flow.component.dependency.JsModule} and before
- * {@link com.vaadin.flow.component.dependency.CssImport}.
+ * Source locations (same as {@link StyleSheet}):
+ * <ul>
+ * <li>Application projects: {@code src/main/resources/META-INF/resources/}. In
+ * Spring Boot projects {@code src/main/resources/public/} or
+ * {@code src/main/resources/static/} are also served.</li>
+ * <li>Add-on JARs: {@code META-INF/resources/}.</li>
+ * </ul>
  * <p>
- * NOTE: Currently all frontend resources are bundled together into one big
- * bundle. This means, that JavaScript files loaded by one class will be present
- * on a view constructed by another class. For example, if there are two classes
- * {@code RootRoute} annotated with {@code @Route("")}, and another class
- * {@code RouteA} annotated with {@code @Route("route-a")} and
- * {@code @JavaScript("./src/javascript.js")}, the {@code javascript.js} will be
- * run on the root route as well.
+ * URL resolution follows the same rules as {@link StyleSheet#value()} —
+ * {@code context://}, {@code base://}, absolute URLs, and bare relative paths
+ * are all supported. Use {@code context://foo.js} to load
+ * {@code META-INF/resources/foo.js} regardless of the Vaadin servlet mapping.
+ * External URLs ({@code https://cdn.example/foo.js}) work the same way.
  * <p>
- * External JavaScript dependencies (e.g. "http://example.com/some.js") are
- * added in the same way as {@link Page#addJavaScript(String)} and the result is
- * just adding a classic {@code javscript} element to the page. Other paths used
- * in the {@link JavaScript#value()} method are considered as relative to
- * {@code frontend} directory and they are added to the page as a JavaScript
- * module (a {@code javscript} element with {@code type="module"}). In this case
- * a {@link JavaScript} annotation behaves exactly as a {@link JsModule}
- * annotation.
+ * For adding multiple JavaScript files for a single component, use this
+ * annotation multiple times. It is guaranteed that dependencies will be loaded
+ * only once.
  * <p>
- * It's not possible to execute a function defined in JavaScript module via
+ * <b>Deprecated bundled interpretation:</b> Historically, a bare relative URL
+ * (e.g. {@code @JavaScript("./foo.js")}) was collected by the scanner and
+ * bundled like {@link JsModule}. This behavior is deprecated when
+ * {@link #type()} is the default {@link Type#SCRIPT}. To opt into runtime
+ * semantics, either prefix the value with {@code context://}, {@code base://},
+ * or {@code /}, or set {@link #type()} to {@link Type#MODULE}. Bare-relative
+ * SCRIPT-typed values still bundle but emit a build-time warning. A future
+ * major release will flip the default so bare relatives resolve against the
+ * context root.
+ * <p>
+ * NOTE: When loaded with {@link Type#MODULE} (or via {@link JsModule}), it is
+ * not possible to execute a function defined in the file via
  *
  * <pre>
  *
@@ -66,16 +73,18 @@ import com.vaadin.flow.shared.ui.LoadMode;
  * </code>
  * </pre>
  *
- * because the function is private there (unless it's explicitly exposed). The
- * JavaScript where the function is defined should be either external or it
- * should be added using {@link Page#addJavaScript(String)}: in this case all
- * declared functions become available in the global scope.
+ * because the function is private to the module (unless it's explicitly
+ * exposed). The JavaScript where the function is defined should be loaded with
+ * {@link Type#SCRIPT} (the default) or added using
+ * {@link Page#addJavaScript(String)}: in this case all declared functions
+ * become available in the global scope.
  *
  *
  * @author Vaadin Ltd
  * @since 1.0
  * @see Page#addJavaScript(String)
  * @see JsModule
+ * @see StyleSheet
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
@@ -109,17 +118,21 @@ public @interface JavaScript {
      * JavaScript file URL to load before using the annotated {@link Component}
      * in the browser.
      * <p>
-     * Relative URLs are interpreted as relative to the configured
-     * {@code frontend} directory location.
-     * <p>
-     * This URL identifies a file which will be bundled, so the file should be
-     * available to be able to bundle it.
-     * <p>
-     * You can prefix the URL with {@code context://} to make it relative to the
-     * context path or use an absolute URL to refer to files outside the
-     * frontend directory. Such URLs are not bundled but included into the page
-     * as standalone scripts in the same way as it's done by
-     * {@link Page#addJavaScript(String)}.
+     * URL resolution rules (same as {@link StyleSheet#value()}), in order:
+     * <ul>
+     * <li>{@code http://...}, {@code https://...}, {@code //...} — used
+     * unchanged.</li>
+     * <li>{@code context://foo.js} — resolved against the servlet context root
+     * (independent of the Vaadin servlet mapping).</li>
+     * <li>{@code base://foo.js} — resolved against the page's {@code <base>}
+     * URI, i.e. the Vaadin servlet mapping path.</li>
+     * <li>{@code /foo.js} — used unchanged as an absolute server path.</li>
+     * <li>Any other value (bare relative, {@code "./foo.js"},
+     * {@code "../foo.js"}) is currently treated as a bundle source for
+     * backwards compatibility — see the deprecation notice on the class
+     * Javadoc. Migrate to {@code @JavaScript("context://foo.js")} for runtime
+     * loading or to {@link JsModule} for bundling.</li>
+     * </ul>
      * <p>
      * When {@link #type()} is {@link Type#MODULE}, the value is loaded at
      * runtime regardless of whether it has a URL prefix; bare relative paths

--- a/flow-server/src/main/java/com/vaadin/flow/component/dependency/JavaScript.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/dependency/JavaScript.java
@@ -85,6 +85,27 @@ import com.vaadin.flow.shared.ui.LoadMode;
 public @interface JavaScript {
 
     /**
+     * The kind of {@code <script>} tag to render for the dependency.
+     */
+    enum Type {
+        /**
+         * Render a classic {@code <script>} tag. Functions declared in the
+         * loaded file become available in the global scope.
+         */
+        SCRIPT,
+        /**
+         * Render a {@code <script type="module">} tag. The loaded file is
+         * treated as an ES module: functions and variables declared in it are
+         * private to the module unless explicitly exported. The file is loaded
+         * at runtime and is not bundled, even when the URL is a bare relative
+         * path. Use this for hand-authored or CDN-hosted modules that should
+         * not go through Vite. For build-time bundled ES modules use
+         * {@link JsModule} instead.
+         */
+        MODULE
+    }
+
+    /**
      * JavaScript file URL to load before using the annotated {@link Component}
      * in the browser.
      * <p>
@@ -99,10 +120,27 @@ public @interface JavaScript {
      * frontend directory. Such URLs are not bundled but included into the page
      * as standalone scripts in the same way as it's done by
      * {@link Page#addJavaScript(String)}.
+     * <p>
+     * When {@link #type()} is {@link Type#MODULE}, the value is loaded at
+     * runtime regardless of whether it has a URL prefix; bare relative paths
+     * are normalized to {@code context://<value>} and served as static
+     * resources by the servlet container.
      *
      * @return a JavaScript file URL
      */
     String value();
+
+    /**
+     * The kind of {@code <script>} tag to use when loading the file. Defaults
+     * to {@link Type#SCRIPT} (a classic {@code <script>} element). Set to
+     * {@link Type#MODULE} to render a {@code <script type="module">} element
+     * instead, e.g. for hand-authored or CDN-hosted ES modules that should not
+     * go through Vite. For build-time bundled ES modules use {@link JsModule}
+     * instead.
+     *
+     * @return the kind of script tag to render
+     */
+    Type type() default Type.SCRIPT;
 
     /**
      * Defines if the JavaScript should be loaded only when running in

--- a/flow-server/src/main/java/com/vaadin/flow/component/dependency/JsModule.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/dependency/JsModule.java
@@ -26,39 +26,48 @@ import java.lang.annotation.Target;
 import com.vaadin.flow.component.Component;
 
 /**
- * Annotation for defining JavaScript Module dependencies on a {@link Component}
- * class. For adding multiple JavaScript Module files for a single component,
- * you can use this annotation multiple times.
+ * Defines a JavaScript module dependency on a {@link Component} class.
  * <p>
- * The JavaScript module files should be located:
+ * This is a <em>build-time</em> dependency: the referenced file is a bundle
+ * source, fed into Vite at build time, and is not served as a static resource
+ * at runtime. Use {@link JavaScript} for files that should be loaded at runtime
+ * (including external URLs and CDN-hosted scripts).
+ * <p>
+ * Source locations:
  * <ul>
- * <li>inside {@code frontend} directory in your root project folder in case of
- * WAR project
- * <li>inside {@code META-INF/resources/frontend} directory (inside a project
- * resources folder) in case of JAR project (if you are using Maven this is
- * {@code src/main/resources/META-INF/resources/frontend} directory).
+ * <li>Application projects: {@code src/main/frontend/} (recommended), or the
+ * legacy top-level {@code frontend/} directory.</li>
+ * <li>Add-on JARs: {@code META-INF/frontend/} (recommended). The legacy
+ * location {@code META-INF/resources/frontend/} is still supported but
+ * deprecated and emits a build-time warning.</li>
  * </ul>
  * <p>
- * It is guaranteed that dependencies will be loaded only once. The files loaded
- * will be in the same order as the annotations were on the class. However,
- * loading order is only guaranteed on a class level; Annotations from different
- * classes may appear in different order, grouped by the annotated class. Also,
- * files identified by {@code @JsModule} will be loaded before
- * {@link com.vaadin.flow.component.dependency.JavaScript} and
- * {@link com.vaadin.flow.component.dependency.CssImport}.
+ * For adding multiple JavaScript module files for a single component, use this
+ * annotation multiple times.
+ * <p>
+ * It is guaranteed that dependencies will be loaded only once. Loading order is
+ * guaranteed at the class level (annotations on different classes may appear in
+ * different orders relative to each other). {@code @JsModule} files load before
+ * {@link JavaScript} and {@link CssImport}.
+ * <p>
+ * <b>Deprecated runtime URLs:</b> Historically, {@code @JsModule} also accepted
+ * runtime URLs ({@code http://}, {@code https://}, {@code //},
+ * {@code context://}, {@code base://}, {@code /…}); such values were loaded at
+ * runtime as {@code <script type="module">}. This is deprecated. Use
+ * {@link JavaScript} for runtime script loading. Existing runtime URLs in
+ * {@code @JsModule} keep working for backwards compatibility but are excluded
+ * from the bundle and emit a build-time warning.
  * <p>
  * NOTE: Currently all frontend resources are bundled together into one big
- * bundle. This means, that JavaScript files loaded by one class will be present
- * on a view constructed by another class. For example, if there are two classes
- * {@code RootRoute} annotated with {@code @Route("")}, and another class
- * {@code RouteA} annotated with {@code @Route("route-a")} and
- * {@code @JsModule("./src/jsmodule.js")}, the {@code jsmodule.js} will be run
- * on the root route as well.
+ * bundle. JavaScript files loaded by one class will therefore be present on a
+ * view constructed by another class.
  *
  * @author Vaadin Ltd
  * @since 2.0
  *
  * @see CssImport
+ * @see JavaScript
+ * @see StyleSheet
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
@@ -70,6 +79,16 @@ public @interface JsModule {
     /**
      * JavaScript module to load before using the annotated {@link Component} in
      * the browser.
+     * <p>
+     * The recommended value is a bundler import specifier — typically a
+     * relative path (e.g. {@code "./my-element.js"}), an npm package specifier
+     * (e.g. {@code "@scope/pkg/foo.js"}), or an alias. The bundler resolves
+     * these against the configured frontend directory.
+     * <p>
+     * Values with a runtime URL prefix ({@code http://}, {@code https://},
+     * {@code //}, {@code context://}, {@code base://}, or a leading {@code /})
+     * are deprecated; they are excluded from the bundle and emit a build-time
+     * warning. Migrate them to {@link JavaScript}.
      * <p>
      * NOTE: In the case of using JsModule with LitTemplate, the value needs to
      * point to a real file as it will be copied to the templates folder under

--- a/flow-server/src/main/java/com/vaadin/flow/component/dependency/StyleSheet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/dependency/StyleSheet.java
@@ -27,13 +27,25 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.shared.ui.LoadMode;
 
 /**
- * Loads style sheets into the browser according to a given loading mode. Style
- * sheet URLs can be either a file served by the application itself, i.e. in
- * public static resource locations like
- * {@code src/main/resources/META-INF/resources/}, or an external URL.
+ * Loads a style sheet into the browser at runtime as a
+ * {@code <link rel="stylesheet">} element. The referenced file is served as a
+ * static resource by the servlet container; it is not bundled. Use
+ * {@link CssImport} when the CSS file should be processed as a bundle source by
+ * Vite at build time.
  * <p>
- * Can define style sheet dependencies for a {@link Component} class or
- * globally.
+ * Source locations:
+ * <ul>
+ * <li>Application projects: {@code src/main/resources/META-INF/resources/}. In
+ * Spring Boot projects {@code src/main/resources/public/} or
+ * {@code src/main/resources/static/} are also served.</li>
+ * <li>Add-on JARs: {@code META-INF/resources/}. Files placed there are served
+ * automatically by the servlet container when the JAR is on the classpath.</li>
+ * </ul>
+ * <p>
+ * URL resolution is identical whether the annotation is placed on an
+ * {@link com.vaadin.flow.component.page.AppShellConfigurator}, a route
+ * component, or any other {@link Component}. See {@link #value()} for the
+ * resolution rules.
  * <p>
  * When this annotation is placed on the
  * {@link com.vaadin.flow.component.page.AppShellConfigurator}, the referenced
@@ -45,7 +57,7 @@ import com.vaadin.flow.shared.ui.LoadMode;
  * stylesheets. To be put on a class implementing
  * {@link com.vaadin.flow.component.page.AppShellConfigurator} in this case.
  * Example of usage:
- * 
+ *
  * <pre>
  *     // theme selection
  *     &#64;StyleSheet(Aura.STYLESHEET) // or Lumo.STYLESHEET
@@ -68,10 +80,6 @@ import com.vaadin.flow.shared.ui.LoadMode;
  * For adding multiple style sheets, you can use this annotation multiple times.
  * It is guaranteed that dependencies will be loaded only once.
  * <p>
- * Absolute URLs are used as-is; values prefixed with {@code context://} are
- * resolved using context path (e.g. {@code context://styles.css} becomes
- * {@code /my-app/styles.css}) for context path {@code /my-app}.
- * <p>
  * NOTE: while this annotation is not inherited using the
  * {@link Inherited @Inherited} annotation, the annotations of the possible
  * parent components or implemented interfaces are read when sending the
@@ -79,6 +87,9 @@ import com.vaadin.flow.shared.ui.LoadMode;
  *
  * @author Vaadin Ltd
  * @since 1.0
+ *
+ * @see CssImport
+ * @see JavaScript
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
@@ -90,10 +101,23 @@ public @interface StyleSheet {
      * Style sheet file URL to load before using the annotated {@link Component}
      * in the browser.
      * <p>
-     * Relative URLs are interpreted as relative to the configured
-     * {@code frontend} directory location. You can prefix the URL with
-     * {@code context://} to make it relative to the context path or use an
-     * absolute URL to refer to files outside the frontend directory.
+     * URL resolution rules, in order:
+     * <ul>
+     * <li>{@code http://...}, {@code https://...}, {@code //...} — used
+     * unchanged.</li>
+     * <li>{@code context://foo.css} — resolved against the servlet context root
+     * (independent of the Vaadin servlet mapping).</li>
+     * <li>{@code base://foo.css} — resolved against the page's {@code <base>}
+     * URI, i.e. the Vaadin servlet mapping path. Use this as an explicit opt-in
+     * for servlet-mapping-relative loading.</li>
+     * <li>{@code /foo.css} — used unchanged as an absolute server path.</li>
+     * <li>{@code ./foo.css} — leading {@code ./} is stripped, then treated as
+     * context-root relative.</li>
+     * <li>{@code foo.css}, {@code styles/foo.css} — context-root relative, i.e.
+     * equivalent to {@code context://foo.css}.</li>
+     * <li>Values containing {@code ..} (path traversal) are rejected with a
+     * warning.</li>
+     * </ul>
      *
      * @return a style sheet file URL
      */

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -1197,7 +1197,7 @@ public class UIInternals implements Serializable {
 
         List<String> jsDeps = new ArrayList<>();
         jsDeps.addAll(dependencies.getJavaScripts().stream()
-                .map(dep -> dep.value()).filter(src -> !UrlUtil.isExternal(src))
+                .filter(js -> !isRuntimeJavaScript(js)).map(dep -> dep.value())
                 .collect(Collectors.toList()));
         jsDeps.addAll(dependencies.getJsModules().stream()
                 .map(dep -> dep.value()).filter(src -> !UrlUtil.isExternal(src))
@@ -1246,7 +1246,8 @@ public class UIInternals implements Serializable {
 
     private boolean isRuntimeJavaScript(JavaScript js) {
         return js.type() == JavaScript.Type.MODULE
-                || UrlUtil.isExternal(js.value());
+                || FrontendDependencyUrlResolver
+                        .isRuntimeDependencyUrl(js.value());
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -94,6 +94,7 @@ import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.communication.PushConnection;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.shared.communication.PushMode;
+import com.vaadin.flow.shared.ui.LoadMode;
 import com.vaadin.flow.signals.Signal;
 import com.vaadin.flow.signals.local.ValueSignal;
 
@@ -1228,12 +1229,24 @@ public class UIInternals implements Serializable {
 
     private void addExternalDependencies(DependencyInfo dependency) {
         Page page = ui.getPage();
-        dependency.getJavaScripts().stream()
-                .filter(js -> UrlUtil.isExternal(js.value()))
-                .forEach(js -> page.addJavaScript(js.value(), js.loadMode()));
+        dependency.getJavaScripts().stream().filter(this::isRuntimeJavaScript)
+                .forEach(js -> {
+                    String resolved = FrontendDependencyUrlResolver
+                            .resolveToContextRoot(js.value());
+                    if (resolved == null) {
+                        return;
+                    }
+                    page.addJavaScript(resolved, js.loadMode(), js.type());
+                });
         dependency.getJsModules().stream()
                 .filter(js -> UrlUtil.isExternal(js.value()))
-                .forEach(js -> page.addJsModule(js.value()));
+                .forEach(js -> page.addJavaScript(js.value(), LoadMode.EAGER,
+                        JavaScript.Type.MODULE));
+    }
+
+    private boolean isRuntimeJavaScript(JavaScript js) {
+        return js.type() == JavaScript.Type.MODULE
+                || UrlUtil.isExternal(js.value());
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -156,7 +156,8 @@ public class Page implements Serializable {
      * <p>
      * You can prefix the URL with {@code context://} to make it relative to the
      * context path or use an absolute URL to refer to files outside the
-     * frontend directory.
+     * frontend directory. See {@link StyleSheet#value()} for the full prefix
+     * resolution table used by the annotation path.
      * <p>
      * For component related style sheet dependencies, you should use the
      * {@link StyleSheet @StyleSheet} annotation.
@@ -184,7 +185,8 @@ public class Page implements Serializable {
      * <p>
      * You can prefix the URL with {@code context://} to make it relative to the
      * context path or use an absolute URL to refer to files outside the
-     * frontend directory.
+     * frontend directory. See {@link StyleSheet#value()} for the full prefix
+     * resolution table used by the annotation path.
      * <p>
      * For component related style sheet dependencies, you should use the
      * {@link StyleSheet @StyleSheet} annotation.
@@ -232,7 +234,8 @@ public class Page implements Serializable {
      * <p>
      * You can prefix the URL with {@code context://} to make it relative to the
      * context path or use an absolute URL to refer to files outside the
-     * frontend directory.
+     * frontend directory. See {@link JavaScript#value()} for the full prefix
+     * resolution table used by the annotation path.
      * <p>
      * For component related JavaScript dependencies, you should use the
      * {@link JavaScript @JavaScript} annotation.
@@ -259,7 +262,8 @@ public class Page implements Serializable {
      * <p>
      * You can prefix the URL with {@code context://} to make it relative to the
      * context path or use an absolute URL to refer to files outside the
-     * frontend directory.
+     * frontend directory. See {@link JavaScript#value()} for the full prefix
+     * resolution table used by the annotation path.
      * <p>
      * For component related JavaScript dependencies, you should use the
      * {@link JavaScript @JavaScript} annotation.

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -271,7 +271,42 @@ public class Page implements Serializable {
      *            details
      */
     public void addJavaScript(String url, LoadMode loadMode) {
-        addDependency(new Dependency(Type.JAVASCRIPT, url, loadMode));
+        addJavaScript(url, loadMode, JavaScript.Type.SCRIPT);
+    }
+
+    /**
+     * Adds the given JavaScript to the page and ensures that it is loaded
+     * successfully.
+     * <p>
+     * Relative URLs are interpreted as relative to the static web resources
+     * directory. You can prefix the URL with {@code context://} to make it
+     * relative to the context path or use an absolute URL to refer to files
+     * outside the frontend directory.
+     * <p>
+     * The {@code type} parameter selects the kind of {@code <script>} tag the
+     * browser receives: {@link JavaScript.Type#SCRIPT} renders a classic
+     * {@code <script>} element (the default of {@link #addJavaScript(String)});
+     * {@link JavaScript.Type#MODULE} renders a {@code <script type="module">}
+     * element, which is the recommended way to load runtime ES modules
+     * (replaces the deprecated {@link #addJsModule(String)}).
+     * <p>
+     * For component related JavaScript dependencies, you should use the
+     * {@link JavaScript @JavaScript} annotation.
+     *
+     * @param url
+     *            the URL to load the JavaScript from, not <code>null</code>
+     * @param loadMode
+     *            determines dependency load mode, refer to {@link LoadMode} for
+     *            details
+     * @param type
+     *            the kind of {@code <script>} tag to render; {@code null} is
+     *            treated as {@link JavaScript.Type#SCRIPT}
+     */
+    public void addJavaScript(String url, LoadMode loadMode,
+            JavaScript.Type type) {
+        Type dependencyType = type == JavaScript.Type.MODULE ? Type.JS_MODULE
+                : Type.JAVASCRIPT;
+        addDependency(new Dependency(dependencyType, url, loadMode));
     }
 
     /**
@@ -284,7 +319,11 @@ public class Page implements Serializable {
      * @param url
      *            the URL to load the JavaScript module from, not
      *            <code>null</code>
+     * @deprecated use {@link #addJavaScript(String, LoadMode, JavaScript.Type)}
+     *             with {@link JavaScript.Type#MODULE} instead. The new overload
+     *             also accepts a {@link LoadMode}.
      */
+    @Deprecated
     public void addJsModule(String url) {
         if (UrlUtil.isExternal(url) || url.startsWith("/")) {
             addDependency(new Dependency(Type.JS_MODULE, url, LoadMode.EAGER));

--- a/flow-server/src/main/java/com/vaadin/flow/server/FrontendDependencyUrlResolver.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/FrontendDependencyUrlResolver.java
@@ -24,12 +24,15 @@ import com.vaadin.flow.shared.ApplicationConstants;
 
 /**
  * Resolves the {@code value()} of
- * {@link com.vaadin.flow.component.dependency.StyleSheet} annotation values to
+ * {@link com.vaadin.flow.component.dependency.StyleSheet} and
+ * {@link com.vaadin.flow.component.dependency.JavaScript} annotation values to
  * a canonical form that
  * {@link com.vaadin.flow.server.BootstrapHandler.BootstrapUriResolver} can
- * expand at render time. The same rules are used whether the annotation is on
- * an {@link com.vaadin.flow.component.page.AppShellConfigurator} or on an
- * ordinary {@link com.vaadin.flow.component.Component}.
+ * expand at render time.
+ * <p>
+ * The same rules are used whether the annotation is on an
+ * {@link com.vaadin.flow.component.page.AppShellConfigurator} or on an ordinary
+ * {@link com.vaadin.flow.component.Component}.
  * <p>
  * For internal framework use only.
  */
@@ -91,5 +94,35 @@ public final class FrontendDependencyUrlResolver implements Serializable {
             return value;
         }
         return ApplicationConstants.CONTEXT_PROTOCOL_PREFIX + value;
+    }
+
+    /**
+     * Tells whether the given value is a runtime-loaded URL — i.e. should be
+     * served by the servlet container at runtime rather than passed to the
+     * frontend bundler.
+     * <p>
+     * Returns {@code true} for values starting with any of: {@code http://},
+     * {@code https://}, {@code //}, {@code context://}, {@code base://}, or
+     * {@code /}. Returns {@code false} for {@code null}, blank, or any other
+     * value (e.g. bare relative paths and bundler import specifiers).
+     *
+     * @param value
+     *            the raw annotation value
+     * @return {@code true} if the value is a runtime URL
+     */
+    public static boolean isRuntimeDependencyUrl(String value) {
+        if (value == null || value.isBlank()) {
+            return false;
+        }
+        String trimmed = value.trim();
+        if (trimmed.startsWith("/")) {
+            return true;
+        }
+        String lower = trimmed.toLowerCase();
+        return lower.startsWith("http://") || lower.startsWith("https://")
+                || lower.startsWith("//")
+                || lower.startsWith(
+                        ApplicationConstants.CONTEXT_PROTOCOL_PREFIX)
+                || lower.startsWith(ApplicationConstants.BASE_PROTOCOL_PREFIX);
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/FrontendDependencyUrlResolverTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/FrontendDependencyUrlResolverTest.java
@@ -82,4 +82,42 @@ public class FrontendDependencyUrlResolverTest {
         Assert.assertEquals("context://foo.css", FrontendDependencyUrlResolver
                 .resolveToContextRoot("  foo.css  "));
     }
+
+    @Test
+    public void isRuntimeDependencyUrl_runtimePrefixes_true() {
+        Assert.assertTrue(FrontendDependencyUrlResolver
+                .isRuntimeDependencyUrl("context://foo.js"));
+        Assert.assertTrue(FrontendDependencyUrlResolver
+                .isRuntimeDependencyUrl("base://foo.js"));
+        Assert.assertTrue(FrontendDependencyUrlResolver
+                .isRuntimeDependencyUrl("http://cdn/foo.js"));
+        Assert.assertTrue(FrontendDependencyUrlResolver
+                .isRuntimeDependencyUrl("https://cdn/foo.js"));
+        Assert.assertTrue(FrontendDependencyUrlResolver
+                .isRuntimeDependencyUrl("//cdn/foo.js"));
+        Assert.assertTrue(FrontendDependencyUrlResolver
+                .isRuntimeDependencyUrl("/assets/foo.js"));
+    }
+
+    @Test
+    public void isRuntimeDependencyUrl_bareRelativeOrBundlerSpecifier_false() {
+        Assert.assertFalse(
+                FrontendDependencyUrlResolver.isRuntimeDependencyUrl("foo.js"));
+        Assert.assertFalse(FrontendDependencyUrlResolver
+                .isRuntimeDependencyUrl("./foo.js"));
+        Assert.assertFalse(FrontendDependencyUrlResolver
+                .isRuntimeDependencyUrl("../foo.js"));
+        Assert.assertFalse(FrontendDependencyUrlResolver
+                .isRuntimeDependencyUrl("@scope/pkg/foo.js"));
+    }
+
+    @Test
+    public void isRuntimeDependencyUrl_nullOrBlank_false() {
+        Assert.assertFalse(
+                FrontendDependencyUrlResolver.isRuntimeDependencyUrl(null));
+        Assert.assertFalse(
+                FrontendDependencyUrlResolver.isRuntimeDependencyUrl(""));
+        Assert.assertFalse(
+                FrontendDependencyUrlResolver.isRuntimeDependencyUrl("   "));
+    }
 }


### PR DESCRIPTION
Concrete changes:

- New FrontendDependencyUrlResolver with resolveToContextRoot and isRuntimeDependencyUrl. Single source of truth for the prefix table: http(s)://, //, context://, base://, /abs are runtime; bare relatives and ./foo are normalized to context://foo.
- AppShellRegistry.resolveStyleSheetHref delegates to the resolver.
- UIInternals.addComponentDependencies eagerly resolves @StyleSheet values via the same resolver, so component-level @StyleSheet now bypasses the Vaadin servlet mapping the same way AppShell-level @StyleSheet already did. Fixes the issue where @StyleSheet("foo.css") returned 404 when the Vaadin servlet was mapped at a non-root path.
- @JavaScript values with a runtime prefix (context://, base://, /abs, http(s)://, //) are now served as runtime <script> elements rather than bundled. Bare-relative @JavaScript values still bundle for backwards compatibility but emit a one-time consolidated build-time warning per (class, value).
- @JsModule with a runtime URL is similarly deprecated. The scanner filters such values out of the bundle imports and tracks them on ClassInfo.deprecatedRuntimeModules. FrontendDependencies emits a consolidated build-time warning recommending migration to @JavaScript(value=..., type=Type.MODULE) for runtime <script type="module"> loading. The runtime path in UIInternals.addExternalDependencies continues to load external @JsModule URLs as runtime modules so existing apps keep working; the previous double-load (bundle + runtime) is gone.
- TaskCopyFrontendFiles emits a once-per-jar/dir warning when an addon uses META-INF/resources/frontend/, recommending the split layout.

References vaadin/flow#22888, vaadin/flow#23326, vaadin/flow#16780 and the v25 web-component-path / CSS-loading forum threads.
