### PR TITLE
feat: fail loudly when a trigger is created without an action

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/fullscreen/FullscreenBinding.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/fullscreen/FullscreenBinding.java
@@ -100,7 +100,7 @@ public final class FullscreenBinding implements Serializable {
      */
     public void enter(Component component) {
         Objects.requireNonNull(component, "component must not be null");
-        triggersWhenAttached(component,
+        bindWhenAttached(component,
                 () -> new RequestFullscreenAction(component));
     }
 
@@ -119,12 +119,11 @@ public final class FullscreenBinding implements Serializable {
     public void enter(Component component, SerializableRunnable onSuccess,
             SerializableConsumer<Error> onError) {
         Objects.requireNonNull(component, "component must not be null");
-        triggersWhenAttached(component,
-                () -> new RequestFullscreenAction(component, onSuccess,
-                        onError));
+        bindWhenAttached(component, () -> new RequestFullscreenAction(component,
+                onSuccess, onError));
     }
 
-    private void triggersWhenAttached(Component component,
+    private void bindWhenAttached(Component component,
             SerializableSupplier<Action> action) {
         // Defer wiring until attach so the action's wrapper-element lookup
         // (target.getUI().getInternals().getWrapperElement()) has a UI to
@@ -132,7 +131,7 @@ public final class FullscreenBinding implements Serializable {
         // check sees the same visibility state as the install JS would. The
         // trigger counts as armed straight away, so the deferral is not flagged
         // as a forgotten action.
-        trigger.triggersWhenAttached(component, action);
+        trigger.triggers(component, action);
     }
 
     private void bind(RequestFullscreenAction action) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/fullscreen/FullscreenBinding.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/fullscreen/FullscreenBinding.java
@@ -19,11 +19,13 @@ import java.io.Serializable;
 import java.util.Objects;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.trigger.internal.Action;
 import com.vaadin.flow.component.trigger.internal.PromiseAction.Error;
 import com.vaadin.flow.component.trigger.internal.RequestFullscreenAction;
 import com.vaadin.flow.component.trigger.internal.Trigger;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableRunnable;
+import com.vaadin.flow.function.SerializableSupplier;
 
 /**
  * Fluent surface returned from {@link Fullscreen#onClick}. Each {@code enter}
@@ -98,8 +100,8 @@ public final class FullscreenBinding implements Serializable {
      */
     public void enter(Component component) {
         Objects.requireNonNull(component, "component must not be null");
-        whenAttached(component,
-                () -> bind(new RequestFullscreenAction(component)));
+        triggersWhenAttached(component,
+                () -> new RequestFullscreenAction(component));
     }
 
     /**
@@ -117,18 +119,20 @@ public final class FullscreenBinding implements Serializable {
     public void enter(Component component, SerializableRunnable onSuccess,
             SerializableConsumer<Error> onError) {
         Objects.requireNonNull(component, "component must not be null");
-        whenAttached(component, () -> bind(
-                new RequestFullscreenAction(component, onSuccess, onError)));
+        triggersWhenAttached(component,
+                () -> new RequestFullscreenAction(component, onSuccess,
+                        onError));
     }
 
-    private static void whenAttached(Component component, Runnable task) {
+    private void triggersWhenAttached(Component component,
+            SerializableSupplier<Action> action) {
         // Defer wiring until attach so the action's wrapper-element lookup
         // (target.getUI().getInternals().getWrapperElement()) has a UI to
         // resolve against, and so that RequestFullscreenAction's visibility
-        // check sees the same visibility state as the install JS would.
-        // runWhenAttached fires immediately if already attached and is
-        // one-shot otherwise.
-        component.getElement().getNode().runWhenAttached(ui -> task.run());
+        // check sees the same visibility state as the install JS would. The
+        // trigger counts as armed straight away, so the deferral is not flagged
+        // as a forgotten action.
+        trigger.triggersWhenAttached(component, action);
     }
 
     private void bind(RequestFullscreenAction action) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/fullscreen/FullscreenBinding.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/fullscreen/FullscreenBinding.java
@@ -19,13 +19,11 @@ import java.io.Serializable;
 import java.util.Objects;
 
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.trigger.internal.Action;
 import com.vaadin.flow.component.trigger.internal.PromiseAction.Error;
 import com.vaadin.flow.component.trigger.internal.RequestFullscreenAction;
 import com.vaadin.flow.component.trigger.internal.Trigger;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableRunnable;
-import com.vaadin.flow.function.SerializableSupplier;
 
 /**
  * Fluent surface returned from {@link Fullscreen#onClick}. Each {@code enter}
@@ -100,7 +98,10 @@ public final class FullscreenBinding implements Serializable {
      */
     public void enter(Component component) {
         Objects.requireNonNull(component, "component must not be null");
-        bindWhenAttached(component,
+        // Defer wiring until the target attaches so RequestFullscreenAction can
+        // resolve the UI's wrapper element and see the target's install-time
+        // visibility; the trigger counts as armed straight away.
+        trigger.triggers(component,
                 () -> new RequestFullscreenAction(component));
     }
 
@@ -119,19 +120,8 @@ public final class FullscreenBinding implements Serializable {
     public void enter(Component component, SerializableRunnable onSuccess,
             SerializableConsumer<Error> onError) {
         Objects.requireNonNull(component, "component must not be null");
-        bindWhenAttached(component, () -> new RequestFullscreenAction(component,
+        trigger.triggers(component, () -> new RequestFullscreenAction(component,
                 onSuccess, onError));
-    }
-
-    private void bindWhenAttached(Component component,
-            SerializableSupplier<Action> action) {
-        // Defer wiring until attach so the action's wrapper-element lookup
-        // (target.getUI().getInternals().getWrapperElement()) has a UI to
-        // resolve against, and so that RequestFullscreenAction's visibility
-        // check sees the same visibility state as the install JS would. The
-        // trigger counts as armed straight away, so the deferral is not flagged
-        // as a forgotten action.
-        trigger.triggers(component, action);
     }
 
     private void bind(RequestFullscreenAction action) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/Trigger.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/Trigger.java
@@ -23,6 +23,8 @@ import java.util.Objects;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.JsFunction;
+import com.vaadin.flow.function.SerializableSupplier;
+import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.shared.Registration;
 
 /**
@@ -41,6 +43,14 @@ import com.vaadin.flow.shared.Registration;
  * may reach the server arbitrarily later than the gesture itself, after one or
  * more event-loop turns.
  * <p>
+ * A trigger only does something once it is armed with an action: every trigger
+ * is expected to have an action committed to it — via
+ * {@link #triggers(Action...)} or
+ * {@link #triggersWhenAttached(Component, SerializableSupplier)} — during the
+ * same server visit that creates it. A trigger left unarmed is treated as a
+ * programming error and reported with an {@link IllegalStateException} when the
+ * client response is built.
+ * <p>
  * Each {@link Action} passed to {@link #triggers(Action...)} produces one
  * {@link Element#addJsInitializer addJsInitializer} registration on the host
  * element via {@link #install(JsFunction)} — so a call with N actions yields N
@@ -56,6 +66,12 @@ public abstract class Trigger implements Serializable {
     private final Element host;
     private final List<Registration> registrations = new ArrayList<>();
 
+    // Whether an action has been committed to this trigger, whether wired
+    // straight away by triggers(...) or scheduled by triggersWhenAttached(...).
+    // The unarmed-trigger check reads this rather than the registration list so
+    // a legitimately deferred wiring is not mistaken for a forgotten one.
+    private boolean armed;
+
     /**
      * Creates a new trigger bound to the given host component's root element.
      *
@@ -65,6 +81,44 @@ public abstract class Trigger implements Serializable {
      */
     protected Trigger(Component host) {
         this.host = Objects.requireNonNull(host).getElement();
+        verifyArmedBeforeClientResponse();
+    }
+
+    /**
+     * Schedules a check, run once the host is attached and just before the
+     * client response is built, that fails if no action was committed to this
+     * trigger via {@link #triggers(Action...)} or
+     * {@link #triggersWhenAttached(Component, SerializableSupplier)}.
+     * <p>
+     * A trigger with no action does nothing on the client, so an unarmed
+     * trigger is almost always a bug — typically a fluent binding whose
+     * terminal action call was forgotten (for example
+     * {@code Clipboard.onClick(button)} with no following
+     * {@code writeText(…)}). The check is deferred to
+     * {@code beforeClientResponse} rather than run from the constructor because
+     * the action is committed in a separate call right after construction;
+     * deferring lets that call happen first. The check looks at whether an
+     * action was <em>committed</em>, not whether it has been wired yet, so
+     * {@code triggersWhenAttached} — which records the action now but wires it
+     * only once a target component attaches, possibly in a later round trip —
+     * passes from the moment it is called.
+     */
+    private void verifyArmedBeforeClientResponse() {
+        StateNode node = host.getNode();
+        node.runWhenAttached(ui -> ui.getInternals().getStateTree()
+                .beforeClientResponse(node, context -> {
+                    if (!armed) {
+                        throw new IllegalStateException("A "
+                                + getClass().getSimpleName()
+                                + " was created but no action was assigned to "
+                                + "it, so it does nothing. Assign at least one "
+                                + "action to the trigger when you create it — "
+                                + "for example "
+                                + "Clipboard.onClick(button).writeText(field) "
+                                + "rather than Clipboard.onClick(button) on its "
+                                + "own.");
+                    }
+                }));
     }
 
     /**
@@ -90,11 +144,42 @@ public abstract class Trigger implements Serializable {
             throw new IllegalArgumentException(
                     "At least one action is required");
         }
+        armed = true;
         for (Action action : actions) {
             Objects.requireNonNull(action, "Action must not be null");
             registrations.add(Objects.requireNonNull(install(action.toJs(this)),
                     "install must return a Registration"));
         }
+    }
+
+    /**
+     * Wires the action produced by {@code action} to this trigger once
+     * {@code attachTarget} is attached to a UI — immediately if it already is.
+     * Use this instead of {@link #triggers(Action...)} when the action can only
+     * be built after some component is attached (for example because the action
+     * needs the UI's wrapper element, or wants to inspect the target's
+     * visibility as it will be at install time).
+     * <p>
+     * The trigger counts as armed from the moment this method is called, so the
+     * unarmed-trigger check is satisfied straight away even though the actual
+     * wiring waits for the attach — exactly what distinguishes a legitimately
+     * deferred binding from a forgotten one.
+     *
+     * @param attachTarget
+     *            the component whose attach gates the wiring, not {@code null}
+     * @param action
+     *            supplies the action to wire once {@code attachTarget} is
+     *            attached, not {@code null}
+     */
+    public final void triggersWhenAttached(Component attachTarget,
+            SerializableSupplier<Action> action) {
+        Objects.requireNonNull(attachTarget, "attachTarget must not be null");
+        Objects.requireNonNull(action, "action must not be null");
+        // Record intent now so the deferred wiring is not flagged as forgotten;
+        // the actual triggers(...) call (which also sets armed) runs at attach.
+        armed = true;
+        attachTarget.getElement().getNode()
+                .runWhenAttached(ui -> triggers(action.get()));
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/Trigger.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/trigger/internal/Trigger.java
@@ -45,9 +45,9 @@ import com.vaadin.flow.shared.Registration;
  * <p>
  * A trigger only does something once it is armed with an action: every trigger
  * is expected to have an action committed to it — via
- * {@link #triggers(Action...)} or
- * {@link #triggersWhenAttached(Component, SerializableSupplier)} — during the
- * same server visit that creates it. A trigger left unarmed is treated as a
+ * {@link #triggers(Action...)} or its deferred
+ * {@link #triggers(Component, SerializableSupplier)} overload — during the same
+ * server visit that creates it. A trigger left unarmed is treated as a
  * programming error and reported with an {@link IllegalStateException} when the
  * client response is built.
  * <p>
@@ -67,9 +67,10 @@ public abstract class Trigger implements Serializable {
     private final List<Registration> registrations = new ArrayList<>();
 
     // Whether an action has been committed to this trigger, whether wired
-    // straight away by triggers(...) or scheduled by triggersWhenAttached(...).
-    // The unarmed-trigger check reads this rather than the registration list so
-    // a legitimately deferred wiring is not mistaken for a forgotten one.
+    // straight away by triggers(Action...) or scheduled by the deferred
+    // triggers(Component, SerializableSupplier) overload. The unarmed-trigger
+    // check reads this rather than the registration list so a legitimately
+    // deferred wiring is not mistaken for a forgotten one.
     private boolean armed;
 
     /**
@@ -87,8 +88,8 @@ public abstract class Trigger implements Serializable {
     /**
      * Schedules a check, run once the host is attached and just before the
      * client response is built, that fails if no action was committed to this
-     * trigger via {@link #triggers(Action...)} or
-     * {@link #triggersWhenAttached(Component, SerializableSupplier)}.
+     * trigger via {@link #triggers(Action...)} or its deferred
+     * {@link #triggers(Component, SerializableSupplier)} overload.
      * <p>
      * A trigger with no action does nothing on the client, so an unarmed
      * trigger is almost always a bug — typically a fluent binding whose
@@ -98,10 +99,10 @@ public abstract class Trigger implements Serializable {
      * {@code beforeClientResponse} rather than run from the constructor because
      * the action is committed in a separate call right after construction;
      * deferring lets that call happen first. The check looks at whether an
-     * action was <em>committed</em>, not whether it has been wired yet, so
-     * {@code triggersWhenAttached} — which records the action now but wires it
-     * only once a target component attaches, possibly in a later round trip —
-     * passes from the moment it is called.
+     * action was <em>committed</em>, not whether it has been wired yet, so the
+     * deferred {@code triggers} overload — which records the action now but
+     * wires it only once a target component attaches, possibly in a later round
+     * trip — passes from the moment it is called.
      */
     private void verifyArmedBeforeClientResponse() {
         StateNode node = host.getNode();
@@ -153,12 +154,13 @@ public abstract class Trigger implements Serializable {
     }
 
     /**
-     * Wires the action produced by {@code action} to this trigger once
-     * {@code attachTarget} is attached to a UI — immediately if it already is.
-     * Use this instead of {@link #triggers(Action...)} when the action can only
-     * be built after some component is attached (for example because the action
-     * needs the UI's wrapper element, or wants to inspect the target's
-     * visibility as it will be at install time).
+     * Deferred variant of {@link #triggers(Action...)}: builds the action via
+     * {@code action} and wires it once {@code attachTarget} is attached to a UI
+     * — immediately if it already is. Use this overload when the action can
+     * only be built after some component is attached (for example because the
+     * action needs the UI's wrapper element, or wants to inspect the target's
+     * visibility as it will be at install time), so the {@link Action} cannot
+     * be constructed up front and handed to {@link #triggers(Action...)}.
      * <p>
      * The trigger counts as armed from the moment this method is called, so the
      * unarmed-trigger check is satisfied straight away even though the actual
@@ -171,7 +173,7 @@ public abstract class Trigger implements Serializable {
      *            supplies the action to wire once {@code attachTarget} is
      *            attached, not {@code null}
      */
-    public final void triggersWhenAttached(Component attachTarget,
+    public final void triggers(Component attachTarget,
             SerializableSupplier<Action> action) {
         Objects.requireNonNull(attachTarget, "attachTarget must not be null");
         Objects.requireNonNull(action, "action must not be null");

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/TriggerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/TriggerTest.java
@@ -28,6 +28,7 @@ import static com.vaadin.flow.component.trigger.internal.TriggerTestUtil.actionO
 import static com.vaadin.flow.component.trigger.internal.TriggerTestUtil.installFns;
 import static com.vaadin.flow.component.trigger.internal.TriggerTestUtil.singleInstallFn;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -155,6 +156,63 @@ class TriggerTest {
         DomEventTrigger trigger = new DomEventTrigger(button, "click");
         assertThrows(IllegalArgumentException.class,
                 () -> trigger.triggers(new Action[0]));
+    }
+
+    @Test
+    void unarmedTrigger_failsWhenClientResponseIsBuilt() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        ui.getElement().appendChild(button.getElement());
+
+        // Trigger created but never armed via triggers(...) — the mistake the
+        // check exists to catch.
+        new DomEventTrigger(button, "click");
+
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+                () -> ui.getInternals().getStateTree()
+                        .runExecutionsBeforeClientResponse());
+        String message = e.getMessage();
+        assertNotNull(message);
+        assertTrue(message.contains("no action was assigned"),
+                "Message should explain the trigger was left unarmed");
+    }
+
+    @Test
+    void deferredArming_passesCheckBeforeTargetAttaches() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        TagComponent target = new TagComponent("input");
+        ui.getElement().appendChild(button.getElement());
+
+        // Wiring is deferred until the (still detached) target attaches, but
+        // the
+        // trigger counts as armed immediately — so the check must not fire even
+        // though no action has been installed yet.
+        new DomEventTrigger(button, "click").triggersWhenAttached(target,
+                () -> new SetPropertyAction<>(target, "value", "x"));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+        assertTrue(installFns(ui).isEmpty(),
+                "No install expected before the target attaches");
+
+        // Attaching the target performs the deferred wiring.
+        ui.getElement().appendChild(target.getElement());
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+        assertEquals(1, installFns(ui).size());
+    }
+
+    @Test
+    void armedTrigger_passesCheck() {
+        UI ui = new MockUI();
+        TagComponent button = new TagComponent("button");
+        TagComponent target = new TagComponent("input");
+        ui.getElement().appendChild(button.getElement(), target.getElement());
+
+        new DomEventTrigger(button, "click")
+                .triggers(new SetPropertyAction<>(target, "value", "x"));
+
+        // Does not throw: the trigger was armed before the response is built.
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
     }
 
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/TriggerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/trigger/internal/TriggerTest.java
@@ -188,7 +188,7 @@ class TriggerTest {
         // the
         // trigger counts as armed immediately — so the check must not fire even
         // though no action has been installed yet.
-        new DomEventTrigger(button, "click").triggersWhenAttached(target,
+        new DomEventTrigger(button, "click").triggers(target,
                 () -> new SetPropertyAction<>(target, "value", "x"));
 
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();


### PR DESCRIPTION
A Trigger that is never armed with an action does nothing on the client, which is almost always a forgotten terminal binding call (e.g. Clipboard.onClick(button) with no following writeText(...)). Detect this in the Trigger base class — so it covers every trigger/action user, not just clipboard — by deferring a check to beforeClientResponse and throwing an IllegalStateException if no action was committed.

Track arming as an intent flag set the moment a binding commits to an action, and add Trigger.triggersWhenAttached(target, supplier) so a binding that legitimately defers wiring until a target component attaches (Fullscreen.enter(detachedPanel)) is not mistaken for a forgotten one.
