### PR TITLE
chore: warn about deprecated packages instead of failing the update (#24619) (CP: 25.2)

### DIFF
--- a/scripts/update-frontend-dependencies.sh
+++ b/scripts/update-frontend-dependencies.sh
@@ -34,6 +34,7 @@ done
 echo ""
 echo "Checking for deprecated packages..."
 deprecationFound=false
+deprecationDetails=""
 
 for a in "$depsFolder"/*
 do
@@ -45,9 +46,11 @@ do
 
   # Check if there are any deprecated packages (output will contain package names if found)
   if echo "$deprecatedOutput" | grep -q "deprecated"; then
-    echo "❌ Deprecated packages found in $folderName:"
+    echo "⚠️ Deprecated packages found in $folderName:"
     echo "$deprecatedOutput"
     deprecationFound=true
+    deprecationDetails+="$folderName:"$'\n'
+    deprecationDetails+="$(echo "$deprecatedOutput" | grep "deprecated")"$'\n'
   else
     echo "✓ No deprecated packages in $folderName"
   fi
@@ -57,8 +60,19 @@ done
 
 if [ "$deprecationFound" = true ]; then
   echo ""
-  echo "ERROR: Deprecated packages detected!"
+  echo "WARNING: Deprecated packages detected!"
   echo "On maintenance branches, deprecated packages cannot be auto-updated to major versions."
   echo "Please review and update these packages manually."
-  exit 1
+
+  # Expose the warning so the workflow can include it in the commit message
+  if [ -n "$GITHUB_ENV" ]; then
+    {
+      echo "DEPRECATION_WARNING<<DEPRECATION_WARNING_EOF"
+      echo ""
+      echo "Warning: deprecated packages detected. They cannot be auto-updated to"
+      echo "major versions on maintenance branches and need manual review:"
+      echo "$deprecationDetails"
+      echo "DEPRECATION_WARNING_EOF"
+    } >> "$GITHUB_ENV"
+  fi
 fi


### PR DESCRIPTION
The frontend dependency update script previously exited with an error when deprecated packages were detected, preventing the update PR from being created. Now the script always completes and exports the deprecation details via GITHUB_ENV so the workflow appends them as a warning to the commit message of the generated PR.
