### PR TITLE
test: assert rebinding works after removeBinding before attach

### DIFF
--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderSignalTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderSignalTest.java
@@ -970,31 +970,37 @@ class BinderSignalTest extends SignalsUnitTest {
         assertFalse(field.isInvalid());
     }
 
-    // Binding a not-yet-attached field registers a deferred attach listener
-    // that sets up the internal validation signal effect on attach. Removing
-    // the binding must also cancel that pending listener; otherwise it later
-    // creates an effect for an already-unbound binding whose field is null.
+    // Reproduces #24790: removing a binding and then re-binding the same field
+    // with a different configuration must not throw when the field is later
+    // attached. The field is bound while detached, removed, re-bound, and only
+    // then added to the UI.
     @Test
-    void removeBinding_beforeAttach_doesNotSetUpEffectForUnboundBinding() {
-        var field = new TestTextField();
+    void removeBinding_thenRebindAndAttach_noErrorAndRebindingWorks() {
+        item.setFirstName("first");
+        item.setLastName("last");
         binder.setBean(item);
-        var binding = binder.forField(field)
+
+        var field = new TestTextField();
+        binder.forField(field)
                 .withValidator(value -> !value.isEmpty(), "Required")
                 .bind(Person::getFirstName, Person::setFirstName);
 
-        // Field is not attached yet, so the validation effect is only scheduled
-        // via an attach listener. Removing the binding must cancel it.
-        binder.removeBinding(binding);
+        binder.removeBinding(field);
 
-        // Re-bind the same field with a different configuration.
         binder.forField(field).bind(Person::getLastName, Person::setLastName);
 
-        // Attaching used to fire the stale attach listener of the removed
-        // binding, creating an effect that reads the now-null field.
         UI.getCurrent().add(field);
 
-        // The error handler (see SignalsUnitTest) records any exception thrown
-        // from an effect; events must stay empty.
+        // No exception was reported to the session error handler on attach.
         assertTrue(events.isEmpty());
+
+        // The re-bound binding is the one that is now active.
+        assertEquals("last", field.getValue());
+
+        // The re-bound binding still propagates edits back to the bean instead
+        // of the stale, removed binding.
+        field.setValue("edited");
+        assertEquals("edited", item.getLastName());
+        assertEquals("first", item.getFirstName());
     }
 }


### PR DESCRIPTION
Strengthen the regression test for #24790 to mirror the reported reproduction: bind a detached field, remove the binding, re-bind the same field with a different configuration, and only then attach it. Besides asserting no error is reported on attach, the test now verifies the re-bound binding is the active one by reading its value and checking edits propagate to the correct bean property.
