### PR TITLE
fix: Write frontend build files into build dir when it is outside project dir (#24805) (CP: 25.0)

### DIFF
--- a/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
+++ b/flow-plugins/flow-dev-bundle-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildDevBundleMojo.java
@@ -493,11 +493,24 @@ public class BuildDevBundleMojo extends AbstractMojo
 
     @Override
     public String buildFolder() {
-        if (projectBuildDir.startsWith(projectBasedir.toString())) {
-            return projectBaseDirectory().relativize(Paths.get(projectBuildDir))
-                    .toString();
+        Path buildDir = Paths.get(projectBuildDir);
+        // buildFolder() is consumed as a path relative to the project folder
+        // (new File(npmFolder, buildFolder)), so always return it relative to
+        // the project basedir. A build dir outside basedir then yields a "../"
+        // path. Returning the absolute path would instead append it to the
+        // project folder and point outside the build dir.
+        if (!buildDir.isAbsolute()) {
+            return projectBuildDir;
         }
-        return projectBuildDir;
+        // relativize() requires both paths to be absolute; basedir is always
+        // absolute in a real build, toAbsolutePath() only guards exotic setups.
+        try {
+            return projectBaseDirectory().toAbsolutePath().relativize(buildDir)
+                    .toString();
+        } catch (IllegalArgumentException e) {
+            // Different filesystem roots (e.g. on Windows): cannot relativize.
+            return projectBuildDir;
+        }
     }
 
     @Override

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscMultiModuleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscMultiModuleTest.kt
@@ -19,6 +19,7 @@ package com.vaadin.flow.gradle
 import com.vaadin.flow.internal.JacksonUtils
 import com.vaadin.flow.internal.StringUtil
 import com.vaadin.flow.server.InitParameters
+import com.vaadin.flow.server.frontend.TaskUpdateSettingsFile
 import org.gradle.testkit.runner.BuildResult
 import org.junit.Test
 import java.io.File
@@ -279,6 +280,60 @@ class MiscMultiModuleTest : AbstractGradleTest() {
         val result2 = testProject.build("--configuration-cache", "vaadinPrepareFrontend", checkTasksSuccessful = false)
         result2.expectTaskOutcome("web:vaadinPrepareFrontend", TaskOutcome.UP_TO_DATE)
         assertContains(result2.output, "Reusing configuration cache")
+    }
+
+    /**
+     * When the build directory is relocated outside the module project directory, the plugin must still write
+     * vaadin-dev-server-settings.json into that build directory.
+     */
+    @Test
+    fun `build dir relocated outside project dir writes settings into build dir`() {
+        testProject.settingsFile.writeText("include 'web'")
+        testProject.buildFile.writeText("""
+            plugins {
+                id 'java'
+                id 'com.vaadin.flow' apply false
+            }
+            allprojects {
+                repositories {
+                    mavenLocal()
+                    mavenCentral()
+                    maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
+                }
+            }
+            project(':web') {
+                apply plugin: 'war'
+                apply plugin: 'com.vaadin.flow'
+
+                dependencies {
+                    implementation("com.vaadin:flow:$flowVersion")
+                }
+
+                // Relocate the build dir outside the :web project dir (here a sibling of
+                // the module, like builds that share one top-level build/ folder). The
+                // resulting value is absolute and is not a sub-directory of projectDir.
+                layout.buildDirectory = file("${'$'}{rootDir}/custom-build")
+
+                vaadin {
+                    eagerServerLoad = false
+                }
+            }
+        """.trimIndent())
+        testProject.newFolder("web")
+
+        testProject.build("web:vaadinPrepareFrontend")
+
+        // The settings file must be written into the relocated build dir...
+        val settingsInBuildDir = File(testProject.dir,
+                "custom-build/${TaskUpdateSettingsFile.DEV_SETTINGS_FILE}")
+        expect(true, "$settingsInBuildDir should exist") { settingsInBuildDir.exists() }
+
+        // ...and must not leak into a junk tree under the :web source directory.
+        val leaked = File(testProject.dir, "web").walkTopDown()
+                .filter { it.name == TaskUpdateSettingsFile.DEV_SETTINGS_FILE }
+                .toList()
+        expect(emptyList<File>(),
+                "vaadin-dev-server-settings.json leaked under the web source dir: $leaked") { leaked }
     }
 
 

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
@@ -267,10 +267,19 @@ internal class GradlePluginAdapter private constructor(
 
     override fun buildFolder(): String {
         val projectBuildDir = config.projectBuildDir.get()
-        if (projectBuildDir.startsWith(projectDir.toString())) {
-            return File(projectBuildDir).relativeTo(projectDir).toString()
+        val buildDirFile = File(projectBuildDir)
+        // buildFolder() is consumed as a path relative to the project folder
+        // (new File(npmFolder, buildFolder)), so always return it relative to
+        // projectDir. When the build dir is outside projectDir this yields a "../"
+        // path. Returning the absolute path would instead append it to the project
+        // folder and point outside the build dir.
+        // relativeToOrNull() needs a shared root; projectDir is always absolute
+        // in a real build, absoluteFile only guards exotic setups.
+        return when {
+            !buildDirFile.isAbsolute -> projectBuildDir
+            else -> buildDirFile.relativeToOrNull(projectDir.absoluteFile)
+                    ?.toString() ?: projectBuildDir
         }
-        return projectBuildDir
     }
 
     override fun postinstallPackages(): List<String> =

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -681,11 +681,24 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
 
     @Override
     public String buildFolder() {
-        if (projectBuildDir.startsWith(projectBasedir.toString())) {
-            return projectBaseDirectory().relativize(Paths.get(projectBuildDir))
-                    .toString();
+        Path buildDir = Paths.get(projectBuildDir);
+        // buildFolder() is consumed as a path relative to the project folder
+        // (new File(npmFolder, buildFolder)), so always return it relative to
+        // the project basedir. A build dir outside basedir then yields a "../"
+        // path. Returning the absolute path would instead append it to the
+        // project folder and point outside the build dir.
+        if (!buildDir.isAbsolute()) {
+            return projectBuildDir;
         }
-        return projectBuildDir;
+        // relativize() requires both paths to be absolute; basedir is always
+        // absolute in a real build, toAbsolutePath() only guards exotic setups.
+        try {
+            return projectBaseDirectory().toAbsolutePath().relativize(buildDir)
+                    .toString();
+        } catch (IllegalArgumentException e) {
+            // Different filesystem roots (e.g. on Windows): cannot relativize.
+            return projectBuildDir;
+        }
     }
 
     @Override

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.plugin.maven;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.apache.maven.plugin.MojoExecutionException;
@@ -51,6 +52,7 @@ import static com.vaadin.flow.server.Constants.VAADIN_WEBAPP_RESOURCES;
 import static com.vaadin.flow.server.InitParameters.FRONTEND_HOTDEPLOY;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE;
 import static com.vaadin.flow.server.frontend.FrontendUtils.TOKEN_FILE;
+import static org.junit.Assert.assertEquals;
 
 public class PrepareFrontendMojoTest {
     @Rule
@@ -282,5 +284,74 @@ public class PrepareFrontendMojoTest {
         assertContainsPackage(packageJsonObject.get("devDependencies"), "vite",
                 "@rollup/plugin-replace", "rollup-plugin-brotli",
                 "vite-plugin-checker");
+    }
+
+    @Test
+    public void buildFolder_buildDirInsideBasedir_returnsRelativeName()
+            throws Exception {
+        ReflectionUtils.setVariableValueInObject(mojo, "projectBuildDir",
+                new File(projectBase, "target").getAbsolutePath());
+
+        assertEquals("target", mojo.buildFolder());
+    }
+
+    // buildFolder() is consumed as new File(npmFolder, buildFolder()), so the
+    // four absolute/relative combinations of basedir and build dir must all
+    // resolve back to the real build dir, never a nested junk path under the
+    // source tree. Only the absolute/absolute combination occurs in a real
+    // Maven build; the others guard exotic setups.
+
+    @Test
+    public void buildFolder_baseAbsolute_buildAbsolute_resolvesToBuildDir()
+            throws Exception {
+        File basedir = projectBase; // absolute
+        File buildDir = new File(projectBase.getParentFile(), "custom-build");
+        assertBuildFolderResolvesTo(basedir, buildDir.getAbsolutePath(),
+                buildDir);
+    }
+
+    @Test
+    public void buildFolder_baseAbsolute_buildRelative_resolvesToBuildDir()
+            throws Exception {
+        File basedir = projectBase; // absolute
+        String buildDir = "../custom-build"; // relative to basedir
+        assertBuildFolderResolvesTo(basedir, buildDir,
+                new File(basedir, buildDir));
+    }
+
+    @Test
+    public void buildFolder_baseRelative_buildAbsolute_resolvesToBuildDir()
+            throws Exception {
+        File basedir = new File("relative-base");
+        File buildDir = new File(projectBase.getParentFile(), "custom-build");
+        assertBuildFolderResolvesTo(basedir, buildDir.getAbsolutePath(),
+                buildDir);
+    }
+
+    @Test
+    public void buildFolder_baseRelative_buildRelative_resolvesToBuildDir()
+            throws Exception {
+        File basedir = new File("relative-base");
+        String buildDir = "../custom-build"; // relative to basedir
+        assertBuildFolderResolvesTo(basedir, buildDir,
+                new File(basedir, buildDir));
+    }
+
+    private void assertBuildFolderResolvesTo(File basedir,
+            String projectBuildDir, File expectedBuildDir) throws Exception {
+        // npmFolder always equals basedir in a real project.
+        ReflectionUtils.setVariableValueInObject(mojo, Constants.NPM_TOKEN,
+                basedir);
+        ReflectionUtils.setVariableValueInObject(mojo, "projectBasedir",
+                basedir);
+        ReflectionUtils.setVariableValueInObject(mojo, "projectBuildDir",
+                projectBuildDir);
+
+        File resolved = new File(mojo.npmFolder(), mojo.buildFolder());
+        assertEquals(normalize(expectedBuildDir), normalize(resolved));
+    }
+
+    private static Path normalize(File file) {
+        return file.getAbsoluteFile().toPath().normalize();
     }
 }

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBase.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBase.java
@@ -298,8 +298,15 @@ public interface PluginAdapterBase {
 
     /**
      * The folder where everything is built into.
+     * <p>
+     * The returned value must be a path <em>relative</em> to the project root
+     * (the {@link #npmFolder() npm folder}), because consumers resolve it
+     * against that folder, e.g. {@code new File(npmFolder(), buildFolder())}.
+     * When the build directory lives outside the project root this means
+     * returning a {@code "../"} path; returning an absolute path would instead
+     * be appended under the project root and point to the wrong location.
      *
-     * @return build folder
+     * @return build folder, relative to the project root
      */
     String buildFolder();
 


### PR DESCRIPTION
This PR cherry-picks changes from the original PR #24805 to branch 25.0.
---
#### Original PR description
> ## Description
>
> When the build dir is relocated outside the project dir, vaadinPrepareFrontend wrote vaadin-dev-server-settings.json and the dev-bundle output paths under the source tree. buildFolder() is now always relative to projectDir.
>
> Fixes #24804
>
> ## Type of change
>
> - [ x] Bugfix
> - [ ] Feature
>
> ## Checklist
>
> - [x ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
> - [x ] I have added a description following the guideline.
> - [ x] The issue is created in the corresponding repository and I have referenced it.
> - [ x] I have added tests to ensure my change is effective and works as intended.
> - [ x] New and existing tests are passing locally with my change.
> - [ x] I have performed self-review and corrected misspellings.
>
>
