### PR TITLE
feat: add HasAriaRole interface

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/HasAriaRole.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasAriaRole.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component;
+
+import java.util.Optional;
+
+/**
+ * A generic interface for components and other user interface objects that may
+ * have a role DOM attribute to define the semantic meaning of the component for
+ * assistive technologies such as screen readers.
+ * <p>
+ * The default implementation sets the role of the component to the given
+ * {@link #getElement()}. Override the methods in this interface if the role
+ * should be added to some other element.
+ * <p>
+ * See: https://www.w3.org/TR/wai-aria/#usage_intro
+ *
+ * @author Vaadin Ltd
+ */
+public interface HasAriaRole extends HasElement {
+
+    /**
+     * Sets the ARIA role attribute of the component to the given role.
+     *
+     * @param role
+     *            the role to set, or {@code null} to clear
+     */
+    default void setAriaRole(String role) {
+        if (role != null) {
+            getElement().setAttribute("role", role);
+        } else {
+            getElement().removeAttribute("role");
+        }
+    }
+
+    /**
+     * Gets the ARIA role attribute of the component.
+     *
+     * @return an optional ARIA role of the component if no ARIA role has been
+     *         set
+     */
+    default Optional<String> getAriaRole() {
+        return Optional.ofNullable(getElement().getAttribute("role"));
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasAriaRoleTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasAriaRoleTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class HasAriaRoleTest {
+
+    @Tag(Tag.DIV)
+    private static class TestComponent extends Component
+            implements HasAriaRole {
+
+    }
+
+    @Test
+    void withoutAriaRole_getAriaRoleReturnsEmptyOptional() {
+        TestComponent component = new TestComponent();
+
+        assertFalse(component.getAriaRole().isPresent());
+    }
+
+    @Test
+    void withNullAriaRole_getAriaRoleReturnsEmptyOptional() {
+        TestComponent component = new TestComponent();
+        component.setAriaRole(null);
+        assertFalse(component.getAriaRole().isPresent());
+    }
+
+    @Test
+    void setAriaRole() {
+        TestComponent component = new TestComponent();
+        component.setAriaRole("alertdialog");
+
+        assertEquals("alertdialog", component.getAriaRole().get());
+    }
+
+    @Test
+    void withAriaRole_setAriaRoleToNullClearsAriaRole() {
+        TestComponent component = new TestComponent();
+        component.setAriaRole("alertdialog");
+
+        component.setAriaRole(null);
+        assertFalse(component.getAriaRole().isPresent());
+    }
+}


### PR DESCRIPTION
Added a shared `HasAriaRole` mixin interface so that components like Card, Badge, Dialog, and Popover could implement a single common contract instead of duplicating the logic.

The interface is placed next to `HasAriaLabel` in `com.vaadin.flow.component` and follows the same pattern: attribute-based storage, `null` clears the attribute, and the getter returns an `Optional`.

Part of vaadin/flow-components#9489

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
