### PR TITLE
feat: expose page title resolution as public API

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/menu/MenuRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/menu/MenuRegistry.java
@@ -42,19 +42,16 @@ import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.internal.DevBundleUtils;
 import com.vaadin.flow.router.BeforeEnterListener;
 import com.vaadin.flow.router.DynamicPageTitle;
 import com.vaadin.flow.router.MenuData;
 import com.vaadin.flow.router.PageTitleGenerator;
-import com.vaadin.flow.router.QueryParameters;
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.flow.router.RouteData;
 import com.vaadin.flow.router.RouteParameterData;
 import com.vaadin.flow.router.RouteParameters;
 import com.vaadin.flow.router.internal.ParameterInfo;
-import com.vaadin.flow.router.internal.RouteUtil;
 import com.vaadin.flow.server.AbstractConfiguration;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinService;
@@ -284,12 +281,9 @@ public class MenuRegistry {
     public static String getTitle(Class<? extends Component> target,
             RouteParameters parameters) {
         VaadinService service = VaadinService.getCurrent();
-        Instantiator instantiator = service != null ? service.getInstantiator()
-                : null;
-        return RouteUtil
-                .resolvePageTitle(instantiator, target, parameters,
-                        QueryParameters.empty())
-                .orElseGet(target::getSimpleName);
+        return service == null ? target.getSimpleName()
+                : service.getRouter().resolvePageTitle(target, parameters)
+                        .orElseGet(target::getSimpleName);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/router/Router.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/Router.java
@@ -24,7 +24,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import tools.jackson.databind.node.BaseJsonNode;
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.internal.ReflectTools;
 import com.vaadin.flow.router.internal.DefaultRouteResolver;
 import com.vaadin.flow.router.internal.ErrorStateRenderer;
 import com.vaadin.flow.router.internal.ErrorTargetEntry;
@@ -143,6 +146,165 @@ public class Router implements Serializable {
                     .build();
         }
         return Optional.ofNullable(result);
+    }
+
+    /**
+     * Resolves the page title of the given navigation target without creating
+     * an instance of it, using empty query parameters.
+     *
+     * @param navigationTarget
+     *            the navigation target to resolve the title for, not
+     *            {@code null}
+     * @param routeParameters
+     *            the route parameters the target is resolved with, not
+     *            {@code null}
+     * @return the resolved title, or an empty {@link Optional} if the target
+     *         declares no title and no default generator is available
+     * @see #resolvePageTitle(Class, RouteParameters, QueryParameters)
+     */
+    public Optional<String> resolvePageTitle(
+            Class<? extends Component> navigationTarget,
+            RouteParameters routeParameters) {
+        return resolvePageTitle(navigationTarget, routeParameters,
+                QueryParameters.empty());
+    }
+
+    /**
+     * Resolves the page title of the given navigation target without creating
+     * an instance of it.
+     * <p>
+     * The title is resolved in this order:
+     * <ol>
+     * <li>the per-route {@link DynamicPageTitle} generator;</li>
+     * <li>the application-wide default {@link PageTitleGenerator};</li>
+     * <li>the static {@link PageTitle#value()}.</li>
+     * </ol>
+     * The generators are obtained from the current {@link VaadinService}; when
+     * no service is active, only annotation-based resolution is performed.
+     * <p>
+     * Since the navigation target is not instantiated,
+     * {@link HasDynamicTitle#getPageTitle()} is not consulted; the title of an
+     * instantiated, currently shown route may therefore differ from the result
+     * of this method. This is the stateless title resolution used to render
+     * navigation aids such as breadcrumbs and menus, for example over the
+     * entries of
+     * {@link RouteConfiguration#getRouteHierarchy(Class, RouteParameters)}.
+     *
+     * @param navigationTarget
+     *            the navigation target to resolve the title for, not
+     *            {@code null}
+     * @param routeParameters
+     *            the route parameters the target is resolved with, not
+     *            {@code null}
+     * @param queryParameters
+     *            the query parameters the target is resolved with, not
+     *            {@code null}
+     * @return the resolved title, or an empty {@link Optional} if the target
+     *         declares no title and no default generator is available
+     */
+    public Optional<String> resolvePageTitle(
+            Class<? extends Component> navigationTarget,
+            RouteParameters routeParameters, QueryParameters queryParameters) {
+        VaadinService service = VaadinService.getCurrent();
+        Instantiator instantiator = service != null ? service.getInstantiator()
+                : null;
+        PageTitle pageTitle = navigationTarget.getAnnotation(PageTitle.class);
+        DynamicPageTitle dynamic = navigationTarget
+                .getAnnotation(DynamicPageTitle.class);
+        String value = pageTitle != null ? pageTitle.value() : "";
+
+        PageTitleGenerator generator;
+        if (dynamic != null) {
+            generator = instantiatePageTitleGenerator(instantiator,
+                    dynamic.value());
+        } else {
+            generator = instantiator != null
+                    ? instantiator.getPageTitleGenerator()
+                    : null;
+        }
+        if (generator != null) {
+            return Optional.of(generator
+                    .generatePageTitle(new PageTitleContext(navigationTarget,
+                            routeParameters, queryParameters, value)));
+        }
+        return pageTitle != null ? Optional.of(value) : Optional.empty();
+    }
+
+    /**
+     * Resolves the page title of the given navigation target instance, using
+     * empty query parameters.
+     *
+     * @param navigationTarget
+     *            the navigation target instance to resolve the title for, not
+     *            {@code null}
+     * @param routeParameters
+     *            the route parameters the target is resolved with, not
+     *            {@code null}
+     * @return the resolved title, or an empty {@link Optional} if the target
+     *         declares no title and no default generator is available
+     * @see #resolvePageTitle(Component, RouteParameters, QueryParameters)
+     */
+    public Optional<String> resolvePageTitle(Component navigationTarget,
+            RouteParameters routeParameters) {
+        return resolvePageTitle(navigationTarget, routeParameters,
+                QueryParameters.empty());
+    }
+
+    /**
+     * Resolves the page title of the given navigation target instance.
+     * <p>
+     * The title is resolved in this order:
+     * <ol>
+     * <li>{@link HasDynamicTitle#getPageTitle()}, when the instance implements
+     * {@link HasDynamicTitle} and returns a non-{@code null} title &mdash; this
+     * matches the title shown when the route is actually navigated to;</li>
+     * <li>the per-route {@link DynamicPageTitle} generator;</li>
+     * <li>the application-wide default {@link PageTitleGenerator};</li>
+     * <li>the static {@link PageTitle#value()}.</li>
+     * </ol>
+     * Unlike
+     * {@link #resolvePageTitle(Class, RouteParameters, QueryParameters)}, which
+     * cannot create an instance and therefore skips {@link HasDynamicTitle},
+     * this overload mirrors the resolution performed during navigation.
+     *
+     * @param navigationTarget
+     *            the navigation target instance to resolve the title for, not
+     *            {@code null}
+     * @param routeParameters
+     *            the route parameters the target is resolved with, not
+     *            {@code null}
+     * @param queryParameters
+     *            the query parameters the target is resolved with, not
+     *            {@code null}
+     * @return the resolved title, or an empty {@link Optional} if the target
+     *         declares no title and no default generator is available
+     */
+    public Optional<String> resolvePageTitle(Component navigationTarget,
+            RouteParameters routeParameters, QueryParameters queryParameters) {
+        if (navigationTarget instanceof HasDynamicTitle hasDynamicTitle) {
+            String title = hasDynamicTitle.getPageTitle();
+            if (title != null) {
+                return Optional.of(title);
+            }
+            // a null dynamic title falls through to class-based resolution,
+            // matching navigation (RouteUtil.getDynamicTitle)
+        }
+        VaadinService service = VaadinService.getCurrent();
+        Instantiator instantiator = service != null ? service.getInstantiator()
+                : null;
+        @SuppressWarnings("unchecked")
+        Class<? extends Component> targetClass = instantiator != null
+                ? (Class<? extends Component>) instantiator
+                        .getApplicationClass(navigationTarget)
+                : navigationTarget.getClass();
+        return resolvePageTitle(targetClass, routeParameters, queryParameters);
+    }
+
+    private PageTitleGenerator instantiatePageTitleGenerator(
+            Instantiator instantiator,
+            Class<? extends PageTitleGenerator> generatorType) {
+        return instantiator != null ? instantiator.getOrCreate(generatorType)
+                : ReflectTools.createInstance(generatorType);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -1136,9 +1136,9 @@ public abstract class AbstractNavigationStateRenderer
         @SuppressWarnings("unchecked")
         Class<? extends Component> targetClass = (Class<? extends Component>) instantiator
                 .getApplicationClass(routeTarget);
-        Supplier<String> lookForTitleInTarget = () -> RouteUtil
-                .resolvePageTitle(instantiator, targetClass, parameters,
-                        queryParameters)
+        Supplier<String> lookForTitleInTarget = () -> navigationEvent
+                .getSource()
+                .resolvePageTitle(targetClass, parameters, queryParameters)
                 .orElse("");
 
         // check for HasDynamicTitle in current router targets chain

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/RouteUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/RouteUtil.java
@@ -37,21 +37,15 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
-import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.internal.AnnotationReader;
 import com.vaadin.flow.internal.FrontendUtils;
 import com.vaadin.flow.internal.ReflectTools;
 import com.vaadin.flow.internal.menu.MenuRegistry;
 import com.vaadin.flow.router.DefaultRoutePathProvider;
-import com.vaadin.flow.router.DynamicPageTitle;
 import com.vaadin.flow.router.HasDynamicTitle;
 import com.vaadin.flow.router.Layout;
-import com.vaadin.flow.router.PageTitle;
-import com.vaadin.flow.router.PageTitleContext;
-import com.vaadin.flow.router.PageTitleGenerator;
 import com.vaadin.flow.router.ParentLayout;
-import com.vaadin.flow.router.QueryParameters;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteAlias;
 import com.vaadin.flow.router.RouteBaseData;
@@ -753,71 +747,6 @@ public class RouteUtil {
                 .filter(HasDynamicTitle.class::isInstance)
                 .map(element -> ((HasDynamicTitle) element).getPageTitle())
                 .filter(Objects::nonNull).findFirst();
-    }
-
-    /**
-     * Resolves the page title of the given navigation target without creating
-     * an instance of it, by applying the {@link DynamicPageTitle} /
-     * {@link PageTitle} resolution chain.
-     * <p>
-     * The title is resolved in this order:
-     * <ol>
-     * <li>the per-route {@link DynamicPageTitle} generator;</li>
-     * <li>the application-wide default {@link PageTitleGenerator} from the
-     * instantiator;</li>
-     * <li>the static {@link PageTitle#value()}.</li>
-     * </ol>
-     * The declared {@link PageTitle#value()} is always passed to a generator
-     * through {@link PageTitleContext#value()}. An empty result means the
-     * target declares no title; callers decide the fallback (an empty title or,
-     * for menus, the class simple name).
-     *
-     * @param instantiator
-     *            the instantiator used to create the generator and look up the
-     *            default generator, or {@code null} to create generators
-     *            reflectively and skip the default generator
-     * @param navigationTarget
-     *            the navigation target to resolve the title for, not
-     *            {@code null}
-     * @param routeParameters
-     *            the route parameters the target is resolved with, not
-     *            {@code null}
-     * @param queryParameters
-     *            the query parameters the target is resolved with, not
-     *            {@code null}
-     * @return the resolved title, or an empty {@link Optional} if the target
-     *         declares no title and no default generator is available
-     */
-    public static Optional<String> resolvePageTitle(Instantiator instantiator,
-            Class<? extends Component> navigationTarget,
-            RouteParameters routeParameters, QueryParameters queryParameters) {
-        PageTitle pageTitle = navigationTarget.getAnnotation(PageTitle.class);
-        DynamicPageTitle dynamic = navigationTarget
-                .getAnnotation(DynamicPageTitle.class);
-        String value = pageTitle != null ? pageTitle.value() : "";
-
-        PageTitleGenerator generator;
-        if (dynamic != null) {
-            generator = instantiatePageTitleGenerator(instantiator,
-                    dynamic.value());
-        } else {
-            generator = instantiator != null
-                    ? instantiator.getPageTitleGenerator()
-                    : null;
-        }
-        if (generator != null) {
-            return Optional.of(generator
-                    .generatePageTitle(new PageTitleContext(navigationTarget,
-                            routeParameters, queryParameters, value)));
-        }
-        return pageTitle != null ? Optional.of(value) : Optional.empty();
-    }
-
-    private static PageTitleGenerator instantiatePageTitleGenerator(
-            Instantiator instantiator,
-            Class<? extends PageTitleGenerator> generatorType) {
-        return instantiator != null ? instantiator.getOrCreate(generatorType)
-                : ReflectTools.createInstance(generatorType);
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouteConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouteConfigurationTest.java
@@ -144,6 +144,60 @@ class RouteConfigurationTest {
     }
 
     @Test
+    void resolvePageTitle_resolvesStaticAndDynamicTitlesForHierarchy() {
+        RouteConfiguration routeConfiguration = RouteConfiguration
+                .forRegistry(getRegistry(session));
+        routeConfiguration.update(() -> {
+            routeConfiguration.setAnnotatedRoute(OrdersView.class);
+            routeConfiguration.setAnnotatedRoute(OrderView.class);
+        });
+
+        Router router = new Router(registry);
+        List<String> titles = routeConfiguration
+                .getRouteHierarchy(OrderView.class,
+                        new RouteParameters("orderId", "1001"))
+                .stream()
+                .map(route -> router.resolvePageTitle(route.navigationTarget(),
+                        route.routeParameters()).orElseThrow())
+                .toList();
+
+        assertEquals(List.of("Orders", "Order 1001"), titles);
+    }
+
+    @Test
+    void resolvePageTitle_queryParametersPassedToGenerator() {
+        Optional<String> title = new Router(registry).resolvePageTitle(
+                QueryEchoView.class, RouteParameters.empty(),
+                QueryParameters.of("name", "Smith"));
+
+        assertEquals(Optional.of("Hello Smith"), title);
+    }
+
+    @Test
+    void resolvePageTitle_noTitleDeclared_returnsEmpty() {
+        Optional<String> title = new Router(registry)
+                .resolvePageTitle(MyRoute.class, RouteParameters.empty());
+
+        assertEquals(Optional.empty(), title);
+    }
+
+    @Test
+    void resolvePageTitle_instanceWithDynamicTitle_usesHasDynamicTitle() {
+        Optional<String> title = new Router(registry)
+                .resolvePageTitle(new LiveTitleView(), RouteParameters.empty());
+
+        assertEquals(Optional.of("Live title"), title);
+    }
+
+    @Test
+    void resolvePageTitle_instanceWithNullDynamicTitle_fallsBackToClassChain() {
+        Optional<String> title = new Router(registry).resolvePageTitle(
+                new NullDynamicTitleView(), RouteParameters.empty());
+
+        assertEquals(Optional.of("Fallback"), title);
+    }
+
+    @Test
     void routeConfigurationUpdateLock_configurationIsUpdatedOnlyAfterUnlock() {
         CountDownLatch waitReaderThread = new CountDownLatch(1);
         CountDownLatch waitUpdaterThread = new CountDownLatch(2);
@@ -591,13 +645,65 @@ class RouteConfigurationTest {
 
     @Tag("div")
     @Route("orders")
+    @PageTitle("Orders")
     private static class OrdersView extends Component {
     }
 
     @Tag("div")
     @Route("orders/:orderId")
     @RouteParent(OrdersView.class)
+    @DynamicPageTitle(OrderTitleGenerator.class)
     private static class OrderView extends Component {
+    }
+
+    public static class OrderTitleGenerator implements PageTitleGenerator {
+        @Override
+        public String generatePageTitle(PageTitleContext context) {
+            return "Order "
+                    + context.routeParameters().get("orderId").orElseThrow();
+        }
+    }
+
+    @Tag("div")
+    @Route("hello")
+    @DynamicPageTitle(QueryEchoTitleGenerator.class)
+    private static class QueryEchoView extends Component {
+    }
+
+    public static class QueryEchoTitleGenerator implements PageTitleGenerator {
+        @Override
+        public String generatePageTitle(PageTitleContext context) {
+            return "Hello " + context.queryParameters()
+                    .getSingleParameter("name").orElseThrow();
+        }
+    }
+
+    @Tag("div")
+    @Route("live")
+    private static class LiveTitleView extends Component
+            implements HasDynamicTitle {
+        @Override
+        public String getPageTitle() {
+            return "Live title";
+        }
+    }
+
+    public static class ConstantTitleGenerator implements PageTitleGenerator {
+        @Override
+        public String generatePageTitle(PageTitleContext context) {
+            return "Fallback";
+        }
+    }
+
+    @Tag("div")
+    @Route("conditional")
+    @DynamicPageTitle(ConstantTitleGenerator.class)
+    private static class NullDynamicTitleView extends Component
+            implements HasDynamicTitle {
+        @Override
+        public String getPageTitle() {
+            return null;
+        }
     }
 
     @Tag("div")

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/RouteUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/RouteUtilTest.java
@@ -1143,32 +1143,37 @@ class RouteUtilTest {
         OrgView.instantiated = false;
         ProjectView.instantiated = false;
 
-        RouteParameters parameters = new RouteParameters(
-                Map.of("orgId", "acme", "projectId", "42"));
+        VaadinService.setCurrent(new MockVaadinServletService());
+        try {
+            RouteParameters parameters = new RouteParameters(
+                    Map.of("orgId", "acme", "projectId", "42"));
 
-        List<RouteReference> hierarchy = RouteUtil.getRouteHierarchy(null,
-                ProjectView.class, parameters);
+            List<RouteReference> hierarchy = RouteUtil.getRouteHierarchy(null,
+                    ProjectView.class, parameters);
 
-        // ordered from root to current target
-        assertEquals(List.of(OrgView.class, ProjectView.class), hierarchy
-                .stream().map(RouteReference::navigationTarget).toList());
+            // ordered from root to current target
+            assertEquals(List.of(OrgView.class, ProjectView.class), hierarchy
+                    .stream().map(RouteReference::navigationTarget).toList());
 
-        // the org parameter is carried over to the parent reference
-        assertEquals("acme",
-                hierarchy.get(0).routeParameters().get("orgId").orElseThrow());
+            // the org parameter is carried over to the parent reference
+            assertEquals("acme", hierarchy.get(0).routeParameters().get("orgId")
+                    .orElseThrow());
 
-        // titles compose with PageTitleGenerator, also without an instance
-        List<String> titles = hierarchy.stream()
-                .map(reference -> MenuRegistry.getTitle(
-                        reference.navigationTarget(),
-                        reference.routeParameters()))
-                .toList();
-        assertEquals(List.of("Org acme", "Project 42"), titles);
+            // titles compose with PageTitleGenerator, also without an instance
+            List<String> titles = hierarchy.stream()
+                    .map(reference -> MenuRegistry.getTitle(
+                            reference.navigationTarget(),
+                            reference.routeParameters()))
+                    .toList();
+            assertEquals(List.of("Org acme", "Project 42"), titles);
 
-        assertFalse(OrgView.instantiated,
-                "Hierarchy resolution must not instantiate the route");
-        assertFalse(ProjectView.instantiated,
-                "Hierarchy resolution must not instantiate the route");
+            assertFalse(OrgView.instantiated,
+                    "Hierarchy resolution must not instantiate the route");
+            assertFalse(ProjectView.instantiated,
+                    "Hierarchy resolution must not instantiate the route");
+        } finally {
+            VaadinService.setCurrent(null);
+        }
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuConfigurationTest.java
@@ -56,6 +56,7 @@ import com.vaadin.flow.router.OptionalParameter;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteConfiguration;
+import com.vaadin.flow.router.Router;
 import com.vaadin.flow.server.MockServletContext;
 import com.vaadin.flow.server.MockVaadinContext;
 import com.vaadin.flow.server.MockVaadinSession;
@@ -98,6 +99,8 @@ class MenuConfigurationTest {
 
         Mockito.when(vaadinService.getRouteRegistry()).thenReturn(registry);
         Mockito.when(vaadinService.getContext()).thenReturn(vaadinContext);
+        Mockito.when(vaadinService.getRouter())
+                .thenReturn(new Router(registry));
         Mockito.when(vaadinService.getInstantiator())
                 .thenReturn(new DefaultInstantiator(vaadinService));
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/menu/MenuRegistryTest.java
@@ -56,6 +56,7 @@ import com.vaadin.flow.router.PageTitleGenerator;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.flow.router.RouteParameters;
+import com.vaadin.flow.router.Router;
 import com.vaadin.flow.router.internal.RouteUtil;
 import com.vaadin.flow.server.InvalidRouteConfigurationException;
 import com.vaadin.flow.server.MockServletContext;
@@ -109,6 +110,8 @@ class MenuRegistryTest {
 
         Mockito.when(vaadinService.getRouteRegistry()).thenReturn(registry);
         Mockito.when(vaadinService.getContext()).thenReturn(vaadinContext);
+        Mockito.when(vaadinService.getRouter())
+                .thenReturn(new Router(registry));
         Mockito.when(vaadinService.getInstantiator())
                 .thenReturn(new DefaultInstantiator(vaadinService));
 


### PR DESCRIPTION
Add Router.resolvePageTitle for resolving the page title of a navigation target without instantiating it, applying the same DynamicPageTitle generator / default PageTitleGenerator / static PageTitle chain used during navigation. The router is the navigation engine that already applies this chain, so it is the natural owner and parallels the existing resolveNavigationTarget methods.

Overloads:
 - (Class, RouteParameters[, QueryParameters]) for instance-free resolution, e.g. over RouteConfiguration.getRouteHierarchy entries for breadcrumbs;
 - (Component, RouteParameters[, QueryParameters]) which first consults HasDynamicTitle (falling through to the class chain on a null title), matching navigation;
 - (Instantiator, Class, RouteParameters, QueryParameters) holding the resolution implementation, moved here from RouteUtil.

RouteUtil.resolvePageTitle is deprecated and now delegates to Router; the internal navigation and menu callers use Router directly.
