### PR TITLE
fix: keep functional indicator styles when default theme is disabled

### DIFF
--- a/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
+++ b/flow-build-tools/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
@@ -483,7 +483,9 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
             addInternalEntryPoint(errorParameters);
         }
 
-        // UI should always be collected as it contains 'ConnectionIndicator.js'
+        // The UI class is always collected so that frontend dependencies
+        // declared on it via annotations (@JsModule, @CssImport, ...) are
+        // included in the bundle even when no other entry point references it.
         addInternalEntryPoint(UI.class);
 
         if (generateEmbeddableWebComponents) {

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/BundleValidationTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/BundleValidationTest.java
@@ -821,7 +821,8 @@ class BundleValidationTest {
         bundleImports
                 .add("@Frontend/generated/jar-resources/dndConnector-es6.js");
         bundleImports.add("@polymer/paper-input/paper-input.js");
-        bundleImports.add("@vaadin/common-frontend/ConnectionIndicator.js");
+        bundleImports.add(
+                "@Frontend/generated/jar-resources/ConnectionIndicator.js");
 
         setupFrontendUtilsMock(stats);
 

--- a/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-build-tools/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -125,7 +125,6 @@ class NodeUpdaterTest {
         Map<String, String> defaultDeps = nodeUpdater.getDefaultDependencies();
         Set<String> expectedDependencies = new HashSet<>();
         expectedDependencies.add("@polymer/polymer");
-        expectedDependencies.add("@vaadin/common-frontend");
         expectedDependencies.add("lit");
         expectedDependencies.add("react");
         expectedDependencies.add("react-dom");
@@ -140,7 +139,6 @@ class NodeUpdaterTest {
     void getDefaultDependencies_includesAllDependencies() {
         Map<String, String> defaultDeps = nodeUpdater.getDefaultDependencies();
         Set<String> expectedDependencies = new HashSet<>();
-        expectedDependencies.add("@vaadin/common-frontend");
         expectedDependencies.add("lit");
         expectedDependencies.add("react");
         expectedDependencies.add("react-dom");

--- a/flow-client/package-lock.json
+++ b/flow-client/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vaadin/common-frontend": "0.0.22",
         "lit": "3.3.3"
       },
       "devDependencies": {
@@ -3417,15 +3416,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@vaadin/common-frontend": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/@vaadin/common-frontend/-/common-frontend-0.0.22.tgz",
-      "integrity": "sha512-3mG/AvrbmFGKDM4rsWruxnWuk/j91TJdet2gAvZ3iugs/stfplA4M11FxPpqH87dqtXVki+FtBWy24WyMIXeTg==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "lit": "^3.0.0"
-      }
     },
     "node_modules/@web/browser-logs": {
       "version": "0.4.1",

--- a/flow-client/package.json
+++ b/flow-client/package.json
@@ -44,7 +44,6 @@
     "typescript": "^6.0.3"
   },
   "dependencies": {
-    "@vaadin/common-frontend": "0.0.22",
     "lit": "3.3.3"
   }
 }

--- a/flow-client/src/main/frontend/ConnectionIndicator.ts
+++ b/flow-client/src/main/frontend/ConnectionIndicator.ts
@@ -1,0 +1,534 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { html, LitElement, type PropertyValues } from 'lit';
+import { property, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { ConnectionState, type ConnectionStateStore } from './ConnectionState';
+
+const DEFAULT_STYLE_ID = 'css-loading-indicator';
+
+/**
+ * The loading indicator states
+ */
+export const enum LoadingBarState {
+  IDLE = '',
+  FIRST = 'first',
+  SECOND = 'second',
+  THIRD = 'third'
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'vaadin-connection-indicator': ConnectionIndicator;
+  }
+}
+
+/**
+ * Component showing loading and connection indicator. When added to DOM,
+ * listens for changes on `window.Vaadin.connectionState` ConnectionStateStore.
+ */
+export class ConnectionIndicator extends LitElement {
+  static get instance(): ConnectionIndicator {
+    return ConnectionIndicator.create();
+  }
+
+  /**
+   * Initialize global connection indicator instance at
+   * window.Vaadin.connectionIndicator and add instance to the document body.
+   */
+  static create(): ConnectionIndicator {
+    const $wnd = window as any;
+    if (!$wnd.Vaadin?.connectionIndicator) {
+      $wnd.Vaadin ??= {};
+      $wnd.Vaadin.connectionIndicator = document.createElement('vaadin-connection-indicator');
+      document.body.appendChild($wnd.Vaadin.connectionIndicator);
+    }
+    return $wnd.Vaadin?.connectionIndicator as ConnectionIndicator;
+  }
+
+  /**
+   * The delay before showing the loading indicator, in ms.
+   */
+  @property({ type: Number })
+  accessor firstDelay = 450;
+
+  /**
+   * The delay before the loading indicator goes into "second" state, in ms.
+   */
+  @property({ type: Number })
+  accessor secondDelay = 1500;
+
+  /**
+   * The delay before the loading indicator goes into "third" state, in ms.
+   */
+  @property({ type: Number })
+  accessor thirdDelay = 5000;
+
+  /**
+   * The duration for which the connection state change message is visible,
+   * in ms.
+   */
+  @property({ type: Number })
+  accessor expandedDuration = 2000;
+
+  /**
+   * The message shown when the connection goes to connected state.
+   */
+  @property({ type: String })
+  accessor onlineText = 'Online';
+
+  /**
+   * The message shown when the connection goes to lost state.
+   */
+  @property({ type: String })
+  accessor offlineText = 'Connection lost';
+
+  /**
+   * The message shown when the connection goes to reconnecting state.
+   */
+  @property({ type: String })
+  accessor reconnectingText = 'Connection lost, trying to reconnect...';
+
+  @property({ type: Boolean, reflect: true })
+  accessor offline = false;
+
+  @property({ type: Boolean, reflect: true })
+  accessor reconnecting = false;
+
+  @property({ type: Boolean, reflect: true })
+  accessor expanded = false;
+
+  @property({ type: Boolean, reflect: true })
+  accessor loading = false;
+
+  @state()
+  accessor #loadingBarState: LoadingBarState = LoadingBarState.IDLE;
+
+  accessor #isPopover: boolean = false;
+
+  #applyDefaultThemeState = true;
+
+  #firstTimeout = 0;
+
+  #secondTimeout = 0;
+
+  #thirdTimeout = 0;
+
+  #expandedTimeout = 0;
+
+  #connectionStateStore?: ConnectionStateStore;
+
+  readonly connectionStateListener: () => void;
+
+  #lastMessageState: ConnectionState = ConnectionState.CONNECTED;
+
+  constructor() {
+    super();
+
+    this.connectionStateListener = () => {
+      this.expanded = this.#updateConnectionState();
+      this.#expandedTimeout = this.#timeoutFor(
+        this.#expandedTimeout,
+        this.expanded,
+        () => {
+          this.expanded = false;
+        },
+        this.expandedDuration
+      );
+    };
+  }
+
+  protected override render() {
+    return html`
+      <div class="v-loading-indicator ${this.#loadingBarState}" style=${this.#getLoadingBarStyle()}></div>
+
+      <div
+        class="v-status-message ${classMap({
+          active: this.reconnecting
+        })}"
+      >
+        <span class="text"> ${this.#renderMessage()} </span>
+      </div>
+    `;
+  }
+
+  override connectedCallback() {
+    super.connectedCallback();
+
+    this.#initPopover();
+
+    const $wnd = window as any;
+    if ($wnd.Vaadin?.connectionState) {
+      this.#connectionStateStore = $wnd.Vaadin.connectionState as ConnectionStateStore;
+      this.#connectionStateStore.addStateChangeListener(this.connectionStateListener);
+      this.#updateConnectionState();
+    }
+
+    this.#updateTheme();
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+
+    if (this.#connectionStateStore) {
+      this.#connectionStateStore.removeStateChangeListener(this.connectionStateListener);
+    }
+
+    this.#updateTheme();
+    this.#isPopover = false;
+  }
+
+  protected override updated(props: PropertyValues): void {
+    if (['loading', 'offline', 'reconnecting', 'expanded'].some((p) => props.has(p))) {
+      this.#updatePopoverState();
+    }
+  }
+
+  get applyDefaultTheme() {
+    return this.#applyDefaultThemeState;
+  }
+
+  @property({ type: Boolean, reflect: true })
+  set applyDefaultTheme(applyDefaultTheme: boolean) {
+    if (applyDefaultTheme !== this.#applyDefaultThemeState) {
+      this.#applyDefaultThemeState = applyDefaultTheme;
+      this.#updateTheme();
+    }
+  }
+
+  protected override createRenderRoot() {
+    return this;
+  }
+
+  #initPopover() {
+    // Allow showing the indicator as popover
+    this.setAttribute('popover', 'manual');
+    // Override user agent styles for popover
+    this.style.display = 'contents';
+    this.style.width = 'auto';
+    this.style.height = 'auto';
+    this.style.top = '0';
+    this.style.right = '0';
+    this.style.bottom = 'auto';
+    this.style.left = '0';
+    this.style.margin = '0';
+    this.style.padding = '0';
+    this.style.background = 'none';
+    this.style.border = 'none';
+  }
+
+  /**
+   * Update state flags.
+   *
+   * @returns true if the connection message changes, and therefore a new
+   * message should be shown
+   */
+  #updateConnectionState(): boolean {
+    const connectionState = this.#connectionStateStore?.state;
+    this.offline = connectionState === ConnectionState.CONNECTION_LOST;
+    this.reconnecting = connectionState === ConnectionState.RECONNECTING;
+    this.#updateLoading(connectionState === ConnectionState.LOADING);
+    if (this.loading) {
+      // Entering loading state, do not show message
+      return false;
+    }
+
+    if (connectionState !== this.#lastMessageState) {
+      this.#lastMessageState = connectionState!;
+      // Message changes, show new message
+      return true;
+    }
+
+    // Message did not change
+    return false;
+  }
+
+  #updateLoading(loading: boolean) {
+    this.loading = loading;
+    this.#loadingBarState = LoadingBarState.IDLE;
+
+    this.#firstTimeout = this.#timeoutFor(
+      this.#firstTimeout,
+      loading,
+      () => {
+        this.#loadingBarState = LoadingBarState.FIRST;
+      },
+      this.firstDelay
+    );
+
+    this.#secondTimeout = this.#timeoutFor(
+      this.#secondTimeout,
+      loading,
+      () => {
+        this.#loadingBarState = LoadingBarState.SECOND;
+      },
+      this.secondDelay
+    );
+
+    this.#thirdTimeout = this.#timeoutFor(
+      this.#thirdTimeout,
+      loading,
+      () => {
+        this.#loadingBarState = LoadingBarState.THIRD;
+      },
+      this.thirdDelay
+    );
+  }
+
+  #updatePopoverState() {
+    const showPopover = this.loading || this.offline || this.reconnecting || this.expanded;
+
+    // Always close the popover first on state changes. This way, on every state change,
+    // showPopover is called again, resulting in the connection indicator being shown on
+    // top of other popovers that might have been added, for example after a reconnect.
+    if (this.#isPopover) {
+      this.hidePopover();
+    }
+    if (showPopover) {
+      this.showPopover();
+    }
+    this.#isPopover = showPopover;
+  }
+
+  #renderMessage() {
+    if (this.reconnecting) {
+      return this.reconnectingText;
+    }
+
+    if (this.offline) {
+      return this.offlineText;
+    }
+
+    return this.onlineText;
+  }
+
+  #updateTheme() {
+    if (this.#applyDefaultThemeState && this.isConnected) {
+      if (!document.getElementById(DEFAULT_STYLE_ID)) {
+        const style = document.createElement('style');
+        style.id = DEFAULT_STYLE_ID;
+        style.textContent = this.#getDefaultStyle();
+        document.head.appendChild(style);
+      }
+    } else {
+      const style = document.getElementById(DEFAULT_STYLE_ID);
+      if (style) {
+        document.head.removeChild(style);
+      }
+    }
+  }
+
+  #getDefaultStyle(): string {
+    return `
+      @keyframes v-progress-start {
+        0% {
+          width: 0%;
+        }
+        100% {
+          width: 50%;
+        }
+      }
+      @keyframes v-progress-delay {
+        0% {
+          width: 50%;
+        }
+        100% {
+          width: 90%;
+        }
+      }
+      @keyframes v-progress-wait {
+        0% {
+          width: 90%;
+          height: 4px;
+        }
+        3% {
+          width: 91%;
+          height: 7px;
+        }
+        100% {
+          width: 96%;
+          height: 7px;
+        }
+      }
+      @keyframes v-progress-wait-pulse {
+        0% {
+          opacity: 1;
+        }
+        50% {
+          opacity: 0.1;
+        }
+        100% {
+          opacity: 1;
+        }
+      }
+      .v-loading-indicator,
+      .v-status-message {
+        box-sizing: border-box;
+        position: fixed;
+        left: 0;
+        right: 0;
+        top: 0;
+        background-color: var(--lumo-primary-color, var(--material-primary-color, blue));
+        transition: none;
+      }
+      .v-loading-indicator {
+        right: auto;
+        width: 50%;
+        height: 4px;
+        opacity: 1;
+        pointer-events: none;
+        animation: v-progress-start 1000ms 200ms both;
+      }
+      .v-loading-indicator[style*='none'] {
+        display: block !important;
+        width: 100%;
+        opacity: 0;
+        animation: none;
+        transition: opacity 500ms 300ms, width 300ms;
+      }
+      .v-loading-indicator.second {
+        width: 90%;
+        animation: v-progress-delay 3.8s forwards;
+      }
+      .v-loading-indicator.third {
+        width: 96%;
+        animation: v-progress-wait 5s forwards, v-progress-wait-pulse 1s 4s infinite backwards;
+      }
+
+      vaadin-connection-indicator[offline] .v-loading-indicator,
+      vaadin-connection-indicator[reconnecting] .v-loading-indicator {
+        display: none;
+      }
+
+      .v-status-message {
+        opacity: 0;
+        pointer-events: none;
+        max-height: var(--status-height-collapsed, 8px);
+        overflow: hidden;
+        background-color: var(--status-bg-color-online, var(--lumo-primary-color, var(--material-primary-color, blue)));
+        color: var(
+          --status-text-color-online,
+          var(--lumo-primary-contrast-color, var(--material-primary-contrast-color, #fff))
+        );
+        font-size: 0.75rem;
+        font-weight: 600;
+        line-height: 1;
+        transition: all 0.5s;
+        padding: 0 0.5em;
+      }
+
+      vaadin-connection-indicator[offline] .v-status-message,
+      vaadin-connection-indicator[reconnecting] .v-status-message {
+        opacity: 1;
+        pointer-events: auto;
+        background-color: var(--status-bg-color-offline, var(--lumo-shade, #333));
+        color: var(
+          --status-text-color-offline,
+          var(--lumo-primary-contrast-color, var(--material-primary-contrast-color, #fff))
+        );
+        background-image: repeating-linear-gradient(
+          45deg,
+          rgba(255, 255, 255, 0),
+          rgba(255, 255, 255, 0) 10px,
+          rgba(255, 255, 255, 0.1) 10px,
+          rgba(255, 255, 255, 0.1) 20px
+        );
+      }
+
+      vaadin-connection-indicator[reconnecting] .v-status-message {
+        animation: show-reconnecting-status 2s;
+      }
+
+      vaadin-connection-indicator[offline] .v-status-message:hover,
+      vaadin-connection-indicator[reconnecting] .v-status-message:hover,
+      vaadin-connection-indicator[expanded] .v-status-message {
+        max-height: var(--status-height, 1.75rem);
+      }
+
+      vaadin-connection-indicator[expanded] .v-status-message {
+        opacity: 1;
+        pointer-events: auto;
+      }
+
+      .v-status-message span {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: var(--status-height, 1.75rem);
+      }
+
+      vaadin-connection-indicator[reconnecting] .v-status-message span::before {
+        content: '';
+        width: 1em;
+        height: 1em;
+        border-top: 2px solid
+          var(--status-spinner-color, var(--lumo-primary-color, var(--material-primary-color, blue)));
+        border-left: 2px solid
+          var(--status-spinner-color, var(--lumo-primary-color, var(--material-primary-color, blue)));
+        border-right: 2px solid transparent;
+        border-bottom: 2px solid transparent;
+        border-radius: 50%;
+        box-sizing: border-box;
+        animation: v-spin 0.4s linear infinite;
+        margin: 0 0.5em;
+      }
+
+      @keyframes v-spin {
+        100% {
+          transform: rotate(360deg);
+        }
+      }
+    `;
+  }
+
+  #getLoadingBarStyle(): string {
+    switch (this.#loadingBarState) {
+      case LoadingBarState.IDLE:
+        return 'display: none';
+      case LoadingBarState.FIRST:
+      case LoadingBarState.SECOND:
+      case LoadingBarState.THIRD:
+        return 'display: block';
+      default:
+        return '';
+    }
+  }
+
+  #timeoutFor(timeoutId: number, enabled: boolean, handler: () => void, delay: number): number {
+    if (timeoutId !== 0) {
+      window.clearTimeout(timeoutId);
+    }
+
+    return enabled ? window.setTimeout(handler, delay) : 0;
+  }
+}
+
+if (customElements.get('vaadin-connection-indicator') === undefined) {
+  customElements.define('vaadin-connection-indicator', ConnectionIndicator);
+}
+
+/**
+ * The global connection indicator object. Its appearance and behavior can be
+ * configured via properties:
+ *
+ * connectionIndicator.firstDelay = 0;
+ * connectionIndicator.onlineText = 'The application is online';
+ *
+ * To avoid altering the appearance while the indicator is active, apply the
+ * configuration in your application 'frontend/index.ts' file.
+ */
+export const connectionIndicator = ConnectionIndicator.instance;

--- a/flow-client/src/main/frontend/ConnectionIndicator.ts
+++ b/flow-client/src/main/frontend/ConnectionIndicator.ts
@@ -20,6 +20,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { ConnectionState, type ConnectionStateStore } from './ConnectionState';
 
 const DEFAULT_STYLE_ID = 'css-loading-indicator';
+const STRUCTURAL_STYLE_ID = 'css-loading-indicator-structure';
 
 /**
  * The loading indicator states
@@ -198,6 +199,15 @@ export class ConnectionIndicator extends LitElement {
     }
   }
 
+  /**
+   * Whether the default theme (the indicator's skin: colors, fonts and the
+   * progress bar height) is applied. Defaults to `true`.
+   *
+   * Setting this to `false` removes only the skin so the indicator can be
+   * fully restyled by the application. The structural styles that make the
+   * indicator function - positioning, the progress animation and the
+   * state-driven visibility of the bar and status message - are always kept.
+   */
   get applyDefaultTheme() {
     return this.#applyDefaultThemeState;
   }
@@ -317,22 +327,44 @@ export class ConnectionIndicator extends LitElement {
   }
 
   #updateTheme() {
-    if (this.#applyDefaultThemeState && this.isConnected) {
-      if (!document.getElementById(DEFAULT_STYLE_ID)) {
+    // The structural styles are required for the indicator to function
+    // (positioning, progress animation, state-driven visibility) and are
+    // always present while the indicator is in the document, regardless of
+    // applyDefaultTheme.
+    this.#ensureStyle(STRUCTURAL_STYLE_ID, this.isConnected, () => this.#getStructuralStyle());
+    // The default theme is only the skin (colors, fonts, bar height) that an
+    // application would naturally override. It is removed when
+    // applyDefaultTheme is set to false, leaving the structural styles in
+    // place so the indicator keeps working.
+    this.#ensureStyle(DEFAULT_STYLE_ID, this.#applyDefaultThemeState && this.isConnected, () => this.#getThemeStyle());
+  }
+
+  #ensureStyle(id: string, present: boolean, content: () => string) {
+    const existing = document.getElementById(id);
+    if (present) {
+      if (!existing) {
         const style = document.createElement('style');
-        style.id = DEFAULT_STYLE_ID;
-        style.textContent = this.#getDefaultStyle();
+        style.id = id;
+        style.textContent = content();
         document.head.appendChild(style);
       }
-    } else {
-      const style = document.getElementById(DEFAULT_STYLE_ID);
-      if (style) {
-        document.head.removeChild(style);
-      }
+    } else if (existing) {
+      existing.remove();
     }
   }
 
-  #getDefaultStyle(): string {
+  /**
+   * Styles required for the indicator to function: where it is positioned, how
+   * the progress bar grows and pulses, and how the bar and status message
+   * appear and disappear based on the connection state. These are always
+   * applied so that disabling the default theme does not break the indicator.
+   *
+   * The progress keyframes are defined here as the single source of truth. The
+   * height steps in `v-progress-wait` only have a visible effect once the bar
+   * has a base height, which the default theme provides; without the theme the
+   * bar has no height and stays invisible.
+   */
+  #getStructuralStyle(): string {
     return `
       @keyframes v-progress-start {
         0% {
@@ -375,6 +407,11 @@ export class ConnectionIndicator extends LitElement {
           opacity: 1;
         }
       }
+      @keyframes v-spin {
+        100% {
+          transform: rotate(360deg);
+        }
+      }
       .v-loading-indicator,
       .v-status-message {
         box-sizing: border-box;
@@ -382,13 +419,11 @@ export class ConnectionIndicator extends LitElement {
         left: 0;
         right: 0;
         top: 0;
-        background-color: var(--lumo-primary-color, var(--material-primary-color, blue));
         transition: none;
       }
       .v-loading-indicator {
         right: auto;
         width: 50%;
-        height: 4px;
         opacity: 1;
         pointer-events: none;
         animation: v-progress-start 1000ms 200ms both;
@@ -419,34 +454,13 @@ export class ConnectionIndicator extends LitElement {
         pointer-events: none;
         max-height: var(--status-height-collapsed, 8px);
         overflow: hidden;
-        background-color: var(--status-bg-color-online, var(--lumo-primary-color, var(--material-primary-color, blue)));
-        color: var(
-          --status-text-color-online,
-          var(--lumo-primary-contrast-color, var(--material-primary-contrast-color, #fff))
-        );
-        font-size: 0.75rem;
-        font-weight: 600;
-        line-height: 1;
         transition: all 0.5s;
-        padding: 0 0.5em;
       }
 
       vaadin-connection-indicator[offline] .v-status-message,
       vaadin-connection-indicator[reconnecting] .v-status-message {
         opacity: 1;
         pointer-events: auto;
-        background-color: var(--status-bg-color-offline, var(--lumo-shade, #333));
-        color: var(
-          --status-text-color-offline,
-          var(--lumo-primary-contrast-color, var(--material-primary-contrast-color, #fff))
-        );
-        background-image: repeating-linear-gradient(
-          45deg,
-          rgba(255, 255, 255, 0),
-          rgba(255, 255, 255, 0) 10px,
-          rgba(255, 255, 255, 0.1) 10px,
-          rgba(255, 255, 255, 0.1) 20px
-        );
       }
 
       vaadin-connection-indicator[reconnecting] .v-status-message {
@@ -475,22 +489,60 @@ export class ConnectionIndicator extends LitElement {
         content: '';
         width: 1em;
         height: 1em;
-        border-top: 2px solid
-          var(--status-spinner-color, var(--lumo-primary-color, var(--material-primary-color, blue)));
-        border-left: 2px solid
-          var(--status-spinner-color, var(--lumo-primary-color, var(--material-primary-color, blue)));
-        border-right: 2px solid transparent;
-        border-bottom: 2px solid transparent;
+        border: 2px solid transparent;
+        border-top-color: currentColor;
+        border-left-color: currentColor;
         border-radius: 50%;
         box-sizing: border-box;
         animation: v-spin 0.4s linear infinite;
         margin: 0 0.5em;
       }
+    `;
+  }
 
-      @keyframes v-spin {
-        100% {
-          transform: rotate(360deg);
-        }
+  /**
+   * The default skin: colors, fonts and the bar height. These are the styles an
+   * application would naturally override to make the indicator look different,
+   * and are the only styles removed when applyDefaultTheme is set to false.
+   */
+  #getThemeStyle(): string {
+    return `
+      .v-loading-indicator {
+        height: 4px;
+        background-color: var(--lumo-primary-color, var(--material-primary-color, blue));
+      }
+
+      .v-status-message {
+        background-color: var(--status-bg-color-online, var(--lumo-primary-color, var(--material-primary-color, blue)));
+        color: var(
+          --status-text-color-online,
+          var(--lumo-primary-contrast-color, var(--material-primary-contrast-color, #fff))
+        );
+        font-size: 0.75rem;
+        font-weight: 600;
+        line-height: 1;
+        padding: 0 0.5em;
+      }
+
+      vaadin-connection-indicator[offline] .v-status-message,
+      vaadin-connection-indicator[reconnecting] .v-status-message {
+        background-color: var(--status-bg-color-offline, var(--lumo-shade, #333));
+        color: var(
+          --status-text-color-offline,
+          var(--lumo-primary-contrast-color, var(--material-primary-contrast-color, #fff))
+        );
+        background-image: repeating-linear-gradient(
+          45deg,
+          rgba(255, 255, 255, 0),
+          rgba(255, 255, 255, 0) 10px,
+          rgba(255, 255, 255, 0.1) 10px,
+          rgba(255, 255, 255, 0.1) 20px
+        );
+      }
+
+      vaadin-connection-indicator[reconnecting] .v-status-message span::before {
+        border-top-color: var(--status-spinner-color, var(--lumo-primary-color, var(--material-primary-color, blue)));
+        border-left-color: var(--status-spinner-color, var(--lumo-primary-color, var(--material-primary-color, blue)));
       }
     `;
   }

--- a/flow-client/src/main/frontend/ConnectionState.ts
+++ b/flow-client/src/main/frontend/ConnectionState.ts
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+export enum ConnectionState {
+  /**
+   * Application is connected to server: last transaction over the wire (XHR /
+   * heartbeat / endpoint call) was successful.
+   */
+  CONNECTED = 'connected',
+
+  /**
+   * Application is connected and Flow is loading application state from the
+   * server, or Hilla is waiting for an endpoint call to return.
+   */
+  LOADING = 'loading',
+
+  /**
+   * Application has been temporarily disconnected from the server because the
+   * last transaction over the wire (XHR / heartbeat / endpoint call) resulted
+   * in a network error, or the browser has received the 'online' event and needs
+   * to verify reconnection with the server. Flow is attempting to reconnect
+   * a configurable number of times before giving up.
+   */
+  RECONNECTING = 'reconnecting',
+
+  /**
+   * Application has been permanently disconnected due to browser receiving the
+   * 'offline' event, or the server not being reached after a number of reconnect
+   * attempts.
+   */
+  CONNECTION_LOST = 'connection-lost'
+}
+
+export type ConnectionStateChangeListener = (previous: ConnectionState, current: ConnectionState) => void;
+
+export class ConnectionStateStore {
+  readonly #stateChangeListeners = new Set<ConnectionStateChangeListener>();
+
+  #connectionState: ConnectionState;
+  #loadingCount = 0;
+
+  constructor(initialState: ConnectionState) {
+    this.#connectionState = initialState;
+
+    if (navigator.serviceWorker) {
+      // Query service worker if the most recent fetch was served from cache
+      // Add message listener for handling response
+      navigator.serviceWorker.addEventListener('message', this.#serviceWorkerMessageListener);
+      // Send JSON-RPC request to Vaadin service worker
+      void navigator.serviceWorker.ready.then((registration) => {
+        registration.active?.postMessage({
+          method: 'Vaadin.ServiceWorker.isConnectionLost',
+          id: 'Vaadin.ServiceWorker.isConnectionLost'
+        });
+      });
+    }
+  }
+
+  addStateChangeListener(listener: ConnectionStateChangeListener): void {
+    this.#stateChangeListeners.add(listener);
+  }
+
+  removeStateChangeListener(listener: ConnectionStateChangeListener): void {
+    this.#stateChangeListeners.delete(listener);
+  }
+
+  loadingStarted(): void {
+    this.state = ConnectionState.LOADING;
+    this.#loadingCount += 1;
+  }
+
+  loadingFinished(): void {
+    this.#decreaseLoadingCount(ConnectionState.CONNECTED);
+  }
+
+  loadingFailed(): void {
+    this.#decreaseLoadingCount(ConnectionState.CONNECTION_LOST);
+  }
+
+  #decreaseLoadingCount(finalState: ConnectionState) {
+    if (this.#loadingCount > 0) {
+      this.#loadingCount -= 1;
+      if (this.#loadingCount === 0) {
+        this.state = finalState;
+      }
+    }
+  }
+
+  get state(): ConnectionState {
+    return this.#connectionState;
+  }
+
+  set state(newState: ConnectionState) {
+    if (newState !== this.#connectionState) {
+      const prevState = this.#connectionState;
+      this.#connectionState = newState;
+      this.#loadingCount = 0;
+      for (const listener of this.#stateChangeListeners) {
+        listener(prevState, this.#connectionState);
+      }
+    }
+  }
+
+  get online(): boolean {
+    return this.#connectionState === ConnectionState.CONNECTED || this.#connectionState === ConnectionState.LOADING;
+  }
+
+  get offline(): boolean {
+    return !this.online;
+  }
+
+  readonly #serviceWorkerMessageListener = (event: MessageEvent) => {
+    // Handle JSON-RPC response from service worker
+    if (typeof event.data === 'object' && event.data.id === 'Vaadin.ServiceWorker.isConnectionLost') {
+      if (event.data.result === true) {
+        this.state = ConnectionState.CONNECTION_LOST;
+      }
+
+      // Cleanup: remove event listener upon receiving response
+      navigator.serviceWorker.removeEventListener('message', this.#serviceWorkerMessageListener);
+    }
+  };
+}
+
+export function isLocalhost(hostname: string): boolean {
+  if (hostname === 'localhost') {
+    return true;
+  }
+
+  if (hostname === '[::1]') {
+    return true;
+  }
+
+  return /^127\.\d+\.\d+\.\d+$/u.test(hostname);
+}
+
+const $wnd = window as any;
+if (!$wnd.Vaadin?.connectionState) {
+  let online;
+  if (isLocalhost(window.location.hostname)) {
+    // We do not know if we are online or not as we cannot trust navigator.onLine which checks availability of a network connection. Better to assume online so localhost apps can work
+    online = true;
+  } else {
+    online = navigator.onLine;
+  }
+
+  $wnd.Vaadin ??= {};
+  $wnd.Vaadin.connectionState = new ConnectionStateStore(
+    online ? ConnectionState.CONNECTED : ConnectionState.CONNECTION_LOST
+  );
+}

--- a/flow-client/src/main/frontend/Flow.ts
+++ b/flow-client/src/main/frontend/Flow.ts
@@ -1,9 +1,5 @@
-import {
-  ConnectionIndicator,
-  ConnectionState,
-  type ConnectionStateChangeListener,
-  type ConnectionStateStore
-} from '@vaadin/common-frontend';
+import { ConnectionIndicator } from './ConnectionIndicator';
+import { ConnectionState, type ConnectionStateChangeListener, type ConnectionStateStore } from './ConnectionState';
 import './Clipboard';
 import { currentFullscreenState } from './Fullscreen';
 import './Download';

--- a/flow-client/src/test/frontend/FlowTests.ts
+++ b/flow-client/src/test/frontend/FlowTests.ts
@@ -1,7 +1,7 @@
 import { expect } from '@open-wc/testing';
 
 // API to test
-import { ConnectionState, ConnectionStateStore } from '@vaadin/common-frontend';
+import { ConnectionState, ConnectionStateStore } from '../../main/frontend/ConnectionState';
 import { Flow, type NavigationParameters } from '../../main/frontend/Flow';
 // Intern does not serve webpack chunks, adding deps here in order to
 // produce one chunk, because dynamic imports in Flow.ts  will not work.

--- a/flow-client/src/test/frontend/FlowTests.ts
+++ b/flow-client/src/test/frontend/FlowTests.ts
@@ -197,6 +197,36 @@ describe('Flow', () => {
     expect(indicator.classList.contains('third')).to.be.false;
   });
 
+  it('should keep structural styles but drop the skin when the default theme is disabled', async () => {
+    new Flow({ imports: () => {} });
+    await $wnd.Vaadin.connectionIndicator.updateComplete;
+
+    const structural = () => $wnd.document.querySelector('style#css-loading-indicator-structure');
+    const theme = () => $wnd.document.querySelector('style#css-loading-indicator');
+
+    // By default both the structural styles and the default theme are applied
+    expect(structural()).not.to.be.null;
+    expect(theme()).not.to.be.null;
+
+    // Disabling the default theme removes only the skin (e.g. the bar height
+    // and colors), the structural styles that make the indicator work remain
+    $wnd.Vaadin.connectionIndicator.applyDefaultTheme = false;
+    await $wnd.Vaadin.connectionIndicator.updateComplete;
+
+    expect(theme()).to.be.null;
+    expect(structural()).not.to.be.null;
+    expect(structural()!.textContent).to.contain('position: fixed');
+    // Paint such as background-color lives only in the removable theme
+    expect(structural()!.textContent).to.not.contain('background-color');
+
+    // Re-enabling restores the default theme
+    $wnd.Vaadin.connectionIndicator.applyDefaultTheme = true;
+    await $wnd.Vaadin.connectionIndicator.updateComplete;
+
+    expect(theme()).not.to.be.null;
+    expect(theme()!.textContent).to.contain('background-color');
+  });
+
   it('should throw when an incorrect server response is received', () => {
     // Configure an invalid server response
     server.addHandler('GET', /^.*\?v-r=init&location=.*/, (req) => {

--- a/flow-client/tsconfig.json
+++ b/flow-client/tsconfig.json
@@ -12,7 +12,6 @@
     "noImplicitThis": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "experimentalDecorators": true,
     "rootDir": "src/main/frontend",
     "outDir": "target/classes/META-INF/frontend",
     "declaration": true,

--- a/flow-client/web-test-runner.config.mjs
+++ b/flow-client/web-test-runner.config.mjs
@@ -6,6 +6,11 @@ export default {
   plugins: [
     esbuildPlugin({
       ts: true,
+      // esbuild does not read 'target' from tsconfig and defaults to esnext,
+      // which leaves standard decorators and accessor fields untransformed and
+      // unparseable by the browser. Set it explicitly to match tsconfig so the
+      // ConnectionIndicator Lit element is lowered for the test browser.
+      target: 'es2023',
       tsconfig: fileURLToPath(new URL('./tsconfig.json', import.meta.url))
     })
   ]

--- a/flow-plugins/flow-maven-plugin/src/it/frontend-scanner-tuning-project/verify.bsh
+++ b/flow-plugins/flow-maven-plugin/src/it/frontend-scanner-tuning-project/verify.bsh
@@ -10,35 +10,30 @@ import com.vaadin.flow.plugin.maven.it.IntegrationTestHelper;
 
 verifications = new LinkedHashMap();
 verifications.put("all-deps", List.of(
-    "@vaadin/common-frontend/ConnectionIndicator.js",
     "Frontend/generated/jar-resources/ReactRouterOutletElement.tsx",
     "Frontend/project-component.js",
     "Frontend/generated/jar-resources/alpha.js",
     "Frontend/generated/jar-resources/beta.js"
 ));
 verifications.put("exclude-alpha", List.of(
-    "@vaadin/common-frontend/ConnectionIndicator.js",
     "Frontend/generated/jar-resources/ReactRouterOutletElement.tsx",
     "Frontend/project-component.js",
     "!Frontend/generated/jar-resources/alpha.js",
     "Frontend/generated/jar-resources/beta.js"
 ));
 verifications.put("include-alpha", List.of(
-    "@vaadin/common-frontend/ConnectionIndicator.js",
     "Frontend/generated/jar-resources/ReactRouterOutletElement.tsx",
     "Frontend/project-component.js",
     "Frontend/generated/jar-resources/alpha.js",
     "!Frontend/generated/jar-resources/beta.js"
 ));
 verifications.put("exclude-all", List.of(
-    "@vaadin/common-frontend/ConnectionIndicator.js",
     "Frontend/generated/jar-resources/ReactRouterOutletElement.tsx",
     "Frontend/project-component.js",
     "!Frontend/generated/jar-resources/alpha.js",
     "!Frontend/generated/jar-resources/beta.js"
 ));
 verifications.put("exclude-target", List.of(
-    "@vaadin/common-frontend/ConnectionIndicator.js",
     "Frontend/generated/jar-resources/ReactRouterOutletElement.tsx",
     "!Frontend/project-component.js",
     "Frontend/generated/jar-resources/alpha.js",

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -32,7 +32,6 @@ import org.slf4j.LoggerFactory;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.BaseJsonNode;
 
-import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.internal.JavaScriptNavigationStateRenderer;
 import com.vaadin.flow.component.internal.UIInternalUpdater;
 import com.vaadin.flow.component.internal.UIInternals;
@@ -112,7 +111,6 @@ import com.vaadin.flow.signals.local.ValueSignal;
  *
  * @since 1.0
  */
-@JsModule("@vaadin/common-frontend/ConnectionIndicator.js")
 public class UI extends Component
         implements PollNotifier, HasComponents, RouterLayout {
 

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/default/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/default/package.json
@@ -3,7 +3,6 @@
   "description": "A list of default Flow dependencies",
   "dependencies": {
     "@polymer/polymer": "3.5.2",
-    "@vaadin/common-frontend": "0.0.22",
     "lit": "3.3.3"
   },
   "devDependencies": {

--- a/flow-tests/test-ccdm-flow-navigation/src/main/frontend/index.ts
+++ b/flow-tests/test-ccdm-flow-navigation/src/main/frontend/index.ts
@@ -1,6 +1,6 @@
 import { Flow } from 'Frontend/generated/jar-resources/Flow';
 import { Router } from '@vaadin/router';
-import { connectionIndicator } from '@vaadin/common-frontend';
+import { connectionIndicator } from 'Frontend/generated/jar-resources/ConnectionIndicator';
 
 const { serverSideRoutes } = new Flow({
   imports: () => import('Frontend/generated/flow/generated-flow-imports.js')


### PR DESCRIPTION
Split the connection indicator CSS into a structural sheet that is always
applied and a removable theme sheet. Disabling applyDefaultTheme previously
removed all styles, breaking positioning, the progress animation and the
state-driven visibility of the indicator. Now only the skin (colors, fonts
and the bar height) is removed, leaving the indicator functional and ready
to be restyled by the application.

Fixes #24072
