### PR TITLE
ci: correct update strategy description for frontend dependency PRs

### DIFF
--- a/.github/workflows/update-frontend-dependencies.yml
+++ b/.github/workflows/update-frontend-dependencies.yml
@@ -40,7 +40,7 @@ jobs:
           if [ "${{ matrix.branch }}" = "main" ]; then
             echo "UPDATE_DESC=All new versions (major, minor, patch)" >> $GITHUB_ENV
           else
-            echo "UPDATE_DESC=Patch releases only" >> $GITHUB_ENV
+            echo "UPDATE_DESC=Minor and patch releases (no major)" >> $GITHUB_ENV
           fi
 
       - name: Create Pull Request


### PR DESCRIPTION
Maintenance branches update dependencies with npm-check-updates' "minor" target, which pulls in minor and patch releases. The PR body still claimed "Patch releases only", which was accurate before minor updates were enabled but is now misleading. Update the description to reflect that minor and patch (but not major) releases are applied.
