### PR TITLE
test: run headless Chrome with --no-sandbox in container environments

### DIFF
--- a/flow-test-util/src/main/java/com/vaadin/flow/testutil/ChromeBrowserTest.java
+++ b/flow-test-util/src/main/java/com/vaadin/flow/testutil/ChromeBrowserTest.java
@@ -181,6 +181,10 @@ public class ChromeBrowserTest extends ViewOrUITest {
         // behavior.
         options.addArguments("--disable-backgrounding-occluded-windows");
 
+        // Required to run reliably in CI and other headless/container
+        // environments such as Docker, where Chrome cannot use its sandbox.
+        options.addArguments("--no-sandbox", "--disable-dev-shm-usage");
+
         return options;
     }
 }


### PR DESCRIPTION
Add --no-sandbox and --disable-dev-shm-usage to the shared headless Chrome options so the TestBench ITs start Chrome reliably in CI and other headless/container environments (e.g. Docker), where Chrome cannot use its sandbox and otherwise exits immediately with 'session not created: Chrome instance exited'. Mirrors the driver setup in the test-default module (#24835).
