### PR TITLE
feat(clipboard): add browserless-testing seam (ClipboardClient port)

### DIFF
--- a/clipboard-seam-spec.md
+++ b/clipboard-seam-spec.md
@@ -1,0 +1,301 @@
+# Clipboard browserless-testing seam — flow-side spec
+
+Design for the **flow-side SPI seam** that issue
+[#64](https://github.com/vaadin/browserless-test/issues/64) needs before the
+`browserless-test` simulator can be built. Modeled on the Geolocation seam
+(`GeolocationClient` / `GeolocationClientFactory`, flow PR #24259) that already
+ships in `flow-server`.
+
+> **Status:** the seam does **not** exist yet. This spec is the prerequisite
+> flow PR. Once it lands in a `25.x-SNAPSHOT`, the browserless side (§4) follows
+> the Geolocation pattern mechanically.
+
+---
+
+## 1. Why the original issue can't be implemented as written
+
+Issue #64 is a **stale proposal**. Two facts block a literal implementation:
+
+1. **No SPI seam exists.** `flow-server:25.2-SNAPSHOT` has the clipboard feature
+   classes but **no `ClipboardClient`, no `ClipboardClientFactory`**, and
+   `UIInternals` carries **no clipboard hooks** (it has the geolocation ones:
+   `getGeolocationClient` / `setGeolocationClient` /
+   `getGeolocationAvailabilitySignal`). The `Clipboard` facade resolves nothing
+   from `Lookup` — it talks straight to the DOM via triggers and listeners, so
+   there is nothing for a test client to replace.
+
+2. **The proposed API never shipped.** The issue describes `copyOnClick(...)`,
+   `ClipboardCopy`, `registerCopyText`, `PasteState`, `ClipboardAvailability`.
+   The API that actually shipped is different:
+
+   ```java
+   // com.vaadin.flow.component.clipboard.Clipboard  (25.2-SNAPSHOT)
+   static <T extends Component & ClickNotifier<?>> ClipboardBinding onClick(T trigger);
+   static Registration onPaste(Component target, SerializableConsumer<PasteEvent> listener);
+   static Registration onPaste(Component target, PasteOptions options,
+                               SerializableConsumer<PasteEvent> listener);
+   static Registration onFilePaste(Component target, UploadHandler uploadHandler);
+   ```
+
+   `ClipboardBinding` (returned by `onClick`) is where copy/read live:
+
+   ```java
+   void writeText(String);                                  // + (value, onSuccess, onError) overloads
+   <C extends Component & HasValue<?,String>> void writeText(C source);
+   void writeHtml(String);
+   void writeImage(Component);                               // + DownloadHandler overload
+   void write(ClipboardContent);
+   void read(SerializableConsumer<ClipboardPayload>, SerializableConsumer<PromiseAction.Error>);
+   void readText(SerializableConsumer<String>, SerializableConsumer<PromiseAction.Error>);
+   void readHtml(SerializableConsumer<String>, SerializableConsumer<PromiseAction.Error>);
+   ```
+
+So this spec **re-derives the seam against the real API**, keeping the
+Geolocation resolution mechanics 1:1.
+
+### Dropped from the original issue
+
+- **Affordance #3 "query/override availability."** There is no
+  `ClipboardAvailability` type and no clipboard availability signal in
+  `UIInternals`. Clipboard isn't a permissioned async sensor like geolocation;
+  its reads/writes are click-gated `Promise`s whose rejection (e.g. denied
+  permission, insecure context) surfaces through the existing `onError`
+  callback. **No availability API is added.** If a future PRD wants a coarse
+  "is the Clipboard API present" hint, it should be a separate proposal.
+
+---
+
+## 2. The real wire behavior the port must abstract
+
+Lifted from the current `Clipboard` / `ClipboardBinding` implementation, so the
+port covers every production path with no behavior change:
+
+| Facade entry | Today's wire mechanism | What the port must expose |
+|---|---|---|
+| `onPaste(target, [opts], listener)` | `element.addEventListener("paste", …)` with event data `event.clipboardData?.getData('text/plain')` / `'text/html'`, `mapEventTargetElement()`, and (when `opts` excludes input fields) a `composedPath()` filter | register a paste listener keyed by element + options; deliver a `PasteEvent` |
+| `onFilePaste(target, uploadHandler)` | DOM paste listener + file upload over HTTP carrying `Clipboard.PASTE_ID_HEADER` / `PASTE_FILE_COUNT_HEADER`; bytes flow through the `UploadHandler` | register the upload handler keyed by element; feed it synthetic files |
+| `ClipboardBinding.writeText/writeHtml/writeImage/write` | `ClickTrigger` + `WriteToClipboardAction` (a `PromiseAction<String>`) bound via `trigger.bind(action)`; success/error delivered through a `ReturnChannelRegistration` | bind a write action to a trigger element; carry the value source + `onSuccess`/`onError`; allow the test to resolve the promise |
+| `ClipboardBinding.read/readText/readHtml` | `ClickTrigger` + `ReadFromClipboardAction` (a `PromiseAction<ClipboardPayload>`) | bind a read action to a trigger element; carry `onSuccess`/`onError`; allow the test to resolve with a payload/error |
+
+`PromiseAction.Error(String name, String message)` lives in
+`com.vaadin.flow.component.trigger.internal` but is already part of the public
+clipboard surface (it appears in `ClipboardBinding`'s signatures), so the port
+may reference it.
+
+---
+
+## 3. Flow changes
+
+Mirrors the Geolocation split: **PR-A** extracts the port + default impl +
+facade refactor; **PR-B** adds the `Lookup` factory. They can ship as one PR —
+Geolocation only split because of late classloader fallout, which we avoid by
+designing the seam public from the start.
+
+### 3.1 `ClipboardClient` — the port (`com.vaadin.flow.component.clipboard`)
+
+Public interface, the analogue of `GeolocationClient`. One instance per UI.
+
+```java
+public interface ClipboardClient extends Serializable {
+
+    // --- write / read, bound to a click trigger on `trigger` ---
+    WriteHandle registerWrite(Component trigger, ClipboardWrite write,
+            @Nullable SerializableConsumer<String> onSuccess,
+            @Nullable SerializableConsumer<PromiseAction.Error> onError);
+
+    ReadHandle registerRead(Component trigger, ClipboardReadKind kind,
+            SerializableConsumer<?> onSuccess,                 // String or ClipboardPayload
+            SerializableConsumer<PromiseAction.Error> onError);
+
+    // --- paste ---
+    Registration registerPaste(Component target, PasteOptions options,
+            SerializableConsumer<PasteEvent> listener);
+
+    Registration registerFilePaste(Component target, UploadHandler uploadHandler);
+
+    // --- lifecycle (parity with GeolocationClient.close()) ---
+    void close();
+
+    /** Inspect/resolve handle for a bound write action. */
+    interface WriteHandle extends Registration {
+        Element trigger();
+        ClipboardWrite write();              // text/html/image/payload descriptor
+        boolean hasSuccessCallback();
+        boolean hasErrorCallback();
+    }
+
+    /** Inspect/resolve handle for a bound read action. */
+    interface ReadHandle extends Registration {
+        Element trigger();
+        ClipboardReadKind kind();            // READ, READ_TEXT, READ_HTML
+    }
+}
+```
+
+`ClipboardWrite` is a small public descriptor capturing what
+`ClipboardBinding` builds today (a literal string, a bound `HasValue` source,
+an image component/`DownloadHandler`, or a composed `ClipboardContent`). It
+replaces the per-call `WriteToClipboardAction` construction so the value is
+inspectable without a DOM. `ClipboardReadKind` is a 3-value enum.
+
+> **Note on `ClipboardBinding`:** it becomes a thin facade over the client,
+> exactly like `Clipboard` itself. Each `writeText(...)` / `read(...)` call
+> delegates to `client.registerWrite(...)` / `client.registerRead(...)` instead
+> of constructing a `WriteToClipboardAction` and calling `trigger.bind(...)`.
+> The `WriteToClipboardAction` / `ReadFromClipboardAction` / return-channel code
+> moves into `BrowserClipboardClient` (§3.2).
+
+### 3.2 `BrowserClipboardClient` — production default (package-private)
+
+Lifts the current trigger/`PromiseAction`/`ReturnChannelRegistration` and
+`addEventListener("paste", …)` / `UploadHandler` plumbing out of `Clipboard` and
+`ClipboardBinding` and puts it behind `ClipboardClient`. **Production wire
+behavior is byte-for-byte unchanged**; `Clipboard` and `ClipboardBinding` end up
+as thin facades. This is the analogue of `BrowserGeolocationClient`.
+
+### 3.3 `ClipboardClientFactory` — the SPI (PR-B)
+
+```java
+public interface ClipboardClientFactory extends Serializable {
+    ClipboardClient create(UI ui);
+}
+```
+
+### 3.4 `Clipboard` / `ClipboardBinding` facade refactor
+
+Resolution mirrors `Geolocation.resolveClient` / `lookupFactory` exactly:
+
+```java
+static ClipboardClient client(UI ui) {
+    ClipboardClient existing = ui.getInternals().getClipboardClient();
+    if (existing != null) {
+        return existing;
+    }
+    ClipboardClientFactory factory = lookupFactory(ui);   // VaadinService → Lookup
+    ClipboardClient client = (factory != null)
+            ? factory.create(ui)
+            : new BrowserClipboardClient(ui);
+    ui.getInternals().setClipboardClient(client);
+    return client;
+}
+
+private static ClipboardClientFactory lookupFactory(UI ui) {
+    VaadinService service = ui.getSession().getService();
+    Lookup lookup = service.getContext().getAttribute(Lookup.class);
+    return lookup == null ? null : lookup.lookup(ClipboardClientFactory.class);
+}
+```
+
+Resolution happens **at first use, not at UI construction**, so a factory
+registered after UI init still takes effect (same constraint Geolocation has).
+Public facade signatures stay byte-for-byte stable.
+
+### 3.5 `UIInternals` additions
+
+Add the clipboard equivalents of the existing geolocation fields (the cache, not
+a signal — there is no availability signal):
+
+```java
+private ClipboardClient clipboardClient;
+public ClipboardClient getClipboardClient();
+public void setClipboardClient(ClipboardClient client);
+```
+
+### 3.6 In-JAR tests
+
+`ClipboardClientSeamTest` (parallel to `GeolocationClientSeamTest`):
+
+- `Clipboard` / `ClipboardBinding` resolve the client via `Lookup`.
+- A registered `ClipboardClientFactory` overrides the default.
+- Without a factory the fallback is `BrowserClipboardClient`.
+- Existing `ClipboardTest` keeps its wire-protocol assertions to pin production
+  behavior unchanged.
+
+---
+
+## 4. Downstream: `browserless-test` (after the seam lands)
+
+Drops into `shared/src/main/java/com/vaadin/flow/component/clipboard/`, 1:1 with
+the existing `…/geolocation/` package.
+
+- **`BrowserlessClipboardClient`** (package-private) — in-memory
+  `ClipboardClient`, no DOM. Registries: `List<WriteHandle>`, `List<ReadHandle>`
+  keyed by trigger element; `Map<Element, PasteRegistration>`;
+  `Map<Element, UploadHandler>`. Files arrive as `byte[]` and are pushed through
+  the `UploadHandler` with a synthetic `UploadEvent` (see open question).
+- **`BrowserlessClipboardClientFactory`** — publishes a `ClipboardSimulator` on
+  the UI via `ComponentUtil.setData(...)`, exactly like
+  `BrowserlessGeolocationClientFactory`.
+- **`MockVaadinHelper.BrowserlessLookupInitializer.additionalServices`** gains
+  one line next to the geolocation entry:
+
+  ```kotlin
+  ClipboardClientFactory::class to BrowserlessClipboardClientFactory::class
+  ```
+
+- **`ClipboardSimulator`** (public test API), obtained via `current()` /
+  `forUI(UI)`:
+
+  ```java
+  // copy / write (PRD affordance #1)
+  List<CopyHandleInspection> activeWriteHandles();
+  void simulateClick(Component trigger);          // fires the bound write/read promise
+  void simulateWriteSuccess(Component trigger);
+  void simulateWriteError(Component trigger, String name, String message);
+
+  // read
+  void simulateReadResult(Component trigger, String text, @Nullable String html);
+  void simulateReadError(Component trigger, String name, String message);
+
+  // paste (PRD affordance #2)
+  List<PasteSessionInspection> activePasteSessions();
+  PasteBuilder pasteInto(Component target);       // .text(..).html(..).file(name,mime,bytes).simulate()
+  ```
+
+  `PasteBuilder.simulate()` runs the production dispatch order: deliver the
+  `PasteEvent` to `onPaste` listeners, then run each file through the
+  `onFilePaste` `UploadHandler`, emitting the `PasteFile` records the real
+  handler would see (`PasteFileHandler.perFile` / `.batch`).
+
+- **Tests:** `ClipboardSimulatorTest` (direct controller behavior) +
+  `ClipboardFacadeIntegrationTest` (through the real `Clipboard` /
+  `ClipboardBinding` facade), parallel to the geolocation test pair.
+
+---
+
+## 5. Open questions for the flow author
+
+1. **`UploadEvent` synthesis.** Feeding `UploadHandler.handleUploadRequest`
+   outside an HTTP request needs a prototype. Cleanest fallback is a
+   package-private hook on `InMemoryUploadHandler` / `TemporaryFileUploadHandler`
+   that bypasses request plumbing — same shape as keeping
+   `Geolocation.setClient` package-private. Worth a spike before locking
+   `PasteBuilder.file(...)`.
+
+2. **`ClipboardWrite` descriptor shape.** Does the port carry a live reference to
+   a bound `HasValue` source (so `simulateClick` reads its current value, like
+   `readSourceText` does today), or snapshot at registration time? Recommend
+   **live** to match production. Decision belongs to PR-A.
+
+3. **Per-trigger action stacking.** A single `onClick` binding can register
+   multiple write/read actions over its lifetime. The simulator assumes a
+   resolvable handle per trigger; confirm whether the client keeps a stack or
+   the latest wins. Decision belongs to PR-A.
+
+4. **`PromiseAction.Error` package.** It currently lives in
+   `…trigger.internal`. It's already exposed through `ClipboardBinding`'s public
+   signatures, so the port can reference it — but the flow team may prefer to
+   promote it to a public clipboard type.
+
+---
+
+## 6. PR sequence
+
+1. **flow PR-A** — `ClipboardClient` port, `BrowserClipboardClient` default,
+   `Clipboard` + `ClipboardBinding` facade refactor, `UIInternals` cache. No
+   behavior change.
+2. **flow PR-B** — `ClipboardClientFactory` + `Lookup` resolution (mergeable
+   into PR-A).
+3. **browserless-test PR** (§4) — depends on a `25.x-SNAPSHOT` carrying PR-A+B.
+</content>
+</invoke>

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/BrowserClipboardClient.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/BrowserClipboardClient.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.clipboard;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.jspecify.annotations.Nullable;
+import tools.jackson.databind.JsonNode;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.trigger.internal.ClickTrigger;
+import com.vaadin.flow.component.trigger.internal.PromiseAction;
+import com.vaadin.flow.component.trigger.internal.ReadFromClipboardAction;
+import com.vaadin.flow.component.trigger.internal.WriteToClipboardAction;
+import com.vaadin.flow.dom.DomListenerRegistration;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.server.streams.UploadHandler;
+import com.vaadin.flow.shared.Registration;
+
+/**
+ * {@link ClipboardClient} implementation backed by the real browser Clipboard
+ * API. It performs writes/reads by binding a {@code click} trigger that runs
+ * the matching {@code window.Vaadin.Flow.clipboard} helper, and handles pastes
+ * via native {@code paste} DOM listeners and per-paste file uploads. This is
+ * the default implementation used when no {@link ClipboardClientFactory} is
+ * registered through {@link com.vaadin.flow.di.Lookup Lookup}.
+ * <p>
+ * The production wire behavior lives here, unchanged from when it lived
+ * directly in {@link Clipboard} and {@link ClipboardBinding}; those classes are
+ * now thin facades that resolve this client and delegate to it.
+ * <p>
+ * <b>Framework internal.</b> Application code does not reference this class
+ * directly.
+ */
+final class BrowserClipboardClient implements ClipboardClient {
+
+    // The same string is used both as the JS expression evaluated client-side
+    // and as the lookup key in DomEvent#getEventData() server-side. Any drift
+    // between the two would silently produce a null value, so the expressions
+    // are kept in a single constant each. `?.` guards against synthetic events
+    // without a DataTransfer; `|| null` collapses the empty string (the
+    // browser's value for an absent MIME type) and the optional-chain
+    // short-circuit into JSON null.
+    private static final String PASTE_TEXT_EXPR = "event.clipboardData?.getData('text/plain') || null";
+    private static final String PASTE_HTML_EXPR = "event.clipboardData?.getData('text/html') || null";
+
+    // Walks event.composedPath() so the check sees through open shadow DOMs
+    // (e.g. a Vaadin web component's internal <input>). Matches input,
+    // textarea, or anything with isContentEditable; the filter passes only
+    // when none of those are in the path.
+    private static final String PASTE_FILTER_SKIP_EDITABLE = "!event.composedPath().some(function(e){"
+            + "return e.tagName&&(e.tagName==='INPUT'||e.tagName==='TEXTAREA'||e.isContentEditable===true);})";
+
+    // DOM event the client paste-upload helper dispatches once every upload of
+    // a paste has settled. A server-side listener for it (registered in
+    // registerFilePaste) does nothing but force a Flow round trip, which
+    // flushes the UI changes the per-file UploadHandler queued via UI.access —
+    // so onFilePaste updates reach the client without @Push. Must stay in sync
+    // with the literal dispatched in flow-client/Clipboard.ts.
+    private static final String FILE_PASTE_FINISHED_EVENT = "vaadin-paste-upload-finished";
+
+    @SuppressWarnings("unused")
+    private final UI ui;
+    private final List<Registration> registrations = new ArrayList<>();
+    private boolean closed;
+
+    BrowserClipboardClient(UI ui) {
+        this.ui = ui;
+    }
+
+    @Override
+    public WriteHandle registerWrite(Component trigger, ClipboardWrite write,
+            @Nullable SerializableConsumer<@Nullable String> onSuccess,
+            @Nullable SerializableConsumer<PromiseAction.Error> onError) {
+        ClickTrigger clickTrigger = new ClickTrigger(trigger);
+        // The facade passes both callbacks or neither: both present means an
+        // observed write, neither means fire-and-forget.
+        WriteToClipboardAction action;
+        if (onSuccess != null && onError != null) {
+            action = new WriteToClipboardAction(write.textInput(),
+                    write.htmlInput(), write.imageInput(), onSuccess, onError);
+        } else {
+            action = new WriteToClipboardAction(write.textInput(),
+                    write.htmlInput(), write.imageInput());
+        }
+        clickTrigger.triggers(action);
+        BrowserWriteHandle handle = new BrowserWriteHandle(clickTrigger,
+                trigger.getElement(), write, onSuccess != null,
+                onError != null);
+        registrations.add(handle);
+        return handle;
+    }
+
+    @Override
+    public ReadHandle registerRead(Component trigger, ClipboardReadKind kind,
+            SerializableConsumer<@Nullable ClipboardPayload> onSuccess,
+            SerializableConsumer<PromiseAction.Error> onError) {
+        ClickTrigger clickTrigger = new ClickTrigger(trigger);
+        clickTrigger.triggers(new ReadFromClipboardAction(onSuccess, onError));
+        BrowserReadHandle handle = new BrowserReadHandle(clickTrigger,
+                trigger.getElement(), kind);
+        registrations.add(handle);
+        return handle;
+    }
+
+    @Override
+    public Registration registerPaste(Component target, PasteOptions options,
+            SerializableConsumer<PasteEvent> listener) {
+        Element host = target.getElement();
+        DomListenerRegistration registration = host.addEventListener("paste",
+                domEvent -> {
+                    JsonNode data = domEvent.getEventData();
+                    // mapEventTargetElement() does the DOM ancestor walk in
+                    // the browser to find the closest Flow-tracked element to
+                    // event.target. That gives DOM-truth (not state-tree
+                    // order, which can diverge from DOM for virtual children,
+                    // slotted content, etc.).
+                    Element targetElement = domEvent.getEventTarget()
+                            .orElse(null);
+                    // The JS `|| null` already collapses "" and missing MIME
+                    // types to JSON null; asStringOpt() then yields empty for
+                    // those, so callers see null (not "").
+                    listener.accept(new PasteEvent(target,
+                            data.optional(PASTE_TEXT_EXPR)
+                                    .flatMap(JsonNode::asStringOpt)
+                                    .orElse(null),
+                            data.optional(PASTE_HTML_EXPR)
+                                    .flatMap(JsonNode::asStringOpt)
+                                    .orElse(null),
+                            targetElement));
+                });
+        registration.addEventData(PASTE_TEXT_EXPR);
+        registration.addEventData(PASTE_HTML_EXPR);
+        registration.mapEventTargetElement();
+        if (!options.includeInputFieldPastes()) {
+            registration.setFilter(PASTE_FILTER_SKIP_EDITABLE);
+        }
+        Registration result = registration::remove;
+        registrations.add(result);
+        return result;
+    }
+
+    @Override
+    public Registration registerFilePaste(Component target,
+            UploadHandler uploadHandler) {
+        Element element = target.getElement();
+        // setAttribute(name, ElementRequestHandler) registers the handler as a
+        // stream resource and stores its URL as the attribute value. A fresh
+        // UUID scopes the slot per-registration (the same approach as
+        // StreamResource) so multiple file-paste listeners on the same element
+        // resolve to independent upload URLs.
+        String attributeName = "_vaadin-paste-upload-" + UUID.randomUUID();
+        element.setAttribute(attributeName, uploadHandler);
+
+        // Attach a native paste listener in the browser via the TS helper
+        // window.Vaadin.Flow.clipboard.uploadPastedFiles (defined in
+        // flow-client/Clipboard.ts, registered at bootstrap). On each paste the
+        // helper reads the upload URL from the per-registration attribute and
+        // POSTs one upload per file. addJsInitializer re-runs the install on a
+        // real re-attach and invokes the returned cleanup (removeEventListener)
+        // when the registration is removed or the client DOM node is discarded.
+        Registration jsRegistration = element.addJsInitializer("""
+                const upload = (event) => window.Vaadin.Flow.clipboard
+                        .uploadPastedFiles(event, this, $0);
+                this.addEventListener('paste', upload);
+                return () => this.removeEventListener('paste', upload);""",
+                attributeName);
+
+        // Once the helper has finished POSTing a paste's files it dispatches
+        // FILE_PASTE_FINISHED_EVENT on the element. This listener does nothing
+        // on its own — its sole purpose is to make the browser perform a Flow
+        // round trip, which flushes the UI changes the UploadHandler queued via
+        // UI.access while handling each upload. Without it those changes would
+        // sit on the server until the next round trip, which is why the API
+        // would otherwise need @Push.
+        DomListenerRegistration finishedRegistration = element
+                .addEventListener(FILE_PASTE_FINISHED_EVENT, domEvent -> {
+                    // intentionally empty; see comment above
+                });
+
+        Registration result = () -> {
+            jsRegistration.remove();
+            finishedRegistration.remove();
+            element.removeAttribute(attributeName);
+        };
+        registrations.add(result);
+        return result;
+    }
+
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        // Copy first: a handle's remove() also removes itself from the list.
+        for (Registration registration : new ArrayList<>(registrations)) {
+            registration.remove();
+        }
+        registrations.clear();
+    }
+
+    private final class BrowserWriteHandle implements WriteHandle {
+        private final ClickTrigger trigger;
+        private final Element triggerElement;
+        private final ClipboardWrite write;
+        private final boolean hasSuccessCallback;
+        private final boolean hasErrorCallback;
+
+        BrowserWriteHandle(ClickTrigger trigger, Element triggerElement,
+                ClipboardWrite write, boolean hasSuccessCallback,
+                boolean hasErrorCallback) {
+            this.trigger = trigger;
+            this.triggerElement = triggerElement;
+            this.write = write;
+            this.hasSuccessCallback = hasSuccessCallback;
+            this.hasErrorCallback = hasErrorCallback;
+        }
+
+        @Override
+        public Element trigger() {
+            return triggerElement;
+        }
+
+        @Override
+        public ClipboardWrite write() {
+            return write;
+        }
+
+        @Override
+        public boolean hasSuccessCallback() {
+            return hasSuccessCallback;
+        }
+
+        @Override
+        public boolean hasErrorCallback() {
+            return hasErrorCallback;
+        }
+
+        @Override
+        public void remove() {
+            trigger.remove();
+            registrations.remove(this);
+        }
+    }
+
+    private final class BrowserReadHandle implements ReadHandle {
+        private final ClickTrigger trigger;
+        private final Element triggerElement;
+        private final ClipboardReadKind kind;
+
+        BrowserReadHandle(ClickTrigger trigger, Element triggerElement,
+                ClipboardReadKind kind) {
+            this.trigger = trigger;
+            this.triggerElement = triggerElement;
+            this.kind = kind;
+        }
+
+        @Override
+        public Element trigger() {
+            return triggerElement;
+        }
+
+        @Override
+        public ClipboardReadKind kind() {
+            return kind;
+        }
+
+        @Override
+        public void remove() {
+            trigger.remove();
+            registrations.remove(this);
+        }
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/Clipboard.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/Clipboard.java
@@ -17,16 +17,16 @@ package com.vaadin.flow.component.clipboard;
 
 import java.io.Serializable;
 import java.util.Objects;
-import java.util.UUID;
 
-import tools.jackson.databind.JsonNode;
+import org.jspecify.annotations.Nullable;
 
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.trigger.internal.ClickTrigger;
-import com.vaadin.flow.dom.DomListenerRegistration;
-import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.server.VaadinContext;
+import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.streams.UploadHandler;
 import com.vaadin.flow.shared.Registration;
 
@@ -79,31 +79,6 @@ import com.vaadin.flow.shared.Registration;
  */
 public final class Clipboard implements Serializable {
 
-    // The same string is used both as the JS expression evaluated client-side
-    // and as the lookup key in DomEvent#getEventData() server-side. Any drift
-    // between the two would silently produce a null value, so the expressions
-    // are kept in a single constant each. `?.` guards against synthetic events
-    // without a DataTransfer; `|| null` collapses the empty string (the
-    // browser's value for an absent MIME type) and the optional-chain
-    // short-circuit into JSON null.
-    private static final String PASTE_TEXT_EXPR = "event.clipboardData?.getData('text/plain') || null";
-    private static final String PASTE_HTML_EXPR = "event.clipboardData?.getData('text/html') || null";
-
-    // Walks event.composedPath() so the check sees through open shadow DOMs
-    // (e.g. a Vaadin web component's internal <input>). Matches input,
-    // textarea, or anything with isContentEditable; the filter passes only
-    // when none of those are in the path.
-    private static final String PASTE_FILTER_SKIP_EDITABLE = "!event.composedPath().some(function(e){"
-            + "return e.tagName&&(e.tagName==='INPUT'||e.tagName==='TEXTAREA'||e.isContentEditable===true);})";
-
-    // DOM event the client paste-upload helper dispatches once every upload of
-    // a paste has settled. A server-side listener for it (registered in
-    // registerFilePaste) does nothing but force a Flow round trip, which
-    // flushes the UI changes the per-file UploadHandler queued via UI.access —
-    // so onFilePaste updates reach the client without @Push. Must stay in sync
-    // with the literal dispatched in flow-client/Clipboard.ts.
-    private static final String FILE_PASTE_FINISHED_EVENT = "vaadin-paste-upload-finished";
-
     /**
      * Request header set by the client-side paste-upload helper on every fetch
      * POST that originates from a paste gesture. The value is a monotonically
@@ -149,7 +124,7 @@ public final class Clipboard implements Serializable {
     public static <T extends Component & ClickNotifier<?>> ClipboardBinding onClick(
             T component) {
         Objects.requireNonNull(component, "component must not be null");
-        return new ClipboardBinding(new ClickTrigger(component));
+        return new ClipboardBinding(component);
     }
 
     /**
@@ -230,7 +205,7 @@ public final class Clipboard implements Serializable {
         Objects.requireNonNull(component, "component must not be null");
         Objects.requireNonNull(options, "options must not be null");
         Objects.requireNonNull(listener, "listener must not be null");
-        return register(component, options, listener);
+        return client(component).registerPaste(component, options, listener);
     }
 
     /**
@@ -285,83 +260,56 @@ public final class Clipboard implements Serializable {
             UploadHandler handler) {
         Objects.requireNonNull(component, "component must not be null");
         Objects.requireNonNull(handler, "handler must not be null");
-        return registerFilePaste(component, handler);
+        return client(component).registerFilePaste(component, handler);
     }
 
-    private static Registration register(Component host, PasteOptions options,
-            SerializableConsumer<PasteEvent> listener) {
-        DomListenerRegistration registration = host.getElement()
-                .addEventListener("paste", domEvent -> {
-                    JsonNode data = domEvent.getEventData();
-                    // mapEventTargetElement() does the DOM ancestor walk in
-                    // the browser to find the closest Flow-tracked element to
-                    // event.target. That gives DOM-truth (not state-tree
-                    // order, which can diverge from DOM for virtual children,
-                    // slotted content, etc.).
-                    Element targetElement = domEvent.getEventTarget()
-                            .orElse(null);
-                    // The JS `|| null` already collapses "" and missing MIME
-                    // types to JSON null; asStringOpt() then yields empty for
-                    // those, so callers see null (not "").
-                    listener.accept(new PasteEvent(host,
-                            data.optional(PASTE_TEXT_EXPR)
-                                    .flatMap(JsonNode::asStringOpt)
-                                    .orElse(null),
-                            data.optional(PASTE_HTML_EXPR)
-                                    .flatMap(JsonNode::asStringOpt)
-                                    .orElse(null),
-                            targetElement));
-                });
-        registration.addEventData(PASTE_TEXT_EXPR);
-        registration.addEventData(PASTE_HTML_EXPR);
-        registration.mapEventTargetElement();
-        if (!options.includeInputFieldPastes()) {
-            registration.setFilter(PASTE_FILTER_SKIP_EDITABLE);
+    /**
+     * Resolves the {@link ClipboardClient} for the UI the given component
+     * belongs to, installing the default browser-backed client (or a
+     * {@link ClipboardClientFactory}-produced one) on first use. The UI is
+     * taken from the component, falling back to {@link UI#getCurrent()} for
+     * components that are not yet attached.
+     */
+    static ClipboardClient client(Component component) {
+        UI ui = component.getUI().orElseGet(UI::getCurrent);
+        if (ui == null) {
+            throw new IllegalStateException(
+                    "Cannot resolve a UI for the clipboard operation: the "
+                            + "component is not attached and there is no current "
+                            + "UI. Call this from the UI thread, or attach the "
+                            + "component first.");
         }
-        return registration::remove;
+        return client(ui);
     }
 
-    private static Registration registerFilePaste(Component host,
-            UploadHandler handler) {
-        Element element = host.getElement();
-        // setAttribute(name, ElementRequestHandler) registers the handler as a
-        // stream resource and stores its URL as the attribute value. A fresh
-        // UUID scopes the slot per-registration (the same approach as
-        // StreamResource) so multiple file-paste listeners on the same element
-        // resolve to independent upload URLs.
-        String attributeName = "_vaadin-paste-upload-" + UUID.randomUUID();
-        element.setAttribute(attributeName, handler);
+    static ClipboardClient client(UI ui) {
+        ClipboardClient existing = ui.getInternals().getClipboardClient();
+        if (existing != null) {
+            return existing;
+        }
+        ClipboardClientFactory factory = lookupFactory(ui);
+        ClipboardClient client = factory != null ? factory.create(ui)
+                : new BrowserClipboardClient(ui);
+        ui.getInternals().setClipboardClient(client);
+        return client;
+    }
 
-        // Attach a native paste listener in the browser via the TS helper
-        // window.Vaadin.Flow.clipboard.uploadPastedFiles (defined in
-        // flow-client/Clipboard.ts, registered at bootstrap). On each paste the
-        // helper reads the upload URL from the per-registration attribute and
-        // POSTs one upload per file. addJsInitializer re-runs the install on a
-        // real re-attach and invokes the returned cleanup (removeEventListener)
-        // when the registration is removed or the client DOM node is discarded.
-        Registration jsRegistration = element.addJsInitializer("""
-                const upload = (event) => window.Vaadin.Flow.clipboard
-                        .uploadPastedFiles(event, this, $0);
-                this.addEventListener('paste', upload);
-                return () => this.removeEventListener('paste', upload);""",
-                attributeName);
-
-        // Once the helper has finished POSTing a paste's files it dispatches
-        // FILE_PASTE_FINISHED_EVENT on the element. This listener does nothing
-        // on its own — its sole purpose is to make the browser perform a Flow
-        // round trip, which flushes the UI changes the UploadHandler queued via
-        // UI.access while handling each upload. Without it those changes would
-        // sit on the server until the next round trip, which is why the API
-        // would otherwise need @Push.
-        DomListenerRegistration finishedRegistration = element
-                .addEventListener(FILE_PASTE_FINISHED_EVENT, domEvent -> {
-                    // intentionally empty; see comment above
-                });
-
-        return () -> {
-            jsRegistration.remove();
-            finishedRegistration.remove();
-            element.removeAttribute(attributeName);
-        };
+    private static @Nullable ClipboardClientFactory lookupFactory(UI ui) {
+        VaadinService service = VaadinService.getCurrent();
+        if (service == null && ui.getSession() != null) {
+            service = ui.getSession().getService();
+        }
+        if (service == null) {
+            return null;
+        }
+        VaadinContext context = service.getContext();
+        if (context == null) {
+            return null;
+        }
+        Lookup lookup = context.getAttribute(Lookup.class);
+        if (lookup == null) {
+            return null;
+        }
+        return lookup.lookup(ClipboardClientFactory.class);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/ClipboardBinding.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/ClipboardBinding.java
@@ -23,14 +23,8 @@ import org.jspecify.annotations.Nullable;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.trigger.internal.Action;
 import com.vaadin.flow.component.trigger.internal.ImageBlobInput;
-import com.vaadin.flow.component.trigger.internal.LiteralInput;
 import com.vaadin.flow.component.trigger.internal.PromiseAction.Error;
-import com.vaadin.flow.component.trigger.internal.PropertyInput;
-import com.vaadin.flow.component.trigger.internal.ReadFromClipboardAction;
-import com.vaadin.flow.component.trigger.internal.Trigger;
-import com.vaadin.flow.component.trigger.internal.WriteToClipboardAction;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableRunnable;
@@ -38,9 +32,11 @@ import com.vaadin.flow.server.streams.DownloadHandler;
 
 /**
  * Fluent surface returned from {@link Clipboard#onClick}. Each {@code write*}
- * action attaches one {@link WriteToClipboardAction} to the underlying
- * {@link Trigger}; each {@code read*} action attaches one
- * {@link ReadFromClipboardAction}.
+ * action binds one clipboard write to the trigger component; each {@code read*}
+ * action binds one clipboard read. The binding is a thin facade that resolves
+ * the UI's {@link ClipboardClient} on each call and delegates to
+ * {@link ClipboardClient#registerWrite registerWrite} /
+ * {@link ClipboardClient#registerRead registerRead}.
  * <p>
  * Write actions come in two flavours: fire-and-forget (one argument) and
  * observed (with {@code onCopied}/{@code onError} callbacks). {@code onCopied}
@@ -71,9 +67,9 @@ import com.vaadin.flow.server.streams.DownloadHandler;
  */
 public final class ClipboardBinding implements Serializable {
 
-    private final Trigger trigger;
+    private final Component trigger;
 
-    ClipboardBinding(Trigger trigger) {
+    ClipboardBinding(Component trigger) {
         this.trigger = Objects.requireNonNull(trigger);
     }
 
@@ -86,7 +82,7 @@ public final class ClipboardBinding implements Serializable {
      */
     public void writeText(String literal) {
         Objects.requireNonNull(literal, "literal must not be null");
-        bind(new WriteToClipboardAction(new LiteralInput<>(literal), null));
+        write(ClipboardWrite.ofText(literal), null, null);
     }
 
     /**
@@ -106,8 +102,7 @@ public final class ClipboardBinding implements Serializable {
             SerializableConsumer<@Nullable String> onCopied,
             SerializableConsumer<Error> onError) {
         Objects.requireNonNull(literal, "literal must not be null");
-        bind(new WriteToClipboardAction(new LiteralInput<>(literal), null,
-                onCopied, onError));
+        write(ClipboardWrite.ofText(literal), onCopied, onError);
     }
 
     /**
@@ -126,8 +121,7 @@ public final class ClipboardBinding implements Serializable {
     public <C extends Component & HasValue<?, String>> void writeText(
             C source) {
         Objects.requireNonNull(source, "source must not be null");
-        bind(new WriteToClipboardAction(
-                new PropertyInput<>(source, "value", String.class), null));
+        write(ClipboardWrite.ofText(source), null, null);
     }
 
     /**
@@ -150,9 +144,7 @@ public final class ClipboardBinding implements Serializable {
             SerializableConsumer<@Nullable String> onCopied,
             SerializableConsumer<Error> onError) {
         Objects.requireNonNull(source, "source must not be null");
-        bind(new WriteToClipboardAction(
-                new PropertyInput<>(source, "value", String.class), null,
-                onCopied, onError));
+        write(ClipboardWrite.ofText(source), onCopied, onError);
     }
 
     /**
@@ -164,7 +156,7 @@ public final class ClipboardBinding implements Serializable {
      */
     public void writeHtml(String literal) {
         Objects.requireNonNull(literal, "literal must not be null");
-        bind(new WriteToClipboardAction(null, new LiteralInput<>(literal)));
+        write(ClipboardWrite.ofHtml(literal), null, null);
     }
 
     /**
@@ -183,8 +175,7 @@ public final class ClipboardBinding implements Serializable {
             SerializableConsumer<@Nullable String> onCopied,
             SerializableConsumer<Error> onError) {
         Objects.requireNonNull(literal, "literal must not be null");
-        bind(new WriteToClipboardAction(null, new LiteralInput<>(literal),
-                onCopied, onError));
+        write(ClipboardWrite.ofHtml(literal), onCopied, onError);
     }
 
     /**
@@ -206,7 +197,7 @@ public final class ClipboardBinding implements Serializable {
      */
     public void writeImage(Component source) {
         Objects.requireNonNull(source, "source must not be null");
-        bind(new WriteToClipboardAction(new ImageBlobInput(source)));
+        write(ClipboardWrite.ofImage(new ImageBlobInput(source)), null, null);
     }
 
     /**
@@ -229,8 +220,8 @@ public final class ClipboardBinding implements Serializable {
     public void writeImage(Component source, SerializableRunnable onCopied,
             SerializableConsumer<Error> onError) {
         Objects.requireNonNull(source, "source must not be null");
-        bind(new WriteToClipboardAction(new ImageBlobInput(source), onCopied,
-                onError));
+        write(ClipboardWrite.ofImage(new ImageBlobInput(source)),
+                runnableAsConsumer(onCopied), onError);
     }
 
     /**
@@ -252,8 +243,8 @@ public final class ClipboardBinding implements Serializable {
      */
     public void writeImage(DownloadHandler handler) {
         Objects.requireNonNull(handler, "handler must not be null");
-        bind(new WriteToClipboardAction(
-                new ImageBlobInput(attachHiddenImg(handler))));
+        write(ClipboardWrite.ofImage(
+                new ImageBlobInput(attachHiddenImg(handler))), null, null);
     }
 
     /**
@@ -276,16 +267,16 @@ public final class ClipboardBinding implements Serializable {
             SerializableRunnable onCopied,
             SerializableConsumer<Error> onError) {
         Objects.requireNonNull(handler, "handler must not be null");
-        bind(new WriteToClipboardAction(
-                new ImageBlobInput(attachHiddenImg(handler)), onCopied,
-                onError));
+        write(ClipboardWrite
+                .ofImage(new ImageBlobInput(attachHiddenImg(handler))),
+                runnableAsConsumer(onCopied), onError);
     }
 
     private Element attachHiddenImg(DownloadHandler handler) {
         Element img = new Element(Tag.IMG);
         img.getStyle().set("display", "none");
         img.setAttribute("src", handler.allowDisabled());
-        trigger.getHost().appendChild(img);
+        trigger.getElement().appendChild(img);
         return img;
     }
 
@@ -300,8 +291,8 @@ public final class ClipboardBinding implements Serializable {
      */
     public void write(ClipboardContent content) {
         Objects.requireNonNull(content, "content must not be null");
-        bind(new WriteToClipboardAction(content.getTextInput(),
-                content.getHtmlInput(), content.getImageInput()));
+        validateContent(content);
+        write(ClipboardWrite.ofContent(content), null, null);
     }
 
     /**
@@ -322,9 +313,8 @@ public final class ClipboardBinding implements Serializable {
             SerializableConsumer<@Nullable String> onCopied,
             SerializableConsumer<Error> onError) {
         Objects.requireNonNull(content, "content must not be null");
-        bind(new WriteToClipboardAction(content.getTextInput(),
-                content.getHtmlInput(), content.getImageInput(), onCopied,
-                onError));
+        validateContent(content);
+        write(ClipboardWrite.ofContent(content), onCopied, onError);
     }
 
     /**
@@ -349,7 +339,8 @@ public final class ClipboardBinding implements Serializable {
             SerializableConsumer<Error> onError) {
         Objects.requireNonNull(onPayload, "onPayload must not be null");
         Objects.requireNonNull(onError, "onError must not be null");
-        bind(new ReadFromClipboardAction(onPayload, onError));
+        Clipboard.client(trigger).registerRead(trigger, ClipboardReadKind.READ,
+                onPayload, onError);
     }
 
     /**
@@ -368,8 +359,9 @@ public final class ClipboardBinding implements Serializable {
             SerializableConsumer<Error> onError) {
         Objects.requireNonNull(onText, "onText must not be null");
         Objects.requireNonNull(onError, "onError must not be null");
-        bind(new ReadFromClipboardAction(
-                p -> onText.accept(p == null ? null : p.text()), onError));
+        Clipboard.client(trigger).registerRead(trigger,
+                ClipboardReadKind.READ_TEXT,
+                p -> onText.accept(p == null ? null : p.text()), onError);
     }
 
     /**
@@ -388,11 +380,29 @@ public final class ClipboardBinding implements Serializable {
             SerializableConsumer<Error> onError) {
         Objects.requireNonNull(onHtml, "onHtml must not be null");
         Objects.requireNonNull(onError, "onError must not be null");
-        bind(new ReadFromClipboardAction(
-                p -> onHtml.accept(p == null ? null : p.html()), onError));
+        Clipboard.client(trigger).registerRead(trigger,
+                ClipboardReadKind.READ_HTML,
+                p -> onHtml.accept(p == null ? null : p.html()), onError);
     }
 
-    private void bind(Action action) {
-        trigger.triggers(action);
+    private void write(ClipboardWrite content,
+            @Nullable SerializableConsumer<@Nullable String> onCopied,
+            @Nullable SerializableConsumer<Error> onError) {
+        Clipboard.client(trigger).registerWrite(trigger, content, onCopied,
+                onError);
+    }
+
+    private static void validateContent(ClipboardContent content) {
+        if (content.getTextInput() == null && content.getHtmlInput() == null
+                && content.getImageInput() == null) {
+            throw new IllegalArgumentException(
+                    "ClipboardContent must have at least one slot set");
+        }
+    }
+
+    private static SerializableConsumer<@Nullable String> runnableAsConsumer(
+            SerializableRunnable onCopied) {
+        Objects.requireNonNull(onCopied, "onCopied must not be null");
+        return ignored -> onCopied.run();
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/ClipboardClient.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/ClipboardClient.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.clipboard;
+
+import java.io.Serializable;
+
+import org.jspecify.annotations.Nullable;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.trigger.internal.PromiseAction;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.server.streams.UploadHandler;
+import com.vaadin.flow.shared.Registration;
+
+/**
+ * Framework-internal port between the {@link Clipboard} /
+ * {@link ClipboardBinding} static API and whatever actually performs the
+ * clipboard operations — the browser in production, an in-memory driver in
+ * browserless tests. Application code does not interact with this interface; it
+ * is exposed so external test drivers can replace the production client via
+ * {@link com.vaadin.flow.component.internal.UIInternals#setClipboardClient(ClipboardClient)}.
+ * <p>
+ * Every write/read is bound to a click trigger on a component, mirroring the
+ * Clipboard API's requirement that the underlying browser call happen inside a
+ * user gesture. Paste registration attaches a listener (or upload handler) to a
+ * target element directly. One instance per UI.
+ * <p>
+ * <b>Threading:</b> every callback passed to this interface (write
+ * {@code onSuccess}/{@code onError}, read {@code onSuccess}/{@code onError},
+ * paste {@code listener}) is invoked on the UI thread.
+ *
+ * @since 25.2
+ */
+public interface ClipboardClient extends Serializable {
+
+    /**
+     * Binds a clipboard write to a click trigger on {@code trigger}. The write
+     * runs in the browser when the trigger fires. Pass {@code null} for both
+     * {@code onSuccess} and {@code onError} for a fire-and-forget write, or
+     * both non-{@code null} to be notified of the outcome.
+     *
+     * @param trigger
+     *            the component whose click fires the write, not {@code null}
+     * @param write
+     *            the content descriptor to write, not {@code null}
+     * @param onSuccess
+     *            UI-thread callback receiving the copied string (the
+     *            {@code text/plain} value if present, otherwise
+     *            {@code text/html}, otherwise {@code null} for an image-only
+     *            write), or {@code null} for fire-and-forget
+     * @param onError
+     *            UI-thread callback receiving the browser's error, or
+     *            {@code null} for fire-and-forget
+     * @return a handle that can inspect and remove the binding
+     */
+    WriteHandle registerWrite(Component trigger, ClipboardWrite write,
+            @Nullable SerializableConsumer<@Nullable String> onSuccess,
+            @Nullable SerializableConsumer<PromiseAction.Error> onError);
+
+    /**
+     * Binds a clipboard read to a click trigger on {@code trigger}. The read
+     * runs in the browser when the trigger fires and delivers the full
+     * {@link ClipboardPayload} to {@code onSuccess}; {@code kind} records which
+     * slice of the payload the application asked for (the binding extracts the
+     * requested field before the application sees it).
+     *
+     * @param trigger
+     *            the component whose click fires the read, not {@code null}
+     * @param kind
+     *            which slice of the clipboard the application requested, not
+     *            {@code null}
+     * @param onSuccess
+     *            UI-thread callback receiving the clipboard contents, or
+     *            {@code null} if the clipboard was empty, not {@code null}
+     * @param onError
+     *            UI-thread callback receiving the browser's error, not
+     *            {@code null}
+     * @return a handle that can inspect and remove the binding
+     */
+    ReadHandle registerRead(Component trigger, ClipboardReadKind kind,
+            SerializableConsumer<@Nullable ClipboardPayload> onSuccess,
+            SerializableConsumer<PromiseAction.Error> onError);
+
+    /**
+     * Registers a listener for browser {@code paste} events on {@code target}.
+     *
+     * @param target
+     *            the component to listen on, not {@code null}
+     * @param options
+     *            paste filtering options, not {@code null}
+     * @param listener
+     *            UI-thread callback invoked for each matching paste, not
+     *            {@code null}
+     * @return a registration that detaches the listener
+     */
+    Registration registerPaste(Component target, PasteOptions options,
+            SerializableConsumer<PasteEvent> listener);
+
+    /**
+     * Registers a file-upload handler for browser {@code paste} events on
+     * {@code target}. Each pasted file is fed through {@code uploadHandler}.
+     *
+     * @param target
+     *            the component to listen on, not {@code null}
+     * @param uploadHandler
+     *            the handler invoked per pasted file, not {@code null}
+     * @return a registration that detaches the listener and discards the upload
+     *         URL
+     */
+    Registration registerFilePaste(Component target,
+            UploadHandler uploadHandler);
+
+    /**
+     * Releases any resources held by this client. Called when one client is
+     * being replaced by another (e.g. when a test driver is installed).
+     * Idempotent: calling more than once is a no-op.
+     */
+    void close();
+
+    /**
+     * Inspect/resolve handle for a bound write action. {@link #remove()}
+     * detaches the binding.
+     */
+    interface WriteHandle extends Registration {
+
+        /**
+         * The element whose click fires the write.
+         *
+         * @return the trigger element, never {@code null}
+         */
+        Element trigger();
+
+        /**
+         * The content descriptor that will be written.
+         *
+         * @return the write descriptor, never {@code null}
+         */
+        ClipboardWrite write();
+
+        /**
+         * Whether the write reports success back to the server.
+         *
+         * @return {@code true} if an {@code onSuccess} callback was supplied
+         */
+        boolean hasSuccessCallback();
+
+        /**
+         * Whether the write reports failure back to the server.
+         *
+         * @return {@code true} if an {@code onError} callback was supplied
+         */
+        boolean hasErrorCallback();
+    }
+
+    /**
+     * Inspect/resolve handle for a bound read action. {@link #remove()}
+     * detaches the binding.
+     */
+    interface ReadHandle extends Registration {
+
+        /**
+         * The element whose click fires the read.
+         *
+         * @return the trigger element, never {@code null}
+         */
+        Element trigger();
+
+        /**
+         * Which slice of the clipboard the application requested.
+         *
+         * @return the read kind, never {@code null}
+         */
+        ClipboardReadKind kind();
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/ClipboardClientFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/ClipboardClientFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.clipboard;
+
+import java.io.Serializable;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.di.Lookup;
+
+/**
+ * <b>Framework internal.</b> Factory SPI that produces {@link ClipboardClient}
+ * instances per {@link UI}, resolved via {@link Lookup} the first time
+ * {@link Clipboard} is used for a UI. When a factory is registered the
+ * resulting client replaces the built-in browser-backed client for every
+ * {@code UI} in the application; when none is, {@code Clipboard} uses the
+ * browser-backed client.
+ * <p>
+ * Used by external browserless test drivers to swap the production wire client
+ * for an in-memory driver in environments where package-private cross-JAR
+ * access is unreliable (split-classloader topologies such as Quarkus).
+ * Application code does not reference this interface directly. May be renamed
+ * or removed in a future release.
+ *
+ * @since 25.2
+ */
+public interface ClipboardClientFactory extends Serializable {
+
+    /**
+     * Creates a {@link ClipboardClient} for the given UI. Called once per UI,
+     * the first time a {@link Clipboard} entry point is invoked for that UI.
+     *
+     * @param ui
+     *            the UI for which the client is created
+     * @return a client that will receive every {@code Clipboard} call for that
+     *         UI; never null
+     */
+    ClipboardClient create(UI ui);
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/ClipboardContent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/ClipboardContent.java
@@ -26,6 +26,7 @@ import com.vaadin.flow.component.trigger.internal.Action;
 import com.vaadin.flow.component.trigger.internal.ImageBlobInput;
 import com.vaadin.flow.component.trigger.internal.LiteralInput;
 import com.vaadin.flow.component.trigger.internal.PropertyInput;
+import com.vaadin.flow.function.SerializableSupplier;
 
 /**
  * Multi-format payload for {@link ClipboardBinding#write}. Any combination of
@@ -46,6 +47,13 @@ public final class ClipboardContent implements Serializable {
     private Action.@Nullable Input<String> textInput;
     private Action.@Nullable Input<String> htmlInput;
     private Action.@Nullable Input<?> imageInput;
+
+    // Server-side views of the slot values, mirroring what the client would
+    // read when the trigger fires; consumed by ClipboardWrite for browserless
+    // inspection. Null until the corresponding slot is set.
+    private @Nullable SerializableSupplier<@Nullable String> textValue;
+    private @Nullable SerializableSupplier<@Nullable String> htmlValue;
+    private boolean hasImage;
 
     private ClipboardContent() {
     }
@@ -69,6 +77,7 @@ public final class ClipboardContent implements Serializable {
     public ClipboardContent text(String literal) {
         Objects.requireNonNull(literal, "literal must not be null");
         this.textInput = new LiteralInput<>(literal);
+        this.textValue = () -> literal;
         return this;
     }
 
@@ -88,6 +97,7 @@ public final class ClipboardContent implements Serializable {
             C source) {
         Objects.requireNonNull(source, "source must not be null");
         this.textInput = new PropertyInput<>(source, "value", String.class);
+        this.textValue = source::getValue;
         return this;
     }
 
@@ -101,6 +111,7 @@ public final class ClipboardContent implements Serializable {
     public ClipboardContent html(String literal) {
         Objects.requireNonNull(literal, "literal must not be null");
         this.htmlInput = new LiteralInput<>(literal);
+        this.htmlValue = () -> literal;
         return this;
     }
 
@@ -123,6 +134,7 @@ public final class ClipboardContent implements Serializable {
     public ClipboardContent image(Component source) {
         Objects.requireNonNull(source, "source must not be null");
         this.imageInput = new ImageBlobInput(source);
+        this.hasImage = true;
         return this;
     }
 
@@ -136,5 +148,19 @@ public final class ClipboardContent implements Serializable {
 
     Action.@Nullable Input<?> getImageInput() {
         return imageInput;
+    }
+
+    @Nullable
+    SerializableSupplier<@Nullable String> getTextValue() {
+        return textValue;
+    }
+
+    @Nullable
+    SerializableSupplier<@Nullable String> getHtmlValue() {
+        return htmlValue;
+    }
+
+    boolean hasImage() {
+        return hasImage;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/ClipboardReadKind.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/ClipboardReadKind.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.clipboard;
+
+/**
+ * Which slice of a clipboard read a {@link ClipboardBinding} read action asks
+ * for. Recorded on the {@link ClipboardClient.ReadHandle} so a test driver can
+ * tell what the application wanted without re-deriving it from the delivered
+ * payload — the production read always fetches the full
+ * {@link ClipboardPayload} regardless of kind, and the binding extracts the
+ * requested field on delivery.
+ *
+ * @since 25.2
+ */
+public enum ClipboardReadKind {
+
+    /** The full {@link ClipboardPayload} ({@link ClipboardBinding#read}). */
+    READ,
+
+    /**
+     * Only the {@code text/plain} field ({@link ClipboardBinding#readText}).
+     */
+    READ_TEXT,
+
+    /** Only the {@code text/html} field ({@link ClipboardBinding#readHtml}). */
+    READ_HTML
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/ClipboardWrite.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/ClipboardWrite.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.clipboard;
+
+import java.io.Serializable;
+
+import org.jspecify.annotations.Nullable;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasValue;
+import com.vaadin.flow.component.trigger.internal.Action;
+import com.vaadin.flow.component.trigger.internal.LiteralInput;
+import com.vaadin.flow.component.trigger.internal.PropertyInput;
+import com.vaadin.flow.function.SerializableSupplier;
+
+/**
+ * Describes what a {@link ClipboardBinding} write action copies to the
+ * clipboard: any combination of a {@code text/plain} value, a {@code text/html}
+ * value and an image. It replaces the per-call construction of the internal
+ * write action so the content is inspectable server-side — a browserless test
+ * driver can read {@link #text()} / {@link #html()} / {@link #hasImage()}
+ * without a DOM.
+ * <p>
+ * Text and HTML slots may be a literal string or a live binding to a
+ * {@link HasValue} component's value. In both cases {@link #text()} /
+ * {@link #html()} reflect the <em>current</em> value at the moment they are
+ * called, matching the production behavior of reading the field's value on the
+ * client when the trigger fires.
+ *
+ * @since 25.2
+ */
+public final class ClipboardWrite implements Serializable {
+
+    private final Action.@Nullable Input<String> textInput;
+    private final Action.@Nullable Input<String> htmlInput;
+    private final Action.@Nullable Input<?> imageInput;
+
+    // Server-side views of the slot values, evaluated live so a test driver
+    // sees the same value the client would read at fire time. Null when the
+    // corresponding MIME slot is unset.
+    private final @Nullable SerializableSupplier<@Nullable String> textValue;
+    private final @Nullable SerializableSupplier<@Nullable String> htmlValue;
+    private final boolean hasImage;
+
+    ClipboardWrite(Action.@Nullable Input<String> textInput,
+            Action.@Nullable Input<String> htmlInput,
+            Action.@Nullable Input<?> imageInput,
+            @Nullable SerializableSupplier<@Nullable String> textValue,
+            @Nullable SerializableSupplier<@Nullable String> htmlValue,
+            boolean hasImage) {
+        this.textInput = textInput;
+        this.htmlInput = htmlInput;
+        this.imageInput = imageInput;
+        this.textValue = textValue;
+        this.htmlValue = htmlValue;
+        this.hasImage = hasImage;
+    }
+
+    static ClipboardWrite ofText(String literal) {
+        return new ClipboardWrite(new LiteralInput<>(literal), null, null,
+                () -> literal, null, false);
+    }
+
+    static <C extends Component & HasValue<?, String>> ClipboardWrite ofText(
+            C source) {
+        return new ClipboardWrite(
+                new PropertyInput<>(source, "value", String.class), null, null,
+                source::getValue, null, false);
+    }
+
+    static ClipboardWrite ofHtml(String literal) {
+        return new ClipboardWrite(null, new LiteralInput<>(literal), null, null,
+                () -> literal, false);
+    }
+
+    static ClipboardWrite ofImage(Action.Input<?> imageInput) {
+        return new ClipboardWrite(null, null, imageInput, null, null, true);
+    }
+
+    static ClipboardWrite ofContent(ClipboardContent content) {
+        return new ClipboardWrite(content.getTextInput(),
+                content.getHtmlInput(), content.getImageInput(),
+                content.getTextValue(), content.getHtmlValue(),
+                content.hasImage());
+    }
+
+    /**
+     * The current {@code text/plain} value this write would copy, or
+     * {@code null} if the text slot is unset. For a value bound to a
+     * {@link HasValue} source the result reflects the source's current value on
+     * each call.
+     *
+     * @return the text value, or {@code null}
+     */
+    public @Nullable String text() {
+        return textValue == null ? null : textValue.get();
+    }
+
+    /**
+     * The current {@code text/html} value this write would copy, or
+     * {@code null} if the HTML slot is unset.
+     *
+     * @return the HTML value, or {@code null}
+     */
+    public @Nullable String html() {
+        return htmlValue == null ? null : htmlValue.get();
+    }
+
+    /**
+     * Whether this write includes an image slot.
+     *
+     * @return {@code true} if an image is part of the payload
+     */
+    public boolean hasImage() {
+        return hasImage;
+    }
+
+    Action.@Nullable Input<String> textInput() {
+        return textInput;
+    }
+
+    Action.@Nullable Input<String> htmlInput() {
+        return htmlInput;
+    }
+
+    Action.@Nullable Input<?> imageInput() {
+        return imageInput;
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -46,6 +46,7 @@ import com.vaadin.flow.component.HeartbeatEvent;
 import com.vaadin.flow.component.HeartbeatListener;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.clipboard.ClipboardClient;
 import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.geolocation.GeolocationAvailability;
@@ -263,6 +264,8 @@ public class UIInternals implements Serializable {
     private GeolocationClient geolocationClient;
 
     private Registration geolocationClientAvailabilityRegistration;
+
+    private ClipboardClient clipboardClient;
 
     private final ValueSignal<Boolean> wakeLockActiveSignal = new ValueSignal<>(
             Boolean.FALSE);
@@ -1588,6 +1591,35 @@ public class UIInternals implements Serializable {
         setGeolocationAvailability(client.currentAvailability());
         geolocationClientAvailabilityRegistration = client
                 .subscribeAvailability(this::setGeolocationAvailability);
+    }
+
+    /**
+     * Returns the clipboard client currently bound to this UI, or {@code null}
+     * if none has been installed yet. Framework-internal: application code
+     * resolves the client through the static
+     * {@link com.vaadin.flow.component.clipboard.Clipboard} API, which lazily
+     * installs a default client on first use.
+     *
+     * @return the installed clipboard client, or {@code null}
+     */
+    public ClipboardClient getClipboardClient() {
+        return clipboardClient;
+    }
+
+    /**
+     * Installs the given clipboard client on this UI, replacing any previous
+     * one. The previous client, if any, is closed. Framework-internal entry
+     * point used by the default {@code Clipboard} bootstrap and by external
+     * test drivers that substitute a browserless client.
+     *
+     * @param client
+     *            the client to install, never {@code null}
+     */
+    public void setClipboardClient(ClipboardClient client) {
+        if (clipboardClient != null) {
+            clipboardClient.close();
+        }
+        clipboardClient = client;
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/component/clipboard/ClipboardClientSeamTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/clipboard/ClipboardClientSeamTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.clipboard;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.component.AbstractField;
+import com.vaadin.flow.component.ClickNotifier;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.trigger.internal.PromiseAction;
+import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.streams.UploadHandler;
+import com.vaadin.flow.shared.Registration;
+import com.vaadin.tests.util.MockUI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the {@link ClipboardClient} seam — both the public
+ * {@link ClipboardClientFactory} extension point that external test drivers
+ * register through {@link Lookup}, and the
+ * {@link com.vaadin.flow.component.internal.UIInternals#setClipboardClient(ClipboardClient)}
+ * direct-install seam used by flow-server's own tests. The wire-protocol
+ * assertions that pin production behavior unchanged live in
+ * {@code ClipboardTest}.
+ */
+class ClipboardClientSeamTest {
+
+    private MockUI ui;
+
+    @BeforeEach
+    void setUp() {
+        ui = new MockUI();
+    }
+
+    @Tag("test-button")
+    private static final class TestButton extends Component
+            implements ClickNotifier<TestButton> {
+    }
+
+    @Tag("test-field")
+    private static final class TestField
+            extends AbstractField<TestField, String> {
+        TestField() {
+            super("");
+        }
+
+        @Override
+        protected void setPresentationValue(String newPresentationValue) {
+            // not exercised in these tests
+        }
+    }
+
+    private TestButton attachedButton() {
+        TestButton button = new TestButton();
+        ui.getElement().appendChild(button.getElement());
+        return button;
+    }
+
+    @Test
+    void lookupFactory_resolvedOnFirstUse_clientReceivesWriteCalls() {
+        FakeClient fake = new FakeClient();
+        stubFactory(unused -> fake);
+
+        Clipboard.onClick(attachedButton()).writeText("Hello");
+
+        assertEquals(1, fake.writes.size(),
+                "factory-produced client should receive writeText() calls");
+        assertSame(fake, ui.getInternals().getClipboardClient(),
+                "the factory-produced client should be cached on the UI");
+    }
+
+    @Test
+    void noFactory_fallsBackToBrowserClipboardClient() {
+        // Explicitly clear any factory stubbed by another test (the mock
+        // Lookup is shared across MockUIs that reuse the same session).
+        stubFactory(null);
+
+        Clipboard.onClick(attachedButton()).writeText("Hello");
+
+        assertInstanceOf(BrowserClipboardClient.class,
+                ui.getInternals().getClipboardClient(),
+                "without a factory the default browser client should be used");
+    }
+
+    @Test
+    void setClipboardClient_routesWriteThroughInstalledClient() {
+        FakeClient fake = new FakeClient();
+        ui.getInternals().setClipboardClient(fake);
+
+        Clipboard.onClick(attachedButton()).writeText("Hello");
+
+        assertEquals(1, fake.writes.size(),
+                "writeText() should route through the installed client");
+    }
+
+    @Test
+    void setClipboardClient_closesPreviousClient() {
+        FakeClient first = new FakeClient();
+        FakeClient second = new FakeClient();
+        ui.getInternals().setClipboardClient(first);
+        ui.getInternals().setClipboardClient(second);
+
+        assertTrue(first.closed,
+                "previous client should be closed when setClipboardClient replaces it");
+    }
+
+    @Test
+    void write_carriesContentAndCallbackPresenceToClient() {
+        FakeClient fake = new FakeClient();
+        ui.getInternals().setClipboardClient(fake);
+
+        TestField field = new TestField();
+        field.setValue("live-value");
+        ui.getElement().appendChild(field.getElement());
+        Clipboard.onClick(attachedButton()).writeText(field, copied -> {
+        }, err -> {
+        });
+
+        assertEquals(1, fake.writes.size());
+        FakeClient.WriteCall call = fake.writes.get(0);
+        assertEquals("live-value", call.write.text(),
+                "the descriptor should report the bound field's live value");
+        assertTrue(call.hasSuccess, "observed write should carry onSuccess");
+        assertTrue(call.hasError, "observed write should carry onError");
+    }
+
+    @Test
+    void read_routesThroughClientWithKind() {
+        FakeClient fake = new FakeClient();
+        ui.getInternals().setClipboardClient(fake);
+
+        Clipboard.onClick(attachedButton()).readText(text -> {
+        }, err -> {
+        });
+
+        assertEquals(1, fake.reads.size(),
+                "readText() should route through the installed client");
+        assertEquals(ClipboardReadKind.READ_TEXT, fake.reads.get(0),
+                "the read kind should be carried to the client");
+    }
+
+    @Test
+    void onPaste_routesThroughInstalledClient() {
+        FakeClient fake = new FakeClient();
+        ui.getInternals().setClipboardClient(fake);
+
+        Clipboard.onPaste(attachedButton(), event -> {
+        });
+
+        assertEquals(1, fake.pasteRegistrations,
+                "onPaste() should route through the installed client");
+    }
+
+    @Test
+    void onFilePaste_routesThroughInstalledClient() {
+        FakeClient fake = new FakeClient();
+        ui.getInternals().setClipboardClient(fake);
+
+        Clipboard.onFilePaste(attachedButton(),
+                UploadHandler.inMemory((m, b) -> {
+                }));
+
+        assertEquals(1, fake.filePasteRegistrations,
+                "onFilePaste() should route through the installed client");
+    }
+
+    private void stubFactory(@Nullable ClipboardClientFactory factory) {
+        VaadinService service = VaadinService.getCurrent();
+        Lookup lookup = service.getContext().getAttribute(Lookup.class);
+        Mockito.when(lookup.lookup(ClipboardClientFactory.class))
+                .thenReturn(factory);
+    }
+
+    /**
+     * Minimal in-test fake recording the calls routed through the seam.
+     */
+    private static final class FakeClient implements ClipboardClient {
+
+        record WriteCall(ClipboardWrite write, boolean hasSuccess,
+                boolean hasError) {
+        }
+
+        final List<WriteCall> writes = new ArrayList<>();
+        final List<ClipboardReadKind> reads = new ArrayList<>();
+        int pasteRegistrations;
+        int filePasteRegistrations;
+        boolean closed;
+
+        @Override
+        public WriteHandle registerWrite(Component trigger,
+                ClipboardWrite write,
+                @Nullable SerializableConsumer<@Nullable String> onSuccess,
+                @Nullable SerializableConsumer<PromiseAction.Error> onError) {
+            writes.add(
+                    new WriteCall(write, onSuccess != null, onError != null));
+            return new FakeWriteHandle(trigger.getElement(), write,
+                    onSuccess != null, onError != null);
+        }
+
+        @Override
+        public ReadHandle registerRead(Component trigger,
+                ClipboardReadKind kind,
+                SerializableConsumer<@Nullable ClipboardPayload> onSuccess,
+                SerializableConsumer<PromiseAction.Error> onError) {
+            reads.add(kind);
+            return new FakeReadHandle(trigger.getElement(), kind);
+        }
+
+        @Override
+        public Registration registerPaste(Component target,
+                PasteOptions options,
+                SerializableConsumer<PasteEvent> listener) {
+            pasteRegistrations++;
+            return () -> {
+            };
+        }
+
+        @Override
+        public Registration registerFilePaste(Component target,
+                UploadHandler uploadHandler) {
+            filePasteRegistrations++;
+            return () -> {
+            };
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+    }
+
+    private record FakeWriteHandle(Element trigger, ClipboardWrite write,
+            boolean hasSuccessCallback,
+            boolean hasErrorCallback) implements ClipboardClient.WriteHandle {
+        @Override
+        public void remove() {
+        }
+    }
+
+    private record FakeReadHandle(Element trigger,
+            ClipboardReadKind kind) implements ClipboardClient.ReadHandle {
+        @Override
+        public void remove() {
+        }
+    }
+}


### PR DESCRIPTION
Introduce an SPI seam for the clipboard feature, modeled 1:1 on the Geolocation seam (GeolocationClient / GeolocationClientFactory), so an external browserless-test simulator can replace the production wire client without a DOM.

- ClipboardClient: public port with registerWrite/registerRead/ registerPaste/registerFilePaste/close and inspectable WriteHandle/ ReadHandle.
- ClipboardWrite: public write descriptor with live server-side value views (text()/html()/hasImage()).
- ClipboardReadKind: READ/READ_TEXT/READ_HTML, recorded on the read handle.
- ClipboardClientFactory: Lookup-resolved SPI.
- BrowserClipboardClient: production default; the trigger/PromiseAction/ return-channel write/read plumbing and the paste/file-upload plumbing move here unchanged.
- Clipboard/ClipboardBinding become thin facades that resolve the UI's client and delegate; public signatures stay stable.
- UIInternals gains a clipboardClient cache (get/setClipboardClient).
- ClipboardClientSeamTest covers Lookup-factory and direct-install resolution; existing ClipboardTest pins production behavior unchanged.

First part and related-to https://github.com/vaadin/browserless-test/issues/64
