### PR TITLE
chore: update default Node.js version to v24.17.0

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -64,7 +64,7 @@ public class FrontendTools {
      * the installed version is older than {@link #SUPPORTED_NODE_VERSION}, i.e.
      * {@value #SUPPORTED_NODE_MAJOR_VERSION}.{@value #SUPPORTED_NODE_MINOR_VERSION}.
      */
-    public static final String DEFAULT_NODE_VERSION = "v24.16.0";
+    public static final String DEFAULT_NODE_VERSION = "v24.17.0";
     /**
      * This is the version shipped with the default Node version.
      */


### PR DESCRIPTION
Node.js security release for the 24.x line.