### PR TITLE
fix: support the configuration cache when packaging the production jar

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
@@ -707,6 +707,27 @@ class VaadinSmokeTest : AbstractGradleTest() {
         assertContains(result.output, "Calculating task graph as no cached configuration is available for tasks: vaadinBuildFrontend")
     }
 
+    @Test
+    fun testWarPackaging_configurationCache_productionMode() {
+        // Regression test for https://github.com/vaadin/flow/issues/24794
+        // In production mode the token-restore action is attached to the
+        // Jar/War packaging task. If that action captures the Project, the
+        // configuration cache cannot serialize the War task and the build
+        // fails. The existing config-cache tests only run vaadinBuildFrontend,
+        // so they never exercise the packaging task; this test does.
+
+        // Create frontend folder, that will otherwise be created by the first
+        // execution, invalidating the cache on the second run
+        testProject.newFolder("src/main/frontend")
+
+        val result = testProject.build("--configuration-cache", "-Pvaadin.productionMode", "war")
+        result.expectTaskSucceded("war")
+        assertContains(result.output, "Configuration cache entry stored")
+
+        val result2 = testProject.build("--configuration-cache", "-Pvaadin.productionMode", "war", checkTasksSuccessful = false)
+        assertContains(result2.output, "Reusing configuration cache")
+    }
+
     private fun enableHilla() {
         testProject.newFolder(FrontendUtils.DEFAULT_FRONTEND_DIR)
         testProject.newFile(FrontendUtils.DEFAULT_FRONTEND_DIR + "index.ts")

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/FlowPlugin.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/FlowPlugin.kt
@@ -75,13 +75,6 @@ public class FlowPlugin : Plugin<Project> {
                 // this will also catch the War task since it extends from Jar
                 project.tasks.withType(Jar::class.java) { task: Jar ->
                     task.dependsOn("vaadinBuildFrontend")
-                    // Restore the production token before packaging in
-                    // case it was deleted by a previous build's cleanup.
-                    task.doFirst {
-                        val svc = (project.tasks.getByName("vaadinBuildFrontend")
-                            as VaadinBuildFrontendTask).getTokenService().orNull
-                        svc?.ensureToken()
-                    }
                 }
             } else if (config.alwaysExecutePrepareFrontend.get()) {
                 // In development mode, vaadinPrepareFrontend is not
@@ -150,6 +143,13 @@ public class FlowPlugin : Plugin<Project> {
                 buildFrontendTask.usesService(tokenService)
                 project.tasks.withType(Jar::class.java) { task: Jar ->
                     task.usesService(tokenService)
+                    // Restore the production token before packaging in
+                    // case it was deleted by a previous build's cleanup.
+                    // Capture the service provider rather than the Project so
+                    // the action stays compatible with the configuration cache.
+                    task.doFirst {
+                        tokenService.get().ensureToken()
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Description

The production-mode token-restore action was added as a Jar.doFirst {} whose lambda captures the whole Project, which can't be serialized for the configuration cache. It's moved to the block where the vaadinBuildFrontendToken service is already in scope, and now captures that service provider instead of the Project.

Fixes #24794

## Type of change

- [x ] Bugfix
- [ ] Feature

## Checklist

- [ x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ x] I have added a description following the guideline.
- [ x] The issue is created in the corresponding repository and I have referenced it.
- [x ] I have performed self-review and corrected misspellings.

- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.

There are no suitable existing tests for this, this is simply a regression fix. It affects any Gradle with the configuration cache active.