### PR TITLE
feat: allow setting frontend build toggles via system properties

### DIFF
--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -73,21 +73,30 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo
 
     /**
      * Whether to generate a bundle from the project frontend sources or not.
+     * <p>
+     * Can be set from the command line with
+     * {@code -Dvaadin.generateBundle=false}.
      */
-    @Parameter(defaultValue = "true")
+    @Parameter(property = "vaadin.generateBundle", defaultValue = "true")
     private boolean generateBundle;
 
     /**
      * Whether to run <code>npm install</code> after updating dependencies.
+     * <p>
+     * Can be set from the command line with
+     * {@code -Dvaadin.runNpmInstall=false}.
      */
-    @Parameter(defaultValue = "true")
+    @Parameter(property = "vaadin.runNpmInstall", defaultValue = "true")
     private boolean runNpmInstall;
 
     /**
      * Whether to generate embeddable web components from WebComponentExporter
      * inheritors.
+     * <p>
+     * Can be set from the command line with
+     * {@code -Dvaadin.generateEmbeddableWebComponents=false}.
      */
-    @Parameter(defaultValue = "true")
+    @Parameter(property = "vaadin.generateEmbeddableWebComponents", defaultValue = "true")
     private boolean generateEmbeddableWebComponents;
 
     /**
@@ -101,8 +110,12 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo
     /**
      * Whether to use byte code scanner strategy to discover frontend
      * components.
+     * <p>
+     * Can be set from the command line with
+     * {@code -Dvaadin.devmode.optimizeBundle=false}.
      */
-    @Parameter(defaultValue = "true")
+    @Parameter(property = "vaadin."
+            + InitParameters.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE, defaultValue = "true")
     private boolean optimizeBundle;
 
     /**

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -83,9 +83,12 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
 
     /**
      * Whether or not insert the initial Uidl object in the bootstrap index.html
+     * <p>
+     * Can be set from the command line with
+     * {@code -Dvaadin.eagerServerLoad=true}.
      */
-    @Parameter(defaultValue = "${vaadin."
-            + InitParameters.SERVLET_PARAMETER_INITIAL_UIDL + "}")
+    @Parameter(property = "vaadin."
+            + InitParameters.SERVLET_PARAMETER_INITIAL_UIDL, defaultValue = "false")
     private boolean eagerServerLoad;
 
     /**


### PR DESCRIPTION
Several `build-frontend` toggles could only be configured through a POM `<configuration>` block, making it hard to override them for a single build.

Add a `property` attribute to `generateBundle`, `runNpmInstall`, `generateEmbeddableWebComponents`, `optimizeBundle` and `eagerServerLoad` so they can be set at runtime, e.g. `-Dvaadin.generateBundle=false`.
