### PR TITLE
docs: document remaining web API javadocs for users, not internals

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/clipboard/package-info.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/clipboard/package-info.java
@@ -13,6 +13,24 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+/**
+ * Server-side access to the browser's clipboard — both writing (copy) and
+ * reading (paste).
+ * <p>
+ * Use
+ * {@link com.vaadin.flow.component.clipboard.Clipboard#onClick(com.vaadin.flow.component.Component)
+ * Clipboard.onClick(component)} to copy text, an image, or custom content to
+ * the clipboard when a component is clicked. Use
+ * {@link com.vaadin.flow.component.clipboard.Clipboard#onPaste(com.vaadin.flow.component.Component, com.vaadin.flow.function.SerializableConsumer)
+ * Clipboard.onPaste(...)} to react to text the user pastes onto a component,
+ * and {@code Clipboard.onFilePaste(...)} to receive pasted files.
+ * <p>
+ * Copying goes through {@code onClick} rather than an ordinary server-side
+ * click listener because the browser only grants clipboard write access while
+ * it is handling a genuine user gesture, which is no longer valid by the time a
+ * server round trip completes. Clipboard access also requires a secure context
+ * (HTTPS or {@code localhost}).
+ */
 @NullMarked
 package com.vaadin.flow.component.clipboard;
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/fullscreen/FullscreenState.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/fullscreen/FullscreenState.java
@@ -16,13 +16,14 @@
 package com.vaadin.flow.component.fullscreen;
 
 /**
- * Represents the fullscreen state of a browser page.
+ * The fullscreen state of the browser page, as reported by
+ * {@link Fullscreen#stateSignal()}.
  * <p>
- * Wraps the browser's Fullscreen API ({@code document.fullscreenEnabled} and
- * {@code document.fullscreenElement}) into four observable states: the browser
- * does not support fullscreen at all, fullscreen is supported but the page is
- * not in it, the page is currently fullscreen, and an {@link #UNKNOWN} sentinel
- * used before the first value has arrived from the client.
+ * There are four observable states: the browser cannot go fullscreen at all
+ * ({@link #UNSUPPORTED}), it can but the page is not currently fullscreen
+ * ({@link #NOT_FULLSCREEN}), the page is fullscreen ({@link #FULLSCREEN}), and
+ * an {@link #UNKNOWN} sentinel used before the browser has reported its first
+ * value.
  *
  * @see Fullscreen#stateSignal()
  * @see Fullscreen#exit()
@@ -31,34 +32,30 @@ package com.vaadin.flow.component.fullscreen;
 public enum FullscreenState {
 
     /**
-     * No value has been reported by the browser yet. Used only as the initial
-     * value of the signal before the first client handshake delivers the real
-     * one. In normal request handling the signal is seeded before any user code
-     * (UI initialization, {@code UIInitListener}, component attach) runs, so
-     * this value is essentially never observed in practice; once a real value
-     * has arrived, the signal never returns to {@code UNKNOWN}.
+     * The browser has not reported a value yet. This is only the signal's
+     * initial value before the first client round-trip completes; in practice a
+     * real value is in place before any application code runs, and the signal
+     * never returns to {@code UNKNOWN} once it has a real value. Treat it as
+     * "not known yet" if you ever observe it.
      */
     UNKNOWN,
 
     /**
-     * The browser does not support fullscreen mode, or the document is not
-     * permitted to enter it. In the browser, this corresponds to
-     * {@code document.fullscreenEnabled} being {@code false}. Fullscreen
-     * requests bound via {@link Fullscreen} resolve to a rejection in this
-     * state.
+     * The browser cannot go fullscreen — either it does not support fullscreen,
+     * or the page is not permitted to enter it (for example when embedded in an
+     * iframe without the required permission). A fullscreen request started via
+     * {@link Fullscreen#onClick} fails in this state.
      */
     UNSUPPORTED,
 
     /**
-     * Fullscreen mode is supported and the page is currently not in it. In the
-     * browser, this corresponds to {@code document.fullscreenEnabled} being
-     * {@code true} and {@code document.fullscreenElement} being {@code null}.
+     * The browser can go fullscreen and the page is currently not fullscreen.
+     * This is the normal state before the user triggers a fullscreen request.
      */
     NOT_FULLSCREEN,
 
     /**
-     * The page is currently in fullscreen mode. In the browser, this
-     * corresponds to {@code document.fullscreenElement} being non-{@code null}.
+     * The page is currently displayed in fullscreen.
      */
     FULLSCREEN
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/fullscreen/package-info.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/fullscreen/package-info.java
@@ -13,6 +13,24 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+/**
+ * Server-side access to the browser's Fullscreen API.
+ * <p>
+ * Use
+ * {@link com.vaadin.flow.component.fullscreen.Fullscreen#onClick(com.vaadin.flow.component.Component)
+ * Fullscreen.onClick(component)} to make a button (or other clickable
+ * component) enter fullscreen, and
+ * {@link com.vaadin.flow.component.fullscreen.Fullscreen#stateSignal()} to
+ * observe the current
+ * {@link com.vaadin.flow.component.fullscreen.FullscreenState fullscreen
+ * state}. {@link com.vaadin.flow.component.fullscreen.Fullscreen#exit()} leaves
+ * fullscreen again.
+ * <p>
+ * Entering fullscreen goes through {@code onClick} rather than an ordinary
+ * server-side click listener because the browser only honours a fullscreen
+ * request while it is handling a genuine user gesture, which is no longer valid
+ * by the time a server round trip completes.
+ */
 @NullMarked
 package com.vaadin.flow.component.fullscreen;
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/geolocation/package-info.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/geolocation/package-info.java
@@ -13,6 +13,28 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+/**
+ * Server-side access to the browser's Geolocation API for reading the user's
+ * location.
+ * <p>
+ * {@link com.vaadin.flow.component.geolocation.Geolocation#getPosition(com.vaadin.flow.function.SerializableConsumer, com.vaadin.flow.function.SerializableConsumer)
+ * Geolocation.getPosition(...)} reads the location once;
+ * {@link com.vaadin.flow.component.geolocation.Geolocation#watchPosition(com.vaadin.flow.component.Component)
+ * Geolocation.watchPosition(...)} returns a
+ * {@link com.vaadin.flow.component.geolocation.GeolocationWatcher} that
+ * delivers continuous updates (as a listener or a reactive signal) and stops
+ * automatically when its owning component is detached.
+ * {@link com.vaadin.flow.component.geolocation.Geolocation#availabilityHintSignal()}
+ * gives a best-effort hint about whether permission has been granted, so you
+ * can decide whether to prompt the user.
+ * <p>
+ * Geolocation requires a secure context (HTTPS or {@code localhost}) and
+ * explicit user permission; the first request shows the browser's permission
+ * prompt, and a denied or unavailable request reports a
+ * {@link com.vaadin.flow.component.geolocation.GeolocationError}. Accuracy
+ * varies by device, and fields such as altitude and speed may be absent when
+ * the device cannot measure them.
+ */
 @NullMarked
 package com.vaadin.flow.component.geolocation;
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/PageVisibility.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/PageVisibility.java
@@ -16,13 +16,25 @@
 package com.vaadin.flow.component.page;
 
 /**
- * Represents the visibility state of a browser page.
+ * The visibility state of the browser page, as reported by
+ * {@link Page#pageVisibilitySignal()}.
  * <p>
- * Uses the browser's Page Visibility API ({@code document.hidden}) combined
- * with {@code document.hasFocus()} to distinguish between three observable
- * states — fully visible and focused, visible but not focused, and hidden —
- * plus an {@link #UNKNOWN} sentinel used before the first value has arrived
- * from the client.
+ * Distinguishes three observable states — the page is visible and focused
+ * ({@link #VISIBLE}), visible but not focused ({@link #VISIBLE_NOT_FOCUSED}),
+ * and hidden ({@link #HIDDEN}) — plus an {@link #UNKNOWN} sentinel used before
+ * the browser has reported its first value. Use it to pause work the user
+ * cannot see, such as polling or animations:
+ *
+ * <pre>{@code
+ * Page page = UI.getCurrent().getPage();
+ * Signal.effect(this, () -> {
+ *     if (page.pageVisibilitySignal().get() == PageVisibility.HIDDEN) {
+ *         pausePolling();
+ *     } else {
+ *         resumePolling();
+ *     }
+ * });
+ * }</pre>
  *
  * @see Page#pageVisibilitySignal()
  * @since 25.2
@@ -30,37 +42,30 @@ package com.vaadin.flow.component.page;
 public enum PageVisibility {
 
     /**
-     * No value has been reported by the browser yet. Used only as the initial
-     * value of the signal before the first client handshake delivers the real
-     * one. In normal request handling the signal is seeded before any user code
-     * (UI initialization, {@code UIInitListener}, component attach) runs, so
-     * this value is essentially never observed in practice; once a real value
-     * has arrived, the signal never returns to {@code UNKNOWN}.
+     * The browser has not reported a value yet. This is only the signal's
+     * initial value before the first client round-trip completes; in practice a
+     * real value is in place before any application code runs, and the signal
+     * never returns to {@code UNKNOWN} once it has a real value. Treat it as
+     * "not known yet" if you ever observe it.
      */
     UNKNOWN,
 
     /**
-     * The page is visible and focused.
-     * <p>
-     * In the browser, this means {@code !document.hidden} and
-     * {@code document.hasFocus()} is {@code true}.
+     * The page is visible and currently has focus — the user is looking at this
+     * tab and it is the active window.
      */
     VISIBLE,
 
     /**
-     * The page is visible but not focused, e.g. behind another window.
-     * <p>
-     * In the browser, this means {@code !document.hidden} and
-     * {@code document.hasFocus()} is {@code false}.
+     * The page is visible but does not have focus, for example when it sits
+     * behind another window or the user is interacting with a different
+     * application.
      */
     VISIBLE_NOT_FOCUSED,
 
     /**
-     * The page is not visible, e.g. the browser tab is in the background or the
-     * window is minimized.
-     * <p>
-     * In the browser, this is indicated by {@code document.hidden} being
-     * {@code true}.
+     * The page is not visible, for example when its browser tab is in the
+     * background or the window is minimized.
      */
     HIDDEN
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/screenorientation/ScreenOrientationData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/screenorientation/ScreenOrientationData.java
@@ -18,13 +18,21 @@ package com.vaadin.flow.component.screenorientation;
 import java.io.Serializable;
 
 /**
- * Represents the current screen orientation state, including the orientation
- * type and the angle of rotation.
+ * The current screen orientation, as reported by
+ * {@link ScreenOrientation#orientationSignal()}: both its
+ * {@link ScreenOrientationType type} (portrait or landscape, primary or
+ * secondary) and its rotation angle.
  *
  * @param type
- *            the screen orientation type
+ *            the screen orientation type; never {@code null}
  * @param angle
- *            the screen orientation angle in degrees
+ *            how far the screen is rotated from its natural orientation,
+ *            clockwise in degrees (typically {@code 0}, {@code 90},
+ *            {@code 180}, or {@code 270}). The natural orientation is
+ *            device-dependent: on a phone it is usually portrait, on many
+ *            tablets and desktops landscape, so the same angle can mean
+ *            different orientations on different devices — use {@link #type()}
+ *            to reason about the orientation itself.
  */
 public record ScreenOrientationData(ScreenOrientationType type,
         int angle) implements Serializable {

--- a/flow-server/src/main/java/com/vaadin/flow/component/screenorientation/ScreenOrientationLockErrorCode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/screenorientation/ScreenOrientationLockErrorCode.java
@@ -48,10 +48,9 @@ public enum ScreenOrientationLockErrorCode {
     ABORT,
 
     /**
-     * The browser rejected the request for a reason that does not match a more
-     * specific code, or the executeJs round-trip itself failed.
-     * {@link ScreenOrientationLockError#debugInfo()} holds the underlying
-     * browser message for diagnostics.
+     * The request failed for a reason that does not match a more specific code.
+     * See {@link ScreenOrientationLockError#debugInfo()} for the underlying
+     * browser message.
      */
     UNKNOWN;
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/screenorientation/package-info.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/screenorientation/package-info.java
@@ -13,6 +13,21 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+/**
+ * Server-side access to the browser's Screen Orientation API for observing and
+ * locking the device's screen orientation.
+ * <p>
+ * {@link com.vaadin.flow.component.screenorientation.ScreenOrientation#orientationSignal()}
+ * reports the current orientation (portrait, landscape, and its angle) and
+ * updates as the device rotates.
+ * {@link com.vaadin.flow.component.screenorientation.ScreenOrientation#lock(com.vaadin.flow.component.screenorientation.ScreenOrientationType)
+ * ScreenOrientation.lock(...)} pins the screen to a chosen orientation.
+ * <p>
+ * Locking is mainly relevant on mobile devices and typically only succeeds
+ * while the page is in fullscreen; it is commonly rejected on desktop browsers
+ * and on devices without an orientation sensor. A failed lock reports a
+ * {@link com.vaadin.flow.component.screenorientation.ScreenOrientationLockError}.
+ */
 @NullMarked
 package com.vaadin.flow.component.screenorientation;
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/wakelock/WakeLockErrorCode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/wakelock/WakeLockErrorCode.java
@@ -25,27 +25,23 @@ package com.vaadin.flow.component.wakelock;
 public enum WakeLockErrorCode {
     /**
      * The Screen Wake Lock API is unusable in this context — the browser does
-     * not implement it, or the page is served over an insecure connection.
-     * Matches the {@link WakeLockAvailability#UNSUPPORTED} signal value and is
-     * delivered without a server-to-client round-trip when the bootstrap probe
-     * already established unavailability.
+     * not implement it, or the page is served over an insecure connection (not
+     * HTTPS or {@code localhost}). This matches the
+     * {@link WakeLockAvailability#UNSUPPORTED} availability hint, so you can
+     * hide wake-lock controls up front rather than letting the request fail.
      */
     UNSUPPORTED,
 
     /**
-     * The browser refused the request — usually because the tab is currently
-     * hidden, the feature policy blocks wake lock in this frame, or the user's
-     * operating-system power-management settings prevent it. Corresponds to a
-     * {@code NotAllowedError} DOMException from
-     * {@code navigator.wakeLock.request('screen')}.
+     * The browser refused the request, usually because the tab is currently
+     * hidden, a permissions policy blocks wake lock in this frame, or the
+     * operating system's power-management settings prevent it.
      */
     NOT_ALLOWED,
 
     /**
-     * The browser rejected the request for a reason that does not match a more
-     * specific code, or the executeJs round-trip itself failed. The
-     * {@link WakeLockError#message()} carries the underlying message for
-     * diagnostics.
+     * The request failed for a reason that does not match a more specific code.
+     * See {@link WakeLockError#message()} for the underlying browser message.
      */
     UNKNOWN
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/wakelock/package-info.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/wakelock/package-info.java
@@ -13,6 +13,25 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+/**
+ * Server-side access to the browser's Screen Wake Lock API, which keeps the
+ * device screen from dimming or locking — useful for dashboards, kiosks,
+ * presentations, and recipe or workout screens.
+ * <p>
+ * {@link com.vaadin.flow.component.wakelock.WakeLock#request()} asks the
+ * browser to hold a wake lock and re-acquire it across tab visibility changes;
+ * {@link com.vaadin.flow.component.wakelock.WakeLock#release()} drops it.
+ * {@link com.vaadin.flow.component.wakelock.WakeLock#activeSignal()} reflects
+ * whether a lock is currently held, and
+ * {@link com.vaadin.flow.component.wakelock.WakeLock#availabilitySignal()}
+ * hints at whether the API is usable so you can hide wake-lock controls up
+ * front.
+ * <p>
+ * The API requires a secure context (HTTPS or {@code localhost}). The browser
+ * releases the lock automatically when the tab is hidden (the client
+ * re-acquires it when the tab is shown again) and may drop it under power
+ * saving or low battery.
+ */
 @NullMarked
 package com.vaadin.flow.component.wakelock;
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/webshare/package-info.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webshare/package-info.java
@@ -13,6 +13,24 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+/**
+ * Server-side access to the browser's Web Share API, which opens the device's
+ * native share sheet so the user can send a title, text, and/or URL to another
+ * app.
+ * <p>
+ * Use
+ * {@link com.vaadin.flow.component.webshare.WebShare#onClick(com.vaadin.flow.component.Component)
+ * WebShare.onClick(component)} to share when a component is clicked, building
+ * the payload with {@link com.vaadin.flow.component.webshare.ShareContent}, and
+ * {@link com.vaadin.flow.component.webshare.WebShare#supportSignal()} to check
+ * whether sharing is available before showing a share button.
+ * <p>
+ * Sharing goes through {@code onClick} rather than an ordinary server-side
+ * click listener because the browser only opens the share sheet while it is
+ * handling a genuine user gesture, which is no longer valid by the time a
+ * server round trip completes. The Web Share API also requires a secure context
+ * (HTTPS or {@code localhost}) and is not available on every desktop browser.
+ */
 @NullMarked
 package com.vaadin.flow.component.webshare;
 


### PR DESCRIPTION
Continue the user-facing javadoc pass over the 25.2 web APIs, covering the members the onClick rewrite did not touch.

Stop enum constants from leaking the underlying browser/JS API and framework internals, describing each state in terms a Java developer sees instead:
- FullscreenState dropped the document.fullscreenEnabled / document.fullscreenElement references.
- PageVisibility dropped document.hidden / document.hasFocus() and gained a runnable example that pauses work while the page is hidden.
- WakeLockErrorCode dropped the "server-to-client round-trip", "executeJs round-trip" and NotAllowedError / navigator.wakeLock DOM references.
- ScreenOrientationLockErrorCode.UNKNOWN dropped "executeJs round-trip".

Fill documentation gaps:
- Add package overviews to the previously empty fullscreen, webshare, clipboard, geolocation, screenorientation and wakelock package-info files, each naming the entry points and the user-gesture / HTTPS / permission caveat.
- Explain ScreenOrientationData.angle (clockwise from the device's natural orientation, which varies by device) instead of just calling it "the angle in degrees".
