### PR TITLE
fix: read Vaadin version from vaadin-core-internal pom.properties

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/Platform.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Platform.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
  */
 public class Platform implements Serializable {
     static final String HILLA_POM_PROPERTIES = "META-INF/maven/com.vaadin/hilla/pom.properties";
+    static final String VAADIN_CORE_POM_PROPERTIES = "META-INF/maven/com.vaadin/vaadin-core-internal/pom.properties";
     private static final Logger LOGGER = LoggerFactory
             .getLogger(Platform.class);
     /**
@@ -55,15 +56,17 @@ public class Platform implements Serializable {
         // immutable and thread-safe.
         if (vaadinVersion == null) {
             try (final InputStream vaadinPomProperties = Thread.currentThread()
-                    .getContextClassLoader().getResourceAsStream(
-                            "META-INF/maven/com.vaadin/vaadin-core/pom.properties")) {
+                    .getContextClassLoader()
+                    .getResourceAsStream(VAADIN_CORE_POM_PROPERTIES)) {
                 if (vaadinPomProperties != null) {
                     final Properties properties = new Properties();
                     properties.load(vaadinPomProperties);
                     vaadinVersion = properties.getProperty("version", "");
                 } else {
-                    LOGGER.info("Unable to determine Vaadin version. "
-                            + "No META-INF/maven/com.vaadin/vaadin-core/pom.properties found");
+                    LOGGER.info(
+                            "Unable to determine Vaadin version. "
+                                    + "No {} found",
+                            VAADIN_CORE_POM_PROPERTIES);
                     vaadinVersion = "";
                 }
             } catch (Exception e) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/PlatformTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/PlatformTest.java
@@ -73,8 +73,8 @@ class PlatformTest {
         if (vaadinVersion != null) {
             final Path vaadinJar = Files.createTempDirectory(temporary, "temp")
                     .toFile().toPath();
-            final Path pomProperties = vaadinJar.resolve(
-                    "META-INF/maven/com.vaadin/vaadin-core/pom.properties");
+            final Path pomProperties = vaadinJar
+                    .resolve(Platform.VAADIN_CORE_POM_PROPERTIES);
             Files.createDirectories(pomProperties.getParent());
             Files.writeString(pomProperties, "version=" + vaadinVersion);
             classPath.add(vaadinJar.toUri().toURL());


### PR DESCRIPTION
## Summary

- Replace the hardcoded `vaadin-core/pom.properties` path in
  `Platform.getVaadinVersion()` with a constant pointing to
  `vaadin-core-internal/pom.properties`.
- `vaadin-core` always depends on `vaadin-core-internal`, so the
  version is always available on the classpath.