### PR TITLE
fix: keep component-fullscreen working when target is the view root

### DIFF
--- a/flow-client/src/main/frontend/Fullscreen.ts
+++ b/flow-client/src/main/frontend/Fullscreen.ts
@@ -90,21 +90,32 @@ $wnd.Vaadin.Flow.fullscreen = {
     if (!originalParent) {
       throw new Error('Component is not attached to the DOM');
     }
+
+    // The view root is the wrapper's current element child (the route
+    // content). Capture it before touching the DOM, because the steps below
+    // insert a placeholder comment and move the element into the wrapper —
+    // after that, the wrapper's first node may be the placeholder rather than
+    // the view root. Use firstElementChild so comment/text nodes are skipped.
+    const viewRoot = wrapper.firstElementChild as HTMLElement | null;
+
     const placeholder = document.createComment('vaadin-fullscreen-placeholder');
     originalParent.insertBefore(placeholder, element);
-
     wrapper.appendChild(element);
-    const viewRoot = wrapper.firstChild as HTMLElement | null;
-    const previousDisplay = viewRoot?.style.display ?? '';
-    if (viewRoot) {
-      viewRoot.style.display = 'none';
+
+    // When the fullscreened component *is* the view root there is nothing
+    // else to hide; hiding it would blank the fullscreen. Otherwise hide the
+    // view root so only the fullscreened component shows.
+    const hidden = viewRoot === element ? null : viewRoot;
+    const previousDisplay = hidden?.style.display ?? '';
+    if (hidden) {
+      hidden.style.display = 'none';
     }
 
     activeComponentReset = () => {
       placeholder.parentNode?.insertBefore(element, placeholder);
       placeholder.remove();
-      if (viewRoot) {
-        viewRoot.style.display = previousDisplay;
+      if (hidden) {
+        hidden.style.display = previousDisplay;
       }
     };
 

--- a/flow-client/src/test/frontend/FullscreenTests.ts
+++ b/flow-client/src/test/frontend/FullscreenTests.ts
@@ -1,0 +1,70 @@
+import { expect } from '@open-wc/testing';
+
+// API under test — importing registers window.Vaadin.Flow.fullscreen.
+import '../../main/frontend/Fullscreen';
+
+const $wnd = window as any;
+
+// Replace document.documentElement.requestFullscreen with a resolving stub so
+// the tests exercise the DOM manipulation without depending on a real
+// fullscreen grant (which requires user activation and is denied in CI).
+function stubRequestFullscreen(): () => void {
+  const original = document.documentElement.requestFullscreen;
+  document.documentElement.requestFullscreen = () => Promise.resolve();
+  return () => {
+    document.documentElement.requestFullscreen = original;
+  };
+}
+
+describe('requestComponentFullscreen', () => {
+  let restore: () => void;
+  let wrapper: HTMLElement;
+
+  beforeEach(() => {
+    restore = stubRequestFullscreen();
+    wrapper = document.createElement('flow-container-test');
+    document.body.appendChild(wrapper);
+  });
+
+  afterEach(() => {
+    restore();
+    wrapper.remove();
+    // Drop any active reset state captured by a previous test run.
+    document.dispatchEvent(new Event('fullscreenchange'));
+  });
+
+  it('keeps the component visible when it is the view root (direct child of wrapper)', async () => {
+    // The view root is the only child of the wrapper, and it is itself the
+    // component being fullscreened. The placeholder ends up as the wrapper's
+    // first node, so the old firstChild-based logic crashed on the comment.
+    const viewRoot = document.createElement('div');
+    wrapper.appendChild(viewRoot);
+
+    await $wnd.Vaadin.Flow.fullscreen.requestComponentFullscreen(viewRoot, wrapper);
+
+    expect(viewRoot.parentElement).to.equal(wrapper);
+    // Must not be hidden — hiding the view root here would blank the screen.
+    expect(viewRoot.style.display).to.not.equal('none');
+  });
+
+  it('hides the view root and restores it on exit for a nested component', async () => {
+    const viewRoot = document.createElement('div');
+    const panel = document.createElement('div');
+    viewRoot.appendChild(panel);
+    wrapper.appendChild(viewRoot);
+
+    await $wnd.Vaadin.Flow.fullscreen.requestComponentFullscreen(panel, wrapper);
+
+    // Panel moved into the wrapper, view root hidden, placeholder left behind.
+    expect(panel.parentElement).to.equal(wrapper);
+    expect(viewRoot.style.display).to.equal('none');
+    expect(viewRoot.firstChild?.nodeType).to.equal(Node.COMMENT_NODE);
+
+    // Exiting fullscreen restores the original DOM.
+    document.dispatchEvent(new Event('fullscreenchange'));
+
+    expect(panel.parentElement).to.equal(viewRoot);
+    expect(viewRoot.style.display).to.not.equal('none');
+    expect(viewRoot.firstChild).to.equal(panel);
+  });
+});

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerRequestFullscreenRootView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TriggerRequestFullscreenRootView.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.fullscreen.Fullscreen;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+
+/**
+ * Wires {@code Fullscreen.onClick(button).enter(this, ...)} so the component
+ * being fullscreened is the route root itself. With no parent layout the view
+ * is the wrapper's direct child, which is the case where
+ * {@code requestComponentFullscreen} used to crash because the placeholder
+ * comment became the wrapper's first node. The button and status div live
+ * inside this root so the IT can drive and assert the outcome.
+ */
+@Route("com.vaadin.flow.uitest.ui.TriggerRequestFullscreenRootView")
+public class TriggerRequestFullscreenRootView extends AbstractDivView {
+
+    @Override
+    protected void onShow() {
+        setId("root");
+        NativeButton goButton = new NativeButton("Fullscreen");
+        goButton.setId("go");
+        Div status = new Div();
+        status.setId("status");
+
+        add(goButton, status);
+
+        Fullscreen.onClick(goButton).enter(this, () -> status.setText("ok"),
+                err -> status
+                        .setText("err:" + err.name() + ":" + err.message()));
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerRequestFullscreenRootIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TriggerRequestFullscreenRootIT.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2000-2026 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class TriggerRequestFullscreenRootIT extends ChromeBrowserTest {
+
+    @Test
+    public void fullscreenViewRoot_doesNotCrash_andServerReceivesSuccess() {
+        open();
+        installResolvingFullscreenShim();
+
+        WebElement button = findElement(By.id("go"));
+        WebElement status = findElement(By.id("status"));
+
+        button.click();
+
+        // The fullscreened component is the wrapper's direct child (the view
+        // root). The old firstChild-based logic threw a TypeError before
+        // reaching document.documentElement.requestFullscreen(), so the shim
+        // was never invoked and the success path never ran. Both assertions
+        // therefore fail without the fix.
+        Boolean called = (Boolean) ((JavascriptExecutor) getDriver())
+                .executeScript("return window.__fsCalled === true;");
+        Assert.assertTrue("requestFullscreen shim should have been invoked",
+                called);
+
+        // The view root stays visible here (there is nothing else to hide), so
+        // the status text is reachable directly.
+        waitUntil(d -> "ok".equals(status.getDomProperty("textContent")));
+    }
+
+    // Replace Element.prototype.requestFullscreen with a resolving shim so the
+    // IT doesn't depend on the browser actually granting fullscreen (which
+    // headless CI Chrome routinely denies).
+    private void installResolvingFullscreenShim() {
+        ((JavascriptExecutor) getDriver())
+                .executeScript("window.__fsCalled = false;"
+                        + "Element.prototype.requestFullscreen = function() {"
+                        + "  window.__fsCalled = true;"
+                        + "  return Promise.resolve();" + "};");
+    }
+}


### PR DESCRIPTION
requestComponentFullscreen captured the view root to hide via
wrapper.firstChild after inserting the placeholder comment and moving
the element into the wrapper. When the fullscreened component is the
wrapper's direct child (the route view root), the placeholder becomes
the wrapper's first node, so firstChild returned the comment and reading
.style.display on it threw "Cannot read properties of undefined".

Capture the view root via firstElementChild before mutating the DOM so
comment/text nodes are skipped, and skip hiding when the fullscreened
component is itself the view root (hiding it would blank the screen).
