### PR TITLE
feat: Warn when overriding packages to different minor version

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -30,8 +30,6 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ObjectNode;
 import tools.jackson.databind.node.StringNode;
@@ -89,6 +87,8 @@ public class TaskUpdatePackages extends NodeUpdater {
             Map<String, String> scannedApplicationDevDependencies = frontDeps
                     .getDevPackages();
             ObjectNode packageJson = getPackageJson();
+            warnOnVersionRangeMismatch(packageJson);
+
             modified = updatePackageJsonDependencies(packageJson,
                     scannedApplicationDependencies,
                     scannedApplicationDevDependencies);
@@ -580,7 +580,7 @@ public class TaskUpdatePackages extends NodeUpdater {
             // version through exclusion
             if (!filteredApplicationDependencies.containsKey(key)
                     && pinPlatformDependency(packageJson,
-                            platformPinnedDependencies, key, true)) {
+                            platformPinnedDependencies, key)) {
                 added++;
             }
             // make sure platform pinned dependency is not cleared
@@ -660,13 +660,6 @@ public class TaskUpdatePackages extends NodeUpdater {
 
     protected static boolean pinPlatformDependency(JsonNode packageJson,
             JsonNode platformPinnedVersions, String pkg) {
-        return pinPlatformDependency(packageJson, platformPinnedVersions, pkg,
-                false);
-    }
-
-    protected static boolean pinPlatformDependency(JsonNode packageJson,
-            JsonNode platformPinnedVersions, String pkg,
-            boolean warnOnRangeMismatch) {
         final FrontendVersion platformPinnedVersion = FrontendUtils
                 .getPackageVersionFromJson(platformPinnedVersions, pkg,
                         "vaadin_dependencies.json");
@@ -705,10 +698,6 @@ public class TaskUpdatePackages extends NodeUpdater {
         if ((vaadinDepsVersion != null && packageJsonVersion != null)
                 && !vaadinDepsVersion.equals(packageJsonVersion)) {
             // The user has overridden the version, use that
-            if (warnOnRangeMismatch) {
-                warnIfOverrideInDifferentRange(pkg, platformPinnedVersion,
-                        packageJsonVersion);
-            }
             return false;
         }
 
@@ -723,46 +712,132 @@ public class TaskUpdatePackages extends NodeUpdater {
     }
 
     /**
-     * Warns when a user override in {@code package.json} pins a
-     * platform-managed package to a different minor or major version than the
-     * one expected by the current Vaadin version.
+     * Warns about platform-managed packages that the project has pinned in
+     * {@code package.json} to a version from a different minor or major range
+     * than the one expected by the current Vaadin version.
      * <p>
-     * Overriding a package to another maintenance (patch) release of the same
-     * minor is a supported way of picking up a fix early. Overriding to a
-     * different minor or major version is usually a mistake, as the rest of the
-     * platform is built and tested against the expected version, and the
-     * mismatch can lead to runtime errors or broken generated frontend files.
+     * This is checked on the package.json as it is read, before the version
+     * locking updates it, so that pins that the build would simply overwrite
+     * are not reported. Only values that differ from the ones Vaadin manages
+     * (kept in the {@code vaadin} section) are considered, as those are the
+     * explicit opt-outs that the build leaves untouched. Pinning a package to
+     * another maintenance (patch) release of the same minor is a supported way
+     * of picking up a fix early, but pinning it to a different minor or major
+     * version is usually a mistake, since the rest of the platform is built and
+     * tested against the expected version. Such mismatches can lead to runtime
+     * errors or broken generated frontend files (a blank page).
      *
-     * @param pkg
-     *            the name of the overridden package
-     * @param expectedVersion
-     *            the version expected by the current Vaadin version
-     * @param overrideVersion
-     *            the version the user has set in {@code package.json}
+     * @param packageJson
+     *            the package.json as read, before version locking
+     * @throws IOException
+     *             if the platform versions cannot be read
      */
-    private static void warnIfOverrideInDifferentRange(String pkg,
-            FrontendVersion expectedVersion, FrontendVersion overrideVersion) {
-        if (expectedVersion.getMajorVersion() != overrideVersion
-                .getMajorVersion()
-                || expectedVersion.getMinorVersion() != overrideVersion
-                        .getMinorVersion()) {
-            getLogger().warn(
+    void warnOnVersionRangeMismatch(ObjectNode packageJson) throws IOException {
+        final ObjectNode expectedVersions = getFullPlatformDependencies();
+        final JsonNode vaadin = packageJson.get(VAADIN_DEP_KEY);
+
+        // Collect mismatches into a single warning to avoid flooding the log
+        // when a whole platform worth of packages has drifted.
+        final List<String> mismatches = new ArrayList<>();
+        collectRangeMismatches(sectionToMap(packageJson.get(DEPENDENCIES)),
+                sectionToMap(vaadin == null ? null : vaadin.get(DEPENDENCIES)),
+                expectedVersions, DEPENDENCIES, mismatches);
+        collectRangeMismatches(sectionToMap(packageJson.get(DEV_DEPENDENCIES)),
+                sectionToMap(
+                        vaadin == null ? null : vaadin.get(DEV_DEPENDENCIES)),
+                expectedVersions, DEV_DEPENDENCIES, mismatches);
+        collectRangeMismatches(projectOverrides(packageJson),
+                flatOverrides(vaadin == null ? null : vaadin.get(OVERRIDES)),
+                expectedVersions, OVERRIDES, mismatches);
+
+        if (!mismatches.isEmpty()) {
+            log().warn(
                     """
-                            The package '{}' is overridden in package.json to version '{}', \
-                            which is from a different minor/major version than the version '{}' \
-                            expected by Vaadin. Overriding to another maintenance release is \
-                            supported, but using a different minor or major version is usually a \
-                            mistake and may cause runtime errors or a blank page. Unless the \
-                            override is intentional, remove it from the 'dependencies' block in \
-                            package.json or run 'mvn vaadin:clean-frontend' to reset the \
+                            The following packages are pinned in package.json to a different \
+                            minor/major version than the version expected by the current Vaadin \
+                            version. Overriding to another maintenance release is supported, but \
+                            using a different minor or major version is usually a mistake and may \
+                            cause runtime errors or a blank page:
+                            {}
+                            Unless these versions are intentional, remove the entries from \
+                            package.json and run 'mvn vaadin:clean-frontend' to reset the \
                             frontend to a clean state.""",
-                    pkg, overrideVersion.getFullVersion(),
-                    expectedVersion.getFullVersion());
+                    String.join("\n", mismatches));
         }
     }
 
-    private static Logger getLogger() {
-        return LoggerFactory.getLogger(TaskUpdatePackages.class);
+    private void collectRangeMismatches(Map<String, String> projectSection,
+            Map<String, String> vaadinSection, ObjectNode expectedVersions,
+            String location, List<String> mismatches) {
+        for (Map.Entry<String, String> entry : projectSection.entrySet()) {
+            final String pkg = entry.getKey();
+            final FrontendVersion expected = parseVersion(
+                    expectedVersions.has(pkg)
+                            ? expectedVersions.get(pkg).asString()
+                            : null);
+            if (expected == null) {
+                continue;
+            }
+            // Skip values managed by Vaadin: the build updates those itself, so
+            // any range difference is transient and not a user mistake.
+            if (entry.getValue().equals(vaadinSection.get(pkg))) {
+                continue;
+            }
+            final FrontendVersion pinned = parseVersion(entry.getValue());
+            if (pinned != null && isDifferentRange(expected, pinned)) {
+                mismatches.add(String.format("  - %s: %s (in %s), expected %s",
+                        pkg, pinned.getFullVersion(), location,
+                        expected.getFullVersion()));
+            }
+        }
+    }
+
+    private FrontendVersion parseVersion(String version) {
+        if (version == null || version.startsWith("$")) {
+            return null;
+        }
+        try {
+            return new FrontendVersion(version);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private boolean isDifferentRange(FrontendVersion expected,
+            FrontendVersion actual) {
+        return expected.getMajorVersion() != actual.getMajorVersion()
+                || expected.getMinorVersion() != actual.getMinorVersion();
+    }
+
+    private Map<String, String> sectionToMap(JsonNode section) {
+        if (section == null) {
+            return Map.of();
+        }
+        final Map<String, String> map = new HashMap<>();
+        for (String key : JacksonUtils.getKeys(section)) {
+            map.put(key, section.get(key).asString());
+        }
+        return map;
+    }
+
+    private Map<String, String> flatOverrides(JsonNode overrides) {
+        if (overrides == null) {
+            return Map.of();
+        }
+        return flattenOverrides((ObjectNode) overrides);
+    }
+
+    /**
+     * Returns the project's overrides as a flat map, reading from the
+     * {@code pnpm.overrides} section when pnpm is enabled and from the
+     * top-level {@code overrides} section otherwise.
+     */
+    private Map<String, String> projectOverrides(ObjectNode packageJson) {
+        if (enablePnpm && packageJson.has(PNPM)
+                && packageJson.get(PNPM).has(OVERRIDES)) {
+            return flatOverrides(packageJson.get(PNPM).get(OVERRIDES));
+        }
+        return flatOverrides(packageJson.get(OVERRIDES));
     }
 
     /**

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -752,9 +752,10 @@ public class TaskUpdatePackages extends NodeUpdater {
                             which is from a different minor/major version than the version '{}' \
                             expected by Vaadin. Overriding to another maintenance release is \
                             supported, but using a different minor or major version is usually a \
-                            mistake and may cause runtime errors or a blank page. Remove the \
-                            override from the 'dependencies' block in package.json unless it is \
-                            intentional.""",
+                            mistake and may cause runtime errors or a blank page. Unless the \
+                            override is intentional, remove it from the 'dependencies' block in \
+                            package.json or run 'mvn vaadin:clean-frontend' to reset the \
+                            frontend to a clean state.""",
                     pkg, overrideVersion.getFullVersion(),
                     expectedVersion.getFullVersion());
         }

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -30,6 +30,8 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ObjectNode;
 import tools.jackson.databind.node.StringNode;
@@ -578,7 +580,7 @@ public class TaskUpdatePackages extends NodeUpdater {
             // version through exclusion
             if (!filteredApplicationDependencies.containsKey(key)
                     && pinPlatformDependency(packageJson,
-                            platformPinnedDependencies, key)) {
+                            platformPinnedDependencies, key, true)) {
                 added++;
             }
             // make sure platform pinned dependency is not cleared
@@ -658,6 +660,13 @@ public class TaskUpdatePackages extends NodeUpdater {
 
     protected static boolean pinPlatformDependency(JsonNode packageJson,
             JsonNode platformPinnedVersions, String pkg) {
+        return pinPlatformDependency(packageJson, platformPinnedVersions, pkg,
+                false);
+    }
+
+    protected static boolean pinPlatformDependency(JsonNode packageJson,
+            JsonNode platformPinnedVersions, String pkg,
+            boolean warnOnRangeMismatch) {
         final FrontendVersion platformPinnedVersion = FrontendUtils
                 .getPackageVersionFromJson(platformPinnedVersions, pkg,
                         "vaadin_dependencies.json");
@@ -696,6 +705,10 @@ public class TaskUpdatePackages extends NodeUpdater {
         if ((vaadinDepsVersion != null && packageJsonVersion != null)
                 && !vaadinDepsVersion.equals(packageJsonVersion)) {
             // The user has overridden the version, use that
+            if (warnOnRangeMismatch) {
+                warnIfOverrideInDifferentRange(pkg, platformPinnedVersion,
+                        packageJsonVersion);
+            }
             return false;
         }
 
@@ -707,6 +720,48 @@ public class TaskUpdatePackages extends NodeUpdater {
         packageJsonDeps.put(pkg, platformPinnedVersion.getFullVersion());
         vaadinDeps.put(pkg, platformPinnedVersion.getFullVersion());
         return true;
+    }
+
+    /**
+     * Warns when a user override in {@code package.json} pins a
+     * platform-managed package to a different minor or major version than the
+     * one expected by the current Vaadin version.
+     * <p>
+     * Overriding a package to another maintenance (patch) release of the same
+     * minor is a supported way of picking up a fix early. Overriding to a
+     * different minor or major version is usually a mistake, as the rest of the
+     * platform is built and tested against the expected version, and the
+     * mismatch can lead to runtime errors or broken generated frontend files.
+     *
+     * @param pkg
+     *            the name of the overridden package
+     * @param expectedVersion
+     *            the version expected by the current Vaadin version
+     * @param overrideVersion
+     *            the version the user has set in {@code package.json}
+     */
+    private static void warnIfOverrideInDifferentRange(String pkg,
+            FrontendVersion expectedVersion, FrontendVersion overrideVersion) {
+        if (expectedVersion.getMajorVersion() != overrideVersion
+                .getMajorVersion()
+                || expectedVersion.getMinorVersion() != overrideVersion
+                        .getMinorVersion()) {
+            getLogger().warn(
+                    """
+                            The package '{}' is overridden in package.json to version '{}', \
+                            which is from a different minor/major version than the version '{}' \
+                            expected by Vaadin. Overriding to another maintenance release is \
+                            supported, but using a different minor or major version is usually a \
+                            mistake and may cause runtime errors or a blank page. Remove the \
+                            override from the 'dependencies' block in package.json unless it is \
+                            intentional.""",
+                    pkg, overrideVersion.getFullVersion(),
+                    expectedVersion.getFullVersion());
+        }
+    }
+
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(TaskUpdatePackages.class);
     }
 
     /**

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -33,8 +33,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ObjectNode;
 import tools.jackson.databind.node.StringNode;
@@ -92,6 +90,8 @@ public class TaskUpdatePackages extends NodeUpdater {
             Map<String, String> scannedApplicationDevDependencies = frontDeps
                     .getDevPackages();
             ObjectNode packageJson = getPackageJson();
+            warnOnVersionRangeMismatch(packageJson);
+
             modified = updatePackageJsonDependencies(packageJson,
                     scannedApplicationDependencies,
                     scannedApplicationDevDependencies);
@@ -678,7 +678,7 @@ public class TaskUpdatePackages extends NodeUpdater {
             // version through exclusion
             if (!filteredApplicationDependencies.containsKey(key)
                     && pinPlatformDependency(packageJson,
-                            platformPinnedDependencies, key, true)) {
+                            platformPinnedDependencies, key)) {
                 added++;
             }
             // make sure platform pinned dependency is not cleared
@@ -758,13 +758,6 @@ public class TaskUpdatePackages extends NodeUpdater {
 
     protected static boolean pinPlatformDependency(JsonNode packageJson,
             JsonNode platformPinnedVersions, String pkg) {
-        return pinPlatformDependency(packageJson, platformPinnedVersions, pkg,
-                false);
-    }
-
-    protected static boolean pinPlatformDependency(JsonNode packageJson,
-            JsonNode platformPinnedVersions, String pkg,
-            boolean warnOnRangeMismatch) {
         final FrontendVersion platformPinnedVersion = FrontendUtils
                 .getPackageVersionFromJson(platformPinnedVersions, pkg,
                         "vaadin_dependencies.json");
@@ -803,10 +796,6 @@ public class TaskUpdatePackages extends NodeUpdater {
         if ((vaadinDepsVersion != null && packageJsonVersion != null)
                 && !vaadinDepsVersion.equals(packageJsonVersion)) {
             // The user has overridden the version, use that
-            if (warnOnRangeMismatch) {
-                warnIfOverrideInDifferentRange(pkg, platformPinnedVersion,
-                        packageJsonVersion);
-            }
             return false;
         }
 
@@ -821,46 +810,132 @@ public class TaskUpdatePackages extends NodeUpdater {
     }
 
     /**
-     * Warns when a user override in {@code package.json} pins a
-     * platform-managed package to a different minor or major version than the
-     * one expected by the current Vaadin version.
+     * Warns about platform-managed packages that the project has pinned in
+     * {@code package.json} to a version from a different minor or major range
+     * than the one expected by the current Vaadin version.
      * <p>
-     * Overriding a package to another maintenance (patch) release of the same
-     * minor is a supported way of picking up a fix early. Overriding to a
-     * different minor or major version is usually a mistake, as the rest of the
-     * platform is built and tested against the expected version, and the
-     * mismatch can lead to runtime errors or broken generated frontend files.
+     * This is checked on the package.json as it is read, before the version
+     * locking updates it, so that pins that the build would simply overwrite
+     * are not reported. Only values that differ from the ones Vaadin manages
+     * (kept in the {@code vaadin} section) are considered, as those are the
+     * explicit opt-outs that the build leaves untouched. Pinning a package to
+     * another maintenance (patch) release of the same minor is a supported way
+     * of picking up a fix early, but pinning it to a different minor or major
+     * version is usually a mistake, since the rest of the platform is built and
+     * tested against the expected version. Such mismatches can lead to runtime
+     * errors or broken generated frontend files (a blank page).
      *
-     * @param pkg
-     *            the name of the overridden package
-     * @param expectedVersion
-     *            the version expected by the current Vaadin version
-     * @param overrideVersion
-     *            the version the user has set in {@code package.json}
+     * @param packageJson
+     *            the package.json as read, before version locking
+     * @throws IOException
+     *             if the platform versions cannot be read
      */
-    private static void warnIfOverrideInDifferentRange(String pkg,
-            FrontendVersion expectedVersion, FrontendVersion overrideVersion) {
-        if (expectedVersion.getMajorVersion() != overrideVersion
-                .getMajorVersion()
-                || expectedVersion.getMinorVersion() != overrideVersion
-                        .getMinorVersion()) {
-            getLogger().warn(
+    void warnOnVersionRangeMismatch(ObjectNode packageJson) throws IOException {
+        final ObjectNode expectedVersions = getFullPlatformDependencies();
+        final JsonNode vaadin = packageJson.get(VAADIN_DEP_KEY);
+
+        // Collect mismatches into a single warning to avoid flooding the log
+        // when a whole platform worth of packages has drifted.
+        final List<String> mismatches = new ArrayList<>();
+        collectRangeMismatches(sectionToMap(packageJson.get(DEPENDENCIES)),
+                sectionToMap(vaadin == null ? null : vaadin.get(DEPENDENCIES)),
+                expectedVersions, DEPENDENCIES, mismatches);
+        collectRangeMismatches(sectionToMap(packageJson.get(DEV_DEPENDENCIES)),
+                sectionToMap(
+                        vaadin == null ? null : vaadin.get(DEV_DEPENDENCIES)),
+                expectedVersions, DEV_DEPENDENCIES, mismatches);
+        collectRangeMismatches(projectOverrides(packageJson),
+                flatOverrides(vaadin == null ? null : vaadin.get(OVERRIDES)),
+                expectedVersions, OVERRIDES, mismatches);
+
+        if (!mismatches.isEmpty()) {
+            log().warn(
                     """
-                            The package '{}' is overridden in package.json to version '{}', \
-                            which is from a different minor/major version than the version '{}' \
-                            expected by Vaadin. Overriding to another maintenance release is \
-                            supported, but using a different minor or major version is usually a \
-                            mistake and may cause runtime errors or a blank page. Unless the \
-                            override is intentional, remove it from the 'dependencies' block in \
-                            package.json or run 'mvn vaadin:clean-frontend' to reset the \
+                            The following packages are pinned in package.json to a different \
+                            minor/major version than the version expected by the current Vaadin \
+                            version. Overriding to another maintenance release is supported, but \
+                            using a different minor or major version is usually a mistake and may \
+                            cause runtime errors or a blank page:
+                            {}
+                            Unless these versions are intentional, remove the entries from \
+                            package.json and run 'mvn vaadin:clean-frontend' to reset the \
                             frontend to a clean state.""",
-                    pkg, overrideVersion.getFullVersion(),
-                    expectedVersion.getFullVersion());
+                    String.join("\n", mismatches));
         }
     }
 
-    private static Logger getLogger() {
-        return LoggerFactory.getLogger(TaskUpdatePackages.class);
+    private void collectRangeMismatches(Map<String, String> projectSection,
+            Map<String, String> vaadinSection, ObjectNode expectedVersions,
+            String location, List<String> mismatches) {
+        for (Map.Entry<String, String> entry : projectSection.entrySet()) {
+            final String pkg = entry.getKey();
+            final FrontendVersion expected = parseVersion(
+                    expectedVersions.has(pkg)
+                            ? expectedVersions.get(pkg).asString()
+                            : null);
+            if (expected == null) {
+                continue;
+            }
+            // Skip values managed by Vaadin: the build updates those itself, so
+            // any range difference is transient and not a user mistake.
+            if (entry.getValue().equals(vaadinSection.get(pkg))) {
+                continue;
+            }
+            final FrontendVersion pinned = parseVersion(entry.getValue());
+            if (pinned != null && isDifferentRange(expected, pinned)) {
+                mismatches.add(String.format("  - %s: %s (in %s), expected %s",
+                        pkg, pinned.getFullVersion(), location,
+                        expected.getFullVersion()));
+            }
+        }
+    }
+
+    private FrontendVersion parseVersion(String version) {
+        if (version == null || version.startsWith("$")) {
+            return null;
+        }
+        try {
+            return new FrontendVersion(version);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private boolean isDifferentRange(FrontendVersion expected,
+            FrontendVersion actual) {
+        return expected.getMajorVersion() != actual.getMajorVersion()
+                || expected.getMinorVersion() != actual.getMinorVersion();
+    }
+
+    private Map<String, String> sectionToMap(JsonNode section) {
+        if (section == null) {
+            return Map.of();
+        }
+        final Map<String, String> map = new HashMap<>();
+        for (String key : JacksonUtils.getKeys(section)) {
+            map.put(key, section.get(key).asString());
+        }
+        return map;
+    }
+
+    private Map<String, String> flatOverrides(JsonNode overrides) {
+        if (overrides == null) {
+            return Map.of();
+        }
+        return flattenOverrides((ObjectNode) overrides);
+    }
+
+    /**
+     * Returns the project's overrides as a flat map, reading from the
+     * {@code pnpm.overrides} section when pnpm is enabled and from the
+     * top-level {@code overrides} section otherwise.
+     */
+    private Map<String, String> projectOverrides(ObjectNode packageJson) {
+        if (enablePnpm && packageJson.has(PNPM)
+                && packageJson.get(PNPM).has(OVERRIDES)) {
+            return flatOverrides(packageJson.get(PNPM).get(OVERRIDES));
+        }
+        return flatOverrides(packageJson.get(OVERRIDES));
     }
 
     /**

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -850,9 +850,10 @@ public class TaskUpdatePackages extends NodeUpdater {
                             which is from a different minor/major version than the version '{}' \
                             expected by Vaadin. Overriding to another maintenance release is \
                             supported, but using a different minor or major version is usually a \
-                            mistake and may cause runtime errors or a blank page. Remove the \
-                            override from the 'dependencies' block in package.json unless it is \
-                            intentional.""",
+                            mistake and may cause runtime errors or a blank page. Unless the \
+                            override is intentional, remove it from the 'dependencies' block in \
+                            package.json or run 'mvn vaadin:clean-frontend' to reset the \
+                            frontend to a clean state.""",
                     pkg, overrideVersion.getFullVersion(),
                     expectedVersion.getFullVersion());
         }

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -33,6 +33,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ObjectNode;
 import tools.jackson.databind.node.StringNode;
@@ -676,7 +678,7 @@ public class TaskUpdatePackages extends NodeUpdater {
             // version through exclusion
             if (!filteredApplicationDependencies.containsKey(key)
                     && pinPlatformDependency(packageJson,
-                            platformPinnedDependencies, key)) {
+                            platformPinnedDependencies, key, true)) {
                 added++;
             }
             // make sure platform pinned dependency is not cleared
@@ -756,6 +758,13 @@ public class TaskUpdatePackages extends NodeUpdater {
 
     protected static boolean pinPlatformDependency(JsonNode packageJson,
             JsonNode platformPinnedVersions, String pkg) {
+        return pinPlatformDependency(packageJson, platformPinnedVersions, pkg,
+                false);
+    }
+
+    protected static boolean pinPlatformDependency(JsonNode packageJson,
+            JsonNode platformPinnedVersions, String pkg,
+            boolean warnOnRangeMismatch) {
         final FrontendVersion platformPinnedVersion = FrontendUtils
                 .getPackageVersionFromJson(platformPinnedVersions, pkg,
                         "vaadin_dependencies.json");
@@ -794,6 +803,10 @@ public class TaskUpdatePackages extends NodeUpdater {
         if ((vaadinDepsVersion != null && packageJsonVersion != null)
                 && !vaadinDepsVersion.equals(packageJsonVersion)) {
             // The user has overridden the version, use that
+            if (warnOnRangeMismatch) {
+                warnIfOverrideInDifferentRange(pkg, platformPinnedVersion,
+                        packageJsonVersion);
+            }
             return false;
         }
 
@@ -805,6 +818,48 @@ public class TaskUpdatePackages extends NodeUpdater {
         packageJsonDeps.put(pkg, platformPinnedVersion.getFullVersion());
         vaadinDeps.put(pkg, platformPinnedVersion.getFullVersion());
         return true;
+    }
+
+    /**
+     * Warns when a user override in {@code package.json} pins a
+     * platform-managed package to a different minor or major version than the
+     * one expected by the current Vaadin version.
+     * <p>
+     * Overriding a package to another maintenance (patch) release of the same
+     * minor is a supported way of picking up a fix early. Overriding to a
+     * different minor or major version is usually a mistake, as the rest of the
+     * platform is built and tested against the expected version, and the
+     * mismatch can lead to runtime errors or broken generated frontend files.
+     *
+     * @param pkg
+     *            the name of the overridden package
+     * @param expectedVersion
+     *            the version expected by the current Vaadin version
+     * @param overrideVersion
+     *            the version the user has set in {@code package.json}
+     */
+    private static void warnIfOverrideInDifferentRange(String pkg,
+            FrontendVersion expectedVersion, FrontendVersion overrideVersion) {
+        if (expectedVersion.getMajorVersion() != overrideVersion
+                .getMajorVersion()
+                || expectedVersion.getMinorVersion() != overrideVersion
+                        .getMinorVersion()) {
+            getLogger().warn(
+                    """
+                            The package '{}' is overridden in package.json to version '{}', \
+                            which is from a different minor/major version than the version '{}' \
+                            expected by Vaadin. Overriding to another maintenance release is \
+                            supported, but using a different minor or major version is usually a \
+                            mistake and may cause runtime errors or a blank page. Remove the \
+                            override from the 'dependencies' block in package.json unless it is \
+                            intentional.""",
+                    pkg, overrideVersion.getFullVersion(),
+                    expectedVersion.getFullVersion());
+        }
+    }
+
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(TaskUpdatePackages.class);
     }
 
     /**

--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -810,20 +810,24 @@ public class TaskUpdatePackages extends NodeUpdater {
     }
 
     /**
-     * Warns about platform-managed packages that the project has pinned in
-     * {@code package.json} to a version from a different minor or major range
-     * than the one expected by the current Vaadin version.
+     * Warns about platform-managed packages that the project has pinned in the
+     * {@code dependencies} or {@code devDependencies} of {@code package.json}
+     * to a version from a different minor or major range than the one expected
+     * by the current Vaadin version.
      * <p>
      * This is checked on the package.json as it is read, before the version
-     * locking updates it, so that pins that the build would simply overwrite
-     * are not reported. Only values that differ from the ones Vaadin manages
-     * (kept in the {@code vaadin} section) are considered, as those are the
-     * explicit opt-outs that the build leaves untouched. Pinning a package to
-     * another maintenance (patch) release of the same minor is a supported way
-     * of picking up a fix early, but pinning it to a different minor or major
-     * version is usually a mistake, since the rest of the platform is built and
-     * tested against the expected version. Such mismatches can lead to runtime
-     * errors or broken generated frontend files (a blank page).
+     * locking updates it, so that pins the build would simply overwrite are not
+     * reported. Only values that differ from the ones Vaadin manages (kept in
+     * the {@code vaadin} section) are considered, as those are the explicit
+     * opt-outs that the build leaves untouched. Entries in the
+     * {@code overrides} section are intentionally not reported here, as those
+     * are reconciled with the platform versions by the override management.
+     * Pinning a package to another maintenance (patch) release of the same
+     * minor is a supported way of picking up a fix early, but pinning it to a
+     * different minor or major version is usually a mistake, since the rest of
+     * the platform is built and tested against the expected version. Such
+     * mismatches can lead to runtime errors or broken generated frontend files
+     * (a blank page).
      *
      * @param packageJson
      *            the package.json as read, before version locking
@@ -844,16 +848,13 @@ public class TaskUpdatePackages extends NodeUpdater {
                 sectionToMap(
                         vaadin == null ? null : vaadin.get(DEV_DEPENDENCIES)),
                 expectedVersions, DEV_DEPENDENCIES, mismatches);
-        collectRangeMismatches(projectOverrides(packageJson),
-                flatOverrides(vaadin == null ? null : vaadin.get(OVERRIDES)),
-                expectedVersions, OVERRIDES, mismatches);
 
         if (!mismatches.isEmpty()) {
             log().warn(
                     """
                             The following packages are pinned in package.json to a different \
                             minor/major version than the version expected by the current Vaadin \
-                            version. Overriding to another maintenance release is supported, but \
+                            version. Pinning to another maintenance release is supported, but \
                             using a different minor or major version is usually a mistake and may \
                             cause runtime errors or a blank page:
                             {}
@@ -916,26 +917,6 @@ public class TaskUpdatePackages extends NodeUpdater {
             map.put(key, section.get(key).asString());
         }
         return map;
-    }
-
-    private Map<String, String> flatOverrides(JsonNode overrides) {
-        if (overrides == null) {
-            return Map.of();
-        }
-        return flattenOverrides((ObjectNode) overrides);
-    }
-
-    /**
-     * Returns the project's overrides as a flat map, reading from the
-     * {@code pnpm.overrides} section when pnpm is enabled and from the
-     * top-level {@code overrides} section otherwise.
-     */
-    private Map<String, String> projectOverrides(ObjectNode packageJson) {
-        if (enablePnpm && packageJson.has(PNPM)
-                && packageJson.get(PNPM).has(OVERRIDES)) {
-            return flatOverrides(packageJson.get(PNPM).get(OVERRIDES));
-        }
-        return flatOverrides(packageJson.get(OVERRIDES));
     }
 
     /**

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
@@ -35,6 +35,7 @@ import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -276,6 +277,75 @@ class TaskUpdatePackagesNpmTest {
         overrides = getOrCreatePackageJson().get(OVERRIDES);
 
         assertEquals("$@vaadin/aura", overrides.get("@vaadin/aura").asString());
+    }
+
+    @Test
+    void pinPlatformDependency_overrideToDifferentMinor_warningLogged() {
+        // vaadin section has the framework version, top-level dependencies has
+        // a user override to a different minor than the expected platform
+        // version
+        ObjectNode packageJson = packageJsonWithOverride(VAADIN_DIALOG,
+                "25.1.0", "25.2.5");
+        ObjectNode platformPinnedVersions = JacksonUtils.createObjectNode();
+        platformPinnedVersions.put(VAADIN_DIALOG, "25.1.3");
+
+        Logger logger = Mockito.spy(Logger.class);
+        try (MockedStatic<LoggerFactory> loggerFactoryMocked = Mockito
+                .mockStatic(LoggerFactory.class)) {
+            loggerFactoryMocked.when(
+                    () -> LoggerFactory.getLogger(TaskUpdatePackages.class))
+                    .thenReturn(logger);
+
+            boolean pinned = TaskUpdatePackages.pinPlatformDependency(
+                    packageJson, platformPinnedVersions, VAADIN_DIALOG, true);
+
+            assertFalse(pinned, "User override should be left untouched");
+            Mockito.verify(logger, Mockito.times(1)).warn(Mockito.anyString(),
+                    Mockito.eq(VAADIN_DIALOG), Mockito.eq("25.2.5"),
+                    Mockito.eq("25.1.3"));
+        }
+    }
+
+    @Test
+    void pinPlatformDependency_overrideToDifferentMaintenanceRelease_noWarning() {
+        // override only differs from the expected version in the maintenance
+        // (patch) part, which is supported and should not warn
+        ObjectNode packageJson = packageJsonWithOverride(VAADIN_DIALOG,
+                "25.1.0", "25.1.7");
+        ObjectNode platformPinnedVersions = JacksonUtils.createObjectNode();
+        platformPinnedVersions.put(VAADIN_DIALOG, "25.1.3");
+
+        Logger logger = Mockito.spy(Logger.class);
+        try (MockedStatic<LoggerFactory> loggerFactoryMocked = Mockito
+                .mockStatic(LoggerFactory.class)) {
+            loggerFactoryMocked.when(
+                    () -> LoggerFactory.getLogger(TaskUpdatePackages.class))
+                    .thenReturn(logger);
+
+            boolean pinned = TaskUpdatePackages.pinPlatformDependency(
+                    packageJson, platformPinnedVersions, VAADIN_DIALOG, true);
+
+            assertFalse(pinned, "User override should be left untouched");
+            Mockito.verify(logger, Mockito.never()).warn(Mockito.anyString(),
+                    Mockito.any(), Mockito.any(), Mockito.any());
+        }
+    }
+
+    private static ObjectNode packageJsonWithOverride(String pkg,
+            String vaadinVersion, String overrideVersion) {
+        ObjectNode packageJson = JacksonUtils.createObjectNode();
+
+        ObjectNode dependencies = JacksonUtils.createObjectNode();
+        dependencies.put(pkg, overrideVersion);
+        packageJson.set(DEPENDENCIES, dependencies);
+
+        ObjectNode vaadin = JacksonUtils.createObjectNode();
+        ObjectNode vaadinDependencies = JacksonUtils.createObjectNode();
+        vaadinDependencies.put(pkg, vaadinVersion);
+        vaadin.set(DEPENDENCIES, vaadinDependencies);
+        packageJson.set(VAADIN_DEP_KEY, vaadin);
+
+        return packageJson;
     }
 
     @Test

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
@@ -35,7 +35,6 @@ import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -280,72 +279,126 @@ class TaskUpdatePackagesNpmTest {
     }
 
     @Test
-    void pinPlatformDependency_overrideToDifferentMinor_warningLogged() {
-        // vaadin section has the framework version, top-level dependencies has
-        // a user override to a different minor than the expected platform
-        // version
-        ObjectNode packageJson = packageJsonWithOverride(VAADIN_DIALOG,
-                "25.1.0", "25.2.5");
-        ObjectNode platformPinnedVersions = JacksonUtils.createObjectNode();
-        platformPinnedVersions.put(VAADIN_DIALOG, "25.1.3");
+    void warnOnVersionRangeMismatch_overrideToDifferentMinor_warningLogged()
+            throws IOException {
+        // platform expects 25.3.x for dialog, but the overrides section locks
+        // it to a different minor (25.1.0)
+        createVaadinVersionsJson("25.3.0", PLATFORM_ELEMENT_MIXIN_VERSION,
+                PLATFORM_OVERLAY_VERSION);
 
-        Logger logger = Mockito.spy(Logger.class);
-        try (MockedStatic<LoggerFactory> loggerFactoryMocked = Mockito
-                .mockStatic(LoggerFactory.class)) {
-            loggerFactoryMocked.when(
-                    () -> LoggerFactory.getLogger(TaskUpdatePackages.class))
-                    .thenReturn(logger);
+        ObjectNode packageJson = JacksonUtils.createObjectNode();
+        ObjectNode overrides = JacksonUtils.createObjectNode();
+        overrides.put(VAADIN_DIALOG, "25.1.0");
+        packageJson.set(OVERRIDES, overrides);
 
-            boolean pinned = TaskUpdatePackages.pinPlatformDependency(
-                    packageJson, platformPinnedVersions, VAADIN_DIALOG, true);
+        Logger logger = Mockito.mock(Logger.class);
+        createTaskWithLogger(logger).warnOnVersionRangeMismatch(packageJson);
 
-            assertFalse(pinned, "User override should be left untouched");
-            Mockito.verify(logger, Mockito.times(1)).warn(Mockito.anyString(),
-                    Mockito.eq(VAADIN_DIALOG), Mockito.eq("25.2.5"),
-                    Mockito.eq("25.1.3"));
-        }
+        Mockito.verify(logger, Mockito.times(1)).warn(Mockito.anyString(),
+                Mockito.contains(VAADIN_DIALOG));
     }
 
     @Test
-    void pinPlatformDependency_overrideToDifferentMaintenanceRelease_noWarning() {
+    void warnOnVersionRangeMismatch_overrideToDifferentMaintenanceRelease_noWarning()
+            throws IOException {
         // override only differs from the expected version in the maintenance
         // (patch) part, which is supported and should not warn
-        ObjectNode packageJson = packageJsonWithOverride(VAADIN_DIALOG,
-                "25.1.0", "25.1.7");
-        ObjectNode platformPinnedVersions = JacksonUtils.createObjectNode();
-        platformPinnedVersions.put(VAADIN_DIALOG, "25.1.3");
+        createVaadinVersionsJson("25.1.4", PLATFORM_ELEMENT_MIXIN_VERSION,
+                PLATFORM_OVERLAY_VERSION);
 
-        Logger logger = Mockito.spy(Logger.class);
-        try (MockedStatic<LoggerFactory> loggerFactoryMocked = Mockito
-                .mockStatic(LoggerFactory.class)) {
-            loggerFactoryMocked.when(
-                    () -> LoggerFactory.getLogger(TaskUpdatePackages.class))
-                    .thenReturn(logger);
+        ObjectNode packageJson = JacksonUtils.createObjectNode();
+        ObjectNode overrides = JacksonUtils.createObjectNode();
+        overrides.put(VAADIN_DIALOG, "25.1.0");
+        packageJson.set(OVERRIDES, overrides);
 
-            boolean pinned = TaskUpdatePackages.pinPlatformDependency(
-                    packageJson, platformPinnedVersions, VAADIN_DIALOG, true);
+        Logger logger = Mockito.mock(Logger.class);
+        createTaskWithLogger(logger).warnOnVersionRangeMismatch(packageJson);
 
-            assertFalse(pinned, "User override should be left untouched");
-            Mockito.verify(logger, Mockito.never()).warn(Mockito.anyString(),
-                    Mockito.any(), Mockito.any(), Mockito.any());
-        }
+        Mockito.verifyNoInteractions(logger);
     }
 
-    private static ObjectNode packageJsonWithOverride(String pkg,
-            String vaadinVersion, String overrideVersion) {
-        ObjectNode packageJson = JacksonUtils.createObjectNode();
+    @Test
+    void execute_overridesDriftedToOlderMinor_warningLogged()
+            throws IOException {
+        // Reproduces #24702: the overrides section keeps a transitive component
+        // pinned to an older minor (25.1.0) than the platform now expects
+        // (25.3.0-SNAPSHOT). Such a stale override is a user opt-out that the
+        // version locking leaves in place, so the build should warn about it.
+        // A SNAPSHOT platform version is used to match the reported scenario.
+        createVaadinVersionsJson("25.3.0-SNAPSHOT",
+                PLATFORM_ELEMENT_MIXIN_VERSION, PLATFORM_OVERLAY_VERSION);
+        writeDriftedPackageJson("25.1.0");
 
-        ObjectNode dependencies = JacksonUtils.createObjectNode();
-        dependencies.put(pkg, overrideVersion);
-        packageJson.set(DEPENDENCIES, dependencies);
+        Logger logger = Mockito.mock(Logger.class);
+        createTaskWithLogger(logger, Collections.emptyMap()).execute();
+
+        Mockito.verify(logger, Mockito.atLeastOnce()).warn(Mockito.anyString(),
+                Mockito.contains(VAADIN_DIALOG));
+    }
+
+    @Test
+    void execute_overridesDriftedWithinSameMinor_noWarning()
+            throws IOException {
+        // A drift that stays within the same minor (25.3.0 expected, 25.3.1
+        // pinned) is a supported maintenance override and should not warn.
+        createVaadinVersionsJson("25.3.0", PLATFORM_ELEMENT_MIXIN_VERSION,
+                PLATFORM_OVERLAY_VERSION);
+        writeDriftedPackageJson("25.3.1");
+
+        Logger logger = Mockito.mock(Logger.class);
+        createTaskWithLogger(logger, Collections.emptyMap()).execute();
+
+        Mockito.verify(logger, Mockito.never()).warn(Mockito.anyString(),
+                Mockito.contains(VAADIN_DIALOG));
+    }
+
+    /**
+     * Writes a package.json where {@link #VAADIN_DIALOG} is a transitive
+     * component locked in the overrides section to {@code overrideVersion},
+     * while the Vaadin-managed sections still reference 25.1.4 (simulating a
+     * project upgraded from 25.1).
+     */
+    private void writeDriftedPackageJson(String overrideVersion)
+            throws IOException {
+        ObjectNode packageJson = JacksonUtils.createObjectNode();
+        packageJson.set(DEPENDENCIES, JacksonUtils.createObjectNode());
+        packageJson.set(DEV_DEPENDENCIES, JacksonUtils.createObjectNode());
+
+        ObjectNode overrides = JacksonUtils.createObjectNode();
+        overrides.put(VAADIN_DIALOG, overrideVersion);
+        packageJson.set(OVERRIDES, overrides);
 
         ObjectNode vaadin = JacksonUtils.createObjectNode();
-        ObjectNode vaadinDependencies = JacksonUtils.createObjectNode();
-        vaadinDependencies.put(pkg, vaadinVersion);
-        vaadin.set(DEPENDENCIES, vaadinDependencies);
+        vaadin.set(DEPENDENCIES, JacksonUtils.createObjectNode());
+        vaadin.set(DEV_DEPENDENCIES, JacksonUtils.createObjectNode());
+        ObjectNode vaadinOverrides = JacksonUtils.createObjectNode();
+        vaadinOverrides.put(VAADIN_DIALOG, "25.1.4");
+        vaadin.set(OVERRIDES, vaadinOverrides);
         packageJson.set(VAADIN_DEP_KEY, vaadin);
 
-        return packageJson;
+        FileUtils.writeStringToFile(new File(npmFolder, PACKAGE_JSON),
+                packageJson.toPrettyString(), StandardCharsets.UTF_8);
+    }
+
+    private TaskUpdatePackages createTaskWithLogger(Logger logger) {
+        return createTaskWithLogger(logger, createApplicationDependencies());
+    }
+
+    private TaskUpdatePackages createTaskWithLogger(Logger logger,
+            Map<String, String> applicationDependencies) {
+        final FrontendDependencies scanner = Mockito
+                .mock(FrontendDependencies.class);
+        Mockito.when(scanner.getPackages()).thenReturn(applicationDependencies);
+        Options options = new MockOptions(finder, npmFolder)
+                .withBuildDirectory(TARGET).withEnablePnpm(false)
+                .withBundleBuild(true).withReact(false)
+                .withFrontendDependenciesScanner(scanner);
+        return new TaskUpdatePackages(options) {
+            @Override
+            Logger log() {
+                return logger;
+            }
+        };
     }
 
     @Test

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
@@ -15,6 +15,22 @@
  */
 package com.vaadin.flow.server.frontend;
 
+import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
+import static com.vaadin.flow.server.Constants.TARGET;
+import static com.vaadin.flow.server.frontend.NodeUpdater.DEPENDENCIES;
+import static com.vaadin.flow.server.frontend.NodeUpdater.DEV_DEPENDENCIES;
+import static com.vaadin.flow.server.frontend.NodeUpdater.OVERRIDES;
+import static com.vaadin.flow.server.frontend.NodeUpdater.PNPM;
+import static com.vaadin.flow.server.frontend.NodeUpdater.VAADIN_DEP_KEY;
+import static com.vaadin.flow.server.frontend.VersionsJsonConverter.VAADIN_CORE_NPM_PACKAGE;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -35,12 +51,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Isolated;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.node.ObjectNode;
-import tools.jackson.databind.node.StringNode;
 
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.server.Constants;
@@ -49,21 +63,9 @@ import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
 import com.vaadin.tests.util.MockOptions;
 
-import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
-import static com.vaadin.flow.server.Constants.TARGET;
-import static com.vaadin.flow.server.frontend.NodeUpdater.DEPENDENCIES;
-import static com.vaadin.flow.server.frontend.NodeUpdater.DEV_DEPENDENCIES;
-import static com.vaadin.flow.server.frontend.NodeUpdater.OVERRIDES;
-import static com.vaadin.flow.server.frontend.NodeUpdater.PNPM;
-import static com.vaadin.flow.server.frontend.NodeUpdater.VAADIN_DEP_KEY;
-import static com.vaadin.flow.server.frontend.VersionsJsonConverter.VAADIN_CORE_NPM_PACKAGE;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.StringNode;
 
 @Isolated
 class TaskUpdatePackagesNpmTest {
@@ -276,6 +278,75 @@ class TaskUpdatePackagesNpmTest {
         overrides = getOrCreatePackageJson().get(OVERRIDES);
 
         assertEquals("$@vaadin/aura", overrides.get("@vaadin/aura").asString());
+    }
+
+    @Test
+    void pinPlatformDependency_overrideToDifferentMinor_warningLogged() {
+        // vaadin section has the framework version, top-level dependencies has
+        // a user override to a different minor than the expected platform
+        // version
+        ObjectNode packageJson = packageJsonWithOverride(VAADIN_DIALOG,
+                "25.1.0", "25.2.5");
+        ObjectNode platformPinnedVersions = JacksonUtils.createObjectNode();
+        platformPinnedVersions.put(VAADIN_DIALOG, "25.1.3");
+
+        Logger logger = Mockito.spy(Logger.class);
+        try (MockedStatic<LoggerFactory> loggerFactoryMocked = Mockito
+                .mockStatic(LoggerFactory.class)) {
+            loggerFactoryMocked.when(
+                    () -> LoggerFactory.getLogger(TaskUpdatePackages.class))
+                    .thenReturn(logger);
+
+            boolean pinned = TaskUpdatePackages.pinPlatformDependency(
+                    packageJson, platformPinnedVersions, VAADIN_DIALOG, true);
+
+            assertFalse(pinned, "User override should be left untouched");
+            Mockito.verify(logger, Mockito.times(1)).warn(Mockito.anyString(),
+                    Mockito.eq(VAADIN_DIALOG), Mockito.eq("25.2.5"),
+                    Mockito.eq("25.1.3"));
+        }
+    }
+
+    @Test
+    void pinPlatformDependency_overrideToDifferentMaintenanceRelease_noWarning() {
+        // override only differs from the expected version in the maintenance
+        // (patch) part, which is supported and should not warn
+        ObjectNode packageJson = packageJsonWithOverride(VAADIN_DIALOG,
+                "25.1.0", "25.1.7");
+        ObjectNode platformPinnedVersions = JacksonUtils.createObjectNode();
+        platformPinnedVersions.put(VAADIN_DIALOG, "25.1.3");
+
+        Logger logger = Mockito.spy(Logger.class);
+        try (MockedStatic<LoggerFactory> loggerFactoryMocked = Mockito
+                .mockStatic(LoggerFactory.class)) {
+            loggerFactoryMocked.when(
+                    () -> LoggerFactory.getLogger(TaskUpdatePackages.class))
+                    .thenReturn(logger);
+
+            boolean pinned = TaskUpdatePackages.pinPlatformDependency(
+                    packageJson, platformPinnedVersions, VAADIN_DIALOG, true);
+
+            assertFalse(pinned, "User override should be left untouched");
+            Mockito.verify(logger, Mockito.never()).warn(Mockito.anyString(),
+                    Mockito.any(), Mockito.any(), Mockito.any());
+        }
+    }
+
+    private static ObjectNode packageJsonWithOverride(String pkg,
+            String vaadinVersion, String overrideVersion) {
+        ObjectNode packageJson = JacksonUtils.createObjectNode();
+
+        ObjectNode dependencies = JacksonUtils.createObjectNode();
+        dependencies.put(pkg, overrideVersion);
+        packageJson.set(DEPENDENCIES, dependencies);
+
+        ObjectNode vaadin = JacksonUtils.createObjectNode();
+        ObjectNode vaadinDependencies = JacksonUtils.createObjectNode();
+        vaadinDependencies.put(pkg, vaadinVersion);
+        vaadin.set(DEPENDENCIES, vaadinDependencies);
+        packageJson.set(VAADIN_DEP_KEY, vaadin);
+
+        return packageJson;
     }
 
     @Test

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
@@ -280,55 +280,15 @@ class TaskUpdatePackagesNpmTest {
     }
 
     @Test
-    void warnOnVersionRangeMismatch_overrideToDifferentMinor_warningLogged()
+    void execute_dependencyPinnedToDifferentMinor_warningLogged()
             throws IOException {
-        // platform expects 25.3.x for dialog, but the overrides section locks
-        // it to a different minor (25.1.0)
-        createVaadinVersionsJson("25.3.0", PLATFORM_ELEMENT_MIXIN_VERSION,
-                PLATFORM_OVERLAY_VERSION);
-
-        ObjectNode packageJson = JacksonUtils.createObjectNode();
-        ObjectNode overrides = JacksonUtils.createObjectNode();
-        overrides.put(VAADIN_DIALOG, "25.1.0");
-        packageJson.set(OVERRIDES, overrides);
-
-        Logger logger = Mockito.mock(Logger.class);
-        createTaskWithLogger(logger).warnOnVersionRangeMismatch(packageJson);
-
-        Mockito.verify(logger, Mockito.times(1)).warn(Mockito.anyString(),
-                Mockito.contains(VAADIN_DIALOG));
-    }
-
-    @Test
-    void warnOnVersionRangeMismatch_overrideToDifferentMaintenanceRelease_noWarning()
-            throws IOException {
-        // override only differs from the expected version in the maintenance
-        // (patch) part, which is supported and should not warn
-        createVaadinVersionsJson("25.1.4", PLATFORM_ELEMENT_MIXIN_VERSION,
-                PLATFORM_OVERLAY_VERSION);
-
-        ObjectNode packageJson = JacksonUtils.createObjectNode();
-        ObjectNode overrides = JacksonUtils.createObjectNode();
-        overrides.put(VAADIN_DIALOG, "25.1.0");
-        packageJson.set(OVERRIDES, overrides);
-
-        Logger logger = Mockito.mock(Logger.class);
-        createTaskWithLogger(logger).warnOnVersionRangeMismatch(packageJson);
-
-        Mockito.verifyNoInteractions(logger);
-    }
-
-    @Test
-    void execute_overridesDriftedToOlderMinor_warningLogged()
-            throws IOException {
-        // Reproduces #24702: the overrides section keeps a transitive component
-        // pinned to an older minor (25.1.0) than the platform now expects
-        // (25.3.0-SNAPSHOT). Such a stale override is a user opt-out that the
-        // version locking leaves in place, so the build should warn about it.
-        // A SNAPSHOT platform version is used to match the reported scenario.
+        // The project pins dialog in 'dependencies' to an older minor (25.1.0)
+        // than the platform expects (25.3.0-SNAPSHOT). The version locking
+        // respects this user pin, so the build should warn about it. A SNAPSHOT
+        // platform version is used to match the scenario in #24702.
         createVaadinVersionsJson("25.3.0-SNAPSHOT",
                 PLATFORM_ELEMENT_MIXIN_VERSION, PLATFORM_OVERLAY_VERSION);
-        writeDriftedPackageJson("25.1.0");
+        writePinnedDependencyPackageJson("25.1.0");
 
         Logger logger = Mockito.mock(Logger.class);
         createTaskWithLogger(logger, Collections.emptyMap()).execute();
@@ -338,45 +298,69 @@ class TaskUpdatePackagesNpmTest {
     }
 
     @Test
-    void execute_overridesDriftedWithinSameMinor_noWarning()
+    void warnOnVersionRangeMismatch_dependencyPinnedToMaintenanceRelease_noWarning()
             throws IOException {
-        // A drift that stays within the same minor (25.3.0 expected, 25.3.1
-        // pinned) is a supported maintenance override and should not warn.
-        createVaadinVersionsJson("25.3.0", PLATFORM_ELEMENT_MIXIN_VERSION,
+        // The pin differs from the expected version only in the maintenance
+        // (patch) part, which is supported and should not warn.
+        createVaadinVersionsJson("25.1.4", PLATFORM_ELEMENT_MIXIN_VERSION,
                 PLATFORM_OVERLAY_VERSION);
-        writeDriftedPackageJson("25.3.1");
 
         Logger logger = Mockito.mock(Logger.class);
-        createTaskWithLogger(logger, Collections.emptyMap()).execute();
+        createTaskWithLogger(logger).warnOnVersionRangeMismatch(
+                dependencyPackageJson("25.1.0", "25.1.4"));
 
-        Mockito.verify(logger, Mockito.never()).warn(Mockito.anyString(),
-                Mockito.contains(VAADIN_DIALOG));
+        Mockito.verifyNoInteractions(logger);
+    }
+
+    @Test
+    void warnOnVersionRangeMismatch_dependencyManagedByVaadin_noWarning()
+            throws IOException {
+        // The dependency matches the Vaadin-managed version, so it is not a
+        // user
+        // opt-out: the build updates it itself and no warning should be
+        // emitted,
+        // even though it is currently from an older minor than expected.
+        createVaadinVersionsJson("25.3.0", PLATFORM_ELEMENT_MIXIN_VERSION,
+                PLATFORM_OVERLAY_VERSION);
+
+        Logger logger = Mockito.mock(Logger.class);
+        createTaskWithLogger(logger).warnOnVersionRangeMismatch(
+                dependencyPackageJson("25.1.4", "25.1.4"));
+
+        Mockito.verifyNoInteractions(logger);
     }
 
     /**
-     * Writes a package.json where {@link #VAADIN_DIALOG} is a transitive
-     * component locked in the overrides section to {@code overrideVersion},
-     * while the Vaadin-managed sections still reference 25.1.4 (simulating a
-     * project upgraded from 25.1).
+     * Builds a package.json where {@link #VAADIN_DIALOG} is declared in
+     * {@code dependencies} at {@code dependencyVersion} while the
+     * Vaadin-managed {@code vaadin.dependencies} section references
+     * {@code vaadinVersion}.
      */
-    private void writeDriftedPackageJson(String overrideVersion)
-            throws IOException {
+    private ObjectNode dependencyPackageJson(String dependencyVersion,
+            String vaadinVersion) {
         ObjectNode packageJson = JacksonUtils.createObjectNode();
-        packageJson.set(DEPENDENCIES, JacksonUtils.createObjectNode());
-        packageJson.set(DEV_DEPENDENCIES, JacksonUtils.createObjectNode());
-
-        ObjectNode overrides = JacksonUtils.createObjectNode();
-        overrides.put(VAADIN_DIALOG, overrideVersion);
-        packageJson.set(OVERRIDES, overrides);
+        ObjectNode dependencies = JacksonUtils.createObjectNode();
+        dependencies.put(VAADIN_DIALOG, dependencyVersion);
+        packageJson.set(DEPENDENCIES, dependencies);
 
         ObjectNode vaadin = JacksonUtils.createObjectNode();
-        vaadin.set(DEPENDENCIES, JacksonUtils.createObjectNode());
-        vaadin.set(DEV_DEPENDENCIES, JacksonUtils.createObjectNode());
-        ObjectNode vaadinOverrides = JacksonUtils.createObjectNode();
-        vaadinOverrides.put(VAADIN_DIALOG, "25.1.4");
-        vaadin.set(OVERRIDES, vaadinOverrides);
+        ObjectNode vaadinDependencies = JacksonUtils.createObjectNode();
+        vaadinDependencies.put(VAADIN_DIALOG, vaadinVersion);
+        vaadin.set(DEPENDENCIES, vaadinDependencies);
         packageJson.set(VAADIN_DEP_KEY, vaadin);
+        return packageJson;
+    }
 
+    /**
+     * Writes a package.json where {@link #VAADIN_DIALOG} is pinned in
+     * {@code dependencies} to {@code dependencyVersion}, while the
+     * Vaadin-managed section still references 25.1.4 (simulating a project
+     * upgraded from 25.1 with a user pin).
+     */
+    private void writePinnedDependencyPackageJson(String dependencyVersion)
+            throws IOException {
+        ObjectNode packageJson = dependencyPackageJson(dependencyVersion,
+                "25.1.4");
         FileUtils.writeStringToFile(new File(npmFolder, PACKAGE_JSON),
                 packageJson.toPrettyString(), StandardCharsets.UTF_8);
     }

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
@@ -51,7 +51,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Isolated;
-import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -281,72 +280,126 @@ class TaskUpdatePackagesNpmTest {
     }
 
     @Test
-    void pinPlatformDependency_overrideToDifferentMinor_warningLogged() {
-        // vaadin section has the framework version, top-level dependencies has
-        // a user override to a different minor than the expected platform
-        // version
-        ObjectNode packageJson = packageJsonWithOverride(VAADIN_DIALOG,
-                "25.1.0", "25.2.5");
-        ObjectNode platformPinnedVersions = JacksonUtils.createObjectNode();
-        platformPinnedVersions.put(VAADIN_DIALOG, "25.1.3");
+    void warnOnVersionRangeMismatch_overrideToDifferentMinor_warningLogged()
+            throws IOException {
+        // platform expects 25.3.x for dialog, but the overrides section locks
+        // it to a different minor (25.1.0)
+        createVaadinVersionsJson("25.3.0", PLATFORM_ELEMENT_MIXIN_VERSION,
+                PLATFORM_OVERLAY_VERSION);
 
-        Logger logger = Mockito.spy(Logger.class);
-        try (MockedStatic<LoggerFactory> loggerFactoryMocked = Mockito
-                .mockStatic(LoggerFactory.class)) {
-            loggerFactoryMocked.when(
-                    () -> LoggerFactory.getLogger(TaskUpdatePackages.class))
-                    .thenReturn(logger);
+        ObjectNode packageJson = JacksonUtils.createObjectNode();
+        ObjectNode overrides = JacksonUtils.createObjectNode();
+        overrides.put(VAADIN_DIALOG, "25.1.0");
+        packageJson.set(OVERRIDES, overrides);
 
-            boolean pinned = TaskUpdatePackages.pinPlatformDependency(
-                    packageJson, platformPinnedVersions, VAADIN_DIALOG, true);
+        Logger logger = Mockito.mock(Logger.class);
+        createTaskWithLogger(logger).warnOnVersionRangeMismatch(packageJson);
 
-            assertFalse(pinned, "User override should be left untouched");
-            Mockito.verify(logger, Mockito.times(1)).warn(Mockito.anyString(),
-                    Mockito.eq(VAADIN_DIALOG), Mockito.eq("25.2.5"),
-                    Mockito.eq("25.1.3"));
-        }
+        Mockito.verify(logger, Mockito.times(1)).warn(Mockito.anyString(),
+                Mockito.contains(VAADIN_DIALOG));
     }
 
     @Test
-    void pinPlatformDependency_overrideToDifferentMaintenanceRelease_noWarning() {
+    void warnOnVersionRangeMismatch_overrideToDifferentMaintenanceRelease_noWarning()
+            throws IOException {
         // override only differs from the expected version in the maintenance
         // (patch) part, which is supported and should not warn
-        ObjectNode packageJson = packageJsonWithOverride(VAADIN_DIALOG,
-                "25.1.0", "25.1.7");
-        ObjectNode platformPinnedVersions = JacksonUtils.createObjectNode();
-        platformPinnedVersions.put(VAADIN_DIALOG, "25.1.3");
+        createVaadinVersionsJson("25.1.4", PLATFORM_ELEMENT_MIXIN_VERSION,
+                PLATFORM_OVERLAY_VERSION);
 
-        Logger logger = Mockito.spy(Logger.class);
-        try (MockedStatic<LoggerFactory> loggerFactoryMocked = Mockito
-                .mockStatic(LoggerFactory.class)) {
-            loggerFactoryMocked.when(
-                    () -> LoggerFactory.getLogger(TaskUpdatePackages.class))
-                    .thenReturn(logger);
+        ObjectNode packageJson = JacksonUtils.createObjectNode();
+        ObjectNode overrides = JacksonUtils.createObjectNode();
+        overrides.put(VAADIN_DIALOG, "25.1.0");
+        packageJson.set(OVERRIDES, overrides);
 
-            boolean pinned = TaskUpdatePackages.pinPlatformDependency(
-                    packageJson, platformPinnedVersions, VAADIN_DIALOG, true);
+        Logger logger = Mockito.mock(Logger.class);
+        createTaskWithLogger(logger).warnOnVersionRangeMismatch(packageJson);
 
-            assertFalse(pinned, "User override should be left untouched");
-            Mockito.verify(logger, Mockito.never()).warn(Mockito.anyString(),
-                    Mockito.any(), Mockito.any(), Mockito.any());
-        }
+        Mockito.verifyNoInteractions(logger);
     }
 
-    private static ObjectNode packageJsonWithOverride(String pkg,
-            String vaadinVersion, String overrideVersion) {
-        ObjectNode packageJson = JacksonUtils.createObjectNode();
+    @Test
+    void execute_overridesDriftedToOlderMinor_warningLogged()
+            throws IOException {
+        // Reproduces #24702: the overrides section keeps a transitive component
+        // pinned to an older minor (25.1.0) than the platform now expects
+        // (25.3.0-SNAPSHOT). Such a stale override is a user opt-out that the
+        // version locking leaves in place, so the build should warn about it.
+        // A SNAPSHOT platform version is used to match the reported scenario.
+        createVaadinVersionsJson("25.3.0-SNAPSHOT",
+                PLATFORM_ELEMENT_MIXIN_VERSION, PLATFORM_OVERLAY_VERSION);
+        writeDriftedPackageJson("25.1.0");
 
-        ObjectNode dependencies = JacksonUtils.createObjectNode();
-        dependencies.put(pkg, overrideVersion);
-        packageJson.set(DEPENDENCIES, dependencies);
+        Logger logger = Mockito.mock(Logger.class);
+        createTaskWithLogger(logger, Collections.emptyMap()).execute();
+
+        Mockito.verify(logger, Mockito.atLeastOnce()).warn(Mockito.anyString(),
+                Mockito.contains(VAADIN_DIALOG));
+    }
+
+    @Test
+    void execute_overridesDriftedWithinSameMinor_noWarning()
+            throws IOException {
+        // A drift that stays within the same minor (25.3.0 expected, 25.3.1
+        // pinned) is a supported maintenance override and should not warn.
+        createVaadinVersionsJson("25.3.0", PLATFORM_ELEMENT_MIXIN_VERSION,
+                PLATFORM_OVERLAY_VERSION);
+        writeDriftedPackageJson("25.3.1");
+
+        Logger logger = Mockito.mock(Logger.class);
+        createTaskWithLogger(logger, Collections.emptyMap()).execute();
+
+        Mockito.verify(logger, Mockito.never()).warn(Mockito.anyString(),
+                Mockito.contains(VAADIN_DIALOG));
+    }
+
+    /**
+     * Writes a package.json where {@link #VAADIN_DIALOG} is a transitive
+     * component locked in the overrides section to {@code overrideVersion},
+     * while the Vaadin-managed sections still reference 25.1.4 (simulating a
+     * project upgraded from 25.1).
+     */
+    private void writeDriftedPackageJson(String overrideVersion)
+            throws IOException {
+        ObjectNode packageJson = JacksonUtils.createObjectNode();
+        packageJson.set(DEPENDENCIES, JacksonUtils.createObjectNode());
+        packageJson.set(DEV_DEPENDENCIES, JacksonUtils.createObjectNode());
+
+        ObjectNode overrides = JacksonUtils.createObjectNode();
+        overrides.put(VAADIN_DIALOG, overrideVersion);
+        packageJson.set(OVERRIDES, overrides);
 
         ObjectNode vaadin = JacksonUtils.createObjectNode();
-        ObjectNode vaadinDependencies = JacksonUtils.createObjectNode();
-        vaadinDependencies.put(pkg, vaadinVersion);
-        vaadin.set(DEPENDENCIES, vaadinDependencies);
+        vaadin.set(DEPENDENCIES, JacksonUtils.createObjectNode());
+        vaadin.set(DEV_DEPENDENCIES, JacksonUtils.createObjectNode());
+        ObjectNode vaadinOverrides = JacksonUtils.createObjectNode();
+        vaadinOverrides.put(VAADIN_DIALOG, "25.1.4");
+        vaadin.set(OVERRIDES, vaadinOverrides);
         packageJson.set(VAADIN_DEP_KEY, vaadin);
 
-        return packageJson;
+        FileUtils.writeStringToFile(new File(npmFolder, PACKAGE_JSON),
+                packageJson.toPrettyString(), StandardCharsets.UTF_8);
+    }
+
+    private TaskUpdatePackages createTaskWithLogger(Logger logger) {
+        return createTaskWithLogger(logger, createApplicationDependencies());
+    }
+
+    private TaskUpdatePackages createTaskWithLogger(Logger logger,
+            Map<String, String> applicationDependencies) {
+        final FrontendDependencies scanner = Mockito
+                .mock(FrontendDependencies.class);
+        Mockito.when(scanner.getPackages()).thenReturn(applicationDependencies);
+        Options options = new MockOptions(finder, npmFolder)
+                .withBuildDirectory(TARGET).withEnablePnpm(false)
+                .withBundleBuild(true).withReact(false)
+                .withFrontendDependenciesScanner(scanner);
+        return new TaskUpdatePackages(options) {
+            @Override
+            Logger log() {
+                return logger;
+            }
+        };
     }
 
     @Test

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
@@ -15,22 +15,6 @@
  */
 package com.vaadin.flow.server.frontend;
 
-import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
-import static com.vaadin.flow.server.Constants.TARGET;
-import static com.vaadin.flow.server.frontend.NodeUpdater.DEPENDENCIES;
-import static com.vaadin.flow.server.frontend.NodeUpdater.DEV_DEPENDENCIES;
-import static com.vaadin.flow.server.frontend.NodeUpdater.OVERRIDES;
-import static com.vaadin.flow.server.frontend.NodeUpdater.PNPM;
-import static com.vaadin.flow.server.frontend.NodeUpdater.VAADIN_DEP_KEY;
-import static com.vaadin.flow.server.frontend.VersionsJsonConverter.VAADIN_CORE_NPM_PACKAGE;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -54,6 +38,9 @@ import org.junit.jupiter.api.parallel.Isolated;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.StringNode;
 
 import com.vaadin.flow.internal.JacksonUtils;
 import com.vaadin.flow.server.Constants;
@@ -62,9 +49,21 @@ import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
 import com.vaadin.tests.util.MockOptions;
 
-import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.node.ObjectNode;
-import tools.jackson.databind.node.StringNode;
+import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
+import static com.vaadin.flow.server.Constants.TARGET;
+import static com.vaadin.flow.server.frontend.NodeUpdater.DEPENDENCIES;
+import static com.vaadin.flow.server.frontend.NodeUpdater.DEV_DEPENDENCIES;
+import static com.vaadin.flow.server.frontend.NodeUpdater.OVERRIDES;
+import static com.vaadin.flow.server.frontend.NodeUpdater.PNPM;
+import static com.vaadin.flow.server.frontend.NodeUpdater.VAADIN_DEP_KEY;
+import static com.vaadin.flow.server.frontend.VersionsJsonConverter.VAADIN_CORE_NPM_PACKAGE;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Isolated
 class TaskUpdatePackagesNpmTest {


### PR DESCRIPTION
## Summary

The build now prints a warning when your `package.json` pins a Vaadin-managed npm package to a different minor or major version than the one your Vaadin version expects. Such a pin is usually a mistake and can cause runtime errors or a blank page, and until now the build accepted it silently.

Fixes #24702

## What changed

**Behavior change:** builds can now log a new warning. Nothing fails and no file is written differently — only a log line is added. It affects only projects that pin a platform package in `dependencies` or `devDependencies` to a version from another minor/major range.

- `TaskUpdatePackages` gained a package-private `warnOnVersionRangeMismatch(ObjectNode)`, called from `execute()` **after** the dependency update and **before** the version pinning. That timing matters: at that point the file holds exactly the pins the build respects, so pins that this same run overwrites or removes are not reported.
- Only the `dependencies` and `devDependencies` sections are checked. The `overrides` section is skipped on purpose — it is Vaadin-managed and stale entries there are healed by the override management (see #24718).
- A value that equals the one in the Vaadin-managed `vaadin` section is skipped. Only real user opt-outs are reported.
- A different patch (maintenance) version is fine and stays silent. Only a different minor or major is reported.
- All mismatches go into one warning, listing package, found version, section and expected version, so a whole drifted platform does not flood the log. Sections are read in `package.json` order, so the list is stable between builds.
- Versions that `FrontendVersion` cannot parse are ignored instead of failing the build.
- The warning is logged only from the `package.json` update path, not from the bundle hash computation, so it is not printed twice.

## Use case

A team upgrades an app from Vaadin 25.1 to 25.3. An old pin for a component is still in their `package.json`:

```json
{
  "dependencies": {
    "@vaadin/vaadin-dialog": "25.1.0"
  }
}
```

The app builds fine but the dialog misbehaves at runtime. Instead of digging through the frontend bundle, the developer now sees this during the build:

```
The following packages are pinned in package.json to a different minor/major version
than the version expected by the current Vaadin version. Pinning to another
maintenance release is supported, but using a different minor or major version is
usually a mistake and may cause runtime errors or a blank page:
  - @vaadin/vaadin-dialog: 25.1.0 (in dependencies), expected 25.3.0
Unless these versions are intentional, remove the entries from package.json and run
'mvn vaadin:clean-frontend' to reset the frontend to a clean state.
```

They delete the pin, run `mvn vaadin:clean-frontend`, and the app picks up the platform version again.

## Test summary

| # | Status | What the test verifies | Why it matters |
|---|--------|------------------------|----------------|
| 1 | ✅ | A `dependencies` pin from an older minor that the build leaves in place produces a warning naming the package | The core feature; without it the drift stays silent |
| 2 | ✅ | A pin differing only in the patch part produces no warning | Picking up a fix early is supported and must not be flagged |
| 3 | ✅ | A value equal to the Vaadin-managed `vaadin` section produces no warning | Framework-managed versions are updated by the build itself; warning would be noise on every build |
| 4 | ✅ | A pin that the scanned version overwrites in the same run produces no warning, and the dependency is updated | Warning about a pin the build just removed sends users looking for nothing |
| 5 | ✅ | A `devDependencies` mismatch warns and names that section | devDependencies must be covered, and the section name tells the user where to look |
| 6 | ✅ | A `devDependencies` value managed by Vaadin produces no warning | Same opt-out rule must hold in both sections |
| 7 | ✅ | A mismatch in the `overrides` section produces no warning | Overrides are Vaadin-managed and self-healing; warning there would report entries the same build repairs |
| 8 | ❗ **gap** | Several mismatches are merged into one warning | A per-package warning would flood the log when a whole platform drifted |
| 9 | ❗ **gap** | An unparseable version (e.g. `^25.3.0`) is ignored instead of breaking the build | A parse failure here would break builds that work today |

Tests added in `TaskUpdatePackagesNpmTest`:

- `execute_dependencyPinnedToDifferentMinor_warningLogged` → 1
- `warnOnVersionRangeMismatch_dependencyPinnedToMaintenanceRelease_noWarning` → 2
- `warnOnVersionRangeMismatch_dependencyManagedByVaadin_noWarning` → 3
- `execute_pinnedDependencyUpdatedByScannedVersion_noWarning` → 4
- `warnOnVersionRangeMismatch_devDependencyPinnedToDifferentMinor_warningLogged` → 5
- `warnOnVersionRangeMismatch_devDependencyManagedByVaadin_noWarning` → 6
- `warnOnVersionRangeMismatch_overrideFromDifferentMinor_noWarning` → 7

Rows 3 and 6 check the same rule in the two sections; row 6 is cheap and guards the second call site, so both are kept. Deliberately untested: the exact wording of the warning text and the `mvn vaadin:clean-frontend` hint, since pinning message strings makes the tests brittle without protecting real behaviour.