### PR TITLE
chore: update default Node.js version to v22.23.0

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -64,7 +64,7 @@ public class FrontendTools {
      * the installed version is older than {@link #SUPPORTED_NODE_VERSION}, i.e.
      * {@value #SUPPORTED_NODE_MAJOR_VERSION}.{@value #SUPPORTED_NODE_MINOR_VERSION}.
      */
-    public static final String DEFAULT_NODE_VERSION = "v22.22.2";
+    public static final String DEFAULT_NODE_VERSION = "v22.23.0";
     /**
      * This is the version shipped with the default Node version.
      */


### PR DESCRIPTION
Node.js security release for the 22.x line.