### PR TITLE
feat: serve @JavaScript with a runtime prefix as a runtime <script>

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendClassVisitor.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendClassVisitor.java
@@ -31,6 +31,7 @@ import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.FrontendDependencyUrlResolver;
 import com.vaadin.flow.theme.NoTheme;
 import com.vaadin.flow.theme.Theme;
 
@@ -71,13 +72,16 @@ final class FrontendClassVisitor extends ClassVisitor {
         private String currentModule;
         private boolean currentTypeIsModule = false;
 
-        private LinkedHashSet<String> target;
-        private LinkedHashSet<String> targetDevelopmentOnly;
+        private final LinkedHashSet<String> target;
+        private final LinkedHashSet<String> targetDevelopmentOnly;
+        private final boolean isJavaScriptAnnotation;
 
         public JSAnnotationVisitor(LinkedHashSet<String> target,
-                LinkedHashSet<String> targetDevelopmentOnly) {
+                LinkedHashSet<String> targetDevelopmentOnly,
+                boolean isJavaScriptAnnotation) {
             this.target = target;
             this.targetDevelopmentOnly = targetDevelopmentOnly;
+            this.isJavaScriptAnnotation = isJavaScriptAnnotation;
         }
 
         @Override
@@ -104,12 +108,16 @@ final class FrontendClassVisitor extends ClassVisitor {
         @Override
         public void visitEnd() {
             super.visitEnd();
-            // type=MODULE values are loaded at runtime as <script
-            // type="module">
-            // by UIInternals; they must not enter the bundle.
             if (currentModule != null && !currentTypeIsModule) {
-                // This visitor is called also for the $Container annotation
-                if (currentDevOnly) {
+                // type=MODULE @JavaScript values are loaded at runtime as
+                // <script type="module"> by UIInternals; skip them entirely.
+                // This visitor is called also for the $Container annotation.
+                boolean runtimeUrl = FrontendDependencyUrlResolver
+                        .isRuntimeDependencyUrl(currentModule);
+                if (isJavaScriptAnnotation && runtimeUrl) {
+                    // @JavaScript with a runtime prefix: load at runtime, not
+                    // bundled. No deprecation — this is the recommended form.
+                } else if (currentDevOnly) {
                     targetDevelopmentOnly.add(currentModule);
                 } else {
                     target.add(currentModule);
@@ -240,10 +248,10 @@ final class FrontendClassVisitor extends ClassVisitor {
         };
         // Visitor for @JsModule annotations
         jsModuleVisitor = new JSAnnotationVisitor(classInfo.modules,
-                classInfo.modulesDevelopmentOnly);
+                classInfo.modulesDevelopmentOnly, false);
         // Visitor for @JavaScript annotations
         jScriptVisitor = new JSAnnotationVisitor(classInfo.scripts,
-                classInfo.scriptsDevelopmentOnly);
+                classInfo.scriptsDevelopmentOnly, true);
         // Visitor all other annotations
         annotationVisitor = new RepeatedAnnotationVisitor() {
             @Override

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendClassVisitor.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendClassVisitor.java
@@ -69,6 +69,7 @@ final class FrontendClassVisitor extends ClassVisitor {
 
         boolean currentDevOnly = false;
         private String currentModule;
+        private boolean currentTypeIsModule = false;
 
         private LinkedHashSet<String> target;
         private LinkedHashSet<String> targetDevelopmentOnly;
@@ -92,9 +93,21 @@ final class FrontendClassVisitor extends ClassVisitor {
         }
 
         @Override
+        public void visitEnum(String name, String descriptor, String value) {
+            // The "type" attribute only exists on @JavaScript; @JsModule has
+            // no such attribute, so this method is a no-op for it.
+            if ("type".equals(name) && "MODULE".equals(value)) {
+                currentTypeIsModule = true;
+            }
+        }
+
+        @Override
         public void visitEnd() {
             super.visitEnd();
-            if (currentModule != null) {
+            // type=MODULE values are loaded at runtime as <script
+            // type="module">
+            // by UIInternals; they must not enter the bundle.
+            if (currentModule != null && !currentTypeIsModule) {
                 // This visitor is called also for the $Container annotation
                 if (currentDevOnly) {
                     targetDevelopmentOnly.add(currentModule);
@@ -104,6 +117,7 @@ final class FrontendClassVisitor extends ClassVisitor {
             }
             currentModule = null;
             currentDevOnly = false;
+            currentTypeIsModule = false;
         }
 
     }

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
@@ -135,6 +135,7 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
             computePackages();
             computePwaConfiguration();
             aggregateEntryPointInformation();
+            warnAboutDeprecatedJavaScriptUses();
             long ms = (System.nanoTime() - start) / 1000000;
             log().info("Visited {} classes. Took {} ms.", visitedClasses.size(),
                     ms);
@@ -203,6 +204,33 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
             }
         }
 
+    }
+
+    private void warnAboutDeprecatedJavaScriptUses() {
+        Set<String> warnedJavaScriptKeys = new LinkedHashSet<>();
+        for (Entry<String, ClassInfo> entry : visitedClasses.entrySet()) {
+            String className = entry.getKey();
+            ClassInfo classInfo = entry.getValue();
+            if (classInfo == null) {
+                continue;
+            }
+            for (String value : classInfo.scripts) {
+                if (warnedJavaScriptKeys.add(className + ':' + value)) {
+                    log().warn(
+                            "@JavaScript on {} with value \"{}\" uses the deprecated bundled interpretation. "
+                                    + "Prepend context:// for a runtime <script> tag, set type=Type.MODULE for a runtime <script type=\"module\"> tag, or migrate to @JsModule for bundling.",
+                            className, value);
+                }
+            }
+            for (String value : classInfo.scriptsDevelopmentOnly) {
+                if (warnedJavaScriptKeys.add(className + ':' + value)) {
+                    log().warn(
+                            "@JavaScript on {} with value \"{}\" uses the deprecated bundled interpretation. "
+                                    + "Prepend context:// for a runtime <script> tag, set type=Type.MODULE for a runtime <script type=\"module\"> tag, or migrate to @JsModule for bundling.",
+                            className, value);
+                }
+            }
+        }
     }
 
     Set<String> collectReachableClasses(EntryPointData entryPointData) {

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
@@ -51,6 +51,7 @@ import com.vaadin.flow.server.frontend.scanner.samples.MyServiceListener;
 import com.vaadin.flow.server.frontend.scanner.samples.MyUIInitListener;
 import com.vaadin.flow.server.frontend.scanner.samples.RouteComponent;
 import com.vaadin.flow.server.frontend.scanner.samples.RouteComponentWithMethodReference;
+import com.vaadin.flow.server.frontend.scanner.samples.RuntimeJavaScriptComponent;
 import com.vaadin.flow.theme.AbstractTheme;
 import com.vaadin.flow.theme.Theme;
 import com.vaadin.flow.theme.ThemeDefinition;
@@ -96,6 +97,16 @@ class FrontendDependenciesTest {
 
         DepsTests.assertImportsExcludingUI(dependencies.getModules(), "foo.js");
         DepsTests.assertImports(dependencies.getScripts(), "bar.js");
+    }
+
+    @Test
+    void javaScriptWithTypeModule_excludedFromBundleImports() {
+        Mockito.when(classFinder.getAnnotatedClasses(Route.class)).thenReturn(
+                Collections.singleton(RuntimeJavaScriptComponent.class));
+        FrontendDependencies dependencies = new FrontendDependencies(
+                classFinder, false, null, true);
+
+        DepsTests.assertImports(dependencies.getScripts(), "bundled.js");
     }
 
     @Test

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
@@ -100,7 +100,7 @@ class FrontendDependenciesTest {
     }
 
     @Test
-    void javaScriptWithTypeModule_excludedFromBundleImports() {
+    void javaScriptWithRuntimePrefixOrTypeModule_excludedFromBundleImports() {
         Mockito.when(classFinder.getAnnotatedClasses(Route.class)).thenReturn(
                 Collections.singleton(RuntimeJavaScriptComponent.class));
         FrontendDependencies dependencies = new FrontendDependencies(

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/scanner/samples/RuntimeJavaScriptComponent.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/scanner/samples/RuntimeJavaScriptComponent.java
@@ -21,6 +21,9 @@ import com.vaadin.flow.router.Route;
 
 @Route("runtime-js")
 @JavaScript("bundled.js")
+@JavaScript("context://runtime.js")
+@JavaScript("/absolute.js")
+@JavaScript("base://servlet-relative.js")
 @JavaScript(value = "module-runtime.js", type = JavaScript.Type.MODULE)
 public class RuntimeJavaScriptComponent extends Component {
 }

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/scanner/samples/RuntimeJavaScriptComponent.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/scanner/samples/RuntimeJavaScriptComponent.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.frontend.scanner.samples;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.dependency.JavaScript;
+import com.vaadin.flow.router.Route;
+
+@Route("runtime-js")
+@JavaScript("bundled.js")
+@JavaScript(value = "module-runtime.js", type = JavaScript.Type.MODULE)
+public class RuntimeJavaScriptComponent extends Component {
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/dependency/JavaScript.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/dependency/JavaScript.java
@@ -85,6 +85,27 @@ import com.vaadin.flow.shared.ui.LoadMode;
 public @interface JavaScript {
 
     /**
+     * The kind of {@code <script>} tag to render for the dependency.
+     */
+    enum Type {
+        /**
+         * Render a classic {@code <script>} tag. Functions declared in the
+         * loaded file become available in the global scope.
+         */
+        SCRIPT,
+        /**
+         * Render a {@code <script type="module">} tag. The loaded file is
+         * treated as an ES module: functions and variables declared in it are
+         * private to the module unless explicitly exported. The file is loaded
+         * at runtime and is not bundled, even when the URL is a bare relative
+         * path. Use this for hand-authored or CDN-hosted modules that should
+         * not go through Vite. For build-time bundled ES modules use
+         * {@link JsModule} instead.
+         */
+        MODULE
+    }
+
+    /**
      * JavaScript file URL to load before using the annotated {@link Component}
      * in the browser.
      * <p>
@@ -99,10 +120,27 @@ public @interface JavaScript {
      * frontend directory. Such URLs are not bundled but included into the page
      * as standalone scripts in the same way as it's done by
      * {@link Page#addJavaScript(String)}.
+     * <p>
+     * When {@link #type()} is {@link Type#MODULE}, the value is loaded at
+     * runtime regardless of whether it has a URL prefix; bare relative paths
+     * are normalized to {@code context://<value>} and served as static
+     * resources by the servlet container.
      *
      * @return a JavaScript file URL
      */
     String value();
+
+    /**
+     * The kind of {@code <script>} tag to use when loading the file. Defaults
+     * to {@link Type#SCRIPT} (a classic {@code <script>} element). Set to
+     * {@link Type#MODULE} to render a {@code <script type="module">} element
+     * instead, e.g. for hand-authored or CDN-hosted ES modules that should not
+     * go through Vite. For build-time bundled ES modules use {@link JsModule}
+     * instead.
+     *
+     * @return the kind of script tag to render
+     */
+    Type type() default Type.SCRIPT;
 
     /**
      * Defines if the JavaScript should be loaded only when running in

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -97,6 +97,7 @@ import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.communication.PushConnection;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.shared.communication.PushMode;
+import com.vaadin.flow.shared.ui.LoadMode;
 import com.vaadin.flow.signals.Signal;
 import com.vaadin.flow.signals.local.ValueSignal;
 
@@ -1241,12 +1242,24 @@ public class UIInternals implements Serializable {
 
     private void addExternalDependencies(DependencyInfo dependency) {
         Page page = ui.getPage();
-        dependency.getJavaScripts().stream()
-                .filter(js -> UrlUtil.isExternal(js.value()))
-                .forEach(js -> page.addJavaScript(js.value(), js.loadMode()));
+        dependency.getJavaScripts().stream().filter(this::isRuntimeJavaScript)
+                .forEach(js -> {
+                    String resolved = FrontendDependencyUrlResolver
+                            .resolveToContextRoot(js.value());
+                    if (resolved == null) {
+                        return;
+                    }
+                    page.addJavaScript(resolved, js.loadMode(), js.type());
+                });
         dependency.getJsModules().stream()
                 .filter(js -> UrlUtil.isExternal(js.value()))
-                .forEach(js -> page.addJsModule(js.value()));
+                .forEach(js -> page.addJavaScript(js.value(), LoadMode.EAGER,
+                        JavaScript.Type.MODULE));
+    }
+
+    private boolean isRuntimeJavaScript(JavaScript js) {
+        return js.type() == JavaScript.Type.MODULE
+                || UrlUtil.isExternal(js.value());
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -1210,7 +1210,7 @@ public class UIInternals implements Serializable {
 
         List<String> jsDeps = new ArrayList<>();
         jsDeps.addAll(dependencies.getJavaScripts().stream()
-                .map(dep -> dep.value()).filter(src -> !UrlUtil.isExternal(src))
+                .filter(js -> !isRuntimeJavaScript(js)).map(dep -> dep.value())
                 .collect(Collectors.toList()));
         jsDeps.addAll(dependencies.getJsModules().stream()
                 .map(dep -> dep.value()).filter(src -> !UrlUtil.isExternal(src))
@@ -1259,7 +1259,8 @@ public class UIInternals implements Serializable {
 
     private boolean isRuntimeJavaScript(JavaScript js) {
         return js.type() == JavaScript.Type.MODULE
-                || UrlUtil.isExternal(js.value());
+                || FrontendDependencyUrlResolver
+                        .isRuntimeDependencyUrl(js.value());
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -271,7 +271,42 @@ public class Page implements Serializable {
      *            details
      */
     public void addJavaScript(String url, LoadMode loadMode) {
-        addDependency(new Dependency(Type.JAVASCRIPT, url, loadMode));
+        addJavaScript(url, loadMode, JavaScript.Type.SCRIPT);
+    }
+
+    /**
+     * Adds the given JavaScript to the page and ensures that it is loaded
+     * successfully.
+     * <p>
+     * Relative URLs are interpreted as relative to the static web resources
+     * directory. You can prefix the URL with {@code context://} to make it
+     * relative to the context path or use an absolute URL to refer to files
+     * outside the frontend directory.
+     * <p>
+     * The {@code type} parameter selects the kind of {@code <script>} tag the
+     * browser receives: {@link JavaScript.Type#SCRIPT} renders a classic
+     * {@code <script>} element (the default of {@link #addJavaScript(String)});
+     * {@link JavaScript.Type#MODULE} renders a {@code <script type="module">}
+     * element, which is the recommended way to load runtime ES modules
+     * (replaces the deprecated {@link #addJsModule(String)}).
+     * <p>
+     * For component related JavaScript dependencies, you should use the
+     * {@link JavaScript @JavaScript} annotation.
+     *
+     * @param url
+     *            the URL to load the JavaScript from, not <code>null</code>
+     * @param loadMode
+     *            determines dependency load mode, refer to {@link LoadMode} for
+     *            details
+     * @param type
+     *            the kind of {@code <script>} tag to render; {@code null} is
+     *            treated as {@link JavaScript.Type#SCRIPT}
+     */
+    public void addJavaScript(String url, LoadMode loadMode,
+            JavaScript.Type type) {
+        Type dependencyType = type == JavaScript.Type.MODULE ? Type.JS_MODULE
+                : Type.JAVASCRIPT;
+        addDependency(new Dependency(dependencyType, url, loadMode));
     }
 
     /**
@@ -284,7 +319,11 @@ public class Page implements Serializable {
      * @param url
      *            the URL to load the JavaScript module from, not
      *            <code>null</code>
+     * @deprecated use {@link #addJavaScript(String, LoadMode, JavaScript.Type)}
+     *             with {@link JavaScript.Type#MODULE} instead. The new overload
+     *             also accepts a {@link LoadMode}.
      */
+    @Deprecated
     public void addJsModule(String url) {
         if (UrlUtil.isExternal(url) || url.startsWith("/")) {
             addDependency(new Dependency(Type.JS_MODULE, url, LoadMode.EAGER));

--- a/flow-server/src/main/java/com/vaadin/flow/server/FrontendDependencyUrlResolver.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/FrontendDependencyUrlResolver.java
@@ -24,12 +24,15 @@ import com.vaadin.flow.shared.ApplicationConstants;
 
 /**
  * Resolves the {@code value()} of
- * {@link com.vaadin.flow.component.dependency.StyleSheet} annotation values to
+ * {@link com.vaadin.flow.component.dependency.StyleSheet} and
+ * {@link com.vaadin.flow.component.dependency.JavaScript} annotation values to
  * a canonical form that
  * {@link com.vaadin.flow.server.BootstrapHandler.BootstrapUriResolver} can
- * expand at render time. The same rules are used whether the annotation is on
- * an {@link com.vaadin.flow.component.page.AppShellConfigurator} or on an
- * ordinary {@link com.vaadin.flow.component.Component}.
+ * expand at render time.
+ * <p>
+ * The same rules are used whether the annotation is on an
+ * {@link com.vaadin.flow.component.page.AppShellConfigurator} or on an ordinary
+ * {@link com.vaadin.flow.component.Component}.
  * <p>
  * For internal framework use only.
  */
@@ -91,5 +94,35 @@ public final class FrontendDependencyUrlResolver implements Serializable {
             return value;
         }
         return ApplicationConstants.CONTEXT_PROTOCOL_PREFIX + value;
+    }
+
+    /**
+     * Tells whether the given value is a runtime-loaded URL — i.e. should be
+     * served by the servlet container at runtime rather than passed to the
+     * frontend bundler.
+     * <p>
+     * Returns {@code true} for values starting with any of: {@code http://},
+     * {@code https://}, {@code //}, {@code context://}, {@code base://}, or
+     * {@code /}. Returns {@code false} for {@code null}, blank, or any other
+     * value (e.g. bare relative paths and bundler import specifiers).
+     *
+     * @param value
+     *            the raw annotation value
+     * @return {@code true} if the value is a runtime URL
+     */
+    public static boolean isRuntimeDependencyUrl(String value) {
+        if (value == null || value.isBlank()) {
+            return false;
+        }
+        String trimmed = value.trim();
+        if (trimmed.startsWith("/")) {
+            return true;
+        }
+        String lower = trimmed.toLowerCase();
+        return lower.startsWith("http://") || lower.startsWith("https://")
+                || lower.startsWith("//")
+                || lower.startsWith(
+                        ApplicationConstants.CONTEXT_PROTOCOL_PREFIX)
+                || lower.startsWith(ApplicationConstants.BASE_PROTOCOL_PREFIX);
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/FrontendDependencyUrlResolverTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/FrontendDependencyUrlResolverTest.java
@@ -82,4 +82,42 @@ public class FrontendDependencyUrlResolverTest {
         Assert.assertEquals("context://foo.css", FrontendDependencyUrlResolver
                 .resolveToContextRoot("  foo.css  "));
     }
+
+    @Test
+    public void isRuntimeDependencyUrl_runtimePrefixes_true() {
+        Assert.assertTrue(FrontendDependencyUrlResolver
+                .isRuntimeDependencyUrl("context://foo.js"));
+        Assert.assertTrue(FrontendDependencyUrlResolver
+                .isRuntimeDependencyUrl("base://foo.js"));
+        Assert.assertTrue(FrontendDependencyUrlResolver
+                .isRuntimeDependencyUrl("http://cdn/foo.js"));
+        Assert.assertTrue(FrontendDependencyUrlResolver
+                .isRuntimeDependencyUrl("https://cdn/foo.js"));
+        Assert.assertTrue(FrontendDependencyUrlResolver
+                .isRuntimeDependencyUrl("//cdn/foo.js"));
+        Assert.assertTrue(FrontendDependencyUrlResolver
+                .isRuntimeDependencyUrl("/assets/foo.js"));
+    }
+
+    @Test
+    public void isRuntimeDependencyUrl_bareRelativeOrBundlerSpecifier_false() {
+        Assert.assertFalse(
+                FrontendDependencyUrlResolver.isRuntimeDependencyUrl("foo.js"));
+        Assert.assertFalse(FrontendDependencyUrlResolver
+                .isRuntimeDependencyUrl("./foo.js"));
+        Assert.assertFalse(FrontendDependencyUrlResolver
+                .isRuntimeDependencyUrl("../foo.js"));
+        Assert.assertFalse(FrontendDependencyUrlResolver
+                .isRuntimeDependencyUrl("@scope/pkg/foo.js"));
+    }
+
+    @Test
+    public void isRuntimeDependencyUrl_nullOrBlank_false() {
+        Assert.assertFalse(
+                FrontendDependencyUrlResolver.isRuntimeDependencyUrl(null));
+        Assert.assertFalse(
+                FrontendDependencyUrlResolver.isRuntimeDependencyUrl(""));
+        Assert.assertFalse(
+                FrontendDependencyUrlResolver.isRuntimeDependencyUrl("   "));
+    }
 }


### PR DESCRIPTION
@JavaScript values with a runtime prefix (context://, base://, /abs, http(s)://, //) are now served as runtime <script> elements rather than bundled, matching how the corresponding @StyleSheet values are resolved.

- New FrontendDependencyUrlResolver.isRuntimeDependencyUrl recognises the runtime prefix table (http(s)://, //, context://, base://, /abs) and is the single source of truth for distinguishing runtime URLs from bundler import specifiers.
- UIInternals treats such @JavaScript values as runtime dependencies via isRuntimeJavaScript, alongside type=MODULE values.
- The scanner (FrontendClassVisitor) filters runtime-prefixed @JavaScript values out of the bundle imports.
- Bare-relative @JavaScript values still bundle for backwards compatibility but FrontendDependencies emits a one-time consolidated build-time warning per (class, value) recommending migration.
